### PR TITLE
Keep the home feed intact when reading an article

### DIFF
--- a/src/routes/_layout.index.tsx
+++ b/src/routes/_layout.index.tsx
@@ -76,14 +76,45 @@ export const Route = createFileRoute("/_layout/")({
   },
   loaderDeps: ({ search }) => ({ scope: search.scope }),
   loader: async ({ context, deps }) => {
+    const { queryClient } = context;
+
+    // Cache-first, mirroring /latest. Reading an article optimistically flips its
+    // card to read in the home-feed cache (see applyMarkReadOptimisticUpdate)
+    // without dropping it from the list. Blindly re-running getHomePage() on every
+    // navigation and overwriting the cache with setQueryData would clobber those
+    // edits and hand back a server-recomputed feed with the just-read article gone
+    // or reordered — so the list jumps under the reader on Back. When the feed is
+    // still fresh in the cache, reuse it and skip the fetch, so the just-read
+    // article stays put and the feed stays intact for browsing.
+    const session = queryClient.getQueryData(
+      user.getSessionQueryOptions.queryKey,
+    );
+    const readerScope = user.readerQueryScope(session);
+    const cachedScope = queryClient.getQueryData(
+      user.getHomeScopePreferenceQueryOptions.queryKey,
+    )?.scope;
+    const scope = deps.scope ?? cachedScope ?? "follows";
+
+    const feedOptions = feedApi.getHomeFeedQueryOptions({ scope, readerScope });
+    const feedStaleTime =
+      typeof feedOptions.staleTime === "number" ? feedOptions.staleTime : 0;
+    const feedQuery = queryClient.getQueryCache().find({
+      queryKey: feedOptions.queryKey,
+    });
+    if (
+      feedQuery?.state.data !== undefined &&
+      !feedQuery.isStaleByTime(feedStaleTime)
+    ) {
+      return { scope, readerScope };
+    }
+
     const page = await feedApi.getHomePage({
       data: { scope: deps.scope },
     });
-    context.queryClient.setQueryData(
-      user.getHomeScopePreferenceQueryOptions.queryKey,
-      { scope: page.scope },
-    );
-    context.queryClient.setQueryData(
+    queryClient.setQueryData(user.getHomeScopePreferenceQueryOptions.queryKey, {
+      scope: page.scope,
+    });
+    queryClient.setQueryData(
       feedApi.getHomeFeedQueryOptions({
         scope: page.scope,
         readerScope: page.readerScope,


### PR DESCRIPTION
The home route loader unconditionally called getHomePage() and overwrote
the home-feed cache via setQueryData on every navigation. Reading an
article optimistically flips its card to read in that cache without
dropping it, but on Back the loader re-ran and replaced the cache with a
server-recomputed feed where the just-read article was gone or reordered,
so the list jumped under the reader.

Make the loader cache-first, mirroring /latest: resolve scope/readerScope
from the cached session and scope preference, and when the home-feed query
is still fresh, reuse it and skip the fetch instead of clobbering the
optimistic edits. Cold loads and genuinely stale caches still fetch via
getHomePage as before.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C8aerD3EBmPtjoS7MQR7Rc