### PR TITLE
Render captions and alt text for standalone Markdown images

### DIFF
--- a/src/components/reader/content/renderers/shared/markdown-article.tsx
+++ b/src/components/reader/content/renderers/shared/markdown-article.tsx
@@ -19,6 +19,7 @@ import {
   startLightboxViewTransition,
 } from "#/design-system/lightbox/transition";
 import { radius } from "#/design-system/theme/radius.stylex";
+import { gap } from "#/design-system/theme/semantic-spacing.stylex";
 import { spacing } from "#/design-system/theme/spacing.stylex";
 import { stripLeadingMarkupImage } from "#/lib/document/lead-image";
 import { normalizeImageAlt } from "#/lib/document/structured-content/image";
@@ -58,6 +59,13 @@ const markdownStyles = stylex.create({
     display: "block",
     height: "auto",
     maxWidth: "100%",
+  },
+  // Layered over `articleBodyStyles.imageCaption` so the shared caption style
+  // (used by structured image blocks) is untouched: center the caption under
+  // the image and open up a touch more breathing room above it.
+  imageCaption: {
+    marginTop: gap.xl,
+    textAlign: "center",
   },
 });
 
@@ -226,7 +234,10 @@ function useMarkdownComponents(
               {caption ? (
                 <figcaption
                   aria-hidden="true"
-                  {...stylex.props(articleBodyStyles.imageCaption)}
+                  {...stylex.props(
+                    articleBodyStyles.imageCaption,
+                    markdownStyles.imageCaption,
+                  )}
                 >
                   {caption}
                 </figcaption>

--- a/src/components/reader/content/renderers/shared/markdown-article.tsx
+++ b/src/components/reader/content/renderers/shared/markdown-article.tsx
@@ -21,6 +21,7 @@ import {
 import { radius } from "#/design-system/theme/radius.stylex";
 import { spacing } from "#/design-system/theme/spacing.stylex";
 import { stripLeadingMarkupImage } from "#/lib/document/lead-image";
+import { normalizeImageAlt } from "#/lib/document/structured-content/image";
 import { articleMarkdownSanitizeSchema } from "#/lib/markdown/article-sanitize-schema";
 import { useReadingTypography } from "#/lib/use-reading-typography";
 
@@ -32,6 +33,7 @@ import { ArticleBody } from "./article-body";
 import { CodeBlockView } from "./code-block";
 import { MarkdownIframeEmbed } from "./iframe-embed";
 import { reactNodeHasText, splitLeadingChar } from "./react-node-text";
+import { standaloneImageParagraph } from "./standalone-image-paragraph";
 
 const markdownStyles = stylex.create({
   blockquote: {
@@ -43,7 +45,10 @@ const markdownStyles = stylex.create({
     borderWidth: 0,
     cursor: "zoom-in",
     display: "block",
-    marginBottom: spacing["6"],
+    // Spacing below a standalone image is owned by the enclosing <figure>
+    // (`imageFigure`), so the button itself adds none — otherwise the margin
+    // would open a gap between the image and its caption inside the figure.
+    marginBottom: spacing["0"],
     marginTop: spacing["0"],
     maxWidth: "100%",
     padding: spacing["0"],
@@ -59,12 +64,14 @@ const markdownStyles = stylex.create({
 function MarkdownImage({
   src,
   alt,
+  title,
   className,
   width,
   height,
 }: {
   src?: string;
   alt?: string;
+  title?: string;
   className?: string;
   width?: string | number;
   height?: string | number;
@@ -77,6 +84,7 @@ function MarkdownImage({
       <img
         src={src}
         alt={alt ?? ""}
+        title={title}
         loading="lazy"
         referrerPolicy="no-referrer"
         width={width ?? 72}
@@ -109,6 +117,7 @@ function MarkdownImage({
         <img
           src={src}
           alt={altText}
+          title={title}
           loading="lazy"
           referrerPolicy="no-referrer"
           width={width}
@@ -196,6 +205,35 @@ function useMarkdownComponents(
           children,
         ),
       p: ({ children, node }) => {
+        // A paragraph that is nothing but a lone image renders as a semantic
+        // <figure>. The Markdown title (`![alt](url "title")`) becomes the
+        // visible caption, falling back to the alt text — matching how
+        // structured image blocks caption themselves (`ImageFigureView`). The
+        // real alt stays on the <img> (set in `MarkdownImage`) for screen
+        // readers, so the caption is `aria-hidden` to avoid double-announcing.
+        // Lifting the image out of the <p> also keeps the <figure> from being
+        // illegally nested inside a paragraph, which the SSR HTML parser would
+        // otherwise unwrap and break hydration.
+        const standaloneImage = node ? standaloneImageParagraph(node) : null;
+        if (standaloneImage) {
+          const caption = normalizeImageAlt(
+            standaloneImage.title,
+            standaloneImage.alt,
+          );
+          return (
+            <figure {...stylex.props(articleBodyStyles.imageFigure)}>
+              {children}
+              {caption ? (
+                <figcaption
+                  aria-hidden="true"
+                  {...stylex.props(articleBodyStyles.imageCaption)}
+                >
+                  {caption}
+                </figcaption>
+              ) : null}
+            </figure>
+          );
+        }
         // The drop cap belongs on the first letter of the first prose paragraph,
         // and nowhere else. A paragraph is eligible only when no other paragraph
         // has claimed the slot, or when THIS paragraph is the one that claimed it

--- a/src/components/reader/content/renderers/shared/standalone-image-paragraph.test.ts
+++ b/src/components/reader/content/renderers/shared/standalone-image-paragraph.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { standaloneImageParagraph } from "./standalone-image-paragraph";
+
+const img = (properties: Record<string, unknown>) => ({
+  type: "element",
+  tagName: "img",
+  properties,
+  children: [],
+});
+
+const text = (value: string) => ({ type: "text", value });
+
+describe("standaloneImageParagraph", () => {
+  it("returns alt and title for a lone captioned image", () => {
+    expect(
+      standaloneImageParagraph({
+        type: "element",
+        tagName: "p",
+        children: [img({ src: "u", alt: "Alt text", title: "Caption" })],
+      }),
+    ).toEqual({ alt: "Alt text", title: "Caption" });
+  });
+
+  it("ignores insignificant whitespace around the image", () => {
+    expect(
+      standaloneImageParagraph({
+        children: [text("\n"), img({ src: "u", alt: "Alt" }), text("  ")],
+      }),
+    ).toEqual({ alt: "Alt", title: undefined });
+  });
+
+  it("returns null when real text sits alongside the image", () => {
+    expect(
+      standaloneImageParagraph({
+        children: [text("see "), img({ src: "u", alt: "Alt" })],
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for two images in one paragraph", () => {
+    expect(
+      standaloneImageParagraph({
+        children: [img({ src: "a" }), img({ src: "b" })],
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when another element accompanies the image", () => {
+    expect(
+      standaloneImageParagraph({
+        children: [
+          img({ src: "u" }),
+          { type: "element", tagName: "a", properties: {}, children: [] },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for a text-only paragraph", () => {
+    expect(
+      standaloneImageParagraph({ children: [text("just prose")] }),
+    ).toBeNull();
+  });
+
+  it("returns null for a node with no children", () => {
+    const empties: Array<Parameters<typeof standaloneImageParagraph>[0]> = [
+      {},
+      undefined,
+      null,
+    ];
+    for (const node of empties) {
+      expect(standaloneImageParagraph(node)).toBeNull();
+    }
+  });
+
+  it("drops non-string alt/title values", () => {
+    expect(
+      standaloneImageParagraph({
+        children: [img({ src: "u", alt: 42, title: true })],
+      }),
+    ).toEqual({ alt: undefined, title: undefined });
+  });
+});

--- a/src/components/reader/content/renderers/shared/standalone-image-paragraph.ts
+++ b/src/components/reader/content/renderers/shared/standalone-image-paragraph.ts
@@ -1,0 +1,60 @@
+/**
+ * Detects a paragraph whose only content is a single image.
+ *
+ * Markdown wraps a lone `![alt](url "title")` in its own paragraph. The article
+ * renderer lifts those into a semantic `<figure>` with a caption, so it needs
+ * to tell a standalone image apart from one sitting inline amid prose (which
+ * stays inline and uncaptioned).
+ *
+ * Typed against the minimal shape of a hast element node — the same value
+ * `react-markdown` hands a component as its `node` prop — to avoid coupling to
+ * the full `@types/hast` tree.
+ */
+
+interface HastNodeLike {
+  type?: string;
+  tagName?: string;
+  value?: string;
+  properties?: Record<string, unknown>;
+  children?: Array<HastNodeLike>;
+}
+
+export interface StandaloneImage {
+  alt?: string;
+  title?: string;
+}
+
+/**
+ * Returns the lone image's `alt`/`title` when `node` is a paragraph containing
+ * nothing but a single image (insignificant whitespace aside), otherwise
+ * `null`. Anything else in the paragraph — real text or a second element —
+ * disqualifies it.
+ */
+export function standaloneImageParagraph(
+  node: HastNodeLike | undefined | null,
+): StandaloneImage | null {
+  const children = node?.children;
+  if (!children) return null;
+
+  let image: HastNodeLike | null = null;
+  for (const child of children) {
+    if (child.type === "text") {
+      // Whitespace between block tokens is insignificant; real text is not.
+      if ((child.value ?? "").trim() === "") continue;
+      return null;
+    }
+    if (child.type === "element" && child.tagName === "img") {
+      if (image) return null;
+      image = child;
+      continue;
+    }
+    return null;
+  }
+
+  if (!image) return null;
+  const properties = image.properties ?? {};
+  return {
+    alt: typeof properties.alt === "string" ? properties.alt : undefined,
+    title: typeof properties.title === "string" ? properties.title : undefined,
+  };
+}


### PR DESCRIPTION
A lone `![alt](url "title")` now renders as a semantic <figure> with a
visible <figcaption> — using the Markdown title as the caption, falling
back to the alt text — matching how structured image blocks already
caption themselves (ImageFigureView). The real alt stays on the <img>
for screen readers (and the title becomes a hover tooltip), so the
caption is aria-hidden to avoid double-announcing.

Lifting the image out of its wrapping <p> also avoids nesting a <figure>
inside a paragraph, which the SSR HTML parser would otherwise unwrap and
break hydration. Inline images amid prose stay inline and uncaptioned.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Bymyp2sfLbbbyuJYQ9kStm