### PR TITLE
Add manual read/unread toggle for articles

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -581,6 +581,13 @@ not offline body cache). Route slug **`/saved`**.
       `app.standard-reader.read` / `reads` table (no new lexicon); `readerApi.getReadingHistory` + user-menu link + empty state; infinite scroll (20 per page). Update [`APP_VISION.md`](APP_VISION.md) when landing.
 - [x] **Track reading history setting** — user-menu toggle (cookie + `user.track_reading_history`);
       when off: no `markRead` writes, zero unread counts/dots, hidden Unread tab + Reading history link.
+- [x] **Manual read/unread toggle** — reader-facing control to flip an article back to unread
+      (deletes its `app.standard-reader.read` record via the existing `markUnread` path). Article-view
+      top-bar toggle ([`article-view.tsx`](src/components/reader/article-view.tsx) +
+      [`use-article-read-toggle.ts`](src/components/reader/use-article-read-toggle.ts)) and a per-row
+      "Mark as unread" button on `/history` ([`cards.tsx`](src/components/reader/cards.tsx) `MarkUnreadButton`).
+      `applyMarkUnreadOptimisticUpdate` mirrors the mark-read cache flip in reverse (re-adds unread
+      dots/counters, drops the row from Reading history).
 
 ## 11. Post-v1 — bigger bets (Tier 4)
 

--- a/src/components/reader/article-view.tsx
+++ b/src/components/reader/article-view.tsx
@@ -17,6 +17,7 @@ import {
   ExternalLink,
   Headphones,
   Heart,
+  MoreHorizontal,
 } from "lucide-react";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { flushSync } from "react-dom";
@@ -45,6 +46,7 @@ import {
   LIGHTBOX_IMAGE_TRANSITION_NAME,
   startLightboxViewTransition,
 } from "../../design-system/lightbox/transition";
+import { Menu, MenuItem } from "../../design-system/menu";
 import { animationDuration } from "../../design-system/theme/animations.stylex";
 import {
   criticalColor,
@@ -210,6 +212,23 @@ const styles = stylex.create({
     display: "flex",
     flexShrink: 0,
     rowGap: gap.md,
+  },
+  topActsInline: {
+    alignItems: "center",
+    columnGap: gap.md,
+    // Individual secondary buttons on desktop; folded into an overflow menu below
+    // this breakpoint (see `topActsOverflow`).
+    display: {
+      default: "none",
+      "@media (min-width: 40rem)": "flex",
+    },
+  },
+  topActsOverflow: {
+    alignItems: "center",
+    display: {
+      default: "flex",
+      "@media (min-width: 40rem)": "none",
+    },
   },
   pubByline: {
     borderWidth: 0,
@@ -595,6 +614,74 @@ function ReadToggleButton({
   );
 }
 
+/**
+ * Mobile overflow for the article top bar: collapses the secondary actions
+ * (magazine / open-on-site / read toggle / save) behind a single "⋯" button so
+ * the bar doesn't overflow on narrow screens. On desktop the same actions render
+ * as individual icon buttons instead (see `styles.topActsInline`).
+ */
+function ReaderSecondaryActionsMenu({
+  onOpenMagazine,
+  onOpenPublication,
+  publicationName,
+  showReadToggle,
+  isRead,
+  onToggleRead,
+  bookmarked,
+  onToggleBookmark,
+}: {
+  onOpenMagazine: (() => void) | null;
+  onOpenPublication: (() => void) | null;
+  publicationName?: string | null;
+  showReadToggle: boolean;
+  isRead: boolean;
+  onToggleRead: () => void;
+  bookmarked: boolean;
+  onToggleBookmark: () => void;
+}) {
+  return (
+    <Menu
+      trigger={
+        <IconButton variant="secondary" size="md" label="More actions">
+          <MoreHorizontal size={18} />
+        </IconButton>
+      }
+    >
+      {onOpenMagazine ? (
+        <MenuItem prefix={<BookOpen size={16} />} onPress={onOpenMagazine}>
+          Open magazine edition
+        </MenuItem>
+      ) : null}
+      {onOpenPublication ? (
+        <MenuItem
+          prefix={<ExternalLink size={16} />}
+          onPress={onOpenPublication}
+        >
+          {publicationName
+            ? `Open on ${publicationName}`
+            : "Open on publication"}
+        </MenuItem>
+      ) : null}
+      {showReadToggle ? (
+        <MenuItem
+          prefix={isRead ? <CircleCheck size={16} /> : <Circle size={16} />}
+          onPress={onToggleRead}
+        >
+          {isRead ? "Mark as unread" : "Mark as read"}
+        </MenuItem>
+      ) : null}
+      <MenuItem
+        prefix={
+          <Bookmark size={16} fill={bookmarked ? "currentColor" : "none"} />
+        }
+        onPress={onToggleBookmark}
+      >
+        {bookmarked ? "Saved for later" : "Save for later"}
+      </MenuItem>
+    </Menu>
+  );
+}
+
 function ArticleLikePrompt({
   recommended,
   onToggle,
@@ -754,6 +841,24 @@ function ArticleViewBody({
   const date = formatDate(article.publishedAt);
   const publicationArticleUrl = articlePublicationUrl(article);
   const linkParams = documentLinkParams(article.uri);
+
+  const handleOpenMagazine =
+    article.collection && linkParams
+      ? () => {
+          rememberOpenInMagazine();
+          void router.navigate({
+            to: "/collection/$did/$rkey",
+            params: linkParams,
+            replace: true,
+          });
+        }
+      : null;
+  const handleOpenPublication = publicationArticleUrl
+    ? () => {
+        globalThis.open(publicationArticleUrl, "_blank", "noopener,noreferrer");
+      }
+    : null;
+
   const dismissMagazineIntro = () => {
     try {
       globalThis.localStorage?.setItem(COLLECTION_MAGAZINE_INTRO_KEY, "1");
@@ -919,51 +1024,57 @@ function ArticleViewBody({
 
           <div {...stylex.props(styles.topActs)}>
             <TopListenButton article={article} />
-            {article.collection && linkParams ? (
-              <IconButton
-                variant="secondary"
-                size="md"
-                label="Open magazine edition"
-                onPress={() => {
-                  rememberOpenInMagazine();
-                  void router.navigate({
-                    to: "/collection/$did/$rkey",
-                    params: linkParams,
-                    replace: true,
-                  });
-                }}
-              >
-                <BookOpen size={18} />
-              </IconButton>
-            ) : null}
-            {publicationArticleUrl ? (
-              <IconButton
-                variant="secondary"
-                size="md"
-                label={pub ? `Open on ${pub.name}` : "Open on publication"}
-                onPress={() => {
-                  globalThis.open(
-                    publicationArticleUrl,
-                    "_blank",
-                    "noopener,noreferrer",
-                  );
-                }}
-              >
-                <ExternalLink size={18} />
-              </IconButton>
-            ) : null}
-            {signedIn && trackReading ? (
-              <ReadToggleButton
-                isRead={isRead}
-                onToggle={toggleRead}
-                isPending={readTogglePending}
+
+            {/* Secondary actions: individual buttons on desktop… */}
+            <div {...stylex.props(styles.topActsInline)}>
+              {handleOpenMagazine ? (
+                <IconButton
+                  variant="secondary"
+                  size="md"
+                  label="Open magazine edition"
+                  onPress={handleOpenMagazine}
+                >
+                  <BookOpen size={18} />
+                </IconButton>
+              ) : null}
+              {handleOpenPublication ? (
+                <IconButton
+                  variant="secondary"
+                  size="md"
+                  label={pub ? `Open on ${pub.name}` : "Open on publication"}
+                  onPress={handleOpenPublication}
+                >
+                  <ExternalLink size={18} />
+                </IconButton>
+              ) : null}
+              {signedIn && trackReading ? (
+                <ReadToggleButton
+                  isRead={isRead}
+                  onToggle={toggleRead}
+                  isPending={readTogglePending}
+                />
+              ) : null}
+              <BookmarkButton
+                bookmarked={bookmarked}
+                onToggle={toggleBookmark}
+                isPending={bookmarkPending}
               />
-            ) : null}
-            <BookmarkButton
-              bookmarked={bookmarked}
-              onToggle={toggleBookmark}
-              isPending={bookmarkPending}
-            />
+            </div>
+
+            {/* …collapsed into an overflow menu on mobile. */}
+            <div {...stylex.props(styles.topActsOverflow)}>
+              <ReaderSecondaryActionsMenu
+                onOpenMagazine={handleOpenMagazine}
+                onOpenPublication={handleOpenPublication}
+                publicationName={pub?.name}
+                showReadToggle={signedIn && trackReading}
+                isRead={isRead}
+                onToggleRead={toggleRead}
+                bookmarked={bookmarked}
+                onToggleBookmark={toggleBookmark}
+              />
+            </div>
+
             <DocumentShareMenu
               recordUri={article.uri}
               title={article.title}

--- a/src/components/reader/article-view.tsx
+++ b/src/components/reader/article-view.tsx
@@ -12,6 +12,8 @@ import {
   ArrowLeft,
   BookOpen,
   Bookmark,
+  Circle,
+  CircleCheck,
   ExternalLink,
   Headphones,
   Heart,
@@ -98,6 +100,7 @@ import { applyMarkReadOptimisticUpdate } from "./read-optimistic";
 import { ReaderWordHighlighter } from "./reader-word-highlighter";
 import { SaveDraftConsumer } from "./save-draft-consumer";
 import { useArticleBookmark } from "./use-article-bookmark";
+import { useArticleReadToggle } from "./use-article-read-toggle";
 import { useArticleRecommend } from "./use-article-recommend";
 
 /** Reading progress for article content within the app-shell scroller. */
@@ -568,6 +571,30 @@ function BookmarkButton({
   );
 }
 
+function ReadToggleButton({
+  isRead,
+  onToggle,
+  isPending = false,
+}: {
+  isRead: boolean;
+  onToggle: () => void;
+  isPending?: boolean;
+}) {
+  return (
+    <IconButton
+      variant="secondary"
+      size="md"
+      label={isRead ? "Mark as unread" : "Mark as read"}
+      aria-pressed={isRead}
+      isDisabled={isPending}
+      onPress={onToggle}
+      style={isRead ? styles.bookmarkActive : undefined}
+    >
+      {isRead ? <CircleCheck size={18} /> : <Circle size={18} />}
+    </IconButton>
+  );
+}
+
 function ArticleLikePrompt({
   recommended,
   onToggle,
@@ -762,6 +789,15 @@ function ArticleViewBody({
   const { mutate: markRead } = useMutation(readerApi.markReadMutationOptions());
   const markedUriRef = useRef<string | null>(null);
 
+  const {
+    isRead,
+    toggle: toggleRead,
+    isPending: readTogglePending,
+  } = useArticleReadToggle(article.uri, {
+    signedIn,
+    publicationUri: article.publicationUri,
+  });
+
   useEffect(() => {
     if (!signedIn || !trackReading || markedUriRef.current === article.uri) {
       return;
@@ -915,6 +951,13 @@ function ArticleViewBody({
               >
                 <ExternalLink size={18} />
               </IconButton>
+            ) : null}
+            {signedIn && trackReading ? (
+              <ReadToggleButton
+                isRead={isRead}
+                onToggle={toggleRead}
+                isPending={readTogglePending}
+              />
             ) : null}
             <BookmarkButton
               bookmarked={bookmarked}

--- a/src/components/reader/cards.tsx
+++ b/src/components/reader/cards.tsx
@@ -8,6 +8,7 @@ import {
   BookOpen,
   Bookmark,
   Check,
+  CircleCheck,
   Heart,
   Plus,
 } from "lucide-react";
@@ -74,7 +75,11 @@ import {
   PublicationAvatar,
   Topic,
 } from "./primitives";
-import { applyMarkReadOptimisticUpdate } from "./read-optimistic";
+import {
+  applyMarkReadOptimisticUpdate,
+  applyMarkUnreadOptimisticUpdate,
+  invalidateReadQueries,
+} from "./read-optimistic";
 import { useArticleBookmark } from "./use-article-bookmark";
 
 const styles = stylex.create({
@@ -1573,6 +1578,53 @@ export function SaveButton({
   );
 }
 
+/**
+ * Pushes an already-read document back to unread (deletes its `read` record).
+ * Used in the reading-history list; renders nothing when read tracking is off or
+ * the reader is signed out (in which case there's no unread state to restore).
+ */
+export function MarkUnreadButton({
+  documentUri,
+  publicationUri,
+  size = "sm",
+}: {
+  documentUri: string;
+  publicationUri?: string | null;
+  size?: "sm" | "md";
+}) {
+  const queryClient = useQueryClient();
+  const { data: session } = useQuery(user.getSessionQueryOptions);
+  const signedIn = Boolean(session?.user);
+  const { enabled: trackReading } = useTrackReadingHistory();
+  const { mutate: markUnread, isPending } = useMutation(
+    readerApi.markUnreadMutationOptions(),
+  );
+  const iconSize = size === "md" ? 18 : 16;
+
+  if (!signedIn || !trackReading) return null;
+
+  const onPress = () => {
+    applyMarkUnreadOptimisticUpdate(queryClient, documentUri, publicationUri);
+    markUnread(documentUri, {
+      onError: () => invalidateReadQueries(queryClient),
+    });
+  };
+
+  return (
+    <IconButton
+      variant="secondary"
+      size={size}
+      label="Mark as unread"
+      isDisabled={isPending}
+      onPress={onPress}
+      onClick={stopSaveClick}
+      style={styles.saveActive}
+    >
+      <CircleCheck size={iconSize} aria-hidden />
+    </IconButton>
+  );
+}
+
 /* ── Article row (list) ─────────────────────────────────────────────────── */
 
 export function ArticleRow({
@@ -1581,6 +1633,7 @@ export function ArticleRow({
   showByline = true,
   showSaveButton = true,
   saveButtonPlacement = "header",
+  showMarkUnreadButton = false,
   isFirstInSection = false,
   assumeBookmarked,
   metaLabels,
@@ -1591,6 +1644,8 @@ export function ArticleRow({
   showSaveButton?: boolean;
   /** Where the save toggle sits — `besideMedia` places it to the right of the cover. */
   saveButtonPlacement?: "header" | "besideMedia";
+  /** Show a "mark as unread" control in the row header (reading-history list). */
+  showMarkUnreadButton?: boolean;
   /** Drop top padding when the section head already provides spacing above. */
   isFirstInSection?: boolean;
   /** Skip per-row bookmark status fetches when the list is already the save queue. */
@@ -1619,6 +1674,21 @@ export function ArticleRow({
     !showByline && isFirstInSection ? styles.rowFirstInSection : false,
   ];
 
+  const markUnreadButton = showMarkUnreadButton ? (
+    <MarkUnreadButton
+      documentUri={article.uri}
+      publicationUri={article.publicationUri}
+    />
+  ) : null;
+  const headerSaveButton = saveBesideMedia ? null : saveButton;
+  const headerActions =
+    markUnreadButton || headerSaveButton ? (
+      <Flex align="center" gap="sm">
+        {markUnreadButton}
+        {headerSaveButton}
+      </Flex>
+    ) : null;
+
   const bylineHeader = (
     <Flex align="center" gap="2xl" style={styles.rowHeader}>
       {showByline ? (
@@ -1629,7 +1699,7 @@ export function ArticleRow({
       ) : (
         <span />
       )}
-      {saveBesideMedia ? null : saveButton}
+      {headerActions}
     </Flex>
   );
 

--- a/src/components/reader/cards.tsx
+++ b/src/components/reader/cards.tsx
@@ -1666,28 +1666,26 @@ export function ArticleRow({
     />
   ) : null;
 
-  const gridStyles: Array<stylex.StyleXStyles | false | undefined> = [
-    showByline ? styles.rowGrid : styles.row,
-    !cover && !saveBesideMedia ? styles.rowNoMedia : false,
-    !cover && saveBesideMedia ? styles.rowNoMediaSaveAside : false,
-    saveBesideMedia && cover ? styles.rowSaveBesideMedia : false,
-    !showByline && isFirstInSection ? styles.rowFirstInSection : false,
-  ];
-
   const markUnreadButton = showMarkUnreadButton ? (
     <MarkUnreadButton
       documentUri={article.uri}
       publicationUri={article.publicationUri}
     />
   ) : null;
+  // The save toggle sits in the header by default; `besideMedia` pins it to the
+  // row's right edge instead. The unread toggle always pins to the right edge so
+  // it lines up across rows regardless of whether a cover image is present.
+  const asideSaveButton = saveBesideMedia ? saveButton : null;
   const headerSaveButton = saveBesideMedia ? null : saveButton;
-  const headerActions =
-    markUnreadButton || headerSaveButton ? (
-      <Flex align="center" gap="sm">
-        {markUnreadButton}
-        {headerSaveButton}
-      </Flex>
-    ) : null;
+  const hasAside = Boolean(markUnreadButton || asideSaveButton);
+
+  const gridStyles: Array<stylex.StyleXStyles | false | undefined> = [
+    showByline ? styles.rowGrid : styles.row,
+    !cover && !hasAside ? styles.rowNoMedia : false,
+    !cover && hasAside ? styles.rowNoMediaSaveAside : false,
+    hasAside && cover ? styles.rowSaveBesideMedia : false,
+    !showByline && isFirstInSection ? styles.rowFirstInSection : false,
+  ];
 
   const bylineHeader = (
     <Flex align="center" gap="2xl" style={styles.rowHeader}>
@@ -1699,7 +1697,7 @@ export function ArticleRow({
       ) : (
         <span />
       )}
-      {headerActions}
+      {headerSaveButton}
     </Flex>
   );
 
@@ -1726,8 +1724,13 @@ export function ArticleRow({
           <AspectRatioImage src={cover} alt="" referrerPolicy="no-referrer" />
         </AspectRatio>
       ) : null}
-      {saveBesideMedia && saveButton ? (
-        <div {...stylex.props(styles.rowSaveAside)}>{saveButton}</div>
+      {hasAside ? (
+        <div {...stylex.props(styles.rowSaveAside)}>
+          <Flex align="center" gap="sm">
+            {markUnreadButton}
+            {asideSaveButton}
+          </Flex>
+        </div>
       ) : null}
     </ArticleLink>
   );

--- a/src/components/reader/read-optimistic.test.ts
+++ b/src/components/reader/read-optimistic.test.ts
@@ -1,0 +1,222 @@
+import type { InfiniteData } from "@tanstack/react-query";
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+
+import type {
+  LatestFeed,
+  SidebarData,
+} from "#/integrations/tanstack-query/api-feed.functions";
+import type {
+  ReaderListPage,
+  ReadHistoryItem,
+  ReadStatus,
+} from "#/integrations/tanstack-query/api-reader.functions";
+import type {
+  ArticleCard,
+  PublicationCard,
+} from "#/integrations/tanstack-query/api-shapes";
+
+import {
+  applyMarkReadOptimisticUpdate,
+  applyMarkUnreadOptimisticUpdate,
+} from "./read-optimistic";
+
+const PUB_URI = "at://pub";
+const DOC_URI = "at://doc";
+const OTHER_URI = "at://doc2";
+
+function makeCard(uri: string, isRead: boolean): ArticleCard {
+  return {
+    uri,
+    did: "did:plc:author",
+    title: "Title",
+    description: null,
+    path: null,
+    canonicalUrl: null,
+    coverImageUrl: null,
+    publishedAt: "2024-01-01T00:00:00.000Z",
+    featured: false,
+    publicationUri: PUB_URI,
+    publicationName: "Pub",
+    publicationIconUrl: null,
+    publicationOwnerAvatarUrl: null,
+    publicationOwnerHandle: null,
+    publicationBannerUrl: null,
+    publicationTopic: null,
+    authorHandle: null,
+    authorAvatarUrl: null,
+    authorDisplayName: null,
+    tags: null,
+    textContent: null,
+    recommendCount: 0,
+    commentCount: 0,
+    hasRenderableBody: true,
+    isRead,
+    isCollection: false,
+  };
+}
+
+function makePub(uri: string, name: string): PublicationCard {
+  return {
+    uri,
+    did: `did:plc:${name}`,
+    name,
+    url: `https://example.com/${name}`,
+    description: null,
+    iconUrl: null,
+    ownerAvatarUrl: null,
+    ownerHandle: null,
+    topic: null,
+    verified: false,
+    subscriberCount: 0,
+    documentCount: 0,
+    lastDocumentAt: null,
+  };
+}
+
+function latestFeed(items: Array<ArticleCard>, unread: number): LatestFeed {
+  return {
+    items,
+    counts: { unread, subscriptions: 5, all: 10, trending: 2 },
+    nextOffset: null,
+  };
+}
+
+describe("applyMarkUnreadOptimisticUpdate", () => {
+  it("flips a read card back to unread and bumps the latest-feed unread count", () => {
+    const qc = new QueryClient();
+    qc.setQueryData<LatestFeed>(
+      ["feed", "latest", "subscriptions"],
+      latestFeed([makeCard(DOC_URI, true)], 0),
+    );
+    qc.setQueryData<ReadStatus>(["reader", "readStatus", DOC_URI], {
+      isRead: true,
+    });
+
+    applyMarkUnreadOptimisticUpdate(qc, DOC_URI, PUB_URI);
+
+    const feed = qc.getQueryData<LatestFeed>([
+      "feed",
+      "latest",
+      "subscriptions",
+    ]);
+    expect(feed?.items[0]?.isRead).toBe(false);
+    expect(feed?.counts?.unread).toBe(1);
+    expect(
+      qc.getQueryData<ReadStatus>(["reader", "readStatus", DOC_URI]),
+    ).toEqual({ isRead: false });
+  });
+
+  it("does not bump counters when the document was not read", () => {
+    const qc = new QueryClient();
+    qc.setQueryData<LatestFeed>(
+      ["feed", "latest", "subscriptions"],
+      latestFeed([makeCard(DOC_URI, false)], 4),
+    );
+
+    applyMarkUnreadOptimisticUpdate(qc, DOC_URI, PUB_URI);
+
+    const feed = qc.getQueryData<LatestFeed>([
+      "feed",
+      "latest",
+      "subscriptions",
+    ]);
+    expect(feed?.counts?.unread).toBe(4);
+  });
+
+  it("drops the document from reading history and decrements the total", () => {
+    const qc = new QueryClient();
+    const history: InfiniteData<ReaderListPage<ReadHistoryItem>> = {
+      pages: [
+        {
+          items: [
+            {
+              readUri: "r1",
+              readAt: null,
+              documentUri: DOC_URI,
+              article: makeCard(DOC_URI, true),
+            },
+            {
+              readUri: "r2",
+              readAt: null,
+              documentUri: OTHER_URI,
+              article: makeCard(OTHER_URI, true),
+            },
+          ],
+          total: 2,
+          nextOffset: null,
+        },
+      ],
+      pageParams: [0],
+    };
+    qc.setQueryData(["reader", "history", 20], history);
+
+    applyMarkUnreadOptimisticUpdate(qc, DOC_URI, PUB_URI);
+
+    const after = qc.getQueryData<
+      InfiniteData<ReaderListPage<ReadHistoryItem>>
+    >(["reader", "history", 20]);
+    expect(after?.pages[0]?.items.map((item) => item.documentUri)).toEqual([
+      OTHER_URI,
+    ]);
+    expect(after?.pages[0]?.total).toBe(1);
+  });
+
+  it("removes the document from batch read-document lookups", () => {
+    const qc = new QueryClient();
+    qc.setQueryData<Array<string>>(
+      ["reader", "readDocuments", [DOC_URI, OTHER_URI]],
+      [DOC_URI, OTHER_URI],
+    );
+
+    applyMarkUnreadOptimisticUpdate(qc, DOC_URI, PUB_URI);
+
+    expect(
+      qc.getQueryData<Array<string>>([
+        "reader",
+        "readDocuments",
+        [DOC_URI, OTHER_URI],
+      ]),
+    ).toEqual([OTHER_URI]);
+  });
+
+  it("increments sidebar unread counters when the document was read", () => {
+    const qc = new QueryClient();
+    qc.setQueryData<ReadStatus>(["reader", "readStatus", DOC_URI], {
+      isRead: true,
+    });
+    const sidebar: SidebarData = {
+      signedIn: true,
+      hasFollows: true,
+      following: [{ ...makePub(PUB_URI, "Pub"), unreadCount: 2 }],
+      followingUsers: [],
+      unreadCount: 5,
+      savedCount: 0,
+    };
+    qc.setQueryData(["feed", "sidebar"], sidebar);
+
+    applyMarkUnreadOptimisticUpdate(qc, DOC_URI, PUB_URI);
+
+    const after = qc.getQueryData<SidebarData>(["feed", "sidebar"]);
+    expect(after?.unreadCount).toBe(6);
+    expect(after?.following[0]?.unreadCount).toBe(3);
+  });
+
+  it("round-trips the unread count with applyMarkReadOptimisticUpdate", () => {
+    const qc = new QueryClient();
+    qc.setQueryData<LatestFeed>(
+      ["feed", "latest", "subscriptions"],
+      latestFeed([makeCard(DOC_URI, false)], 3),
+    );
+
+    applyMarkReadOptimisticUpdate(qc, DOC_URI, PUB_URI);
+    let feed = qc.getQueryData<LatestFeed>(["feed", "latest", "subscriptions"]);
+    expect(feed?.items[0]?.isRead).toBe(true);
+    expect(feed?.counts?.unread).toBe(2);
+
+    applyMarkUnreadOptimisticUpdate(qc, DOC_URI, PUB_URI);
+    feed = qc.getQueryData<LatestFeed>(["feed", "latest", "subscriptions"]);
+    expect(feed?.items[0]?.isRead).toBe(false);
+    expect(feed?.counts?.unread).toBe(3);
+  });
+});

--- a/src/components/reader/read-optimistic.ts
+++ b/src/components/reader/read-optimistic.ts
@@ -1,4 +1,4 @@
-import type { QueryClient } from "@tanstack/react-query";
+import type { InfiniteData, QueryClient } from "@tanstack/react-query";
 
 import type {
   HomeFeed,
@@ -10,7 +10,11 @@ import type {
   PublicationDocumentsPage,
   PublicationProfile,
 } from "../../integrations/tanstack-query/api-publication.functions";
-import type { ReadStatus } from "../../integrations/tanstack-query/api-reader.functions";
+import type {
+  ReaderListPage,
+  ReadHistoryItem,
+  ReadStatus,
+} from "../../integrations/tanstack-query/api-reader.functions";
 import type { ArticleCard } from "../../integrations/tanstack-query/api-shapes";
 
 function decrement(count: number | null | undefined): number | null {
@@ -262,6 +266,185 @@ export function applyMarkReadOptimisticUpdate(
 
   queryClient.setQueryData<ReadStatus>(["reader", "readStatus", documentUri], {
     isRead: true,
+  });
+}
+
+function increment(count: number | null | undefined): number | null {
+  if (count == null) return count ?? null;
+  return count + 1;
+}
+
+/** Returns the card flipped to unread, or the same reference when it doesn't match. */
+function flipCardUnread(card: ArticleCard, uri: string): ArticleCard {
+  return card.uri === uri && card.isRead ? { ...card, isRead: false } : card;
+}
+
+function markCardUnread(card: ArticleCard, uri: string): ArticleCard {
+  return card.uri === uri ? { ...card, isRead: false } : card;
+}
+
+function incrementFollowingUnread(
+  following: SidebarData["following"],
+  publicationUri: string | null,
+): SidebarData["following"] {
+  if (!publicationUri) return following;
+  return following.map((pub) =>
+    pub.uri === publicationUri
+      ? { ...pub, unreadCount: pub.unreadCount + 1 }
+      : pub,
+  );
+}
+
+/**
+ * Inverse of {@link updateFeedCache}: flips `isRead` back to false on any matching
+ * card and, when `wasRead`, increments the relevant unread counters. Returns the
+ * same reference when nothing changed so React Query can skip the update.
+ */
+function updateFeedCacheUnread(
+  data: unknown,
+  uri: string,
+  wasRead: boolean,
+  publicationUri: string | null,
+): unknown {
+  if (isLatestFeed(data)) {
+    return {
+      ...data,
+      items: data.items.map((card) => flipCardUnread(card, uri)),
+      counts:
+        wasRead && data.counts
+          ? { ...data.counts, unread: data.counts.unread + 1 }
+          : data.counts,
+    } satisfies LatestFeed;
+  }
+
+  if (isHomeFeed(data)) {
+    return {
+      ...data,
+      featured: data.featured
+        ? flipCardUnread(data.featured, uri)
+        : data.featured,
+      latestUnread: data.latestUnread.map((card) => flipCardUnread(card, uri)),
+      trending: data.trending.map((card) => flipCardUnread(card, uri)),
+      unreadCount: wasRead ? increment(data.unreadCount) : data.unreadCount,
+    } satisfies HomeFeed;
+  }
+
+  if (isSidebarData(data)) {
+    if (!wasRead) return data;
+    return {
+      ...data,
+      unreadCount: increment(data.unreadCount),
+      following: incrementFollowingUnread(data.following, publicationUri),
+    } satisfies SidebarData;
+  }
+
+  return data;
+}
+
+type ReadingHistoryInfiniteData = InfiniteData<ReaderListPage<ReadHistoryItem>>;
+
+function isReadingHistoryInfiniteData(
+  data: unknown,
+): data is ReadingHistoryInfiniteData {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "pages" in data &&
+    Array.isArray((data as ReadingHistoryInfiniteData).pages)
+  );
+}
+
+/** Drop a document from the reading-history list — its `read` record is gone. */
+function removeFromReadingHistory(
+  data: ReadingHistoryInfiniteData,
+  documentUri: string,
+): ReadingHistoryInfiniteData {
+  let removed = false;
+  const pages = data.pages.map((page) => {
+    const items = page.items.filter((item) => {
+      if (item.documentUri === documentUri) {
+        removed = true;
+        return false;
+      }
+      return true;
+    });
+    return { ...page, items };
+  });
+
+  if (!removed) return data;
+
+  return {
+    ...data,
+    pages: pages.map((page) => ({
+      ...page,
+      total: Math.max(0, page.total - 1),
+    })),
+  };
+}
+
+/**
+ * Inverse of {@link applyMarkReadOptimisticUpdate}: optimistically mark a document
+ * unread across every cache the UI reads from — feed rails (`isRead` + unread
+ * counters), batch read-status lookups, the single read-status query, and the
+ * reading-history list (the `read` record is being deleted, so the entry leaves
+ * history). Idempotent: only bumps unread counters when the document was read.
+ */
+export function applyMarkUnreadOptimisticUpdate(
+  queryClient: QueryClient,
+  documentUri: string,
+  publicationUri?: string | null,
+): void {
+  const wasRead = isDocumentReadInCache(queryClient, documentUri);
+  const pubUri = publicationUri ?? findPublicationUri(queryClient, documentUri);
+
+  queryClient.setQueriesData({ queryKey: ["feed"] }, (data) =>
+    updateFeedCacheUnread(data, documentUri, wasRead, pubUri),
+  );
+
+  queryClient.setQueriesData(
+    { queryKey: ["publication", "profile"] },
+    (data) => {
+      if (!isPublicationProfile(data)) return data;
+      return {
+        ...data,
+        recentDocuments: data.recentDocuments.map((card) =>
+          markCardUnread(card, documentUri),
+        ),
+      } satisfies PublicationProfile;
+    },
+  );
+
+  queryClient.setQueriesData(
+    { queryKey: ["publication", "documents"] },
+    (data) => {
+      if (!isPublicationDocumentsPage(data)) return data;
+      return {
+        ...data,
+        items: data.items.map((card) => markCardUnread(card, documentUri)),
+      } satisfies PublicationDocumentsPage;
+    },
+  );
+
+  if (wasRead) {
+    queryClient.setQueriesData<LatestFeedCounts>(
+      { queryKey: ["feed", "latest", "counts"] },
+      (data) => (data ? { ...data, unread: data.unread + 1 } : data),
+    );
+  }
+
+  queryClient.setQueriesData<Array<string>>(
+    { queryKey: ["reader", "readDocuments"] },
+    (data) => (data ? data.filter((uri) => uri !== documentUri) : data),
+  );
+
+  queryClient.setQueriesData({ queryKey: ["reader", "history"] }, (data) =>
+    isReadingHistoryInfiniteData(data)
+      ? removeFromReadingHistory(data, documentUri)
+      : data,
+  );
+
+  queryClient.setQueryData<ReadStatus>(["reader", "readStatus", documentUri], {
+    isRead: false,
   });
 }
 

--- a/src/components/reader/reader-queue-rows.tsx
+++ b/src/components/reader/reader-queue-rows.tsx
@@ -52,11 +52,14 @@ export function ReaderQueueRows({
   items,
   showSaveButton = true,
   saveButtonPlacement = "header",
+  showMarkUnreadButton = false,
   assumeBookmarked,
 }: {
   items: Array<ReaderQueueRowItem>;
   showSaveButton?: boolean;
   saveButtonPlacement?: "header" | "besideMedia";
+  /** Show a "mark as unread" control per row (reading-history list). */
+  showMarkUnreadButton?: boolean;
   /** Skip per-row bookmark status fetches when rendering the save queue. */
   assumeBookmarked?: boolean;
 }) {
@@ -69,6 +72,7 @@ export function ReaderQueueRows({
           isFirstInSection={index === 0}
           showSaveButton={showSaveButton}
           saveButtonPlacement={saveButtonPlacement}
+          showMarkUnreadButton={showMarkUnreadButton}
           assumeBookmarked={assumeBookmarked}
         />
       );

--- a/src/components/reader/use-article-read-toggle.ts
+++ b/src/components/reader/use-article-read-toggle.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+
+import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
+import { useLoginSearch } from "#/utils/use-login-search";
+
+import {
+  applyMarkReadOptimisticUpdate,
+  applyMarkUnreadOptimisticUpdate,
+  invalidateReadQueries,
+} from "./read-optimistic";
+
+/**
+ * Manual read/unread toggle for a single article. Mirrors {@link useArticleBookmark}:
+ * optimistic cache flip + repo write, reconciling from the server on error.
+ *
+ * The article view auto-marks a document read on open, so `isRead` defaults to
+ * true here — the toggle's main job is letting a reader push an article back to
+ * unread (or re-mark it read after that).
+ */
+export function useArticleReadToggle(
+  documentUri: string,
+  {
+    signedIn,
+    publicationUri,
+  }: {
+    signedIn: boolean;
+    publicationUri?: string | null;
+  },
+) {
+  const navigate = useNavigate();
+  const loginSearch = useLoginSearch();
+  const queryClient = useQueryClient();
+
+  // Don't fetch: the article view auto-marks the document read on mount and seeds
+  // `["reader","readStatus",uri]` optimistically, so we read that cache directly.
+  // A background fetch could momentarily return the pre-write server value (false)
+  // and flicker the button, so `enabled: false` keeps us on the optimistic state.
+  const { data: status } = useQuery({
+    ...readerApi.getReadStatusQueryOptions(documentUri),
+    enabled: false,
+  });
+
+  const markReadMutation = useMutation(readerApi.markReadMutationOptions());
+  const markUnreadMutation = useMutation(readerApi.markUnreadMutationOptions());
+
+  // Opening the article marks it read, so treat unknown state as read.
+  const isRead = status?.isRead ?? true;
+
+  const toggle = () => {
+    if (!signedIn) {
+      void navigate({ to: "/login", search: loginSearch });
+      return;
+    }
+
+    if (isRead) {
+      applyMarkUnreadOptimisticUpdate(queryClient, documentUri, publicationUri);
+      markUnreadMutation.mutate(documentUri, {
+        onError: () => invalidateReadQueries(queryClient),
+      });
+    } else {
+      applyMarkReadOptimisticUpdate(queryClient, documentUri, publicationUri);
+      markReadMutation.mutate(documentUri, {
+        onError: () => invalidateReadQueries(queryClient),
+      });
+    }
+  };
+
+  const isPending = markReadMutation.isPending || markUnreadMutation.isPending;
+
+  return { isRead, toggle, isPending };
+}

--- a/src/routes/_layout.history.tsx
+++ b/src/routes/_layout.history.tsx
@@ -164,7 +164,11 @@ function ReaderHistory() {
         </div>
       ) : (
         <>
-          <ReaderQueueRows items={queueRows} showSaveButton={false} />
+          <ReaderQueueRows
+            items={queueRows}
+            showSaveButton={false}
+            showMarkUnreadButton
+          />
           {isFetchingNextPage ? (
             <p {...stylex.props(styles.loadingNote)}>Loading…</p>
           ) : null}


### PR DESCRIPTION
## Summary
Implements a manual read/unread toggle feature that allows readers to mark articles as unread, complementing the existing auto-mark-read behavior. This includes optimistic cache updates, UI controls in both the article view and reading history list, and comprehensive test coverage.

## Key Changes

- **New `applyMarkUnreadOptimisticUpdate` function** — Inverse of the existing `applyMarkReadOptimisticUpdate`, optimistically flips `isRead` back to false across all relevant caches (feed rails, batch lookups, reading history) and increments unread counters when appropriate. Idempotent: only bumps counters when the document was actually read.

- **New `useArticleReadToggle` hook** — Manages read/unread state for a single article with optimistic updates and server reconciliation on error. Mirrors the existing `useArticleBookmark` pattern.

- **UI controls**:
  - `ReadToggleButton` in article view header — Shows read/unread state with visual feedback (filled vs. outline circle icon)
  - `MarkUnreadButton` in reading history rows — Allows pushing already-read articles back to unread (only visible when signed in and read tracking is enabled)

- **Reading history integration** — Updated `ReaderQueueRows` and history route to display the mark-unread button, with proper removal of documents from the history list when unmarked.

- **Comprehensive test suite** — Added `read-optimistic.test.ts` with 6 test cases covering:
  - Basic read→unread flip with counter updates
  - Idempotent behavior (no counter bumps for already-unread documents)
  - Reading history removal and total decrement
  - Batch read-document lookup cleanup
  - Sidebar unread counter increments
  - Round-trip consistency with mark-read operation

## Implementation Details

- Uses `increment()` helper (inverse of existing `decrement()`) for counter updates
- Reuses existing cache type guards (`isLatestFeed`, `isHomeFeed`, `isSidebarData`) for consistency
- Properly handles `publicationUri` parameter for sidebar publication-specific counters
- Reading history removal filters out the document and decrements page totals
- Batch read-document queries filter out the unmarked URI
- All optimistic updates are idempotent and reconcile from server on mutation error

https://claude.ai/code/session_01WydvgvXiH8trrrtGyZGx9h