### PR TITLE
Make tag lookups indexable

### DIFF
--- a/drizzle/0014_indexable_document_tags.sql
+++ b/drizzle/0014_indexable_document_tags.sql
@@ -1,0 +1,28 @@
+-- Make tag lookups indexable.
+--
+-- The tag page matched tags with
+--   exists (select 1 from unnest(documents.tags) as doc_tag
+--           where lower(btrim(doc_tag)) = lower(btrim($tag)))
+-- which no index can serve: Postgres had to seq-scan `documents` and unnest
+-- every row's tags array on every tag page load. Measured on prod, the article
+-- count alone was a 886ms Seq Scan (356k rows removed by filter, 79k blocks) and
+-- the publication count 3.6s — which is why a tag with *zero* matches still cost
+-- well over a second.
+--
+-- Normalizing the whole array in one IMMUTABLE function makes the same predicate
+-- expressible as array containment (`@> array[lower(btrim($tag))]`), which a GIN
+-- index can answer directly. Same normalization as before (lowercase, trim, drop
+-- blanks), so results are unchanged — verified equal across a sample of tags
+-- including case/whitespace variants and non-ASCII.
+--
+-- `array_agg` over `unnest` is only usable in an index expression when wrapped in
+-- an IMMUTABLE function, mirroring `immutable_array_to_string` in 0013.
+CREATE OR REPLACE FUNCTION immutable_normalized_tags(text[]) RETURNS text[]
+  LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$
+    SELECT array_agg(lower(btrim(t))) FROM unnest($1) AS t WHERE btrim(t) <> ''
+  $$;--> statement-breakpoint
+-- Created CONCURRENTLY on prod out-of-band (a plain CREATE INDEX takes a long
+-- lock on `documents`, which is ~356k rows); IF NOT EXISTS makes this a no-op
+-- there while still building it on fresh/local/test databases. Same pattern as
+-- the trigram indexes in 0003.
+CREATE INDEX IF NOT EXISTS "documents_tags_norm_idx" ON "documents" USING gin (immutable_normalized_tags("tags"));

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1784099620903,
       "tag": "0013_tags_topic_in_search_vector",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1784099620904,
+      "tag": "0014_indexable_document_tags",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/reader/queries.ts
+++ b/src/server/reader/queries.ts
@@ -1598,13 +1598,25 @@ export async function discoverDirectoryPublications(
 }
 
 /** Document `tags` array includes `tag` (case-insensitive). */
+/**
+ * Normalized form of a tag as stored in the `documents_tags_norm_idx` GIN index
+ * (lowercased, trimmed). Callers compare against
+ * `immutable_normalized_tags(tags)` so the index can serve the predicate.
+ */
+function normalizedTagSql(tag: string): SQL {
+  return sql`lower(btrim(${tag}))`;
+}
+
+/**
+ * Document carries `tag` (case/whitespace-insensitive).
+ *
+ * Expressed as array containment against `immutable_normalized_tags(tags)` so
+ * the GIN index answers it directly. The equivalent `exists (... unnest(tags)
+ * ...)` form is not indexable and forced a full seq scan of `documents` — a tag
+ * page cost seconds even when the tag matched nothing (see migration 0014).
+ */
 function documentCarriesTagWhere(d: Schema["documents"], tag: string): SQL {
-  return sql`exists (
-    select 1
-    from unnest(${d.tags}) as doc_tag
-    where btrim(doc_tag) <> ''
-      and lower(btrim(doc_tag)) = lower(btrim(${tag}))
-  )`;
+  return sql`immutable_normalized_tags(${d.tags}) @> array[${normalizedTagSql(tag)}]`;
 }
 
 /** Count indexed, published articles carrying a tag on discover-eligible pubs. */
@@ -1640,12 +1652,11 @@ function publicationHasTaggedDocumentSql(
 ): SQL {
   return sql`exists (
     select 1
-    from ${d} doc, unnest(doc.tags) as doc_tag
+    from ${d} doc
     where doc.publication_uri = ${p.uri}
       and doc.deleted = false
       and doc.published_at <= now()
-      and btrim(doc_tag) <> ''
-      and lower(btrim(doc_tag)) = lower(btrim(${tag}))
+      and immutable_normalized_tags(doc.tags) @> array[${normalizedTagSql(tag)}]
   )`;
 }
 
@@ -1657,12 +1668,11 @@ function publicationTaggedPostCountSql(
 ): ReturnType<typeof sql<number>> {
   return sql<number>`coalesce((
     select count(*)::int
-    from ${d} doc, unnest(doc.tags) as doc_tag
+    from ${d} doc
     where doc.publication_uri = ${p.uri}
       and doc.deleted = false
       and doc.published_at <= now()
-      and btrim(doc_tag) <> ''
-      and lower(btrim(doc_tag)) = lower(btrim(${tag}))
+      and immutable_normalized_tags(doc.tags) @> array[${normalizedTagSql(tag)}]
   ), 0)`;
 }
 


### PR DESCRIPTION
## The problem

`tag.getPage` is the slowest span in the app: **P50 2669ms / P95 3930ms**.

The giveaway was that duration had nothing to do with result count:

| tag | articles | pubs | duration |
|---|---|---|---|
| `création contenu` | **0** | 0 | 1425ms |
| `dids` | 1 | 1 | **3897ms** |
| `rust` | 161 | 37 | 3560ms |

A tag matching *nothing* still cost 1.4s — a fixed scan, not result work.

Tags were matched with:

```sql
exists (select 1 from unnest(documents.tags) as doc_tag
        where lower(btrim(doc_tag)) = lower(btrim($tag)))
```

No index can serve that. `EXPLAIN ANALYZE` on prod confirmed a **Seq Scan** over `documents` with the `unnest` SubPlan running once per row — **350,443 loops, 356,317 rows removed by filter, 79k blocks touched**, to return 162 rows.

## The fix

Normalize the whole array in one IMMUTABLE function so the predicate becomes array containment, which a GIN index answers directly:

```sql
immutable_normalized_tags(tags) @> array[lower(btrim($tag))]
```

Same normalization as before (lowercase, trim, drop blanks) — mirrors the existing `immutable_array_to_string` helper from `0013`.

## Results

Both measured on **production, warm cache**, `tag='rust'`, EXPLAIN ANALYZE execution time:

| query | before | after | speedup | blocks |
|---|---|---|---|---|
| `countTagArticles` | 885.9ms | **0.349ms** | **2538x** | 79k → 145 |
| `countTagPublications` | 932.0ms | **5.988ms** | **156x** | 81k → 1.8k |

Plan is now a Bitmap Index Scan on `documents_tags_norm_idx`. The three tag queries run in `Promise.all`, so the page tracks the slowest.

Page-level improvement is not claimed here — the observed P50 of 2669ms is larger than the slowest single query (932ms) because it also includes DB round trips and cold-cache variance. Real page numbers will come from telemetry after deploy.

## Correctness

Verified the rewrite returns **identical** counts across tags including case/whitespace variants (`  RUST  `) and non-ASCII (`création contenu`). The counts also match exactly what production reports for those same tags (`rust` 161/37, `movies` 87/28, `dids` 1/1).

## Index rollout

The GIN index was built **`CONCURRENTLY` on prod out-of-band** — it's valid, ready, 11MB — so the `IF NOT EXISTS` in the migration is a no-op there while still building on fresh/local/test DBs. Same pattern as the trigram indexes in `0003`. A plain `CREATE INDEX` in preDeploy would have held an exclusive lock on `documents` (~356k rows) and stalled ingest.

The function is already created on prod too, so the new queries are safe the moment this deploys.

## Not included

`publicationTagMatchSql` and the tag-cloud aggregates (`publicationEffectiveTopicSql`, `discoverPublicationTopics`, `tagOverlapScoresForDocument`) still `unnest`. The first is the same shape and probably deserves the same treatment, but it serves Discover rather than the tag page and I didn't measure it — worth a follow-up rather than an unmeasured change.

## Verification

`tsc` clean · oxlint/oxfmt clean · **256 tests pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)