### PR TITLE
Default signed-out users to Trending instead of Follows

### DIFF
--- a/src/integrations/tanstack-query/api-feed.functions.ts
+++ b/src/integrations/tanstack-query/api-feed.functions.ts
@@ -4,6 +4,7 @@ import { getCookie, getRequest } from "@tanstack/react-start/server";
 import { z } from "zod";
 
 import {
+  DEFAULT_GUEST_HOME_SCOPE,
   HOME_SCOPE_COOKIE,
   dbValueToHomeScope,
   parseHomeScope,
@@ -548,7 +549,14 @@ const getHomePage = createServerFn({ method: "GET" })
       if (reader) {
         scope = data.scope ?? dbValueToHomeScope(reader.homeScope ?? null);
       } else {
-        scope = data.scope ?? parseHomeScope(getCookie(HOME_SCOPE_COOKIE));
+        // Signed-out: default to Trending (see DEFAULT_GUEST_HOME_SCOPE) since a
+        // guest has no follows to personalize.
+        scope =
+          data.scope ??
+          parseHomeScope(
+            getCookie(HOME_SCOPE_COOKIE),
+            DEFAULT_GUEST_HOME_SCOPE,
+          );
       }
 
       const trackReading =

--- a/src/integrations/tanstack-query/api-user.functions.ts
+++ b/src/integrations/tanstack-query/api-user.functions.ts
@@ -18,6 +18,7 @@ import {
   parseCountOldPostsAsUnreadCookie,
 } from "#/lib/count-old-posts-as-unread";
 import {
+  DEFAULT_GUEST_HOME_SCOPE,
   HOME_SCOPE_COOKIE,
   HOME_SCOPE_COOKIE_MAX_AGE_SECONDS,
   dbValueToHomeScope,
@@ -234,7 +235,10 @@ const getShellBootstrap = createServerFn({ method: "GET" }).handler(
         ),
       },
       homeScope: {
-        scope: parseHomeScope(cookies[HOME_SCOPE_COOKIE]),
+        scope: parseHomeScope(
+          cookies[HOME_SCOPE_COOKIE],
+          DEFAULT_GUEST_HOME_SCOPE,
+        ),
       },
       readerVoice: {
         preference: parseReaderVoicePreference(cookies[READER_VOICE_COOKIE]),
@@ -888,7 +892,12 @@ const getHomeScopePreference = createServerFn({ method: "GET" })
       return { scope: dbValueToHomeScope(session.user.homeScope ?? null) };
     }
 
-    return { scope: parseHomeScope(getCookie(HOME_SCOPE_COOKIE)) };
+    return {
+      scope: parseHomeScope(
+        getCookie(HOME_SCOPE_COOKIE),
+        DEFAULT_GUEST_HOME_SCOPE,
+      ),
+    };
   });
 
 const getHomeScopePreferenceQueryOptions = queryOptions({

--- a/src/lib/home-scope.ts
+++ b/src/lib/home-scope.ts
@@ -9,12 +9,31 @@ import type { HomeScope } from "#/integrations/tanstack-query/api-feed.functions
 
 export const DEFAULT_HOME_SCOPE: HomeScope = "follows";
 
+/**
+ * Home scope default for a signed-out visitor. `follows` is meaningless without
+ * an account (it degrades to the latest network feed), so guests land on
+ * Trending — the most-read writing across the network — unless a cookie says
+ * otherwise.
+ */
+export const DEFAULT_GUEST_HOME_SCOPE: HomeScope = "trending";
+
 export const HOME_SCOPE_COOKIE = "standard-reader-home-scope";
 
 export const HOME_SCOPE_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
 
-export function parseHomeScope(value: unknown): HomeScope {
-  return value === "trending" || value === "network" ? "trending" : "follows";
+/**
+ * Parse a stored scope value (cookie). An explicit `follows`/`trending`
+ * (or legacy `network`) is honored; anything else falls back to `fallback`
+ * ({@link DEFAULT_HOME_SCOPE} by default — pass {@link DEFAULT_GUEST_HOME_SCOPE}
+ * for signed-out reads).
+ */
+export function parseHomeScope(
+  value: unknown,
+  fallback: HomeScope = DEFAULT_HOME_SCOPE,
+): HomeScope {
+  if (value === "trending" || value === "network") return "trending";
+  if (value === "follows") return "follows";
+  return fallback;
 }
 
 export function homeScopeToCookieValue(scope: HomeScope): HomeScope {


### PR DESCRIPTION
## Summary
Updated the home scope logic to provide a better default experience for signed-out users by defaulting them to the "Trending" feed instead of "Follows", which is meaningless without an account.

## Key Changes
- Added `DEFAULT_GUEST_HOME_SCOPE` constant set to `"trending"` for signed-out visitors
- Enhanced `parseHomeScope()` function to accept an optional `fallback` parameter, allowing callers to specify different defaults for authenticated vs. guest users
- Updated the function's logic to explicitly handle `"trending"`, `"follows"`, and legacy `"network"` values before falling back to the provided default
- Updated three call sites to pass `DEFAULT_GUEST_HOME_SCOPE` when parsing home scope for unauthenticated users:
  - `getShellBootstrap()` in api-user.functions.ts
  - `getHomeScopePreference()` in api-user.functions.ts
  - `getHomePage()` in api-feed.functions.ts

## Implementation Details
- The `parseHomeScope()` function maintains backward compatibility by defaulting the `fallback` parameter to `DEFAULT_HOME_SCOPE` (which is `"follows"`)
- Authenticated users continue to default to "Follows" when no explicit preference is stored
- Guest users now default to "Trending" unless they have a stored cookie preference
- Added comprehensive JSDoc comments explaining the new behavior and parameter usage

https://claude.ai/code/session_01HbnTsTSq37RP2ebarx4vEi