### PR TITLE
Stop claudeslop exhausting its container's thread budget

### DIFF
--- a/services/claudeslop/Dockerfile
+++ b/services/claudeslop/Dockerfile
@@ -13,6 +13,15 @@ RUN corepack enable
 
 WORKDIR /app
 
+# Cap the native thread pools. Without this, OpenMP/MKL size themselves from
+# the host's core count rather than the container's share and blow through the
+# thread limit — see the matching note in detector/model.py. Set here so it
+# also applies to the model-baking step below.
+ENV OMP_NUM_THREADS=2 \
+    MKL_NUM_THREADS=2 \
+    OPENBLAS_NUM_THREADS=2 \
+    TOKENIZERS_PARALLELISM=false
+
 # --- Python detector: deps + baked model (cached unless these change) ---
 COPY services/claudeslop/detector/requirements.txt services/claudeslop/detector/requirements.txt
 RUN python3 -m venv /opt/pyenv \

--- a/services/claudeslop/detector/app.py
+++ b/services/claudeslop/detector/app.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import os
 from contextlib import asynccontextmanager
 
+import anyio.to_thread
 import py3langid as langid
 from fastapi import FastAPI
 from pydantic import BaseModel
@@ -31,6 +32,12 @@ _detector: Detector | None = None
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
     global _detector
+    # `score` is a sync handler, so Starlette runs it on anyio's threadpool —
+    # 40 workers by default. Each concurrent forward pass spins up its own
+    # OpenMP thread team on top of that, which exhausts the container's thread
+    # budget and segfaults torch. One model, one CPU-bound pass at a time: cap
+    # the pool so requests queue instead of piling up.
+    anyio.to_thread.current_default_thread_limiter().total_tokens = 1
     # Load the model at startup so the first request isn't slow.
     _detector = Detector()
     yield

--- a/services/claudeslop/detector/model.py
+++ b/services/claudeslop/detector/model.py
@@ -15,6 +15,8 @@ reconstruct the architecture here rather than relying on an Auto* class.
 
 from __future__ import annotations
 
+import os
+
 import torch
 import torch.nn as nn
 from huggingface_hub import hf_hub_download
@@ -23,6 +25,15 @@ from transformers import AutoConfig, AutoModel, AutoTokenizer
 
 MODEL_ID = "desklib/ai-text-detector-v1.01"
 MAX_TOKENS = 768
+
+# torch sizes its thread pools from the *host's* core count, which on a shared
+# platform is far larger than the cores the container can actually use. The
+# oversized OpenMP teams exhaust the container's thread limit ("libgomp: Thread
+# creation failed") and take the process down with them. Scoring is already
+# serialized by the caller, so a small fixed pool is all we want.
+_THREADS = int(os.environ.get("TORCH_NUM_THREADS", "2"))
+torch.set_num_threads(_THREADS)
+torch.set_num_interop_threads(1)
 
 
 class DesklibDetector(nn.Module):

--- a/services/claudeslop/detector/requirements.txt
+++ b/services/claudeslop/detector/requirements.txt
@@ -9,3 +9,5 @@ py3langid>=0.3.0
 fastapi>=0.115
 uvicorn[standard]>=0.32
 pydantic>=2.9
+# Transitive via starlette, but we import it directly to cap the threadpool.
+anyio>=4.0

--- a/services/claudeslop/src/detector.ts
+++ b/services/claudeslop/src/detector.ts
@@ -71,6 +71,22 @@ export async function preload(timeoutMs = 180_000): Promise<void> {
   }
 }
 
+/**
+ * The ingest loop dispatches events fire-and-forget, so a firehose backlog can
+ * put hundreds of scores in flight at once. The detector is a single CPU-bound
+ * model that scores one request at a time regardless, so the only thing that
+ * concurrency buys us is a pile of open sockets and torch fighting itself for
+ * threads. Serialize the calls here and let the rest wait their turn.
+ */
+let pending: Promise<unknown> = Promise.resolve();
+
+function enqueue<T>(task: () => Promise<T>): Promise<T> {
+  const result = pending.then(task, task);
+  // Keep the chain alive when a task rejects; callers still see the rejection.
+  pending = result.catch(() => {});
+  return result;
+}
+
 /** Score a chunk of prose. Higher = more likely AI-generated. */
 export async function score(input: string): Promise<DetectorResult> {
   const text = (input ?? "").trim();
@@ -84,11 +100,14 @@ export async function score(input: string): Promise<DetectorResult> {
     };
   }
 
-  const res = await fetch(`${config.detectorUrl}/score`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ text }),
-  });
+  const res = await enqueue(() =>
+    fetch(`${config.detectorUrl}/score`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text }),
+      signal: AbortSignal.timeout(60_000),
+    }),
+  );
   if (!res.ok) {
     throw new Error(`detector /score failed: ${res.status}`);
   }


### PR DESCRIPTION
## The crash

```
libgomp: Thread creation failed: Resource temporarily unavailable
services/claudeslop/start.sh: line 23: 3 Segmentation fault  /opt/pyenv/bin/uvicorn app:app ...
```

The detector sidecar ran out of threads, torch segfaulted, and `start.sh`'s `wait -n` tore the whole container down.

## Why

Three things multiplied together:

1. **`src/ingest.ts:80`** dispatches `void handleEvent(...)` per websocket message, unbounded. A firehose backlog — notably a reconnect that replays from the stored cursor — puts hundreds of `/score` calls in flight at once.
2. **`/score` is a sync `def`**, so Starlette runs it on anyio's threadpool: 40 workers by default.
3. **OpenMP sizes its thread team from the host's core count**, not the container's cgroup share, so each forward pass spawns ~32 threads.

40 concurrent passes × ~32 OpenMP threads against one DeBERTa-v3-large is what exhausted the container.

## Changes

| File | Change |
| --- | --- |
| `detector/model.py` | `torch.set_num_threads(2)` + `set_num_interop_threads(1)` at import |
| `Dockerfile` | `OMP`/`MKL`/`OPENBLAS_NUM_THREADS=2`, `TOKENIZERS_PARALLELISM=false` — set before the pip layer so the model-baking step is covered too |
| `detector/app.py` | Cap the anyio threadpool to 1 in `lifespan`; requests queue rather than pile up |
| `src/detector.ts` | Serialize `/score` through a promise chain, add a 60s `AbortSignal.timeout` (there was no timeout before) |
| `detector/requirements.txt` | Pin `anyio`, now a direct import |

## Verification

7 tests pass; Python and shell syntax check clean. **I could not reproduce the crash locally** — no torch environment here, and it's contingent on Railway's host core count — so the thread pinning is reasoned from the `libgomp` error rather than observed fixed. Worth watching the first deploy's logs.

## Not addressed

- **Memory may be a co-factor.** DeBERTa-v3-large at fp32 is ~1.7GB resident; if the service's memory ceiling is tight, serialization helps but may not be sufficient.
- **`restartPolicyMaxRetries: 10`** in `railway.json` — once burned through, Railway stops restarting and the labeler stays down silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)