### PR TITLE
Fix article header handle wrap and Obsidian callout spacing

### DIFF
--- a/src/components/reader/article-view.tsx
+++ b/src/components/reader/article-view.tsx
@@ -359,10 +359,15 @@ const styles = stylex.create({
     minWidth: 0,
   },
   bylineName: {
-    gap: gap.lg,
-    alignItems: "center",
+    // On mobile the name + @handle rarely fit on one line, so stack them as a
+    // tight two-line byline instead of letting the handle wrap with the wide
+    // inline gap. From `sm` up they sit inline again.
+    columnGap: gap.lg,
+    rowGap: spacing["1"],
+    alignItems: { default: "flex-start", "@media (min-width: 40rem)": "center" },
     color: uiColor.text2,
     display: "flex",
+    flexDirection: { default: "column", "@media (min-width: 40rem)": "row" },
     flexWrap: "wrap",
     fontFamily: fontFamily.serif,
     fontSize: fontSize.base,

--- a/src/components/reader/article-view.tsx
+++ b/src/components/reader/article-view.tsx
@@ -364,7 +364,10 @@ const styles = stylex.create({
     // inline gap. From `sm` up they sit inline again.
     columnGap: gap.lg,
     rowGap: spacing["1"],
-    alignItems: { default: "flex-start", "@media (min-width: 40rem)": "center" },
+    alignItems: {
+      default: "flex-start",
+      "@media (min-width: 40rem)": "center",
+    },
     color: uiColor.text2,
     display: "flex",
     flexDirection: { default: "column", "@media (min-width: 40rem)": "row" },

--- a/src/components/reader/content/renderers/shared/callout.tsx
+++ b/src/components/reader/content/renderers/shared/callout.tsx
@@ -76,7 +76,9 @@ const styles = stylex.create({
     fontSize: fontSize.base,
     fontWeight: fontWeight.semibold,
     lineHeight: 1.4,
-    paddingBottom: spacing["3"],
+    // Tighter than the top padding: the title should sit close to the body it
+    // introduces rather than floating in the middle of the box.
+    paddingBottom: spacing["2"],
     paddingLeft: spacing["4"],
     paddingRight: spacing["4"],
     paddingTop: spacing["3"],

--- a/src/components/reader/content/renderers/shared/callout.tsx
+++ b/src/components/reader/content/renderers/shared/callout.tsx
@@ -115,9 +115,23 @@ const styles = stylex.create({
     color: "var(--callout-body)",
     fontSize: fontSize.base,
     lineHeight: 1.55,
-    paddingBottom: spacing["1"],
+    // Bottom padding mirrors the header's vertical padding so the prose sits
+    // evenly inside the box instead of hugging one edge.
+    paddingBottom: spacing["3"],
     paddingLeft: spacing["4"],
     paddingRight: spacing["4"],
+    // Callout prose reuses the article paragraph style (a full 1.5rem bottom
+    // margin), which leaves an oversized, unbalanced gap inside the box. Tighten
+    // the gap between stacked blocks and drop the trailing margin so the body
+    // padding alone controls the bottom edge.
+    // eslint-disable-next-line @stylexjs/no-legacy-contextual-styles, @stylexjs/valid-styles
+    ":is(*) > p": {
+      marginBottom: spacing["3"],
+    },
+    // eslint-disable-next-line @stylexjs/no-legacy-contextual-styles, @stylexjs/valid-styles
+    ":is(*) > :last-child": {
+      marginBottom: spacing["0"],
+    },
   },
 });
 


### PR DESCRIPTION
Fixes two spacing issues in the article reader.

## Mobile byline handle

On mobile the byline was a wrapping flex row with a single wide gap on both
axes, so the author's `@handle` dropped below the name with that large row
gap — reading as a loose, awkward break.

- Stack the name and `@handle` as a tight two-line byline below the `sm`
  (40rem) breakpoint, and keep them inline from `sm` up.

## Obsidian callout spacing

The Obsidian-flavored callouts had two spacing problems:

- **Body prose was unbalanced.** Callout paragraphs reuse the article
  paragraph style (a full 1.5rem bottom margin) while the body's bottom
  padding was only `spacing[1]`, so the trailing paragraph margin stacked into
  an oversized, lopsided gap at the bottom. Mirror the header's vertical
  padding on the body, tighten the gap between stacked blocks, and drop the
  trailing block's margin so the padding alone controls the bottom edge.
- **Title floated too far from the body.** The header's 0.75rem bottom padding
  left the title sitting in the middle of the box. Drop it to 0.5rem so the
  title sits close to the prose it introduces, while keeping the top padding
  for separation from the box edge.

## Files

- `src/components/reader/article-view.tsx` — mobile byline stacking
- `src/components/reader/content/renderers/shared/callout.tsx` — callout body
  and header spacing

## Testing

Verified against the deployed PR preview by inspecting the rendered markup and
compiled CSS to confirm the header/body padding and paragraph margins resolve
as intended. Note: `tsc`/`oxlint` could not be run in the working environment
because `pnpm install` is blocked by an org egress-policy 403 on an unrelated
GitHub-tarball dependency (`grid-lanes-polyfill`); the changes are CSS-only
StyleX edits mirroring existing patterns in the codebase.