### PR TITLE
Render GFM/Obsidian callouts in the Reader

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "shiki": "^4.2.0",
     "swr": "^2.4.1",
     "tsx": "^4.22.4",
+    "unist-util-visit": "^5.1.0",
     "universal-cookie": "^8.1.2",
     "web-haptics": "^0.0.6",
     "zod": "^4.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
       universal-cookie:
         specifier: ^8.1.2
         version: 8.1.2

--- a/src/components/reader/content/renderers/shared/callout.tsx
+++ b/src/components/reader/content/renderers/shared/callout.tsx
@@ -22,15 +22,15 @@ import type { ReactNode } from "react";
 import { useId, useState } from "react";
 
 import { animationDuration } from "#/design-system/theme/animations.stylex";
-import { amber } from "#/design-system/theme/colors/amber.stylex";
-import { blue } from "#/design-system/theme/colors/blue.stylex";
-import { cyan } from "#/design-system/theme/colors/cyan.stylex";
-import { gray } from "#/design-system/theme/colors/gray.stylex";
-import { green } from "#/design-system/theme/colors/green.stylex";
-import { orange } from "#/design-system/theme/colors/orange.stylex";
-import { purple } from "#/design-system/theme/colors/purple.stylex";
-import { red } from "#/design-system/theme/colors/red.stylex";
-import { teal } from "#/design-system/theme/colors/teal.stylex";
+import { amberA } from "#/design-system/theme/colors/amber.stylex";
+import { blueA } from "#/design-system/theme/colors/blue.stylex";
+import { cyanA } from "#/design-system/theme/colors/cyan.stylex";
+import { grayA } from "#/design-system/theme/colors/gray.stylex";
+import { greenA } from "#/design-system/theme/colors/green.stylex";
+import { orangeA } from "#/design-system/theme/colors/orange.stylex";
+import { purpleA } from "#/design-system/theme/colors/purple.stylex";
+import { redA } from "#/design-system/theme/colors/red.stylex";
+import { tealA } from "#/design-system/theme/colors/teal.stylex";
 import { radius } from "#/design-system/theme/radius.stylex";
 import { spacing } from "#/design-system/theme/spacing.stylex";
 import {
@@ -123,89 +123,91 @@ const styles = stylex.create({
   },
 });
 
-// Each kind maps to a Radix color scale via four custom properties the layout
-// styles above consume: surface (bgSubtle), border, accent (icon + title), and
-// body text. StyleX needs these spelled out literally, so `note` and `todo`
-// (both blue), `tip` and `success` (both green), and the red family repeat the
-// same tokens rather than sharing a helper.
+// Each kind maps to a Radix *alpha* color scale via four custom properties the
+// layout styles above consume: surface (bgSubtle), border, accent (icon +
+// title), and body text. Alpha tokens composite over the reader's muted mauve
+// background, so callouts read as a soft tint of the theme rather than a bright
+// opaque panel. StyleX needs these spelled out literally, so `note`/`todo`
+// (both blue), `tip`/`success` (both green), and the red family repeat the same
+// tokens rather than sharing a helper.
 const kindTheme = stylex.create({
   note: {
-    "--callout-surface": blue.bgSubtle,
-    "--callout-border": blue.border1,
-    "--callout-accent": blue.text1,
-    "--callout-body": blue.text2,
+    "--callout-surface": blueA.bgSubtle,
+    "--callout-border": blueA.border1,
+    "--callout-accent": blueA.text1,
+    "--callout-body": blueA.text2,
   },
   abstract: {
-    "--callout-surface": teal.bgSubtle,
-    "--callout-border": teal.border1,
-    "--callout-accent": teal.text1,
-    "--callout-body": teal.text2,
+    "--callout-surface": tealA.bgSubtle,
+    "--callout-border": tealA.border1,
+    "--callout-accent": tealA.text1,
+    "--callout-body": tealA.text2,
   },
   info: {
-    "--callout-surface": cyan.bgSubtle,
-    "--callout-border": cyan.border1,
-    "--callout-accent": cyan.text1,
-    "--callout-body": cyan.text2,
+    "--callout-surface": cyanA.bgSubtle,
+    "--callout-border": cyanA.border1,
+    "--callout-accent": cyanA.text1,
+    "--callout-body": cyanA.text2,
   },
   todo: {
-    "--callout-surface": blue.bgSubtle,
-    "--callout-border": blue.border1,
-    "--callout-accent": blue.text1,
-    "--callout-body": blue.text2,
+    "--callout-surface": blueA.bgSubtle,
+    "--callout-border": blueA.border1,
+    "--callout-accent": blueA.text1,
+    "--callout-body": blueA.text2,
   },
   tip: {
-    "--callout-surface": green.bgSubtle,
-    "--callout-border": green.border1,
-    "--callout-accent": green.text1,
-    "--callout-body": green.text2,
+    "--callout-surface": greenA.bgSubtle,
+    "--callout-border": greenA.border1,
+    "--callout-accent": greenA.text1,
+    "--callout-body": greenA.text2,
   },
   success: {
-    "--callout-surface": green.bgSubtle,
-    "--callout-border": green.border1,
-    "--callout-accent": green.text1,
-    "--callout-body": green.text2,
+    "--callout-surface": greenA.bgSubtle,
+    "--callout-border": greenA.border1,
+    "--callout-accent": greenA.text1,
+    "--callout-body": greenA.text2,
   },
   question: {
-    "--callout-surface": amber.bgSubtle,
-    "--callout-border": amber.border1,
-    "--callout-accent": amber.text1,
-    "--callout-body": amber.text2,
+    "--callout-surface": amberA.bgSubtle,
+    "--callout-border": amberA.border1,
+    "--callout-accent": amberA.text1,
+    "--callout-body": amberA.text2,
   },
   warning: {
-    "--callout-surface": orange.bgSubtle,
-    "--callout-border": orange.border1,
-    "--callout-accent": orange.text1,
-    "--callout-body": orange.text2,
+    "--callout-surface": orangeA.bgSubtle,
+    "--callout-border": orangeA.border1,
+    "--callout-accent": orangeA.text1,
+    "--callout-body": orangeA.text2,
   },
   failure: {
-    "--callout-surface": red.bgSubtle,
-    "--callout-border": red.border1,
-    "--callout-accent": red.text1,
-    "--callout-body": red.text2,
+    "--callout-surface": redA.bgSubtle,
+    "--callout-border": redA.border1,
+    "--callout-accent": redA.text1,
+    "--callout-body": redA.text2,
   },
   danger: {
-    "--callout-surface": red.bgSubtle,
-    "--callout-border": red.border1,
-    "--callout-accent": red.text1,
-    "--callout-body": red.text2,
+    "--callout-surface": redA.bgSubtle,
+    "--callout-border": redA.border1,
+    "--callout-accent": redA.text1,
+    "--callout-body": redA.text2,
   },
   bug: {
-    "--callout-surface": red.bgSubtle,
-    "--callout-border": red.border1,
-    "--callout-accent": red.text1,
-    "--callout-body": red.text2,
+    "--callout-surface": redA.bgSubtle,
+    "--callout-border": redA.border1,
+    "--callout-accent": redA.text1,
+    "--callout-body": redA.text2,
   },
   example: {
-    "--callout-surface": purple.bgSubtle,
-    "--callout-border": purple.border1,
-    "--callout-accent": purple.text1,
-    "--callout-body": purple.text2,
+    "--callout-surface": purpleA.bgSubtle,
+    "--callout-border": purpleA.border1,
+    "--callout-accent": purpleA.text1,
+    "--callout-body": purpleA.text2,
   },
   quote: {
-    "--callout-surface": gray.bgSubtle,
-    "--callout-border": gray.border1,
-    "--callout-accent": gray.text1,
-    "--callout-body": gray.text2,
+    "--callout-surface": grayA.bgSubtle,
+    "--callout-border": grayA.border1,
+    "--callout-accent": grayA.text1,
+    "--callout-body": grayA.text2,
   },
 });
 

--- a/src/components/reader/content/renderers/shared/callout.tsx
+++ b/src/components/reader/content/renderers/shared/callout.tsx
@@ -22,15 +22,13 @@ import type { ReactNode } from "react";
 import { useId, useState } from "react";
 
 import { animationDuration } from "#/design-system/theme/animations.stylex";
-import { amberA } from "#/design-system/theme/colors/amber.stylex";
-import { blueA } from "#/design-system/theme/colors/blue.stylex";
-import { cyanA } from "#/design-system/theme/colors/cyan.stylex";
-import { grayA } from "#/design-system/theme/colors/gray.stylex";
-import { greenA } from "#/design-system/theme/colors/green.stylex";
-import { orangeA } from "#/design-system/theme/colors/orange.stylex";
-import { purpleA } from "#/design-system/theme/colors/purple.stylex";
-import { redA } from "#/design-system/theme/colors/red.stylex";
-import { tealA } from "#/design-system/theme/colors/teal.stylex";
+import {
+  criticalColor,
+  primaryColor,
+  successColor,
+  uiColor,
+  warningColor,
+} from "#/design-system/theme/color.stylex";
 import { radius } from "#/design-system/theme/radius.stylex";
 import { spacing } from "#/design-system/theme/spacing.stylex";
 import {
@@ -123,91 +121,60 @@ const styles = stylex.create({
   },
 });
 
-// Each kind maps to a Radix *alpha* color scale via four custom properties the
-// layout styles above consume: surface (bgSubtle), border, accent (icon +
-// title), and body text. Alpha tokens composite over the reader's muted mauve
-// background, so callouts read as a soft tint of the theme rather than a bright
-// opaque panel. StyleX needs these spelled out literally, so `note`/`todo`
-// (both blue), `tip`/`success` (both green), and the red family repeat the same
-// tokens rather than sharing a helper.
-const kindTheme = stylex.create({
-  note: {
-    "--callout-surface": blueA.bgSubtle,
-    "--callout-border": blueA.border1,
-    "--callout-accent": blueA.text1,
-    "--callout-body": blueA.text2,
+// Callouts are colored from the reader's own design-system tokens — not raw
+// Radix scales — so they inherit the editorial theme (warm-paper `uiColor` and
+// camel `primaryColor`) and its light/dark overrides. Informational kinds carry
+// the camel accent; only the genuinely stateful kinds reach for the semantic
+// success/warning/critical families. That keeps most callouts on-theme (brown),
+// with color reserved for the few that mean something.
+type CalloutFamily = "primary" | "neutral" | "success" | "warning" | "critical";
+
+const KIND_FAMILY: Record<CalloutKind, CalloutFamily> = {
+  note: "primary",
+  abstract: "primary",
+  info: "primary",
+  todo: "primary",
+  example: "primary",
+  quote: "neutral",
+  tip: "success",
+  success: "success",
+  question: "warning",
+  warning: "warning",
+  failure: "critical",
+  danger: "critical",
+  bug: "critical",
+};
+
+const familyTheme = stylex.create({
+  primary: {
+    "--callout-surface": primaryColor.bgSubtle,
+    "--callout-border": primaryColor.border1,
+    "--callout-accent": primaryColor.text1,
+    "--callout-body": primaryColor.text2,
   },
-  abstract: {
-    "--callout-surface": tealA.bgSubtle,
-    "--callout-border": tealA.border1,
-    "--callout-accent": tealA.text1,
-    "--callout-body": tealA.text2,
-  },
-  info: {
-    "--callout-surface": cyanA.bgSubtle,
-    "--callout-border": cyanA.border1,
-    "--callout-accent": cyanA.text1,
-    "--callout-body": cyanA.text2,
-  },
-  todo: {
-    "--callout-surface": blueA.bgSubtle,
-    "--callout-border": blueA.border1,
-    "--callout-accent": blueA.text1,
-    "--callout-body": blueA.text2,
-  },
-  tip: {
-    "--callout-surface": greenA.bgSubtle,
-    "--callout-border": greenA.border1,
-    "--callout-accent": greenA.text1,
-    "--callout-body": greenA.text2,
+  neutral: {
+    "--callout-surface": uiColor.bgSubtle,
+    "--callout-border": uiColor.border1,
+    "--callout-accent": uiColor.text1,
+    "--callout-body": uiColor.text2,
   },
   success: {
-    "--callout-surface": greenA.bgSubtle,
-    "--callout-border": greenA.border1,
-    "--callout-accent": greenA.text1,
-    "--callout-body": greenA.text2,
-  },
-  question: {
-    "--callout-surface": amberA.bgSubtle,
-    "--callout-border": amberA.border1,
-    "--callout-accent": amberA.text1,
-    "--callout-body": amberA.text2,
+    "--callout-surface": successColor.bgSubtle,
+    "--callout-border": successColor.border1,
+    "--callout-accent": successColor.text1,
+    "--callout-body": successColor.text2,
   },
   warning: {
-    "--callout-surface": orangeA.bgSubtle,
-    "--callout-border": orangeA.border1,
-    "--callout-accent": orangeA.text1,
-    "--callout-body": orangeA.text2,
+    "--callout-surface": warningColor.bgSubtle,
+    "--callout-border": warningColor.border1,
+    "--callout-accent": warningColor.text1,
+    "--callout-body": warningColor.text2,
   },
-  failure: {
-    "--callout-surface": redA.bgSubtle,
-    "--callout-border": redA.border1,
-    "--callout-accent": redA.text1,
-    "--callout-body": redA.text2,
-  },
-  danger: {
-    "--callout-surface": redA.bgSubtle,
-    "--callout-border": redA.border1,
-    "--callout-accent": redA.text1,
-    "--callout-body": redA.text2,
-  },
-  bug: {
-    "--callout-surface": redA.bgSubtle,
-    "--callout-border": redA.border1,
-    "--callout-accent": redA.text1,
-    "--callout-body": redA.text2,
-  },
-  example: {
-    "--callout-surface": purpleA.bgSubtle,
-    "--callout-border": purpleA.border1,
-    "--callout-accent": purpleA.text1,
-    "--callout-body": purpleA.text2,
-  },
-  quote: {
-    "--callout-surface": grayA.bgSubtle,
-    "--callout-border": grayA.border1,
-    "--callout-accent": grayA.text1,
-    "--callout-body": grayA.text2,
+  critical: {
+    "--callout-surface": criticalColor.bgSubtle,
+    "--callout-border": criticalColor.border1,
+    "--callout-accent": criticalColor.text1,
+    "--callout-body": criticalColor.text2,
   },
 });
 
@@ -242,7 +209,7 @@ export function Callout({
   );
 
   return (
-    <div {...stylex.props(styles.callout, kindTheme[kind])}>
+    <div {...stylex.props(styles.callout, familyTheme[KIND_FAMILY[kind]])}>
       {collapsible ? (
         <button
           type="button"

--- a/src/components/reader/content/renderers/shared/callout.tsx
+++ b/src/components/reader/content/renderers/shared/callout.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import {
+  Bug,
+  Check,
+  ChevronRight,
+  CircleHelp,
+  ClipboardList,
+  Info,
+  Lightbulb,
+  List,
+  ListTodo,
+  Pencil,
+  Quote,
+  TriangleAlert,
+  X,
+  Zap,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import { useId, useState } from "react";
+
+import { animationDuration } from "#/design-system/theme/animations.stylex";
+import { amber } from "#/design-system/theme/colors/amber.stylex";
+import { blue } from "#/design-system/theme/colors/blue.stylex";
+import { cyan } from "#/design-system/theme/colors/cyan.stylex";
+import { gray } from "#/design-system/theme/colors/gray.stylex";
+import { green } from "#/design-system/theme/colors/green.stylex";
+import { orange } from "#/design-system/theme/colors/orange.stylex";
+import { purple } from "#/design-system/theme/colors/purple.stylex";
+import { red } from "#/design-system/theme/colors/red.stylex";
+import { teal } from "#/design-system/theme/colors/teal.stylex";
+import { radius } from "#/design-system/theme/radius.stylex";
+import { spacing } from "#/design-system/theme/spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+} from "#/design-system/theme/typography.stylex";
+import type { CalloutKind } from "#/lib/markdown/callouts";
+
+const KIND_ICON: Record<CalloutKind, LucideIcon> = {
+  note: Pencil,
+  abstract: ClipboardList,
+  info: Info,
+  todo: ListTodo,
+  tip: Lightbulb,
+  success: Check,
+  question: CircleHelp,
+  warning: TriangleAlert,
+  failure: X,
+  danger: Zap,
+  bug: Bug,
+  example: List,
+  quote: Quote,
+};
+
+const styles = stylex.create({
+  callout: {
+    backgroundColor: "var(--callout-surface)",
+    borderColor: "var(--callout-border)",
+    borderStyle: "solid",
+    borderWidth: 1,
+    borderRadius: radius.md,
+    cornerShape: "squircle",
+    fontFamily: fontFamily.sans,
+    marginBottom: spacing["6"],
+    marginTop: spacing["6"],
+    overflow: "hidden",
+  },
+  header: {
+    alignItems: "center",
+    color: "var(--callout-accent)",
+    columnGap: spacing["2"],
+    display: "flex",
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.base,
+    fontWeight: fontWeight.semibold,
+    lineHeight: 1.4,
+    paddingBottom: spacing["3"],
+    paddingLeft: spacing["4"],
+    paddingRight: spacing["4"],
+    paddingTop: spacing["3"],
+  },
+  headerButton: {
+    backgroundColor: "transparent",
+    borderWidth: 0,
+    cursor: "pointer",
+    textAlign: "start",
+    width: "100%",
+  },
+  icon: {
+    color: "var(--callout-accent)",
+    flexShrink: 0,
+    height: "1.125rem",
+    width: "1.125rem",
+  },
+  title: {
+    flexGrow: 1,
+    minWidth: 0,
+  },
+  chevron: {
+    flexShrink: 0,
+    height: "1.125rem",
+    transitionDuration: animationDuration.default,
+    transitionProperty: "rotate",
+    transitionTimingFunction: "ease",
+    width: "1.125rem",
+  },
+  chevronOpen: {
+    rotate: "90deg",
+  },
+  body: {
+    // No font family: inherit the article's serif so callout prose matches the
+    // surrounding body copy.
+    color: "var(--callout-body)",
+    fontSize: fontSize.base,
+    lineHeight: 1.55,
+    paddingBottom: spacing["1"],
+    paddingLeft: spacing["4"],
+    paddingRight: spacing["4"],
+  },
+});
+
+// Each kind maps to a Radix color scale via four custom properties the layout
+// styles above consume: surface (bgSubtle), border, accent (icon + title), and
+// body text. StyleX needs these spelled out literally, so `note` and `todo`
+// (both blue), `tip` and `success` (both green), and the red family repeat the
+// same tokens rather than sharing a helper.
+const kindTheme = stylex.create({
+  note: {
+    "--callout-surface": blue.bgSubtle,
+    "--callout-border": blue.border1,
+    "--callout-accent": blue.text1,
+    "--callout-body": blue.text2,
+  },
+  abstract: {
+    "--callout-surface": teal.bgSubtle,
+    "--callout-border": teal.border1,
+    "--callout-accent": teal.text1,
+    "--callout-body": teal.text2,
+  },
+  info: {
+    "--callout-surface": cyan.bgSubtle,
+    "--callout-border": cyan.border1,
+    "--callout-accent": cyan.text1,
+    "--callout-body": cyan.text2,
+  },
+  todo: {
+    "--callout-surface": blue.bgSubtle,
+    "--callout-border": blue.border1,
+    "--callout-accent": blue.text1,
+    "--callout-body": blue.text2,
+  },
+  tip: {
+    "--callout-surface": green.bgSubtle,
+    "--callout-border": green.border1,
+    "--callout-accent": green.text1,
+    "--callout-body": green.text2,
+  },
+  success: {
+    "--callout-surface": green.bgSubtle,
+    "--callout-border": green.border1,
+    "--callout-accent": green.text1,
+    "--callout-body": green.text2,
+  },
+  question: {
+    "--callout-surface": amber.bgSubtle,
+    "--callout-border": amber.border1,
+    "--callout-accent": amber.text1,
+    "--callout-body": amber.text2,
+  },
+  warning: {
+    "--callout-surface": orange.bgSubtle,
+    "--callout-border": orange.border1,
+    "--callout-accent": orange.text1,
+    "--callout-body": orange.text2,
+  },
+  failure: {
+    "--callout-surface": red.bgSubtle,
+    "--callout-border": red.border1,
+    "--callout-accent": red.text1,
+    "--callout-body": red.text2,
+  },
+  danger: {
+    "--callout-surface": red.bgSubtle,
+    "--callout-border": red.border1,
+    "--callout-accent": red.text1,
+    "--callout-body": red.text2,
+  },
+  bug: {
+    "--callout-surface": red.bgSubtle,
+    "--callout-border": red.border1,
+    "--callout-accent": red.text1,
+    "--callout-body": red.text2,
+  },
+  example: {
+    "--callout-surface": purple.bgSubtle,
+    "--callout-border": purple.border1,
+    "--callout-accent": purple.text1,
+    "--callout-body": purple.text2,
+  },
+  quote: {
+    "--callout-surface": gray.bgSubtle,
+    "--callout-border": gray.border1,
+    "--callout-accent": gray.text1,
+    "--callout-body": gray.text2,
+  },
+});
+
+export function Callout({
+  kind,
+  title,
+  fold,
+  children,
+}: {
+  kind: CalloutKind;
+  title: string;
+  /** `"open"`/`"closed"` makes the callout collapsible; omit for a static one. */
+  fold?: "open" | "closed";
+  children: ReactNode;
+}) {
+  const Icon = KIND_ICON[kind];
+  const bodyId = useId();
+  const collapsible = fold !== undefined;
+  const [open, setOpen] = useState(fold !== "closed");
+
+  const headerInner = (
+    <>
+      <Icon aria-hidden {...stylex.props(styles.icon)} />
+      <span {...stylex.props(styles.title)}>{title}</span>
+      {collapsible ? (
+        <ChevronRight
+          aria-hidden
+          {...stylex.props(styles.chevron, open && styles.chevronOpen)}
+        />
+      ) : null}
+    </>
+  );
+
+  return (
+    <div {...stylex.props(styles.callout, kindTheme[kind])}>
+      {collapsible ? (
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-controls={bodyId}
+          onClick={() => setOpen((value) => !value)}
+          {...stylex.props(styles.header, styles.headerButton)}
+        >
+          {headerInner}
+        </button>
+      ) : (
+        <div {...stylex.props(styles.header)}>{headerInner}</div>
+      )}
+      {(!collapsible || open) && (
+        <div id={bodyId} {...stylex.props(styles.body)}>
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/reader/content/renderers/shared/markdown-article.tsx
+++ b/src/components/reader/content/renderers/shared/markdown-article.tsx
@@ -22,6 +22,8 @@ import { radius } from "#/design-system/theme/radius.stylex";
 import { spacing } from "#/design-system/theme/spacing.stylex";
 import { stripLeadingMarkupImage } from "#/lib/document/lead-image";
 import { articleMarkdownSanitizeSchema } from "#/lib/markdown/article-sanitize-schema";
+import { readCalloutProps } from "#/lib/markdown/callouts";
+import { remarkCallouts } from "#/lib/markdown/remark-callouts";
 import { useReadingTypography } from "#/lib/use-reading-typography";
 
 import "katex/dist/katex.min.css";
@@ -29,6 +31,7 @@ import "katex/dist/katex.min.css";
 import { articleBodyStyles, readingDropCapStyleProps } from "../../body-styles";
 import type { ContentRendererProps } from "../../types";
 import { ArticleBody } from "./article-body";
+import { Callout } from "./callout";
 import { CodeBlockView } from "./code-block";
 import { MarkdownIframeEmbed } from "./iframe-embed";
 import { reactNodeHasText, splitLeadingChar } from "./react-node-text";
@@ -257,16 +260,30 @@ function useMarkdownComponents(
       li: ({ children }) => (
         <li {...stylex.props(articleBodyStyles.listItem)}>{children}</li>
       ),
-      blockquote: ({ children }) => (
-        <blockquote
-          {...stylex.props(
-            articleBodyStyles.pullquote,
-            markdownStyles.blockquote,
-          )}
-        >
-          {children}
-        </blockquote>
-      ),
+      blockquote: ({ children, node }) => {
+        const callout = readCalloutProps(node?.properties);
+        if (callout) {
+          return (
+            <Callout
+              kind={callout.kind}
+              title={callout.title}
+              fold={callout.fold}
+            >
+              {children}
+            </Callout>
+          );
+        }
+        return (
+          <blockquote
+            {...stylex.props(
+              articleBodyStyles.pullquote,
+              markdownStyles.blockquote,
+            )}
+          >
+            {children}
+          </blockquote>
+        );
+      },
       hr: () => <hr {...stylex.props(articleBodyStyles.horizontalRule)} />,
       pre: ({ children }) => <>{children}</>,
       code: ({ className, children }) => {
@@ -391,6 +408,7 @@ export function MarkdownArticle({
     const plugins = [];
     if (flavor === "gfm") plugins.push(remarkGfm);
     if (enableMath) plugins.push(remarkMath);
+    plugins.push(remarkCallouts);
     return plugins;
   }, [enableMath, flavor]);
 

--- a/src/lib/markdown/article-sanitize-schema.ts
+++ b/src/lib/markdown/article-sanitize-schema.ts
@@ -34,6 +34,14 @@ export const articleMarkdownSanitizeSchema: SanitizeSchema = {
   ],
   attributes: {
     ...defaultSchema.attributes,
+    // GFM/Obsidian callouts: `remarkCallouts` marks the blockquote with a
+    // `callout` class and `data-callout-*` attributes the renderer reads.
+    blockquote: mergeAttributes("blockquote", [
+      ["className", "callout"],
+      "dataCalloutKind",
+      "dataCalloutTitle",
+      "dataCalloutFold",
+    ]),
     div: mergeAttributes("div", [["className", playlistClass]]),
     span: mergeAttributes("span", [
       ["className", playlistClass],

--- a/src/lib/markdown/callouts.test.ts
+++ b/src/lib/markdown/callouts.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { parseCalloutMarker } from "./callouts";
+
+describe("parseCalloutMarker", () => {
+  it("parses a plain GFM marker and derives the label", () => {
+    const marker = parseCalloutMarker("[!NOTE]\nBody");
+    expect(marker).toMatchObject({
+      type: "note",
+      kind: "note",
+      collapsible: false,
+      title: "Note",
+    });
+    // The match consumes the marker line including its trailing newline.
+    expect("[!NOTE]\nBody".slice(marker?.matchLength ?? 0)).toBe("Body");
+  });
+
+  it("lowercases the type keyword", () => {
+    expect(parseCalloutMarker("[!Warning]")?.type).toBe("warning");
+    expect(parseCalloutMarker("[!warning]")?.kind).toBe("warning");
+  });
+
+  it("maps GFM aliases to GitHub's colors", () => {
+    // GitHub renders `important` purple and `caution` red.
+    expect(parseCalloutMarker("[!IMPORTANT]")?.kind).toBe("example");
+    expect(parseCalloutMarker("[!CAUTION]")?.kind).toBe("danger");
+  });
+
+  it("reads an Obsidian collapse indicator and custom title", () => {
+    const collapsed = parseCalloutMarker("[!tip]- Custom title\nBody");
+    expect(collapsed).toMatchObject({
+      type: "tip",
+      kind: "tip",
+      collapsible: true,
+      defaultOpen: false,
+      title: "Custom title",
+    });
+
+    const expanded = parseCalloutMarker("[!tip]+ Open me");
+    expect(expanded).toMatchObject({
+      collapsible: true,
+      defaultOpen: true,
+      title: "Open me",
+    });
+  });
+
+  it("falls back to a note-styled callout titled after the keyword", () => {
+    const marker = parseCalloutMarker("[!custom]");
+    expect(marker?.kind).toBe("note");
+    // The keyword itself is preserved and title-cased as the header.
+    expect(marker?.type).toBe("custom");
+    expect(marker?.title).toBe("Custom");
+  });
+
+  it("returns null when the text does not open with a marker", () => {
+    expect(parseCalloutMarker("Just a normal quote")).toBeNull();
+    expect(parseCalloutMarker("Text [!NOTE] mid-line")).toBeNull();
+  });
+});

--- a/src/lib/markdown/callouts.ts
+++ b/src/lib/markdown/callouts.ts
@@ -1,0 +1,167 @@
+/**
+ * Shared definitions for GFM- and Obsidian-style callouts (a.k.a. alerts /
+ * admonitions). A callout is a blockquote whose first line is a type marker:
+ *
+ * ```
+ * > [!NOTE]
+ * > Body text.
+ * ```
+ *
+ * Obsidian extends the syntax with a fold indicator and a custom title on the
+ * marker line:
+ *
+ * ```
+ * > [!warning]- Collapsed by default
+ * > Body text.
+ * ```
+ *
+ * The `-` / `+` after the marker makes the callout collapsible (`-` starts
+ * closed, `+` starts open); anything after that on the line is a custom title.
+ *
+ * References:
+ * - https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts
+ * - https://help.obsidian.md/callouts
+ */
+
+/** The visual families a callout can map to. Each drives a color + icon. */
+export type CalloutKind =
+  | "note"
+  | "abstract"
+  | "info"
+  | "todo"
+  | "tip"
+  | "success"
+  | "question"
+  | "warning"
+  | "failure"
+  | "danger"
+  | "bug"
+  | "example"
+  | "quote";
+
+/**
+ * Every recognized type keyword (GFM's five plus Obsidian's aliases) mapped to
+ * its visual kind. GFM's `important` is purple in GitHub, so it maps to
+ * `example`; `caution` is red, so it maps to `danger` — matching how those
+ * alerts render on GitHub.
+ */
+const TYPE_TO_KIND: Record<string, CalloutKind> = {
+  note: "note",
+  abstract: "abstract",
+  summary: "abstract",
+  tldr: "abstract",
+  info: "info",
+  todo: "todo",
+  tip: "tip",
+  hint: "tip",
+  important: "example",
+  success: "success",
+  check: "success",
+  done: "success",
+  question: "question",
+  help: "question",
+  faq: "question",
+  warning: "warning",
+  caution: "danger",
+  attention: "warning",
+  failure: "failure",
+  fail: "failure",
+  missing: "failure",
+  danger: "danger",
+  error: "danger",
+  bug: "bug",
+  example: "example",
+  quote: "quote",
+  cite: "quote",
+};
+
+export interface CalloutMarker {
+  /** The normalized type keyword, e.g. `note` (always lowercase). */
+  type: string;
+  /** The visual kind the type maps to. */
+  kind: CalloutKind;
+  /** Whether the callout is collapsible (a `-`/`+` fold indicator was present). */
+  collapsible: boolean;
+  /** For a collapsible callout, whether it starts open (`+`) or closed (`-`). */
+  defaultOpen: boolean;
+  /** Author-supplied title, or the canonical label for the kind. */
+  title: string;
+  /** Length of the matched marker (marker + fold + title + trailing newline). */
+  matchLength: number;
+}
+
+// [!TYPE] then an optional -/+ fold indicator, optional inline title, and the
+// rest of that one line. Anchored to the start of the blockquote's text.
+const MARKER_RE = /^[ \t]*\[!([A-Za-z][\w-]*)\]([-+]?)[ \t]*([^\n]*)(\n|$)/;
+
+/** Resolve a type keyword to its visual kind (defaults to `note`). */
+export function calloutKindForType(type: string): CalloutKind {
+  return TYPE_TO_KIND[type.toLowerCase()] ?? "note";
+}
+
+/** Title-case a type keyword for the default header, e.g. `note` → `Note`. */
+function titleCaseType(type: string): string {
+  return type.charAt(0).toUpperCase() + type.slice(1).toLowerCase();
+}
+
+export interface CalloutProps {
+  kind: CalloutKind;
+  title: string;
+  /** `"open"`/`"closed"` when collapsible; `undefined` for a static callout. */
+  fold?: "open" | "closed";
+}
+
+/**
+ * Read callout metadata off a blockquote's hast properties. `remarkCallouts`
+ * tags callout blockquotes with `className: callout` plus `data-callout-*`
+ * attributes; an ordinary blockquote returns `null`.
+ */
+export function readCalloutProps(
+  properties: Record<string, unknown> | undefined,
+): CalloutProps | null {
+  if (!properties) return null;
+  const className = properties.className;
+  const isCallout = Array.isArray(className)
+    ? className.includes("callout")
+    : className === "callout";
+  if (!isCallout) return null;
+
+  const kind =
+    typeof properties.dataCalloutKind === "string"
+      ? (properties.dataCalloutKind as CalloutKind)
+      : "note";
+  const title =
+    typeof properties.dataCalloutTitle === "string"
+      ? properties.dataCalloutTitle
+      : "";
+  const fold = properties.dataCalloutFold;
+  return {
+    kind,
+    title,
+    fold: fold === "open" || fold === "closed" ? fold : undefined,
+  };
+}
+
+/**
+ * Parse a callout marker from the start of a blockquote's leading text. Returns
+ * `null` when the text does not open with `[!type]`, in which case the
+ * blockquote should render as an ordinary quote.
+ */
+export function parseCalloutMarker(text: string): CalloutMarker | null {
+  const match = MARKER_RE.exec(text);
+  if (!match) return null;
+
+  const type = match[1].toLowerCase();
+  const fold = match[2];
+  const rawTitle = match[3].trim();
+  const kind = calloutKindForType(type);
+
+  return {
+    type,
+    kind,
+    collapsible: fold !== "",
+    defaultOpen: fold !== "-",
+    title: rawTitle || titleCaseType(type),
+    matchLength: match[0].length,
+  };
+}

--- a/src/lib/markdown/remark-callouts.test.ts
+++ b/src/lib/markdown/remark-callouts.test.ts
@@ -1,0 +1,131 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import ReactMarkdown from "react-markdown";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize from "rehype-sanitize";
+import remarkGfm from "remark-gfm";
+import { describe, expect, it } from "vitest";
+
+import { articleMarkdownSanitizeSchema } from "./article-sanitize-schema";
+import { readCalloutProps } from "./callouts";
+import { remarkCallouts } from "./remark-callouts";
+
+/**
+ * Render markdown through the exact plugin + sanitize stack the article uses,
+ * surfacing the callout metadata the renderer would read (`readCalloutProps`)
+ * as plain attributes so the transform can be asserted without pulling in the
+ * StyleX-based `Callout` component (StyleX needs build-time compilation).
+ */
+function render(md: string): string {
+  return renderToStaticMarkup(
+    createElement(
+      ReactMarkdown,
+      {
+        remarkPlugins: [remarkGfm, remarkCallouts],
+        rehypePlugins: [
+          rehypeRaw,
+          [rehypeSanitize, articleMarkdownSanitizeSchema],
+        ],
+        components: {
+          blockquote: ({ children, node }) => {
+            const callout = readCalloutProps(
+              node?.properties as Record<string, unknown> | undefined,
+            );
+            if (!callout) {
+              return createElement(
+                "blockquote",
+                { "data-plain-quote": true },
+                children,
+              );
+            }
+            return createElement(
+              "blockquote",
+              {
+                "data-callout-kind": callout.kind,
+                "data-callout-title": callout.title,
+                "data-callout-fold": callout.fold ?? "none",
+              },
+              children,
+            );
+          },
+        },
+      },
+      md,
+    ),
+  );
+}
+
+describe("remarkCallouts pipeline", () => {
+  it("annotates a GFM callout and strips the marker from the body", () => {
+    const html = render("> [!NOTE]\n> Some text for callouts\n");
+    expect(html).toContain('data-callout-kind="note"');
+    expect(html).toContain('data-callout-title="Note"');
+    expect(html).toContain('data-callout-fold="none"');
+    expect(html).toContain("Some text for callouts");
+    // The raw marker never reaches the rendered body.
+    expect(html).not.toContain("[!NOTE]");
+  });
+
+  it("carries an Obsidian custom title and collapsed fold state", () => {
+    const html = render(
+      "> [!warning]- Custom title and collapsed\n> Body text\n",
+    );
+    expect(html).toContain('data-callout-kind="warning"');
+    expect(html).toContain('data-callout-title="Custom title and collapsed"');
+    expect(html).toContain('data-callout-fold="closed"');
+  });
+
+  it("marks a `+` callout as an expanded collapsible", () => {
+    const html = render("> [!tip]+ Open tip\n> Body\n");
+    expect(html).toContain('data-callout-fold="open"');
+    expect(html).toContain('data-callout-title="Open tip"');
+  });
+
+  it("keeps an ordinary blockquote as a plain quote", () => {
+    const html = render("> Just a normal quote\n");
+    expect(html).toContain("data-plain-quote");
+    expect(html).not.toContain("data-callout-kind");
+  });
+
+  it("preserves inline markup inside the callout body", () => {
+    const html = render("> [!info]\n> Body with **bold** and a [link](/x)\n");
+    expect(html).toContain('data-callout-kind="info"');
+    expect(html).toContain("<strong>bold</strong>");
+    expect(html).toContain("<a");
+  });
+
+  it("supports a single-line callout with only a title", () => {
+    const html = render("> [!success] All done\n");
+    expect(html).toContain('data-callout-kind="success"');
+    expect(html).toContain('data-callout-title="All done"');
+  });
+});
+
+describe("readCalloutProps", () => {
+  it("returns null without the callout class", () => {
+    const missing: Record<string, unknown> | undefined = undefined;
+    expect(readCalloutProps(missing)).toBeNull();
+    expect(readCalloutProps({ className: ["other"] })).toBeNull();
+  });
+
+  it("reads kind, title, and fold from properties", () => {
+    expect(
+      readCalloutProps({
+        className: ["callout"],
+        dataCalloutKind: "warning",
+        dataCalloutTitle: "Heads up",
+        dataCalloutFold: "closed",
+      }),
+    ).toEqual({ kind: "warning", title: "Heads up", fold: "closed" });
+  });
+
+  it("treats a missing fold as a static callout", () => {
+    const props = readCalloutProps({
+      className: ["callout"],
+      dataCalloutKind: "note",
+      dataCalloutTitle: "Note",
+    });
+    expect(props).toMatchObject({ kind: "note", title: "Note" });
+    expect(props?.fold).toBeUndefined();
+  });
+});

--- a/src/lib/markdown/remark-callouts.ts
+++ b/src/lib/markdown/remark-callouts.ts
@@ -1,0 +1,69 @@
+import { visit } from "unist-util-visit";
+
+import { parseCalloutMarker } from "./callouts";
+
+// Minimal structural types for the mdast nodes this plugin touches. Kept local
+// so the plugin depends only on `unist-util-visit` and not on `@types/mdast` /
+// `@types/unified`, which are not direct dependencies of this project.
+interface MdastNode {
+  type: string;
+  value?: string;
+  children?: Array<MdastNode>;
+  data?: { hProperties?: Record<string, unknown> } & Record<string, unknown>;
+}
+
+/**
+ * remark plugin: turn GFM/Obsidian callout blockquotes into annotated
+ * blockquotes the renderer can pick up.
+ *
+ * A blockquote whose first line is a `[!type]` marker gets `className: callout`
+ * plus `data-callout-*` properties describing its kind, title, and fold state,
+ * and the marker line is stripped from the body. Everything else about the
+ * blockquote (nested markdown, lists, code) is left untouched, so callout
+ * bodies render exactly like normal prose.
+ */
+export function remarkCallouts() {
+  return (tree: MdastNode) => {
+    visit(tree as never, "blockquote", (raw) => {
+      const node = raw as MdastNode;
+      const paragraph = node.children?.[0];
+      if (!paragraph || paragraph.type !== "paragraph") return;
+
+      const leading = paragraph.children?.[0];
+      if (!leading || leading.type !== "text" || leading.value === undefined) {
+        return;
+      }
+
+      const marker = parseCalloutMarker(leading.value);
+      if (!marker) return;
+
+      // Drop the marker line from the body. If that empties the text node (and
+      // then the paragraph), remove the now-empty nodes so the callout body
+      // starts at the real content.
+      const remaining = leading.value.slice(marker.matchLength);
+      if (remaining === "") {
+        paragraph.children?.shift();
+      } else {
+        leading.value = remaining;
+      }
+      if (paragraph.children && paragraph.children.length === 0) {
+        node.children?.shift();
+      }
+
+      const data = (node.data ??= {});
+      const properties: Record<string, string> = {
+        className: "callout",
+        "data-callout-kind": marker.kind,
+        "data-callout-title": marker.title,
+      };
+      if (marker.collapsible) {
+        properties["data-callout-fold"] = marker.defaultOpen
+          ? "open"
+          : "closed";
+      }
+      data.hProperties = { ...data.hProperties, ...properties };
+    });
+  };
+}
+
+export default remarkCallouts;


### PR DESCRIPTION
Blockquotes that open with a `[!type]` marker now render as styled
callouts (a.k.a. alerts / admonitions) instead of raw text, covering both
GFM's five alert keywords and Obsidian's extended set:

    > [!NOTE]
    > Some text for callouts

    > [!warning]- Custom title, collapsed by default
    > Some text for callouts

A `remarkCallouts` plugin detects the marker on a blockquote's first line,
strips it from the body, and annotates the node with its kind, title, and
fold state; the article sanitize schema is widened to preserve those
attributes. The `Callout` component renders a colored container with a
per-kind icon and title, and — for Obsidian's `-`/`+` fold indicators — a
collapsible body backed by an accessible toggle button.

Types map to Radix color scales (GitHub's semantics for the GFM five:
`important` purple, `caution` red); unknown types fall back to a
note-styled callout titled after the keyword.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013ogwNyG4cKFG8Zvz1xbsGd