### PR TITLE
fix double underline on links with underline facet

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -8,59 +8,149 @@
         "role": "primary",
         "displayName": "Camel",
         "canonical": "#ad7f58",
-        "tonalRamp": ["#3e332e", "#815e46", "#a07553", "#ad7f58", "#cea37e", "#dcbc9f", "#e4cdb7", "#f6eee7"]
+        "tonalRamp": [
+          "#3e332e",
+          "#815e46",
+          "#a07553",
+          "#ad7f58",
+          "#cea37e",
+          "#dcbc9f",
+          "#e4cdb7",
+          "#f6eee7"
+        ]
       },
       "ink": {
         "role": "neutral",
         "displayName": "Warm Ink",
         "canonical": "oklch(0.245 0.012 60)",
-        "tonalRamp": ["oklch(0.245 0.012 60)", "oklch(0.40 0.012 60)", "oklch(0.56 0.012 65)", "oklch(0.72 0.016 68)", "oklch(0.80 0.014 70)", "oklch(0.88 0.012 75)", "oklch(0.945 0.012 83)", "oklch(0.985 0.007 85)"]
+        "tonalRamp": [
+          "oklch(0.245 0.012 60)",
+          "oklch(0.40 0.012 60)",
+          "oklch(0.56 0.012 65)",
+          "oklch(0.72 0.016 68)",
+          "oklch(0.80 0.014 70)",
+          "oklch(0.88 0.012 75)",
+          "oklch(0.945 0.012 83)",
+          "oklch(0.985 0.007 85)"
+        ]
       },
       "page-bg": {
         "role": "neutral",
         "displayName": "Almanac Paper",
         "canonical": "oklch(0.985 0.007 85)",
-        "tonalRamp": ["oklch(0.16 0.012 60)", "oklch(0.19 0.012 58)", "oklch(0.22 0.014 56)", "oklch(0.72 0.016 68)", "oklch(0.88 0.012 75)", "oklch(0.945 0.012 83)", "oklch(0.965 0.01 84)", "oklch(0.985 0.007 85)"]
+        "tonalRamp": [
+          "oklch(0.16 0.012 60)",
+          "oklch(0.19 0.012 58)",
+          "oklch(0.22 0.014 56)",
+          "oklch(0.72 0.016 68)",
+          "oklch(0.88 0.012 75)",
+          "oklch(0.945 0.012 83)",
+          "oklch(0.965 0.01 84)",
+          "oklch(0.985 0.007 85)"
+        ]
       },
       "critical-solid": {
         "role": "critical",
         "displayName": "Critical Red",
         "canonical": "#e5484d",
-        "tonalRamp": ["#641723", "#822025", "#aa2429", "#ce2c31", "#e5484d", "#eb8e90", "#f4a9aa", "#ffdbdc"]
+        "tonalRamp": [
+          "#641723",
+          "#822025",
+          "#aa2429",
+          "#ce2c31",
+          "#e5484d",
+          "#eb8e90",
+          "#f4a9aa",
+          "#ffdbdc"
+        ]
       },
       "success-solid": {
         "role": "success",
         "displayName": "Success Green",
         "canonical": "#30a46c",
-        "tonalRamp": ["#193b2d", "#1b543a", "#20573e", "#218358", "#30a46c", "#5bb98b", "#8eceaa", "#c4e8d1"]
+        "tonalRamp": [
+          "#193b2d",
+          "#1b543a",
+          "#20573e",
+          "#218358",
+          "#30a46c",
+          "#5bb98b",
+          "#8eceaa",
+          "#c4e8d1"
+        ]
       },
       "warning-solid": {
         "role": "warning",
         "displayName": "Warning Yellow",
         "canonical": "#ffe629",
-        "tonalRamp": ["#473b1f", "#5c4d0f", "#8f7d0e", "#9e6c00", "#ffe629", "#f5e147", "#f9e68c", "#fdf8ba"]
+        "tonalRamp": [
+          "#473b1f",
+          "#5c4d0f",
+          "#8f7d0e",
+          "#9e6c00",
+          "#ffe629",
+          "#f5e147",
+          "#f9e68c",
+          "#fdf8ba"
+        ]
       }
     },
     "typographyMeta": {
-      "display": { "displayName": "Display", "purpose": "Article titles and editorial headlines (Newsreader serif)." },
-      "heading": { "displayName": "Heading", "purpose": "All screen/section headings h1–h5 (Newsreader serif)." },
-      "reading": { "displayName": "Reading", "purpose": "Long-form article prose (Newsreader), capped 65–75ch." },
-      "body": { "displayName": "Body", "purpose": "Running interface text (Atkinson Hyperlegible Next)." },
-      "label": { "displayName": "Label", "purpose": "Buttons, form labels, nav, chips (Atkinson, semibold)." },
-      "mono": { "displayName": "Mono", "purpose": "Counts, dates, handles/DIDs, code only (Spline Sans Mono)." }
+      "display": {
+        "displayName": "Display",
+        "purpose": "Article titles and editorial headlines (Newsreader serif)."
+      },
+      "heading": {
+        "displayName": "Heading",
+        "purpose": "All screen/section headings h1–h5 (Newsreader serif)."
+      },
+      "reading": {
+        "displayName": "Reading",
+        "purpose": "Long-form article prose (Newsreader), capped 65–75ch."
+      },
+      "body": {
+        "displayName": "Body",
+        "purpose": "Running interface text (Atkinson Hyperlegible Next)."
+      },
+      "label": {
+        "displayName": "Label",
+        "purpose": "Buttons, form labels, nav, chips (Atkinson, semibold)."
+      },
+      "mono": {
+        "displayName": "Mono",
+        "purpose": "Counts, dates, handles/DIDs, code only (Spline Sans Mono)."
+      }
     },
     "shadows": [
-      { "name": "xs-rest", "value": "0 1px 2px 0 rgb(0 0 0 / 0.05)", "purpose": "The most a resting surface earns — buttons, occasional raised card." },
-      { "name": "lg-floating", "value": "0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)", "purpose": "Popovers, menus, autocomplete — detached from flow. Stronger on dark." },
-      { "name": "xl-modal", "value": "0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)", "purpose": "Dialogs and sheets over a warm dimmed backdrop." }
+      {
+        "name": "xs-rest",
+        "value": "0 1px 2px 0 rgb(0 0 0 / 0.05)",
+        "purpose": "The most a resting surface earns — buttons, occasional raised card."
+      },
+      {
+        "name": "lg-floating",
+        "value": "0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)",
+        "purpose": "Popovers, menus, autocomplete — detached from flow. Stronger on dark."
+      },
+      {
+        "name": "xl-modal",
+        "value": "0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)",
+        "purpose": "Dialogs and sheets over a warm dimmed backdrop."
+      }
     ],
     "motion": [
-      { "name": "duration-fast", "value": "120ms", "purpose": "Default state transitions (button/input hover, focus)." },
-      { "name": "ease-standard", "value": "ease-in-out", "purpose": "Easing for color/state transitions — no bounce, no elastic." }
+      {
+        "name": "duration-fast",
+        "value": "120ms",
+        "purpose": "Default state transitions (button/input hover, focus)."
+      },
+      {
+        "name": "ease-standard",
+        "value": "ease-in-out",
+        "purpose": "Easing for color/state transitions — no bounce, no elastic."
+      }
     ],
-    "breakpoints": [
-      { "name": "md", "value": "768px" }
-    ]
+    "breakpoints": [{ "name": "md", "value": "768px" }]
   },
   "components": [
     {
@@ -124,11 +214,31 @@
       "Squircle corners on interactive surfaces; radii stay modest (8–12px), never over-rounded."
     ],
     "rules": [
-      { "name": "The One Lamp Rule", "body": "The camel accent appears on ≤10% of any given screen. If two things on a screen are both camel, one of them is wrong. Emphasis beyond that is carried by weight, size, and whitespace — not more color.", "section": "colors" },
-      { "name": "The Disciplined Warmth Rule", "body": "The paper is warm on purpose, but at a whisper of chroma (C ≈ 0.007–0.014). The warmth is carried by the serif, the reading rhythm, and the earthen accent — never by widening the background into a loud cream, sand, or parchment. Warm off-white, not coffee stain.", "section": "colors" },
-      { "name": "The Serif-Sans Split Rule", "body": "Newsreader carries display, headings, and reading content (titles, prose, publication names). Atkinson carries running UI text, labels, buttons, counts, and metadata. If a heading renders in the sans, or a button renders in the serif, the split has been broken.", "section": "typography" },
-      { "name": "The Legible-Floor Rule", "body": "Body and reading text never drop below their tokened size for density's sake, and muted text never goes lighter than Ink Muted (oklch(0.56 0.012 65)). Reading comfort is the product.", "section": "typography" },
-      { "name": "The Float-To-Earn Rule", "body": "A surface gets a shadow only when it literally floats above another layer. If it lives in the page flow, it is flat and bordered. A resting card with a soft 16px+ drop shadow is prohibited — that is the 2014-app tell.", "section": "elevation" }
+      {
+        "name": "The One Lamp Rule",
+        "body": "The camel accent appears on ≤10% of any given screen. If two things on a screen are both camel, one of them is wrong. Emphasis beyond that is carried by weight, size, and whitespace — not more color.",
+        "section": "colors"
+      },
+      {
+        "name": "The Disciplined Warmth Rule",
+        "body": "The paper is warm on purpose, but at a whisper of chroma (C ≈ 0.007–0.014). The warmth is carried by the serif, the reading rhythm, and the earthen accent — never by widening the background into a loud cream, sand, or parchment. Warm off-white, not coffee stain.",
+        "section": "colors"
+      },
+      {
+        "name": "The Serif-Sans Split Rule",
+        "body": "Newsreader carries display, headings, and reading content (titles, prose, publication names). Atkinson carries running UI text, labels, buttons, counts, and metadata. If a heading renders in the sans, or a button renders in the serif, the split has been broken.",
+        "section": "typography"
+      },
+      {
+        "name": "The Legible-Floor Rule",
+        "body": "Body and reading text never drop below their tokened size for density's sake, and muted text never goes lighter than Ink Muted (oklch(0.56 0.012 65)). Reading comfort is the product.",
+        "section": "typography"
+      },
+      {
+        "name": "The Float-To-Earn Rule",
+        "body": "A surface gets a shadow only when it literally floats above another layer. If it lives in the page flow, it is flat and bordered. A resting card with a soft 16px+ drop shadow is prohibited — that is the 2014-app tell.",
+        "section": "elevation"
+      }
     ],
     "dos": [
       "Do carry warmth through Newsreader, reading rhythm, generous margins, and the earthen accent — the background stays a whisper-chroma warm off-white.",

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -139,6 +139,7 @@ trendy AI-startup landing aesthetic (no gradient text, no glassmorphism, no trac
 is a reading room, not a control panel.
 
 **Key Characteristics:**
+
 - Warm paper + warm ink neutrals (the Almanac palette), theme-aware light/dark via `light-dark()`.
 - Disciplined warmth: whisper-chroma OKLCH off-white, never pushed to loud cream/sand.
 - One earthen camel accent (`#ad7f58`), used on ≤10% of any screen: actions, selection, state.
@@ -153,14 +154,16 @@ semantic set for state. The neutrals and the accent are theme-aware through CSS 
 values below are light mode with the dark equivalent noted.
 
 ### Primary
+
 - **Camel** (`#ad7f58` solid; link/accent text `#815e46` light / `#dbb594` dark): The single
   accent — a muted, earthen tan-brown. (The source `editorialPrimary` theme labels it "terracotta,"
   but the value reads as a soft camel/tan, not orange-red clay.) Used for primary action buttons, the
   current navigation selection, focus and active states, unread markers, and links. Never decoration.
-  Its rarity is the entire point. On the warm paper, accent *text* uses the deeper brown (`#815e46`)
+  Its rarity is the entire point. On the warm paper, accent _text_ uses the deeper brown (`#815e46`)
   so links stay legible; the brighter `#ad7f58` is for solid fills and markers.
 
 ### Neutral (the Almanac paper + ink)
+
 - **Ink** (`oklch(0.245 0.012 60)` light / `oklch(0.92 0.01 85)` dark): Primary text — headings,
   body, high-emphasis labels. A warm near-black, never pure `#000`.
 - **Ink Muted** (`oklch(0.56 0.012 65)` light / `oklch(0.62 0.012 70)` dark): Secondary text —
@@ -173,11 +176,13 @@ values below are light mode with the dark equivalent noted.
   off-white in light, a warm dark reading surface in dark — both first-class.
 
 ### Semantic (Radix Red / Green / Yellow — unchanged by the editorial theme)
+
 - **Critical** (`#e5484d`, text `#ce2c31`): Errors, destructive actions, failed states.
 - **Success** (`#30a46c`, text `#218358`): Confirmation, completed, healthy.
 - **Warning** (`#ffe629`, text `#9e6c00`): Caution. The yellow solid takes **black** text, not white.
 
 ### Named Rules
+
 **The One Lamp Rule.** The camel accent appears on ≤10% of any given screen. If two things on a
 screen are both camel, one of them is wrong. Emphasis beyond that is carried by weight, size,
 and whitespace — not more color.
@@ -200,6 +205,7 @@ running interface quiet, accessible, and out of the way. Metric-adjusted Capsize
 (generated into `src/styles.css`) hold the layout so text doesn't shift as the web fonts load.
 
 ### Hierarchy
+
 - **Display** (Newsreader, 400, `clamp(2.25rem, 5vw, 3rem)`, line-height 1.25, tracking -0.025em):
   Article titles and editorial headlines — the content voice at its largest.
 - **Heading** (Newsreader, 500–600, 1.25rem → 3rem responsive by level, tracking -0.025em):
@@ -214,6 +220,7 @@ running interface quiet, accessible, and out of the way. Metric-adjusted Capsize
   never body copy.
 
 ### Named Rules
+
 **The Serif-Sans Split Rule.** Newsreader carries display, headings, and reading content (titles,
 prose, publication names). Atkinson carries running UI text, labels, buttons, counts, and metadata.
 If a heading renders in the sans, or a button renders in the serif, the split has been broken.
@@ -232,6 +239,7 @@ dark mode the shadow tokens are deliberately strengthened (via `editorialShadow`
 surfaces stay legible against the dark reading ground.
 
 ### Shadow Vocabulary
+
 - **Rest** (`box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05)` — `xs`): The most a resting surface earns —
   buttons, occasionally a raised card. Barely there.
 - **Floating** (`shadow.lg`, stronger on dark): Popovers, menus, autocomplete panels — things
@@ -240,6 +248,7 @@ surfaces stay legible against the dark reading ground.
   (`overlayBackdrop` is a warm-tinted translucent, not neutral black).
 
 ### Named Rules
+
 **The Float-To-Earn Rule.** A surface gets a shadow only when it literally floats above another
 layer. If it lives in the page flow, it is flat and bordered. A resting card with a soft 16px+ drop
 shadow is prohibited — that is the 2014-app tell.
@@ -253,6 +262,7 @@ error — because they are wired through react-aria. The overall feel is **refin
 quiet and low-contrast at rest, precise on interaction, receding so the reading leads.
 
 ### Buttons
+
 - **Shape:** Squircle corners at 8px (`rounded.md`, `corner-shape: squircle`), 1px border.
 - **Primary:** Camel solid fill (`#ad7f58`) with contrast text; the one high-emphasis action
   per view. Small size is 1.75rem tall with `0.75rem` horizontal padding.
@@ -262,25 +272,29 @@ quiet and low-contrast at rest, precise on interaction, receding so the reading 
   no transform, no bounce. Focus-visible shows a camel ring. Disabled drops to 50% opacity.
 
 ### Inputs / Fields
+
 - **Style:** Page-background fill, 1px tonal border, 8px squircle corners, Atkinson body text.
 - **Focus:** Border shifts to camel with a matching focus ring; no glow, no scale.
 - **Error:** Border and helper text shift to Critical red (`#e5484d` / `#ce2c31`).
 - **Placeholder:** Uses Ink Muted, never a lighter gray — placeholders must stay legible.
 
 ### Chips / Tags
+
 - **Style:** Full-pill (`rounded.full`), Surface fill, Ink Muted label; topic and filter tags.
 - **State:** Selected filters take the camel accent (text or subtle camel background);
   unselected stay neutral. Reserve the pill radius for tags and toggles, not cards.
 
 ### Cards / Containers
+
 - **Corner Style:** 12px (`rounded.lg`), squircle where supported.
 - **Background:** Page or Surface Subtle; **Border:** hairline warm tonal border.
 - **Shadow Strategy:** Flat at rest (see Elevation). No resting drop shadow.
 - **Internal Padding:** 1rem baseline (`lg`), scaling up for featured/lead cards.
 - Cards are used only where they are the right affordance (a discrete publication or article
-  object). Article and feed *rows* are the default list unit — not a wall of identical cards.
+  object). Article and feed _rows_ are the default list unit — not a wall of identical cards.
 
 ### Navigation
+
 - **Desktop:** Persistent left sidebar — Home, Latest, Saved, Discover, Search, plus the followed-
   publications list. Atkinson labels; current item marked with the camel accent.
 - **Mobile:** Top bar + bottom tab nav. Same items, same components, restructured — responsive
@@ -288,6 +302,7 @@ quiet and low-contrast at rest, precise on interaction, receding so the reading 
 - **States:** Default (Ink Muted), hover (Ink + Surface), active/current (camel).
 
 ### Signature: The Discover Directory & Editorial Rows
+
 The differentiator surface. A browsable directory of every known publication with recommendations,
 trending, and topic browsing — presented with real editorial care (Newsreader publication names,
 lead/featured treatments, "You might follow" rails), never as a flat utilitarian list. Article and
@@ -297,11 +312,12 @@ restrained camel affordance for save/follow — the recurring atom of the readin
 ## 6. Do's and Don'ts
 
 ### Do:
+
 - **Do** carry warmth through Newsreader, reading rhythm, generous margins, and the earthen accent —
   the background stays a whisper-chroma warm off-white.
 - **Do** keep the paper at Almanac chroma (`C ≈ 0.007–0.014`, hue ~60–85); warm, never loud.
 - **Do** reserve camel (`#ad7f58`) for primary actions, current selection, and state — ≤10% of
-  any screen (The One Lamp Rule). Use the deeper brown (`#815e46`) for accent *text* on light.
+  any screen (The One Lamp Rule). Use the deeper brown (`#815e46`) for accent _text_ on light.
 - **Do** use Newsreader for headings and reading content, and Atkinson Hyperlegible Next for running
   UI text, labels, and controls — never cross them (The Serif-Sans Split Rule).
 - **Do** keep surfaces flat and bordered at rest; add shadow only to things that float.
@@ -310,6 +326,7 @@ restrained camel affordance for save/follow — the recurring atom of the readin
 - **Do** honor `prefers-reduced-motion` with a crossfade or instant alternative for every transition.
 
 ### Don't:
+
 - **Don't** widen the warm paper into a loud cream, sand, parchment, or beige, or push its chroma
   past the Almanac whisper. This is warm off-white, not a coffee-stain aesthetic.
 - **Don't** design an algorithmic social feed: no engagement-bait, infinite-scroll dopamine

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -16,8 +16,17 @@ import {
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
 const require = createRequire(import.meta.url);
-/** onnxruntime-web runtime files shipped inside @huggingface/transformers. */
-const ortDistDir = path.dirname(require.resolve("@huggingface/transformers"));
+/**
+ * onnxruntime-web runtime files. Newer @huggingface/transformers no longer
+ * ships the `.wasm` binaries in its own dist (only the `.mjs` loader), so
+ * resolve them from the onnxruntime-web package it depends on — that dir holds
+ * both the loader and the version-matched wasm.
+ */
+const ortDistDir = path.dirname(
+  createRequire(require.resolve("@huggingface/transformers")).resolve(
+    "onnxruntime-web",
+  ),
+);
 const ORT_RUNTIME_FILES = [
   "ort-wasm-simd-threaded.jsep.mjs",
   "ort-wasm-simd-threaded.jsep.wasm",

--- a/src/components/reader/about-view.tsx
+++ b/src/components/reader/about-view.tsx
@@ -22,9 +22,9 @@ import {
   Users,
 } from "lucide-react";
 
-import { CHROME_STORE_URL, FIREFOX_STORE_URL } from "#/lib/extension-links";
 import { discoverApi } from "#/integrations/tanstack-query/api-discover.functions";
 import type { PublicationCard } from "#/integrations/tanstack-query/api-shapes";
+import { CHROME_STORE_URL, FIREFOX_STORE_URL } from "#/lib/extension-links";
 import { usePageReader } from "#/lib/page-reader/page-reader-context";
 
 import { animationDuration } from "../../design-system/theme/animations.stylex";
@@ -1286,7 +1286,10 @@ export function AboutView() {
             </div>
           </div>
 
-          <IntegrationCard icon={Heart} title="Save, like, subscribe — everywhere">
+          <IntegrationCard
+            icon={Heart}
+            title="Save, like, subscribe — everywhere"
+          >
             One tap from the reading view, on any device, instantly in sync.
             Your library is always where you left it.
           </IntegrationCard>
@@ -1386,9 +1389,9 @@ export function AboutView() {
               </h2>
               <p {...stylex.props(styles.panelPara, styles.panelParaSpaced)}>
                 Don’t want another app to check? Opt into a weekly email with
-                the best of the publications you subscribe to, plus a couple worth
-                discovering. One email, one click to leave — and you can preview
-                exactly what it looks like before you ever turn it on.
+                the best of the publications you subscribe to, plus a couple
+                worth discovering. One email, one click to leave — and you can
+                preview exactly what it looks like before you ever turn it on.
               </p>
               <CtaButton to="/settings" variant="ghost" icon={Mail}>
                 Turn on in Settings

--- a/src/components/reader/add-to-list-button.tsx
+++ b/src/components/reader/add-to-list-button.tsx
@@ -21,7 +21,9 @@ export function AddToListButton({
   const queryClient = useQueryClient();
   const { data: lists } = useQuery(listApi.getListsQueryOptions());
   const addMutation = useMutation(listApi.addUserToListMutationOptions());
-  const removeMutation = useMutation(listApi.removeUserFromListMutationOptions());
+  const removeMutation = useMutation(
+    listApi.removeUserFromListMutationOptions(),
+  );
 
   const iconSize = size === "md" ? 15 : 14;
 

--- a/src/components/reader/cards.tsx
+++ b/src/components/reader/cards.tsx
@@ -3,7 +3,14 @@
 import * as stylex from "@stylexjs/stylex";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { ArrowRight, BookOpen, Bookmark, Check, Heart, Plus } from "lucide-react";
+import {
+  ArrowRight,
+  BookOpen,
+  Bookmark,
+  Check,
+  Heart,
+  Plus,
+} from "lucide-react";
 import { Fragment, useCallback } from "react";
 
 import { AuthorProfileLink } from "#/components/reader/author-profile-link";

--- a/src/components/reader/content/renderers/shared/faceted-text.tsx
+++ b/src/components/reader/content/renderers/shared/faceted-text.tsx
@@ -14,8 +14,6 @@ import {
   UserHoverCardBody,
 } from "#/components/reader/mention-hover-card";
 import { PublicationAvatar } from "#/components/reader/primitives";
-import { authorApi } from "#/integrations/tanstack-query/api-author.functions";
-import { publicationApi } from "#/integrations/tanstack-query/api-publication.functions";
 import {
   DropCapChar,
   QuoteShareMark,
@@ -25,6 +23,8 @@ import {
   useQuoteHighlightTracker,
 } from "#/components/reader/quote-highlight-tracker";
 import { Avatar } from "#/design-system/avatar";
+import { authorApi } from "#/integrations/tanstack-query/api-author.functions";
+import { publicationApi } from "#/integrations/tanstack-query/api-publication.functions";
 import { segmentFacetedText, shiftFacets } from "#/lib/leaflet/facets";
 import type {
   ResolvedActorMention,
@@ -257,15 +257,15 @@ function LinkedActorChip({
   return (
     <EntityHoverCard
       onIntent={() =>
-        queryClient.prefetchQuery(
-          authorApi.getAuthorSummaryQueryOptions(ident),
-        )
+        queryClient.prefetchQuery(authorApi.getAuthorSummaryQueryOptions(ident))
       }
       card={
         <UserHoverCardBody
           did={ident}
           fallbackLabel={label}
-          fallbackHandle={actor?.handle ?? (ident.startsWith("did:") ? null : ident)}
+          fallbackHandle={
+            actor?.handle ?? (ident.startsWith("did:") ? null : ident)
+          }
           fallbackAvatarUrl={actor?.avatarUrl ?? null}
         />
       }

--- a/src/components/reader/content/renderers/shared/faceted-text.tsx
+++ b/src/components/reader/content/renderers/shared/faceted-text.tsx
@@ -326,6 +326,11 @@ function FacetSegment({
 
   let node: React.ReactNode = text;
 
+  // A rendered link already carries its own underline (`facetLink`). Track that
+  // so a co-located `underline` facet doesn't wrap it in a second `<u>` — two
+  // underline decorations at different offsets render as a double underline.
+  let nodeIsUnderlinedLink = false;
+
   if (isCode) {
     node = <code {...stylex.props(articleBodyStyles.facetCode)}>{text}</code>;
   }
@@ -356,6 +361,7 @@ function FacetSegment({
         {text}
       </SmartArticleLink>
     );
+    nodeIsUnderlinedLink = true;
   } else if (didMention?.did) {
     node = (
       <ActorMentionChip
@@ -378,7 +384,7 @@ function FacetSegment({
     );
   }
 
-  if (isUnderline) {
+  if (isUnderline && !nodeIsUnderlinedLink) {
     node = <u {...stylex.props(articleBodyStyles.facetUnderline)}>{node}</u>;
   }
 

--- a/src/components/reader/content/smart-article-link.tsx
+++ b/src/components/reader/content/smart-article-link.tsx
@@ -119,7 +119,9 @@ export function SmartArticleLink({
     return <ArticleLinkChip target={target}>{children}</ArticleLinkChip>;
   }
   if (target?.kind === "publication") {
-    return <PublicationLinkChip target={target}>{children}</PublicationLinkChip>;
+    return (
+      <PublicationLinkChip target={target}>{children}</PublicationLinkChip>
+    );
   }
   return (
     <AppLink href={href} linkStyle={linkStyle}>
@@ -241,7 +243,9 @@ function PublicationLinkChip({
     <EntityHoverCard
       onIntent={() =>
         queryClient.prefetchQuery(
-          publicationApi.getPublicationHeaderQueryOptions(target.publicationUri),
+          publicationApi.getPublicationHeaderQueryOptions(
+            target.publicationUri,
+          ),
         )
       }
       card={

--- a/src/components/reader/follow-user-button.tsx
+++ b/src/components/reader/follow-user-button.tsx
@@ -1,10 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Check, Plus } from "lucide-react";
 
+import { ButtonLink } from "#/components/router-links";
 import { Button } from "#/design-system/button";
 import type { FollowingUser } from "#/integrations/tanstack-query/api-feed.functions";
 import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
-import { ButtonLink } from "#/components/router-links";
 import { useLoginSearch } from "#/utils/use-login-search";
 
 import {
@@ -50,7 +50,12 @@ export function FollowUserButton({
 
   if (!signedIn) {
     return (
-      <ButtonLink to="/login" search={loginSearch} variant="secondary" size={size}>
+      <ButtonLink
+        to="/login"
+        search={loginSearch}
+        variant="secondary"
+        size={size}
+      >
         {icon} Follow
       </ButtonLink>
     );

--- a/src/components/reader/mention-hover-card.tsx
+++ b/src/components/reader/mention-hover-card.tsx
@@ -226,7 +226,8 @@ export function UserHoverCardBody({
 
   const handle = profile?.handle ?? fallbackHandle ?? null;
   const displayName = profile?.displayName ?? null;
-  const name = displayName ?? (handle ? `@${handle}` : (fallbackLabel ?? "Reader"));
+  const name =
+    displayName ?? (handle ? `@${handle}` : (fallbackLabel ?? "Reader"));
   const avatarUrl = profile?.avatarUrl ?? fallbackAvatarUrl ?? undefined;
   const showHandle = displayName != null && handle != null;
 
@@ -336,10 +337,7 @@ export function PublicationHoverCardBody({
       }
     >
       <div {...stylex.props(styles.head)}>
-        <PublicationAvatar
-          pub={{ name, iconUrl }}
-          size="lg"
-        />
+        <PublicationAvatar pub={{ name, iconUrl }} size="lg" />
         <div {...stylex.props(styles.headMeta)}>
           {pub?.topic ? (
             <span {...stylex.props(styles.kicker)}>{pub.topic}</span>

--- a/src/components/reader/publication-social-proof.tsx
+++ b/src/components/reader/publication-social-proof.tsx
@@ -206,7 +206,8 @@ export function PublicationSocialProofLine({
           trigger={<span hidden aria-hidden />}
         >
           <DialogHeader>
-            Subscribed by {total} {total === 1 ? "reader" : "readers"} you follow
+            Subscribed by {total} {total === 1 ? "reader" : "readers"} you
+            follow
           </DialogHeader>
           <DialogBody style={styles.modalBody}>
             {modalReaders.map((reader, index) => (

--- a/src/integrations/auth/callback.server.ts
+++ b/src/integrations/auth/callback.server.ts
@@ -178,9 +178,8 @@ export async function handleAtprotoOAuthCallback(args: {
       !priorUser.weeklyDigestWelcomeSentAt
     ) {
       try {
-        const { sendDigestWelcomeEmail } = await import(
-          "#/server/digest/welcome.server"
-        );
+        const { sendDigestWelcomeEmail } =
+          await import("#/server/digest/welcome.server");
         const sent = await sendDigestWelcomeEmail({
           userId,
           email: accountEmail,

--- a/src/integrations/tanstack-query/api-author.functions.ts
+++ b/src/integrations/tanstack-query/api-author.functions.ts
@@ -18,10 +18,7 @@ import {
   authorRecommendations,
   authorSubscriptions,
 } from "#/server/reader/queries";
-import type {
-  AuthorProfileStats,
-  AuthorReader,
-} from "#/server/reader/queries";
+import type { AuthorProfileStats, AuthorReader } from "#/server/reader/queries";
 
 import type {
   ArticleCard,

--- a/src/lib/leaflet/publication-mentions.test.ts
+++ b/src/lib/leaflet/publication-mentions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { PublicationMentionMap } from "./publication-mentions";
 import {
+  actorLinkIdent,
   collectInlineMentionRefs,
   documentMentionKey,
   lookupActorMention,
@@ -301,5 +302,39 @@ describe("lookupPublicationMention", () => {
       mentions,
     );
     expect(hit).toBeNull();
+  });
+});
+
+describe("actorLinkIdent", () => {
+  it("resolves a bare Bluesky profile link to the actor ident", () => {
+    expect(actorLinkIdent("https://bsky.app/profile/alice.bsky.social")).toBe(
+      "alice.bsky.social",
+    );
+    expect(actorLinkIdent("https://bsky.app/profile/did:plc:abc123")).toBe(
+      "did:plc:abc123",
+    );
+  });
+
+  it("keeps a Bluesky post link as-is (not a mention of its author)", () => {
+    expect(
+      actorLinkIdent("https://bsky.app/profile/alice.bsky.social/post/3abc123"),
+    ).toBeNull();
+    expect(
+      actorLinkIdent("https://bsky.app/profile/did:plc:abc123/post/3abc123"),
+    ).toBeNull();
+  });
+
+  it("ignores other profile sub-resources (lists, feeds)", () => {
+    expect(
+      actorLinkIdent("https://bsky.app/profile/alice.bsky.social/lists/xyz"),
+    ).toBeNull();
+    expect(
+      actorLinkIdent("https://bsky.app/profile/alice.bsky.social/feed/xyz"),
+    ).toBeNull();
+  });
+
+  it("resolves a relative in-app author path", () => {
+    expect(actorLinkIdent("/u/did:plc:abc123")).toBe("did:plc:abc123");
+    expect(actorLinkIdent("/u/alice.bsky.social")).toBe("alice.bsky.social");
   });
 });

--- a/src/lib/leaflet/publication-mentions.ts
+++ b/src/lib/leaflet/publication-mentions.ts
@@ -108,9 +108,9 @@ const BSKY_PROFILE_HOSTS = new Set(["bsky.app", "staging.bsky.app"]);
  * If a `#link` facet's target is a *user profile*, return the user's ident
  * (handle or DID) so the segment can render as an actor mention (avatar chip +
  * hovercard, linking in-app to `/u/$did`) instead of a bare off-site link.
- * Recognizes an in-app author path (`/u/<handle-or-did>`, relative) and a
- * Bluesky profile or post link (`bsky.app/profile/<handle-or-did>[/post/…]`).
- * Returns null for any other link.
+ * Recognizes an in-app author path (`/u/<handle-or-did>`, relative) and a bare
+ * Bluesky profile link (`bsky.app/profile/<handle-or-did>`). Returns null for
+ * any other link.
  */
 export function actorLinkIdent(uri: string): string | null {
   const trimmed = uri.trim();
@@ -132,10 +132,10 @@ export function actorLinkIdent(uri: string): string | null {
   }
 
   if (host && BSKY_PROFILE_HOSTS.has(host)) {
-    // ONLY a bare profile or a post counts as a person reference. A list
-    // (`/profile/<ident>/lists/…`), a feed (`/profile/<ident>/feed/…`), or any
-    // other sub-resource is about that object, not a mention of its owner.
-    const match = /^\/profile\/([^/]+)(?:\/post\/[^/]+)?\/?$/.exec(pathname);
+    // ONLY a bare profile counts as a person reference. A post
+    // (`/profile/<ident>/post/…`), list, or feed is about that object, not a
+    // mention of its owner — keep it a plain link to the original.
+    const match = /^\/profile\/([^/]+)\/?$/.exec(pathname);
     if (match?.[1]) {
       const ident = normalizeAuthorRef(decodeURIComponent(match[1]));
       // A handle needs a dot; a DID is taken verbatim. Guards against
@@ -149,7 +149,8 @@ export function actorLinkIdent(uri: string): string | null {
   // URL that happens to carry a `/u/` segment is not our profile route.
   if (host === null) {
     const match = /^\/u\/([^/]+)\/?$/.exec(pathname);
-    if (match?.[1]) return normalizeAuthorRef(decodeURIComponent(match[1])) || null;
+    if (match?.[1])
+      return normalizeAuthorRef(decodeURIComponent(match[1])) || null;
   }
   return null;
 }

--- a/src/lib/site-metadata.ts
+++ b/src/lib/site-metadata.ts
@@ -103,7 +103,8 @@ export const PAGE_OG_CARDS = {
   login: {
     path: "/login",
     title: "Sign in",
-    tagline: "Use your Atmosphere account to subscribe to writers and save reads.",
+    tagline:
+      "Use your Atmosphere account to subscribe to writers and save reads.",
   },
   feedback: {
     path: "/feedback",

--- a/src/routes/_layout.l.$did.$rkey.tsx
+++ b/src/routes/_layout.l.$did.$rkey.tsx
@@ -468,12 +468,14 @@ function ListPeoplePanel({
   return (
     <div>
       {users.map((member, index) => {
-        const name =
-          member.displayName?.trim() || member.handle || member.did;
+        const name = member.displayName?.trim() || member.handle || member.did;
         return (
           <div
             key={member.did}
-            {...stylex.props(styles.userRow, index === 0 && styles.userRowFirst)}
+            {...stylex.props(
+              styles.userRow,
+              index === 0 && styles.userRowFirst,
+            )}
           >
             <AuthorProfileLink
               authorRef={member.did}

--- a/src/routes/_layout.latest.tsx
+++ b/src/routes/_layout.latest.tsx
@@ -616,7 +616,9 @@ function Latest() {
     <ReaderContent>
       <Masthead
         kicker={
-          isTrending || isNetwork ? "Across the network" : "From your subscriptions"
+          isTrending || isNetwork
+            ? "Across the network"
+            : "From your subscriptions"
         }
         title={isTrending ? "Trending" : "Latest"}
         dek={

--- a/src/routes/_layout.p.$did.$rkey.tsx
+++ b/src/routes/_layout.p.$did.$rkey.tsx
@@ -11,6 +11,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { authorApi } from "#/integrations/tanstack-query/api-author.functions";
 import { publicationApi } from "#/integrations/tanstack-query/api-publication.functions";
+import type {
+  PublicationEmbedMeta,
+  PublicationHeader,
+  PublicationSocialProof,
+} from "#/integrations/tanstack-query/api-publication.functions";
 import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
 import { user } from "#/integrations/tanstack-query/api-user.functions";
 import { getPublicUrlClient } from "#/lib/public-url";
@@ -72,11 +77,6 @@ import {
   tracking,
 } from "../design-system/theme/typography.stylex";
 import type { ArticleCard } from "../integrations/tanstack-query/api-shapes";
-import type {
-  PublicationEmbedMeta,
-  PublicationHeader,
-  PublicationSocialProof,
-} from "#/integrations/tanstack-query/api-publication.functions";
 
 /** Documents loaded with the profile (page 0) before infinite scroll kicks in. */
 const PUBLICATION_RECENT_LIMIT = 12;

--- a/src/server/atproto/repo-records.ts
+++ b/src/server/atproto/repo-records.ts
@@ -272,9 +272,7 @@ export async function putUserFollowRecord(
     record: {
       $type: COLLECTION.graphFollow,
       subject: subjectDid,
-      ...(excludedPublications.length > 0
-        ? { excludedPublications }
-        : {}),
+      ...(excludedPublications.length > 0 ? { excludedPublications } : {}),
       createdAt,
     },
   });

--- a/src/server/ingest/handlers.ts
+++ b/src/server/ingest/handlers.ts
@@ -861,10 +861,14 @@ export async function upsertSidebarPref(
   record: SidebarPrefRecord,
 ): Promise<void> {
   const listOrder = Array.isArray(record.listOrder)
-    ? record.listOrder.filter((item): item is string => typeof item === "string")
+    ? record.listOrder.filter(
+        (item): item is string => typeof item === "string",
+      )
     : [];
   const collapsed = Array.isArray(record.collapsed)
-    ? record.collapsed.filter((item): item is string => typeof item === "string")
+    ? record.collapsed.filter(
+        (item): item is string => typeof item === "string",
+      )
     : [];
 
   const values = {

--- a/src/server/reader/content-links.ts
+++ b/src/server/reader/content-links.ts
@@ -7,8 +7,8 @@ import {
 import type { Db, Schema } from "#/integrations/tanstack-query/api-shapes";
 import { publicationDisplayName } from "#/integrations/tanstack-query/api-shapes";
 import { isAppOriginHref } from "#/lib/app-origin";
-import { actorLinkIdent } from "#/lib/leaflet/publication-mentions";
 import { parseInternalRoute } from "#/lib/internal-route";
+import { actorLinkIdent } from "#/lib/leaflet/publication-mentions";
 import { linkTargetVariants } from "#/lib/link-target-variants";
 import { getPublicUrl } from "#/lib/public-url";
 import { cdnImageUrl } from "#/server/atproto/blob";

--- a/src/server/reader/followed-publications-sync.server.ts
+++ b/src/server/reader/followed-publications-sync.server.ts
@@ -25,7 +25,9 @@ import { deleteRecord, upsertSubscription } from "#/server/ingest/handlers";
  */
 
 /** The subject's live publication URIs (the owner-authored publications). */
-async function subjectPublicationUris(subjectDid: string): Promise<Array<string>> {
+async function subjectPublicationUris(
+  subjectDid: string,
+): Promise<Array<string>> {
   const p = schema.publications;
   const rows = await db
     .select({ uri: p.uri })
@@ -104,10 +106,16 @@ export async function syncFollowedPublications(
         publicationUri,
         createdAt,
       );
-      await upsertSubscription(uri, followerDid, subjectRkey(publicationUri), cid, {
-        publication: publicationUri,
-        createdAt,
-      });
+      await upsertSubscription(
+        uri,
+        followerDid,
+        subjectRkey(publicationUri),
+        cid,
+        {
+          publication: publicationUri,
+          createdAt,
+        },
+      );
       created += 1;
     } catch (error) {
       console.warn(
@@ -156,7 +164,12 @@ export async function unsubscribeFollowedPublications(
   let removed = 0;
   for (const [publicationUri, rkeys] of byPub) {
     try {
-      await deleteSubscriptionRecords(client, followerDid, publicationUri, rkeys);
+      await deleteSubscriptionRecords(
+        client,
+        followerDid,
+        publicationUri,
+        rkeys,
+      );
       const allRkeys = new Set([subjectRkey(publicationUri), ...rkeys]);
       await Promise.all(
         [...allRkeys].map((rkey) =>
@@ -196,9 +209,8 @@ export function scheduleFollowedPublicationReconcile(readerDid: string): void {
   reconciled.add(readerDid);
   void (async () => {
     try {
-      const { restoreAuthenticatedClient } = await import(
-        "#/integrations/auth/restore-client.server"
-      );
+      const { restoreAuthenticatedClient } =
+        await import("#/integrations/auth/restore-client.server");
       const client = await restoreAuthenticatedClient(readerDid as Did);
       if (!client) {
         reconciled.delete(readerDid); // no session now — retry on a later load


### PR DESCRIPTION
A text segment carrying both a `link` facet and an `underline` facet rendered two stacked underlines: SmartArticleLink already applies `facetLink` (text-decoration: underline, offset 1.5), and the segment was then wrapped in a `<u>` with `facetUnderline` (offset 2px). The two decorations at different offsets read as a double underline.

Track when the node is already an underlined link and skip the redundant `<u>` wrapper in that case.