### PR TITLE
Clear unread dots when a post is optimistically marked read

### DIFF
--- a/src/routes/_layout.l.$did.$rkey.tsx
+++ b/src/routes/_layout.l.$did.$rkey.tsx
@@ -47,6 +47,7 @@ import { ArticleRow, PubDirectoryRow } from "../components/reader/cards";
 import { initials } from "../components/reader/format";
 import { ListEditModal } from "../components/reader/list-edit-modal";
 import { Handle, Kicker, ReaderContent } from "../components/reader/primitives";
+import { isArticleUnreadForReader } from "../components/reader/read-optimistic";
 import { RssFeedButton } from "../components/reader/rss-feed-button";
 import { ShareMenu } from "../components/reader/share-menu";
 import {
@@ -326,6 +327,7 @@ function ListFeedPanel({
   isOwner: boolean;
   hideRead: boolean;
 }) {
+  const queryClient = useQueryClient();
   const { data: session } = useQuery(user.getSessionQueryOptions);
   const signedIn = Boolean(session?.user);
   const { enabled: trackReading } = useTrackReadingHistory();
@@ -400,9 +402,13 @@ function ListFeedPanel({
     );
   }
 
+  // Cache-aware so a just-read article's dot clears (and it hides under "hide
+  // read") the moment it's optimistically marked read, before the list refetches.
+  const isUnread = (article: ArticleCard) =>
+    isArticleUnreadForReader(queryClient, article, { trackReading, signedIn });
   const canFilterRead = hideRead && trackReading && signedIn;
   const visibleItems = canFilterRead
-    ? items.filter((article) => !article.isRead)
+    ? items.filter((article) => isUnread(article))
     : items;
 
   if (items.length === 0) {
@@ -430,7 +436,7 @@ function ListFeedPanel({
             key={article.uri}
             article={article}
             isFirstInSection={index === 0}
-            unread={trackReading && signedIn && !article.isRead}
+            unread={isUnread(article)}
             showSaveButton={false}
           />
         ))}

--- a/src/routes/_layout.latest.tsx
+++ b/src/routes/_layout.latest.tsx
@@ -38,6 +38,7 @@ import { Masthead, ReaderContent } from "../components/reader/primitives";
 import {
   applyMarkReadManyOptimisticUpdate,
   invalidateReadQueries,
+  isArticleUnreadForReader,
 } from "../components/reader/read-optimistic";
 import { RssFeedButton } from "../components/reader/rss-feed-button";
 import {
@@ -308,6 +309,7 @@ function LatestFeedPanel({
   readerScope: string;
 }) {
   const navigate = useNavigate({ from: Route.fullPath });
+  const queryClient = useQueryClient();
   const pageSize = latestFeedPageSize(filter);
 
   const { data: feed } = useSuspenseQuery({
@@ -340,8 +342,12 @@ function LatestFeedPanel({
     [feed.items, extraItems],
   );
 
+  // Cache-aware so the dot clears the moment an article is optimistically marked
+  // read (visiting it, or "mark as read"), even on the unread filter where every
+  // row was unread when the page loaded. Reading `isRead` alone would keep the dot
+  // on until a refetch; the optimistic read-status cache flips first.
   const isUnread = (article: ArticleCard) =>
-    trackReading && signedIn && !article.isRead;
+    isArticleUnreadForReader(queryClient, article, { trackReading, signedIn });
 
   const loadMoreFeed = useCallback(async () => {
     if (nextOffset == null || loadingMoreRef.current) return;
@@ -446,7 +452,7 @@ function LatestFeedPanel({
           <ArticleRow
             key={article.uri}
             article={article}
-            unread={signedIn && (filter === "unread" || isUnread(article))}
+            unread={isUnread(article)}
             showSaveButton={false}
             isFirstInSection={index === 0}
           />

--- a/src/routes/_layout.tag.$tag.tsx
+++ b/src/routes/_layout.tag.$tag.tsx
@@ -35,6 +35,7 @@ import {
   ReaderContent,
   SectionHead,
 } from "#/components/reader/primitives";
+import { isArticleUnreadForReader } from "#/components/reader/read-optimistic";
 import { RssFeedButton } from "#/components/reader/rss-feed-button";
 import { ButtonLink } from "#/components/router-links";
 import {
@@ -430,6 +431,7 @@ function TagDirectorySkeleton({
 }
 
 function TagArticlesPanel({ tag }: { tag: string }) {
+  const queryClient = useQueryClient();
   const { data: session } = useQuery(user.getSessionQueryOptions);
   const signedIn = Boolean(session?.user);
   const { enabled: trackReading } = useTrackReadingHistory();
@@ -534,7 +536,10 @@ function TagArticlesPanel({ tag }: { tag: string }) {
             key={article.uri}
             article={article}
             isFirstInSection={index === 0}
-            unread={trackReading && signedIn && !article.isRead}
+            unread={isArticleUnreadForReader(queryClient, article, {
+              trackReading,
+              signedIn,
+            })}
             showSaveButton={false}
           />
         ))}


### PR DESCRIPTION
Visiting a post decremented the unread counts (which read from the
optimistic read-status/sidebar caches) but left the article's unread dot
showing. The feed dots were derived straight from the card's `isRead`
flag, so they only cleared when the flag was flipped in the exact cache
the optimistic update touched — and never on the Latest "unread" filter,
where the dot was hard-forced on for every row.

Make the dot honor actual read state via `isArticleUnreadForReader`, the
same cache-aware check the publication page already uses. It consults the
`["reader","readStatus"]` / `["reader","readDocuments"]` caches that the
optimistic mark-read seeds, so the dot clears immediately regardless of
which list the card came from:

- Latest feed: drop the `filter === "unread"` force; the unread filter's
  cards carry a real `isRead`, so the optimistic flip now clears the dot.
- Tag and collection/list feeds: their article queries aren't under the
  `["feed"]` key the optimistic update rewrites, so their cards were never
  flipped — the cache-aware check fixes them too. The list "hide read"
  filter now also hides a just-read article.

Counts already reconcile from the read-model once the read record is
ingested; this aligns the dots with that same optimistic state.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Rw7LMYiYF7FmyhoFMPhjQD