### PR TITLE
Render pub.leaflet.blocks.standardSitePublication embeds

### DIFF
--- a/src/components/reader/content/renderers/leaflet-block.tsx
+++ b/src/components/reader/content/renderers/leaflet-block.tsx
@@ -24,6 +24,7 @@ import { LeafletPollBlockView } from "./leaflet-poll";
 import { LeafletSeparatorView } from "./leaflet-separator";
 import { LeafletSignupBlockView } from "./leaflet-signup";
 import { LeafletStandardSitePostBlockView } from "./leaflet-standard-site-post";
+import { LeafletStandardSitePublicationBlockView } from "./leaflet-standard-site-publication";
 import { BlockquoteBlockView } from "./shared/blockquote-block";
 import { BskyPostEmbedView } from "./shared/bsky-post-embed";
 import { CodeBlockView } from "./shared/code-block";
@@ -159,6 +160,9 @@ export function LeafletBlockView({
     }
     case "standardSitePost": {
       return <LeafletStandardSitePostBlockView block={block.block} />;
+    }
+    case "standardSitePublication": {
+      return <LeafletStandardSitePublicationBlockView block={block.block} />;
     }
     case "imageGallery": {
       return (

--- a/src/components/reader/content/renderers/leaflet-standard-site-publication.tsx
+++ b/src/components/reader/content/renderers/leaflet-standard-site-publication.tsx
@@ -4,10 +4,12 @@ import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { use } from "react";
+import { useHover } from "react-aria";
 
 import { publicationLinkParams } from "#/components/reader/format";
 import { PublicationAvatar } from "#/components/reader/primitives";
 import { Skeleton } from "#/design-system/skeleton";
+import { animationDuration } from "#/design-system/theme/animations.stylex";
 import { primaryColor, uiColor } from "#/design-system/theme/color.stylex";
 import { radius } from "#/design-system/theme/radius.stylex";
 import { gap } from "#/design-system/theme/semantic-spacing.stylex";
@@ -53,6 +55,10 @@ export function LeafletStandardSitePublicationBlockView({
   const { resolvedScheme } = useTheme();
   const dark = magazine ? magazine.dark : resolvedScheme === "dark";
 
+  // react-aria's useHover drives the subtle background darken on pointer hover
+  // (and correctly ignores hover from touch, unlike CSS `:hover`).
+  const { hoverProps, isHovered } = useHover({});
+
   const { data: meta, isLoading } = useQuery({
     ...publicationApi.getPublicationEmbedMetaQueryOptions(uri ?? ""),
     enabled: Boolean(uri),
@@ -91,13 +97,16 @@ export function LeafletStandardSitePublicationBlockView({
     </>
   );
 
+  const cardStyle = stylex.props(styles.card, isHovered && styles.cardHovered);
+
   if (linkParams) {
     return (
       <Link
         to="/p/$did/$rkey"
         params={linkParams}
-        style={themeVars ?? undefined}
-        {...stylex.props(styles.card)}
+        {...hoverProps}
+        className={cardStyle.className}
+        style={{ ...cardStyle.style, ...themeVars }}
       >
         {inner}
       </Link>
@@ -105,7 +114,11 @@ export function LeafletStandardSitePublicationBlockView({
   }
 
   return (
-    <div style={themeVars ?? undefined} {...stylex.props(styles.card)}>
+    <div
+      {...hoverProps}
+      className={cardStyle.className}
+      style={{ ...cardStyle.style, ...themeVars }}
+    >
       {inner}
     </div>
   );
@@ -133,10 +146,13 @@ function publicationThemeVars(
   const vars = dark ? palette.dark : palette.light;
   return {
     "--pub-card-bg": vars["--paper"],
-    // Tint the border with the publication's accent (Radix "UI element border"
-    // step) so the card reads as belonging to that publication, matching the
-    // accent-colored title.
-    "--pub-card-border": vars["--accent"],
+    // Slightly darker/sunk surface for the hover state.
+    "--pub-card-bg-hover": vars["--paper-sunk"],
+    // Tint the border with the publication's accent, but softened toward the
+    // paper so it reads as belonging to the publication without shouting —
+    // Radix's exposed accent step (8) is its *hovered* border and too loud at
+    // rest, so mix it back toward the background.
+    "--pub-card-border": `color-mix(in oklab, ${vars["--accent"]} 40%, ${vars["--paper"]})`,
     "--pub-card-title": vars["--accent-ink"],
     "--pub-card-text": vars["--ink"],
     "--pub-card-muted": vars["--ink-soft"],
@@ -171,6 +187,12 @@ const styles = stylex.create({
     marginTop: spacing["0"],
     padding: spacing["4"],
     textDecoration: "none",
+    transitionDuration: animationDuration.default,
+    transitionProperty: "background-color",
+    transitionTimingFunction: "ease",
+  },
+  cardHovered: {
+    backgroundColor: `var(--pub-card-bg-hover, ${uiColor.component2})`,
   },
   avatar: {
     flexShrink: 0,

--- a/src/components/reader/content/renderers/leaflet-standard-site-publication.tsx
+++ b/src/components/reader/content/renderers/leaflet-standard-site-publication.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { use } from "react";
+
+import { publicationLinkParams } from "#/components/reader/format";
+import { PublicationAvatar } from "#/components/reader/primitives";
+import { Skeleton } from "#/design-system/skeleton";
+import { primaryColor, uiColor } from "#/design-system/theme/color.stylex";
+import { radius } from "#/design-system/theme/radius.stylex";
+import { gap } from "#/design-system/theme/semantic-spacing.stylex";
+import { spacing } from "#/design-system/theme/spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+} from "#/design-system/theme/typography.stylex";
+import type { PublicationEmbedMeta } from "#/integrations/tanstack-query/api-publication.functions";
+import { publicationApi } from "#/integrations/tanstack-query/api-publication.functions";
+import { buildMagazinePalette } from "#/lib/collections/radix-theme";
+import type { CollectionTheme } from "#/lib/collections/theme";
+import type { LeafletStandardSitePublicationBlock } from "#/lib/leaflet/types";
+import { useTheme } from "#/lib/use-theme";
+import { MagazineColorContext } from "#/magazine/context";
+
+/**
+ * Renders a `pub.leaflet.blocks.standardSitePublication` embed: a card linking
+ * to the referenced Standard publication with its icon, name, description, and
+ * author byline — the same information Leaflet shows.
+ *
+ * When the block opts into the publication's theme (the default), the card is
+ * painted with that publication's `basicTheme`. Rather than reuse the raw theme
+ * colors — which would break down in the reader's other color scheme — we run
+ * the accent + background through the same Radix scale generator the magazine
+ * uses (`buildMagazinePalette`), which produces properly contrasted light AND
+ * dark palettes with a11y fallbacks, then pick the one matching the active
+ * scheme.
+ */
+export function LeafletStandardSitePublicationBlockView({
+  block,
+}: {
+  block: LeafletStandardSitePublicationBlock;
+}) {
+  const uri = block.uri?.trim();
+  // Leaflet's editor defaults `showPublicationTheme` to on; only an explicit
+  // `false` disables the publication's theme for this embed.
+  const applyTheme = block.showPublicationTheme !== false;
+
+  const magazine = use(MagazineColorContext);
+  const { resolvedScheme } = useTheme();
+  const dark = magazine ? magazine.dark : resolvedScheme === "dark";
+
+  const { data: meta, isLoading } = useQuery({
+    ...publicationApi.getPublicationEmbedMetaQueryOptions(uri ?? ""),
+    enabled: Boolean(uri),
+  });
+
+  if (!uri) return null;
+
+  if (!meta) {
+    if (isLoading) return <PublicationCardSkeleton />;
+    return <p {...stylex.props(styles.notFound)}>Publication not found.</p>;
+  }
+
+  const themeVars = applyTheme ? publicationThemeVars(meta, dark) : null;
+  const linkParams = publicationLinkParams(uri);
+  const author =
+    meta.ownerDisplayName ?? (meta.ownerHandle ? `@${meta.ownerHandle}` : null);
+
+  const inner = (
+    <>
+      <PublicationAvatar
+        pub={{
+          name: meta.name,
+          iconUrl: meta.iconUrl,
+          ownerAvatarUrl: meta.ownerAvatarUrl,
+        }}
+        size="lg"
+        style={styles.avatar}
+      />
+      <div {...stylex.props(styles.meta)}>
+        <p {...stylex.props(styles.name)}>{meta.name}</p>
+        {meta.description ? (
+          <p {...stylex.props(styles.description)}>{meta.description}</p>
+        ) : null}
+        {author ? <p {...stylex.props(styles.byline)}>{author}</p> : null}
+      </div>
+    </>
+  );
+
+  if (linkParams) {
+    return (
+      <Link
+        to="/p/$did/$rkey"
+        params={linkParams}
+        style={themeVars ?? undefined}
+        {...stylex.props(styles.card)}
+      >
+        {inner}
+      </Link>
+    );
+  }
+
+  return (
+    <div style={themeVars ?? undefined} {...stylex.props(styles.card)}>
+      {inner}
+    </div>
+  );
+}
+
+/**
+ * Card-scoped CSS variables derived from the publication's theme. Returns null
+ * when the theme carries no accent (nothing to generate a scale from), so the
+ * card falls back to the reader's own design-system tokens.
+ */
+function publicationThemeVars(
+  meta: PublicationEmbedMeta,
+  dark: boolean,
+): Record<string, string> | null {
+  const theme: CollectionTheme = {
+    background: meta.themeBackground,
+    foreground: meta.themeForeground,
+    accent: meta.themeAccent,
+    accentForeground: meta.themeAccentForeground,
+    fontTitle: null,
+    fontBody: null,
+  };
+  const palette = buildMagazinePalette(theme);
+  if (!palette) return null;
+  const vars = dark ? palette.dark : palette.light;
+  return {
+    "--pub-card-bg": vars["--paper"],
+    "--pub-card-border": vars["--line"],
+    "--pub-card-title": vars["--accent-ink"],
+    "--pub-card-text": vars["--ink"],
+    "--pub-card-muted": vars["--ink-soft"],
+  };
+}
+
+function PublicationCardSkeleton() {
+  return (
+    <div {...stylex.props(styles.card)} aria-hidden>
+      <Skeleton variant="circle" size="md" style={styles.avatar} />
+      <div {...stylex.props(styles.meta)}>
+        <Skeleton variant="rectangle" height="1.1rem" width="45%" />
+        <Skeleton variant="rectangle" height="0.8rem" width="100%" />
+        <Skeleton variant="rectangle" height="0.8rem" width="35%" />
+      </div>
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  card: {
+    alignItems: "flex-start",
+    backgroundColor: `var(--pub-card-bg, ${uiColor.component1})`,
+    borderColor: `var(--pub-card-border, ${uiColor.border1})`,
+    borderRadius: radius.md,
+    borderStyle: "solid",
+    borderWidth: 1,
+    columnGap: gap.md,
+    cornerShape: "squircle",
+    display: "flex",
+    marginBottom: spacing["6"],
+    marginTop: spacing["0"],
+    padding: spacing["4"],
+    textDecoration: "none",
+  },
+  avatar: {
+    flexShrink: 0,
+  },
+  meta: {
+    display: "flex",
+    flexDirection: "column",
+    flexGrow: 1,
+    minWidth: 0,
+    rowGap: spacing["1"],
+  },
+  name: {
+    color: `var(--pub-card-title, ${primaryColor.text2})`,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.lg,
+    fontWeight: fontWeight.semibold,
+    lineHeight: lineHeight.sm,
+    marginBottom: spacing["0"],
+    marginTop: spacing["0"],
+  },
+  description: {
+    color: `var(--pub-card-text, ${uiColor.text1})`,
+    display: "-webkit-box",
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.sm,
+    lineHeight: lineHeight.base,
+    marginBottom: spacing["0"],
+    marginTop: spacing["0"],
+    overflow: "hidden",
+    // eslint-disable-next-line @stylexjs/valid-styles
+    WebkitBoxOrient: "vertical",
+    // eslint-disable-next-line @stylexjs/valid-styles
+    WebkitLineClamp: 3,
+  },
+  byline: {
+    color: `var(--pub-card-muted, ${uiColor.text1})`,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.sm,
+    marginBottom: spacing["0"],
+    marginTop: spacing["0"],
+  },
+  notFound: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.sm,
+    fontStyle: "italic",
+    marginBottom: spacing["6"],
+    marginTop: spacing["0"],
+  },
+});

--- a/src/components/reader/content/renderers/leaflet-standard-site-publication.tsx
+++ b/src/components/reader/content/renderers/leaflet-standard-site-publication.tsx
@@ -133,7 +133,10 @@ function publicationThemeVars(
   const vars = dark ? palette.dark : palette.light;
   return {
     "--pub-card-bg": vars["--paper"],
-    "--pub-card-border": vars["--line"],
+    // Tint the border with the publication's accent (Radix "UI element border"
+    // step) so the card reads as belonging to that publication, matching the
+    // accent-colored title.
+    "--pub-card-border": vars["--accent"],
     "--pub-card-title": vars["--accent-ink"],
     "--pub-card-text": vars["--ink"],
     "--pub-card-muted": vars["--ink-soft"],

--- a/src/lib/leaflet/blocks.ts
+++ b/src/lib/leaflet/blocks.ts
@@ -15,6 +15,7 @@ import type {
   LeafletPollBlock,
   LeafletRenderableBlock,
   LeafletStandardSitePostBlock,
+  LeafletStandardSitePublicationBlock,
   LeafletTextBlock,
   LeafletUnorderedListBlock,
   LeafletWebsiteBlock,
@@ -188,6 +189,15 @@ function asRenderableBlock(value: unknown): LeafletRenderableBlock | null {
     return {
       kind: "standardSitePost",
       block: value as unknown as LeafletStandardSitePostBlock,
+    };
+  }
+
+  if (value.$type === LEAFLET_BLOCK.standardSitePublication) {
+    const uri = typeof value.uri === "string" ? value.uri : null;
+    if (!uri) return null;
+    return {
+      kind: "standardSitePublication",
+      block: value as unknown as LeafletStandardSitePublicationBlock,
     };
   }
 
@@ -449,7 +459,8 @@ export function plaintextLinesFromBlock(
       const label = block.block.text?.trim();
       return label ? [label] : [];
     }
-    case "standardSitePost": {
+    case "standardSitePost":
+    case "standardSitePublication": {
       return [];
     }
     case "pageEmbed": {

--- a/src/lib/leaflet/types.ts
+++ b/src/lib/leaflet/types.ts
@@ -32,6 +32,7 @@ export const LEAFLET_BLOCK = {
   page: "pub.leaflet.blocks.page",
   separator: "pub.leaflet.blocks.separator",
   standardSitePost: "pub.leaflet.blocks.standardSitePost",
+  standardSitePublication: "pub.leaflet.blocks.standardSitePublication",
   imageGallery: "pub.leaflet.blocks.imageGallery",
   imageGalleryImage: "pub.leaflet.blocks.imageGallery#image",
   signup: "pub.leaflet.blocks.signup",
@@ -155,6 +156,18 @@ export interface LeafletStandardSitePostBlock {
   uri?: string;
 }
 
+export interface LeafletStandardSitePublicationBlock {
+  $type?: string;
+  /** AT-URI of the referenced `site.standard.publication` record. */
+  uri?: string;
+  cid?: string;
+  /**
+   * Whether to style the embed with the publication's own theme. Defaults to
+   * true when omitted (matching Leaflet's editor default).
+   */
+  showPublicationTheme?: boolean;
+}
+
 /** A single image entry inside a `pub.leaflet.blocks.imageGallery` block. */
 export interface LeafletImageGalleryImage {
   $type?: string;
@@ -210,6 +223,10 @@ export type LeafletRenderableBlock =
   | { kind: "poll"; block: LeafletPollBlock }
   | { kind: "separator" }
   | { kind: "standardSitePost"; block: LeafletStandardSitePostBlock }
+  | {
+      kind: "standardSitePublication";
+      block: LeafletStandardSitePublicationBlock;
+    }
   | { kind: "imageGallery"; block: LeafletImageGalleryBlock }
   | { kind: "signup" }
   | {


### PR DESCRIPTION
## What

Adds support for the new Leaflet block type `pub.leaflet.blocks.standardSitePublication`, which embeds a Standard publication inside an article. Previously it rendered as **Unsupported block: pub.leaflet.blocks.standardSitePublication** (e.g. [this article](https://standard-reader.app/a/did:plc:btxrwcaeyodrap5mnjw2fvmz/3mquhjtnhcc2z)).

The embed renders the same information [Leaflet does](https://lab.leaflet.pub/3mquhjtnhcc2z): a card linking to the publication (`/p/$did/$rkey`) with its **icon, name, description, and author byline**.

## Theming

When the block opts into the publication's theme (the default — Leaflet's `showPublicationTheme` flag), the card is painted with that publication's `basicTheme`.

Rather than reuse the raw theme colors (which break down in the reader's *other* color scheme), the accent + background are run through the same Radix scale generator the magazine already uses (`buildMagazinePalette`), producing properly contrasted **light and dark** palettes with a11y fallbacks. The palette matching the active scheme is applied via card-scoped CSS variables, and the scheme is resolved the same way the Bluesky embed does (magazine context, falling back to `useTheme`). Setting `showPublicationTheme: false` falls back to the reader's own design-system tokens.

## Changes

Mirrors the existing `standardSitePost` block, wiring the new kind through each layer:

- **`src/lib/leaflet/types.ts`** — `LEAFLET_BLOCK` constant, `LeafletStandardSitePublicationBlock` interface, `LeafletRenderableBlock` union variant
- **`src/lib/leaflet/blocks.ts`** — parser branch + `plaintextLinesFromBlock` narration case
- **`src/components/reader/content/renderers/leaflet-block.tsx`** — render dispatch
- **`src/components/reader/content/renderers/leaflet-standard-site-publication.tsx`** (new) — the card view, with loading skeleton and a graceful "Publication not found" fallback

Data comes from the existing `publicationApi.getPublicationEmbedMetaQueryOptions`, which already returns the publication's name/description/icon/owner and theme colors.

## Verification

- `tsc --noEmit` — no new errors in the changed files
- `oxlint` / `oxfmt` — clean on the changed files

Not yet driven in the live app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)