### PR TITLE
Move alignSelf style from brand to brandSidebar variant

### DIFF
--- a/src/components/reader/app-shell.tsx
+++ b/src/components/reader/app-shell.tsx
@@ -134,7 +134,6 @@ const styles = stylex.create({
     // Hug the wordmark so the focus ring is tight to it, not a full-width box
     // wrapping empty space.
     alignItems: "center",
-    alignSelf: "flex-start",
     display: "inline-flex",
     width: "fit-content",
     borderRadius: radius.sm,
@@ -149,6 +148,10 @@ const styles = stylex.create({
     outlineOffset: "2px",
   },
   brandSidebar: {
+    // Left-align in the sidebar's column flow; only relevant here — in the
+    // mobile bar's row flow this would pin the wordmark to the top instead of
+    // letting it center vertically.
+    alignSelf: "flex-start",
     // Margin, not padding — the separation below the logo must sit outside the
     // focusable box so the focus ring hugs the wordmark.
     marginBottom: verticalSpace["7xl"],


### PR DESCRIPTION
## Summary
Relocated the `alignSelf: "flex-start"` style property from the shared `brand` style to the `brandSidebar` variant, making the alignment behavior specific to the sidebar layout context.

## Key Changes
- Removed `alignSelf: "flex-start"` from the base `brand` style object
- Added `alignSelf: "flex-start"` to the `brandSidebar` style object with clarifying comments
- Added explanatory comments documenting why this property is only needed in the sidebar's column flow, not in the mobile bar's row flow

## Implementation Details
The change reflects a layout-specific concern: the `alignSelf: "flex-start"` property is only appropriate when the brand element is used in the sidebar's vertical (column) layout. In the mobile bar's horizontal (row) layout, this property would incorrectly pin the wordmark to the top instead of allowing it to center vertically. By moving it to the `brandSidebar` variant, the style is now applied only where it's needed.

https://claude.ai/code/session_01AHbRAEVKTrwWRtnoxhBjpg