### PR TITLE
Lower floating bottom nav closer to the viewport bottom on iOS

### DIFF
--- a/src/components/reader/app-shell.tsx
+++ b/src/components/reader/app-shell.tsx
@@ -504,11 +504,13 @@ const styles = stylex.create({
     position: "fixed",
     rowGap: gap.lg,
     zIndex: 30,
-    // Hug the home-indicator safe area with no extra float. The safe-area inset
-    // alone supplies the OS clearance on iOS (in a standalone PWA it's the ~34px
-    // home-indicator inset); adding to it made the pill read as floating too
-    // high above the bottom.
-    bottom: "env(safe-area-inset-bottom, 0px)",
+    // Sit a floor of 16px above the bottom, or hug the home-indicator safe area
+    // where that's larger. On iOS (standalone PWA) the ~34px safe-area inset
+    // wins, so the pill hugs the home indicator with no extra float. Where there
+    // is no safe area (Android, desktop) the inset resolves to 0 and the 16px
+    // floor keeps the pill off the very bottom edge. `max()` — not env()'s
+    // second arg, which only applies when env() is entirely unsupported.
+    bottom: `max(env(safe-area-inset-bottom, 0px), ${verticalSpace["3xl"]})`,
     insetInlineStart: { [DESKTOP]: "264px", default: 0 },
     paddingInlineStart: horizontalSpace["3xl"],
     paddingInlineEnd: horizontalSpace["3xl"],

--- a/src/components/reader/app-shell.tsx
+++ b/src/components/reader/app-shell.tsx
@@ -504,7 +504,10 @@ const styles = stylex.create({
     position: "fixed",
     rowGap: gap.lg,
     zIndex: 30,
-    bottom: `calc(env(safe-area-inset-bottom, 0px) + ${verticalSpace["3xl"]})`,
+    // Sit just above the home-indicator safe area. The safe-area inset already
+    // supplies the OS clearance on iOS, so only a small extra gap is needed —
+    // a larger one made the pill read as floating too high above the bottom.
+    bottom: `calc(env(safe-area-inset-bottom, 0px) + ${verticalSpace["md"]})`,
     insetInlineStart: { [DESKTOP]: "264px", default: 0 },
     paddingInlineStart: horizontalSpace["3xl"],
     paddingInlineEnd: horizontalSpace["3xl"],

--- a/src/components/reader/app-shell.tsx
+++ b/src/components/reader/app-shell.tsx
@@ -504,10 +504,11 @@ const styles = stylex.create({
     position: "fixed",
     rowGap: gap.lg,
     zIndex: 30,
-    // Sit just above the home-indicator safe area. The safe-area inset already
-    // supplies the OS clearance on iOS, so only a small extra gap is needed —
-    // a larger one made the pill read as floating too high above the bottom.
-    bottom: `calc(env(safe-area-inset-bottom, 0px) + ${verticalSpace["md"]})`,
+    // Hug the home-indicator safe area with no extra float. The safe-area inset
+    // alone supplies the OS clearance on iOS (in a standalone PWA it's the ~34px
+    // home-indicator inset); adding to it made the pill read as floating too
+    // high above the bottom.
+    bottom: "env(safe-area-inset-bottom, 0px)",
     insetInlineStart: { [DESKTOP]: "264px", default: 0 },
     paddingInlineStart: horizontalSpace["3xl"],
     paddingInlineEnd: horizontalSpace["3xl"],


### PR DESCRIPTION
The floating dock (bottom nav pill + reader bar) sat at
env(safe-area-inset-bottom) + 16px, which on iOS read as floating too
high above the bottom edge. Reduce the extra gap above the safe-area
inset to 8px so the pill hugs closer to the bottom while still clearing
the home indicator.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012a4oYMASJ5NHUY7zvnB1Hj