### PR TITLE
fix: account for frame border in fixed-height iframe embeds

### DIFF
--- a/src/components/reader/content/body-styles.ts
+++ b/src/components/reader/content/body-styles.ts
@@ -17,6 +17,15 @@ import {
 import type { ReadingTypographyPreference } from "#/lib/reading-typography";
 import { readingCustomFontFamily } from "#/lib/reading-typography";
 
+/**
+ * Border width of `iframeFrame`. Exported so callers that set an explicit
+ * pixel height on the frame can add it back: the frame is `border-box`, so a
+ * bare `height: 352px` leaves the iframe only 350px of content box, and some
+ * embeds (Spotify switches to its compact player below 352px) change layout
+ * over a couple of pixels.
+ */
+export const IFRAME_FRAME_BORDER_WIDTH = 1;
+
 export const articleBodyStyles = stylex.create({
   body: {
     color: uiColor.text2,
@@ -246,7 +255,7 @@ export const articleBodyStyles = stylex.create({
     borderColor: uiColor.border1,
     borderRadius: radius.md,
     borderStyle: "solid",
-    borderWidth: 1,
+    borderWidth: IFRAME_FRAME_BORDER_WIDTH,
     overflow: "hidden",
     backgroundColor: uiColor.component1,
     position: "relative",

--- a/src/components/reader/content/body-styles.ts
+++ b/src/components/reader/content/body-styles.ts
@@ -255,7 +255,9 @@ export const articleBodyStyles = stylex.create({
     borderColor: uiColor.border1,
     borderRadius: radius.md,
     borderStyle: "solid",
-    borderWidth: IFRAME_FRAME_BORDER_WIDTH,
+    // Keep in sync with `IFRAME_FRAME_BORDER_WIDTH`; the stylex lint rule
+    // can't resolve an identifier here.
+    borderWidth: 1,
     overflow: "hidden",
     backgroundColor: uiColor.component1,
     position: "relative",

--- a/src/components/reader/content/renderers/shared/iframe-embed.tsx
+++ b/src/components/reader/content/renderers/shared/iframe-embed.tsx
@@ -3,7 +3,10 @@
 import { useLingui } from "@lingui/react/macro";
 import * as stylex from "@stylexjs/stylex";
 
-import { articleBodyStyles } from "../../body-styles";
+import {
+  articleBodyStyles,
+  IFRAME_FRAME_BORDER_WIDTH,
+} from "../../body-styles";
 
 const DEFAULT_ASPECT_RATIO = "16 / 9";
 
@@ -69,9 +72,11 @@ export function IframeEmbedView({
         {...stylex.props(articleBodyStyles.iframeFrame)}
         style={{
           aspectRatio: aspectRatioCss,
+          // The frame is `border-box`, so grow it by the border so the iframe
+          // itself gets exactly the height the embed asked for.
           height:
             aspectRatioCss == null && fixedHeight != null
-              ? `${fixedHeight}px`
+              ? `${fixedHeight + IFRAME_FRAME_BORDER_WIDTH * 2}px`
               : undefined,
         }}
       >


### PR DESCRIPTION
## Problem

Spotify playlist embeds render as the **compact** player floating in a mostly-empty box. Example: [Jump on that fire horse?](https://standard-reader.app/a/did:plc:v46ojbiop5ebs5h7gaomixcc/3memtyj4kw2jy) (the same embed renders fine on pckt).

## Cause

The pckt block declares `height: 352`. `IframeEmbedView` puts that height on the wrapper (`articleBodyStyles.iframeFrame`), which is `border-box` with `borderWidth: 1` — so the iframe inside (`height: 100%`) ends up **350px**.

Spotify's embed picks its layout at exactly `innerHeight >= 352`. Bisected against a bare iframe on a blank page:

| iframe height | layout |
|---|---|
| 349 / 350 / 351 | compact |
| **352** | full track list |

Ruled out along the way (by mutating attributes on the live page and reloading the iframe): `sandbox`, `referrerPolicy="no-referrer"`, `allow`, `loading="lazy"`, absolute positioning, width breakpoints, and Spotify CSS loading. Stripping *every* attribute still rendered compact; a freshly injected 600×352 iframe on the same page rendered full.

## Fix

Export `IFRAME_FRAME_BORDER_WIDTH` and grow the frame by it so the iframe gets the height the embed asked for:

```ts
height: `${fixedHeight + IFRAME_FRAME_BORDER_WIDTH * 2}px`
```

Only touches the fixed-height path — aspect-ratio embeds (YouTube, etc.) are unaffected.

## Verification

Set the wrapper to 354px at runtime on prod: iframe measures 352 and Spotify renders the full track list.

Not run: `tsc`/lint (known pre-existing failures on a clean tree); no local dev server was up, so verification was against prod plus isolated repros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)