### PR TITLE
Rank the digest's network section like the weekly thread

### DIFF
--- a/src/server/digest/builder.ts
+++ b/src/server/digest/builder.ts
@@ -8,6 +8,12 @@
  * (co-subscription / co-recommend blend, already excludes follows, cold-starts
  * to popular). "Saved for later" reuses {@link savedForLater} (the reader's most
  * recent bookmarks). Mirrors how `src/server/feeds/build.ts` composes cards.
+ *
+ * "Top on the network" reuses {@link weekInReviewArticles} — the same ranking the
+ * weekly Bluesky thread posts, so both weekly surfaces agree on what the week's
+ * biggest articles were. It scores engagement live rather than reading
+ * `trending_score`, which is only recomputed for the 4-day discover slice and so
+ * goes stale across days 5–7 of this section's 7-day window.
  */
 
 import type {
@@ -21,7 +27,7 @@ import {
   recommendedPublications,
   savedForLater,
   selectFollowUris,
-  topNetworkArticles,
+  weekInReviewArticles,
 } from "#/server/reader/queries";
 import { rotationSeed } from "#/server/reader/rail-rotation";
 
@@ -121,7 +127,7 @@ export async function buildDigestForUser(
 
   const [networkArticles, saved, recommendations] = await Promise.all([
     sections.network
-      ? topNetworkArticles(db, schema, {
+      ? weekInReviewArticles(db, schema, {
           sinceDays: DIGEST_WINDOW_DAYS,
           limit: DIGEST_NETWORK_ARTICLE_LIMIT,
           excludeUris: articleUris,

--- a/src/server/reader/queries.ts
+++ b/src/server/reader/queries.ts
@@ -1311,8 +1311,9 @@ export async function savedForLater(
 }
 
 /**
- * "Week in review" ranking for the weekly Bluesky thread: the biggest discover-
- * eligible articles across the whole network over the last `sinceDays`, ranked by
+ * "Week in review" ranking, shared by the weekly Bluesky thread and the weekly
+ * digest's "Top on the network this week" section: the biggest discover-eligible
+ * articles across the whole network over the last `sinceDays`, ranked by
  * engagement ACCUMULATED across the window rather than by `trending_score`.
  *
  * Unlike {@link topNetworkArticles} (which orders by the precomputed
@@ -1334,7 +1335,19 @@ export async function savedForLater(
 export async function weekInReviewArticles(
   db: Db,
   schema: Schema,
-  { sinceDays, limit }: { sinceDays: number; limit: number },
+  {
+    sinceDays,
+    limit,
+    excludeUris = [],
+    excludeReadForDid,
+  }: {
+    sinceDays: number;
+    limit: number;
+    /** Articles already shown elsewhere (the digest's best-of picks). */
+    excludeUris?: Array<string>;
+    /** Omit documents this reader has already read (weekly digest). */
+    excludeReadForDid?: string;
+  },
 ): Promise<Array<ArticleCard>> {
   const d = schema.documents;
   const p = schema.publications;
@@ -1371,6 +1384,12 @@ export async function weekInReviewArticles(
     sql`${d.publishedAt} > now() - (${sinceDays}::text || ' days')::interval`,
     sql`${distinctLikers} >= ${MIN_ARTICLE_RECOMMENDERS}`,
   ];
+  if (excludeUris.length > 0) {
+    conds.push(notInArray(d.uri, excludeUris));
+  }
+  if (excludeReadForDid) {
+    conds.push(documentUnreadWhere(schema, excludeReadForDid));
+  }
 
   const rows = await db
     .select({


### PR DESCRIPTION
The digest's "Top on the network this week" now uses `weekInReviewArticles` — the same ranking the weekly Bluesky thread posts — so both weekly surfaces agree on what the week's biggest articles were.

## Why

The section ranked by `documents.trending_score`, the discover rail's signal. That's tuned for *hot right now*: a 30h half-life plus a published-at freshness term. Over a 7-day window it systematically prefers barely-liked fresh articles to the week's actual biggest ones.

Run against production, old vs new, same window and limit:

| # | OLD `trending_score` | NEW week-in-review |
|---|---|---|
| 1 | [0.9d] I wanna make $1million for a thousand indies — **9 likes** | [2.0d] People, Not Posts — **17 likes** |
| 2 | [1.1d] The potential for publicly controlled education — **4 likes** | [1.4d] Blogging: It's more social than ever! — **13 likes** |
| 3 | [0.8d] I Spent an Hour Learning Who DHH Is — **3 likes** | [1.7d] Permissioned Data Diary 7: Off the Record — **12 likes** |
| 4 | [0.3d] Permissioned Data Shapes: Private Events — **2 likes** | [0.9d] I wanna make $1million for a thousand indies — **9 likes** |
| 5 | [0.2d] What it means that the AI research community — **2 likes** | [2.3d] How Streamplace Works — **10 likes** |

Only one article overlaps. The old ranking put a 0.2-day-old article with 2 likes above a 2-day-old one with 17.

There's a second, structural problem: `trending_score` is only recomputed inside the 4-day discover slice (`TRENDING_MAX_AGE_DAYS = 4`), so articles on days 5–7 of the digest's 7-day window keep a **frozen** score and stop accruing engagement. 683 of the 1,670 articles currently in the window rank on stale numbers, capped at `7.29` against `28.15` for fresh ones. Worth being precise: in *this* week's data the top picks all fall inside 4 days, so the visible improvement above comes from dropping the freshness bias, not from the staleness fix. The staleness is real but latent.

`weekInReviewArticles` computes engagement live across the window — 84h half-life, plus 1.5× backlinks, gated on ≥2 distinct likers. Its docstring already called out this exact staleness as its reason for existing.

## Changes

- `builder.ts`: network section calls `weekInReviewArticles` instead of `topNetworkArticles`.
- `queries.ts`: adds optional `excludeUris` / `excludeReadForDid` to `weekInReviewArticles`, which the digest needs so the network section can't repeat a reader's best-of picks or resurface something already read. Both optional — the thread bot's call is unchanged.

## Risks checked

- **Liker floor.** The ≥2 distinct-liker gate is new for this section. 47 articles clear it this week against a limit of 5, so ample headroom — but a very quiet week can now yield a shorter section, and the send runner's skip-if-empty guard counts this section.
- **Per-user cost.** This query runs once per recipient, so live scoring could have been a regression. It isn't: **102ms median vs 107ms** for the old query (5 runs, warmed).

## Scope

Only the network section, per the ask. `bestOfFollows` (your subscriptions) has the identical 7-day-window / 4-day-score mismatch and is a candidate for the same treatment, but it's follow-filtered and would need a follow param on the week query — left alone deliberately.

`topNetworkArticles` now has no callers; left in place since docstrings reference it as the contrast case. Easy to delete if you'd rather.

## Testing

`tsc --noEmit` and `oxlint` clean; `builder.test.ts` passes (2/2). The before/after table and the benchmark both come from live production data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)