### PR TITLE
Fix jittery article sticky header on iOS by isolating the blur layer

### DIFF
--- a/src/components/reader/app-shell.tsx
+++ b/src/components/reader/app-shell.tsx
@@ -465,7 +465,16 @@ const styles = stylex.create({
     flexDirection: "column",
     flexGrow: "1",
     minWidth: 0,
-    overflowX: "clip",
+    // …except for views that own a sticky header. A horizontal clip anywhere
+    // above a sticky element makes WebKit re-snap the clip rect to whole device
+    // pixels each frame while the page scrolls at fractional (trackpad /
+    // momentum) offsets, so the header jitters ~1px and leaks a sliver of
+    // content along its top edge. Those views mark themselves with
+    // `data-unclipped-sticky` and contain their own wide content instead.
+    overflowX: {
+      default: "clip",
+      ":has([data-unclipped-sticky])": "visible",
+    },
   },
   mobileBar: {
     alignItems: "center",

--- a/src/components/reader/article-view-skeleton.tsx
+++ b/src/components/reader/article-view-skeleton.tsx
@@ -18,7 +18,9 @@ const styles = stylex.create({
     boxSizing: "border-box",
     maxWidth: "100%",
     minWidth: 0,
-    overflowX: "clip",
+    // No horizontal clip — must match the loaded `ArticleView` root so the
+    // sticky header doesn't gain a clipping ancestor on hydration. See the
+    // comment on `styles.root` in article-view.tsx.
     paddingBottom: {
       default: `calc(env(safe-area-inset-bottom, 0px) + ${spacing["28"]})`,
       "@media (min-width: 60rem)": 0,
@@ -122,6 +124,7 @@ export function ArticleViewSkeleton() {
     <div
       aria-busy="true"
       aria-label={t`Loading article`}
+      data-unclipped-sticky
       {...stylex.props(styles.root)}
     >
       <article {...stylex.props(styles.article, articleMeasureStyles.default)}>

--- a/src/components/reader/article-view.tsx
+++ b/src/components/reader/article-view.tsx
@@ -128,7 +128,14 @@ const styles = stylex.create({
     boxSizing: "border-box",
     maxWidth: "100%",
     minWidth: 0,
-    overflowX: "clip",
+    // Deliberately no `overflow-x: clip` here, and the app shell drops its own
+    // clip for this view (see `scroller` in app-shell). A horizontal clip
+    // anywhere above the sticky article header makes WebKit re-snap the clip
+    // rect to whole device pixels every frame while the page scrolls at
+    // fractional offsets, so the header visibly jitters ~1px and leaks a sliver
+    // of content along its top edge. Wide body content (code blocks, tables,
+    // math, carousels) already scrolls inside its own `overflow-x: auto` box,
+    // so nothing here needs an outer clip.
     // The floating bottom-nav pill overlays the app scroller on mobile, so
     // reserve room for trailing content; the nav is hidden at desktop widths.
     paddingBottom: {
@@ -145,44 +152,15 @@ const styles = stylex.create({
     },
   },
   stickyChrome: {
-    // Translucent base tint sampled by the blur layer below for the frosted
-    // look. The `backdrop-filter` lives on an over-extended child (see
-    // `stickyBlur`), never on the sticky bar itself — applying it directly here
-    // makes iOS Safari clip the filter to the exact sticky edge, leaving a
-    // subpixel seam at the top that reveals the scrolling content and jitters
-    // during momentum scroll.
-    backgroundColor: `color-mix(in oklch, ${uiColor.bg} 90%, transparent)`,
+    backgroundColor: `color-mix(in oklch, ${uiColor.bg} 95%, transparent)`,
     position: "sticky",
     zIndex: 20,
     top: 0,
   },
-  // Clips the over-extended blur layer back to the sticky bar's box. Keeping the
-  // blurred element's own edges outside this clip is what removes the iOS seam.
-  stickyBlurContainer: {
-    inset: 0,
-    overflow: "hidden",
-    pointerEvents: "none",
-    position: "absolute",
-    zIndex: 0,
-  },
-  stickyBlur: {
-    backdropFilter: "blur(12px)",
-    position: "absolute",
-    // Over-extend past every edge so the buggy filter boundary sits outside the
-    // clip (see `stickyBlurContainer`) — only the clean interior is ever shown,
-    // matching the design-system sticky header in `Page.tsx`.
-    top: -48,
-    bottom: -48,
-    insetInlineStart: -48,
-    insetInlineEnd: -48,
-  },
-  // Rides above the blur layer so the top bar and progress track paint crisply.
-  stickyContent: {
-    position: "relative",
-    zIndex: 1,
-  },
   topBar: {
     alignItems: "center",
+    backdropFilter: "blur(12px)",
+    backgroundColor: `color-mix(in oklch, ${uiColor.bg} 90%, transparent)`,
     columnGap: {
       default: gap.sm,
       "@media (min-width: 40rem)": gap.lg,
@@ -1038,128 +1016,124 @@ function ArticleViewBody({
   }, [article.uri, sharedQuote]);
 
   return (
-    <div {...stylex.props(styles.root, readerActive && styles.rootReader)}>
+    <div
+      data-unclipped-sticky
+      {...stylex.props(styles.root, readerActive && styles.rootReader)}
+    >
       <div {...stylex.props(styles.stickyChrome)}>
-        <div {...stylex.props(styles.stickyBlurContainer)} aria-hidden>
-          <div {...stylex.props(styles.stickyBlur)} />
-        </div>
-        <div {...stylex.props(styles.stickyContent)}>
-          <div {...stylex.props(styles.topBar)}>
-            <div {...stylex.props(styles.topLeft)}>
-              <IconButton
-                variant="secondary"
-                size="md"
-                label={t`Back`}
-                onPress={() => {
-                  router.history.back();
-                }}
-              >
-                <DirectionalIcon as={ArrowLeft} size={18} />
-              </IconButton>
+        <div {...stylex.props(styles.topBar)}>
+          <div {...stylex.props(styles.topLeft)}>
+            <IconButton
+              variant="secondary"
+              size="md"
+              label={t`Back`}
+              onPress={() => {
+                router.history.back();
+              }}
+            >
+              <DirectionalIcon as={ArrowLeft} size={18} />
+            </IconButton>
 
-              {pub ? (
-                <>
-                  {pubParams ? (
-                    <Link
-                      to="/p/$did/$rkey"
-                      params={pubParams}
-                      {...stylex.props(styles.pubByline)}
-                    >
-                      <PublicationAvatar pub={pub} size="sm" />
-                      <span {...stylex.props(styles.pubBylineName)}>
-                        {pub.name}
-                      </span>
-                    </Link>
-                  ) : pub.url ? (
-                    <AppLink href={pub.url} linkStyle={styles.pubByline}>
-                      <PublicationAvatar pub={pub} size="sm" />
-                      <span {...stylex.props(styles.pubBylineName)}>
-                        {pub.name}
-                      </span>
-                    </AppLink>
-                  ) : (
-                    <span {...stylex.props(styles.pubByline)}>
-                      <PublicationAvatar pub={pub} size="sm" />
-                      <span {...stylex.props(styles.pubBylineName)}>
-                        {pub.name}
-                      </span>
+            {pub ? (
+              <>
+                {pubParams ? (
+                  <Link
+                    to="/p/$did/$rkey"
+                    params={pubParams}
+                    {...stylex.props(styles.pubByline)}
+                  >
+                    <PublicationAvatar pub={pub} size="sm" />
+                    <span {...stylex.props(styles.pubBylineName)}>
+                      {pub.name}
                     </span>
-                  )}
-                </>
-              ) : null}
-            </div>
-
-            <div {...stylex.props(styles.topActs)}>
-              <TopListenButton article={article} />
-
-              {/* Secondary actions: individual buttons on desktop… */}
-              <div {...stylex.props(styles.topActsInline)}>
-                {handleOpenMagazine ? (
-                  <IconButton
-                    variant="secondary"
-                    size="md"
-                    label={t`Open magazine edition`}
-                    onPress={handleOpenMagazine}
-                  >
-                    <BookOpen size={18} />
-                  </IconButton>
-                ) : null}
-                {handleOpenPublication ? (
-                  <IconButton
-                    variant="secondary"
-                    size="md"
-                    label={
-                      pub
-                        ? t`Open on ${publicationName}`
-                        : t`Open on publication`
-                    }
-                    onPress={handleOpenPublication}
-                  >
-                    <ExternalLink size={18} />
-                  </IconButton>
-                ) : null}
-                {signedIn && trackReading ? (
-                  <ReadToggleButton
-                    isRead={isRead}
-                    onToggle={toggleRead}
-                    isPending={readTogglePending}
-                  />
-                ) : null}
-                <BookmarkButton
-                  bookmarked={bookmarked}
-                  onToggle={toggleBookmark}
-                  isPending={bookmarkPending}
-                />
-              </div>
-
-              {/* …collapsed into an overflow menu on mobile. */}
-              <div {...stylex.props(styles.topActsOverflow)}>
-                <ReaderSecondaryActionsMenu
-                  onOpenMagazine={handleOpenMagazine}
-                  onOpenPublication={handleOpenPublication}
-                  publicationName={publicationName}
-                  showReadToggle={signedIn && trackReading}
-                  isRead={isRead}
-                  onToggleRead={toggleRead}
-                  bookmarked={bookmarked}
-                  onToggleBookmark={toggleBookmark}
-                />
-              </div>
-
-              <DocumentShareMenu
-                recordUri={article.uri}
-                title={article.title}
-                canonicalUrl={article.canonicalUrl}
-                description={article.description}
-                author={primaryAuthor(article)}
-                siteName={pub?.name}
-                imageUrl={article.coverImageUrl}
-              />
-            </div>
+                  </Link>
+                ) : pub.url ? (
+                  <AppLink href={pub.url} linkStyle={styles.pubByline}>
+                    <PublicationAvatar pub={pub} size="sm" />
+                    <span {...stylex.props(styles.pubBylineName)}>
+                      {pub.name}
+                    </span>
+                  </AppLink>
+                ) : (
+                  <span {...stylex.props(styles.pubByline)}>
+                    <PublicationAvatar pub={pub} size="sm" />
+                    <span {...stylex.props(styles.pubBylineName)}>
+                      {pub.name}
+                    </span>
+                  </span>
+                )}
+              </>
+            ) : null}
           </div>
 
-          <ReaderProgress progress={progress} />
+          <div {...stylex.props(styles.topActs)}>
+            <TopListenButton article={article} />
+
+            {/* Secondary actions: individual buttons on desktop… */}
+            <div {...stylex.props(styles.topActsInline)}>
+              {handleOpenMagazine ? (
+                <IconButton
+                  variant="secondary"
+                  size="md"
+                  label={t`Open magazine edition`}
+                  onPress={handleOpenMagazine}
+                >
+                  <BookOpen size={18} />
+                </IconButton>
+              ) : null}
+              {handleOpenPublication ? (
+                <IconButton
+                  variant="secondary"
+                  size="md"
+                  label={
+                    pub ? t`Open on ${publicationName}` : t`Open on publication`
+                  }
+                  onPress={handleOpenPublication}
+                >
+                  <ExternalLink size={18} />
+                </IconButton>
+              ) : null}
+              {signedIn && trackReading ? (
+                <ReadToggleButton
+                  isRead={isRead}
+                  onToggle={toggleRead}
+                  isPending={readTogglePending}
+                />
+              ) : null}
+              <BookmarkButton
+                bookmarked={bookmarked}
+                onToggle={toggleBookmark}
+                isPending={bookmarkPending}
+              />
+            </div>
+
+            {/* …collapsed into an overflow menu on mobile. */}
+            <div {...stylex.props(styles.topActsOverflow)}>
+              <ReaderSecondaryActionsMenu
+                onOpenMagazine={handleOpenMagazine}
+                onOpenPublication={handleOpenPublication}
+                publicationName={publicationName}
+                showReadToggle={signedIn && trackReading}
+                isRead={isRead}
+                onToggleRead={toggleRead}
+                bookmarked={bookmarked}
+                onToggleBookmark={toggleBookmark}
+              />
+            </div>
+
+            <DocumentShareMenu
+              recordUri={article.uri}
+              title={article.title}
+              canonicalUrl={article.canonicalUrl}
+              description={article.description}
+              author={primaryAuthor(article)}
+              siteName={pub?.name}
+              imageUrl={article.coverImageUrl}
+            />
+          </div>
         </div>
+
+        <ReaderProgress progress={progress} />
       </div>
 
       <ReaderWordHighlighter rootRef={articleRef} articleUri={article.uri} />

--- a/src/components/reader/article-view.tsx
+++ b/src/components/reader/article-view.tsx
@@ -145,15 +145,44 @@ const styles = stylex.create({
     },
   },
   stickyChrome: {
-    backgroundColor: `color-mix(in oklch, ${uiColor.bg} 95%, transparent)`,
+    // Translucent base tint sampled by the blur layer below for the frosted
+    // look. The `backdrop-filter` lives on an over-extended child (see
+    // `stickyBlur`), never on the sticky bar itself — applying it directly here
+    // makes iOS Safari clip the filter to the exact sticky edge, leaving a
+    // subpixel seam at the top that reveals the scrolling content and jitters
+    // during momentum scroll.
+    backgroundColor: `color-mix(in oklch, ${uiColor.bg} 90%, transparent)`,
     position: "sticky",
     zIndex: 20,
     top: 0,
   },
+  // Clips the over-extended blur layer back to the sticky bar's box. Keeping the
+  // blurred element's own edges outside this clip is what removes the iOS seam.
+  stickyBlurContainer: {
+    inset: 0,
+    overflow: "hidden",
+    pointerEvents: "none",
+    position: "absolute",
+    zIndex: 0,
+  },
+  stickyBlur: {
+    backdropFilter: "blur(12px)",
+    position: "absolute",
+    // Over-extend past every edge so the buggy filter boundary sits outside the
+    // clip (see `stickyBlurContainer`) — only the clean interior is ever shown,
+    // matching the design-system sticky header in `Page.tsx`.
+    top: -48,
+    bottom: -48,
+    insetInlineStart: -48,
+    insetInlineEnd: -48,
+  },
+  // Rides above the blur layer so the top bar and progress track paint crisply.
+  stickyContent: {
+    position: "relative",
+    zIndex: 1,
+  },
   topBar: {
     alignItems: "center",
-    backdropFilter: "blur(12px)",
-    backgroundColor: `color-mix(in oklch, ${uiColor.bg} 90%, transparent)`,
     columnGap: {
       default: gap.sm,
       "@media (min-width: 40rem)": gap.lg,
@@ -1011,119 +1040,126 @@ function ArticleViewBody({
   return (
     <div {...stylex.props(styles.root, readerActive && styles.rootReader)}>
       <div {...stylex.props(styles.stickyChrome)}>
-        <div {...stylex.props(styles.topBar)}>
-          <div {...stylex.props(styles.topLeft)}>
-            <IconButton
-              variant="secondary"
-              size="md"
-              label={t`Back`}
-              onPress={() => {
-                router.history.back();
-              }}
-            >
-              <DirectionalIcon as={ArrowLeft} size={18} />
-            </IconButton>
-
-            {pub ? (
-              <>
-                {pubParams ? (
-                  <Link
-                    to="/p/$did/$rkey"
-                    params={pubParams}
-                    {...stylex.props(styles.pubByline)}
-                  >
-                    <PublicationAvatar pub={pub} size="sm" />
-                    <span {...stylex.props(styles.pubBylineName)}>
-                      {pub.name}
-                    </span>
-                  </Link>
-                ) : pub.url ? (
-                  <AppLink href={pub.url} linkStyle={styles.pubByline}>
-                    <PublicationAvatar pub={pub} size="sm" />
-                    <span {...stylex.props(styles.pubBylineName)}>
-                      {pub.name}
-                    </span>
-                  </AppLink>
-                ) : (
-                  <span {...stylex.props(styles.pubByline)}>
-                    <PublicationAvatar pub={pub} size="sm" />
-                    <span {...stylex.props(styles.pubBylineName)}>
-                      {pub.name}
-                    </span>
-                  </span>
-                )}
-              </>
-            ) : null}
-          </div>
-
-          <div {...stylex.props(styles.topActs)}>
-            <TopListenButton article={article} />
-
-            {/* Secondary actions: individual buttons on desktop… */}
-            <div {...stylex.props(styles.topActsInline)}>
-              {handleOpenMagazine ? (
-                <IconButton
-                  variant="secondary"
-                  size="md"
-                  label={t`Open magazine edition`}
-                  onPress={handleOpenMagazine}
-                >
-                  <BookOpen size={18} />
-                </IconButton>
-              ) : null}
-              {handleOpenPublication ? (
-                <IconButton
-                  variant="secondary"
-                  size="md"
-                  label={
-                    pub ? t`Open on ${publicationName}` : t`Open on publication`
-                  }
-                  onPress={handleOpenPublication}
-                >
-                  <ExternalLink size={18} />
-                </IconButton>
-              ) : null}
-              {signedIn && trackReading ? (
-                <ReadToggleButton
-                  isRead={isRead}
-                  onToggle={toggleRead}
-                  isPending={readTogglePending}
-                />
-              ) : null}
-              <BookmarkButton
-                bookmarked={bookmarked}
-                onToggle={toggleBookmark}
-                isPending={bookmarkPending}
-              />
-            </div>
-
-            {/* …collapsed into an overflow menu on mobile. */}
-            <div {...stylex.props(styles.topActsOverflow)}>
-              <ReaderSecondaryActionsMenu
-                onOpenMagazine={handleOpenMagazine}
-                onOpenPublication={handleOpenPublication}
-                publicationName={publicationName}
-                showReadToggle={signedIn && trackReading}
-                isRead={isRead}
-                onToggleRead={toggleRead}
-                bookmarked={bookmarked}
-                onToggleBookmark={toggleBookmark}
-              />
-            </div>
-
-            <DocumentShareMenu
-              recordUri={article.uri}
-              title={article.title}
-              canonicalUrl={article.canonicalUrl}
-              description={article.description}
-              author={primaryAuthor(article)}
-              siteName={pub?.name}
-              imageUrl={article.coverImageUrl}
-            />
-          </div>
+        <div {...stylex.props(styles.stickyBlurContainer)} aria-hidden>
+          <div {...stylex.props(styles.stickyBlur)} />
         </div>
+        <div {...stylex.props(styles.stickyContent)}>
+          <div {...stylex.props(styles.topBar)}>
+            <div {...stylex.props(styles.topLeft)}>
+              <IconButton
+                variant="secondary"
+                size="md"
+                label={t`Back`}
+                onPress={() => {
+                  router.history.back();
+                }}
+              >
+                <DirectionalIcon as={ArrowLeft} size={18} />
+              </IconButton>
 
-        <ReaderProgress progress={progress} />
+              {pub ? (
+                <>
+                  {pubParams ? (
+                    <Link
+                      to="/p/$did/$rkey"
+                      params={pubParams}
+                      {...stylex.props(styles.pubByline)}
+                    >
+                      <PublicationAvatar pub={pub} size="sm" />
+                      <span {...stylex.props(styles.pubBylineName)}>
+                        {pub.name}
+                      </span>
+                    </Link>
+                  ) : pub.url ? (
+                    <AppLink href={pub.url} linkStyle={styles.pubByline}>
+                      <PublicationAvatar pub={pub} size="sm" />
+                      <span {...stylex.props(styles.pubBylineName)}>
+                        {pub.name}
+                      </span>
+                    </AppLink>
+                  ) : (
+                    <span {...stylex.props(styles.pubByline)}>
+                      <PublicationAvatar pub={pub} size="sm" />
+                      <span {...stylex.props(styles.pubBylineName)}>
+                        {pub.name}
+                      </span>
+                    </span>
+                  )}
+                </>
+              ) : null}
+            </div>
+
+            <div {...stylex.props(styles.topActs)}>
+              <TopListenButton article={article} />
+
+              {/* Secondary actions: individual buttons on desktop… */}
+              <div {...stylex.props(styles.topActsInline)}>
+                {handleOpenMagazine ? (
+                  <IconButton
+                    variant="secondary"
+                    size="md"
+                    label={t`Open magazine edition`}
+                    onPress={handleOpenMagazine}
+                  >
+                    <BookOpen size={18} />
+                  </IconButton>
+                ) : null}
+                {handleOpenPublication ? (
+                  <IconButton
+                    variant="secondary"
+                    size="md"
+                    label={
+                      pub
+                        ? t`Open on ${publicationName}`
+                        : t`Open on publication`
+                    }
+                    onPress={handleOpenPublication}
+                  >
+                    <ExternalLink size={18} />
+                  </IconButton>
+                ) : null}
+                {signedIn && trackReading ? (
+                  <ReadToggleButton
+                    isRead={isRead}
+                    onToggle={toggleRead}
+                    isPending={readTogglePending}
+                  />
+                ) : null}
+                <BookmarkButton
+                  bookmarked={bookmarked}
+                  onToggle={toggleBookmark}
+                  isPending={bookmarkPending}
+                />
+              </div>
+
+              {/* …collapsed into an overflow menu on mobile. */}
+              <div {...stylex.props(styles.topActsOverflow)}>
+                <ReaderSecondaryActionsMenu
+                  onOpenMagazine={handleOpenMagazine}
+                  onOpenPublication={handleOpenPublication}
+                  publicationName={publicationName}
+                  showReadToggle={signedIn && trackReading}
+                  isRead={isRead}
+                  onToggleRead={toggleRead}
+                  bookmarked={bookmarked}
+                  onToggleBookmark={toggleBookmark}
+                />
+              </div>
+
+              <DocumentShareMenu
+                recordUri={article.uri}
+                title={article.title}
+                canonicalUrl={article.canonicalUrl}
+                description={article.description}
+                author={primaryAuthor(article)}
+                siteName={pub?.name}
+                imageUrl={article.coverImageUrl}
+              />
+            </div>
+          </div>
+
+          <ReaderProgress progress={progress} />
+        </div>
       </div>
 
       <ReaderWordHighlighter rootRef={articleRef} articleUri={article.uri} />


### PR DESCRIPTION
The reader's sticky article header applied `backdrop-filter: blur()` directly to the translucent top bar. On iOS Safari that clips the filter to the exact sticky edge, so subpixel scroll offsets left a hairline seam at the top — scrolling content poked through above the bar and the whole header jittered during momentum scroll, so it never felt like real position: sticky.

Move the blur onto a dedicated absolutely-positioned layer that over-extends 48px past every edge inside an `overflow: hidden` container, with the bar content layered above it. The buggy filter boundary now sits outside the clip, so only the clean interior ever shows and the header pins flush with no seam or jitter. This mirrors the proven sticky-header pattern already used by the design system's Page component.


Claude-Session: https://claude.ai/code/session_01KdXwGdz7HSrssx9xTceQ1M