### PR TITLE
Integrate pckt notes (blog.pckt.mini.post)

### DIFF
--- a/src/components/reader/article-view.tsx
+++ b/src/components/reader/article-view.tsx
@@ -323,7 +323,7 @@ const styles = stylex.create({
     marginLeft: "auto",
     marginRight: "auto",
     marginTop: spacing["0"],
-    maxWidth: "30ch",
+    maxWidth: "48ch",
   },
   magazineIntro: {
     marginBottom: spacing["12"],

--- a/src/components/reader/comments/comment-card.tsx
+++ b/src/components/reader/comments/comment-card.tsx
@@ -181,7 +181,32 @@ export function CommentCard({ comment }: { comment: DocumentComment }) {
       ? "on Margin"
       : comment.source === "semble"
         ? "on Semble"
-        : "on Bluesky";
+        : comment.source === "note"
+          ? "on pckt"
+          : "on Bluesky";
+  const hasLink = comment.postUrl.trim().length > 0;
+
+  const body = (
+    <>
+      {comment.kind === "quote" && comment.quote ? (
+        <blockquote {...stylex.props(commentStyles.blockquote)}>
+          {comment.quote}
+        </blockquote>
+      ) : null}
+
+      <CommentFacetedText
+        text={comment.commentary}
+        facets={comment.commentaryFacets}
+      />
+
+      <Flex align="center" gap="sm" style={commentStyles.footer}>
+        <MessageCircle size={16} aria-hidden />
+        <span>
+          {replyLabel} {replyContext}
+        </span>
+      </Flex>
+    </>
+  );
 
   return (
     <div {...stylex.props(commentStyles.card)}>
@@ -213,30 +238,18 @@ export function CommentCard({ comment }: { comment: DocumentComment }) {
         </time>
       </div>
 
-      <a
-        href={comment.postUrl}
-        target="_blank"
-        rel="noreferrer"
-        {...stylex.props(commentStyles.cardBodyLink)}
-      >
-        {comment.kind === "quote" && comment.quote ? (
-          <blockquote {...stylex.props(commentStyles.blockquote)}>
-            {comment.quote}
-          </blockquote>
-        ) : null}
-
-        <CommentFacetedText
-          text={comment.commentary}
-          facets={comment.commentaryFacets}
-        />
-
-        <Flex align="center" gap="sm" style={commentStyles.footer}>
-          <MessageCircle size={16} aria-hidden />
-          <span>
-            {replyLabel} {replyContext}
-          </span>
-        </Flex>
-      </a>
+      {hasLink ? (
+        <a
+          href={comment.postUrl}
+          target="_blank"
+          rel="noreferrer"
+          {...stylex.props(commentStyles.cardBodyLink)}
+        >
+          {body}
+        </a>
+      ) : (
+        <div {...stylex.props(commentStyles.cardBodyLink)}>{body}</div>
+      )}
     </div>
   );
 }

--- a/src/components/reader/content/article-content.tsx
+++ b/src/components/reader/content/article-content.tsx
@@ -12,9 +12,7 @@ import {
 } from "#/components/reader/quote-highlight-tracker";
 import type { ArticleDetail } from "#/integrations/tanstack-query/api-publication.functions";
 import { parseArticleBlocks } from "#/lib/document/blocks";
-import { LEAFLET_DOCUMENT_FORMAT } from "#/lib/document/content-formats";
 import { resolveArticleHeroImage } from "#/lib/document/lead-image";
-import { LEAFLET_CONTENT } from "#/lib/leaflet/types";
 import { useReadingTypography } from "#/lib/use-reading-typography";
 
 import {
@@ -146,25 +144,18 @@ export function ArticleContent({
       content: article.contentJson,
       hasHero,
       skipFirstBlock,
+      leadDescription: article.description,
     };
-    // Only Leaflet content carries inline publication/actor facets; other
-    // formats skip the resolver (and its lazy fetch) entirely.
-    const isLeaflet =
-      contentType === LEAFLET_CONTENT ||
-      contentType === LEAFLET_DOCUMENT_FORMAT;
-    // Leaflet carries inline publication/actor *facets* (resolved by
-    // InlineMentionProvider). Every content type additionally has plain links,
-    // which ContentLinkProvider resolves to pub/article/user chips — so
-    // mentions work across formats, not just Leaflet.
+    // Inline publication/actor facets (`#didMention`, publication/document
+    // refs) can appear in any content format, not just Leaflet. The provider's
+    // resolver query only fires when the content actually carries mention refs
+    // (`hasInlineMentionRefs`), so mention-free documents pay nothing. Plain
+    // links are additionally upgraded by ContentLinkProvider across all formats.
     return (
       <ContentLinkProvider>
-        {isLeaflet ? (
-          <InlineMentionProvider content={article.contentJson}>
-            <Renderer {...props} />
-          </InlineMentionProvider>
-        ) : (
+        <InlineMentionProvider content={article.contentJson}>
           <Renderer {...props} />
-        )}
+        </InlineMentionProvider>
       </ContentLinkProvider>
     );
   }

--- a/src/components/reader/content/extract-text.ts
+++ b/src/components/reader/content/extract-text.ts
@@ -21,6 +21,7 @@ import { markpubNarrationText } from "#/lib/markpub/markdown";
 import { MARKPUB_MARKDOWN } from "#/lib/markpub/types";
 import { offprintPlaintext } from "#/lib/offprint/plaintext";
 import { OFFPRINT_CONTENT } from "#/lib/offprint/types";
+import { pcktLeadingHeadingMatchesDescription } from "#/lib/pckt/blocks";
 import { pcktPlaintext } from "#/lib/pckt/plaintext";
 import { PCKT_CONTENT } from "#/lib/pckt/types";
 
@@ -67,7 +68,16 @@ export function articleDescriptionIsBodyExcerpt(article: {
   description?: ArticleDetail["description"];
   collection?: ArticleDetail["collection"] | null;
 }): boolean {
-  if (resolveContentType(article) === PCKT_CONTENT) return true;
+  // pckt descriptions are body excerpts by default, so the dek is normally
+  // suppressed — EXCEPT when the description is the leading heading, which the
+  // body renderer drops. In that case the description is unique to the header,
+  // so show it as the dek.
+  if (resolveContentType(article) === PCKT_CONTENT) {
+    return !pcktLeadingHeadingMatchesDescription(
+      article.contentJson,
+      article.description,
+    );
+  }
 
   const description = article.description?.trim();
   if (!description || !article.collection) return false;

--- a/src/components/reader/content/renderers/pckt-block.tsx
+++ b/src/components/reader/content/renderers/pckt-block.tsx
@@ -17,6 +17,7 @@ import {
   PcktOrderedListBlockView,
   PcktTaskListBlockView,
 } from "./pckt-list";
+import { PcktNoteEmbedView } from "./pckt-note-embed";
 import { PcktTableBlockView } from "./pckt-table";
 import { PcktWebsiteBlockView } from "./pckt-website";
 import { BlockquoteBlockView } from "./shared/blockquote-block";
@@ -122,6 +123,9 @@ export function PcktBlockView({
       return (
         <PcktGalleryBlockView block={block.block} blobContext={blobContext} />
       );
+    }
+    case "noteEmbed": {
+      return <PcktNoteEmbedView noteRef={block.block.noteRef} />;
     }
     case "unknown": {
       return <UnknownBlockView blockType={block.blockType} />;

--- a/src/components/reader/content/renderers/pckt-content.tsx
+++ b/src/components/reader/content/renderers/pckt-content.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { pcktBlocks } from "#/lib/pckt/blocks";
+import {
+  pcktBlocks,
+  pcktLeadingHeadingMatchesDescription,
+} from "#/lib/pckt/blocks";
 import type { PcktContent } from "#/lib/pckt/types";
 
 import type { ContentRendererProps } from "../types";
@@ -14,8 +17,17 @@ export function PcktContentRenderer({
   content,
   hasHero,
   skipFirstBlock,
+  leadDescription,
 }: ContentRendererProps) {
-  const blocks = pcktBlocks(content as PcktContent);
+  const parsed = pcktBlocks(content as PcktContent);
+
+  // Drop a leading heading that merely repeats the document's header
+  // description — the reader shows that text as the header dek instead (see
+  // `pcktLeadingHeadingMatchesDescription`), so rendering it here would duplicate it.
+  const blocks = pcktLeadingHeadingMatchesDescription(content, leadDescription)
+    ? parsed.slice(1)
+    : parsed;
+
   if (blocks.length === 0) return null;
 
   const firstTextIndex = blocks.findIndex((block, index) => {

--- a/src/components/reader/content/renderers/pckt-note-embed.tsx
+++ b/src/components/reader/content/renderers/pckt-note-embed.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { useQuery } from "@tanstack/react-query";
+
+import { initials } from "#/components/reader/format";
+import { formatRelativeTime } from "#/components/reader/format";
+import { PublicationAvatar } from "#/components/reader/primitives";
+import { Avatar } from "#/design-system/avatar";
+import { uiColor } from "#/design-system/theme/color.stylex";
+import { radius } from "#/design-system/theme/radius.stylex";
+import { gap } from "#/design-system/theme/semantic-spacing.stylex";
+import { spacing } from "#/design-system/theme/spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+} from "#/design-system/theme/typography.stylex";
+import { authorApi } from "#/integrations/tanstack-query/api-author.functions";
+import { publicationApi } from "#/integrations/tanstack-query/api-publication.functions";
+import { fetchMiniPost, pcktNoteUrl } from "#/lib/pckt/mini";
+
+// An embedded pckt note, delineated from the article prose by a bordered card
+// (mirroring the sibling Bluesky post embed). The body is set in the serif
+// reading face so the note stays in the article's voice; identity + date frame
+// it as metadata. The whole card links to the note on pckt.
+const styles = stylex.create({
+  card: {
+    display: "flex",
+    flexDirection: "column",
+    borderColor: {
+      default: uiColor.border1,
+      ":hover": uiColor.border2,
+    },
+    borderRadius: radius.md,
+    borderStyle: "solid",
+    borderWidth: 1,
+    paddingTop: spacing["4"],
+    paddingInline: spacing["4"],
+    paddingBottom: spacing["3"],
+    marginBlock: spacing["6"],
+    textDecoration: "none",
+    color: "inherit",
+    transitionProperty: "border-color",
+    transitionDuration: "150ms",
+  },
+  header: {
+    display: "flex",
+    alignItems: "center",
+    gap: gap.lg,
+    minWidth: 0,
+  },
+  avatarRound: {
+    borderRadius: radius.full,
+  },
+  meta: {
+    display: "flex",
+    flexDirection: "column",
+    minWidth: 0,
+    flexGrow: 1,
+    rowGap: spacing["2"],
+    lineHeight: lineHeight.xs,
+  },
+  name: {
+    fontWeight: fontWeight.semibold,
+    fontSize: fontSize.base,
+    color: uiColor.text2,
+  },
+  handle: {
+    color: uiColor.text1,
+    fontSize: fontSize.base,
+  },
+  body: {
+    color: uiColor.text2,
+    fontFamily: fontFamily.serif,
+    fontSize: fontSize.lg,
+    lineHeight: lineHeight.sm,
+    marginTop: spacing["4"],
+    whiteSpace: "pre-wrap",
+    wordBreak: "break-word",
+  },
+  time: {
+    color: uiColor.text1,
+    fontSize: fontSize.sm,
+    marginTop: spacing["2"],
+  },
+});
+
+/** Renders `blog.pckt.block.noteEmbed` — a pckt note embedded inline in a post. */
+export function PcktNoteEmbedView({
+  noteRef,
+}: {
+  noteRef?: { uri?: string; cid?: string };
+}) {
+  const uri = noteRef?.uri?.trim();
+
+  const { data: note } = useQuery({
+    queryKey: ["pckt-mini-post", uri] as const,
+    queryFn: async () => (uri ? fetchMiniPost(uri) : null),
+    enabled: Boolean(uri),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const { data: summary } = useQuery({
+    ...authorApi.getAuthorSummaryQueryOptions(note?.did ?? ""),
+    enabled: Boolean(note?.did),
+  });
+  const author = summary?.profile;
+
+  // Notes published under a blog (`publication` set) show the publication —
+  // its icon, name, and domain — instead of the author.
+  const { data: pubHeader } = useQuery({
+    ...publicationApi.getPublicationHeaderQueryOptions(
+      note?.publicationUri ?? "",
+    ),
+    enabled: Boolean(note?.publicationUri),
+  });
+
+  if (!uri || !note) return null;
+
+  const asPublication = pubHeader ?? null;
+  const resolvedHref = pcktNoteUrl(note.did, note.rkey);
+
+  const name = asPublication
+    ? asPublication.publication.name
+    : author?.displayName?.trim() ||
+      (author?.handle ? `@${author.handle}` : note.did.slice(0, 16));
+  const handle = asPublication
+    ? asPublication.owner.handle
+      ? `@${asPublication.owner.handle}`
+      : null
+    : author?.handle
+      ? `@${author.handle}`
+      : null;
+
+  const avatar = asPublication ? (
+    <PublicationAvatar pub={asPublication.publication} size="lg" />
+  ) : (
+    <Avatar
+      size="lg"
+      src={author?.avatarUrl ?? undefined}
+      fallback={initials(name)}
+      alt={name}
+      style={styles.avatarRound}
+    />
+  );
+
+  const inner = (
+    <>
+      <div {...stylex.props(styles.header)}>
+        {avatar}
+        <div {...stylex.props(styles.meta)}>
+          <span {...stylex.props(styles.name)}>{name}</span>
+          {handle ? <span {...stylex.props(styles.handle)}>{handle}</span> : null}
+        </div>
+      </div>
+      <div {...stylex.props(styles.body)}>{note.text}</div>
+      <time dateTime={note.createdAt} {...stylex.props(styles.time)}>
+        {formatRelativeTime(note.createdAt)}
+      </time>
+    </>
+  );
+
+  return resolvedHref ? (
+    <a
+      href={resolvedHref}
+      target="_blank"
+      rel="noreferrer"
+      {...stylex.props(styles.card)}
+    >
+      {inner}
+    </a>
+  ) : (
+    <div {...stylex.props(styles.card)}>{inner}</div>
+  );
+}

--- a/src/components/reader/content/renderers/pckt-note-embed.tsx
+++ b/src/components/reader/content/renderers/pckt-note-embed.tsx
@@ -4,10 +4,10 @@ import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 
-import { initials } from "#/components/reader/format";
-import { formatRelativeTime } from "#/components/reader/format";
+import { formatRelativeTime, initials } from "#/components/reader/format";
 import { PublicationAvatar } from "#/components/reader/primitives";
 import { Avatar } from "#/design-system/avatar";
+import { animationDuration } from "#/design-system/theme/animations.stylex";
 import { uiColor } from "#/design-system/theme/color.stylex";
 import { radius } from "#/design-system/theme/radius.stylex";
 import { gap } from "#/design-system/theme/semantic-spacing.stylex";
@@ -43,7 +43,7 @@ const styles = stylex.create({
     paddingBottom: spacing["3"],
     marginBlock: spacing["6"],
     transitionProperty: "border-color",
-    transitionDuration: "150ms",
+    transitionDuration: animationDuration.default,
   },
   // Stretched link: a transparent overlay that makes the whole card open the
   // note on pckt, while the quoted document (layered above it) keeps its own
@@ -113,7 +113,7 @@ const styles = stylex.create({
     textDecoration: "none",
     color: "inherit",
     transitionProperty: "background-color",
-    transitionDuration: "150ms",
+    transitionDuration: animationDuration.default,
   },
   quoteThumb: {
     width: spacing["12"],
@@ -277,7 +277,9 @@ export function PcktNoteEmbedView({
         {avatar}
         <div {...stylex.props(styles.meta)}>
           <span {...stylex.props(styles.name)}>{name}</span>
-          {handle ? <span {...stylex.props(styles.handle)}>{handle}</span> : null}
+          {handle ? (
+            <span {...stylex.props(styles.handle)}>{handle}</span>
+          ) : null}
         </div>
       </div>
       <div {...stylex.props(styles.body)}>{note.text}</div>

--- a/src/components/reader/content/renderers/pckt-note-embed.tsx
+++ b/src/components/reader/content/renderers/pckt-note-embed.tsx
@@ -2,6 +2,7 @@
 
 import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
 
 import { initials } from "#/components/reader/format";
 import { formatRelativeTime } from "#/components/reader/format";
@@ -27,6 +28,7 @@ import { fetchMiniPost, pcktNoteUrl } from "#/lib/pckt/mini";
 // it as metadata. The whole card links to the note on pckt.
 const styles = stylex.create({
   card: {
+    position: "relative",
     display: "flex",
     flexDirection: "column",
     borderColor: {
@@ -40,10 +42,17 @@ const styles = stylex.create({
     paddingInline: spacing["4"],
     paddingBottom: spacing["3"],
     marginBlock: spacing["6"],
-    textDecoration: "none",
-    color: "inherit",
     transitionProperty: "border-color",
     transitionDuration: "150ms",
+  },
+  // Stretched link: a transparent overlay that makes the whole card open the
+  // note on pckt, while the quoted document (layered above it) keeps its own
+  // in-app link — so neither anchor nests inside the other.
+  stretchedLink: {
+    position: "absolute",
+    inset: 0,
+    zIndex: 0,
+    borderRadius: radius.md,
   },
   header: {
     display: "flex",
@@ -76,7 +85,7 @@ const styles = stylex.create({
     fontFamily: fontFamily.serif,
     fontSize: fontSize.lg,
     lineHeight: lineHeight.sm,
-    marginTop: spacing["4"],
+    marginTop: spacing["3"],
     whiteSpace: "pre-wrap",
     wordBreak: "break-word",
   },
@@ -85,7 +94,116 @@ const styles = stylex.create({
     fontSize: fontSize.sm,
     marginTop: spacing["2"],
   },
+  // A quoted article, shown as a compact reference inside the note. A subtle
+  // fill (not a nested bordered card) groups it; it isn't a separate link — the
+  // whole note card opens on pckt, where the quote is live.
+  quote: {
+    position: "relative",
+    zIndex: 1,
+    display: "flex",
+    alignItems: "center",
+    gap: gap.lg,
+    marginTop: spacing["4"],
+    padding: spacing["2"],
+    borderRadius: radius.sm,
+    backgroundColor: {
+      default: uiColor.component1,
+      ":hover": uiColor.component2,
+    },
+    textDecoration: "none",
+    color: "inherit",
+    transitionProperty: "background-color",
+    transitionDuration: "150ms",
+  },
+  quoteThumb: {
+    width: spacing["12"],
+    height: spacing["12"],
+    borderRadius: radius.xs,
+    objectFit: "cover",
+    flexShrink: 0,
+  },
+  quoteCol: {
+    display: "flex",
+    flexDirection: "column",
+    rowGap: spacing["1"],
+    minWidth: 0,
+  },
+  quoteTitle: {
+    fontFamily: fontFamily.serif,
+    fontSize: fontSize.base,
+    fontWeight: fontWeight.semibold,
+    color: uiColor.text2,
+    lineHeight: lineHeight.sm,
+    display: "-webkit-box",
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: "vertical",
+    overflow: "hidden",
+    // -webkit-box clamps to a fixed line count; a hair of bottom padding keeps
+    // serif descenders on the last line from being trimmed by overflow:hidden.
+    paddingBottom: "0.1em",
+  },
+  quoteByline: {
+    fontSize: fontSize.sm,
+    color: uiColor.text1,
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+  },
 });
+
+const DOCUMENT_COLLECTIONS = new Set([
+  "site.standard.document",
+  "blog.pckt.document",
+  "pub.leaflet.document",
+]);
+
+/** A document quoted by a note (`embed #record`), shown as a compact reference
+ * that links to the article in-app. Layered above the card's stretched link so
+ * it stays independently clickable. Non-document quotes are omitted. */
+function PcktNoteQuoteEmbed({ uri }: { uri: string }) {
+  const parts = uri.split("/");
+  const collection = parts[3];
+  const did = parts[2];
+  const rkey = parts[4];
+  const isDocument = collection ? DOCUMENT_COLLECTIONS.has(collection) : false;
+
+  const { data: article } = useQuery({
+    ...publicationApi.getArticleCardQueryOptions(uri),
+    enabled: isDocument,
+  });
+
+  if (!isDocument || !article || !did || !rkey) return null;
+
+  const byline =
+    article.publicationName ??
+    article.authorDisplayName ??
+    (article.authorHandle ? `@${article.authorHandle}` : null);
+
+  return (
+    <Link
+      to="/a/$did/$rkey"
+      params={{ did, rkey }}
+      {...stylex.props(styles.quote)}
+    >
+      {article.coverImageUrl ? (
+        <img
+          src={article.coverImageUrl}
+          alt=""
+          loading="lazy"
+          decoding="async"
+          referrerPolicy="no-referrer"
+          {...stylex.props(styles.quoteThumb)}
+        />
+      ) : null}
+      <div {...stylex.props(styles.quoteCol)}>
+        <span {...stylex.props(styles.quoteTitle)}>{article.title}</span>
+        {byline ? (
+          <span {...stylex.props(styles.quoteByline)}>{byline}</span>
+        ) : null}
+      </div>
+    </Link>
+  );
+}
 
 /** Renders `blog.pckt.block.noteEmbed` — a pckt note embedded inline in a post. */
 export function PcktNoteEmbedView({
@@ -146,8 +264,15 @@ export function PcktNoteEmbedView({
     />
   );
 
-  const inner = (
-    <>
+  return (
+    <div {...stylex.props(styles.card)}>
+      <a
+        href={resolvedHref}
+        target="_blank"
+        rel="noreferrer"
+        aria-label={`Open note by ${name} on pckt`}
+        {...stylex.props(styles.stretchedLink)}
+      />
       <div {...stylex.props(styles.header)}>
         {avatar}
         <div {...stylex.props(styles.meta)}>
@@ -156,22 +281,12 @@ export function PcktNoteEmbedView({
         </div>
       </div>
       <div {...stylex.props(styles.body)}>{note.text}</div>
+      {note.quotedRecordUri ? (
+        <PcktNoteQuoteEmbed uri={note.quotedRecordUri} />
+      ) : null}
       <time dateTime={note.createdAt} {...stylex.props(styles.time)}>
         {formatRelativeTime(note.createdAt)}
       </time>
-    </>
-  );
-
-  return resolvedHref ? (
-    <a
-      href={resolvedHref}
-      target="_blank"
-      rel="noreferrer"
-      {...stylex.props(styles.card)}
-    >
-      {inner}
-    </a>
-  ) : (
-    <div {...stylex.props(styles.card)}>{inner}</div>
+    </div>
   );
 }

--- a/src/components/reader/content/renderers/shared/blockquote-block.tsx
+++ b/src/components/reader/content/renderers/shared/blockquote-block.tsx
@@ -8,6 +8,14 @@ import type { LeafletFacet } from "#/lib/leaflet/types";
 import { articleBodyStyles } from "../../body-styles";
 import { HighlightedFacetedPlaintext } from "./faceted-text";
 
+const styles = stylex.create({
+  // The blockquote's own margin handles spacing to the next block, so the final
+  // inner paragraph must not add its own bottom margin on top of it.
+  lastParagraph: {
+    marginBottom: 0,
+  },
+});
+
 export interface BlockquoteParagraph {
   plaintext: string;
   facets?: Array<LeafletFacet> | Array<unknown>;
@@ -39,6 +47,7 @@ export function BlockquoteBlockView({
             {...stylex.props(
               articleBodyStyles.paragraph,
               embedded && articleBodyStyles.pageEmbedBlockInner,
+              index === items.length - 1 && styles.lastParagraph,
             )}
           >
             <HighlightedFacetedPlaintext

--- a/src/components/reader/content/types.ts
+++ b/src/components/reader/content/types.ts
@@ -11,6 +11,10 @@ export interface ContentRendererProps {
   hasHero: boolean;
   /** When true, omit the first image block (or leading markdown/HTML image). */
   skipFirstBlock?: boolean;
+  /** The document's header description. When the body's first block is a heading
+   * whose text exactly matches this, the renderer drops that heading (it would
+   * duplicate the header). */
+  leadDescription?: string | null;
   blobContext?: ContentBlobContext;
   codeHighlights?: CodeHighlightsByScheme;
 }

--- a/src/components/reader/publication-latest-note.tsx
+++ b/src/components/reader/publication-latest-note.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { useQuery } from "@tanstack/react-query";
+
+import { uiColor } from "#/design-system/theme/color.stylex";
+import { gap } from "#/design-system/theme/semantic-spacing.stylex";
+import { spacing } from "#/design-system/theme/spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+} from "#/design-system/theme/typography.stylex";
+import { notesApi } from "#/integrations/tanstack-query/api-notes.functions";
+
+import { formatRelativeTime } from "./format";
+
+// A quiet editorial block, not a card — it sits above the writing feed and is
+// set off by the same 1px bottom rule the article rows use, so it recedes into
+// the page's rhythm rather than standing out as boxed UI chrome.
+const styles = stylex.create({
+  block: {
+    display: "block",
+    textDecoration: "none",
+    color: "inherit",
+    borderBottomColor: uiColor.border1,
+    borderBottomStyle: "solid",
+    borderBottomWidth: 1,
+    paddingBottom: spacing["7"],
+  },
+  labelRow: {
+    display: "flex",
+    alignItems: "baseline",
+    columnGap: gap.md,
+    marginBottom: spacing["3"],
+  },
+  label: {
+    color: uiColor.text2,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.sm,
+    fontWeight: fontWeight.medium,
+  },
+  time: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.sm,
+  },
+  text: {
+    color: uiColor.text2,
+    fontFamily: fontFamily.serif,
+    fontSize: fontSize.xl,
+    lineHeight: lineHeight.sm,
+    marginTop: spacing["0"],
+    marginBottom: spacing["0"],
+    maxWidth: "60ch",
+    textDecoration: {
+      default: "none",
+      ":hover": "underline",
+    },
+    textDecorationThickness: "1px",
+    textUnderlineOffset: "3px",
+    // eslint-disable-next-line @stylexjs/valid-styles
+    textWrap: "pretty",
+  },
+});
+
+/**
+ * The publication's most recent note, shown atop its profile as a quiet
+ * editorial lead-in. Links out to the note on pckt. Renders nothing when the
+ * publication has no note.
+ */
+export function PublicationLatestNote({
+  publicationUri,
+}: {
+  publicationUri: string;
+}) {
+  const { data: note } = useQuery(
+    notesApi.getPublicationLatestNoteQueryOptions(publicationUri),
+  );
+
+  if (!note) return null;
+
+  return (
+    <a
+      href={note.url}
+      target="_blank"
+      rel="noreferrer"
+      {...stylex.props(styles.block)}
+    >
+      <div {...stylex.props(styles.labelRow)}>
+        <span {...stylex.props(styles.label)}>Latest note</span>
+        <time dateTime={note.createdAt} {...stylex.props(styles.time)}>
+          {formatRelativeTime(note.createdAt)}
+        </time>
+      </div>
+      <p {...stylex.props(styles.text)}>{note.text}</p>
+    </a>
+  );
+}

--- a/src/integrations/tanstack-query/api-notes.functions.ts
+++ b/src/integrations/tanstack-query/api-notes.functions.ts
@@ -1,0 +1,37 @@
+import { queryOptions } from "@tanstack/react-query";
+import { createServerFn } from "@tanstack/react-start";
+import { z } from "zod";
+
+import { fetchLatestPublicationNote } from "#/server/pckt/notes";
+import { observe } from "#/server/observability/log";
+
+export type { PublicationLatestNote } from "#/server/pckt/notes";
+
+const publicationNoteInput = z.object({
+  publicationUri: z.string().min(1),
+});
+
+const getPublicationLatestNote = createServerFn({ method: "GET" })
+  .validator(publicationNoteInput)
+  .handler(
+    observe("notes.getPublicationLatestNote", async ({ data }, span) => {
+      span.set("publicationUri", data.publicationUri);
+      const note = await fetchLatestPublicationNote(data.publicationUri);
+      span.set("found", note != null);
+      return note;
+    }),
+  );
+
+function getPublicationLatestNoteQueryOptions(publicationUri: string) {
+  return queryOptions({
+    queryKey: ["pckt-latest-note", publicationUri] as const,
+    queryFn: async () =>
+      getPublicationLatestNote({ data: { publicationUri } }),
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export const notesApi = {
+  getPublicationLatestNote,
+  getPublicationLatestNoteQueryOptions,
+};

--- a/src/integrations/tanstack-query/api-notes.functions.ts
+++ b/src/integrations/tanstack-query/api-notes.functions.ts
@@ -2,8 +2,8 @@ import { queryOptions } from "@tanstack/react-query";
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 
-import { fetchLatestPublicationNote } from "#/server/pckt/notes";
 import { observe } from "#/server/observability/log";
+import { fetchLatestPublicationNote } from "#/server/pckt/notes";
 
 export type { PublicationLatestNote } from "#/server/pckt/notes";
 
@@ -25,8 +25,7 @@ const getPublicationLatestNote = createServerFn({ method: "GET" })
 function getPublicationLatestNoteQueryOptions(publicationUri: string) {
   return queryOptions({
     queryKey: ["pckt-latest-note", publicationUri] as const,
-    queryFn: async () =>
-      getPublicationLatestNote({ data: { publicationUri } }),
+    queryFn: async () => getPublicationLatestNote({ data: { publicationUri } }),
     staleTime: 5 * 60 * 1000,
   });
 }

--- a/src/lib/leaflet/publication-mentions.ts
+++ b/src/lib/leaflet/publication-mentions.ts
@@ -19,11 +19,18 @@ export interface ResolvedPublicationMention {
 /** Lookup keyed by publication AT-URI and by `url:<normalized-homepage>`. */
 export type PublicationMentionMap = Record<string, ResolvedPublicationMention>;
 
-const FACET_PREFIX = "pub.leaflet.richtext.facet#";
-
+/**
+ * The `#feature` suffix of any AT-Proto rich-text facet `$type`, regardless of
+ * lexicon namespace — `pub.leaflet.richtext.facet#didMention`,
+ * `blog.pckt.richtext.facet#didMention`, and `app.bsky.richtext.facet#mention`
+ * all yield their trailing kind. Namespace-agnostic so inline mentions resolve
+ * across every content format, not just Leaflet.
+ */
 function facetKind($type: unknown): string | null {
-  if (typeof $type !== "string" || !$type.startsWith(FACET_PREFIX)) return null;
-  return $type.slice(FACET_PREFIX.length);
+  if (typeof $type !== "string") return null;
+  const hash = $type.lastIndexOf("#");
+  if (hash === -1) return null;
+  return $type.slice(hash + 1);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/lib/pckt/blocks.ts
+++ b/src/lib/pckt/blocks.ts
@@ -13,6 +13,7 @@ import type {
   PcktIframeBlock,
   PcktImageBlock,
   PcktListBlock,
+  PcktNoteEmbedBlock,
   PcktRenderableBlock,
   PcktTableBlock,
   PcktTaskListBlock,
@@ -224,6 +225,13 @@ function asRenderableBlock(value: unknown): PcktRenderableBlock | null {
     return { kind: "gallery", block: value as unknown as PcktGalleryBlock };
   }
 
+  if (value.$type === PCKT_BLOCK.noteEmbed) {
+    return {
+      kind: "noteEmbed",
+      block: value as unknown as PcktNoteEmbedBlock,
+    };
+  }
+
   if (value.$type === PCKT_BLOCK.horizontalRule) {
     return { kind: "horizontalRule" };
   }
@@ -231,6 +239,24 @@ function asRenderableBlock(value: unknown): PcktRenderableBlock | null {
   const blockType =
     typeof value.$type === "string" ? value.$type : "unknown block";
   return { kind: "unknown", blockType };
+}
+
+/**
+ * True when the content's first block is a heading whose text exactly matches
+ * the document description. pckt authors often open a post with the description
+ * as an H1; in that case the reader drops the heading from the body (it would
+ * duplicate the header) and instead shows the description as the header dek.
+ * Both the body renderer and the dek-visibility check use this predicate so
+ * they stay in agreement.
+ */
+export function pcktLeadingHeadingMatchesDescription(
+  content: unknown,
+  description: string | null | undefined,
+): boolean {
+  const desc = description?.trim();
+  if (!desc) return false;
+  const first = pcktBlocks(content)[0];
+  return first?.kind === "heading" && first.block.plaintext.trim() === desc;
 }
 
 /** Every renderable block in document order. */
@@ -344,6 +370,7 @@ export function plaintextLinesFromBlock(
     case "iframe":
     case "blueskyEmbed":
     case "gallery":
+    case "noteEmbed":
     case "unknown": {
       return [];
     }

--- a/src/lib/pckt/mini.ts
+++ b/src/lib/pckt/mini.ts
@@ -1,0 +1,145 @@
+/**
+ * pckt "notes" — the `blog.pckt.mini.post` lexicon (a near-clone of
+ * `app.bsky.feed.post`): plaintext `text` + AT-Proto byte facets + a bsky-style
+ * embed union + reply/subject/publication references.
+ *
+ * This module is the ONE place that knows the note record shape. If pckt
+ * revises the lexicon, update {@link normalizeMiniPost} and the path constants
+ * here — nothing downstream inspects raw records.
+ */
+
+import type { JsonValue } from "#/integrations/tanstack-query/api-shapes";
+import { fetchRepoRecordWithFallback } from "#/server/atproto/fetch-record";
+import { parseAtUri } from "#/server/atproto/uri";
+
+/** The notes collection NSID. */
+export const MINI_POST_COLLECTION = "blog.pckt.mini.post";
+
+/** The pckt web permalink for a note: `https://pckt.blog/n/<did>/<rkey>`. */
+export function pcktNoteUrl(did: string, rkey: string): string {
+  return `https://pckt.blog/n/${did}/${rkey}`;
+}
+/** Re-blog records ({subject: strongRef}). */
+export const MINI_REPOST_COLLECTION = "blog.pckt.mini.repost";
+
+/**
+ * Constellation JSON paths on `blog.pckt.mini.post`. A note references a longer
+ * post either by replying to it (`.subject`) or quoting it (`.embed.record`).
+ */
+export const MINI_POST_SUBJECT_PATH = ".subject";
+export const MINI_POST_QUOTE_PATHS = [
+  ".embed.record.uri",
+  ".embed.record.record.uri",
+] as const;
+export const MINI_POST_PUBLICATION_PATH = ".publication";
+export const MINI_POST_REPLY_PARENT_PATH = ".reply.parent.uri";
+export const MINI_POST_REPLY_ROOT_PATH = ".reply.root.uri";
+
+export interface MiniPost {
+  uri: string;
+  cid: string | null;
+  did: string;
+  rkey: string;
+  text: string;
+  facets: Array<JsonValue> | null;
+  langs: Array<string>;
+  tags: Array<string>;
+  /** Raw embed union (`#images` / `#external` / `#record` / `#recordWithMedia`). */
+  embed: JsonValue | null;
+  /** AT-URI of the quoted record when the embed is a `#record`/`#recordWithMedia`. */
+  quotedRecordUri: string | null;
+  replyRootUri: string | null;
+  replyParentUri: string | null;
+  /** AT-URI of the `site.standard.document` this note is about, when set. */
+  subjectUri: string | null;
+  /** AT-URI of the `site.standard.publication` this note is published under. */
+  publicationUri: string | null;
+  createdAt: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function stringArray(value: unknown): Array<string> {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+/** Read the quoted record AT-URI from a `#record` / `#recordWithMedia` embed. */
+function quotedRecordUri(embed: unknown): string | null {
+  if (!isRecord(embed)) return null;
+  // #record: { record: strongRef }; #recordWithMedia: { record: { record: strongRef } }
+  const record = embed.record;
+  if (isRecord(record)) {
+    if (typeof record.uri === "string") return record.uri;
+    const inner = record.record;
+    if (isRecord(inner) && typeof inner.uri === "string") return inner.uri;
+  }
+  return null;
+}
+
+/**
+ * Normalize a raw `blog.pckt.mini.post` record value into a {@link MiniPost}.
+ * Returns null when required fields (`text`, `createdAt`) are missing.
+ */
+export function normalizeMiniPost(
+  uri: string,
+  did: string,
+  rkey: string,
+  cid: string | null,
+  value: unknown,
+): MiniPost | null {
+  if (!isRecord(value)) return null;
+  const text = typeof value.text === "string" ? value.text : null;
+  const createdAt = optionalString(value.createdAt);
+  if (text == null || !createdAt) return null;
+
+  const reply = isRecord(value.reply) ? value.reply : null;
+  const replyRoot = isRecord(reply?.root) ? reply.root : null;
+  const replyParent = isRecord(reply?.parent) ? reply.parent : null;
+
+  return {
+    uri,
+    cid,
+    did,
+    rkey,
+    text,
+    facets: Array.isArray(value.facets)
+      ? (value.facets as Array<JsonValue>)
+      : null,
+    langs: stringArray(value.langs),
+    tags: stringArray(value.tags),
+    embed: (value.embed as JsonValue) ?? null,
+    quotedRecordUri: quotedRecordUri(value.embed),
+    replyRootUri: optionalString(replyRoot?.uri),
+    replyParentUri: optionalString(replyParent?.uri),
+    subjectUri: optionalString(value.subject),
+    publicationUri: optionalString(value.publication),
+    createdAt,
+  };
+}
+
+/**
+ * Fetch and normalize a single `blog.pckt.mini.post` by AT-URI. Routes through
+ * Slingshot (no PDS fallback) so it is safe to call from the browser (e.g. the
+ * `noteEmbed` block renderer), mirroring {@link fetchPcktGallery}.
+ */
+export async function fetchMiniPost(uri: string): Promise<MiniPost | null> {
+  const parsed = parseAtUri(uri);
+  if (!parsed || parsed.collection !== MINI_POST_COLLECTION) return null;
+
+  const result = await fetchRepoRecordWithFallback(uri);
+  if (!result?.value) return null;
+  return normalizeMiniPost(
+    uri,
+    parsed.did,
+    parsed.rkey,
+    result.cid ?? null,
+    result.value,
+  );
+}

--- a/src/lib/pckt/structured.ts
+++ b/src/lib/pckt/structured.ts
@@ -187,6 +187,9 @@ function mapPcktBlock(block: PcktRenderableBlock): StructuredRenderableBlock {
         ref: block.block.ref ?? "",
       };
     }
+    case "noteEmbed": {
+      return { kind: "unknown", blockType: PCKT_BLOCK.noteEmbed };
+    }
     case "unknown": {
       return { kind: "unknown", blockType: block.blockType };
     }

--- a/src/lib/pckt/types.ts
+++ b/src/lib/pckt/types.ts
@@ -32,6 +32,7 @@ export const PCKT_BLOCK = {
   tableCell: "blog.pckt.block.tableCell",
   website: "blog.pckt.block.website",
   hardBreak: "blog.pckt.block.hardBreak",
+  noteEmbed: "blog.pckt.block.noteEmbed",
 } as const;
 
 export const PCKT_CONTENT = "blog.pckt.content";
@@ -160,6 +161,12 @@ export interface PcktGalleryBlock {
   ref?: string;
 }
 
+export interface PcktNoteEmbedBlock {
+  $type?: string;
+  /** strongRef to the embedded `blog.pckt.mini.post`. */
+  noteRef?: { uri?: string; cid?: string };
+}
+
 export type PcktRenderableBlock =
   | { kind: "text"; block: PcktTextBlock }
   | { kind: "heading"; block: PcktHeadingBlock }
@@ -175,6 +182,7 @@ export type PcktRenderableBlock =
   | { kind: "table"; block: PcktTableBlock }
   | { kind: "website"; block: PcktWebsiteBlock }
   | { kind: "gallery"; block: PcktGalleryBlock }
+  | { kind: "noteEmbed"; block: PcktNoteEmbedBlock }
   | { kind: "unknown"; blockType: string };
 
 export interface PcktContent {

--- a/src/routes/_layout.p.$did.$rkey.tsx
+++ b/src/routes/_layout.p.$did.$rkey.tsx
@@ -10,6 +10,7 @@ import { CheckCheck, ExternalLink } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { authorApi } from "#/integrations/tanstack-query/api-author.functions";
+import { notesApi } from "#/integrations/tanstack-query/api-notes.functions";
 import { publicationApi } from "#/integrations/tanstack-query/api-publication.functions";
 import type {
   PublicationEmbedMeta,
@@ -43,6 +44,7 @@ import {
   ReaderContent,
   Topic,
 } from "../components/reader/primitives";
+import { PublicationLatestNote } from "../components/reader/publication-latest-note";
 import { PublicationSocialProofLine } from "../components/reader/publication-social-proof";
 import {
   applyMarkReadManyOptimisticUpdate,
@@ -101,6 +103,8 @@ export const Route = createFileRoute("/_layout/p/$did/$rkey")({
       });
     const socialProofOptions =
       publicationApi.getPublicationSocialProofQueryOptions(uri);
+    const latestNoteOptions =
+      notesApi.getPublicationLatestNoteQueryOptions(uri);
 
     // Non-blocking: ShareMenu and FollowButton read these from React Query.
     void context.queryClient.prefetchQuery(
@@ -115,6 +119,7 @@ export const Route = createFileRoute("/_layout/p/$did/$rkey")({
     if (preload) {
       void context.queryClient.prefetchQuery(headerOptions);
       void context.queryClient.prefetchQuery(recentDocumentsOptions);
+      void context.queryClient.prefetchQuery(latestNoteOptions);
       if (signedIn) void context.queryClient.prefetchQuery(socialProofOptions);
       return {
         publicationName: null,
@@ -128,6 +133,7 @@ export const Route = createFileRoute("/_layout/p/$did/$rkey")({
     const awaitables: Array<Promise<unknown>> = [
       context.queryClient.ensureQueryData(headerOptions),
       context.queryClient.ensureQueryData(recentDocumentsOptions),
+      context.queryClient.ensureQueryData(latestNoteOptions),
     ];
     if (signedIn) {
       awaitables.push(context.queryClient.ensureQueryData(socialProofOptions));
@@ -862,6 +868,7 @@ function PublicationProfileContent({
 
       <ReaderContent>
         <Flex direction="column" gap="6xl" style={styles.writing}>
+          <PublicationLatestNote publicationUri={uri} />
           {documents.length === 0 ? (
             <div {...stylex.props(styles.emptyNote)}>
               No posts indexed from this publication yet.

--- a/src/server/atproto/constellation.ts
+++ b/src/server/atproto/constellation.ts
@@ -5,6 +5,13 @@
  * @see https://constellation.microcosm.blue/
  */
 
+import {
+  MINI_POST_COLLECTION,
+  MINI_POST_PUBLICATION_PATH,
+  MINI_POST_QUOTE_PATHS,
+  MINI_POST_SUBJECT_PATH,
+} from "#/lib/pckt/mini";
+
 export interface ConstellationBacklinkRecord {
   did: string;
   collection: string;
@@ -283,11 +290,16 @@ async function fetchBacklinksPage({
   source,
   cursor,
   limit,
+  forceLegacyLinks = false,
 }: {
   target: string;
   source: string;
   cursor?: string;
   limit: number;
+  /** Force the legacy `/links` endpoint even for AT-URI/DID subjects. Some
+   * sources (e.g. `blog.pckt.mini.post:.subject`) 400 on xrpc but resolve on
+   * legacy `/links`. */
+  forceLegacyLinks?: boolean;
 }): Promise<ConstellationBacklinksResult> {
   const empty: ConstellationBacklinksResult = {
     total: 0,
@@ -302,8 +314,9 @@ async function fetchBacklinksPage({
 
   try {
     // The xrpc endpoint rejects https?:// subjects (400); use legacy /links
-    // for web URLs. AT-URI and DID subjects work on xrpc.
-    const useLegacyLinks = isHttpUrl(target);
+    // for web URLs. AT-URI and DID subjects work on xrpc — except a few sources
+    // that 400 there, for which callers pass `forceLegacyLinks`.
+    const useLegacyLinks = forceLegacyLinks || isHttpUrl(target);
     const url = useLegacyLinks
       ? new URL("/links", constellationBaseUrl())
       : new URL(
@@ -356,6 +369,7 @@ export async function getBacklinks({
 async function getAllBacklinksForSource(
   target: string,
   source: string,
+  forceLegacyLinks = false,
 ): Promise<Array<ConstellationBacklinkRecord>> {
   const merged: Array<ConstellationBacklinkRecord> = [];
   let cursor: string | undefined;
@@ -366,6 +380,7 @@ async function getAllBacklinksForSource(
       source,
       cursor,
       limit: 100,
+      forceLegacyLinks,
     });
     merged.push(...page.records);
     cursor = page.cursor ?? undefined;
@@ -559,4 +574,46 @@ export async function getCitationBacklinksForTarget(
   );
 
   return mergeBacklinkRecords(results, new Set(CITATION_COLLECTIONS));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// pckt notes (`blog.pckt.mini.post`) — replies (`.subject`) and quotes
+// (`.embed.record`) of a document, and notes published under a publication.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Constellation sources for notes that reference a `site.standard.document`. */
+export const NOTE_DOCUMENT_LINK_SOURCES = [
+  `${MINI_POST_COLLECTION}:${MINI_POST_SUBJECT_PATH}`,
+  ...MINI_POST_QUOTE_PATHS.map(
+    (path) => `${MINI_POST_COLLECTION}:${path}` as const,
+  ),
+] as const;
+
+/** Constellation source for notes published under a `site.standard.publication`. */
+export const NOTE_PUBLICATION_LINK_SOURCE =
+  `${MINI_POST_COLLECTION}:${MINI_POST_PUBLICATION_PATH}` as const;
+
+/** Notes (mini.posts) that reply to or quote the given document AT-URI. */
+export async function getNoteBacklinksForDocument(
+  documentUri: string,
+): Promise<Array<ConstellationBacklinkRecord>> {
+  // pckt note sources 400 on the xrpc endpoint; force legacy `/links`.
+  const results = await Promise.all(
+    NOTE_DOCUMENT_LINK_SOURCES.map((source) =>
+      getAllBacklinksForSource(documentUri, source, true),
+    ),
+  );
+  return mergeBacklinkRecords(results, new Set([MINI_POST_COLLECTION]));
+}
+
+/** Notes (mini.posts) published under the given publication AT-URI. */
+export async function getNoteBacklinksForPublication(
+  publicationUri: string,
+): Promise<Array<ConstellationBacklinkRecord>> {
+  const records = await getAllBacklinksForSource(
+    publicationUri,
+    NOTE_PUBLICATION_LINK_SOURCE,
+    true,
+  );
+  return mergeBacklinkRecords([records], new Set([MINI_POST_COLLECTION]));
 }

--- a/src/server/extension/types.ts
+++ b/src/server/extension/types.ts
@@ -70,7 +70,7 @@ export type ExtensionSessionResponse = {
 };
 
 export type ExtensionDiscussionComment = {
-  source: "bluesky" | "margin" | "semble";
+  source: "bluesky" | "margin" | "semble" | "note";
   kind: "link" | "quote";
   postUri: string;
   postUrl: string;

--- a/src/server/pckt/notes.ts
+++ b/src/server/pckt/notes.ts
@@ -7,6 +7,7 @@
  * (`fetchRepoRecordWithFallback` with no `pds` arg reads Slingshot alone).
  */
 
+import type { JsonValue } from "#/integrations/tanstack-query/api-shapes";
 import { fetchBlueskyPublicProfileFields } from "#/lib/bluesky-public-profile";
 import {
   MINI_POST_COLLECTION,
@@ -14,7 +15,6 @@ import {
   pcktNoteUrl,
 } from "#/lib/pckt/mini";
 import type { MiniPost } from "#/lib/pckt/mini";
-import type { JsonValue } from "#/integrations/tanstack-query/api-shapes";
 import type { ConstellationBacklinkRecord } from "#/server/atproto/constellation";
 import {
   getNoteBacklinksForDocument,
@@ -114,9 +114,10 @@ export async function fetchNotesForDocument(
 
   try {
     const records = await getNoteBacklinksForDocument(documentUri);
-    const notes = (
-      await Promise.all(records.map((record) => hydrateNote(record)))
-    ).filter((note): note is MiniPost => note != null);
+    const hydrated = await Promise.all(
+      records.map((record) => hydrateNote(record)),
+    );
+    const notes = hydrated.filter((note): note is MiniPost => note != null);
 
     if (notes.length === 0) {
       noteCommentsCache.set(documentUri, {
@@ -174,9 +175,10 @@ export async function fetchLatestPublicationNote(
 
   try {
     const records = await getNoteBacklinksForPublication(publicationUri);
-    const notes = (
-      await Promise.all(records.map((record) => hydrateNote(record)))
-    ).filter((note): note is MiniPost => note != null);
+    const hydrated = await Promise.all(
+      records.map((record) => hydrateNote(record)),
+    );
+    const notes = hydrated.filter((note): note is MiniPost => note != null);
 
     const latest = notes.toSorted(
       (a, b) =>

--- a/src/server/pckt/notes.ts
+++ b/src/server/pckt/notes.ts
@@ -1,0 +1,221 @@
+/**
+ * pckt "notes" (`blog.pckt.mini.post`) surfaced in a document's Discussion.
+ *
+ * Read-only and microcosm-only: Constellation discovers notes that reply to
+ * (`.subject`) or quote (`.embed.record`) a document; Slingshot hydrates each
+ * note record. Nothing is persisted and no author PDS is ever contacted
+ * (`fetchRepoRecordWithFallback` with no `pds` arg reads Slingshot alone).
+ */
+
+import { fetchBlueskyPublicProfileFields } from "#/lib/bluesky-public-profile";
+import {
+  MINI_POST_COLLECTION,
+  normalizeMiniPost,
+  pcktNoteUrl,
+} from "#/lib/pckt/mini";
+import type { MiniPost } from "#/lib/pckt/mini";
+import type { JsonValue } from "#/integrations/tanstack-query/api-shapes";
+import type { ConstellationBacklinkRecord } from "#/server/atproto/constellation";
+import {
+  getNoteBacklinksForDocument,
+  getNoteBacklinksForPublication,
+} from "#/server/atproto/constellation";
+import { fetchRepoRecordWithFallback } from "#/server/atproto/fetch-record";
+import { resolveIdentity } from "#/server/atproto/identity";
+import type {
+  DocumentComment,
+  DocumentCommentAuthor,
+} from "#/server/reader/document-comments";
+
+const NOTE_CACHE_TTL_MS = 5 * 60 * 1000;
+
+const noteCommentsCache = new Map<
+  string,
+  { expiresAt: number; comments: Array<DocumentComment> }
+>();
+
+function noteUriFromRecord(record: ConstellationBacklinkRecord): string {
+  return `at://${record.did}/${record.collection}/${record.rkey}`;
+}
+
+async function hydrateNote(
+  record: ConstellationBacklinkRecord,
+): Promise<MiniPost | null> {
+  const uri = noteUriFromRecord(record);
+  // Slingshot only — omit the `pds` arg so no author PDS is contacted.
+  const result = await fetchRepoRecordWithFallback(uri);
+  if (!result) return null;
+  return normalizeMiniPost(
+    uri,
+    record.did,
+    record.rkey,
+    result.cid ?? null,
+    result.value,
+  );
+}
+
+async function resolveNoteAuthors(
+  dids: Array<string>,
+): Promise<Map<string, DocumentCommentAuthor>> {
+  const unique = [...new Set(dids)];
+  const authors = new Map<string, DocumentCommentAuthor>();
+
+  await Promise.all(
+    unique.map(async (did) => {
+      const [identity, profile] = await Promise.all([
+        resolveIdentity(did),
+        fetchBlueskyPublicProfileFields(did),
+      ]);
+      authors.set(did, {
+        did,
+        handle: profile?.handle ?? identity.handle,
+        displayName: profile?.displayName ?? null,
+        avatarUrl: profile?.avatarUrl ?? null,
+      });
+    }),
+  );
+
+  return authors;
+}
+
+/** Map a hydrated note to a Discussion comment (links to the note on pckt). */
+function toComment(
+  note: MiniPost,
+  author: DocumentCommentAuthor,
+  documentUri: string,
+): DocumentComment {
+  const isQuote = note.quotedRecordUri === documentUri;
+  return {
+    source: "note",
+    kind: isQuote ? "quote" : "link",
+    postUri: note.uri,
+    postUrl: pcktNoteUrl(note.did, note.rkey),
+    author,
+    commentary: note.text,
+    commentaryFacets: note.facets,
+    quote: null,
+    replyCount: 0,
+    indexedAt: note.createdAt,
+  };
+}
+
+/**
+ * pckt notes that reply to or quote `documentUri`, mapped to Discussion
+ * comments. Best-effort: returns [] on any failure so the section still renders
+ * its other sources.
+ */
+export async function fetchNotesForDocument(
+  documentUri: string,
+): Promise<Array<DocumentComment>> {
+  if (!documentUri.startsWith("at://")) return [];
+
+  const cached = noteCommentsCache.get(documentUri);
+  if (cached && cached.expiresAt > Date.now()) return cached.comments;
+
+  try {
+    const records = await getNoteBacklinksForDocument(documentUri);
+    const notes = (
+      await Promise.all(records.map((record) => hydrateNote(record)))
+    ).filter((note): note is MiniPost => note != null);
+
+    if (notes.length === 0) {
+      noteCommentsCache.set(documentUri, {
+        comments: [],
+        expiresAt: Date.now() + NOTE_CACHE_TTL_MS,
+      });
+      return [];
+    }
+
+    const authorByDid = await resolveNoteAuthors(notes.map((note) => note.did));
+
+    const comments: Array<DocumentComment> = [];
+    for (const note of notes) {
+      const author = authorByDid.get(note.did);
+      if (!author) continue;
+      comments.push(toComment(note, author, documentUri));
+    }
+
+    noteCommentsCache.set(documentUri, {
+      comments,
+      expiresAt: Date.now() + NOTE_CACHE_TTL_MS,
+    });
+    return comments;
+  } catch {
+    return cached?.comments ?? [];
+  }
+}
+
+export interface PublicationLatestNote {
+  uri: string;
+  /** The pckt web permalink for the note. */
+  url: string;
+  text: string;
+  facets: Array<JsonValue> | null;
+  createdAt: string;
+}
+
+const latestPublicationNoteCache = new Map<
+  string,
+  { expiresAt: number; note: PublicationLatestNote | null }
+>();
+
+/**
+ * The most recent pckt note published under `publicationUri` (its `publication`
+ * field), for the teaser atop a publication profile. Best-effort; null on
+ * failure or when the publication has no notes.
+ */
+export async function fetchLatestPublicationNote(
+  publicationUri: string,
+): Promise<PublicationLatestNote | null> {
+  if (!publicationUri.startsWith("at://")) return null;
+
+  const cached = latestPublicationNoteCache.get(publicationUri);
+  if (cached && cached.expiresAt > Date.now()) return cached.note;
+
+  try {
+    const records = await getNoteBacklinksForPublication(publicationUri);
+    const notes = (
+      await Promise.all(records.map((record) => hydrateNote(record)))
+    ).filter((note): note is MiniPost => note != null);
+
+    const latest = notes.toSorted(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    )[0];
+
+    const note: PublicationLatestNote | null = latest
+      ? {
+          uri: latest.uri,
+          url: pcktNoteUrl(latest.did, latest.rkey),
+          text: latest.text,
+          facets: latest.facets,
+          createdAt: latest.createdAt,
+        }
+      : null;
+
+    latestPublicationNoteCache.set(publicationUri, {
+      note,
+      expiresAt: Date.now() + NOTE_CACHE_TTL_MS,
+    });
+    return note;
+  } catch {
+    return cached?.note ?? null;
+  }
+}
+
+/** Count of pckt notes referencing `documentUri` (deduped). Best-effort. */
+export async function countNotesForDocument(
+  documentUri: string,
+): Promise<number> {
+  if (!documentUri.startsWith("at://")) return 0;
+  const cached = noteCommentsCache.get(documentUri);
+  if (cached && cached.expiresAt > Date.now()) return cached.comments.length;
+  try {
+    const records = await getNoteBacklinksForDocument(documentUri);
+    return records.filter(
+      (record) => record.collection === MINI_POST_COLLECTION,
+    ).length;
+  } catch {
+    return cached?.comments.length ?? 0;
+  }
+}

--- a/src/server/reader/document-comments.ts
+++ b/src/server/reader/document-comments.ts
@@ -29,6 +29,10 @@ import {
   countMarginNotesForUrls,
   fetchMarginNotesForUrls,
 } from "#/server/atproto/margin-notes";
+import {
+  countNotesForDocument,
+  fetchNotesForDocument,
+} from "#/server/pckt/notes";
 import { buildCanonicalUrl } from "#/server/ingest/mappers";
 import { listQuoteSharesForDocument } from "#/server/reader/quote-shares";
 
@@ -40,7 +44,7 @@ export interface DocumentCommentAuthor {
 }
 
 export interface DocumentComment {
-  source: "bluesky" | "margin" | "semble";
+  source: "bluesky" | "margin" | "semble" | "note";
   kind: "link" | "quote";
   postUri: string;
   postUrl: string;
@@ -273,12 +277,14 @@ async function refreshCommentCount(
     }
 
     const linkUrls = context.targets.map((target) => target.url);
-    const [backlinkCount, replyCount, marginCount] = await Promise.all([
-      countConstellationBacklinksForTargets(context.targets),
-      countAuthorPostReplies(context.bskyPostUri),
-      countMarginNotesForUrls(linkUrls),
-    ]);
-    const count = backlinkCount + replyCount + marginCount;
+    const [backlinkCount, replyCount, marginCount, noteCount] =
+      await Promise.all([
+        countConstellationBacklinksForTargets(context.targets),
+        countAuthorPostReplies(context.bskyPostUri),
+        countMarginNotesForUrls(linkUrls),
+        countNotesForDocument(documentUri),
+      ]);
+    const count = backlinkCount + replyCount + marginCount + noteCount;
     commentCountCache.set(documentUri, {
       count,
       updatedAt: Date.now(),
@@ -517,12 +523,13 @@ export async function fetchDocumentComments(
   const { targets, stripUrls, bskyPostUri } = context;
   const linkUrls = targets.map((target) => target.url);
 
-  const [discovery, marginComments] = await Promise.all([
+  const [discovery, marginComments, noteComments] = await Promise.all([
     discoverDocumentComments(targets, bskyPostUri),
     fetchMarginNotesForUrls(linkUrls),
+    fetchNotesForDocument(documentUri),
   ]);
 
-  const comments: Array<DocumentComment> = [...marginComments];
+  const comments: Array<DocumentComment> = [...marginComments, ...noteComments];
 
   if (discovery.postMeta.size > 0) {
     const posts = await getPosts([...discovery.postMeta.keys()]);

--- a/src/server/reader/document-comments.ts
+++ b/src/server/reader/document-comments.ts
@@ -29,11 +29,11 @@ import {
   countMarginNotesForUrls,
   fetchMarginNotesForUrls,
 } from "#/server/atproto/margin-notes";
+import { buildCanonicalUrl } from "#/server/ingest/mappers";
 import {
   countNotesForDocument,
   fetchNotesForDocument,
 } from "#/server/pckt/notes";
-import { buildCanonicalUrl } from "#/server/ingest/mappers";
 import { listQuoteSharesForDocument } from "#/server/reader/quote-shares";
 
 export interface DocumentCommentAuthor {

--- a/src/server/reader/publication-mentions.ts
+++ b/src/server/reader/publication-mentions.ts
@@ -14,6 +14,7 @@ import {
   mentionUrlKey,
   normalizeMentionUrl,
 } from "#/lib/leaflet/publication-mentions";
+import { fetchBlueskyPublicProfileFields } from "#/lib/bluesky-public-profile";
 import { getPublicUrl } from "#/lib/public-url";
 import { cdnImageUrl } from "#/server/atproto/blob";
 
@@ -132,6 +133,25 @@ async function resolveActors(
       avatarUrl: row.avatarUrl,
     };
   }
+
+  // Mentions can target any atproto account, not just ones this reader has
+  // indexed (e.g. `@bsky.app`). Fall back to the public Bluesky profile for
+  // DIDs we don't have locally so the mention chip still gets a handle + avatar.
+  const missing = dids.filter((did) => !map[did]);
+  if (missing.length > 0) {
+    await Promise.all(
+      missing.map(async (did) => {
+        const profile = await fetchBlueskyPublicProfileFields(did);
+        if (!profile) return;
+        map[did] = {
+          did,
+          handle: profile.handle,
+          avatarUrl: profile.avatarUrl,
+        };
+      }),
+    );
+  }
+
   return map;
 }
 

--- a/src/server/reader/publication-mentions.ts
+++ b/src/server/reader/publication-mentions.ts
@@ -3,6 +3,7 @@ import { and, eq, inArray, or, sql } from "drizzle-orm";
 import type { Db, Schema } from "#/integrations/tanstack-query/api-shapes";
 import { publicationDisplayName } from "#/integrations/tanstack-query/api-shapes";
 import { isAppOriginHref } from "#/lib/app-origin";
+import { fetchBlueskyPublicProfileFields } from "#/lib/bluesky-public-profile";
 import type {
   ActorMentionMap,
   DocumentMentionMap,
@@ -14,7 +15,6 @@ import {
   mentionUrlKey,
   normalizeMentionUrl,
 } from "#/lib/leaflet/publication-mentions";
-import { fetchBlueskyPublicProfileFields } from "#/lib/bluesky-public-profile";
 import { getPublicUrl } from "#/lib/public-url";
 import { cdnImageUrl } from "#/server/atproto/blob";
 


### PR DESCRIPTION
Surface pckt **notes** (`blog.pckt.mini.post`) across the reader — read-only, sourced live from **microcosm** (constellation backlinks + slingshot record hydration). No ingest pipeline changes, no persistence, no PDS calls.

## What's included

**Notes in the article discussion**
Notes that reply to (`.subject`) or quote (`.embed.record`) a `site.standard.document` render in that article's discussion section as a new `"note"` source in `document-comments`, alongside Bluesky/Margin/Semble. Each deep-links to the note on pckt (`https://pckt.blog/n/<did>/<rkey>`).

**`blog.pckt.block.noteEmbed`**
Embedded notes render inline as a bordered card in the **serif reading voice**, so they stay in the article's register while the border marks them as embedded. Identity resolves to the **publication** (icon + name + domain) when the note carries a `publication`, otherwise the author (round avatar). Hover steps the border up a token; the whole card links to the note.

**Publication profile — latest note**
A quiet editorial "Latest note" lead-in at the top of a pckt publication profile, prefetched in the route loader so it resolves with the page. Links to the note on pckt.

## Related pckt / reader fixes

- **Inline @mentions resolve on every content format**, not just Leaflet: `facetKind` is now namespace-agnostic, content is always wrapped in `InlineMentionProvider` (the resolver query is still gated by `hasInlineMentionRefs`, so mention-free docs cost nothing), and un-indexed DIDs (e.g. `@bsky.app`) fall back to the public Bluesky profile.
- **Heading/description dedup**: pckt docs that open with an H1 equal to the description drop that heading from the body and show it as the header dek.
- **Blockquotes** no longer add a trailing bottom margin on their last paragraph.

## Testing

- `tsc --noEmit` clean.
- Exercised the note fetch/hydrate paths against live records (discussion notes, publication latest note, mention resolution incl. `@bsky.app`/`@marque.at`).
- Screenshotted the note embed and publication teaser in light + dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)