### PR TITLE
Polish weekly digest email chrome

### DIFF
--- a/src/server/digest/comail.ts
+++ b/src/server/digest/comail.ts
@@ -26,6 +26,19 @@ export interface SendEmailResult {
 }
 
 /**
+ * `Standard Reader <digest@standard-reader.app>` so inboxes show a name rather
+ * than a bare address. Passes `COMAIL_FROM` through untouched when it already
+ * carries its own display name, and quotes the name so a comma or period in it
+ * can't split the address per RFC 5322.
+ */
+function fromHeader(): string {
+  const address = digestConfig.comailFrom;
+  if (address.includes("<")) return address;
+  const name = digestConfig.comailFromName.replaceAll('"', String.raw`\"`);
+  return `"${name}" <${address}>`;
+}
+
+/**
  * Send one email through comail. Never throws on an HTTP error — returns a
  * structured result so the runner can distinguish a rate-limit stop (429) from
  * a per-recipient failure and keep going.
@@ -40,7 +53,7 @@ export async function sendEmail(
   };
 
   const body: Record<string, unknown> = {
-    from: digestConfig.comailFrom,
+    from: fromHeader(),
     to: input.to,
     subject: input.subject,
     text: input.text,

--- a/src/server/digest/config.ts
+++ b/src/server/digest/config.ts
@@ -33,6 +33,15 @@ export const digestConfig = {
     return required("COMAIL_FROM");
   },
 
+  /**
+   * Display name shown as the sender in the recipient's inbox. Wrapped around
+   * `comailFrom` as `Standard Reader <digest@standard-reader.app>` unless
+   * `COMAIL_FROM` already carries its own display name.
+   */
+  get comailFromName(): string {
+    return process.env.COMAIL_FROM_NAME ?? "Standard Reader";
+  },
+
   /** HMAC key for one-click unsubscribe tokens. Required in production; in dev
    * it falls back to a static placeholder so the digest preview tool works
    * without extra setup (preview tokens are never acted on). */

--- a/src/server/digest/emails/WeeklyDigestEmail.tsx
+++ b/src/server/digest/emails/WeeklyDigestEmail.tsx
@@ -32,7 +32,6 @@ import {
 import {
   EmailFooter,
   EmailHead,
-  EmailHeader,
   EmailShell,
   PubIcon,
   SectionLabel,
@@ -64,7 +63,6 @@ interface DigestPublication {
 }
 
 interface DigestEmailProps {
-  weekLabel: string; // e.g. "Week of Jul 4, 2026"
   articles: Array<DigestArticle>;
   networkArticles: Array<DigestArticle>;
   saved: Array<DigestArticle>;
@@ -405,7 +403,6 @@ function RecommendationCard({ pub }: { pub: DigestPublication }) {
 /* ------------------------------------------------------------------ */
 
 export default function WeeklyDigestEmail({
-  weekLabel,
   articles,
   networkArticles,
   saved,
@@ -413,7 +410,7 @@ export default function WeeklyDigestEmail({
   unsubscribeUrl,
   logoUrl,
 }: DigestEmailProps) {
-  const px = { paddingLeft: "34px", paddingRight: "34px" };
+  const px = { paddingLeft: "24px", paddingRight: "24px" };
 
   return (
     <Html lang="en">
@@ -428,8 +425,6 @@ export default function WeeklyDigestEmail({
         style={{ margin: 0, padding: 0, background: c.page }}
       >
         <EmailShell>
-          <EmailHeader logoUrl={logoUrl} rightLabel={weekLabel} />
-
           {/* ---- Best of your follows ---- */}
           <Section style={{ ...px, paddingTop: "22px" }}>
             <SectionLabel>Best of your subscriptions</SectionLabel>

--- a/src/server/digest/render.tsx
+++ b/src/server/digest/render.tsx
@@ -48,10 +48,10 @@ const WEEK_LABEL_FMT = new Intl.DateTimeFormat("en-US", {
   year: "numeric",
 });
 
-/** "Week of Jul 4, 2026" for the header label (start of the covered week). */
-function weekLabel(now: Date): string {
+/** "Digest for week of Jul 4, 2026" — subject line; dates the covered week. */
+function subjectFor(now: Date): string {
   const start = new Date(now.getTime() - WEEK_MS);
-  return `Week of ${WEEK_LABEL_FMT.format(start)}`;
+  return `Digest for week of ${WEEK_LABEL_FMT.format(start)}`;
 }
 
 function trimBase(baseUrl: string): string {
@@ -105,13 +105,6 @@ function toDigestPublication(
   };
 }
 
-/** Subject line — lead article title drives opens; degrades for 1 / 0 articles. */
-function subjectFor(articles: Array<DigestArticle>): string {
-  if (articles.length === 0) return "Your weekly Standard digest";
-  if (articles.length === 1) return articles[0].title;
-  return `${articles[0].title} + ${articles.length - 1} more`;
-}
-
 export async function renderDigestEmail(
   digest: DigestData,
   options: RenderDigestOptions,
@@ -130,7 +123,6 @@ export async function renderDigestEmail(
 
   const token = makeUnsubscribeToken(options.userId);
   const props = {
-    weekLabel: weekLabel(now),
     articles,
     networkArticles,
     saved,
@@ -145,5 +137,5 @@ export async function renderDigestEmail(
     render(element, { plainText: true }),
   ]);
 
-  return { subject: subjectFor(articles), html, text };
+  return { subject: subjectFor(now), html, text };
 }


### PR DESCRIPTION
Four presentation changes to the weekly digest email, verified against a real render of a production digest.

| # | Change | Verified |
|---|--------|----------|
| 1 | Masthead removed | `"Week of"` gone from output; the one remaining logo is the footer's |
| 2 | Sender name | `"Standard Reader" <digest@standard-reader.app>` |
| 3 | Subject | `Digest for week of Jul 11, 2026` |
| 4 | X padding | 34px → 24px, 8 gutters converted, zero stragglers |

## Notes for review

**Scoped to the digest.** `EmailHeader` is shared with `WelcomeEmail.tsx`, so this removes the digest's *call site* rather than the component. The welcome email keeps its header.

**The subject change is a deliberate tradeoff.** The old logic led with the top article title (`"CEAVER + 1 more"`) and its comment called that out as an open-rate driver. A fixed date-based subject gives that up — every week's email now looks identical in the inbox list. Intentional, but worth a conscious sign-off.

**Sender name is overridable** via `COMAIL_FROM_NAME`, defaulting to `Standard Reader`. No env change needed to deploy. The name is quoted so a comma can't split the address per RFC 5322, and a `COMAIL_FROM` that already carries its own display name passes through untouched.

## Testing

`tsc --noEmit` and `oxlint` both clean. No test asserts on the digest subject or `weekLabel`, so nothing needed updating — this is untested presentation code either way.

Rendered a live digest through the modified path and asserted on the output HTML rather than eyeballing it: masthead markup absent, logo position confirmed to be after body content (footer, not header), gutter values counted.

Not sent as a live email with these changes applied — the pre-change version was test-sent successfully, but a fresh send is worth doing before the first real weekly run.

## Out of scope

`WeeklyDigestEmail.tsx` trips ~15 pre-existing `design-system-font-size` hook findings. HTML email needs literal px sizing and can't reference the web type ramp, so they're left alone — none are in code this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)