### PR TITLE
ci: give each PR its own Neon database branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,8 @@ jobs:
           DATABASE_URL: ${{ steps.neon.outputs.db_url }}
           PR_BRANCH: ${{ github.event.pull_request.head.ref }}
           PR_NUMBER: ${{ github.event.number }}
-          # Services in the PR environment that read the read-model. Add
-          # `ingest` here if previews should run their own ingest worker.
-          SERVICES: web
+          # Every service in the PR environment that reads DATABASE_URL. The
+          # ingest worker *writes* to the read-model, so leaving it on the
+          # cloned production URL would have previews writing to prod. `tap`
+          # uses its own TAP_DATABASE_URL and is not in scope here.
+          SERVICES: web,ingest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Per-PR database. Branches off the production project's primary branch so
+  # migrations and the Railway preview run against real prod schema + data
+  # without touching prod itself. Skipped on pushes to main and on fork PRs
+  # (forks get no secrets), in which case the jobs below fall back to the
+  # offline placeholder URL.
+  neon-branch:
+    name: Create Neon branch
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    outputs:
+      db_url: ${{ steps.create.outputs.db_url }}
+    steps:
+      - name: Create Neon branch
+        id: create
+        uses: neondatabase/create-branch-action@v6
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          # Stable name so re-runs and later pushes reuse the same branch
+          # rather than piling up one per commit.
+          branch_name: pr-${{ github.event.number }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+
   verify:
     name: Lint, format, typecheck, build
     runs-on: ubuntu-latest
+    needs: [neon-branch]
+    # `needs` would otherwise skip this job whenever neon-branch is skipped
+    # (main pushes, fork PRs). Run unless the branch job actually failed.
+    if: >-
+      !cancelled() &&
+      (needs.neon-branch.result == 'success' ||
+       needs.neon-branch.result == 'skipped')
+    env:
+      # Falls back to a dummy URL when there is no Neon branch. Nothing in this
+      # job connects to it — drizzle-kit check is offline and the vitest suite
+      # mocks the DB layer — it only satisfies module initialization.
+      DATABASE_URL: ${{ needs.neon-branch.outputs.db_url || 'postgres://drizzle:drizzle@localhost:5432/drizzle' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -34,8 +70,14 @@ jobs:
       # check (no DB connection); the URL only satisfies drizzle.config.ts.
       - name: Check migrations
         run: pnpm exec drizzle-kit check
-        env:
-          DATABASE_URL: postgres://drizzle:drizzle@localhost:5432/drizzle
+
+      # Apply the migrations to the PR's Neon branch. This is the check the
+      # offline `drizzle-kit check` above can't do: proving the migrations
+      # actually apply to production's current schema and data before the
+      # deploy's pre-deploy `pnpm db:migrate` tries the same thing for real.
+      - name: Apply migrations to Neon branch
+        if: needs.neon-branch.result == 'success'
+        run: pnpm db:migrate
 
       - name: Format check
         run: pnpm format:check
@@ -62,3 +104,32 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+  # Repoint the Railway PR environment at the Neon branch. Railway clones
+  # variables from production when it creates a preview, so without this the
+  # preview boots against the production DATABASE_URL.
+  railway-preview-db:
+    name: Point Railway preview at Neon branch
+    runs-on: ubuntu-latest
+    needs: [neon-branch]
+    if: needs.neon-branch.result == 'success'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Set preview DATABASE_URL
+        run: node scripts/railway-set-preview-db.mjs
+        env:
+          RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
+          RAILWAY_PROJECT_ID: fbde7ed0-9be3-4364-8892-c4aa80b2f79e
+          DATABASE_URL: ${{ needs.neon-branch.outputs.db_url }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.number }}
+          # Services in the PR environment that read the read-model. Add
+          # `ingest` here if previews should run their own ingest worker.
+          SERVICES: web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,22 @@ jobs:
   # without touching prod itself. Skipped on pushes to main and on fork PRs
   # (forks get no secrets), in which case the jobs below fall back to the
   # offline placeholder URL.
+  #
+  # This job only *ensures the branch exists*. It deliberately exposes no
+  # outputs: the action masks the branch password, and GitHub strips masked
+  # values out of job outputs, so a `db_url` job output always arrives empty
+  # downstream. Each consuming job re-runs the action instead — it is
+  # idempotent and returns the existing branch — and reads it as a step output,
+  # which is not stripped. Creating it here first keeps those two jobs from
+  # racing to create the same branch name.
   neon-branch:
     name: Create Neon branch
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository
-    outputs:
-      db_url: ${{ steps.create.outputs.db_url }}
     steps:
       - name: Create Neon branch
-        id: create
         uses: neondatabase/create-branch-action@v6
         with:
           project_id: ${{ vars.NEON_PROJECT_ID }}
@@ -44,11 +49,6 @@ jobs:
       !cancelled() &&
       (needs.neon-branch.result == 'success' ||
        needs.neon-branch.result == 'skipped')
-    env:
-      # Falls back to a dummy URL when there is no Neon branch. Nothing in this
-      # job connects to it — drizzle-kit check is offline and the vitest suite
-      # mocks the DB layer — it only satisfies module initialization.
-      DATABASE_URL: ${{ needs.neon-branch.outputs.db_url || 'postgres://drizzle:drizzle@localhost:5432/drizzle' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -65,11 +65,24 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Resolves to the branch neon-branch already created. Skipped on main
+      # pushes and fork PRs; the steps below then fall back to a placeholder.
+      - name: Resolve Neon branch
+        id: neon
+        if: needs.neon-branch.result == 'success'
+        uses: neondatabase/create-branch-action@v6
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch_name: pr-${{ github.event.number }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+
       # Validate the drizzle migration journal/snapshots are consistent before
       # the deploy's pre-deploy `pnpm db:migrate` tries to apply them. Offline
       # check (no DB connection); the URL only satisfies drizzle.config.ts.
       - name: Check migrations
         run: pnpm exec drizzle-kit check
+        env:
+          DATABASE_URL: postgres://drizzle:drizzle@localhost:5432/drizzle
 
       # Apply the migrations to the PR's Neon branch. This is the check the
       # offline `drizzle-kit check` above can't do: proving the migrations
@@ -78,6 +91,8 @@ jobs:
       - name: Apply migrations to Neon branch
         if: needs.neon-branch.result == 'success'
         run: pnpm db:migrate
+        env:
+          DATABASE_URL: ${{ steps.neon.outputs.db_url }}
 
       - name: Format check
         run: pnpm format:check
@@ -104,6 +119,10 @@ jobs:
 
       - name: Test
         run: pnpm test
+        env:
+          # Inert today — the suite mocks the DB layer and never connects, and
+          # vitest.setup.ts supplies its own placeholder when this is unset.
+          DATABASE_URL: ${{ steps.neon.outputs.db_url }}
 
   # Repoint the Railway PR environment at the Neon branch. Railway clones
   # variables from production when it creates a preview, so without this the
@@ -122,12 +141,20 @@ jobs:
         with:
           node-version: 22
 
+      - name: Resolve Neon branch
+        id: neon
+        uses: neondatabase/create-branch-action@v6
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch_name: pr-${{ github.event.number }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+
       - name: Set preview DATABASE_URL
         run: node scripts/railway-set-preview-db.mjs
         env:
           RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
           RAILWAY_PROJECT_ID: fbde7ed0-9be3-4364-8892-c4aa80b2f79e
-          DATABASE_URL: ${{ needs.neon-branch.outputs.db_url }}
+          DATABASE_URL: ${{ steps.neon.outputs.db_url }}
           PR_BRANCH: ${{ github.event.pull_request.head.ref }}
           PR_NUMBER: ${{ github.event.number }}
           # Services in the PR environment that read the read-model. Add

--- a/.github/workflows/neon-branch-cleanup.yml
+++ b/.github/workflows/neon-branch-cleanup.yml
@@ -1,0 +1,22 @@
+name: Neon branch cleanup
+
+# Deletes the per-PR Neon branch once the PR is merged or closed. Railway tears
+# down its own PR environment automatically; this reclaims the database side.
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete-branch:
+    name: Delete Neon branch
+    runs-on: ubuntu-latest
+    # Fork PRs never had a branch created (no access to secrets), so there is
+    # nothing to clean up.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Delete Neon branch
+        uses: neondatabase/delete-branch-action@v3
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch: pr-${{ github.event.number }}
+          api_key: ${{ secrets.NEON_API_KEY }}

--- a/scripts/railway-set-preview-db.mjs
+++ b/scripts/railway-set-preview-db.mjs
@@ -74,6 +74,24 @@ const SERVICES_QUERY = `
   }
 `;
 
+const VARIABLES = `
+  query ($projectId: String!, $environmentId: String!, $serviceId: String!) {
+    variables(
+      projectId: $projectId
+      environmentId: $environmentId
+      serviceId: $serviceId
+    )
+  }
+`;
+
+const DEPLOYMENTS = `
+  query ($input: DeploymentListInput!) {
+    deployments(input: $input, first: 1) {
+      edges { node { id status } }
+    }
+  }
+`;
+
 const UPSERT = `
   mutation ($input: VariableUpsertInput!) {
     variableUpsert(input: $input)
@@ -116,6 +134,50 @@ async function findPrEnvironment() {
   return null;
 }
 
+/**
+ * A redeploy issued while Railway's own deploy is still building supersedes it,
+ * and Railway reports the superseded deployment to GitHub as a *failed* check
+ * even though nothing was wrong with it. Wait for whatever is in flight to
+ * settle before replacing it.
+ *
+ * Best-effort: if the status can't be read, proceed anyway rather than blocking
+ * the correction. A noisy check is better than a preview left on the prod DB.
+ */
+async function waitForIdle(environmentId, serviceId, serviceName) {
+  const TERMINAL = new Set([
+    "SUCCESS",
+    "FAILED",
+    "CRASHED",
+    "REMOVED",
+    "SKIPPED",
+  ]);
+
+  for (let attempt = 1; attempt <= 40; attempt++) {
+    let status;
+    try {
+      const data = await gql(DEPLOYMENTS, {
+        input: { projectId: RAILWAY_PROJECT_ID, environmentId, serviceId },
+      });
+      status = data.deployments.edges[0]?.node?.status;
+    } catch (error) {
+      console.log(
+        `Could not read ${serviceName} deploy status: ${error.message}`,
+      );
+      return;
+    }
+
+    if (!status || TERMINAL.has(status)) return;
+
+    console.log(
+      `${serviceName} deployment is ${status}; waiting before redeploy ` +
+        `(attempt ${attempt}/40)`,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 15_000));
+  }
+
+  console.log(`${serviceName} never went idle; redeploying anyway.`);
+}
+
 const environment = await findPrEnvironment();
 
 if (environment) {
@@ -141,6 +203,27 @@ if (environment) {
   });
 
   for (const service of targets) {
+    // Every push to the PR re-runs this job, but the branch URL is stable, so
+    // after the first run there is nothing to change. Skipping keeps later
+    // pushes from redeploying — and superseding — Railway's own deploys.
+    let current;
+    try {
+      const data = await gql(VARIABLES, {
+        projectId: RAILWAY_PROJECT_ID,
+        environmentId: environment.id,
+        serviceId: service.id,
+      });
+      current = data.variables?.DATABASE_URL;
+    } catch (error) {
+      // Degrade to always writing rather than failing outright.
+      console.log(`Could not read ${service.name} variables: ${error.message}`);
+    }
+
+    if (current === DATABASE_URL) {
+      console.log(`${service.name} already points at the branch; skipping.`);
+      continue;
+    }
+
     await gql(UPSERT, {
       input: {
         projectId: RAILWAY_PROJECT_ID,
@@ -151,6 +234,8 @@ if (environment) {
       },
     });
     console.log(`Set DATABASE_URL on ${service.name}`);
+
+    await waitForIdle(environment.id, service.id, service.name);
 
     await gql(REDEPLOY, {
       serviceId: service.id,

--- a/scripts/railway-set-preview-db.mjs
+++ b/scripts/railway-set-preview-db.mjs
@@ -91,9 +91,13 @@ const REDEPLOY = `
  * it may not exist yet when this job runs. Poll rather than racing it.
  */
 async function findPrEnvironment() {
-  // Railway names PR environments after the head branch, but has used
-  // `pr-<number>` in the past — accept either.
-  const candidates = [PR_BRANCH, `pr-${PR_NUMBER}`];
+  // Railway names PR environments `<project>-pr-<number>`. The head branch and
+  // bare `pr-<number>` are kept as fallbacks in case that convention shifts.
+  const candidates = [
+    `standard-reader-pr-${PR_NUMBER}`,
+    `pr-${PR_NUMBER}`,
+    PR_BRANCH,
+  ];
 
   for (let attempt = 1; attempt <= 10; attempt++) {
     const data = await gql(ENVIRONMENTS, { projectId: RAILWAY_PROJECT_ID });

--- a/scripts/railway-set-preview-db.mjs
+++ b/scripts/railway-set-preview-db.mjs
@@ -1,0 +1,163 @@
+/**
+ * Points a Railway PR environment's services at a per-PR Neon branch.
+ *
+ * Railway clones variables from the base environment when it creates a PR
+ * environment, which means the preview boots with production's DATABASE_URL and
+ * would write to the production read-model. This script overwrites that
+ * variable with the PR's Neon branch connection string and redeploys the
+ * affected services so the change takes effect.
+ *
+ * Env:
+ *   RAILWAY_API_TOKEN  account-level token (Authorization: Bearer)
+ *   RAILWAY_PROJECT_ID standard-reader project id
+ *   DATABASE_URL       Neon branch connection string to install
+ *   PR_BRANCH          git head branch of the PR (Railway names envs after it)
+ *   PR_NUMBER          PR number, used as a fallback env-name match
+ *   SERVICES           comma-separated service names to update (default: web)
+ */
+
+const API = "https://backboard.railway.com/graphql/v2";
+
+const {
+  RAILWAY_API_TOKEN,
+  RAILWAY_PROJECT_ID,
+  DATABASE_URL,
+  PR_BRANCH,
+  PR_NUMBER,
+  SERVICES = "web",
+} = process.env;
+
+for (const [name, value] of Object.entries({
+  RAILWAY_API_TOKEN,
+  RAILWAY_PROJECT_ID,
+  DATABASE_URL,
+  PR_BRANCH,
+  PR_NUMBER,
+})) {
+  if (!value) throw new Error(`${name} is required`);
+}
+
+async function gql(query, variables) {
+  const res = await fetch(API, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${RAILWAY_API_TOKEN}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const body = await res.json();
+  if (!res.ok || body.errors) {
+    throw new Error(
+      `Railway API error (${res.status}): ${JSON.stringify(
+        body.errors ?? body,
+      )}`,
+    );
+  }
+  return body.data;
+}
+
+const ENVIRONMENTS = `
+  query ($projectId: String!) {
+    environments(projectId: $projectId) {
+      edges { node { id name } }
+    }
+  }
+`;
+
+const SERVICES_QUERY = `
+  query ($projectId: String!) {
+    project(id: $projectId) {
+      services { edges { node { id name } } }
+    }
+  }
+`;
+
+const UPSERT = `
+  mutation ($input: VariableUpsertInput!) {
+    variableUpsert(input: $input)
+  }
+`;
+
+const REDEPLOY = `
+  mutation ($serviceId: String!, $environmentId: String!) {
+    serviceInstanceRedeploy(serviceId: $serviceId, environmentId: $environmentId)
+  }
+`;
+
+/**
+ * Railway creates the PR environment asynchronously off the GitHub webhook, so
+ * it may not exist yet when this job runs. Poll rather than racing it.
+ */
+async function findPrEnvironment() {
+  // Railway names PR environments after the head branch, but has used
+  // `pr-<number>` in the past — accept either.
+  const candidates = [PR_BRANCH, `pr-${PR_NUMBER}`];
+
+  for (let attempt = 1; attempt <= 10; attempt++) {
+    const data = await gql(ENVIRONMENTS, { projectId: RAILWAY_PROJECT_ID });
+    const envs = data.environments.edges.map((e) => e.node);
+    const match = envs.find((e) => candidates.includes(e.name));
+    if (match) return match;
+
+    console.log(
+      `PR environment not found yet (attempt ${attempt}/10). ` +
+        `Looking for one of ${candidates.join(", ")}; ` +
+        `saw: ${envs.map((e) => e.name).join(", ")}`,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 15_000));
+  }
+
+  return null;
+}
+
+const environment = await findPrEnvironment();
+
+if (environment) {
+  console.log(`Found Railway PR environment: ${environment.name}`);
+
+  const { project } = await gql(SERVICES_QUERY, {
+    projectId: RAILWAY_PROJECT_ID,
+  });
+  const allServices = project.services.edges.map((e) => e.node);
+  const wanted = SERVICES.split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const targets = wanted.map((name) => {
+    const service = allServices.find((s) => s.name === name);
+    if (!service) {
+      throw new Error(
+        `Service "${name}" not found in project. ` +
+          `Available: ${allServices.map((s) => s.name).join(", ")}`,
+      );
+    }
+    return service;
+  });
+
+  for (const service of targets) {
+    await gql(UPSERT, {
+      input: {
+        projectId: RAILWAY_PROJECT_ID,
+        environmentId: environment.id,
+        serviceId: service.id,
+        name: "DATABASE_URL",
+        value: DATABASE_URL,
+      },
+    });
+    console.log(`Set DATABASE_URL on ${service.name}`);
+
+    await gql(REDEPLOY, {
+      serviceId: service.id,
+      environmentId: environment.id,
+    });
+    console.log(`Redeployed ${service.name}`);
+  }
+} else {
+  // Not fatal: PR environments may be disabled for this PR, and failing CI over
+  // a missing preview would be noise. The Neon branch still exists.
+  console.log(
+    "No Railway PR environment found after polling — skipping DB wiring.",
+  );
+}


### PR DESCRIPTION
Creates a `pr-<N>` Neon branch off the production project's primary branch for every non-fork PR, and deletes it when the PR closes.

## What uses it

**Migrations actually run.** The existing `drizzle-kit check` is offline — it validates the journal/snapshots but can't prove migrations apply to production's current schema and data, which is exactly what the deploy's pre-deploy `pnpm db:migrate` attempts for real. Now CI applies them to a branch of prod first.

**Railway previews stop pointing at prod.** Railway clones variables from the base environment when it creates a PR environment, so previews have been booting with production's `DATABASE_URL`. `scripts/railway-set-preview-db.mjs` overwrites it with the branch URL and redeploys.

**The vitest suite gets the branch URL.** Inert today — the suite mocks the DB layer and never connects — but it means the placeholder in `vitest.setup.ts` stops being load-bearing the day a test does connect.

## Structure

| Job | Runs when |
| --- | --- |
| `neon-branch` | non-fork PRs (forks get no secrets) |
| `verify` | always — falls back to the dummy URL when `neon-branch` is skipped |
| `railway-preview-db` | only when a branch was created |
| `delete-branch` (separate workflow) | PR closed |

Branch names are stable (`pr-<N>`) so pushes reuse the branch instead of piling up one per commit.

## Before this works

- Repo variable `NEON_PROJECT_ID`
- Secrets `NEON_API_KEY` and `RAILWAY_API_TOKEN` — account-level; a project token can't list environments
- `RAILWAY_PROJECT_ID` is currently hardcoded in the workflow; move it to a repo variable if you'd prefer

## Unverified

I could not confirm from Railway's docs how PR environments are **named**. The script accepts either the head branch name or `pr-<N>` and logs every environment name it saw, so this PR's own run will show the answer — if it logs "not found" for 10 attempts, the log will name the real convention. A missing environment is treated as a skip, not a CI failure, so this can't wedge the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)