### PR TITLE
Fix horizontal overflow in the home feed and feed cards

### DIFF
--- a/src/components/reader/cards.tsx
+++ b/src/components/reader/cards.tsx
@@ -93,6 +93,13 @@ const styles = stylex.create({
     color: "inherit",
     cursor: "pointer",
     display: "block",
+    // Card text is user-generated — publication names, `@handle`s and titles can
+    // all be long unbreakable tokens (`@a-very-long-handle.bsky.social`). Those
+    // offer no break opportunity, so they overflow the card and push the whole
+    // page sideways. `anywhere` (not `break-word`) also shrinks the intrinsic
+    // min-content width, which is what keeps the surrounding grid track from
+    // being forced wider. Inherited, so it covers every text node in the card.
+    overflowWrap: "anywhere",
   },
   cardShell: {
     textDecoration: "none",
@@ -100,6 +107,8 @@ const styles = stylex.create({
     cursor: "pointer",
     display: "block",
     position: "relative",
+    // See `cardLink` — long unbreakable names/handles must wrap, not overflow.
+    overflowWrap: "anywhere",
   },
   cardOverlay: {
     inset: 0,
@@ -216,6 +225,8 @@ const styles = stylex.create({
     borderBottomColor: uiColor.border1,
     borderBottomStyle: "solid",
     borderBottomWidth: 1,
+    // See `cardLink` — long unbreakable names/handles must wrap, not overflow.
+    overflowWrap: "anywhere",
     paddingBottom: spacing["6"],
     paddingTop: spacing["6"],
   },

--- a/src/routes/_layout.index.tsx
+++ b/src/routes/_layout.index.tsx
@@ -171,8 +171,13 @@ const styles = stylex.create({
     alignItems: "start",
     columnGap: spacing["12"],
     display: "grid",
+    // `minmax(0, 1fr)`, not a bare `1fr` — a bare `1fr` is `minmax(auto, 1fr)`,
+    // so the track keeps an automatic min-content floor and refuses to shrink
+    // below its widest unbreakable content (long `@handle`s in the rail cards).
+    // That pushed the track ~22px past the grid on narrow viewports and spilled
+    // the whole page sideways; the shell's `overflow-x: clip` was hiding it.
     gridTemplateColumns: {
-      default: "1fr",
+      default: "minmax(0, 1fr)",
       "@media (min-width: 64rem)": "minmax(0, 1fr) 320px",
     },
     rowGap: spacing["12"],


### PR DESCRIPTION
Two related fixes for the page spilling sideways on narrow viewports. Neither was visible, because the app shell's `overflow-x: clip` was quietly absorbing the overflow — but the document was genuinely wider than the viewport underneath it.

Found while investigating the [sticky header jiggle](https://github.com/hipstersmoothie/standard-reader/tree/claude/sticky-header-positioning-9xkh3i): removing the shell clip to test that fix exposed a real 3px overflow on Home.

## 1. Home feed grid track (`_layout.index.tsx`)

The two-column grid used `grid-template-columns: 1fr` at mobile widths. A bare `1fr` is shorthand for **`minmax(auto, 1fr)`**, so the track keeps an automatic min-content floor and refuses to shrink below its widest unbreakable content — the long `@handle`s in the trending-publication rail cards (e.g. `@bachhausen.bsky.social`).

At 375px that forced the track to **357.5px inside a 335px grid**, pushing the document 3px past the viewport.

Fixed with `minmax(0, 1fr)` — which is what the `>= 64rem` breakpoint on the very next line already did.

## 2. Unbreakable card text (`cards.tsx`)

Card text is user-generated. Long unbreakable tokens (publication names, `@handle`s, titles) offer no break opportunity, so with the default `overflow-wrap: normal` they overflow the card and push the page sideways.

Set `overflow-wrap: anywhere` on the card containers. It's inherited, so one declaration per card shell covers every text node inside. `anywhere` rather than `break-word` because only `anywhere` also shrinks the intrinsic min-content width — which is what stops a token forcing the surrounding grid track wider to begin with.

## Testing

All measured in Safari with the shell's `overflow-x: clip` **disabled**, so overflow is observable rather than re-hidden.

| Check | Before | After |
|---|---|---|
| Home @375px, track width | 357.5px in a 335px grid | 335px |
| Home @375px, document | `scrollWidth 378` vs `clientWidth 375` | 375 == 375 |
| `/latest` @336px + 47-char handle | overflows by 27px | 0px, wraps to 2 lines |
| Home @336px + 47-char handle | — | 0px |

- Stressed handle wraps to 2 line boxes, `scrollWidth == width`, stays inside both card and viewport.
- `/about`, `/tag/money`, `/latest`, `/discover` all clean. Discover's wide rows are inside `pub-grid-list`'s intentional `overflow-x: auto` carousel.
- Home rail cards visually confirmed at 375px — handles sit inside the card borders, `Real Housewives of San Fran…` still ellipsis-truncates correctly.
- `tsc --noEmit`, `oxlint`, and `vitest` (271 passed) all clean; production build succeeds and emits the expected CSS.

## Deliberately not included

I started to sweep the other ~15 bare `1fr` grid tracks, but **measured that it doesn't help**: none of them overflow on any route I could test, and stress-testing showed `minmax(0, 1fr)` does *not* fix the real latent risk in cards — the containers were already sized correctly at 296px while the text itself overflowed at 343px. Text wrapping was the actual fix, so that's what's here. Happy to do the cosmetic sweep separately if wanted.

Also out of scope: `/docs/publishing` overflows by ~115px at 336px, caused by an unwrapped JSON sample (`docsStyles.jsonStr`), not a grid. Separate issue, worth its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)