### PR TITLE
Scroll the document so keyboard scrolling works

### DIFF
--- a/src/components/reader/app-shell.tsx
+++ b/src/components/reader/app-shell.tsx
@@ -4,7 +4,6 @@ import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
 import {
   Link,
-  useElementScrollRestoration,
   useRouter,
   useRouterState,
 } from "@tanstack/react-router";
@@ -100,10 +99,14 @@ const DESKTOP = "@media (min-width: 60rem)";
 
 const styles = stylex.create({
   shell: {
-    overflow: "hidden",
     display: "flex",
     flexDirection: "row",
-    height: stylex.firstThatWorks("100dvh", "100vh"),
+    // Fill the viewport when content is short, grow past it when tall — the
+    // document is the scroll container now. `flex-start` keeps children pinned
+    // to the top so the sticky sidebar stays viewport-tall in a taller shell
+    // instead of stretching to the full document height.
+    alignItems: "flex-start",
+    minHeight: stylex.firstThatWorks("100dvh", "100vh"),
   },
   sidebar: {
     backgroundColor: uiColor.bgSubtle,
@@ -431,32 +434,27 @@ const styles = stylex.create({
     width: size.lg,
   },
   main: {
-    overflow: "hidden",
     display: "flex",
     flexDirection: "column",
     flexGrow: 1,
     position: "relative",
-    minHeight: 0,
     minWidth: 0,
+    // Keep the content column at least viewport-tall so the footer sits at the
+    // bottom of the screen on short pages instead of floating mid-viewport.
+    minHeight: stylex.firstThatWorks("100dvh", "100vh"),
     // Focused only as the skip-link landing target (tabIndex={-1}); a ring
     // around the whole content region would be noise, not a wayfinding cue.
     outlineStyle: "none",
   },
   scroller: {
-    // Reserve scrollbar width so content width stays stable when the list
-    // height changes (e.g. Discover "Not following" filter).
-
-    scrollbarGutter: "stable",
-    overscrollBehavior: "none",
+    // Content column — no longer a scroll container (the document scrolls).
+    // `overflow-x: clip` still contains any wide child without opening a
+    // horizontal scrollport.
     display: "flex",
-    flexBasis: "0%",
     flexDirection: "column",
     flexGrow: "1",
-    flexShrink: "1",
-    minHeight: 0,
     minWidth: 0,
     overflowX: "clip",
-    overflowY: "auto",
   },
   mobileBar: {
     alignItems: "center",
@@ -488,11 +486,15 @@ const styles = stylex.create({
     display: "flex",
     flexDirection: "column",
     pointerEvents: "none",
-    position: "absolute",
+    // Pinned to the viewport (the document is the scroll container now, so an
+    // absolute dock would ride to the bottom of the whole article instead of
+    // floating above the fold). Offset by the sidebar width on desktop so the
+    // floating card stays centered over the content column.
+    position: "fixed",
     rowGap: gap.lg,
     zIndex: 30,
     bottom: `calc(env(safe-area-inset-bottom, 0px) + ${verticalSpace["3xl"]})`,
-    left: 0,
+    left: { [DESKTOP]: "264px", default: 0 },
     paddingLeft: horizontalSpace["3xl"],
     paddingRight: horizontalSpace["3xl"],
     right: 0,
@@ -1039,27 +1041,8 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = useRouterState({
     select: (s: { location: { pathname: string } }) => s.location.pathname,
   });
-  // Scroll restoration for the custom scroll container. The router's own
-  // restore runs on `resolvedLocation`, which settles only after loaders
-  // finish — a paint after the new content first commits. On back/forward with
-  // cached data the content paints at the top for that one frame (the "flash").
-  // Re-apply the saved offset keyed on `location` (which updates a beat
-  // earlier) in a layout effect so the container is already scrolled before
-  // that first paint. Reads TanStack's own cache, so it can't disagree with the
-  // router's later restore; it just wins the race on the early commit.
-  const scrollerRef = useRef<HTMLDivElement>(null);
-  const scrollEntry = useElementScrollRestoration({ id: "app-scroller" });
-  const locationKey = useRouterState({
-    select: (s: { location: { state: { __TSR_key?: string } } }) =>
-      s.location.state.__TSR_key,
-  });
-  useLayoutEffect(() => {
-    const el = scrollerRef.current;
-    if (el && scrollEntry) {
-      el.scrollTop = scrollEntry.scrollY;
-      el.scrollLeft = scrollEntry.scrollX;
-    }
-  }, [locationKey, scrollEntry]);
+  // Scroll restoration is handled by the router's built-in window restoration
+  // (`scrollRestoration: true`) now that the document itself is the scroller.
   const onAbout = pathname === "/about";
   const onPrivacyExtension = pathname === "/privacy/extension";
   const onPrivacy = pathname === "/privacy" || onPrivacyExtension;
@@ -1322,16 +1305,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         </aside>
 
         <main id="main-content" tabIndex={-1} {...stylex.props(styles.main)}>
-          <div
-            ref={scrollerRef}
-            {...stylex.props(styles.scroller)}
-            data-app-scroller
-            // Stable key for TanStack Router scroll restoration. Without it the
-            // router falls back to a generated nth-child selector that breaks
-            // whenever an ancestor's sibling set changes; a fixed id keeps
-            // home→article→back restoring the previous scroll position.
-            data-scroll-restoration-id="app-scroller"
-          >
+          <div {...stylex.props(styles.scroller)}>
             {staticPageTitle ? (
               <MobileStaticPageBar title={staticPageTitle} />
             ) : (

--- a/src/components/reader/app-shell.tsx
+++ b/src/components/reader/app-shell.tsx
@@ -2,11 +2,7 @@
 
 import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
-import {
-  Link,
-  useRouter,
-  useRouterState,
-} from "@tanstack/react-router";
+import { Link, useRouter, useRouterState } from "@tanstack/react-router";
 import {
   ArrowLeft,
   ArrowUpDown,

--- a/src/components/reader/article-view.tsx
+++ b/src/components/reader/article-view.tsx
@@ -105,30 +105,18 @@ import { useArticleBookmark } from "./use-article-bookmark";
 import { useArticleReadToggle } from "./use-article-read-toggle";
 import { useArticleRecommend } from "./use-article-recommend";
 
-/** Reading progress for article content within the app-shell scroller. */
-function articleReadingProgress(
-  scroller: HTMLElement,
-  content: HTMLElement,
-): number {
-  const viewport = scroller.clientHeight;
-  const contentTop =
-    content.getBoundingClientRect().top -
-    scroller.getBoundingClientRect().top +
-    scroller.scrollTop;
+/** Reading progress of the article content within the document scroll. */
+function articleReadingProgress(content: HTMLElement): number {
+  const viewport = globalThis.innerHeight;
+  const scrollY = globalThis.scrollY;
+  const contentTop = content.getBoundingClientRect().top + scrollY;
   const contentBottom = contentTop + content.offsetHeight;
-  const startScroll = contentTop;
-  const endScroll = Math.max(contentBottom - viewport, startScroll);
-  const range = endScroll - startScroll;
+  const endScroll = Math.max(contentBottom - viewport, contentTop);
+  const range = endScroll - contentTop;
   if (range <= 0) {
-    return scroller.scrollTop >= startScroll ? 1 : 0;
+    return scrollY >= contentTop ? 1 : 0;
   }
-  return Math.min(1, Math.max(0, (scroller.scrollTop - startScroll) / range));
-}
-
-/** App-shell scroller that carries article pages (and the site footer). */
-function articleScrollContainer(anchor: HTMLElement): HTMLElement | null {
-  const outer = anchor.closest("[data-app-scroller]");
-  return outer instanceof HTMLElement ? outer : null;
+  return Math.min(1, Math.max(0, (scrollY - contentTop) / range));
 }
 
 const styles = stylex.create({
@@ -956,25 +944,22 @@ function ArticleViewBody({
     const anchor = rootRef.current;
     if (!anchor) return;
 
-    const scroller = articleScrollContainer(anchor);
-    if (!scroller) return;
-
     const sync = () => {
-      setProgress(articleReadingProgress(scroller, anchor));
+      setProgress(articleReadingProgress(anchor));
     };
 
     if (!sharedQuote?.trim()) {
-      scroller.scrollTop = 0;
+      globalThis.scrollTo(0, 0);
     }
     sync();
 
-    scroller.addEventListener("scroll", sync, { passive: true });
+    // The page (document) is the scroller, so its scroll event fires on window.
+    globalThis.addEventListener("scroll", sync, { passive: true });
     const resizeObserver = new ResizeObserver(() => sync());
     resizeObserver.observe(anchor);
-    resizeObserver.observe(scroller);
 
     return () => {
-      scroller.removeEventListener("scroll", sync);
+      globalThis.removeEventListener("scroll", sync);
       resizeObserver.disconnect();
     };
   }, [article.uri, sharedQuote]);

--- a/src/components/reader/article-view.tsx
+++ b/src/components/reader/article-view.tsx
@@ -806,7 +806,6 @@ function ArticleViewBody({
   const { active: readerActive } = usePageReader();
   const { rememberOpenInMagazine } = useOpenCollectionsInMagazine();
   const { preference: readingTypography } = useReadingTypography();
-  const rootRef = useRef<HTMLDivElement>(null);
   const articleRef = useRef<HTMLElement>(null);
   const [progress, setProgress] = useState(0);
   const [showMagazineIntro, setShowMagazineIntro] = useState(
@@ -941,11 +940,13 @@ function ArticleViewBody({
   }, [article.collection, article.uri, linkParams, queryClient, router]);
 
   useLayoutEffect(() => {
-    const anchor = rootRef.current;
-    if (!anchor) return;
+    // Measure the <article> only — progress should hit 100% at the end of the
+    // article body, not after the "More from" / comments sections below it.
+    const articleEl = articleRef.current;
+    if (!articleEl) return;
 
     const sync = () => {
-      setProgress(articleReadingProgress(anchor));
+      setProgress(articleReadingProgress(articleEl));
     };
 
     if (!sharedQuote?.trim()) {
@@ -956,7 +957,7 @@ function ArticleViewBody({
     // The page (document) is the scroller, so its scroll event fires on window.
     globalThis.addEventListener("scroll", sync, { passive: true });
     const resizeObserver = new ResizeObserver(() => sync());
-    resizeObserver.observe(anchor);
+    resizeObserver.observe(articleEl);
 
     return () => {
       globalThis.removeEventListener("scroll", sync);
@@ -965,10 +966,7 @@ function ArticleViewBody({
   }, [article.uri, sharedQuote]);
 
   return (
-    <div
-      ref={rootRef}
-      {...stylex.props(styles.root, readerActive && styles.rootReader)}
-    >
+    <div {...stylex.props(styles.root, readerActive && styles.rootReader)}>
       <div {...stylex.props(styles.stickyChrome)}>
         <div {...stylex.props(styles.topBar)}>
           <div {...stylex.props(styles.topLeft)}>

--- a/src/components/reader/comments/comment-card.tsx
+++ b/src/components/reader/comments/comment-card.tsx
@@ -239,16 +239,20 @@ export function CommentCard({ comment }: { comment: DocumentComment }) {
       </div>
 
       {hasLink ? (
-        <a
-          href={comment.postUrl}
-          target="_blank"
-          rel="noreferrer"
-          {...stylex.props(commentStyles.cardBodyLink)}
-        >
+        <div {...stylex.props(commentStyles.cardBody)}>
+          {/* Stretched overlay link — a sibling of the facet links, not their
+              ancestor, so no nested <a>. */}
+          <a
+            href={comment.postUrl}
+            target="_blank"
+            rel="noreferrer"
+            aria-label="Open this reply on Bluesky"
+            {...stylex.props(commentStyles.cardBodyOverlay)}
+          />
           {body}
-        </a>
+        </div>
       ) : (
-        <div {...stylex.props(commentStyles.cardBodyLink)}>{body}</div>
+        <div {...stylex.props(commentStyles.cardBody)}>{body}</div>
       )}
     </div>
   );

--- a/src/components/reader/comments/comments-styles.ts
+++ b/src/components/reader/comments/comments-styles.ts
@@ -47,9 +47,12 @@ export const commentStyles = stylex.create({
     paddingRight: horizontalSpace.lg,
     paddingTop: verticalSpace.lg,
   },
-  cardBodyLink: {
+  // A plain container (not a link) with a stretched overlay link below. The
+  // "open post" affordance must not wrap the in-body facet links — a nested
+  // <a> is invalid HTML and breaks hydration.
+  cardBody: {
+    position: "relative",
     borderRadius: radius.sm,
-    textDecoration: "none",
     backgroundColor: {
       default: "transparent",
       ":hover": uiColor.component2,
@@ -64,6 +67,17 @@ export const commentStyles = stylex.create({
     paddingLeft: horizontalSpace.lg,
     paddingRight: horizontalSpace.lg,
     paddingTop: verticalSpace.md,
+  },
+  // Full-card "open the post" link. Sits above the body text (a click anywhere
+  // opens the post) but below the facet links, which lift themselves above it.
+  cardBodyOverlay: {
+    position: "absolute",
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    borderRadius: radius.sm,
+    zIndex: 0,
   },
   cardHeader: {
     alignItems: "center",
@@ -142,12 +156,18 @@ export const commentStyles = stylex.create({
     marginTop: spacing["0"],
   },
   facetMentionLink: {
+    // Lift above the stretched overlay link so the mention stays clickable.
+    position: "relative",
+    zIndex: 1,
     textDecoration: { default: "none", ":hover": "underline" },
     color: "inherit",
     textDecorationColor: "currentColor",
     textUnderlineOffset: "2px",
   },
   facetLink: {
+    // Lift above the stretched overlay link so the link stays clickable.
+    position: "relative",
+    zIndex: 1,
     textDecoration: { default: "underline", ":hover": "none" },
     color: primaryColor.text2,
     textUnderlineOffset: "2px",

--- a/src/components/reader/reader-word-highlighter.tsx
+++ b/src/components/reader/reader-word-highlighter.tsx
@@ -103,8 +103,10 @@ export function ReaderWordHighlighter({
       if (userPointerScrollRef.current) onUserIntent();
     };
 
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (SCROLL_UNLOCK_KEYS.has(event.key)) onUserIntent();
+    // `scrollers` are EventTargets (an element or the Document), so the listener
+    // is typed against the generic Event; narrow to read `key`.
+    const onKeyDown = (event: Event) => {
+      if (SCROLL_UNLOCK_KEYS.has((event as KeyboardEvent).key)) onUserIntent();
     };
 
     for (const el of scrollers) {

--- a/src/components/reader/use-infinite-scroll-sentinel.ts
+++ b/src/components/reader/use-infinite-scroll-sentinel.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from "react";
 
-/** Observe a sentinel inside `[data-app-scroller]` and call `loadMore` when near view. */
+/** Observe a sentinel against the viewport and call `loadMore` when near view. */
 export function useInfiniteScrollSentinel(
   loadMore: () => void,
   enabled: boolean,
@@ -16,14 +16,14 @@ export function useInfiniteScrollSentinel(
     const sentinel = ref.current;
     if (!sentinel) return;
 
-    const root = sentinel.closest("[data-app-scroller]");
+    // The page scrolls at the document level, so observe against the viewport.
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries.some((entry) => entry.isIntersecting)) {
           loadMore();
         }
       },
-      { root, rootMargin: "1200px 0px", threshold: 0 },
+      { root: null, rootMargin: "1200px 0px", threshold: 0 },
     );
 
     observer.observe(sentinel);

--- a/src/lib/page-reader/word-highlight.ts
+++ b/src/lib/page-reader/word-highlight.ts
@@ -296,13 +296,19 @@ export function clearWordHighlight(): void {
   activeHighlight = null;
 }
 
-/** Scroll containers the user may move while reading (app shell scroller). */
-export function articleScrollContainers(root: HTMLElement): Array<HTMLElement> {
-  const outer = root.closest("[data-app-scroller]");
-  if (outer instanceof HTMLElement) {
-    return [outer];
-  }
+/**
+ * Event targets to watch for user-initiated scroll while reading. Returns the
+ * nearest inner overflow container when one exists (e.g. a publisher's own
+ * scroll box under the extension read-along). When the document itself scrolls
+ * — as in the reader app — its `scroll`/`keydown` events fire on the `Document`,
+ * not the `<html>` element `findScrollContainer` returns, so hand back the
+ * document instead.
+ */
+export function articleScrollContainers(root: HTMLElement): Array<EventTarget> {
   const inner = findScrollContainer(root);
+  if (inner === root.ownerDocument.scrollingElement) {
+    return [root.ownerDocument];
+  }
   return [inner];
 }
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -10,9 +10,9 @@ export function getRouter() {
   const router = createTanStackRouter({
     routeTree,
     context,
+    // The document is the scroll container, so the router's default window
+    // scroll restoration + scroll-to-top applies (no custom selector needed).
     scrollRestoration: true,
-    // Main content scrolls in AppShell's `[data-app-scroller]`, not `window`.
-    scrollToTopSelectors: ["[data-app-scroller]"],
     defaultPreload: "intent",
     // Preloaded data stays fresh for 30s — long enough to hover→click without a
     // refetch, short enough to not serve stale data on a real navigation later.

--- a/src/routes/_layout.discover.tsx
+++ b/src/routes/_layout.discover.tsx
@@ -283,19 +283,13 @@ function DeferredMount({
     const node = rootRef.current;
     if (!node) return;
 
-    const scroller = node.closest("[data-app-scroller]");
-    if (!scroller) {
-      queueMicrotask(() => setMounted(true));
-      return;
-    }
-
+    // The page scrolls at the document level, so measure against the viewport.
     const marginY = Number.parseInt(DEFERRED_ROOT_MARGIN, 10) || 600;
     const isNearView = () => {
       const nodeRect = node.getBoundingClientRect();
-      const rootRect = scroller.getBoundingClientRect();
       return (
-        nodeRect.bottom >= rootRect.top - marginY &&
-        nodeRect.top <= rootRect.bottom + marginY
+        nodeRect.bottom >= -marginY &&
+        nodeRect.top <= globalThis.innerHeight + marginY
       );
     };
 
@@ -311,7 +305,7 @@ function DeferredMount({
           observer.disconnect();
         }
       },
-      { root: scroller, rootMargin: DEFERRED_ROOT_MARGIN, threshold: 0 },
+      { root: null, rootMargin: DEFERRED_ROOT_MARGIN, threshold: 0 },
     );
 
     observer.observe(node);
@@ -624,14 +618,14 @@ function DiscoverDirectorySection({ signedIn }: { signedIn: boolean }) {
     const sentinel = loadMoreSentinelRef.current;
     if (!sentinel) return;
 
-    const root = sentinel.closest("[data-app-scroller]");
+    // Viewport observer — the page scrolls at the document level.
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries.some((entry) => entry.isIntersecting)) {
           void loadMoreDirectory();
         }
       },
-      { root, rootMargin: "1200px 0px", threshold: 0 },
+      { root: null, rootMargin: "1200px 0px", threshold: 0 },
     );
 
     observer.observe(sentinel);

--- a/src/routes/_layout.l.$did.$rkey.tsx
+++ b/src/routes/_layout.l.$did.$rkey.tsx
@@ -45,7 +45,6 @@ import { usePersistentToggle } from "#/lib/use-persistent-toggle";
 import { useTrackReadingHistory } from "#/lib/use-track-reading-history";
 
 import { AuthorProfileLink } from "../components/reader/author-profile-link";
-import { useInfiniteScrollSentinel } from "../components/reader/use-infinite-scroll-sentinel";
 import { ArticleRow, PubDirectoryRow } from "../components/reader/cards";
 import { initials } from "../components/reader/format";
 import { ListEditModal } from "../components/reader/list-edit-modal";
@@ -53,6 +52,7 @@ import { Handle, Kicker, ReaderContent } from "../components/reader/primitives";
 import { isArticleUnreadForReader } from "../components/reader/read-optimistic";
 import { RssFeedButton } from "../components/reader/rss-feed-button";
 import { ShareMenu } from "../components/reader/share-menu";
+import { useInfiniteScrollSentinel } from "../components/reader/use-infinite-scroll-sentinel";
 import {
   AlertDialog,
   AlertDialogActionButton,

--- a/src/routes/_layout.l.$did.$rkey.tsx
+++ b/src/routes/_layout.l.$did.$rkey.tsx
@@ -381,14 +381,14 @@ function ListFeedPanel({
     const sentinel = loadMoreSentinelRef.current;
     if (!sentinel) return;
 
-    const root = sentinel.closest("[data-app-scroller]");
+    // Viewport observer — the page scrolls at the document level.
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries.some((entry) => entry.isIntersecting)) {
           void loadMore();
         }
       },
-      { root, rootMargin: "1200px 0px", threshold: 0 },
+      { root: null, rootMargin: "1200px 0px", threshold: 0 },
     );
 
     observer.observe(sentinel);

--- a/src/routes/_layout.l.$did.$rkey.tsx
+++ b/src/routes/_layout.l.$did.$rkey.tsx
@@ -45,6 +45,7 @@ import { usePersistentToggle } from "#/lib/use-persistent-toggle";
 import { useTrackReadingHistory } from "#/lib/use-track-reading-history";
 
 import { AuthorProfileLink } from "../components/reader/author-profile-link";
+import { useInfiniteScrollSentinel } from "../components/reader/use-infinite-scroll-sentinel";
 import { ArticleRow, PubDirectoryRow } from "../components/reader/cards";
 import { initials } from "../components/reader/format";
 import { ListEditModal } from "../components/reader/list-edit-modal";
@@ -346,7 +347,6 @@ function ListFeedPanel({
     () => feed.nextOffset,
   );
   const [loadingMore, setLoadingMore] = useState(false);
-  const loadMoreSentinelRef = useRef<HTMLDivElement>(null);
   const loadingMoreRef = useRef(false);
 
   useEffect(() => {
@@ -376,24 +376,11 @@ function ListFeedPanel({
     }
   }, [did, nextOffset, rkey]);
 
-  useEffect(() => {
-    if (nextOffset == null) return;
-    const sentinel = loadMoreSentinelRef.current;
-    if (!sentinel) return;
-
-    // Viewport observer — the page scrolls at the document level.
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          void loadMore();
-        }
-      },
-      { root: null, rootMargin: "1200px 0px", threshold: 0 },
-    );
-
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [loadMore, nextOffset]);
+  const loadMoreSentinelRef = useInfiniteScrollSentinel(
+    loadMore,
+    nextOffset != null,
+    nextOffset ?? 0,
+  );
 
   if (!hasMembers) {
     return (

--- a/src/routes/_layout.latest.tsx
+++ b/src/routes/_layout.latest.tsx
@@ -34,6 +34,7 @@ import { useTrackReadingHistory } from "#/lib/use-track-reading-history";
 import { useLoginSearch } from "#/utils/use-login-search";
 
 import { ArticleRow } from "../components/reader/cards";
+import { useInfiniteScrollSentinel } from "../components/reader/use-infinite-scroll-sentinel";
 import { Masthead, ReaderContent } from "../components/reader/primitives";
 import {
   applyMarkReadManyOptimisticUpdate,
@@ -325,7 +326,6 @@ function LatestFeedPanel({
   const [extraItems, setExtraItems] = useState<Array<ArticleCard>>([]);
   const [nextOffset, setNextOffset] = useState<number | null>(feed.nextOffset);
   const [loadingMore, setLoadingMore] = useState(false);
-  const loadMoreSentinelRef = useRef<HTMLDivElement>(null);
   const loadingMoreRef = useRef(false);
 
   useEffect(() => {
@@ -365,25 +365,11 @@ function LatestFeedPanel({
     }
   }, [filter, nextOffset, pageSize]);
 
-  useEffect(() => {
-    if (nextOffset == null) return;
-
-    const sentinel = loadMoreSentinelRef.current;
-    if (!sentinel) return;
-
-    // Viewport observer — the page scrolls at the document level.
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          void loadMoreFeed();
-        }
-      },
-      { root: null, rootMargin: "1200px 0px", threshold: 0 },
-    );
-
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [loadMoreFeed, nextOffset]);
+  const loadMoreSentinelRef = useInfiniteScrollSentinel(
+    loadMoreFeed,
+    nextOffset != null,
+    nextOffset ?? 0,
+  );
 
   const isTrending = filter === "trending";
   const isNetwork = !signedIn || filter === "all" || isTrending;

--- a/src/routes/_layout.latest.tsx
+++ b/src/routes/_layout.latest.tsx
@@ -371,14 +371,14 @@ function LatestFeedPanel({
     const sentinel = loadMoreSentinelRef.current;
     if (!sentinel) return;
 
-    const root = sentinel.closest("[data-app-scroller]");
+    // Viewport observer — the page scrolls at the document level.
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries.some((entry) => entry.isIntersecting)) {
           void loadMoreFeed();
         }
       },
-      { root, rootMargin: "1200px 0px", threshold: 0 },
+      { root: null, rootMargin: "1200px 0px", threshold: 0 },
     );
 
     observer.observe(sentinel);

--- a/src/routes/_layout.latest.tsx
+++ b/src/routes/_layout.latest.tsx
@@ -34,7 +34,6 @@ import { useTrackReadingHistory } from "#/lib/use-track-reading-history";
 import { useLoginSearch } from "#/utils/use-login-search";
 
 import { ArticleRow } from "../components/reader/cards";
-import { useInfiniteScrollSentinel } from "../components/reader/use-infinite-scroll-sentinel";
 import { Masthead, ReaderContent } from "../components/reader/primitives";
 import {
   applyMarkReadManyOptimisticUpdate,
@@ -42,6 +41,7 @@ import {
   isArticleUnreadForReader,
 } from "../components/reader/read-optimistic";
 import { RssFeedButton } from "../components/reader/rss-feed-button";
+import { useInfiniteScrollSentinel } from "../components/reader/use-infinite-scroll-sentinel";
 import {
   AlertDialog,
   AlertDialogActionButton,

--- a/src/routes/_layout.p.$did.$rkey.tsx
+++ b/src/routes/_layout.p.$did.$rkey.tsx
@@ -28,7 +28,6 @@ import {
 import { useTrackReadingHistory } from "#/lib/use-track-reading-history";
 
 import { AddToListButton } from "../components/reader/add-to-list-modal";
-import { useInfiniteScrollSentinel } from "../components/reader/use-infinite-scroll-sentinel";
 import {
   ArticleRow,
   FeatureArticle,
@@ -54,6 +53,7 @@ import {
 } from "../components/reader/read-optimistic";
 import { RssFeedButton } from "../components/reader/rss-feed-button";
 import { ShareMenu } from "../components/reader/share-menu";
+import { useInfiniteScrollSentinel } from "../components/reader/use-infinite-scroll-sentinel";
 import {
   AlertDialog,
   AlertDialogActionButton,

--- a/src/routes/_layout.p.$did.$rkey.tsx
+++ b/src/routes/_layout.p.$did.$rkey.tsx
@@ -28,6 +28,7 @@ import {
 import { useTrackReadingHistory } from "#/lib/use-track-reading-history";
 
 import { AddToListButton } from "../components/reader/add-to-list-modal";
+import { useInfiniteScrollSentinel } from "../components/reader/use-infinite-scroll-sentinel";
 import {
   ArticleRow,
   FeatureArticle,
@@ -636,7 +637,6 @@ function PublicationProfileContent({
   );
   const [loadingMore, setLoadingMore] = useState(false);
   const loadingMoreRef = useRef(false);
-  const loadMoreSentinelRef = useRef<HTMLDivElement>(null);
   const [markAllReadCloseSignal, setMarkAllReadCloseSignal] = useState(0);
 
   useEffect(() => {
@@ -715,24 +715,11 @@ function PublicationProfileContent({
     }
   }, [nextOffset, uri]);
 
-  useEffect(() => {
-    if (nextOffset == null) return;
-    const sentinel = loadMoreSentinelRef.current;
-    if (!sentinel) return;
-
-    // Viewport observer — the page scrolls at the document level.
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          void loadMore();
-        }
-      },
-      { root: null, rootMargin: "1200px 0px", threshold: 0 },
-    );
-
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [nextOffset, loadMore]);
+  const loadMoreSentinelRef = useInfiniteScrollSentinel(
+    loadMore,
+    nextOffset != null,
+    nextOffset ?? 0,
+  );
 
   const lead = documents[0];
   const rest = documents.slice(1);

--- a/src/routes/_layout.p.$did.$rkey.tsx
+++ b/src/routes/_layout.p.$did.$rkey.tsx
@@ -720,14 +720,14 @@ function PublicationProfileContent({
     const sentinel = loadMoreSentinelRef.current;
     if (!sentinel) return;
 
-    const root = sentinel.closest("[data-app-scroller]");
+    // Viewport observer — the page scrolls at the document level.
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries.some((entry) => entry.isIntersecting)) {
           void loadMore();
         }
       },
-      { root, rootMargin: "1200px 0px", threshold: 0 },
+      { root: null, rootMargin: "1200px 0px", threshold: 0 },
     );
 
     observer.observe(sentinel);

--- a/src/routes/_layout.search.tsx
+++ b/src/routes/_layout.search.tsx
@@ -16,6 +16,7 @@ import {
   PubDirectoryRow,
   PubDirectoryRowSkeleton,
 } from "../components/reader/cards";
+import { useInfiniteScrollSentinel } from "../components/reader/use-infinite-scroll-sentinel";
 import {
   Kicker,
   ReaderContent,
@@ -356,7 +357,6 @@ function Search() {
   const { q: urlQ = "" } = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
   const inputRef = useRef<HTMLInputElement>(null);
-  const loadMoreArticlesRef = useRef<HTMLDivElement>(null);
   const loadingMorePubsRef = useRef(false);
   const committedQRef = useRef(urlQ.trim());
   const [input, setInput] = useState(urlQ);
@@ -451,25 +451,17 @@ function Search() {
     }
   }, [debouncedQ, pubNextOffset]);
 
-  useEffect(() => {
-    if (!hasNextPage || isFetchingNextPage) return;
+  const loadMoreArticles = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
+    }
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
-    const sentinel = loadMoreArticlesRef.current;
-    if (!sentinel) return;
-
-    // Viewport observer — the page scrolls at the document level.
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          void fetchNextPage();
-        }
-      },
-      { root: null, rootMargin: "1200px 0px", threshold: 0 },
-    );
-
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage, articles.length]);
+  const loadMoreArticlesRef = useInfiniteScrollSentinel(
+    loadMoreArticles,
+    hasNextPage,
+    articles.length,
+  );
 
   const trimmedInput = input.trim();
   const hasQuery = debouncedQ.length > 0;

--- a/src/routes/_layout.search.tsx
+++ b/src/routes/_layout.search.tsx
@@ -457,14 +457,14 @@ function Search() {
     const sentinel = loadMoreArticlesRef.current;
     if (!sentinel) return;
 
-    const root = sentinel.closest("[data-app-scroller]");
+    // Viewport observer — the page scrolls at the document level.
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries.some((entry) => entry.isIntersecting)) {
           void fetchNextPage();
         }
       },
-      { root, rootMargin: "1200px 0px", threshold: 0 },
+      { root: null, rootMargin: "1200px 0px", threshold: 0 },
     );
 
     observer.observe(sentinel);

--- a/src/routes/_layout.search.tsx
+++ b/src/routes/_layout.search.tsx
@@ -16,12 +16,12 @@ import {
   PubDirectoryRow,
   PubDirectoryRowSkeleton,
 } from "../components/reader/cards";
-import { useInfiniteScrollSentinel } from "../components/reader/use-infinite-scroll-sentinel";
 import {
   Kicker,
   ReaderContent,
   SectionHead,
 } from "../components/reader/primitives";
+import { useInfiniteScrollSentinel } from "../components/reader/use-infinite-scroll-sentinel";
 import { Button } from "../design-system/button";
 import { Flex } from "../design-system/flex";
 import { IconButton } from "../design-system/icon-button";

--- a/src/routes/_layout.tag.$tag.tsx
+++ b/src/routes/_layout.tag.$tag.tsx
@@ -500,14 +500,14 @@ function TagArticlesPanel({ tag }: { tag: string }) {
     const sentinel = loadMoreSentinelRef.current;
     if (!sentinel) return;
 
-    const root = sentinel.closest("[data-app-scroller]");
+    // Viewport observer — the page scrolls at the document level.
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries.some((entry) => entry.isIntersecting)) {
           void loadMore();
         }
       },
-      { root, rootMargin: "1200px 0px", threshold: 0 },
+      { root: null, rootMargin: "1200px 0px", threshold: 0 },
     );
 
     observer.observe(sentinel);
@@ -672,14 +672,14 @@ function TagPublicationsPanel({
     const sentinel = loadMoreSentinelRef.current;
     if (!sentinel) return;
 
-    const root = sentinel.closest("[data-app-scroller]");
+    // Viewport observer — the page scrolls at the document level.
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries.some((entry) => entry.isIntersecting)) {
           void loadMore();
         }
       },
-      { root, rootMargin: "1200px 0px", threshold: 0 },
+      { root: null, rootMargin: "1200px 0px", threshold: 0 },
     );
 
     observer.observe(sentinel);

--- a/src/routes/_layout.tag.$tag.tsx
+++ b/src/routes/_layout.tag.$tag.tsx
@@ -15,6 +15,8 @@ import {
 } from "@tanstack/react-router";
 import { Check, LayoutGrid, List, Plus, Tag } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useInfiniteScrollSentinel } from "../components/reader/use-infinite-scroll-sentinel";
 import { z } from "zod";
 
 import {
@@ -459,7 +461,6 @@ function TagArticlesPanel({ tag }: { tag: string }) {
     number | null
   >(null);
   const [loadingMore, setLoadingMore] = useState(false);
-  const loadMoreSentinelRef = useRef<HTMLDivElement>(null);
   const loadingMoreRef = useRef(false);
 
   useEffect(() => {
@@ -494,25 +495,11 @@ function TagArticlesPanel({ tag }: { tag: string }) {
     }
   }, [nextOffset, tag]);
 
-  useEffect(() => {
-    if (nextOffset == null) return;
-
-    const sentinel = loadMoreSentinelRef.current;
-    if (!sentinel) return;
-
-    // Viewport observer — the page scrolls at the document level.
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          void loadMore();
-        }
-      },
-      { root: null, rootMargin: "1200px 0px", threshold: 0 },
-    );
-
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [loadMore, nextOffset]);
+  const loadMoreSentinelRef = useInfiniteScrollSentinel(
+    loadMore,
+    nextOffset != null,
+    nextOffset ?? 0,
+  );
 
   if (showSkeleton) {
     return <TagArticlesSkeleton />;
@@ -581,7 +568,6 @@ function TagPublicationsPanel({
     number | null
   >(null);
   const [loadingMore, setLoadingMore] = useState(false);
-  const loadMoreSentinelRef = useRef<HTMLDivElement>(null);
   const loadingMoreRef = useRef(false);
 
   const {
@@ -666,25 +652,11 @@ function TagPublicationsPanel({
     }
   }, [nextOffset, sort, tag]);
 
-  useEffect(() => {
-    if (nextOffset == null) return;
-
-    const sentinel = loadMoreSentinelRef.current;
-    if (!sentinel) return;
-
-    // Viewport observer — the page scrolls at the document level.
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          void loadMore();
-        }
-      },
-      { root: null, rootMargin: "1200px 0px", threshold: 0 },
-    );
-
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [loadMore, nextOffset]);
+  const loadMoreSentinelRef = useInfiniteScrollSentinel(
+    loadMore,
+    nextOffset != null,
+    nextOffset ?? 0,
+  );
 
   return (
     <>

--- a/src/routes/_layout.tag.$tag.tsx
+++ b/src/routes/_layout.tag.$tag.tsx
@@ -15,8 +15,6 @@ import {
 } from "@tanstack/react-router";
 import { Check, LayoutGrid, List, Plus, Tag } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-
-import { useInfiniteScrollSentinel } from "../components/reader/use-infinite-scroll-sentinel";
 import { z } from "zod";
 
 import {
@@ -81,6 +79,8 @@ import { SITE_NAME, siteSocialMeta, tagFeedUrl } from "#/lib/site-metadata";
 import { useDelayedLoading } from "#/lib/use-delayed-loading";
 import { useTrackReadingHistory } from "#/lib/use-track-reading-history";
 import { useLoginSearch } from "#/utils/use-login-search";
+
+import { useInfiniteScrollSentinel } from "../components/reader/use-infinite-scroll-sentinel";
 
 const PAGE_SIZE = 24;
 /** Ask before bulk-follow when a tag has more than this many unfollowed publications. */

--- a/src/routes/_layout.u.$did.tsx
+++ b/src/routes/_layout.u.$did.tsx
@@ -43,7 +43,6 @@ import {
 } from "#/lib/site-metadata";
 
 import { AddToListButton } from "../components/reader/add-to-list-button";
-import { useInfiniteScrollSentinel } from "../components/reader/use-infinite-scroll-sentinel";
 import { AuthorProfileLink } from "../components/reader/author-profile-link";
 import { ArticleRow, PubDirectoryRow } from "../components/reader/cards";
 import { FollowUserButton } from "../components/reader/follow-user-button";
@@ -53,6 +52,7 @@ import { ProfileTabsSettingsModal } from "../components/reader/profile-tabs-sett
 import { RssFeedButton } from "../components/reader/rss-feed-button";
 import { ShareMenu } from "../components/reader/share-menu";
 import { AuthorSifaResumeChip } from "../components/reader/sifa-resume-chip";
+import { useInfiniteScrollSentinel } from "../components/reader/use-infinite-scroll-sentinel";
 import { Avatar } from "../design-system/avatar";
 import { Badge } from "../design-system/badge";
 import { Button } from "../design-system/button";

--- a/src/routes/_layout.u.$did.tsx
+++ b/src/routes/_layout.u.$did.tsx
@@ -457,14 +457,14 @@ function useInfiniteScroll(
     const sentinel = sentinelRef.current;
     if (!sentinel) return;
 
-    const root = sentinel.closest("[data-app-scroller]");
+    // Viewport observer — the page scrolls at the document level.
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries.some((entry) => entry.isIntersecting)) {
           void load();
         }
       },
-      { root, rootMargin: "1200px 0px", threshold: 0 },
+      { root: null, rootMargin: "1200px 0px", threshold: 0 },
     );
 
     observer.observe(sentinel);

--- a/src/routes/_layout.u.$did.tsx
+++ b/src/routes/_layout.u.$did.tsx
@@ -13,7 +13,7 @@ import {
 } from "@tanstack/react-router";
 import { ExternalLink, ListPlus, Settings } from "lucide-react";
 import type { RefObject } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { Link as AriaLink } from "react-aria-components";
 import { z } from "zod";
 
@@ -43,6 +43,7 @@ import {
 } from "#/lib/site-metadata";
 
 import { AddToListButton } from "../components/reader/add-to-list-button";
+import { useInfiniteScrollSentinel } from "../components/reader/use-infinite-scroll-sentinel";
 import { AuthorProfileLink } from "../components/reader/author-profile-link";
 import { ArticleRow, PubDirectoryRow } from "../components/reader/cards";
 import { FollowUserButton } from "../components/reader/follow-user-button";
@@ -438,7 +439,6 @@ function useInfiniteScroll(
 ) {
   const loadingMoreRef = useRef(false);
   const [loadingMore, setLoadingMore] = useState(false);
-  const sentinelRef = useRef<HTMLDivElement>(null);
 
   const load = useCallback(async () => {
     if (nextOffset == null || loadingMoreRef.current) return;
@@ -452,24 +452,11 @@ function useInfiniteScroll(
     }
   }, [loadMore, nextOffset]);
 
-  useEffect(() => {
-    if (nextOffset == null) return;
-    const sentinel = sentinelRef.current;
-    if (!sentinel) return;
-
-    // Viewport observer — the page scrolls at the document level.
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          void load();
-        }
-      },
-      { root: null, rootMargin: "1200px 0px", threshold: 0 },
-    );
-
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [nextOffset, load]);
+  const sentinelRef = useInfiniteScrollSentinel(
+    load,
+    nextOffset != null,
+    nextOffset ?? 0,
+  );
 
   return { loadingMore, sentinelRef };
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -80,25 +80,14 @@ body {
 }
 /* @generated font-fallbacks:end */
 
-/* App shell scroll lives in [data-app-scroller]; lock the document so home-screen
-   (standalone) launches don't rubber-band the whole page. */
-html:has([data-app-shell]) {
-  height: 100%;
-  overflow: hidden;
-  overscroll-behavior: none;
-}
-
+/* The app scrolls at the document level so native keyboard scrolling (space,
+   PageUp/PageDown, cmd+Up/Down, arrows) has the page as its target. Keeping
+   `overscroll-behavior: none` still stops home-screen (standalone) launches
+   from rubber-banding or pull-to-refreshing the whole page — without locking
+   scroll the way an `overflow: hidden` document would. */
+html:has([data-app-shell]),
 html:has([data-app-shell]) body {
-  height: 100%;
-  overflow: hidden;
   overscroll-behavior: none;
-}
-
-@media (display-mode: standalone) {
-  html:has([data-app-shell]) body {
-    position: fixed;
-    width: 100%;
-  }
 }
 
 /* Page-reader "current sentence" highlight (CSS Custom Highlight API).


### PR DESCRIPTION
## Problem

`cmd+↑/↓`, `space`, `PageUp/Down`, and arrow keys didn't scroll the page. The app locked the document (`html`/`body` `overflow: hidden`) and moved scrolling into a **non-focusable** `<div data-app-scroller>`. Native keyboard scrolling only acts on the document or a focused scrollable element, so those keys had no target (trackpad still worked because the pointer hovered the scroller).

## Fix — scroll at the document level

Hand scrolling back to the browser so keyboard scrolling works everywhere for free:

- **`styles.css`** — drop the `overflow: hidden` document lock; keep `overscroll-behavior: none` (still prevents PWA rubber-band / pull-to-refresh).
- **`app-shell.tsx`** — shell/main grow with content; the scroller div is no longer a scroll container. The sidebar was already `position: sticky`. Removed the custom `useElementScrollRestoration` plumbing in favor of the router's built-in **window** scroll restoration.
- **`router.tsx`** — drop `scrollToTopSelectors` (defaults to window).
- **`article-view.tsx`** — reading progress + scroll-to-top use `window`/document.
- **`word-highlight.ts` / `reader-word-highlighter.tsx`** — TTS auto-follow listeners bind to the `Document` (scroll events fire there, not on `<html>`). Kept the inner-scroller detection that the `extension/` read-along relies on via `scrollWordIntoView`.
- **Infinite-scroll sentinels + discover deferred-mount** — observe the viewport (`root: null`) instead of the now-removed `[data-app-scroller]`.

## Also fixed (surfaced while testing)

- **Dictation controls disappeared.** The player dock was `position: absolute` relative to `main`; once `main` grew with the article it rode to the bottom of the page. Pinned it `position: fixed` to the viewport, offset by the sidebar width on desktop.
- **Nested `<a>` hydration error in comments** (pre-existing). A comment card wrapped its whole body in an `<a>` while facet links rendered their own `<a>`. Replaced with a **stretched overlay link** (a sibling, not an ancestor, of the facet links) so a click anywhere opens the post while facet links stay independently clickable.

## Verification (Playwright, live dev server)

- `space` / `PageDown` / `Home` / `End` / `cmd+↓` scroll on **home**, **discover**, and **article** views.
- Sticky sidebar and article header stay pinned while scrolling; no horizontal scroll.
- Infinite scroll still loads more (`/latest`: 10 → 36 items).
- Dictation controls appear in the viewport on Listen.
- Comments render with **0** nested anchors and no hydration warnings.
- `tsc` + `oxlint` clean on all touched files.

## Notes for review

- Please eyeball **back/forward scroll restoration** (I removed the bespoke anti-flash effect in favor of the router's default window restoration) and the **installed PWA** (standalone) for any rubber-band regression.
- Not included: the 8 route files still have near-identical inline infinite-scroll observers that could be consolidated into the shared `useInfiniteScrollSentinel` hook — happy to do that as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)