### PR TITLE
Cut home-page DB round trips; move web to us-east4

### DIFF
--- a/perf/lib/measure.ts
+++ b/perf/lib/measure.ts
@@ -15,17 +15,36 @@ export interface LoadMeasurement {
   overBudget: boolean;
 }
 
+/**
+ * Ready = the app-shell `<main>` landmark is painted and nothing inside it is
+ * still reporting `aria-busy` (route skeletons set it while their data loads).
+ *
+ * Anchors on `main#main-content` from `components/reader/app-shell.tsx` — every
+ * measured target renders inside that shell. A previous marker
+ * (`[data-app-scroller]`) no longer exists anywhere in `src/`, so this wait
+ * silently timed out on every target and the whole suite failed at 45s.
+ */
 async function waitForViewReady(page: Page, timeoutMs: number): Promise<void> {
-  await page.locator("[data-app-scroller]").waitFor({
+  // A signed-in target that bounces to /login never renders the shell, so the
+  // landmark wait below would burn the full timeout and report a meaningless
+  // "locator not visible". Surface the redirect instead.
+  if (new URL(page.url()).pathname.startsWith("/login")) {
+    throw new Error(
+      `Redirected to ${page.url()} — the perf session was not accepted for this route. ` +
+        `Check PERF_TEST_SESSION_TOKEN / PERF_TEST_APP_PASSWORD in .env.`,
+    );
+  }
+
+  await page.locator("main#main-content").waitFor({
     state: "visible",
     timeout: timeoutMs,
   });
 
   await page.waitForFunction(
     () => {
-      const scroller = document.querySelector("[data-app-scroller]");
-      if (!scroller) return false;
-      return scroller.querySelector("[aria-busy='true']") === null;
+      const main = document.querySelector("main#main-content");
+      if (!main) return false;
+      return main.querySelector("[aria-busy='true']") === null;
     },
     { timeout: timeoutMs },
   );

--- a/perf/lib/targets.ts
+++ b/perf/lib/targets.ts
@@ -163,10 +163,12 @@ function signedInOnlyTargets(): Array<PerfTarget> {
       auth: "signed-in",
       budgetMs: 5000,
     }),
+    // `/likes` is a permanent redirect to `/recommended` (see
+    // `routes/_layout.likes.tsx`) — measure the real route, not the bounce.
     perfTarget({
-      id: "likes",
-      name: "Likes",
-      path: "/likes",
+      id: "recommended",
+      name: "Recommended",
+      path: "/recommended",
       auth: "signed-in",
       budgetMs: 5000,
     }),

--- a/railway.json
+++ b/railway.json
@@ -9,6 +9,11 @@
     "startCommand": "pnpm start",
     "healthcheckPath": "/api/auth/atproto/metadata.json",
     "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 10
+    "restartPolicyMaxRetries": 10,
+    "multiRegionConfig": {
+      "us-east4-eqdc4a": {
+        "numReplicas": 1
+      }
+    }
   }
 }

--- a/src/integrations/tanstack-query/api-feed.functions.ts
+++ b/src/integrations/tanstack-query/api-feed.functions.ts
@@ -15,9 +15,11 @@ import {
 } from "#/lib/track-reading-history";
 import { getReaderContextForRequest } from "#/middleware/auth-session.server";
 import {
+  attachLabelsFromMap,
   attachSubscribedLabels,
   filterHiddenDocuments,
-  hiddenDocumentUris,
+  hiddenUrisFromLabels,
+  readLabelsForUris,
 } from "#/server/labeler/labels.server";
 import type { Span } from "#/server/observability/log";
 import { observe } from "#/server/observability/log";
@@ -43,7 +45,13 @@ import {
 } from "#/server/reader/saved-lists";
 import { loadSidebarData } from "#/server/reader/shell-snapshot.server";
 
-import type { ArticleCard, Db, PublicationCard, Schema } from "./api-shapes";
+import type {
+  ArticleCard,
+  ArticleCardLabel,
+  Db,
+  PublicationCard,
+  Schema,
+} from "./api-shapes";
 import { dbMiddleware } from "./db-middleware";
 
 /**
@@ -374,11 +382,26 @@ async function buildHomeFeedCritical(
     latestUnread = articleCardsAsAllRead(latestUnread);
   }
 
-  // Drop anything the reader hid via a subscribed labeler's label.
-  const hidden = await hiddenDocumentUris(db, schema, ctx.did, [
-    ...(featured ? [featured.uri] : []),
-    ...latestUnread.map((article) => article.uri),
+  // Labels and recommend attribution are independent reads over the same cards,
+  // so fetch them concurrently rather than chaining. Both are computed over the
+  // pre-hide-filter set and the hidden rows are dropped afterwards — filtering
+  // only ever removes cards, so the result is identical to filtering first.
+  //
+  // This replaced three serial round trips (hidden → labels → recommends, where
+  // the first two issued the *same* `document_labels` query) with one wave.
+  const cards = [...(featured ? [featured] : []), ...latestUnread];
+  const cardUris = cards.map((article) => article.uri);
+  const [labelsByUri, withRecs] = await Promise.all([
+    ctx.did
+      ? readLabelsForUris(db, schema, ctx.did, cardUris)
+      : Promise.resolve(new Map<string, Array<ArticleCardLabel>>()),
+    ctx.followedUserDids.length > 0
+      ? attachRecommendedByToArticles(db, schema, ctx.followedUserDids, cards)
+      : Promise.resolve(cards),
   ]);
+
+  // Drop anything the reader hid via a subscribed labeler's label.
+  const hidden = hiddenUrisFromLabels(labelsByUri);
   if (hidden.size > 0) {
     if (featured && hidden.has(featured.uri)) featured = null;
     latestUnread = latestUnread.filter((article) => !hidden.has(article.uri));
@@ -386,25 +409,13 @@ async function buildHomeFeedCritical(
 
   span.set("rows", latestUnread.length);
 
-  const withCounts = await attachCommentCountsToArticles(db, schema, [
-    ...(featured ? [featured] : []),
-    ...latestUnread,
-  ]);
-  const enriched = await attachSubscribedLabels(
+  // No DB work: reads cached counts and schedules background revalidation.
+  const withCounts = await attachCommentCountsToArticles(
     db,
     schema,
-    ctx.did,
-    withCounts,
+    withRecs.filter((article) => !hidden.has(article.uri)),
   );
-  const enrichedWithRecs =
-    ctx.followedUserDids.length > 0
-      ? await attachRecommendedByToArticles(
-          db,
-          schema,
-          ctx.followedUserDids,
-          enriched,
-        )
-      : enriched;
+  const enrichedWithRecs = attachLabelsFromMap(withCounts, labelsByUri);
   const byUri = new Map(
     enrichedWithRecs.map((article) => [article.uri, article]),
   );

--- a/src/integrations/tanstack-query/db-middleware.ts
+++ b/src/integrations/tanstack-query/db-middleware.ts
@@ -2,23 +2,15 @@ import { createMiddleware } from "@tanstack/react-start";
 
 export const dbMiddleware = createMiddleware({ type: "function" }).server(
   async ({ next }) => {
-    const [
-      { db },
-      schema,
-      { resolveTrackReadingHistoryEnabled },
-      { resolveCountOldPostsAsUnreadEnabled },
-    ] = await Promise.all([
-      import("#/db/index.server"),
-      import("#/db/schema"),
-      import("#/server/reader/track-reading-history.server"),
-      import("#/server/reader/count-old-posts-as-unread.server"),
-    ]);
-
-    const [trackReadingEnabled, countOldPostsAsUnreadEnabled] =
+    const [{ db }, schema, { resolveReaderSessionPreferences }] =
       await Promise.all([
-        resolveTrackReadingHistoryEnabled(db, schema),
-        resolveCountOldPostsAsUnreadEnabled(db, schema),
+        import("#/db/index.server"),
+        import("#/db/schema"),
+        import("#/server/reader/session-preferences.server"),
       ]);
+
+    const { trackReadingEnabled, countOldPostsAsUnreadEnabled } =
+      await resolveReaderSessionPreferences(db, schema);
 
     return next({
       context: {

--- a/src/server/labeler/labels.server.ts
+++ b/src/server/labeler/labels.server.ts
@@ -88,7 +88,7 @@ async function readerSubscriptionsImpl(
  * URI, with each label's effective visibility (the reader's pref, default
  * `warn`). Pure SQL against `document_labels` — no labeler network calls.
  */
-async function readLabelsForUris(
+export async function readLabelsForUris(
   db: Db,
   schema: Schema,
   callerDid: string,
@@ -173,6 +173,36 @@ export async function labelsForDocument(
   if (!callerDid) return [];
   const byUri = await readLabelsForUris(db, schema, callerDid, [uri]);
   return byUri.get(uri) ?? [];
+}
+
+/**
+ * Of an already-read label map, which URIs the reader has chosen to hide.
+ *
+ * Pure — pairs with {@link readLabelsForUris} for callers that need both the
+ * hide-filter and the per-card labels. Reading the map once and deriving both
+ * avoids issuing the same `document_labels` query twice per request (the feed
+ * builders previously called `hiddenDocumentUris` and `attachSubscribedLabels`
+ * back to back over the same URI set).
+ */
+export function hiddenUrisFromLabels(
+  byUri: Map<string, Array<ArticleCardLabel>>,
+): Set<string> {
+  const hidden = new Set<string>();
+  for (const [uri, labels] of byUri) {
+    if (labels.some((l) => l.visibility === "hide")) hidden.add(uri);
+  }
+  return hidden;
+}
+
+/** Attach labels from an already-read map. Pure counterpart of {@link attachSubscribedLabels}. */
+export function attachLabelsFromMap<
+  T extends { uri: string; labels?: Array<ArticleCardLabel> },
+>(cards: Array<T>, byUri: Map<string, Array<ArticleCardLabel>>): Array<T> {
+  if (byUri.size === 0) return cards;
+  return cards.map((card) => {
+    const labels = byUri.get(card.uri);
+    return labels ? { ...card, labels } : card;
+  });
 }
 
 /**

--- a/src/server/reader/session-preferences.server.ts
+++ b/src/server/reader/session-preferences.server.ts
@@ -1,0 +1,107 @@
+import { getCookie, getRequest } from "@tanstack/react-start/server";
+import { eq } from "drizzle-orm";
+
+import { AUTH_SESSION_TOKEN_COOKIE } from "#/integrations/auth/constants";
+import type { Db, Schema } from "#/integrations/tanstack-query/api-shapes";
+import {
+  COUNT_OLD_POSTS_AS_UNREAD_COOKIE,
+  DEFAULT_COUNT_OLD_POSTS_AS_UNREAD,
+  dbValueToCountOldPostsAsUnread,
+  parseCountOldPostsAsUnreadCookie,
+} from "#/lib/count-old-posts-as-unread";
+import {
+  TRACK_READING_HISTORY_COOKIE,
+  dbValueToTrackReadingHistory,
+  parseTrackReadingHistoryCookie,
+} from "#/lib/track-reading-history";
+
+export interface ReaderSessionPreferences {
+  trackReadingEnabled: boolean;
+  countOldPostsAsUnreadEnabled: boolean;
+}
+
+function readSessionTokenCookie(
+  cookieHeader: string | null,
+): string | undefined {
+  if (!cookieHeader) return undefined;
+  for (const pair of cookieHeader.split("; ")) {
+    const eqIdx = pair.indexOf("=");
+    if (eqIdx === -1) continue;
+    const name = pair.slice(0, eqIdx);
+    if (name === AUTH_SESSION_TOKEN_COOKIE) {
+      return pair.slice(eqIdx + 1);
+    }
+  }
+  return undefined;
+}
+
+/** Cookie-only fallback, used off-request and for guests / expired sessions. */
+function preferencesFromCookies(): ReaderSessionPreferences {
+  return {
+    trackReadingEnabled: parseTrackReadingHistoryCookie(
+      getCookie(TRACK_READING_HISTORY_COOKIE),
+    ),
+    countOldPostsAsUnreadEnabled: parseCountOldPostsAsUnreadCookie(
+      getCookie(COUNT_OLD_POSTS_AS_UNREAD_COOKIE),
+    ),
+  };
+}
+
+/**
+ * Both reader feed preferences in a single session lookup.
+ *
+ * These are two booleans on the same `user` row reached through the same
+ * session token, so resolving them separately issued two identical
+ * `session.findFirst` queries per request. Every caller wants the pair, so read
+ * the row once and derive both.
+ *
+ * Resolved from the DB row — **not** via `getAtprotoSessionForRequest()`, which
+ * restores the PDS client (a network round trip). Neither preference needs it.
+ */
+export async function resolveReaderSessionPreferences(
+  db: Db,
+  schema: Schema,
+): Promise<ReaderSessionPreferences> {
+  let request: Request;
+  try {
+    request = getRequest();
+  } catch {
+    // Scripts and in-process callers outside TanStack Start request scope.
+    return {
+      trackReadingEnabled: false,
+      countOldPostsAsUnreadEnabled: DEFAULT_COUNT_OLD_POSTS_AS_UNREAD,
+    };
+  }
+
+  const sessionToken = readSessionTokenCookie(request.headers.get("cookie"));
+  if (sessionToken) {
+    const sessionRow = await db.query.session.findFirst({
+      where: eq(schema.session.token, sessionToken),
+      with: {
+        user: {
+          columns: {
+            trackReadingHistory: true,
+            countOldPostsAsUnread: true,
+          },
+        },
+      },
+    });
+
+    if (
+      sessionRow &&
+      sessionRow.expiresAt.getTime() > Date.now() &&
+      sessionRow.user
+    ) {
+      return {
+        trackReadingEnabled: dbValueToTrackReadingHistory(
+          sessionRow.user.trackReadingHistory ?? null,
+        ),
+        countOldPostsAsUnreadEnabled: dbValueToCountOldPostsAsUnread(
+          sessionRow.user.countOldPostsAsUnread ?? null,
+        ),
+      };
+    }
+  }
+
+  return preferencesFromCookies();
+}

--- a/src/server/xrpc/db.ts
+++ b/src/server/xrpc/db.ts
@@ -1,6 +1,5 @@
 import type { Db, Schema } from "#/integrations/tanstack-query/api-shapes";
-import { resolveCountOldPostsAsUnreadEnabled } from "#/server/reader/count-old-posts-as-unread.server";
-import { resolveTrackReadingHistoryEnabled } from "#/server/reader/track-reading-history.server";
+import { resolveReaderSessionPreferences } from "#/server/reader/session-preferences.server";
 
 export type XrpcDbContext = {
   db: Db;
@@ -19,12 +18,8 @@ export async function getXrpcDbContext(): Promise<XrpcDbContext> {
     ]);
     cachedDb = { db, schema };
   }
-  const [trackReadingEnabled, countOldPostsAsUnreadEnabled] = await Promise.all(
-    [
-      resolveTrackReadingHistoryEnabled(cachedDb.db, cachedDb.schema),
-      resolveCountOldPostsAsUnreadEnabled(cachedDb.db, cachedDb.schema),
-    ],
-  );
+  const { trackReadingEnabled, countOldPostsAsUnreadEnabled } =
+    await resolveReaderSessionPreferences(cachedDb.db, cachedDb.schema);
   return { ...cachedDb, trackReadingEnabled, countOldPostsAsUnreadEnabled };
 }
 


### PR DESCRIPTION
## Summary

Profiled the signed-in home page. The client is fine — 198KB JS, zero long tasks, TTFB is **95% of LCP**. All the cost is server-side.

The dominant factor turned out to be infrastructure, not code: **all Railway services run in `us-west2` while Neon is in `aws-us-east-1`**, so every query crosses the country. Prod telemetry (Honeycomb, 7d, excluding local runs) shows a **~230ms per-round-trip floor**:

| span | P50 | P95 |
|---|---|---|
| `feed.getHomePage` (guest) | 720ms | 2258ms |
| `feed.getHomePage` (signed-in) | 685ms | 2025ms |
| `sidebarPref.get` — *one indexed single-row select* | **234ms** | 917ms |

Guests and signed-in readers are equally slow, so the cost isn't personalization. Measuring those same queries directly against the same prod DB shows **~0ms of actual execution time** — the wall time is pure round trip. Latency ≈ (sequential round trips) × ~230ms fits every span measured.

## Changes

**Pin `web` to `us-east4-eqdc4a`** (Ashburn, same metro as Neon). Only web moves:
- Labelers are contacted *solely* by `startLabelSync()` — a 2-minute `setInterval` in the ingest worker (`src/server/ingest/service.ts:621`). Render paths only read the mirrored `document_labels` table, never a labeler over HTTP.
- `Labeler Tap`, `botlabeler`, `tap-docs` have **region-locked volumes** — moving them would need a data migration for zero gain.
- Region moves are latency-only, never cost: both providers price by volume, not distance, and Railway's us-east4 is GCP/Equinix (not AWS), so Railway↔Neon stays public-internet egress regardless.

**Remove three sequential round trips from the home path:**
- One session lookup instead of two identical `session.findFirst` queries for two booleans on the same row (new `session-preferences.server.ts`).
- Collapse the home feed attach chain: was `hidden` → `labels` → `recommends` serially, where the first two issued the **same** `document_labels` query. Labels and recommends now run concurrently; hide-filtering derives from the already-fetched map.

**Un-break the perf suite.** It waited on `[data-app-scroller]`, which exists nowhere in `src/` — every one of the 22 targets timed out at 45s. Now anchors on `main#main-content`, fails fast with a real message when a signed-in target bounces to `/login`, and retargets `/likes` (now a permanent redirect) → `/recommended`.

## Results

Local production build, median of 5 (127ms RTT to Neon from this machine):

| | Before | After |
|---|---|---|
| Signed-in TTFB | 1533ms | **932ms** (−39%) |
| Signed-in LCP | 1612ms | 1020ms |
| `getHomePage` | 1072ms | 704ms |

The region change should be the far larger win in prod, and is not reflected above.

## Verification

`tsc` clean · oxlint/oxfmt clean · **256 tests pass** · perf suite runs again (18/22 targets)

## Notes

- The 4 remaining perf failures are pre-existing and unrelated: `/saved`, `/history`, `/collections`, `/recommended` redirect a **validly signed-in user** to `/login` on direct navigation. Confirmed via `git stash` that this reproduces on unmodified `main`. Real user-facing bug, worth its own issue.
- `resolveTrackReadingHistoryEnabled` / `resolveCountOldPostsAsUnreadEnabled` are now unused in this branch but left in place — other worktrees still import them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)