### PR TITLE
Fix /latest ordering mismatch that defeated the published_at index

### DIFF
--- a/src/integrations/tanstack-query/api-feed.functions.ts
+++ b/src/integrations/tanstack-query/api-feed.functions.ts
@@ -655,31 +655,41 @@ async function loadLatestFeedCritical(
         });
 
   span.set("count", items.length);
+
+  // Labels and recommend attribution are independent reads over the same rows,
+  // so fetch them concurrently rather than chaining. Both are computed over the
+  // pre-hide-filter set and hidden rows are dropped afterwards — filtering only
+  // ever removes rows, so the result is identical to filtering first.
+  //
+  // This replaced three serial round trips (hidden → labels → recommends, where
+  // the first two issued the *same* `document_labels` query) with one wave.
+  // "Recommended by" attribution only applies to followed-user rows (skips the
+  // "all" / signed-out / trending paths, which have no followed-user context).
+  const [labelsByUri, withRecs] = await Promise.all([
+    did
+      ? readLabelsForUris(
+          db,
+          schema,
+          did,
+          items.map((item) => item.uri),
+        )
+      : Promise.resolve(new Map<string, Array<ArticleCardLabel>>()),
+    did && data.filter !== "all" && followedUserDids.length > 0
+      ? attachRecommendedByToArticles(db, schema, followedUserDids, items)
+      : Promise.resolve(items),
+  ]);
+
   // Hide labeled posts for the reader, but page on the pre-filter count so
   // pagination still advances (a page may just show slightly fewer rows).
-  const visibleItems = await filterHiddenDocuments(db, schema, did, items);
+  const hidden = hiddenUrisFromLabels(labelsByUri);
+  const visibleItems = withRecs.filter((item) => !hidden.has(item.uri));
+  // No DB work: reads cached counts and schedules background revalidation.
   const enrichedItems = await attachCommentCountsToArticles(
     db,
     schema,
     trackReading ? visibleItems : articleCardsAsAllRead(visibleItems),
   );
-  const labeledItems = await attachSubscribedLabels(
-    db,
-    schema,
-    did,
-    enrichedItems,
-  );
-  // "Recommended by" attribution for followed-user rows (skips the "all" /
-  // signed-out / trending paths, which have no followed-user context).
-  const attributedItems =
-    did && data.filter !== "all" && followedUserDids.length > 0
-      ? await attachRecommendedByToArticles(
-          db,
-          schema,
-          followedUserDids,
-          labeledItems,
-        )
-      : labeledItems;
+  const attributedItems = attachLabelsFromMap(enrichedItems, labelsByUri);
 
   return {
     items: attributedItems,

--- a/src/server/reader/queries.ts
+++ b/src/server/reader/queries.ts
@@ -493,7 +493,7 @@ export async function selectArticleCards(
 
   const rows = await query
     .where(and(...conds))
-    .orderBy(desc(d.publishedAt), desc(d.uri))
+    .orderBy(...documentsNewestFirst(d))
     .limit(opts.limit)
     .offset(opts.offset ?? 0);
 
@@ -565,7 +565,7 @@ export async function selectPublicationArticleCards(
         eq(d.publicationUri, opts.publicationUri),
       ),
     )
-    .orderBy(desc(d.publishedAt), desc(d.uri))
+    .orderBy(...documentsNewestFirst(d))
     .limit(opts.limit)
     .offset(opts.offset ?? 0);
 
@@ -666,7 +666,7 @@ export async function selectUnreadDocumentUris(
       ),
     )
     .where(and(...conds, isNull(r.uri)))
-    .orderBy(desc(d.publishedAt), desc(d.uri))
+    .orderBy(...documentsNewestFirst(d))
     .limit(limit);
 
   return rows.map((row) => row.uri);
@@ -1617,6 +1617,22 @@ function normalizedTagSql(tag: string): SQL {
  */
 function documentCarriesTagWhere(d: Schema["documents"], tag: string): SQL {
   return sql`immutable_normalized_tags(${d.tags}) @> array[${normalizedTagSql(tag)}]`;
+}
+
+/**
+ * Newest-first document ordering, spelled to match the `published_at DESC NULLS
+ * LAST` indexes (`documents_published_idx`,
+ * `documents_publication_published_idx`).
+ *
+ * Drizzle's `desc()` emits a bare `DESC`, which Postgres reads as NULLS FIRST —
+ * and it will not match a NULLS LAST index even though `published_at` is
+ * `NOT NULL`, so the ordering is semantically identical. That mismatch cost a
+ * full scan: `/latest?filter=all` planned a parallel Seq Scan over ~345k
+ * documents plus a top-N heapsort (726ms) where the index gives an ordered scan
+ * that stops after ~37 rows (0.3ms).
+ */
+function documentsNewestFirst(d: Schema["documents"]): Array<SQL> {
+  return [sql`${d.publishedAt} desc nulls last`, desc(d.uri)];
 }
 
 /** Count indexed, published articles carrying a tag on discover-eligible pubs. */
@@ -3004,7 +3020,7 @@ export async function authorDocuments(
       .leftJoin(pr, eq(pr.did, p.did))
       .leftJoin(pa, eq(pa.did, d.did))
       .where(where)
-      .orderBy(desc(d.publishedAt), desc(d.uri))
+      .orderBy(...documentsNewestFirst(d))
       .limit(opts.limit)
       .offset(opts.offset ?? 0),
   ]);


### PR DESCRIPTION
## The problem

`/latest` was slow on every filter, worst on `all` (7d, clean window):

| filter | P50 | P95 | MAX | calls |
|---|---|---|---|---|
| `all` | **2382ms** | 5368 | 7840 | 468 |
| `trending` | 1365ms | 3593 | 6655 | 463 |
| `unread` | 1058ms | 2652 | **68770** | 1328 |
| `subscriptions` | 693ms | 3232 | 7222 | 477 |

Timing the queries directly against prod isolated it — `all` was the only one doing real work:

| query | measured | real execution |
|---|---|---|
| `selectArticleCards` **all** | 1236ms | **~1100ms** |
| subscriptions / unread / trending | 131–148ms | ~0ms (just round-trip latency) |

## Root cause

The NULLS-ordering mismatch this repo has hit before:

- Indexes are `published_at **DESC NULLS LAST**`
- Drizzle's `desc()` emits a bare `DESC` → Postgres reads it as **NULLS FIRST**

Postgres won't match a NULLS LAST index to a NULLS FIRST sort — *even though `published_at` is `NOT NULL`*, which makes the two orders semantically identical here. So it fell back to scanning everything.

`EXPLAIN ANALYZE` on prod, `filter=all`:

| | plan | time | blocks |
|---|---|---|---|
| before | parallel Seq Scan over ~345k docs + top-N heapsort | 726.319ms | 80,784 |
| after | Index Scan on `documents_published_idx`, stops after 37 rows | **0.271ms** | 197 |

**~2680x faster, 410x fewer blocks.**

## Changes

1. **One shared `documentsNewestFirst()` helper** spelling the sort as `published_at desc nulls last`, applied to all four document-list orderings. Trending sorts lead with `trending_score` against a different index and already execute in ~0ms — left alone.

2. **Collapsed the same serial attach chain** `buildHomeFeedCritical` had (fixed in #26): `filterHiddenDocuments` → comment counts → `attachSubscribedLabels` → recommends ran serially, and the first and third issued the **same** `document_labels` query. Labels and recommends now run concurrently; hide-filtering derives from the already-fetched map. Three serial round trips → one, on every filter.

## Results

Measured against prod (client RTT ~75ms is the floor, so these are near-zero execution):

| query | before | after |
|---|---|---|
| `selectArticleCards` all=20 | 1236ms | **76ms** |
| `selectArticleCards` subscriptions | 139ms | 78ms |
| `selectArticleCards` unread | 148ms | 89ms |

Note subscriptions/unread improved too — they use `documents_publication_published_idx`, which has the same NULLS LAST spelling.

## Verification

Rendered `/latest` for every filter against a local production build — articles present, `main#main-content` present, no skeletons left behind. `tsc` clean · oxlint/oxfmt clean · **256 tests pass**.

Ordering results are unchanged: `published_at` is `NOT NULL`, so NULLS FIRST and NULLS LAST sort identically.

## Not addressed

`countNetworkDocuments` still takes ~440ms counting all 345,431 network documents. It feeds `getLatestFeedCounts`, which is deferred until after first paint. Making it cheap means caching or approximating a number the UI currently shows exactly — that's a product call, so it deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)