### PR TITLE
Persist "hide read articles" filter to localStorage

### DIFF
--- a/src/lib/hide-read.ts
+++ b/src/lib/hide-read.ts
@@ -1,0 +1,6 @@
+/**
+ * `localStorage` key for the "hide read articles" filter. Shared so every
+ * surface that filters a list down to unread articles stays in sync and the
+ * choice persists across navigation and reloads.
+ */
+export const HIDE_READ_STORAGE_KEY = "sr:hide-read";

--- a/src/lib/use-persistent-toggle.ts
+++ b/src/lib/use-persistent-toggle.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * A boolean UI preference persisted to `localStorage` so it survives navigation
+ * and reloads. Used for filters like "hide read articles" that should stick when
+ * the reader opens an article and comes back to the list.
+ *
+ * The value starts at `defaultValue` on the first render (so server and client
+ * markup match) and is reconciled with the stored value right after mount. It
+ * also syncs across tabs via the `storage` event.
+ */
+export function usePersistentToggle(
+  key: string,
+  defaultValue = false,
+): [boolean, (next: boolean | ((prev: boolean) => boolean)) => void] {
+  const [value, setValue] = useState(defaultValue);
+
+  // Hydrate from storage after mount to avoid an SSR/CSR markup mismatch.
+  useEffect(() => {
+    const stored = readStored(key);
+    if (stored !== null) {
+      setValue(stored);
+    }
+  }, [key]);
+
+  // Keep tabs in sync when the same preference changes elsewhere.
+  useEffect(() => {
+    const onStorage = (event: StorageEvent) => {
+      if (event.key !== key) return;
+      const stored = readStored(key);
+      setValue(stored ?? defaultValue);
+    };
+    globalThis.addEventListener?.("storage", onStorage);
+    return () => globalThis.removeEventListener?.("storage", onStorage);
+  }, [key, defaultValue]);
+
+  const set = useCallback(
+    (next: boolean | ((prev: boolean) => boolean)) => {
+      setValue((prev) => {
+        const resolved = typeof next === "function" ? next(prev) : next;
+        writeStored(key, resolved);
+        return resolved;
+      });
+    },
+    [key],
+  );
+
+  return [value, set];
+}
+
+function readStored(key: string): boolean | null {
+  if (globalThis.localStorage === undefined) return null;
+  try {
+    const raw = globalThis.localStorage.getItem(key);
+    if (raw === null) return null;
+    return raw === "1";
+  } catch {
+    return null;
+  }
+}
+
+function writeStored(key: string, value: boolean): void {
+  try {
+    globalThis.localStorage?.setItem(key, value ? "1" : "0");
+  } catch {
+    // Private browsing or disabled storage — the toggle still works for the
+    // current session, it just won't persist.
+  }
+}

--- a/src/routes/_layout.l.$did.$rkey.tsx
+++ b/src/routes/_layout.l.$did.$rkey.tsx
@@ -32,6 +32,7 @@ import type {
   PublicationCard,
 } from "#/integrations/tanstack-query/api-shapes";
 import { user } from "#/integrations/tanstack-query/api-user.functions";
+import { HIDE_READ_STORAGE_KEY } from "#/lib/hide-read";
 import { shareLinkUrl, useNativeShareAvailable } from "#/lib/native-share";
 import { getPublicUrlClient } from "#/lib/public-url";
 import { buildBlueskyComposeUrl } from "#/lib/quote-share";
@@ -40,6 +41,7 @@ import {
   listOgImageUrl,
   siteSocialMeta,
 } from "#/lib/site-metadata";
+import { usePersistentToggle } from "#/lib/use-persistent-toggle";
 import { useTrackReadingHistory } from "#/lib/use-track-reading-history";
 
 import { AuthorProfileLink } from "../components/reader/author-profile-link";
@@ -569,7 +571,7 @@ function ListPage() {
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [rssOpen, setRssOpen] = useState(false);
-  const [hideRead, setHideRead] = useState(false);
+  const [hideRead, setHideRead] = usePersistentToggle(HIDE_READ_STORAGE_KEY);
 
   // Snapshot the current top-of-feed articles so the magazine link is stable:
   // the chosen articles are baked into the URL and won't drift as the list grows.
@@ -660,7 +662,7 @@ function ListPage() {
     ? "Show read articles"
     : "Hide read articles";
 
-  const toggleHideRead = () => setHideRead((value) => !value);
+  const toggleHideRead = () => setHideRead((value: boolean) => !value);
   const onCopyLink = () => {
     void navigator.clipboard.writeText(pageUrl);
   };


### PR DESCRIPTION
## Summary
Add persistent storage for the "hide read articles" filter preference so that users' filtering choices survive navigation, page reloads, and are synced across browser tabs.

## Key Changes
- **New `usePersistentToggle` hook** (`src/lib/use-persistent-toggle.ts`): A reusable React hook that manages boolean UI preferences persisted to `localStorage`. Features include:
  - Starts with a default value on first render to avoid SSR/CSR markup mismatches
  - Hydrates from storage after mount
  - Syncs state across tabs via the `storage` event
  - Gracefully handles missing or disabled `localStorage` (e.g., private browsing)

- **New `HIDE_READ_STORAGE_KEY` constant** (`src/lib/hide-read.ts`): Centralized `localStorage` key for the "hide read articles" filter to ensure consistency across all surfaces that use this preference

- **Updated ListPage component** (`src/routes/_layout.l.$did.$rkey.tsx`):
  - Replaced `useState(false)` with `usePersistentToggle(HIDE_READ_STORAGE_KEY)` for the `hideRead` state
  - Added type annotation to the toggle callback for clarity

## Implementation Details
- The hook uses two `useEffect` calls: one for initial hydration and one for cross-tab synchronization
- Storage values are serialized as "1" (true) or "0" (false) for simplicity
- Errors during storage operations are silently caught, allowing the toggle to function normally for the current session even if persistence fails

https://claude.ai/code/session_01S2GsZxGnRLTYbtD391Gf3p