### PR TITLE
Fix handle.invalid sentinel stranding profiles after handle changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "ingest:start": "tsx src/server/ingest/service.ts",
     "digest:send": "tsx scripts/send-weekly-digest.ts",
     "digest:send:dev": "tsx --env-file=.env scripts/send-weekly-digest.ts",
+    "backfill:actor-handles": "pnpm exec tsx --env-file=.env scripts/backfill-actor-handles.ts",
     "backfill:search-text": "pnpm exec tsx --env-file=.env scripts/backfill-search-text.ts",
     "backfill:renderable": "pnpm exec tsx --env-file=.env scripts/backfill-renderable-body.ts",
     "backfill:content-formats": "pnpm exec tsx --env-file=.env scripts/backfill-content-formats.ts",

--- a/scripts/backfill-actor-handles.ts
+++ b/scripts/backfill-actor-handles.ts
@@ -1,0 +1,15 @@
+/**
+ * One-off / cron-safe backfill for `profiles.handle` on actors stranded without
+ * a usable handle (`null`, or the `handle.invalid` sentinel). Re-resolves each
+ * affected DID from its DID document and writes back the real handle, which in
+ * turn fixes every denormalized `ownerHandle` read off the profile row (issue #4).
+ *
+ *   pnpm backfill:actor-handles
+ */
+import { backfillActorHandles } from "../src/server/ingest/recompute.ts";
+
+const updated = await backfillActorHandles();
+// eslint-disable-next-line no-console
+console.log(`Backfilled handles for ${updated} profiles.`);
+// eslint-disable-next-line unicorn/no-process-exit
+process.exit(0);

--- a/src/lib/bluesky-public-profile.test.ts
+++ b/src/lib/bluesky-public-profile.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchBlueskyPublicProfileFields } from "./bluesky-public-profile";
+
+function mockProfile(body: Record<string, unknown>) {
+  return {
+    ok: true,
+    json: async () => body,
+  } as Response;
+}
+
+describe("fetchBlueskyPublicProfileFields", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns a verified handle", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mockProfile({ handle: "qxm.de" })),
+    );
+    const fields = await fetchBlueskyPublicProfileFields("did:plc:x");
+    expect(fields?.handle).toBe("qxm.de");
+  });
+
+  // Bluesky returns the `handle.invalid` sentinel for an unverified handle;
+  // it must never surface as a usable handle (issue #4).
+  it("drops the handle.invalid sentinel", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mockProfile({ handle: "handle.invalid" })),
+    );
+    const fields = await fetchBlueskyPublicProfileFields("did:plc:x");
+    expect(fields?.handle).toBeNull();
+  });
+});

--- a/src/lib/bluesky-public-profile.ts
+++ b/src/lib/bluesky-public-profile.ts
@@ -21,7 +21,12 @@ function normalizeProfileResponse(raw: unknown): BlueskyPublicProfileFields {
       ? rawAvatar.trim()
       : null;
   return {
-    handle: handle && handle.length > 0 ? handle : null,
+    // `handle.invalid` is the AT Protocol sentinel for a handle bsky couldn't
+    // verify — not a usable handle. Drop it so it never surfaces as one.
+    handle:
+      handle && handle.length > 0 && handle !== "handle.invalid"
+        ? handle
+        : null,
     displayName: displayName && displayName.length > 0 ? displayName : null,
     avatarUrl,
   };

--- a/src/server/atproto/identity.test.ts
+++ b/src/server/atproto/identity.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { resolveIdentity } from "./identity";
+import { INVALID_HANDLE, isUsableHandle, resolveIdentity } from "./identity";
 
 function mockDidDoc(serviceEndpoint: unknown) {
   return {
@@ -45,5 +45,20 @@ describe("resolveIdentity", () => {
       `did:plc:malformed-${ep || "empty"}`,
     );
     expect(identity.pds).toBeNull();
+  });
+});
+
+describe("isUsableHandle", () => {
+  it("accepts a real handle", () => {
+    expect(isUsableHandle("qxm.de")).toBe(true);
+    expect(isUsableHandle("alice.bsky.social")).toBe(true);
+  });
+
+  it("rejects the handle.invalid sentinel, empty, and nullish values", () => {
+    expect(isUsableHandle(INVALID_HANDLE)).toBe(false);
+    expect(isUsableHandle("handle.invalid")).toBe(false);
+    expect(isUsableHandle("")).toBe(false);
+    expect(isUsableHandle(null)).toBe(false);
+    expect(isUsableHandle(undefined)).toBe(false);
   });
 });

--- a/src/server/atproto/identity.test.ts
+++ b/src/server/atproto/identity.test.ts
@@ -55,10 +55,11 @@ describe("isUsableHandle", () => {
   });
 
   it("rejects the handle.invalid sentinel, empty, and nullish values", () => {
+    const missing: string | undefined = undefined;
     expect(isUsableHandle(INVALID_HANDLE)).toBe(false);
     expect(isUsableHandle("handle.invalid")).toBe(false);
     expect(isUsableHandle("")).toBe(false);
     expect(isUsableHandle(null)).toBe(false);
-    expect(isUsableHandle(undefined)).toBe(false);
+    expect(isUsableHandle(missing)).toBe(false);
   });
 });

--- a/src/server/atproto/identity.ts
+++ b/src/server/atproto/identity.ts
@@ -16,6 +16,28 @@ export interface ResolvedIdentity {
   handle: string | null;
 }
 
+/**
+ * The AT Protocol sentinel a relay/PDS emits for a handle it can't
+ * bidirectionally verify at that instant. It is NOT a real handle: never
+ * persist it as one, and never let it short-circuit re-resolution. Doing either
+ * is what strands a profile — and every denormalized `ownerHandle` copied off
+ * it — at `handle.invalid` after a handle change (issue #4).
+ */
+export const INVALID_HANDLE = "handle.invalid";
+
+/**
+ * A handle string we can actually use: non-empty and not the `handle.invalid`
+ * sentinel. Narrows `null`/`undefined`/sentinel away so callers treat those
+ * uniformly as "no known handle" and re-resolve instead of trusting a placeholder.
+ */
+export function isUsableHandle(
+  handle: string | null | undefined,
+): handle is string {
+  return (
+    typeof handle === "string" && handle.length > 0 && handle !== INVALID_HANDLE
+  );
+}
+
 interface CacheEntry extends ResolvedIdentity {
   /**
    * True once this entry reflects an actual DID-document fetch (success *or*

--- a/src/server/ingest/apply-identity.test.ts
+++ b/src/server/ingest/apply-identity.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type * as IdentityModule from "../atproto/identity.ts";
+import { applyIdentity } from "./handlers.ts";
+
 const { insertCalls, refreshIdentity } = vi.hoisted(() => ({
   insertCalls: [] as Array<{
     values: Record<string, unknown>;
@@ -25,16 +28,13 @@ vi.mock("../../db/index.ts", () => ({
 }));
 
 vi.mock("../atproto/identity.ts", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("../atproto/identity.ts")>();
+  const actual = await importOriginal<typeof IdentityModule>();
   return {
     ...actual,
     primeIdentityHandle: vi.fn(),
     refreshIdentity,
   };
 });
-
-import { applyIdentity } from "./handlers.ts";
 
 describe("applyIdentity", () => {
   beforeEach(() => {

--- a/src/server/ingest/apply-identity.test.ts
+++ b/src/server/ingest/apply-identity.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { insertCalls, refreshIdentity } = vi.hoisted(() => ({
+  insertCalls: [] as Array<{
+    values: Record<string, unknown>;
+    set: Record<string, unknown>;
+  }>,
+  refreshIdentity: vi.fn(),
+}));
+
+vi.mock("../../db/index.ts", () => ({
+  db: {
+    insert: () => ({
+      values: (values: Record<string, unknown>) => ({
+        onConflictDoUpdate: async ({
+          set,
+        }: {
+          set: Record<string, unknown>;
+        }) => {
+          insertCalls.push({ values, set });
+        },
+      }),
+    }),
+  },
+}));
+
+vi.mock("../atproto/identity.ts", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../atproto/identity.ts")>();
+  return {
+    ...actual,
+    primeIdentityHandle: vi.fn(),
+    refreshIdentity,
+  };
+});
+
+import { applyIdentity } from "./handlers.ts";
+
+describe("applyIdentity", () => {
+  beforeEach(() => {
+    insertCalls.length = 0;
+    refreshIdentity.mockReset();
+  });
+
+  it("stores a usable handle and never resolves the DID doc", async () => {
+    await applyIdentity({ did: "did:plc:a", handle: "qxm.de" });
+    expect(refreshIdentity).not.toHaveBeenCalled();
+    const [call] = insertCalls;
+    expect(call.values.handle).toBe("qxm.de");
+    expect(call.set.handle).toBe("qxm.de");
+  });
+
+  it("re-resolves the DID doc when the event carries handle.invalid", async () => {
+    refreshIdentity.mockResolvedValue({
+      did: "did:plc:b",
+      pds: null,
+      handle: "qxm.de",
+    });
+    await applyIdentity({ did: "did:plc:b", handle: "handle.invalid" });
+    expect(refreshIdentity).toHaveBeenCalledWith("did:plc:b");
+    const [call] = insertCalls;
+    // The sentinel is never persisted; the resolved handle wins.
+    expect(call.values.handle).toBe("qxm.de");
+    expect(call.set.handle).toBe("qxm.de");
+  });
+
+  it("leaves the stored handle untouched when the sentinel can't be resolved", async () => {
+    refreshIdentity.mockResolvedValue({
+      did: "did:plc:c",
+      pds: null,
+      handle: null,
+    });
+    await applyIdentity({ did: "did:plc:c", handle: "handle.invalid" });
+    const [call] = insertCalls;
+    // Insert value is null (never the sentinel) but the conflict-update `set`
+    // omits handle, so a good stored handle is not clobbered.
+    expect(call.values.handle).toBeNull();
+    expect(call.set).not.toHaveProperty("handle");
+  });
+
+  it("never persists handle.invalid even if the DID doc echoes it", async () => {
+    refreshIdentity.mockResolvedValue({
+      did: "did:plc:d",
+      pds: null,
+      handle: "handle.invalid",
+    });
+    await applyIdentity({ did: "did:plc:d", handle: "handle.invalid" });
+    const [call] = insertCalls;
+    expect(call.values.handle).toBeNull();
+    expect(call.set).not.toHaveProperty("handle");
+  });
+
+  it("does not resolve or overwrite handle for a status-only event", async () => {
+    await applyIdentity({ did: "did:plc:e", status: "deactivated" });
+    expect(refreshIdentity).not.toHaveBeenCalled();
+    const [call] = insertCalls;
+    expect(call.values.handle).toBeNull();
+    expect(call.set).not.toHaveProperty("handle");
+    expect(call.set.isActive).toBe(false);
+  });
+});

--- a/src/server/ingest/handlers.ts
+++ b/src/server/ingest/handlers.ts
@@ -38,7 +38,10 @@ import { listRepoRecords } from "../atproto/fetch-record.ts";
 import {
   authorPds,
   getCachedIdentity,
+  INVALID_HANDLE,
+  isUsableHandle,
   primeIdentityHandle,
+  refreshIdentity,
   resolveIdentity,
 } from "../atproto/identity.ts";
 import type {
@@ -920,27 +923,39 @@ export async function upsertBskyProfile(
 export async function applyIdentity(
   payload: TapIdentityPayload,
 ): Promise<void> {
-  if (payload.handle) {
-    primeIdentityHandle(payload.did, payload.handle);
+  let handle: string | null = null;
+  if (isUsableHandle(payload.handle)) {
+    handle = payload.handle;
+    primeIdentityHandle(payload.did, handle);
+  } else if (payload.handle === INVALID_HANDLE) {
+    // The relay couldn't bidirectionally verify the handle at this instant and
+    // sent the `handle.invalid` sentinel. Persisting it is what strands a
+    // profile — and every denormalized `ownerHandle` — at `handle.invalid`
+    // after a handle change (issue #4). Resolve the current handle straight
+    // from the DID document instead so the change still propagates. A forced
+    // refresh (not the cached read) is required: the cache may still hold the
+    // pre-change handle.
+    const identity = await refreshIdentity(payload.did);
+    if (isUsableHandle(identity.handle)) handle = identity.handle;
   }
+  // A status-only event (no `handle` field at all) leaves any stored handle
+  // untouched — see the conditional `set` below.
+
   const isActive = payload.isActive ?? payload.status !== "deactivated";
-  const values = {
-    did: payload.did,
-    handle: payload.handle ?? null,
-    isActive,
-    updatedAt: sql`now()`,
-  };
+  // Only overwrite the stored handle when we resolved a usable one. This never
+  // writes the sentinel, and never clobbers a good handle back to null when a
+  // status-only event or a transient DID-doc failure leaves us without one.
+  const set: {
+    handle?: string;
+    isActive: boolean;
+    updatedAt: ReturnType<typeof sql>;
+  } = { isActive, updatedAt: sql`now()` };
+  if (handle !== null) set.handle = handle;
+
   await db
     .insert(profiles)
-    .values(values)
-    .onConflictDoUpdate({
-      target: profiles.did,
-      set: {
-        handle: values.handle,
-        isActive: values.isActive,
-        updatedAt: values.updatedAt,
-      },
-    });
+    .values({ did: payload.did, handle, isActive, updatedAt: sql`now()` })
+    .onConflictDoUpdate({ target: profiles.did, set });
 }
 
 /** Index an `app.standard-reader.collection` sidecar onto its document row. */

--- a/src/server/ingest/recompute.ts
+++ b/src/server/ingest/recompute.ts
@@ -1,4 +1,14 @@
-import { and, asc, eq, gt, inArray, isNotNull, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  eq,
+  gt,
+  inArray,
+  isNotNull,
+  isNull,
+  or,
+  sql,
+} from "drizzle-orm";
 
 import { hasRenderableArticleBody } from "#/lib/document/renderable";
 import {
@@ -18,8 +28,13 @@ import {
 } from "#/server/reader/trending-scoring";
 
 import { db } from "../../db/index.ts";
-import { documents, publications } from "../../db/schema.ts";
+import { documents, profiles, publications } from "../../db/schema.ts";
 import { getBacklinkCountForTarget } from "../atproto/constellation.ts";
+import {
+  INVALID_HANDLE,
+  isUsableHandle,
+  refreshIdentity,
+} from "../atproto/identity.ts";
 import { replayDeadLetters } from "./consumer.ts";
 import { reconcileDocumentDup, reconcilePublicationGroup } from "./handlers.ts";
 import { reconcilePublisherReposBatch } from "./repo-sync.ts";
@@ -636,6 +651,59 @@ export async function backfillRenderableBody(): Promise<number> {
 }
 
 /**
+ * Repair `profiles.handle` for actors stranded without a usable handle —
+ * `null`, or the `handle.invalid` sentinel a relay emits when it can't verify a
+ * handle at that instant. Once persisted, that placeholder never refreshed on
+ * its own and leaked into every denormalized `ownerHandle` copied off the row
+ * (issue #4). We re-resolve each affected DID straight from its DID document
+ * (forced, bypassing any stale cache entry) and write back the real handle.
+ *
+ * Idempotent and cron-safe: only rows still lacking a usable handle are read,
+ * and a row is written only when resolution produces a different, usable handle.
+ * Returns how many profiles were updated.
+ */
+export async function backfillActorHandles(): Promise<number> {
+  const BATCH_SIZE = 100;
+  let cursor: string | null = null;
+  let updated = 0;
+
+  for (;;) {
+    const staleHandle = or(
+      isNull(profiles.handle),
+      eq(profiles.handle, INVALID_HANDLE),
+    );
+    const rows = await db
+      .select({ did: profiles.did, handle: profiles.handle })
+      .from(profiles)
+      .where(
+        cursor == null
+          ? staleHandle
+          : and(staleHandle, gt(profiles.did, cursor)),
+      )
+      .orderBy(asc(profiles.did))
+      .limit(BATCH_SIZE);
+
+    if (rows.length === 0) break;
+    cursor = rows.at(-1)?.did ?? null;
+
+    for (const row of rows) {
+      const identity = await refreshIdentity(row.did);
+      if (!isUsableHandle(identity.handle)) continue;
+      if (identity.handle === row.handle) continue;
+      await db
+        .update(profiles)
+        .set({ handle: identity.handle, updatedAt: new Date() })
+        .where(eq(profiles.did, row.did));
+      updated++;
+    }
+
+    if (rows.length < BATCH_SIZE) break;
+  }
+
+  return updated;
+}
+
+/**
  * Collapse duplicate publications (`did, url`) and documents (`did, cid`) to a
  * single canonical row each. Repairs existing data and acts as a safety net for
  * the hot-path dedup. Returns how many duplicate groups were reconciled.
@@ -686,6 +754,13 @@ export async function recomputeDerived(): Promise<void> {
     await reconcilePublisherReposBatch();
   } catch {
     // Best-effort; the background timer retries between sweeps.
+  }
+  // Re-resolve any actor stranded at `null`/`handle.invalid` so a handle change
+  // that never arrived as a usable identity event still self-heals (issue #4).
+  try {
+    await backfillActorHandles();
+  } catch {
+    // Best-effort; only stale-handle rows are touched and the next sweep retries.
   }
   // Dedup first so stats/aggregates compute over canonical rows only.
   await dedupeRecords();

--- a/src/server/xrpc/handlers/catalog.ts
+++ b/src/server/xrpc/handlers/catalog.ts
@@ -2,7 +2,7 @@ import { and, eq } from "drizzle-orm";
 
 import { searchApi } from "#/integrations/tanstack-query/api-search.functions";
 import { fetchBlueskyPublicProfileFields } from "#/lib/bluesky-public-profile";
-import { resolveIdentity } from "#/server/atproto/identity";
+import { isUsableHandle, resolveIdentity } from "#/server/atproto/identity";
 import { resolveAuthorDid } from "#/server/atproto/resolve-author-ref";
 import {
   resolvePageUrl,
@@ -220,15 +220,19 @@ async function resolveAuthorProfileSummary(
     .limit(1);
 
   if (row) {
+    // A stored `handle.invalid` (from before the ingest fix, or a DID whose
+    // handle is momentarily unverifiable) must not short-circuit resolution —
+    // treat it like a missing handle and re-resolve (issue #4).
+    const storedHandle = isUsableHandle(row.handle) ? row.handle : null;
     const [identity, publicProfile] = await Promise.all([
-      row.handle ? Promise.resolve(null) : resolveIdentity(did as never),
+      storedHandle ? Promise.resolve(null) : resolveIdentity(did as never),
       !row.displayName || !row.avatarUrl
         ? fetchBlueskyPublicProfileFields(did)
         : Promise.resolve(null),
     ]);
     return {
       did: row.did,
-      handle: row.handle ?? identity?.handle ?? publicProfile?.handle ?? null,
+      handle: storedHandle ?? identity?.handle ?? publicProfile?.handle ?? null,
       displayName: row.displayName ?? publicProfile?.displayName ?? null,
       description: row.description,
       avatarUrl: row.avatarUrl ?? publicProfile?.avatarUrl ?? null,


### PR DESCRIPTION
## Summary

This PR fixes #4 where profiles become stranded at the `handle.invalid` sentinel after a handle change. The AT Protocol relay emits `handle.invalid` when it can't bidirectionally verify a handle at that instant, but persisting this placeholder prevented profiles from ever recovering when the real handle became available.

## Key Changes

- **Added `INVALID_HANDLE` constant and `isUsableHandle()` validator** in `src/server/atproto/identity.ts` to centralize handling of the `handle.invalid` sentinel and distinguish it from real handles
- **Fixed `applyIdentity()` handler** in `src/server/ingest/handlers.ts` to:
  - Never persist `handle.invalid` as a real handle
  - Force-refresh the DID document when receiving the sentinel to get the current real handle
  - Avoid clobbering good stored handles with null on status-only events
- **Added `backfillActorHandles()` function** in `src/server/ingest/recompute.ts` to repair profiles already stranded at null or `handle.invalid` by re-resolving their DIDs and writing back real handles
- **Integrated backfill into `recomputeDerived()`** so it runs as part of the regular maintenance cycle
- **Updated profile resolution logic** in `src/server/xrpc/handlers/catalog.ts` to treat stored `handle.invalid` like a missing handle and re-resolve
- **Fixed `normalizeProfileResponse()`** in `src/lib/bluesky-public-profile.ts` to drop the sentinel when fetching public profile data
- **Added comprehensive test coverage** for the new validation logic and identity handling behavior
- **Added backfill script** at `scripts/backfill-actor-handles.ts` for manual execution if needed

## Implementation Details

The fix uses a three-pronged approach:
1. **Ingest-time prevention**: The identity event handler now detects the sentinel and resolves the real handle instead of persisting the placeholder
2. **Query-time awareness**: Code that reads stored handles now treats `handle.invalid` as "no known handle" and re-resolves
3. **Maintenance-time repair**: A background backfill task fixes profiles that were already stranded before this fix, making the solution self-healing over time

All changes are idempotent and safe for cron execution.

https://claude.ai/code/session_01GrUWBRgQPHWiTs4y2y7nau