### PR TITLE
Discover publications by the people you follow on Bluesky

### DIFF
--- a/src/components/onboarding/onboarding-pub-row.tsx
+++ b/src/components/onboarding/onboarding-pub-row.tsx
@@ -72,17 +72,19 @@ const styles = stylex.create({
   },
   description: {
     color: uiColor.text1,
-    display: "-webkit-box",
     fontFamily: fontFamily.sans,
     fontSize: fontSize.sm,
     lineHeight: lineHeight.sm,
     marginBottom: 0,
     marginTop: 0,
+    // The row is a <button>, which sets `white-space: nowrap` — inherited, that
+    // pinned descriptions to one unwrappable line that got clipped mid-word.
+    // Restore normal wrapping, then cap the block at two lines.
+    maxHeight: `calc(2 * ${lineHeight.sm} * ${fontSize.sm})`,
+    minWidth: 0,
     overflow: "hidden",
-    // eslint-disable-next-line @stylexjs/valid-styles
-    WebkitBoxOrient: "vertical",
-    // eslint-disable-next-line @stylexjs/valid-styles
-    WebkitLineClamp: 2,
+    overflowWrap: "anywhere",
+    whiteSpace: "normal",
   },
   metaLine: {
     alignItems: "center",

--- a/src/components/onboarding/step-friends.tsx
+++ b/src/components/onboarding/step-friends.tsx
@@ -1,0 +1,151 @@
+import { Plural, Trans } from "@lingui/react/macro";
+import * as stylex from "@stylexjs/stylex";
+import { useQuery } from "@tanstack/react-query";
+import { Check, Plus } from "lucide-react";
+
+import { discoverApi } from "#/integrations/tanstack-query/api-discover.functions";
+import type { FriendPublisher } from "#/integrations/tanstack-query/api-discover.functions";
+import { ONBOARDING_FRIENDS_LIMIT } from "#/lib/onboarding";
+
+import { Button } from "../../design-system/button";
+import { Flex } from "../../design-system/flex";
+import { uiColor } from "../../design-system/theme/color.stylex";
+import { verticalSpace } from "../../design-system/theme/semantic-spacing.stylex";
+import { spacing } from "../../design-system/theme/spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+  lineHeight,
+} from "../../design-system/theme/typography.stylex";
+import {
+  FriendPublisherGroup,
+  FriendPublishersDegradedNote,
+  FriendPublishersSkeleton,
+} from "../reader/friend-publishers";
+import { OnboardingPubRow } from "./onboarding-pub-row";
+
+const styles = stylex.create({
+  groups: {
+    display: "flex",
+    flexDirection: "column",
+    rowGap: verticalSpace["10xl"],
+  },
+  more: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.sm,
+    lineHeight: lineHeight.sm,
+    marginBottom: spacing["0"],
+    marginTop: spacing["0"],
+  },
+});
+
+/**
+ * Onboarding step: publications written by the people the reader follows on
+ * Bluesky — the strongest signal available at first run, so it comes before the
+ * topic and trending suggestions.
+ *
+ * Selection is in-memory (committed with the rest of the wizard's picks at the
+ * end), which is why this uses {@link OnboardingPubRow} rather than the live
+ * subscribe buttons on `/friends`.
+ */
+export function StepFriends({
+  selected,
+  onToggle,
+}: {
+  selected: Set<string>;
+  onToggle: (uri: string, next: boolean) => void;
+}) {
+  const { data, isPending } = useQuery(
+    discoverApi.getFriendPublishersQueryOptions({
+      limit: ONBOARDING_FRIENDS_LIMIT,
+    }),
+  );
+
+  if (isPending) {
+    return <FriendPublishersSkeleton groups={2} />;
+  }
+
+  const people = data?.people ?? [];
+  const remaining = Math.max(0, (data?.totalPeople ?? 0) - people.length);
+  // The wizard skips this step when there's nobody, so an empty render here
+  // only happens if the graph changed under us mid-flow.
+  if (people.length === 0) {
+    return (
+      <Flex direction="column" gap="lg">
+        {data?.degraded ? <FriendPublishersDegradedNote /> : null}
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex direction="column" gap="lg">
+      {data?.degraded ? <FriendPublishersDegradedNote /> : null}
+      <div {...stylex.props(styles.groups)}>
+        {people.map((person) => (
+          <FriendPublisherGroup
+            key={person.did}
+            person={person}
+            action={
+              <SelectAllButton
+                person={person}
+                selected={selected}
+                onToggle={onToggle}
+              />
+            }
+          >
+            {person.publications.map((pub) => (
+              <OnboardingPubRow
+                key={pub.uri}
+                pub={pub}
+                selected={selected.has(pub.uri)}
+                onToggle={(next) => onToggle(pub.uri, next)}
+              />
+            ))}
+          </FriendPublisherGroup>
+        ))}
+      </div>
+      {remaining > 0 ? (
+        <p {...stylex.props(styles.more)}>
+          <Plural
+            value={remaining}
+            one="# more person you follow writes here — find them under Discover once you're set up."
+            other="# more people you follow write here — find them under Discover once you're set up."
+          />
+        </p>
+      ) : null}
+    </Flex>
+  );
+}
+
+/**
+ * Person-level shortcut. People who run several publications are common enough
+ * that "subscribe to all of Anna's writing" deserves one press; for a single
+ * publication the row below already says everything, so the button is omitted.
+ */
+function SelectAllButton({
+  person,
+  selected,
+  onToggle,
+}: {
+  person: FriendPublisher;
+  selected: Set<string>;
+  onToggle: (uri: string, next: boolean) => void;
+}) {
+  if (person.publications.length < 2) return null;
+
+  const all = person.publications.every((pub) => selected.has(pub.uri));
+
+  return (
+    <Button
+      variant={all ? "secondary" : "outline"}
+      size="sm"
+      onPress={() => {
+        for (const pub of person.publications) onToggle(pub.uri, !all);
+      }}
+    >
+      {all ? <Check size={15} aria-hidden /> : <Plus size={15} aria-hidden />}
+      {all ? <Trans>All selected</Trans> : <Trans>Select all</Trans>}
+    </Button>
+  );
+}

--- a/src/components/onboarding/step-friends.tsx
+++ b/src/components/onboarding/step-friends.tsx
@@ -1,34 +1,33 @@
-import { Plural, Trans } from "@lingui/react/macro";
+import { Plural } from "@lingui/react/macro";
 import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
-import { Check, Plus } from "lucide-react";
 
 import { discoverApi } from "#/integrations/tanstack-query/api-discover.functions";
-import type { FriendPublisher } from "#/integrations/tanstack-query/api-discover.functions";
 import { ONBOARDING_FRIENDS_LIMIT } from "#/lib/onboarding";
 
-import { Button } from "../../design-system/button";
 import { Flex } from "../../design-system/flex";
 import { uiColor } from "../../design-system/theme/color.stylex";
-import { verticalSpace } from "../../design-system/theme/semantic-spacing.stylex";
 import { spacing } from "../../design-system/theme/spacing.stylex";
 import {
   fontFamily,
   fontSize,
   lineHeight,
 } from "../../design-system/theme/typography.stylex";
-import {
-  FriendPublisherGroup,
-  FriendPublishersDegradedNote,
-  FriendPublishersSkeleton,
-} from "../reader/friend-publishers";
+import { PubCardSkeleton } from "../reader/cards";
+import { FriendPublishersDegradedNote } from "../reader/friend-publishers";
 import { OnboardingPubRow } from "./onboarding-pub-row";
 
 const styles = stylex.create({
-  groups: {
+  // The same bordered row stack the trending / topic sections use, so every
+  // step of the wizard reads as one list rather than three treatments.
+  rows: {
+    borderColor: uiColor.border1,
+    borderRadius: 12,
+    borderStyle: "solid",
+    borderWidth: 1,
     display: "flex",
     flexDirection: "column",
-    rowGap: verticalSpace["10xl"],
+    overflow: "hidden",
   },
   more: {
     color: uiColor.text1,
@@ -47,7 +46,8 @@ const styles = stylex.create({
  *
  * Selection is in-memory (committed with the rest of the wizard's picks at the
  * end), which is why this uses {@link OnboardingPubRow} rather than the live
- * subscribe buttons on `/friends`.
+ * subscribe buttons on `/friends`. Each row names its author, so the list needs
+ * no per-person grouping.
  */
 export function StepFriends({
   selected,
@@ -63,14 +63,24 @@ export function StepFriends({
   );
 
   if (isPending) {
-    return <FriendPublishersSkeleton groups={2} />;
+    return (
+      <Flex direction="column" gap="lg">
+        {Array.from({ length: 4 }, (_, index) => (
+          <PubCardSkeleton key={index} />
+        ))}
+      </Flex>
+    );
   }
 
-  const people = data?.people ?? [];
-  const remaining = Math.max(0, (data?.totalPeople ?? 0) - people.length);
-  // The wizard skips this step when there's nobody, so an empty render here
-  // only happens if the graph changed under us mid-flow.
-  if (people.length === 0) {
+  const publications = data?.publications ?? [];
+  const remaining = Math.max(
+    0,
+    (data?.publicationCount ?? 0) - publications.length,
+  );
+
+  // The wizard skips this step when there's nothing to show, so an empty render
+  // here only happens if the graph changed under us mid-flow.
+  if (publications.length === 0) {
     return (
       <Flex direction="column" gap="lg">
         {data?.degraded ? <FriendPublishersDegradedNote /> : null}
@@ -81,71 +91,25 @@ export function StepFriends({
   return (
     <Flex direction="column" gap="lg">
       {data?.degraded ? <FriendPublishersDegradedNote /> : null}
-      <div {...stylex.props(styles.groups)}>
-        {people.map((person) => (
-          <FriendPublisherGroup
-            key={person.did}
-            person={person}
-            action={
-              <SelectAllButton
-                person={person}
-                selected={selected}
-                onToggle={onToggle}
-              />
-            }
-          >
-            {person.publications.map((pub) => (
-              <OnboardingPubRow
-                key={pub.uri}
-                pub={pub}
-                selected={selected.has(pub.uri)}
-                onToggle={(next) => onToggle(pub.uri, next)}
-              />
-            ))}
-          </FriendPublisherGroup>
+      <div {...stylex.props(styles.rows)}>
+        {publications.map((pub) => (
+          <OnboardingPubRow
+            key={pub.uri}
+            pub={pub}
+            selected={selected.has(pub.uri)}
+            onToggle={(next) => onToggle(pub.uri, next)}
+          />
         ))}
       </div>
       {remaining > 0 ? (
         <p {...stylex.props(styles.more)}>
           <Plural
             value={remaining}
-            one="# more person you follow writes here — find them under Discover once you're set up."
-            other="# more people you follow write here — find them under Discover once you're set up."
+            one="# more publication from people you follow — find it under Discover once you're set up."
+            other="# more publications from people you follow — find them under Discover once you're set up."
           />
         </p>
       ) : null}
     </Flex>
-  );
-}
-
-/**
- * Person-level shortcut. People who run several publications are common enough
- * that "subscribe to all of Anna's writing" deserves one press; for a single
- * publication the row below already says everything, so the button is omitted.
- */
-function SelectAllButton({
-  person,
-  selected,
-  onToggle,
-}: {
-  person: FriendPublisher;
-  selected: Set<string>;
-  onToggle: (uri: string, next: boolean) => void;
-}) {
-  if (person.publications.length < 2) return null;
-
-  const all = person.publications.every((pub) => selected.has(pub.uri));
-
-  return (
-    <Button
-      variant={all ? "secondary" : "outline"}
-      size="sm"
-      onPress={() => {
-        for (const pub of person.publications) onToggle(pub.uri, !all);
-      }}
-    >
-      {all ? <Check size={15} aria-hidden /> : <Plus size={15} aria-hidden />}
-      {all ? <Trans>All selected</Trans> : <Trans>Select all</Trans>}
-    </Button>
   );
 }

--- a/src/components/onboarding/welcome-wizard.tsx
+++ b/src/components/onboarding/welcome-wizard.tsx
@@ -287,7 +287,7 @@ export function WelcomeWizard({
       limit: ONBOARDING_FRIENDS_LIMIT,
     }),
   );
-  const hasFriends = (friends?.totalPeople ?? 0) > 0;
+  const hasFriends = (friends?.publicationCount ?? 0) > 0;
   // A dedicated step that renders nobody is a dead screen, so it only exists
   // when it has content. While the lookup is still in flight we keep the step
   // in the flow rather than dropping a dot mid-wizard.

--- a/src/components/onboarding/welcome-wizard.tsx
+++ b/src/components/onboarding/welcome-wizard.tsx
@@ -2,12 +2,14 @@ import type { MessageDescriptor } from "@lingui/core";
 import { msg, plural } from "@lingui/core/macro";
 import { Plural, Trans, useLingui } from "@lingui/react/macro";
 import * as stylex from "@stylexjs/stylex";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { discoverApi } from "#/integrations/tanstack-query/api-discover.functions";
 import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
 import { user } from "#/integrations/tanstack-query/api-user.functions";
+import { ONBOARDING_FRIENDS_LIMIT } from "#/lib/onboarding";
 
 import { Button } from "../../design-system/button";
 import { Flex } from "../../design-system/flex";
@@ -33,6 +35,7 @@ import { Body } from "../../design-system/typography";
 import { Text } from "../../design-system/typography/text";
 import { BrandWordmark } from "../reader/brand-wordmark";
 import { StepFollow } from "./step-follow";
+import { StepFriends } from "./step-friends";
 import { StepIntro } from "./step-intro";
 import { StepSettings } from "./step-settings";
 import { StepTopics } from "./step-topics";
@@ -40,6 +43,7 @@ import { StepTopics } from "./step-topics";
 export type OnboardingStep =
   | "intro"
   | "topics"
+  | "friends"
   | "follow"
   | "settings"
   | "done";
@@ -47,6 +51,7 @@ export type OnboardingStep =
 /** Ordered steps that count toward the progress dots (intro excluded). */
 const PROGRESS_STEPS: Array<OnboardingStep> = [
   "topics",
+  "friends",
   "follow",
   "settings",
   "done",
@@ -178,6 +183,10 @@ const STEP_COPY: Record<
     title: msg`What do you like to read?`,
     dek: msg`Pick a few topics — we'll suggest publications to match. Optional.`,
   },
+  friends: {
+    title: msg`People you follow write here`,
+    dek: msg`These accounts you follow on Bluesky publish on standard.site. Subscribing puts their writing on your Home feed.`,
+  },
   follow: {
     title: msg`Subscribe to a few publications`,
     dek: msg`Your Home feed is built from subscriptions. Three is a good start.`,
@@ -271,7 +280,31 @@ export function WelcomeWizard({
     await navigate({ to: "/" });
   }, [selected, followMutation, finishMutation, navigate, t]);
 
-  const progressIndex = PROGRESS_STEPS.indexOf(step);
+  // Whether the reader follows anyone on Bluesky who publishes here. Prefetched
+  // by the /welcome loader, so this has usually resolved by the intro step.
+  const { data: friends, isPending: friendsPending } = useQuery(
+    discoverApi.getFriendPublishersQueryOptions({
+      limit: ONBOARDING_FRIENDS_LIMIT,
+    }),
+  );
+  const hasFriends = (friends?.totalPeople ?? 0) > 0;
+  // A dedicated step that renders nobody is a dead screen, so it only exists
+  // when it has content. While the lookup is still in flight we keep the step
+  // in the flow rather than dropping a dot mid-wizard.
+  const includeFriends = hasFriends || friendsPending;
+  const progressSteps = includeFriends
+    ? PROGRESS_STEPS
+    : PROGRESS_STEPS.filter((s) => s !== "friends");
+
+  // Landing on ?step=friends with nothing to show (deep link, or the lookup
+  // resolved empty while the reader was on it) moves on instead of stranding.
+  useEffect(() => {
+    if (step === "friends" && !friendsPending && !hasFriends) {
+      onStepChange("follow");
+    }
+  }, [step, friendsPending, hasFriends, onStepChange]);
+
+  const progressIndex = progressSteps.indexOf(step);
 
   // Reset the scroll position whenever the step changes so each step starts at
   // the top rather than inheriting the previous step's scroll offset.
@@ -283,7 +316,8 @@ export function WelcomeWizard({
   const backTarget: Record<OnboardingStep, OnboardingStep | null> = {
     intro: null,
     topics: "intro",
-    follow: "topics",
+    friends: "topics",
+    follow: includeFriends ? "friends" : "topics",
     settings: "follow",
     done: "settings",
   };
@@ -295,6 +329,10 @@ export function WelcomeWizard({
         break;
       }
       case "topics": {
+        onStepChange(includeFriends ? "friends" : "follow");
+        break;
+      }
+      case "friends": {
         onStepChange("follow");
         break;
       }
@@ -318,7 +356,7 @@ export function WelcomeWizard({
       ? t`Get started`
       : step === "topics"
         ? t`Continue`
-        : step === "follow"
+        : step === "friends" || step === "follow"
           ? selected.size === 0
             ? t`Skip for now`
             : t`Continue`
@@ -360,6 +398,13 @@ export function WelcomeWizard({
             <>
               <StepHeadingBlock stepKey="topics" />
               <StepTopics selected={topics} onChange={onTopicsChange} />
+            </>
+          ) : null}
+
+          {step === "friends" ? (
+            <>
+              <StepHeadingBlock stepKey="friends" />
+              <StepFriends selected={selected} onToggle={toggleFollow} />
             </>
           ) : null}
 
@@ -407,7 +452,7 @@ export function WelcomeWizard({
       </div>
 
       <div {...stylex.props(styles.footer)}>
-        {step === "follow" ? (
+        {step === "friends" || step === "follow" ? (
           <span
             {...stylex.props(
               styles.counter,
@@ -436,7 +481,9 @@ export function WelcomeWizard({
           </Button>
           <Button
             variant={
-              step === "follow" && selected.size === 0 ? "outline" : "primary"
+              (step === "friends" || step === "follow") && selected.size === 0
+                ? "outline"
+                : "primary"
             }
             isPending={forwardPending}
             onPress={forward}
@@ -447,7 +494,7 @@ export function WelcomeWizard({
       </div>
 
       <div {...stylex.props(styles.dotsBar)} aria-hidden>
-        {PROGRESS_STEPS.map((s, i) => (
+        {progressSteps.map((s, i) => (
           <span
             key={s}
             {...stylex.props(

--- a/src/components/reader/cards.tsx
+++ b/src/components/reader/cards.tsx
@@ -149,6 +149,10 @@ const styles = stylex.create({
   ownerHandleLink: {
     color: uiColor.text1,
   },
+  pubDirHandle: {
+    minWidth: 0,
+    overflowWrap: "anywhere",
+  },
   bylineWhen: {
     color: uiColor.text1,
     fontFamily: fontFamily.sans,
@@ -682,18 +686,19 @@ const styles = stylex.create({
       default: "1",
       "@media (min-width: 40rem)": "auto",
     },
-    alignItems: {
-      default: "flex-start",
-      "@media (min-width: 40rem)": "baseline",
-    },
-    columnGap: spacing["2.5"],
+    // Name and `@handle` sit on one line at every width. They used to stack
+    // below 40rem, which cost a whole row per result and read as two separate
+    // facts rather than one byline. `wrap` still lets the handle drop to its
+    // own line when a long name genuinely leaves it no room.
+    alignItems: "baseline",
+    columnGap: spacing["2"],
     display: "flex",
-    flexDirection: {
-      default: "column",
-      "@media (min-width: 40rem)": "row",
-    },
+    flexDirection: "row",
+    // Wrap rather than truncate: the handle drops to its own line only when a
+    // long name genuinely leaves no room. Truncating either one costs the
+    // reader real information on a directory of unfamiliar publications.
     flexWrap: "wrap",
-    rowGap: spacing["1"],
+    rowGap: spacing["0.5"],
     minWidth: 0,
   },
   pubDirTopRanked: {
@@ -708,7 +713,12 @@ const styles = stylex.create({
     unicodeBidi: "isolate",
     color: uiColor.text2,
     fontFamily: fontFamily.serif,
-    fontSize: fontSize.xl,
+    // A step down on phones: at `xl` the name alone eats the row, pushing the
+    // handle onto a second line for all but the shortest names.
+    fontSize: {
+      default: fontSize.lg,
+      "@media (min-width: 40rem)": fontSize.xl,
+    },
     fontWeight: fontWeight.semibold,
     letterSpacing: tracking.tight,
     lineHeight: lineHeight.sm,
@@ -980,11 +990,20 @@ export function FollowButton({
   );
 }
 
-function OwnerHandleLink({ did, handle }: { did: string; handle: string }) {
+function OwnerHandleLink({
+  did,
+  handle,
+  style,
+}: {
+  did: string;
+  handle: string;
+  /** Extra styles for the link box (e.g. the directory row's shrink rules). */
+  style?: stylex.StyleXStyles;
+}) {
   return (
     <AuthorProfileLink
       authorRef={did}
-      linkStyle={[styles.ownerHandleLink, styles.cardInteractive]}
+      linkStyle={[styles.ownerHandleLink, styles.cardInteractive, style]}
     >
       <Handle>@{handle}</Handle>
     </AuthorProfileLink>
@@ -2302,7 +2321,11 @@ export function PubDirectoryRow({
             </span>
           )}
           {pub.ownerHandle ? (
-            <OwnerHandleLink did={pub.did} handle={pub.ownerHandle} />
+            <OwnerHandleLink
+              did={pub.did}
+              handle={pub.ownerHandle}
+              style={styles.pubDirHandle}
+            />
           ) : null}
           {isHidden ? (
             <span

--- a/src/components/reader/cards.tsx
+++ b/src/components/reader/cards.tsx
@@ -2226,7 +2226,6 @@ export function PubDirectoryRow({
   isLast = false,
   isFirstInSection = false,
   hideTopic = false,
-  hideOwner = false,
   tagPostCount,
   noLink = false,
   markHidden = false,
@@ -2238,8 +2237,6 @@ export function PubDirectoryRow({
   isFirstInSection?: boolean;
   /** Omit topic chips when the surrounding page already names the tag. */
   hideTopic?: boolean;
-  /** Omit the owner handle when rows are already grouped under that person. */
-  hideOwner?: boolean;
   /** Tagged-post tally for tag directory rows. */
   tagPostCount?: number;
   /** Render body only (no stretched link) — for use inside a GridListItem. */
@@ -2304,7 +2301,7 @@ export function PubDirectoryRow({
               {pub.name}
             </span>
           )}
-          {pub.ownerHandle && !hideOwner ? (
+          {pub.ownerHandle ? (
             <OwnerHandleLink did={pub.did} handle={pub.ownerHandle} />
           ) : null}
           {isHidden ? (

--- a/src/components/reader/cards.tsx
+++ b/src/components/reader/cards.tsx
@@ -2226,6 +2226,7 @@ export function PubDirectoryRow({
   isLast = false,
   isFirstInSection = false,
   hideTopic = false,
+  hideOwner = false,
   tagPostCount,
   noLink = false,
   markHidden = false,
@@ -2237,6 +2238,8 @@ export function PubDirectoryRow({
   isFirstInSection?: boolean;
   /** Omit topic chips when the surrounding page already names the tag. */
   hideTopic?: boolean;
+  /** Omit the owner handle when rows are already grouped under that person. */
+  hideOwner?: boolean;
   /** Tagged-post tally for tag directory rows. */
   tagPostCount?: number;
   /** Render body only (no stretched link) — for use inside a GridListItem. */
@@ -2301,7 +2304,7 @@ export function PubDirectoryRow({
               {pub.name}
             </span>
           )}
-          {pub.ownerHandle ? (
+          {pub.ownerHandle && !hideOwner ? (
             <OwnerHandleLink did={pub.did} handle={pub.ownerHandle} />
           ) : null}
           {isHidden ? (

--- a/src/components/reader/format.ts
+++ b/src/components/reader/format.ts
@@ -220,17 +220,3 @@ export function formatTime(seconds: number): string {
   const secs = total % 60;
   return `${minutes}:${secs.toString().padStart(2, "0")}`;
 }
-
-/**
- * Display label for a person in the "people you follow" surfaces: their profile
- * name when they have one, else the handle, else the bare DID.
- */
-export function friendDisplayName(person: {
-  did: string;
-  handle: string | null;
-  displayName: string | null;
-}): string {
-  return (
-    person.displayName ?? (person.handle ? `@${person.handle}` : person.did)
-  );
-}

--- a/src/components/reader/format.ts
+++ b/src/components/reader/format.ts
@@ -220,3 +220,17 @@ export function formatTime(seconds: number): string {
   const secs = total % 60;
   return `${minutes}:${secs.toString().padStart(2, "0")}`;
 }
+
+/**
+ * Display label for a person in the "people you follow" surfaces: their profile
+ * name when they have one, else the handle, else the bare DID.
+ */
+export function friendDisplayName(person: {
+  did: string;
+  handle: string | null;
+  displayName: string | null;
+}): string {
+  return (
+    person.displayName ?? (person.handle ? `@${person.handle}` : person.did)
+  );
+}

--- a/src/components/reader/friend-publishers.tsx
+++ b/src/components/reader/friend-publishers.tsx
@@ -1,92 +1,17 @@
 "use client";
 
-import { Plural, Trans, useLingui } from "@lingui/react/macro";
+import { Plural, Trans } from "@lingui/react/macro";
 import * as stylex from "@stylexjs/stylex";
 
-import type { FriendPublisher } from "#/integrations/tanstack-query/api-discover.functions";
-
-import { Avatar } from "../../design-system/avatar";
-import { Flex } from "../../design-system/flex";
-import { Skeleton } from "../../design-system/skeleton";
 import { uiColor } from "../../design-system/theme/color.stylex";
-import { radius } from "../../design-system/theme/radius.stylex";
-import {
-  gap,
-  horizontalSpace,
-  verticalSpace,
-} from "../../design-system/theme/semantic-spacing.stylex";
 import { spacing } from "../../design-system/theme/spacing.stylex";
 import {
   fontFamily,
   fontSize,
-  fontWeight,
   lineHeight,
 } from "../../design-system/theme/typography.stylex";
-import { AuthorProfileLink } from "./author-profile-link";
-import { friendDisplayName, initials } from "./format";
 
 const styles = stylex.create({
-  group: {
-    display: "flex",
-    flexDirection: "column",
-    rowGap: verticalSpace.lg,
-  },
-  personRow: {
-    alignItems: "center",
-    columnGap: gap.lg,
-    display: "flex",
-    minWidth: 0,
-  },
-  personLink: {
-    alignItems: "center",
-    columnGap: gap.lg,
-    display: "flex",
-    flexGrow: 1,
-    minWidth: 0,
-    textDecoration: "none",
-  },
-  personMeta: {
-    display: "flex",
-    flexDirection: "column",
-    minWidth: 0,
-    rowGap: spacing["0.5"],
-  },
-  personName: {
-    color: uiColor.text2,
-    fontFamily: fontFamily.sans,
-    fontSize: fontSize.base,
-    fontWeight: fontWeight.semibold,
-    lineHeight: lineHeight.sm,
-    overflow: "hidden",
-    textOverflow: "ellipsis",
-    whiteSpace: "nowrap",
-  },
-  personHandle: {
-    color: uiColor.text1,
-    fontFamily: fontFamily.mono,
-    fontSize: fontSize.xs,
-    overflow: "hidden",
-    textOverflow: "ellipsis",
-    unicodeBidi: "isolate",
-    whiteSpace: "nowrap",
-  },
-  personAction: {
-    flexShrink: 0,
-  },
-  pubs: {
-    borderColor: uiColor.border1,
-    borderRadius: radius.md,
-    borderStyle: "solid",
-    borderWidth: 1,
-    display: "flex",
-    flexDirection: "column",
-    overflow: "hidden",
-  },
-  // The person's writing is the point; publications sit in a quieter well so
-  // the eye runs down the list of people first.
-  pubsInset: {
-    backgroundColor: uiColor.bgSubtle,
-  },
   note: {
     color: uiColor.text1,
     fontFamily: fontFamily.sans,
@@ -94,79 +19,11 @@ const styles = stylex.create({
     lineHeight: lineHeight.sm,
     marginBottom: spacing["0"],
     marginTop: spacing["0"],
-  },
-  skeletonPerson: {
-    alignItems: "center",
-    columnGap: gap.lg,
-    display: "flex",
-    paddingBottom: verticalSpace.md,
-  },
-  skeletonPubs: {
-    borderColor: uiColor.border1,
-    borderRadius: radius.md,
-    borderStyle: "solid",
-    borderWidth: 1,
-    display: "flex",
-    flexDirection: "column",
-    paddingBottom: verticalSpace.xl,
-    paddingInlineStart: horizontalSpace.xl,
-    paddingInlineEnd: horizontalSpace.xl,
-    paddingTop: verticalSpace.xl,
-    rowGap: verticalSpace.md,
+    overflowWrap: "anywhere",
   },
 });
 
-/**
- * One person you follow on Bluesky, with the publications they write. The
- * person is the heading and the publications hang beneath: the reader is
- * looking for "who that I follow writes here", not for loose publications.
- *
- * `action` is the person-level control (Follow on the live surface, a
- * select-all toggle in onboarding) and `children` the publication rows, so the
- * same grouping serves both without either owning the other's write model.
- */
-export function FriendPublisherGroup({
-  person,
-  action,
-  children,
-}: {
-  person: FriendPublisher;
-  action?: React.ReactNode;
-  children: React.ReactNode;
-}) {
-  const name = friendDisplayName(person);
-
-  return (
-    <section {...stylex.props(styles.group)}>
-      <div {...stylex.props(styles.personRow)}>
-        <AuthorProfileLink authorRef={person.did} linkStyle={styles.personLink}>
-          <Avatar
-            src={person.avatarUrl ?? undefined}
-            alt={name}
-            size="lg"
-            fallback={initials(name)}
-          />
-          <span {...stylex.props(styles.personMeta)}>
-            <span dir="auto" {...stylex.props(styles.personName)}>
-              {name}
-            </span>
-            {person.handle ? (
-              <span dir="auto" {...stylex.props(styles.personHandle)}>
-                @{person.handle}
-              </span>
-            ) : null}
-          </span>
-        </AuthorProfileLink>
-        {action ? (
-          <div {...stylex.props(styles.personAction)}>{action}</div>
-        ) : null}
-      </div>
-      <div {...stylex.props(styles.pubs, styles.pubsInset)}>{children}</div>
-    </section>
-  );
-}
-
-/** Count line beneath a friends heading: "6 people · 8 publications". */
+/** Count line above the list: "8 publications · 6 people you follow". */
 export function FriendPublishersSummary({
   people,
   publicationCount,
@@ -177,15 +34,15 @@ export function FriendPublishersSummary({
   return (
     <p {...stylex.props(styles.note)}>
       <Plural
-        value={people}
-        one="# person you follow"
-        other="# people you follow"
-      />
-      {" · "}
-      <Plural
         value={publicationCount}
         one="# publication"
         other="# publications"
+      />
+      {" · "}
+      <Plural
+        value={people}
+        one="# person you follow"
+        other="# people you follow"
       />
     </p>
   );
@@ -203,36 +60,5 @@ export function FriendPublishersDegradedNote() {
         try again.
       </Trans>
     </p>
-  );
-}
-
-export function FriendPublishersSkeleton({ groups = 3 }: { groups?: number }) {
-  const { t } = useLingui();
-  return (
-    <Flex direction="column" gap="5xl" aria-label={t`Loading`} aria-busy>
-      {Array.from({ length: groups }, (_, index) => (
-        <div key={index} aria-hidden>
-          <div {...stylex.props(styles.skeletonPerson)}>
-            <Skeleton variant="circle" size="lg" />
-            <Flex direction="column" gap="sm">
-              <Skeleton
-                variant="rectangle"
-                height={spacing["5"]}
-                width={spacing["32"]}
-              />
-              <Skeleton
-                variant="rectangle"
-                height={spacing["3.5"]}
-                width={spacing["24"]}
-              />
-            </Flex>
-          </div>
-          <div {...stylex.props(styles.skeletonPubs)}>
-            <Skeleton variant="rectangle" height={spacing["5"]} width="46%" />
-            <Skeleton variant="rectangle" height={spacing["4"]} width="88%" />
-          </div>
-        </div>
-      ))}
-    </Flex>
   );
 }

--- a/src/components/reader/friend-publishers.tsx
+++ b/src/components/reader/friend-publishers.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { Plural, Trans, useLingui } from "@lingui/react/macro";
+import * as stylex from "@stylexjs/stylex";
+
+import type { FriendPublisher } from "#/integrations/tanstack-query/api-discover.functions";
+
+import { Avatar } from "../../design-system/avatar";
+import { Flex } from "../../design-system/flex";
+import { Skeleton } from "../../design-system/skeleton";
+import { uiColor } from "../../design-system/theme/color.stylex";
+import { radius } from "../../design-system/theme/radius.stylex";
+import {
+  gap,
+  horizontalSpace,
+  verticalSpace,
+} from "../../design-system/theme/semantic-spacing.stylex";
+import { spacing } from "../../design-system/theme/spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+} from "../../design-system/theme/typography.stylex";
+import { AuthorProfileLink } from "./author-profile-link";
+import { friendDisplayName, initials } from "./format";
+
+const styles = stylex.create({
+  group: {
+    display: "flex",
+    flexDirection: "column",
+    rowGap: verticalSpace.lg,
+  },
+  personRow: {
+    alignItems: "center",
+    columnGap: gap.lg,
+    display: "flex",
+    minWidth: 0,
+  },
+  personLink: {
+    alignItems: "center",
+    columnGap: gap.lg,
+    display: "flex",
+    flexGrow: 1,
+    minWidth: 0,
+    textDecoration: "none",
+  },
+  personMeta: {
+    display: "flex",
+    flexDirection: "column",
+    minWidth: 0,
+    rowGap: spacing["0.5"],
+  },
+  personName: {
+    color: uiColor.text2,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.base,
+    fontWeight: fontWeight.semibold,
+    lineHeight: lineHeight.sm,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  personHandle: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.mono,
+    fontSize: fontSize.xs,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    unicodeBidi: "isolate",
+    whiteSpace: "nowrap",
+  },
+  personAction: {
+    flexShrink: 0,
+  },
+  pubs: {
+    borderColor: uiColor.border1,
+    borderRadius: radius.md,
+    borderStyle: "solid",
+    borderWidth: 1,
+    display: "flex",
+    flexDirection: "column",
+    overflow: "hidden",
+  },
+  // The person's writing is the point; publications sit in a quieter well so
+  // the eye runs down the list of people first.
+  pubsInset: {
+    backgroundColor: uiColor.bgSubtle,
+  },
+  note: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.sm,
+    lineHeight: lineHeight.sm,
+    marginBottom: spacing["0"],
+    marginTop: spacing["0"],
+  },
+  skeletonPerson: {
+    alignItems: "center",
+    columnGap: gap.lg,
+    display: "flex",
+    paddingBottom: verticalSpace.md,
+  },
+  skeletonPubs: {
+    borderColor: uiColor.border1,
+    borderRadius: radius.md,
+    borderStyle: "solid",
+    borderWidth: 1,
+    display: "flex",
+    flexDirection: "column",
+    paddingBottom: verticalSpace.xl,
+    paddingInlineStart: horizontalSpace.xl,
+    paddingInlineEnd: horizontalSpace.xl,
+    paddingTop: verticalSpace.xl,
+    rowGap: verticalSpace.md,
+  },
+});
+
+/**
+ * One person you follow on Bluesky, with the publications they write. The
+ * person is the heading and the publications hang beneath: the reader is
+ * looking for "who that I follow writes here", not for loose publications.
+ *
+ * `action` is the person-level control (Follow on the live surface, a
+ * select-all toggle in onboarding) and `children` the publication rows, so the
+ * same grouping serves both without either owning the other's write model.
+ */
+export function FriendPublisherGroup({
+  person,
+  action,
+  children,
+}: {
+  person: FriendPublisher;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  const name = friendDisplayName(person);
+
+  return (
+    <section {...stylex.props(styles.group)}>
+      <div {...stylex.props(styles.personRow)}>
+        <AuthorProfileLink authorRef={person.did} linkStyle={styles.personLink}>
+          <Avatar
+            src={person.avatarUrl ?? undefined}
+            alt={name}
+            size="lg"
+            fallback={initials(name)}
+          />
+          <span {...stylex.props(styles.personMeta)}>
+            <span dir="auto" {...stylex.props(styles.personName)}>
+              {name}
+            </span>
+            {person.handle ? (
+              <span dir="auto" {...stylex.props(styles.personHandle)}>
+                @{person.handle}
+              </span>
+            ) : null}
+          </span>
+        </AuthorProfileLink>
+        {action ? (
+          <div {...stylex.props(styles.personAction)}>{action}</div>
+        ) : null}
+      </div>
+      <div {...stylex.props(styles.pubs, styles.pubsInset)}>{children}</div>
+    </section>
+  );
+}
+
+/** Count line beneath a friends heading: "6 people · 8 publications". */
+export function FriendPublishersSummary({
+  people,
+  publicationCount,
+}: {
+  people: number;
+  publicationCount: number;
+}) {
+  return (
+    <p {...stylex.props(styles.note)}>
+      <Plural
+        value={people}
+        one="# person you follow"
+        other="# people you follow"
+      />
+      {" · "}
+      <Plural
+        value={publicationCount}
+        one="# publication"
+        other="# publications"
+      />
+    </p>
+  );
+}
+
+/**
+ * Shown when the Bluesky AppView didn't answer. Distinct from the empty state
+ * on purpose — "we couldn't check" must never read as "you know nobody here".
+ */
+export function FriendPublishersDegradedNote() {
+  return (
+    <p {...stylex.props(styles.note)}>
+      <Trans>
+        Bluesky didn't answer in time, so this list may be incomplete. Reload to
+        try again.
+      </Trans>
+    </p>
+  );
+}
+
+export function FriendPublishersSkeleton({ groups = 3 }: { groups?: number }) {
+  const { t } = useLingui();
+  return (
+    <Flex direction="column" gap="5xl" aria-label={t`Loading`} aria-busy>
+      {Array.from({ length: groups }, (_, index) => (
+        <div key={index} aria-hidden>
+          <div {...stylex.props(styles.skeletonPerson)}>
+            <Skeleton variant="circle" size="lg" />
+            <Flex direction="column" gap="sm">
+              <Skeleton
+                variant="rectangle"
+                height={spacing["5"]}
+                width={spacing["32"]}
+              />
+              <Skeleton
+                variant="rectangle"
+                height={spacing["3.5"]}
+                width={spacing["24"]}
+              />
+            </Flex>
+          </div>
+          <div {...stylex.props(styles.skeletonPubs)}>
+            <Skeleton variant="rectangle" height={spacing["5"]} width="46%" />
+            <Skeleton variant="rectangle" height={spacing["4"]} width="88%" />
+          </div>
+        </div>
+      ))}
+    </Flex>
+  );
+}

--- a/src/integrations/tanstack-query/api-discover.functions.ts
+++ b/src/integrations/tanstack-query/api-discover.functions.ts
@@ -29,7 +29,7 @@ import type { Db, PublicationCard, Schema } from "./api-shapes";
 import { dbMiddleware } from "./db-middleware";
 
 export type {
-  FriendPublisher,
+  FriendAuthor,
   FriendPublishers,
 } from "#/server/reader/bsky-friends";
 
@@ -620,19 +620,27 @@ function getOnboardingSuggestionsQueryOptions({
 }
 
 /**
- * A single page of friends. The Discover prompt and the onboarding step take a
- * small page (they only need counts and the first few faces); `/friends` pages
- * through with {@link getFriendPublishersInfiniteQueryOptions}. The expensive
- * Bluesky sweep is cached server-side per reader, so later pages are DB-only.
+ * A single page of friends' publications. The Discover prompt and the
+ * onboarding step take a small page (they only need the counts and the first
+ * few faces); `/friends` pages through with
+ * {@link getFriendPublishersInfiniteQueryOptions}. The expensive Bluesky sweep
+ * is cached server-side per reader, so later pages are DB-only.
+ *
+ * Keyed under `friends`, deliberately *not* `discover`: subscribing invalidates
+ * the whole `["discover"]` prefix, and since the server drops publications the
+ * reader already subscribes to, that would make a row vanish the moment it was
+ * subscribed to. Rows should settle into "Subscribed" and stay put until the
+ * next visit.
  */
 function getFriendPublishersQueryOptions({
   limit = FRIEND_PAGE_SIZE,
   offset = 0,
 }: z.input<typeof friendPublishersInput> = {}) {
   return queryOptions({
-    queryKey: ["discover", "friend-publishers", limit, offset] as const,
+    queryKey: ["friends", "publications", limit, offset] as const,
     queryFn: async () => getFriendPublishers({ data: { limit, offset } }),
     staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
   });
 }
 
@@ -640,12 +648,13 @@ function getFriendPublishersInfiniteQueryOptions({
   limit = FRIEND_PAGE_SIZE,
 }: { limit?: number } = {}) {
   return infiniteQueryOptions({
-    queryKey: ["discover", "friend-publishers", "infinite", limit] as const,
+    queryKey: ["friends", "publications", "infinite", limit] as const,
     queryFn: async ({ pageParam }) =>
       getFriendPublishers({ data: { limit, offset: pageParam } }),
     initialPageParam: 0,
     getNextPageParam: (lastPage) => lastPage.nextOffset ?? undefined,
     staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
   });
 }
 

--- a/src/integrations/tanstack-query/api-discover.functions.ts
+++ b/src/integrations/tanstack-query/api-discover.functions.ts
@@ -8,8 +8,11 @@ import type { Span } from "#/server/observability/log";
 import { observe } from "#/server/observability/log";
 import { attachReaderSpanContext } from "#/server/observability/span-context.ts";
 import {
+  EMPTY_FRIEND_ARTICLES,
   EMPTY_FRIEND_PUBLISHERS,
+  FRIEND_ARTICLE_PAGE_SIZE,
   FRIEND_PAGE_SIZE,
+  friendArticles,
   friendPublishers,
 } from "#/server/reader/bsky-friends";
 import {
@@ -29,6 +32,7 @@ import type { Db, PublicationCard, Schema } from "./api-shapes";
 import { dbMiddleware } from "./db-middleware";
 
 export type {
+  FriendArticles,
   FriendAuthor,
   FriendPublishers,
 } from "#/server/reader/bsky-friends";
@@ -191,6 +195,11 @@ const friendPublishersInput = z.object({
   offset: z.number().int().min(0).default(0),
 });
 
+const friendArticlesInput = z.object({
+  limit: z.number().int().min(1).max(50).default(FRIEND_ARTICLE_PAGE_SIZE),
+  offset: z.number().int().min(0).default(0),
+});
+
 const getFriendPublishers = createServerFn({ method: "GET" })
   .middleware([dbMiddleware])
   .validator(friendPublishersInput)
@@ -213,6 +222,31 @@ const getFriendPublishers = createServerFn({ method: "GET" })
       span.set("publications", result.publicationCount);
       span.set("degraded", result.degraded);
       span.set("truncated", result.truncated);
+      return result;
+    }),
+  );
+
+/** The Articles tab of `/friends`: recent writing from those publications. */
+const getFriendArticles = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware])
+  .validator(friendArticlesInput)
+  .handler(
+    observe("discover.getFriendArticles", async ({ data, context }, span) => {
+      const { db, schema } = context;
+      const did = await attachReaderSpanContext(span, getRequest());
+      if (!did) {
+        span.set("signedIn", false);
+        return EMPTY_FRIEND_ARTICLES;
+      }
+      span.set("signedIn", true);
+      span.set("offset", data.offset);
+
+      const result = await friendArticles(db, schema, did, {
+        limit: data.limit,
+        offset: data.offset,
+      });
+      span.set("count", result.items.length);
+      span.set("degraded", result.degraded);
       return result;
     }),
   );
@@ -658,6 +692,23 @@ function getFriendPublishersInfiniteQueryOptions({
   });
 }
 
+function getFriendArticlesInfiniteQueryOptions({
+  limit = FRIEND_ARTICLE_PAGE_SIZE,
+}: { limit?: number } = {}) {
+  return infiniteQueryOptions({
+    // Same `friends` namespace as the Publications tab, and for the same
+    // reason: subscribing must not invalidate the list out from under the
+    // reader mid-visit.
+    queryKey: ["friends", "articles", "infinite", limit] as const,
+    queryFn: async ({ pageParam }) =>
+      getFriendArticles({ data: { limit, offset: pageParam } }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => lastPage.nextOffset ?? undefined,
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+  });
+}
+
 function getEffectiveFollowUrisQueryOptions() {
   return queryOptions({
     queryKey: ["discover", "effectiveFollowUris"] as const,
@@ -680,6 +731,8 @@ export const discoverApi = {
   getRecommendedPublicationsQueryOptions,
   getFollowedByPeopleYouFollow,
   getFollowedByPeopleYouFollowQueryOptions,
+  getFriendArticles,
+  getFriendArticlesInfiniteQueryOptions,
   getFriendPublishers,
   getFriendPublishersQueryOptions,
   getFriendPublishersInfiniteQueryOptions,

--- a/src/integrations/tanstack-query/api-discover.functions.ts
+++ b/src/integrations/tanstack-query/api-discover.functions.ts
@@ -1,4 +1,4 @@
-import { queryOptions } from "@tanstack/react-query";
+import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import { createServerFn } from "@tanstack/react-start";
 import { getRequest } from "@tanstack/react-start/server";
 import { z } from "zod";
@@ -7,6 +7,11 @@ import { getAtprotoSessionForRequest } from "#/middleware/auth-session.server";
 import type { Span } from "#/server/observability/log";
 import { observe } from "#/server/observability/log";
 import { attachReaderSpanContext } from "#/server/observability/span-context.ts";
+import {
+  EMPTY_FRIEND_PUBLISHERS,
+  FRIEND_PAGE_SIZE,
+  friendPublishers,
+} from "#/server/reader/bsky-friends";
 import {
   countKnownPublications,
   discoverDirectoryPublications,
@@ -22,6 +27,11 @@ import { effectiveFollowUris } from "#/server/reader/saved-lists";
 
 import type { Db, PublicationCard, Schema } from "./api-shapes";
 import { dbMiddleware } from "./db-middleware";
+
+export type {
+  FriendPublisher,
+  FriendPublishers,
+} from "#/server/reader/bsky-friends";
 
 /**
  * Discover directory queries (`APP_VISION.md` §5): the topic chips, the full
@@ -168,6 +178,42 @@ const getKnownPublicationCount = createServerFn({ method: "GET" })
       const count = await countKnownPublications(context.db);
       span.set("count", count);
       return count;
+    }),
+  );
+
+/**
+ * Publications written by the Bluesky accounts you follow. Signed-out readers
+ * get the empty shape rather than an error — the surfaces that use it are
+ * hidden when there's nobody to show.
+ */
+const friendPublishersInput = z.object({
+  limit: z.number().int().min(1).max(50).default(FRIEND_PAGE_SIZE),
+  offset: z.number().int().min(0).default(0),
+});
+
+const getFriendPublishers = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware])
+  .validator(friendPublishersInput)
+  .handler(
+    observe("discover.getFriendPublishers", async ({ data, context }, span) => {
+      const { db, schema } = context;
+      const did = await attachReaderSpanContext(span, getRequest());
+      if (!did) {
+        span.set("signedIn", false);
+        return EMPTY_FRIEND_PUBLISHERS;
+      }
+      span.set("signedIn", true);
+      span.set("offset", data.offset);
+
+      const result = await friendPublishers(db, schema, did, {
+        limit: data.limit,
+        offset: data.offset,
+      });
+      span.set("people", result.totalPeople);
+      span.set("publications", result.publicationCount);
+      span.set("degraded", result.degraded);
+      span.set("truncated", result.truncated);
+      return result;
     }),
   );
 
@@ -573,6 +619,36 @@ function getOnboardingSuggestionsQueryOptions({
   });
 }
 
+/**
+ * A single page of friends. The Discover prompt and the onboarding step take a
+ * small page (they only need counts and the first few faces); `/friends` pages
+ * through with {@link getFriendPublishersInfiniteQueryOptions}. The expensive
+ * Bluesky sweep is cached server-side per reader, so later pages are DB-only.
+ */
+function getFriendPublishersQueryOptions({
+  limit = FRIEND_PAGE_SIZE,
+  offset = 0,
+}: z.input<typeof friendPublishersInput> = {}) {
+  return queryOptions({
+    queryKey: ["discover", "friend-publishers", limit, offset] as const,
+    queryFn: async () => getFriendPublishers({ data: { limit, offset } }),
+    staleTime: 5 * 60_000,
+  });
+}
+
+function getFriendPublishersInfiniteQueryOptions({
+  limit = FRIEND_PAGE_SIZE,
+}: { limit?: number } = {}) {
+  return infiniteQueryOptions({
+    queryKey: ["discover", "friend-publishers", "infinite", limit] as const,
+    queryFn: async ({ pageParam }) =>
+      getFriendPublishers({ data: { limit, offset: pageParam } }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => lastPage.nextOffset ?? undefined,
+    staleTime: 5 * 60_000,
+  });
+}
+
 function getEffectiveFollowUrisQueryOptions() {
   return queryOptions({
     queryKey: ["discover", "effectiveFollowUris"] as const,
@@ -595,6 +671,9 @@ export const discoverApi = {
   getRecommendedPublicationsQueryOptions,
   getFollowedByPeopleYouFollow,
   getFollowedByPeopleYouFollowQueryOptions,
+  getFriendPublishers,
+  getFriendPublishersQueryOptions,
+  getFriendPublishersInfiniteQueryOptions,
   getOnboardingSuggestions,
   getOnboardingSuggestionsQueryOptions,
   getEffectiveFollowUris,

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -27,3 +27,9 @@ export function dbValueToOnboardingCompleted(
 ): boolean {
   return value === true;
 }
+
+/**
+ * How many of the people you follow the onboarding step shows. A first-run step
+ * is a decision, not a directory — the rest are one tap away on `/friends`.
+ */
+export const ONBOARDING_FRIENDS_LIMIT = 6;

--- a/src/lib/site-metadata.ts
+++ b/src/lib/site-metadata.ts
@@ -43,6 +43,12 @@ export const PAGE_OG_CARDS = {
     tagline:
       "Articles you've saved for later — in your repo, synced across devices.",
   },
+  friends: {
+    path: "/friends",
+    title: "People you follow",
+    tagline:
+      "Publications written by the people you follow on Bluesky, all in one place.",
+  },
   recommended: {
     path: "/recommended",
     title: "Recommended articles",

--- a/src/lib/use-has-mounted.ts
+++ b/src/lib/use-has-mounted.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+
+/**
+ * `false` during SSR and on the first client render, `true` afterwards.
+ *
+ * For content whose data arrives from a non-blocking loader prefetch: the
+ * server may finish that fetch mid-render and emit the loaded markup, while the
+ * client hydrates before the same data lands, and React reports a mismatch.
+ * Gating on this makes both sides render the pending branch, so hydration is
+ * deterministic and the content streams in a beat later.
+ */
+export function useHasMounted(): boolean {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+  return mounted;
+}

--- a/src/locales/ar/messages.po
+++ b/src/locales/ar/messages.po
@@ -90,6 +90,7 @@ msgstr "إضافة مقال"
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/article-below-fold.tsx
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.friends.tsx
 msgid "Discover"
 msgstr "استكشاف"
 
@@ -593,6 +594,10 @@ msgstr "إعادة ترتيب القوائم"
 msgid "Publication lists"
 msgstr "قوائم المنشورات"
 
+#: src/components/onboarding/welcome-wizard.tsx
+msgid "These accounts you follow on Bluesky publish on standard.site. Subscribing puts their writing on your Home feed."
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Optional: add context, steps to reproduce, or what you'd like to see"
 msgstr "اختياري: أضف سياقًا أو خطوات إعادة الإنتاج أو ما تودّ رؤيته"
@@ -662,6 +667,10 @@ msgstr "{userCount, plural, zero {مستخدم} one {مستخدم} two {مستخ
 #: src/components/reader/privacy-view.tsx
 msgid "<0>Reading activity.</0> When reading history is enabled, articles you open are recorded as public AT Protocol records in <1>your</1> repository — not as private app-only data. You can turn this off in Settings; existing records remain in your repo until you delete them from the Personal data section."
 msgstr "<0>نشاط القراءة.</0> عند تفعيل سجل القراءة، تُسجَّل المقالات التي تفتحها كسجلات عامة على AT Protocol في مستودع<1>ك</1> — لا كبيانات خاصة بالتطبيق. يمكنك تعطيل ذلك من الإعدادات؛ وتبقى السجلات الحالية في مستودعك حتى تحذفها من قسم البيانات الشخصية."
+
+#: src/routes/_layout.friends.tsx
+msgid "Browse the directory"
+msgstr ""
 
 #: src/components/reader/article-view.tsx
 msgid "Did you enjoy this article?"
@@ -1300,6 +1309,10 @@ msgstr "عرض على PDSLS"
 msgid "Subscribe to a few publications to unlock recommendations."
 msgstr "اشترك في بضع منشورات لفتح التوصيات."
 
+#: src/routes/_layout.discover.tsx
+msgid "See publications from the people you follow"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "{shown}+ matches"
 msgstr "أكثر من {shown} مطابقة"
@@ -1353,6 +1366,11 @@ msgstr "تسجيل الخروج"
 msgid "The top articles from publications you subscribe to."
 msgstr ""
 
+#. placeholder {0}: data?.publicationCount ?? 0
+#: src/routes/_layout.discover.tsx
+msgid "{0, plural, one {# publication from your Bluesky follows} other {# publications from your Bluesky follows}}"
+msgstr ""
+
 #: src/routes/review.thanks.tsx
 msgid "Return to the app"
 msgstr "العودة إلى التطبيق"
@@ -1400,6 +1418,10 @@ msgstr "تعذّر العثور على ذلك الكاتب."
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "A few preferences"
 msgstr "بعض التفضيلات"
+
+#: src/routes/_layout.friends.tsx
+msgid "We couldn't reach Bluesky to look up who you follow. Reload in a moment, or browse the directory in the meantime."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "All articles you have marked as read."
@@ -1453,6 +1475,10 @@ msgstr "افتح الدليل"
 #: src/routes/_layout.feedback.index.tsx
 msgid "Answered"
 msgstr "تمت الإجابة"
+
+#: src/routes/_layout.friends.tsx
+msgid "Couldn't check right now"
+msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "Reorder {itemTitle}"
@@ -1638,6 +1664,10 @@ msgstr "آخر تحديث في 13 يونيو 2026"
 msgid "{shown, plural, one {# match} other {# matches}}"
 msgstr "{shown, plural, zero {لا توجد نتائج} one {نتيجة واحدة} two {نتيجتان} few {# نتائج} many {# نتيجة} other {# نتيجة}}"
 
+#: src/components/onboarding/welcome-wizard.tsx
+msgid "People you follow write here"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "Original"
 msgstr "الأصلي"
@@ -1658,6 +1688,10 @@ msgstr "إنشاء"
 #: src/routes/_layout.index.tsx
 msgid "See all trending"
 msgstr "عرض كل الرائج"
+
+#: src/components/onboarding/step-friends.tsx
+msgid "All selected"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Fonts"
@@ -1761,6 +1795,10 @@ msgstr "يستحق الاشتراك"
 msgid "Subscription list actions"
 msgstr "إجراءات قائمة الاشتراكات"
 
+#: src/components/reader/friend-publishers.tsx
+msgid "{people, plural, one {# person you follow} other {# people you follow}}"
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "You don't have any lists to reorder yet."
 msgstr "ليست لديك قوائم لإعادة ترتيبها بعد."
@@ -1788,6 +1826,10 @@ msgstr "على الشبكة"
 #: src/components/reader/collection-builder.tsx
 msgid "Matching articles"
 msgstr "المقالات المطابقة"
+
+#: src/routes/_layout.friends.tsx
+msgid "Writers"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A quiet place to read"
@@ -1838,6 +1880,10 @@ msgstr "اختر الفاتح أو الداكن أو المطابقة لإعدا
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Finish"
 msgstr "إنهاء"
+
+#: src/routes/_layout.friends.tsx
+msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
@@ -2342,6 +2388,10 @@ msgstr "لا أشخاص في هذه القائمة — أضف بعضهم من ن
 msgid "Description"
 msgstr "الوصف"
 
+#: src/routes/_layout.discover.tsx
+msgid "{totalPeople, plural, one {# person you follow writes here} other {# people you follow write here}}"
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
 msgstr "حدث خطأ ما"
@@ -2377,6 +2427,10 @@ msgstr "إغلاق المجلة"
 #: src/components/reader/collection-builder.tsx
 msgid "Introduce the collection… (markdown supported)"
 msgstr "قدّم للمجموعة… (يدعم markdown)"
+
+#: src/components/reader/friend-publishers.tsx
+msgid "Bluesky didn't answer in time, so this list may be incomplete. Reload to try again."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Cited in"
@@ -2595,6 +2649,7 @@ msgstr "سجّل الدخول عبر Bluesky للاشتراك. نطلب الإذ
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/reader/about-view.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.recommended.tsx
@@ -2765,6 +2820,10 @@ msgstr "‏Standard Reader يلتقيك حيث تقرأ"
 msgid "Preview"
 msgstr "معاينة"
 
+#: src/routes/_layout.friends.tsx
+msgid "No one you follow publishes here yet"
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Standard Reader knows about every publication on the network. Find a few worth your mornings."
 msgstr "يعرف Standard Reader كل منشورة على الشبكة. اعثر على ما يستحق صباحاتك."
@@ -2781,6 +2840,10 @@ msgstr "الخصوصية"
 #: src/components/reader/privacy-view.tsx
 msgid "Last updated June 11, 2026"
 msgstr "آخر تحديث 11 يونيو 2026"
+
+#: src/routes/_layout.friends.tsx
+msgid "People you follow"
+msgstr ""
 
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Standard Reader needs write access to your site.standard publications and documents, plus your collection records, to author Collections. You'll be asked to approve this on your PDS login."
@@ -2897,6 +2960,10 @@ msgstr "ما إذا كان النقر على مقال يفتحه داخل Standa
 msgid "Example record"
 msgstr "مثال على سجل"
 
+#: src/components/onboarding/step-friends.tsx
+msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "No articles yet — use “Add an article” to get started."
 msgstr "لا توجد مقالات بعد — استخدم «إضافة مقال» للبدء."
@@ -2933,6 +3000,10 @@ msgstr "الاحتفاظ بسجل القراءة"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Other markdown shapes (avoid).</0> <1>site.standard.content.markdown</1> and a scattering of third-party <2>#markdown</2> shapes — e.g. <3>site.standard.document#markdown</3> — carry a raw markdown string under a format-specific key. Don't add another one — publish Markpub instead."
 msgstr "<0>صيغ markdown أخرى (تجنّبها).</0> يحمل <1>site.standard.content.markdown</1> ومجموعة متفرقة من صيغ <2>#markdown</2> الخارجية — مثل <3>site.standard.document#markdown</3> — نص markdown خامًا تحت مفتاح خاص بكل صيغة. لا تُضِف صيغة أخرى — انشر بصيغة Markpub بدلًا من ذلك."
+
+#: src/routes/_layout.discover.tsx
+msgid "Find your friends"
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "Save list"
@@ -3202,6 +3273,10 @@ msgstr "صوت القراءة الجهرية"
 msgid "Tag"
 msgstr "وسم"
 
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Wander the directory"
 msgstr "تجوّل في الدليل"
@@ -3308,6 +3383,10 @@ msgstr "تحريري"
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Click Run example to fetch a live response with your session."
 msgstr "انقر على «تشغيل المثال» لجلب استجابة حية باستخدام جلستك."
+
+#: src/components/reader/friend-publishers.tsx
+msgid "{publicationCount, plural, one {# publication} other {# publications}}"
+msgstr ""
 
 #. placeholder {0}: selected.size
 #: src/components/onboarding/welcome-wizard.tsx
@@ -3469,6 +3548,10 @@ msgstr "اختارت هذه المنشورة عدم الظهور في الاست
 #: src/routes/_layout.feedback.index.tsx
 msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, zero {لا أصوات} one {صوت واحد} two {صوتان} few {# أصوات} many {# صوتًا} other {# صوت}} — سجّل الدخول للتصويت"
+
+#: src/components/onboarding/step-friends.tsx
+msgid "Select all"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
@@ -3778,6 +3861,10 @@ msgstr "مدعوم بـ <0>Standard Reader</0>"
 #: src/components/reader/about-view.tsx
 msgid "Save from anywhere you browse"
 msgstr "احفظ من أي مكان تتصفحه"
+
+#: src/components/reader/friend-publishers.tsx
+msgid "Loading"
+msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Not on Standard Reader yet"

--- a/src/locales/ar/messages.po
+++ b/src/locales/ar/messages.po
@@ -967,6 +967,10 @@ msgstr "يمكنك تعطيل تراكب الصفحة وزر الحفظ في ت�
 msgid "List members"
 msgstr "أعضاء القائمة"
 
+#: src/components/onboarding/step-friends.tsx
+msgid "{remaining, plural, one {# more publication from people you follow — find it under Discover once you're set up.} other {# more publications from people you follow — find them under Discover once you're set up.}}"
+msgstr ""
+
 #. placeholder {0}: pub.name
 #: src/components/reader/article-below-fold.tsx
 msgid "More from <0>{0}</0>"
@@ -1690,8 +1694,8 @@ msgid "See all trending"
 msgstr "عرض كل الرائج"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "All selected"
-msgstr ""
+#~ msgid "All selected"
+#~ msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Fonts"
@@ -1828,8 +1832,8 @@ msgid "Matching articles"
 msgstr "المقالات المطابقة"
 
 #: src/routes/_layout.friends.tsx
-msgid "Writers"
-msgstr ""
+#~ msgid "Writers"
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A quiet place to read"
@@ -2291,6 +2295,10 @@ msgstr "تابع القراءة"
 #: src/routes/_layout.latest.tsx
 msgid "All"
 msgstr "الكل"
+
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky."
+msgstr ""
 
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
@@ -2961,8 +2969,8 @@ msgid "Example record"
 msgstr "مثال على سجل"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
-msgstr ""
+#~ msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
+#~ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "No articles yet — use “Add an article” to get started."
@@ -3274,8 +3282,8 @@ msgid "Tag"
 msgstr "وسم"
 
 #: src/routes/_layout.friends.tsx
-msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
-msgstr ""
+#~ msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Wander the directory"
@@ -3550,8 +3558,8 @@ msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, zero {لا أصوات} one {صوت واحد} two {صوتان} few {# أصوات} many {# صوتًا} other {# صوت}} — سجّل الدخول للتصويت"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "Select all"
-msgstr ""
+#~ msgid "Select all"
+#~ msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
@@ -3708,6 +3716,7 @@ msgid "We do not post to your account except when you take an explicit action th
 msgstr "لا ننشر من حسابك إلا عند قيامك بإجراء صريح يستلزم ذلك (مثل متابعة منشورة، أو الإعجاب بمقال أو حفظه، أو الاشتراك عبر مسار الاشتراك المخصص). ولا نبيع معلوماتك الشخصية."
 
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
@@ -3863,8 +3872,8 @@ msgid "Save from anywhere you browse"
 msgstr "احفظ من أي مكان تتصفحه"
 
 #: src/components/reader/friend-publishers.tsx
-msgid "Loading"
-msgstr ""
+#~ msgid "Loading"
+#~ msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Not on Standard Reader yet"

--- a/src/locales/ar/messages.po
+++ b/src/locales/ar/messages.po
@@ -261,6 +261,10 @@ msgstr "لم تُفهرس أي منشورات من هذه المنشورة بع�
 msgid "Subscribing…"
 msgstr "جارٍ الاشتراك…"
 
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "List"
 msgstr "قائمة"
@@ -946,6 +950,7 @@ msgstr "لا نشغّل خط تحليلات منفصلًا داخل الإضاف
 msgid "Remove list"
 msgstr "إزالة القائمة"
 
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Loading articles"
@@ -1780,6 +1785,10 @@ msgstr "إيقاف مؤقت"
 msgid "Back"
 msgstr "رجوع"
 
+#: src/routes/_layout.friends.tsx
+msgid "None of these publications have posted anything yet. Subscribe from the Publications tab and their writing will land on your Home feed."
+msgstr ""
+
 #: src/components/reader/link-share-menu.tsx
 #: src/components/reader/share-menu.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -1886,8 +1895,8 @@ msgid "Finish"
 msgstr "إنهاء"
 
 #: src/routes/_layout.friends.tsx
-msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
-msgstr ""
+#~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
@@ -2297,8 +2306,8 @@ msgid "All"
 msgstr "الكل"
 
 #: src/routes/_layout.friends.tsx
-msgid "Publications written by the people you follow on Bluesky."
-msgstr ""
+#~ msgid "Publications written by the people you follow on Bluesky."
+#~ msgstr ""
 
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
@@ -2678,6 +2687,10 @@ msgstr "لم يبدأ {name} القراءة أو النشر هنا. يمكنك �
 msgid "Accent on background"
 msgstr "لون مميز على الخلفية"
 
+#: src/routes/_layout.friends.tsx
+msgid "Either no one you follow on Bluesky publishes here yet, or you're already subscribed to everyone who does. As more of them start publishing, they'll show up here."
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection"
 msgstr "مجموعة"
@@ -2829,8 +2842,8 @@ msgid "Preview"
 msgstr "معاينة"
 
 #: src/routes/_layout.friends.tsx
-msgid "No one you follow publishes here yet"
-msgstr ""
+#~ msgid "No one you follow publishes here yet"
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Standard Reader knows about every publication on the network. Find a few worth your mornings."
@@ -2996,6 +3009,10 @@ msgstr "خط العنوان"
 msgid "You may be asked to grant permission the first time."
 msgstr "قد يُطلب منك منح إذن في المرة الأولى."
 
+#: src/routes/_layout.friends.tsx
+msgid "Friends views"
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/routes/login.tsx
 msgid "Log in"
@@ -3111,6 +3128,10 @@ msgstr "your.handle.com"
 msgid "Open collections in magazine"
 msgstr "فتح المجموعات في المجلة"
 
+#: src/routes/_layout.friends.tsx
+msgid "Nothing new from the people you follow"
+msgstr ""
+
 #: src/components/reader/reader-queue-rows.tsx
 msgid "Article unavailable"
 msgstr "المقالة غير متاحة"
@@ -3160,6 +3181,7 @@ msgid "Your Home feed is empty for now — head to Discover whenever you're read
 msgstr "تغذية الرئيسية فارغة حاليًا — انتقل إلى الاستكشاف متى شئت، وسيبدأ كل ما تشترك فيه بالتجمّع هنا."
 
 #: src/components/reader/collection-builder.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -967,6 +967,10 @@ msgstr "Sie können das Seiten-Overlay und den Speichern-Button in Bluesky-Embed
 msgid "List members"
 msgstr "Mitglieder der Liste"
 
+#: src/components/onboarding/step-friends.tsx
+msgid "{remaining, plural, one {# more publication from people you follow — find it under Discover once you're set up.} other {# more publications from people you follow — find them under Discover once you're set up.}}"
+msgstr ""
+
 #. placeholder {0}: pub.name
 #: src/components/reader/article-below-fold.tsx
 msgid "More from <0>{0}</0>"
@@ -1690,8 +1694,8 @@ msgid "See all trending"
 msgstr "Alle Trends ansehen"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "All selected"
-msgstr ""
+#~ msgid "All selected"
+#~ msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Fonts"
@@ -1828,8 +1832,8 @@ msgid "Matching articles"
 msgstr "Passende Artikel"
 
 #: src/routes/_layout.friends.tsx
-msgid "Writers"
-msgstr ""
+#~ msgid "Writers"
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A quiet place to read"
@@ -2291,6 +2295,10 @@ msgstr "Weiterlesen"
 #: src/routes/_layout.latest.tsx
 msgid "All"
 msgstr "Alle"
+
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky."
+msgstr ""
 
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
@@ -2961,8 +2969,8 @@ msgid "Example record"
 msgstr "Beispiel-Record"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
-msgstr ""
+#~ msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
+#~ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "No articles yet — use “Add an article” to get started."
@@ -3274,8 +3282,8 @@ msgid "Tag"
 msgstr "Tag"
 
 #: src/routes/_layout.friends.tsx
-msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
-msgstr ""
+#~ msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Wander the directory"
@@ -3550,8 +3558,8 @@ msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {# Upvote} other {# Upvotes}} — zum Abstimmen anmelden"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "Select all"
-msgstr ""
+#~ msgid "Select all"
+#~ msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
@@ -3708,6 +3716,7 @@ msgid "We do not post to your account except when you take an explicit action th
 msgstr "Wir posten nichts über Ihr Konto, außer Sie lösen es ausdrücklich aus (etwa einer Publikation folgen, einen Artikel liken oder speichern oder über den Abo-Ablauf abonnieren). Wir verkaufen Ihre personenbezogenen Daten nicht."
 
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
@@ -3863,8 +3872,8 @@ msgid "Save from anywhere you browse"
 msgstr "Speichern, wo immer Sie surfen"
 
 #: src/components/reader/friend-publishers.tsx
-msgid "Loading"
-msgstr ""
+#~ msgid "Loading"
+#~ msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Not on Standard Reader yet"

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -90,6 +90,7 @@ msgstr "Artikel hinzufügen"
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/article-below-fold.tsx
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.friends.tsx
 msgid "Discover"
 msgstr "Entdecken"
 
@@ -593,6 +594,10 @@ msgstr "Listen neu ordnen"
 msgid "Publication lists"
 msgstr "Publikationslisten"
 
+#: src/components/onboarding/welcome-wizard.tsx
+msgid "These accounts you follow on Bluesky publish on standard.site. Subscribing puts their writing on your Home feed."
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Optional: add context, steps to reproduce, or what you'd like to see"
 msgstr "Optional: Kontext, Schritte zum Nachstellen oder Wünsche ergänzen"
@@ -662,6 +667,10 @@ msgstr "{userCount, plural, one {Nutzer} other {Nutzer}}"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>Reading activity.</0> When reading history is enabled, articles you open are recorded as public AT Protocol records in <1>your</1> repository — not as private app-only data. You can turn this off in Settings; existing records remain in your repo until you delete them from the Personal data section."
 msgstr "<0>Leseaktivität.</0> Wenn der Leseverlauf aktiviert ist, werden geöffnete Artikel als öffentliche AT-Protocol-Records in <1>Ihrem</1> Repository festgehalten – nicht als private, app-interne Daten. Sie können das in den Einstellungen deaktivieren; vorhandene Records bleiben in Ihrem Repo, bis Sie sie im Bereich „Persönliche Daten“ löschen."
+
+#: src/routes/_layout.friends.tsx
+msgid "Browse the directory"
+msgstr ""
 
 #: src/components/reader/article-view.tsx
 msgid "Did you enjoy this article?"
@@ -1300,6 +1309,10 @@ msgstr "Auf PDSLS ansehen"
 msgid "Subscribe to a few publications to unlock recommendations."
 msgstr "Abonnieren Sie ein paar Publikationen, um Empfehlungen freizuschalten."
 
+#: src/routes/_layout.discover.tsx
+msgid "See publications from the people you follow"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "{shown}+ matches"
 msgstr "{shown}+ Treffer"
@@ -1353,6 +1366,11 @@ msgstr "Abmelden"
 msgid "The top articles from publications you subscribe to."
 msgstr ""
 
+#. placeholder {0}: data?.publicationCount ?? 0
+#: src/routes/_layout.discover.tsx
+msgid "{0, plural, one {# publication from your Bluesky follows} other {# publications from your Bluesky follows}}"
+msgstr ""
+
 #: src/routes/review.thanks.tsx
 msgid "Return to the app"
 msgstr "Zurück zur App"
@@ -1400,6 +1418,10 @@ msgstr "Wir konnten diesen Autor nicht finden."
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "A few preferences"
 msgstr "Ein paar Einstellungen"
+
+#: src/routes/_layout.friends.tsx
+msgid "We couldn't reach Bluesky to look up who you follow. Reload in a moment, or browse the directory in the meantime."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "All articles you have marked as read."
@@ -1453,6 +1475,10 @@ msgstr "Verzeichnis öffnen"
 #: src/routes/_layout.feedback.index.tsx
 msgid "Answered"
 msgstr "Beantwortet"
+
+#: src/routes/_layout.friends.tsx
+msgid "Couldn't check right now"
+msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "Reorder {itemTitle}"
@@ -1638,6 +1664,10 @@ msgstr "Zuletzt aktualisiert am 13. Juni 2026"
 msgid "{shown, plural, one {# match} other {# matches}}"
 msgstr "{shown, plural, one {# Treffer} other {# Treffer}}"
 
+#: src/components/onboarding/welcome-wizard.tsx
+msgid "People you follow write here"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "Original"
 msgstr "Original"
@@ -1658,6 +1688,10 @@ msgstr "Erstellen"
 #: src/routes/_layout.index.tsx
 msgid "See all trending"
 msgstr "Alle Trends ansehen"
+
+#: src/components/onboarding/step-friends.tsx
+msgid "All selected"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Fonts"
@@ -1761,6 +1795,10 @@ msgstr "Einen Blick wert"
 msgid "Subscription list actions"
 msgstr "Aktionen für Abo-Liste"
 
+#: src/components/reader/friend-publishers.tsx
+msgid "{people, plural, one {# person you follow} other {# people you follow}}"
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "You don't have any lists to reorder yet."
 msgstr "Sie haben noch keine Listen zum Umsortieren."
@@ -1788,6 +1826,10 @@ msgstr "Im Netzwerk"
 #: src/components/reader/collection-builder.tsx
 msgid "Matching articles"
 msgstr "Passende Artikel"
+
+#: src/routes/_layout.friends.tsx
+msgid "Writers"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A quiet place to read"
@@ -1838,6 +1880,10 @@ msgstr "Wählen Sie hell, dunkel oder die Systemeinstellung."
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Finish"
 msgstr "Fertig"
+
+#: src/routes/_layout.friends.tsx
+msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
@@ -2342,6 +2388,10 @@ msgstr "Keine Personen in dieser Liste — fügen Sie welche über den Bearbeite
 msgid "Description"
 msgstr "Beschreibung"
 
+#: src/routes/_layout.discover.tsx
+msgid "{totalPeople, plural, one {# person you follow writes here} other {# people you follow write here}}"
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
 msgstr "Etwas ist schiefgelaufen"
@@ -2377,6 +2427,10 @@ msgstr "Magazin schließen"
 #: src/components/reader/collection-builder.tsx
 msgid "Introduce the collection… (markdown supported)"
 msgstr "Sammlung vorstellen … (Markdown möglich)"
+
+#: src/components/reader/friend-publishers.tsx
+msgid "Bluesky didn't answer in time, so this list may be incomplete. Reload to try again."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Cited in"
@@ -2595,6 +2649,7 @@ msgstr "Melden Sie sich mit Bluesky an, um zu abonnieren. Wir bitten nur um die 
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/reader/about-view.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.recommended.tsx
@@ -2765,6 +2820,10 @@ msgstr "Standard Reader ist da, wo Sie lesen"
 msgid "Preview"
 msgstr "Vorschau"
 
+#: src/routes/_layout.friends.tsx
+msgid "No one you follow publishes here yet"
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Standard Reader knows about every publication on the network. Find a few worth your mornings."
 msgstr "Standard Reader kennt jede Publikation im Netzwerk. Finden Sie ein paar, die Ihre Morgen wert sind."
@@ -2781,6 +2840,10 @@ msgstr "Datenschutz"
 #: src/components/reader/privacy-view.tsx
 msgid "Last updated June 11, 2026"
 msgstr "Zuletzt aktualisiert am 11. Juni 2026"
+
+#: src/routes/_layout.friends.tsx
+msgid "People you follow"
+msgstr ""
 
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Standard Reader needs write access to your site.standard publications and documents, plus your collection records, to author Collections. You'll be asked to approve this on your PDS login."
@@ -2897,6 +2960,10 @@ msgstr "Ob ein Tippen auf einen Artikel ihn direkt in Standard Reader öffnet od
 msgid "Example record"
 msgstr "Beispiel-Record"
 
+#: src/components/onboarding/step-friends.tsx
+msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "No articles yet — use “Add an article” to get started."
 msgstr "Noch keine Artikel – über „Artikel hinzufügen“ geht es los."
@@ -2933,6 +3000,10 @@ msgstr "Leseverlauf behalten"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Other markdown shapes (avoid).</0> <1>site.standard.content.markdown</1> and a scattering of third-party <2>#markdown</2> shapes — e.g. <3>site.standard.document#markdown</3> — carry a raw markdown string under a format-specific key. Don't add another one — publish Markpub instead."
 msgstr "<0>Andere Markdown-Formen (vermeiden).</0> <1>site.standard.content.markdown</1> und diverse <2>#markdown</2>-Formen von Drittanbietern – z. B. <3>site.standard.document#markdown</3> – enthalten einen rohen Markdown-String unter einem formatspezifischen Schlüssel. Fügen Sie keine weitere hinzu – veröffentlichen Sie stattdessen Markpub."
+
+#: src/routes/_layout.discover.tsx
+msgid "Find your friends"
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "Save list"
@@ -3202,6 +3273,10 @@ msgstr "Stimme zum Vorlesen"
 msgid "Tag"
 msgstr "Tag"
 
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Wander the directory"
 msgstr "Durchs Verzeichnis stöbern"
@@ -3308,6 +3383,10 @@ msgstr "Redaktionell"
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Click Run example to fetch a live response with your session."
 msgstr "Klicken Sie auf „Beispiel ausführen“, um mit Ihrer Sitzung eine Live-Antwort abzurufen."
+
+#: src/components/reader/friend-publishers.tsx
+msgid "{publicationCount, plural, one {# publication} other {# publications}}"
+msgstr ""
 
 #. placeholder {0}: selected.size
 #: src/components/onboarding/welcome-wizard.tsx
@@ -3469,6 +3548,10 @@ msgstr "Diese Publikation hat sich gegen die Entdeckung entschieden und ist dahe
 #: src/routes/_layout.feedback.index.tsx
 msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {# Upvote} other {# Upvotes}} — zum Abstimmen anmelden"
+
+#: src/components/onboarding/step-friends.tsx
+msgid "Select all"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
@@ -3778,6 +3861,10 @@ msgstr "Ermöglicht durch <0>Standard Reader</0>"
 #: src/components/reader/about-view.tsx
 msgid "Save from anywhere you browse"
 msgstr "Speichern, wo immer Sie surfen"
+
+#: src/components/reader/friend-publishers.tsx
+msgid "Loading"
+msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Not on Standard Reader yet"

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -261,6 +261,10 @@ msgstr "Aus dieser Publikation sind noch keine Beiträge indexiert."
 msgid "Subscribing…"
 msgstr "Wird abonniert …"
 
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "List"
 msgstr "Liste"
@@ -946,6 +950,7 @@ msgstr "Wir betreiben innerhalb der Erweiterung keine separate Analyse-Pipeline.
 msgid "Remove list"
 msgstr "Liste entfernen"
 
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Loading articles"
@@ -1780,6 +1785,10 @@ msgstr "Pause"
 msgid "Back"
 msgstr "Zurück"
 
+#: src/routes/_layout.friends.tsx
+msgid "None of these publications have posted anything yet. Subscribe from the Publications tab and their writing will land on your Home feed."
+msgstr ""
+
 #: src/components/reader/link-share-menu.tsx
 #: src/components/reader/share-menu.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -1886,8 +1895,8 @@ msgid "Finish"
 msgstr "Fertig"
 
 #: src/routes/_layout.friends.tsx
-msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
-msgstr ""
+#~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
@@ -2297,8 +2306,8 @@ msgid "All"
 msgstr "Alle"
 
 #: src/routes/_layout.friends.tsx
-msgid "Publications written by the people you follow on Bluesky."
-msgstr ""
+#~ msgid "Publications written by the people you follow on Bluesky."
+#~ msgstr ""
 
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
@@ -2678,6 +2687,10 @@ msgstr "{name} hat hier noch nicht gelesen oder veröffentlicht. Sie finden das 
 msgid "Accent on background"
 msgstr "Akzent auf Hintergrund"
 
+#: src/routes/_layout.friends.tsx
+msgid "Either no one you follow on Bluesky publishes here yet, or you're already subscribed to everyone who does. As more of them start publishing, they'll show up here."
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection"
 msgstr "Sammlung"
@@ -2829,8 +2842,8 @@ msgid "Preview"
 msgstr "Vorschau"
 
 #: src/routes/_layout.friends.tsx
-msgid "No one you follow publishes here yet"
-msgstr ""
+#~ msgid "No one you follow publishes here yet"
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Standard Reader knows about every publication on the network. Find a few worth your mornings."
@@ -2996,6 +3009,10 @@ msgstr "Titelschrift"
 msgid "You may be asked to grant permission the first time."
 msgstr "Beim ersten Mal werden Sie eventuell um eine Berechtigung gebeten."
 
+#: src/routes/_layout.friends.tsx
+msgid "Friends views"
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/routes/login.tsx
 msgid "Log in"
@@ -3111,6 +3128,10 @@ msgstr "ihr.handle.com"
 msgid "Open collections in magazine"
 msgstr "Sammlungen im Magazin öffnen"
 
+#: src/routes/_layout.friends.tsx
+msgid "Nothing new from the people you follow"
+msgstr ""
+
 #: src/components/reader/reader-queue-rows.tsx
 msgid "Article unavailable"
 msgstr "Artikel nicht verfügbar"
@@ -3160,6 +3181,7 @@ msgid "Your Home feed is empty for now — head to Discover whenever you're read
 msgstr "Ihr Home-Feed ist noch leer – schauen Sie bei „Entdecken“ vorbei, wann immer Sie mögen, und alles, was Sie abonnieren, sammelt sich hier."
 
 #: src/components/reader/collection-builder.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx

--- a/src/locales/en-XA/messages.po
+++ b/src/locales/en-XA/messages.po
@@ -90,6 +90,7 @@ msgstr ""
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/article-below-fold.tsx
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.friends.tsx
 msgid "Discover"
 msgstr ""
 
@@ -593,6 +594,10 @@ msgstr ""
 msgid "Publication lists"
 msgstr ""
 
+#: src/components/onboarding/welcome-wizard.tsx
+msgid "These accounts you follow on Bluesky publish on standard.site. Subscribing puts their writing on your Home feed."
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Optional: add context, steps to reproduce, or what you'd like to see"
 msgstr ""
@@ -661,6 +666,10 @@ msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "<0>Reading activity.</0> When reading history is enabled, articles you open are recorded as public AT Protocol records in <1>your</1> repository — not as private app-only data. You can turn this off in Settings; existing records remain in your repo until you delete them from the Personal data section."
+msgstr ""
+
+#: src/routes/_layout.friends.tsx
+msgid "Browse the directory"
 msgstr ""
 
 #: src/components/reader/article-view.tsx
@@ -1300,6 +1309,10 @@ msgstr ""
 msgid "Subscribe to a few publications to unlock recommendations."
 msgstr ""
 
+#: src/routes/_layout.discover.tsx
+msgid "See publications from the people you follow"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "{shown}+ matches"
 msgstr ""
@@ -1353,6 +1366,11 @@ msgstr ""
 msgid "The top articles from publications you subscribe to."
 msgstr ""
 
+#. placeholder {0}: data?.publicationCount ?? 0
+#: src/routes/_layout.discover.tsx
+msgid "{0, plural, one {# publication from your Bluesky follows} other {# publications from your Bluesky follows}}"
+msgstr ""
+
 #: src/routes/review.thanks.tsx
 msgid "Return to the app"
 msgstr ""
@@ -1399,6 +1417,10 @@ msgstr ""
 
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "A few preferences"
+msgstr ""
+
+#: src/routes/_layout.friends.tsx
+msgid "We couldn't reach Bluesky to look up who you follow. Reload in a moment, or browse the directory in the meantime."
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -1452,6 +1474,10 @@ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Answered"
+msgstr ""
+
+#: src/routes/_layout.friends.tsx
+msgid "Couldn't check right now"
 msgstr ""
 
 #: src/components/reader/collection-builder.tsx
@@ -1638,6 +1664,10 @@ msgstr ""
 msgid "{shown, plural, one {# match} other {# matches}}"
 msgstr ""
 
+#: src/components/onboarding/welcome-wizard.tsx
+msgid "People you follow write here"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "Original"
 msgstr ""
@@ -1657,6 +1687,10 @@ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "See all trending"
+msgstr ""
+
+#: src/components/onboarding/step-friends.tsx
+msgid "All selected"
 msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
@@ -1761,6 +1795,10 @@ msgstr ""
 msgid "Subscription list actions"
 msgstr ""
 
+#: src/components/reader/friend-publishers.tsx
+msgid "{people, plural, one {# person you follow} other {# people you follow}}"
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "You don't have any lists to reorder yet."
 msgstr ""
@@ -1787,6 +1825,10 @@ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "Matching articles"
+msgstr ""
+
+#: src/routes/_layout.friends.tsx
+msgid "Writers"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -1837,6 +1879,10 @@ msgstr ""
 
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Finish"
+msgstr ""
+
+#: src/routes/_layout.friends.tsx
+msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
 msgstr ""
 
 #: src/routes/_layout.index.tsx
@@ -2342,6 +2388,10 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
+#: src/routes/_layout.discover.tsx
+msgid "{totalPeople, plural, one {# person you follow writes here} other {# people you follow write here}}"
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
 msgstr ""
@@ -2376,6 +2426,10 @@ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "Introduce the collection… (markdown supported)"
+msgstr ""
+
+#: src/components/reader/friend-publishers.tsx
+msgid "Bluesky didn't answer in time, so this list may be incomplete. Reload to try again."
 msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
@@ -2595,6 +2649,7 @@ msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/reader/about-view.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.recommended.tsx
@@ -2765,6 +2820,10 @@ msgstr ""
 msgid "Preview"
 msgstr ""
 
+#: src/routes/_layout.friends.tsx
+msgid "No one you follow publishes here yet"
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Standard Reader knows about every publication on the network. Find a few worth your mornings."
 msgstr ""
@@ -2780,6 +2839,10 @@ msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "Last updated June 11, 2026"
+msgstr ""
+
+#: src/routes/_layout.friends.tsx
+msgid "People you follow"
 msgstr ""
 
 #: src/components/reader/collections-upgrade-gate.tsx
@@ -2897,6 +2960,10 @@ msgstr ""
 msgid "Example record"
 msgstr ""
 
+#: src/components/onboarding/step-friends.tsx
+msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "No articles yet — use “Add an article” to get started."
 msgstr ""
@@ -2932,6 +2999,10 @@ msgstr ""
 
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Other markdown shapes (avoid).</0> <1>site.standard.content.markdown</1> and a scattering of third-party <2>#markdown</2> shapes — e.g. <3>site.standard.document#markdown</3> — carry a raw markdown string under a format-specific key. Don't add another one — publish Markpub instead."
+msgstr ""
+
+#: src/routes/_layout.discover.tsx
+msgid "Find your friends"
 msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
@@ -3202,6 +3273,10 @@ msgstr ""
 msgid "Tag"
 msgstr ""
 
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Wander the directory"
 msgstr ""
@@ -3307,6 +3382,10 @@ msgstr ""
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Click Run example to fetch a live response with your session."
+msgstr ""
+
+#: src/components/reader/friend-publishers.tsx
+msgid "{publicationCount, plural, one {# publication} other {# publications}}"
 msgstr ""
 
 #. placeholder {0}: selected.size
@@ -3468,6 +3547,10 @@ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
+msgstr ""
+
+#: src/components/onboarding/step-friends.tsx
+msgid "Select all"
 msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
@@ -3777,6 +3860,10 @@ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Save from anywhere you browse"
+msgstr ""
+
+#: src/components/reader/friend-publishers.tsx
+msgid "Loading"
 msgstr ""
 
 #: src/routes/_layout.u.$did.tsx

--- a/src/locales/en-XA/messages.po
+++ b/src/locales/en-XA/messages.po
@@ -261,6 +261,10 @@ msgstr ""
 msgid "Subscribing…"
 msgstr ""
 
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "List"
 msgstr ""
@@ -946,6 +950,7 @@ msgstr ""
 msgid "Remove list"
 msgstr ""
 
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Loading articles"
@@ -1780,6 +1785,10 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
+#: src/routes/_layout.friends.tsx
+msgid "None of these publications have posted anything yet. Subscribe from the Publications tab and their writing will land on your Home feed."
+msgstr ""
+
 #: src/components/reader/link-share-menu.tsx
 #: src/components/reader/share-menu.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -1886,8 +1895,8 @@ msgid "Finish"
 msgstr ""
 
 #: src/routes/_layout.friends.tsx
-msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
-msgstr ""
+#~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
@@ -2297,8 +2306,8 @@ msgid "All"
 msgstr ""
 
 #: src/routes/_layout.friends.tsx
-msgid "Publications written by the people you follow on Bluesky."
-msgstr ""
+#~ msgid "Publications written by the people you follow on Bluesky."
+#~ msgstr ""
 
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
@@ -2678,6 +2687,10 @@ msgstr ""
 msgid "Accent on background"
 msgstr ""
 
+#: src/routes/_layout.friends.tsx
+msgid "Either no one you follow on Bluesky publishes here yet, or you're already subscribed to everyone who does. As more of them start publishing, they'll show up here."
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection"
 msgstr ""
@@ -2829,8 +2842,8 @@ msgid "Preview"
 msgstr ""
 
 #: src/routes/_layout.friends.tsx
-msgid "No one you follow publishes here yet"
-msgstr ""
+#~ msgid "No one you follow publishes here yet"
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Standard Reader knows about every publication on the network. Find a few worth your mornings."
@@ -2996,6 +3009,10 @@ msgstr ""
 msgid "You may be asked to grant permission the first time."
 msgstr ""
 
+#: src/routes/_layout.friends.tsx
+msgid "Friends views"
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/routes/login.tsx
 msgid "Log in"
@@ -3111,6 +3128,10 @@ msgstr ""
 msgid "Open collections in magazine"
 msgstr ""
 
+#: src/routes/_layout.friends.tsx
+msgid "Nothing new from the people you follow"
+msgstr ""
+
 #: src/components/reader/reader-queue-rows.tsx
 msgid "Article unavailable"
 msgstr ""
@@ -3160,6 +3181,7 @@ msgid "Your Home feed is empty for now — head to Discover whenever you're read
 msgstr ""
 
 #: src/components/reader/collection-builder.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx

--- a/src/locales/en-XA/messages.po
+++ b/src/locales/en-XA/messages.po
@@ -967,6 +967,10 @@ msgstr ""
 msgid "List members"
 msgstr ""
 
+#: src/components/onboarding/step-friends.tsx
+msgid "{remaining, plural, one {# more publication from people you follow — find it under Discover once you're set up.} other {# more publications from people you follow — find them under Discover once you're set up.}}"
+msgstr ""
+
 #. placeholder {0}: pub.name
 #: src/components/reader/article-below-fold.tsx
 msgid "More from <0>{0}</0>"
@@ -1690,8 +1694,8 @@ msgid "See all trending"
 msgstr ""
 
 #: src/components/onboarding/step-friends.tsx
-msgid "All selected"
-msgstr ""
+#~ msgid "All selected"
+#~ msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Fonts"
@@ -1828,8 +1832,8 @@ msgid "Matching articles"
 msgstr ""
 
 #: src/routes/_layout.friends.tsx
-msgid "Writers"
-msgstr ""
+#~ msgid "Writers"
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A quiet place to read"
@@ -2290,6 +2294,10 @@ msgstr ""
 #: src/routes/_layout.feedback.index.tsx
 #: src/routes/_layout.latest.tsx
 msgid "All"
+msgstr ""
+
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky."
 msgstr ""
 
 #: src/components/reader/article-view.tsx
@@ -2961,8 +2969,8 @@ msgid "Example record"
 msgstr ""
 
 #: src/components/onboarding/step-friends.tsx
-msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
-msgstr ""
+#~ msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
+#~ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "No articles yet — use “Add an article” to get started."
@@ -3274,8 +3282,8 @@ msgid "Tag"
 msgstr ""
 
 #: src/routes/_layout.friends.tsx
-msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
-msgstr ""
+#~ msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Wander the directory"
@@ -3550,8 +3558,8 @@ msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr ""
 
 #: src/components/onboarding/step-friends.tsx
-msgid "Select all"
-msgstr ""
+#~ msgid "Select all"
+#~ msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
@@ -3708,6 +3716,7 @@ msgid "We do not post to your account except when you take an explicit action th
 msgstr ""
 
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
@@ -3863,8 +3872,8 @@ msgid "Save from anywhere you browse"
 msgstr ""
 
 #: src/components/reader/friend-publishers.tsx
-msgid "Loading"
-msgstr ""
+#~ msgid "Loading"
+#~ msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Not on Standard Reader yet"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -967,6 +967,10 @@ msgstr "You can disable the page overlay and Bluesky embed save button in the ex
 msgid "List members"
 msgstr "List members"
 
+#: src/components/onboarding/step-friends.tsx
+msgid "{remaining, plural, one {# more publication from people you follow — find it under Discover once you're set up.} other {# more publications from people you follow — find them under Discover once you're set up.}}"
+msgstr "{remaining, plural, one {# more publication from people you follow — find it under Discover once you're set up.} other {# more publications from people you follow — find them under Discover once you're set up.}}"
+
 #. placeholder {0}: pub.name
 #: src/components/reader/article-below-fold.tsx
 msgid "More from <0>{0}</0>"
@@ -1690,8 +1694,8 @@ msgid "See all trending"
 msgstr "See all trending"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "All selected"
-msgstr "All selected"
+#~ msgid "All selected"
+#~ msgstr "All selected"
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Fonts"
@@ -1828,8 +1832,8 @@ msgid "Matching articles"
 msgstr "Matching articles"
 
 #: src/routes/_layout.friends.tsx
-msgid "Writers"
-msgstr "Writers"
+#~ msgid "Writers"
+#~ msgstr "Writers"
 
 #: src/components/reader/about-view.tsx
 msgid "A quiet place to read"
@@ -2291,6 +2295,10 @@ msgstr "Keep reading"
 #: src/routes/_layout.latest.tsx
 msgid "All"
 msgstr "All"
+
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky."
+msgstr "Publications written by the people you follow on Bluesky."
 
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
@@ -2961,8 +2969,8 @@ msgid "Example record"
 msgstr "Example record"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
-msgstr "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
+#~ msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
+#~ msgstr "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
 
 #: src/components/reader/collection-builder.tsx
 msgid "No articles yet — use “Add an article” to get started."
@@ -3274,8 +3282,8 @@ msgid "Tag"
 msgstr "Tag"
 
 #: src/routes/_layout.friends.tsx
-msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
-msgstr "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
+#~ msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
+#~ msgstr "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
 
 #: src/routes/_layout.index.tsx
 msgid "Wander the directory"
@@ -3550,8 +3558,8 @@ msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "Select all"
-msgstr "Select all"
+#~ msgid "Select all"
+#~ msgstr "Select all"
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
@@ -3708,6 +3716,7 @@ msgid "We do not post to your account except when you take an explicit action th
 msgstr "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
@@ -3863,8 +3872,8 @@ msgid "Save from anywhere you browse"
 msgstr "Save from anywhere you browse"
 
 #: src/components/reader/friend-publishers.tsx
-msgid "Loading"
-msgstr "Loading"
+#~ msgid "Loading"
+#~ msgstr "Loading"
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Not on Standard Reader yet"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -90,6 +90,7 @@ msgstr "Add an article"
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/article-below-fold.tsx
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.friends.tsx
 msgid "Discover"
 msgstr "Discover"
 
@@ -593,6 +594,10 @@ msgstr "Reorder lists"
 msgid "Publication lists"
 msgstr "Publication lists"
 
+#: src/components/onboarding/welcome-wizard.tsx
+msgid "These accounts you follow on Bluesky publish on standard.site. Subscribing puts their writing on your Home feed."
+msgstr "These accounts you follow on Bluesky publish on standard.site. Subscribing puts their writing on your Home feed."
+
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Optional: add context, steps to reproduce, or what you'd like to see"
 msgstr "Optional: add context, steps to reproduce, or what you'd like to see"
@@ -662,6 +667,10 @@ msgstr "{userCount, plural, one {user} other {users}}"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>Reading activity.</0> When reading history is enabled, articles you open are recorded as public AT Protocol records in <1>your</1> repository — not as private app-only data. You can turn this off in Settings; existing records remain in your repo until you delete them from the Personal data section."
 msgstr "<0>Reading activity.</0> When reading history is enabled, articles you open are recorded as public AT Protocol records in <1>your</1> repository — not as private app-only data. You can turn this off in Settings; existing records remain in your repo until you delete them from the Personal data section."
+
+#: src/routes/_layout.friends.tsx
+msgid "Browse the directory"
+msgstr "Browse the directory"
 
 #: src/components/reader/article-view.tsx
 msgid "Did you enjoy this article?"
@@ -1300,6 +1309,10 @@ msgstr "View on PDSLS"
 msgid "Subscribe to a few publications to unlock recommendations."
 msgstr "Subscribe to a few publications to unlock recommendations."
 
+#: src/routes/_layout.discover.tsx
+msgid "See publications from the people you follow"
+msgstr "See publications from the people you follow"
+
 #: src/routes/_layout.search.tsx
 msgid "{shown}+ matches"
 msgstr "{shown}+ matches"
@@ -1353,6 +1366,11 @@ msgstr "Log out"
 msgid "The top articles from publications you subscribe to."
 msgstr "The top articles from publications you subscribe to."
 
+#. placeholder {0}: data?.publicationCount ?? 0
+#: src/routes/_layout.discover.tsx
+msgid "{0, plural, one {# publication from your Bluesky follows} other {# publications from your Bluesky follows}}"
+msgstr "{0, plural, one {# publication from your Bluesky follows} other {# publications from your Bluesky follows}}"
+
 #: src/routes/review.thanks.tsx
 msgid "Return to the app"
 msgstr "Return to the app"
@@ -1400,6 +1418,10 @@ msgstr "We couldn't find that author."
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "A few preferences"
 msgstr "A few preferences"
+
+#: src/routes/_layout.friends.tsx
+msgid "We couldn't reach Bluesky to look up who you follow. Reload in a moment, or browse the directory in the meantime."
+msgstr "We couldn't reach Bluesky to look up who you follow. Reload in a moment, or browse the directory in the meantime."
 
 #: src/components/user-settings-view.tsx
 msgid "All articles you have marked as read."
@@ -1453,6 +1475,10 @@ msgstr "Open the directory"
 #: src/routes/_layout.feedback.index.tsx
 msgid "Answered"
 msgstr "Answered"
+
+#: src/routes/_layout.friends.tsx
+msgid "Couldn't check right now"
+msgstr "Couldn't check right now"
 
 #: src/components/reader/collection-builder.tsx
 msgid "Reorder {itemTitle}"
@@ -1638,6 +1664,10 @@ msgstr "Last updated June 13, 2026"
 msgid "{shown, plural, one {# match} other {# matches}}"
 msgstr "{shown, plural, one {# match} other {# matches}}"
 
+#: src/components/onboarding/welcome-wizard.tsx
+msgid "People you follow write here"
+msgstr "People you follow write here"
+
 #: src/magazine/flow.tsx
 msgid "Original"
 msgstr "Original"
@@ -1658,6 +1688,10 @@ msgstr "Create"
 #: src/routes/_layout.index.tsx
 msgid "See all trending"
 msgstr "See all trending"
+
+#: src/components/onboarding/step-friends.tsx
+msgid "All selected"
+msgstr "All selected"
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Fonts"
@@ -1761,6 +1795,10 @@ msgstr "Worth subscribing to"
 msgid "Subscription list actions"
 msgstr "Subscription list actions"
 
+#: src/components/reader/friend-publishers.tsx
+msgid "{people, plural, one {# person you follow} other {# people you follow}}"
+msgstr "{people, plural, one {# person you follow} other {# people you follow}}"
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "You don't have any lists to reorder yet."
 msgstr "You don't have any lists to reorder yet."
@@ -1788,6 +1826,10 @@ msgstr "On the network"
 #: src/components/reader/collection-builder.tsx
 msgid "Matching articles"
 msgstr "Matching articles"
+
+#: src/routes/_layout.friends.tsx
+msgid "Writers"
+msgstr "Writers"
 
 #: src/components/reader/about-view.tsx
 msgid "A quiet place to read"
@@ -1838,6 +1880,10 @@ msgstr "Choose light, dark, or match your system setting."
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Finish"
 msgstr "Finish"
+
+#: src/routes/_layout.friends.tsx
+msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
+msgstr "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
 
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
@@ -2342,6 +2388,10 @@ msgstr "No people in this list — add some from the edit dialog."
 msgid "Description"
 msgstr "Description"
 
+#: src/routes/_layout.discover.tsx
+msgid "{totalPeople, plural, one {# person you follow writes here} other {# people you follow write here}}"
+msgstr "{totalPeople, plural, one {# person you follow writes here} other {# people you follow write here}}"
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
 msgstr "Something went wrong"
@@ -2377,6 +2427,10 @@ msgstr "Close magazine"
 #: src/components/reader/collection-builder.tsx
 msgid "Introduce the collection… (markdown supported)"
 msgstr "Introduce the collection… (markdown supported)"
+
+#: src/components/reader/friend-publishers.tsx
+msgid "Bluesky didn't answer in time, so this list may be incomplete. Reload to try again."
+msgstr "Bluesky didn't answer in time, so this list may be incomplete. Reload to try again."
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Cited in"
@@ -2595,6 +2649,7 @@ msgstr "Sign in with Bluesky to subscribe. We only ask permission to add this fo
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/reader/about-view.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.recommended.tsx
@@ -2765,6 +2820,10 @@ msgstr "Standard Reader meets you where you read"
 msgid "Preview"
 msgstr "Preview"
 
+#: src/routes/_layout.friends.tsx
+msgid "No one you follow publishes here yet"
+msgstr "No one you follow publishes here yet"
+
 #: src/routes/_layout.index.tsx
 msgid "Standard Reader knows about every publication on the network. Find a few worth your mornings."
 msgstr "Standard Reader knows about every publication on the network. Find a few worth your mornings."
@@ -2781,6 +2840,10 @@ msgstr "Privacy"
 #: src/components/reader/privacy-view.tsx
 msgid "Last updated June 11, 2026"
 msgstr "Last updated June 11, 2026"
+
+#: src/routes/_layout.friends.tsx
+msgid "People you follow"
+msgstr "People you follow"
 
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Standard Reader needs write access to your site.standard publications and documents, plus your collection records, to author Collections. You'll be asked to approve this on your PDS login."
@@ -2897,6 +2960,10 @@ msgstr "Whether tapping an article opens it inline in Standard Reader, or takes 
 msgid "Example record"
 msgstr "Example record"
 
+#: src/components/onboarding/step-friends.tsx
+msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
+msgstr "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
+
 #: src/components/reader/collection-builder.tsx
 msgid "No articles yet — use “Add an article” to get started."
 msgstr "No articles yet — use “Add an article” to get started."
@@ -2933,6 +3000,10 @@ msgstr "Keep reading history"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Other markdown shapes (avoid).</0> <1>site.standard.content.markdown</1> and a scattering of third-party <2>#markdown</2> shapes — e.g. <3>site.standard.document#markdown</3> — carry a raw markdown string under a format-specific key. Don't add another one — publish Markpub instead."
 msgstr "<0>Other markdown shapes (avoid).</0> <1>site.standard.content.markdown</1> and a scattering of third-party <2>#markdown</2> shapes — e.g. <3>site.standard.document#markdown</3> — carry a raw markdown string under a format-specific key. Don't add another one — publish Markpub instead."
+
+#: src/routes/_layout.discover.tsx
+msgid "Find your friends"
+msgstr "Find your friends"
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "Save list"
@@ -3202,6 +3273,10 @@ msgstr "Listen aloud voice"
 msgid "Tag"
 msgstr "Tag"
 
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
+msgstr "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
+
 #: src/routes/_layout.index.tsx
 msgid "Wander the directory"
 msgstr "Wander the directory"
@@ -3308,6 +3383,10 @@ msgstr "Editorial"
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Click Run example to fetch a live response with your session."
 msgstr "Click Run example to fetch a live response with your session."
+
+#: src/components/reader/friend-publishers.tsx
+msgid "{publicationCount, plural, one {# publication} other {# publications}}"
+msgstr "{publicationCount, plural, one {# publication} other {# publications}}"
 
 #. placeholder {0}: selected.size
 #: src/components/onboarding/welcome-wizard.tsx
@@ -3469,6 +3548,10 @@ msgstr "This publication opted out of discovery, so it's hidden everywhere excep
 #: src/routes/_layout.feedback.index.tsx
 msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
+
+#: src/components/onboarding/step-friends.tsx
+msgid "Select all"
+msgstr "Select all"
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
@@ -3778,6 +3861,10 @@ msgstr "Powered by <0>Standard Reader</0>"
 #: src/components/reader/about-view.tsx
 msgid "Save from anywhere you browse"
 msgstr "Save from anywhere you browse"
+
+#: src/components/reader/friend-publishers.tsx
+msgid "Loading"
+msgstr "Loading"
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Not on Standard Reader yet"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -261,6 +261,10 @@ msgstr "No posts indexed from this publication yet."
 msgid "Subscribing…"
 msgstr "Subscribing…"
 
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
+msgstr "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "List"
 msgstr "List"
@@ -946,6 +950,7 @@ msgstr "We do not run a separate analytics pipeline inside the extension."
 msgid "Remove list"
 msgstr "Remove list"
 
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Loading articles"
@@ -1780,6 +1785,10 @@ msgstr "Pause"
 msgid "Back"
 msgstr "Back"
 
+#: src/routes/_layout.friends.tsx
+msgid "None of these publications have posted anything yet. Subscribe from the Publications tab and their writing will land on your Home feed."
+msgstr "None of these publications have posted anything yet. Subscribe from the Publications tab and their writing will land on your Home feed."
+
 #: src/components/reader/link-share-menu.tsx
 #: src/components/reader/share-menu.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -1886,8 +1895,8 @@ msgid "Finish"
 msgstr "Finish"
 
 #: src/routes/_layout.friends.tsx
-msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
-msgstr "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
+#~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
+#~ msgstr "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
 
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
@@ -2297,8 +2306,8 @@ msgid "All"
 msgstr "All"
 
 #: src/routes/_layout.friends.tsx
-msgid "Publications written by the people you follow on Bluesky."
-msgstr "Publications written by the people you follow on Bluesky."
+#~ msgid "Publications written by the people you follow on Bluesky."
+#~ msgstr "Publications written by the people you follow on Bluesky."
 
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
@@ -2678,6 +2687,10 @@ msgstr "{name} hasn't started reading or publishing here. You can find them on B
 msgid "Accent on background"
 msgstr "Accent on background"
 
+#: src/routes/_layout.friends.tsx
+msgid "Either no one you follow on Bluesky publishes here yet, or you're already subscribed to everyone who does. As more of them start publishing, they'll show up here."
+msgstr "Either no one you follow on Bluesky publishes here yet, or you're already subscribed to everyone who does. As more of them start publishing, they'll show up here."
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection"
 msgstr "Collection"
@@ -2829,8 +2842,8 @@ msgid "Preview"
 msgstr "Preview"
 
 #: src/routes/_layout.friends.tsx
-msgid "No one you follow publishes here yet"
-msgstr "No one you follow publishes here yet"
+#~ msgid "No one you follow publishes here yet"
+#~ msgstr "No one you follow publishes here yet"
 
 #: src/routes/_layout.index.tsx
 msgid "Standard Reader knows about every publication on the network. Find a few worth your mornings."
@@ -2996,6 +3009,10 @@ msgstr "Title font"
 msgid "You may be asked to grant permission the first time."
 msgstr "You may be asked to grant permission the first time."
 
+#: src/routes/_layout.friends.tsx
+msgid "Friends views"
+msgstr "Friends views"
+
 #: src/components/NavbarAuth.tsx
 #: src/routes/login.tsx
 msgid "Log in"
@@ -3111,6 +3128,10 @@ msgstr "your.handle.com"
 msgid "Open collections in magazine"
 msgstr "Open collections in magazine"
 
+#: src/routes/_layout.friends.tsx
+msgid "Nothing new from the people you follow"
+msgstr "Nothing new from the people you follow"
+
 #: src/components/reader/reader-queue-rows.tsx
 msgid "Article unavailable"
 msgstr "Article unavailable"
@@ -3160,6 +3181,7 @@ msgid "Your Home feed is empty for now — head to Discover whenever you're read
 msgstr "Your Home feed is empty for now — head to Discover whenever you're ready, and everything you subscribe to will start collecting here."
 
 #: src/components/reader/collection-builder.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -261,6 +261,10 @@ msgstr "Todavía no hay posts indexados de esta publicación."
 msgid "Subscribing…"
 msgstr "Suscribiendo…"
 
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "List"
 msgstr "Lista"
@@ -946,6 +950,7 @@ msgstr "No ejecutamos una canalización de analítica aparte dentro de la extens
 msgid "Remove list"
 msgstr "Quitar lista"
 
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Loading articles"
@@ -1780,6 +1785,10 @@ msgstr "Pausar"
 msgid "Back"
 msgstr "Atrás"
 
+#: src/routes/_layout.friends.tsx
+msgid "None of these publications have posted anything yet. Subscribe from the Publications tab and their writing will land on your Home feed."
+msgstr ""
+
 #: src/components/reader/link-share-menu.tsx
 #: src/components/reader/share-menu.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -1886,8 +1895,8 @@ msgid "Finish"
 msgstr "Finalizar"
 
 #: src/routes/_layout.friends.tsx
-msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
-msgstr ""
+#~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
@@ -2297,8 +2306,8 @@ msgid "All"
 msgstr "Todo"
 
 #: src/routes/_layout.friends.tsx
-msgid "Publications written by the people you follow on Bluesky."
-msgstr ""
+#~ msgid "Publications written by the people you follow on Bluesky."
+#~ msgstr ""
 
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
@@ -2678,6 +2687,10 @@ msgstr "{name} no ha empezado a leer ni a publicar aquí. Puede encontrarlo en B
 msgid "Accent on background"
 msgstr "Acento sobre el fondo"
 
+#: src/routes/_layout.friends.tsx
+msgid "Either no one you follow on Bluesky publishes here yet, or you're already subscribed to everyone who does. As more of them start publishing, they'll show up here."
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection"
 msgstr "Colección"
@@ -2829,8 +2842,8 @@ msgid "Preview"
 msgstr "Vista previa"
 
 #: src/routes/_layout.friends.tsx
-msgid "No one you follow publishes here yet"
-msgstr ""
+#~ msgid "No one you follow publishes here yet"
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Standard Reader knows about every publication on the network. Find a few worth your mornings."
@@ -2996,6 +3009,10 @@ msgstr "Fuente del título"
 msgid "You may be asked to grant permission the first time."
 msgstr "Es posible que se le pida otorgar permiso la primera vez."
 
+#: src/routes/_layout.friends.tsx
+msgid "Friends views"
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/routes/login.tsx
 msgid "Log in"
@@ -3111,6 +3128,10 @@ msgstr "su.handle.com"
 msgid "Open collections in magazine"
 msgstr "Abrir las colecciones en la revista"
 
+#: src/routes/_layout.friends.tsx
+msgid "Nothing new from the people you follow"
+msgstr ""
+
 #: src/components/reader/reader-queue-rows.tsx
 msgid "Article unavailable"
 msgstr "Artículo no disponible"
@@ -3160,6 +3181,7 @@ msgid "Your Home feed is empty for now — head to Discover whenever you're read
 msgstr "Su feed de Inicio está vacío por ahora — pase por Descubrir cuando quiera, y todo aquello a lo que se suscriba empezará a acumularse aquí."
 
 #: src/components/reader/collection-builder.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -90,6 +90,7 @@ msgstr "Añadir un artículo"
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/article-below-fold.tsx
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.friends.tsx
 msgid "Discover"
 msgstr "Descubrir"
 
@@ -593,6 +594,10 @@ msgstr "Reordenar listas"
 msgid "Publication lists"
 msgstr "Listas de publicaciones"
 
+#: src/components/onboarding/welcome-wizard.tsx
+msgid "These accounts you follow on Bluesky publish on standard.site. Subscribing puts their writing on your Home feed."
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Optional: add context, steps to reproduce, or what you'd like to see"
 msgstr "Opcional: añada contexto, pasos para reproducirlo o lo que le gustaría ver"
@@ -662,6 +667,10 @@ msgstr "{userCount, plural, one {usuario} other {usuarios}}"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>Reading activity.</0> When reading history is enabled, articles you open are recorded as public AT Protocol records in <1>your</1> repository — not as private app-only data. You can turn this off in Settings; existing records remain in your repo until you delete them from the Personal data section."
 msgstr "<0>Actividad de lectura.</0> Cuando el historial de lectura está activado, los artículos que abre se registran como registros públicos de AT Protocol en <1>su</1> repositorio, no como datos privados de la app. Puede desactivarlo en Configuración; los registros existentes permanecerán en su repo hasta que los borre desde la sección de Datos personales."
+
+#: src/routes/_layout.friends.tsx
+msgid "Browse the directory"
+msgstr ""
 
 #: src/components/reader/article-view.tsx
 msgid "Did you enjoy this article?"
@@ -1300,6 +1309,10 @@ msgstr "Ver en PDSLS"
 msgid "Subscribe to a few publications to unlock recommendations."
 msgstr "Suscríbase a algunas publicaciones para desbloquear las recomendaciones."
 
+#: src/routes/_layout.discover.tsx
+msgid "See publications from the people you follow"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "{shown}+ matches"
 msgstr "{shown}+ coincidencias"
@@ -1353,6 +1366,11 @@ msgstr "Cerrar sesión"
 msgid "The top articles from publications you subscribe to."
 msgstr ""
 
+#. placeholder {0}: data?.publicationCount ?? 0
+#: src/routes/_layout.discover.tsx
+msgid "{0, plural, one {# publication from your Bluesky follows} other {# publications from your Bluesky follows}}"
+msgstr ""
+
 #: src/routes/review.thanks.tsx
 msgid "Return to the app"
 msgstr "Volver a la aplicación"
@@ -1400,6 +1418,10 @@ msgstr "No encontramos a ese autor."
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "A few preferences"
 msgstr "Algunas preferencias"
+
+#: src/routes/_layout.friends.tsx
+msgid "We couldn't reach Bluesky to look up who you follow. Reload in a moment, or browse the directory in the meantime."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "All articles you have marked as read."
@@ -1453,6 +1475,10 @@ msgstr "Abrir el directorio"
 #: src/routes/_layout.feedback.index.tsx
 msgid "Answered"
 msgstr "Respondida"
+
+#: src/routes/_layout.friends.tsx
+msgid "Couldn't check right now"
+msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "Reorder {itemTitle}"
@@ -1638,6 +1664,10 @@ msgstr "Última actualización: 13 de junio de 2026"
 msgid "{shown, plural, one {# match} other {# matches}}"
 msgstr "{shown, plural, one {# coincidencia} other {# coincidencias}}"
 
+#: src/components/onboarding/welcome-wizard.tsx
+msgid "People you follow write here"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "Original"
 msgstr "Original"
@@ -1658,6 +1688,10 @@ msgstr "Crear"
 #: src/routes/_layout.index.tsx
 msgid "See all trending"
 msgstr "Ver todas las tendencias"
+
+#: src/components/onboarding/step-friends.tsx
+msgid "All selected"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Fonts"
@@ -1761,6 +1795,10 @@ msgstr "Vale la pena suscribirse"
 msgid "Subscription list actions"
 msgstr "Acciones de la lista de suscripciones"
 
+#: src/components/reader/friend-publishers.tsx
+msgid "{people, plural, one {# person you follow} other {# people you follow}}"
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "You don't have any lists to reorder yet."
 msgstr "Todavía no tiene listas que reordenar."
@@ -1788,6 +1826,10 @@ msgstr "En la red"
 #: src/components/reader/collection-builder.tsx
 msgid "Matching articles"
 msgstr "Artículos coincidentes"
+
+#: src/routes/_layout.friends.tsx
+msgid "Writers"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A quiet place to read"
@@ -1838,6 +1880,10 @@ msgstr "Elija claro, oscuro o seguir la configuración del sistema."
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Finish"
 msgstr "Finalizar"
+
+#: src/routes/_layout.friends.tsx
+msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
@@ -2342,6 +2388,10 @@ msgstr "No hay personas en esta lista; añada algunas desde el cuadro de edició
 msgid "Description"
 msgstr "Descripción"
 
+#: src/routes/_layout.discover.tsx
+msgid "{totalPeople, plural, one {# person you follow writes here} other {# people you follow write here}}"
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
 msgstr "Algo salió mal"
@@ -2377,6 +2427,10 @@ msgstr "Cerrar revista"
 #: src/components/reader/collection-builder.tsx
 msgid "Introduce the collection… (markdown supported)"
 msgstr "Presente la colección… (admite markdown)"
+
+#: src/components/reader/friend-publishers.tsx
+msgid "Bluesky didn't answer in time, so this list may be incomplete. Reload to try again."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Cited in"
@@ -2595,6 +2649,7 @@ msgstr "Inicie sesión con Bluesky para suscribirse. Solo pedimos permiso para a
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/reader/about-view.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.recommended.tsx
@@ -2765,6 +2820,10 @@ msgstr "Standard Reader lo acompaña donde lee"
 msgid "Preview"
 msgstr "Vista previa"
 
+#: src/routes/_layout.friends.tsx
+msgid "No one you follow publishes here yet"
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Standard Reader knows about every publication on the network. Find a few worth your mornings."
 msgstr "Standard Reader conoce todas las publicaciones de la red. Encuentre algunas que valgan sus mañanas."
@@ -2781,6 +2840,10 @@ msgstr "Privacidad"
 #: src/components/reader/privacy-view.tsx
 msgid "Last updated June 11, 2026"
 msgstr "Última actualización: 11 de junio de 2026"
+
+#: src/routes/_layout.friends.tsx
+msgid "People you follow"
+msgstr ""
 
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Standard Reader needs write access to your site.standard publications and documents, plus your collection records, to author Collections. You'll be asked to approve this on your PDS login."
@@ -2897,6 +2960,10 @@ msgstr "Que al tocar un artículo este se abra dentro de Standard Reader, o que 
 msgid "Example record"
 msgstr "Registro de ejemplo"
 
+#: src/components/onboarding/step-friends.tsx
+msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "No articles yet — use “Add an article” to get started."
 msgstr "Aún no hay artículos — use “Agregar un artículo” para empezar."
@@ -2933,6 +3000,10 @@ msgstr "Conservar el historial de lectura"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Other markdown shapes (avoid).</0> <1>site.standard.content.markdown</1> and a scattering of third-party <2>#markdown</2> shapes — e.g. <3>site.standard.document#markdown</3> — carry a raw markdown string under a format-specific key. Don't add another one — publish Markpub instead."
 msgstr "<0>Otras formas de markdown (evitar).</0> <1>site.standard.content.markdown</1> y algunas formas <2>#markdown</2> de terceros — p. ej. <3>site.standard.document#markdown</3> — contienen una cadena markdown en bruto bajo una clave propia de cada formato. No agregue otra: publique Markpub en su lugar."
+
+#: src/routes/_layout.discover.tsx
+msgid "Find your friends"
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "Save list"
@@ -3202,6 +3273,10 @@ msgstr "Voz de lectura en voz alta"
 msgid "Tag"
 msgstr "Etiqueta"
 
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Wander the directory"
 msgstr "Recorrer el directorio"
@@ -3308,6 +3383,10 @@ msgstr "Editorial"
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Click Run example to fetch a live response with your session."
 msgstr "Haga clic en Ejecutar ejemplo para obtener una respuesta en vivo con su sesión."
+
+#: src/components/reader/friend-publishers.tsx
+msgid "{publicationCount, plural, one {# publication} other {# publications}}"
+msgstr ""
 
 #. placeholder {0}: selected.size
 #: src/components/onboarding/welcome-wizard.tsx
@@ -3469,6 +3548,10 @@ msgstr "Esta publicación optó por no aparecer en el directorio, así que está
 #: src/routes/_layout.feedback.index.tsx
 msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {# voto} other {# votos}}: inicie sesión para votar"
+
+#: src/components/onboarding/step-friends.tsx
+msgid "Select all"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
@@ -3778,6 +3861,10 @@ msgstr "Con la tecnología de <0>Standard Reader</0>"
 #: src/components/reader/about-view.tsx
 msgid "Save from anywhere you browse"
 msgstr "Guarde desde donde navegue"
+
+#: src/components/reader/friend-publishers.tsx
+msgid "Loading"
+msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Not on Standard Reader yet"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -967,6 +967,10 @@ msgstr "Puede desactivar la superposición de página y el botón de guardado en
 msgid "List members"
 msgstr "Miembros de la lista"
 
+#: src/components/onboarding/step-friends.tsx
+msgid "{remaining, plural, one {# more publication from people you follow — find it under Discover once you're set up.} other {# more publications from people you follow — find them under Discover once you're set up.}}"
+msgstr ""
+
 #. placeholder {0}: pub.name
 #: src/components/reader/article-below-fold.tsx
 msgid "More from <0>{0}</0>"
@@ -1690,8 +1694,8 @@ msgid "See all trending"
 msgstr "Ver todas las tendencias"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "All selected"
-msgstr ""
+#~ msgid "All selected"
+#~ msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Fonts"
@@ -1828,8 +1832,8 @@ msgid "Matching articles"
 msgstr "Artículos coincidentes"
 
 #: src/routes/_layout.friends.tsx
-msgid "Writers"
-msgstr ""
+#~ msgid "Writers"
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A quiet place to read"
@@ -2291,6 +2295,10 @@ msgstr "Seguir leyendo"
 #: src/routes/_layout.latest.tsx
 msgid "All"
 msgstr "Todo"
+
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky."
+msgstr ""
 
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
@@ -2961,8 +2969,8 @@ msgid "Example record"
 msgstr "Registro de ejemplo"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
-msgstr ""
+#~ msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
+#~ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "No articles yet — use “Add an article” to get started."
@@ -3274,8 +3282,8 @@ msgid "Tag"
 msgstr "Etiqueta"
 
 #: src/routes/_layout.friends.tsx
-msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
-msgstr ""
+#~ msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Wander the directory"
@@ -3550,8 +3558,8 @@ msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {# voto} other {# votos}}: inicie sesión para votar"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "Select all"
-msgstr ""
+#~ msgid "Select all"
+#~ msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
@@ -3708,6 +3716,7 @@ msgid "We do not post to your account except when you take an explicit action th
 msgstr "No publicamos nada en su cuenta salvo cuando realiza una acción explícita que lo requiere (por ejemplo, seguir una publicación, dar me gusta o guardar un artículo, o suscribirse mediante el flujo de suscripción específico). No vendemos su información personal."
 
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
@@ -3863,8 +3872,8 @@ msgid "Save from anywhere you browse"
 msgstr "Guarde desde donde navegue"
 
 #: src/components/reader/friend-publishers.tsx
-msgid "Loading"
-msgstr ""
+#~ msgid "Loading"
+#~ msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Not on Standard Reader yet"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -90,6 +90,7 @@ msgstr "Ajouter un article"
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/article-below-fold.tsx
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.friends.tsx
 msgid "Discover"
 msgstr "Découvrir"
 
@@ -593,6 +594,10 @@ msgstr "Réorganiser les listes"
 msgid "Publication lists"
 msgstr "Listes de publications"
 
+#: src/components/onboarding/welcome-wizard.tsx
+msgid "These accounts you follow on Bluesky publish on standard.site. Subscribing puts their writing on your Home feed."
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Optional: add context, steps to reproduce, or what you'd like to see"
 msgstr "Facultatif : ajoutez du contexte, les étapes pour reproduire, ou ce que vous aimeriez voir"
@@ -662,6 +667,10 @@ msgstr "{userCount, plural, one {utilisateur} other {utilisateurs}}"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>Reading activity.</0> When reading history is enabled, articles you open are recorded as public AT Protocol records in <1>your</1> repository — not as private app-only data. You can turn this off in Settings; existing records remain in your repo until you delete them from the Personal data section."
 msgstr "<0>Activité de lecture.</0> Lorsque l’historique de lecture est activé, les articles que vous ouvrez sont consignés comme enregistrements AT Protocol publics dans <1>votre</1> repo — et non comme des données privées propres à l’application. Vous pouvez désactiver cela dans les Paramètres ; les enregistrements existants restent dans votre repo jusqu’à ce que vous les supprimiez depuis la section Données personnelles."
+
+#: src/routes/_layout.friends.tsx
+msgid "Browse the directory"
+msgstr ""
 
 #: src/components/reader/article-view.tsx
 msgid "Did you enjoy this article?"
@@ -1300,6 +1309,10 @@ msgstr "Voir sur PDSLS"
 msgid "Subscribe to a few publications to unlock recommendations."
 msgstr "Abonnez-vous à quelques publications pour débloquer les recommandations."
 
+#: src/routes/_layout.discover.tsx
+msgid "See publications from the people you follow"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "{shown}+ matches"
 msgstr "{shown}+ résultats"
@@ -1353,6 +1366,11 @@ msgstr "Se déconnecter"
 msgid "The top articles from publications you subscribe to."
 msgstr ""
 
+#. placeholder {0}: data?.publicationCount ?? 0
+#: src/routes/_layout.discover.tsx
+msgid "{0, plural, one {# publication from your Bluesky follows} other {# publications from your Bluesky follows}}"
+msgstr ""
+
 #: src/routes/review.thanks.tsx
 msgid "Return to the app"
 msgstr "Revenir à l'application"
@@ -1400,6 +1418,10 @@ msgstr "Nous n'avons pas trouvé cet auteur."
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "A few preferences"
 msgstr "Quelques préférences"
+
+#: src/routes/_layout.friends.tsx
+msgid "We couldn't reach Bluesky to look up who you follow. Reload in a moment, or browse the directory in the meantime."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "All articles you have marked as read."
@@ -1453,6 +1475,10 @@ msgstr "Ouvrir l'annuaire"
 #: src/routes/_layout.feedback.index.tsx
 msgid "Answered"
 msgstr "Répondu"
+
+#: src/routes/_layout.friends.tsx
+msgid "Couldn't check right now"
+msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "Reorder {itemTitle}"
@@ -1638,6 +1664,10 @@ msgstr "Dernière mise à jour le 13 juin 2026"
 msgid "{shown, plural, one {# match} other {# matches}}"
 msgstr "{shown, plural, one {# résultat} other {# résultats}}"
 
+#: src/components/onboarding/welcome-wizard.tsx
+msgid "People you follow write here"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "Original"
 msgstr "Original"
@@ -1658,6 +1688,10 @@ msgstr "Créer"
 #: src/routes/_layout.index.tsx
 msgid "See all trending"
 msgstr "Voir toutes les tendances"
+
+#: src/components/onboarding/step-friends.tsx
+msgid "All selected"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Fonts"
@@ -1761,6 +1795,10 @@ msgstr "Publications à suivre"
 msgid "Subscription list actions"
 msgstr "Actions sur la liste d’abonnements"
 
+#: src/components/reader/friend-publishers.tsx
+msgid "{people, plural, one {# person you follow} other {# people you follow}}"
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "You don't have any lists to reorder yet."
 msgstr "Vous n’avez pas encore de listes à réorganiser."
@@ -1788,6 +1826,10 @@ msgstr "Sur le réseau"
 #: src/components/reader/collection-builder.tsx
 msgid "Matching articles"
 msgstr "Articles correspondants"
+
+#: src/routes/_layout.friends.tsx
+msgid "Writers"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A quiet place to read"
@@ -1838,6 +1880,10 @@ msgstr "Choisissez le thème clair, sombre ou celui de votre système."
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Finish"
 msgstr "Terminer"
+
+#: src/routes/_layout.friends.tsx
+msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
@@ -2342,6 +2388,10 @@ msgstr "Aucune personne dans cette liste — ajoutez-en depuis la fenêtre de mo
 msgid "Description"
 msgstr "Description"
 
+#: src/routes/_layout.discover.tsx
+msgid "{totalPeople, plural, one {# person you follow writes here} other {# people you follow write here}}"
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
 msgstr "Une erreur s’est produite"
@@ -2377,6 +2427,10 @@ msgstr "Fermer le magazine"
 #: src/components/reader/collection-builder.tsx
 msgid "Introduce the collection… (markdown supported)"
 msgstr "Présentez la collection… (markdown pris en charge)"
+
+#: src/components/reader/friend-publishers.tsx
+msgid "Bluesky didn't answer in time, so this list may be incomplete. Reload to try again."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Cited in"
@@ -2595,6 +2649,7 @@ msgstr "Connectez-vous avec Bluesky pour vous abonner. Nous demandons uniquement
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/reader/about-view.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.recommended.tsx
@@ -2765,6 +2820,10 @@ msgstr "Standard Reader vous rejoint là où vous lisez"
 msgid "Preview"
 msgstr "Aperçu"
 
+#: src/routes/_layout.friends.tsx
+msgid "No one you follow publishes here yet"
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Standard Reader knows about every publication on the network. Find a few worth your mornings."
 msgstr "Standard Reader connaît toutes les publications du réseau. Trouvez-en quelques-unes qui méritent vos matinées."
@@ -2781,6 +2840,10 @@ msgstr "Confidentialité"
 #: src/components/reader/privacy-view.tsx
 msgid "Last updated June 11, 2026"
 msgstr "Dernière mise à jour le 11 juin 2026"
+
+#: src/routes/_layout.friends.tsx
+msgid "People you follow"
+msgstr ""
 
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Standard Reader needs write access to your site.standard publications and documents, plus your collection records, to author Collections. You'll be asked to approve this on your PDS login."
@@ -2897,6 +2960,10 @@ msgstr "Qu'un appui sur un article l'ouvre directement dans Standard Reader, ou 
 msgid "Example record"
 msgstr "Exemple d'enregistrement"
 
+#: src/components/onboarding/step-friends.tsx
+msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "No articles yet — use “Add an article” to get started."
 msgstr "Aucun article pour l'instant — utilisez « Ajouter un article » pour commencer."
@@ -2933,6 +3000,10 @@ msgstr "Conserver l'historique de lecture"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Other markdown shapes (avoid).</0> <1>site.standard.content.markdown</1> and a scattering of third-party <2>#markdown</2> shapes — e.g. <3>site.standard.document#markdown</3> — carry a raw markdown string under a format-specific key. Don't add another one — publish Markpub instead."
 msgstr "<0>Autres formes de markdown (à éviter).</0> <1>site.standard.content.markdown</1> et quelques formes tierces <2>#markdown</2> — par ex. <3>site.standard.document#markdown</3> — contiennent une chaîne markdown brute sous une clé spécifique au format. N'en ajoutez pas une de plus — publiez plutôt en Markpub."
+
+#: src/routes/_layout.discover.tsx
+msgid "Find your friends"
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "Save list"
@@ -3202,6 +3273,10 @@ msgstr "Voix de la lecture à voix haute"
 msgid "Tag"
 msgstr "Mot-clé"
 
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Wander the directory"
 msgstr "Parcourir l'annuaire"
@@ -3308,6 +3383,10 @@ msgstr "Éditorial"
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Click Run example to fetch a live response with your session."
 msgstr "Cliquez sur Exécuter l'exemple pour obtenir une réponse en direct avec votre session."
+
+#: src/components/reader/friend-publishers.tsx
+msgid "{publicationCount, plural, one {# publication} other {# publications}}"
+msgstr ""
 
 #. placeholder {0}: selected.size
 #: src/components/onboarding/welcome-wizard.tsx
@@ -3469,6 +3548,10 @@ msgstr "Cette publication a choisi de ne pas apparaître dans la découverte : e
 #: src/routes/_layout.feedback.index.tsx
 msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {# vote} other {# votes}} — connectez-vous pour voter"
+
+#: src/components/onboarding/step-friends.tsx
+msgid "Select all"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
@@ -3778,6 +3861,10 @@ msgstr "Propulsé par <0>Standard Reader</0>"
 #: src/components/reader/about-view.tsx
 msgid "Save from anywhere you browse"
 msgstr "Enregistrez depuis n'importe où sur le web"
+
+#: src/components/reader/friend-publishers.tsx
+msgid "Loading"
+msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Not on Standard Reader yet"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -261,6 +261,10 @@ msgstr "Aucun article indexé pour cette publication."
 msgid "Subscribing…"
 msgstr "Abonnement en cours…"
 
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "List"
 msgstr "Liste"
@@ -946,6 +950,7 @@ msgstr "Nous n'exploitons aucun pipeline d'analyse distinct au sein de l'extensi
 msgid "Remove list"
 msgstr "Retirer la liste"
 
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Loading articles"
@@ -1780,6 +1785,10 @@ msgstr "Pause"
 msgid "Back"
 msgstr "Retour"
 
+#: src/routes/_layout.friends.tsx
+msgid "None of these publications have posted anything yet. Subscribe from the Publications tab and their writing will land on your Home feed."
+msgstr ""
+
 #: src/components/reader/link-share-menu.tsx
 #: src/components/reader/share-menu.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -1886,8 +1895,8 @@ msgid "Finish"
 msgstr "Terminer"
 
 #: src/routes/_layout.friends.tsx
-msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
-msgstr ""
+#~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
@@ -2297,8 +2306,8 @@ msgid "All"
 msgstr "Tout"
 
 #: src/routes/_layout.friends.tsx
-msgid "Publications written by the people you follow on Bluesky."
-msgstr ""
+#~ msgid "Publications written by the people you follow on Bluesky."
+#~ msgstr ""
 
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
@@ -2678,6 +2687,10 @@ msgstr "{name} n'a pas encore commencé à lire ou à publier ici. Vous pouvez l
 msgid "Accent on background"
 msgstr "Accent sur le fond"
 
+#: src/routes/_layout.friends.tsx
+msgid "Either no one you follow on Bluesky publishes here yet, or you're already subscribed to everyone who does. As more of them start publishing, they'll show up here."
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection"
 msgstr "Collection"
@@ -2829,8 +2842,8 @@ msgid "Preview"
 msgstr "Aperçu"
 
 #: src/routes/_layout.friends.tsx
-msgid "No one you follow publishes here yet"
-msgstr ""
+#~ msgid "No one you follow publishes here yet"
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Standard Reader knows about every publication on the network. Find a few worth your mornings."
@@ -2996,6 +3009,10 @@ msgstr "Police des titres"
 msgid "You may be asked to grant permission the first time."
 msgstr "Une autorisation pourra vous être demandée la première fois."
 
+#: src/routes/_layout.friends.tsx
+msgid "Friends views"
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/routes/login.tsx
 msgid "Log in"
@@ -3111,6 +3128,10 @@ msgstr "votre.identifiant.com"
 msgid "Open collections in magazine"
 msgstr "Ouvrir les collections en magazine"
 
+#: src/routes/_layout.friends.tsx
+msgid "Nothing new from the people you follow"
+msgstr ""
+
 #: src/components/reader/reader-queue-rows.tsx
 msgid "Article unavailable"
 msgstr "Article indisponible"
@@ -3160,6 +3181,7 @@ msgid "Your Home feed is empty for now — head to Discover whenever you're read
 msgstr "Votre flux Accueil est vide pour le moment — passez par Découvrir quand vous voulez, et tout ce à quoi vous vous abonnez commencera à s'accumuler ici."
 
 #: src/components/reader/collection-builder.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -967,6 +967,10 @@ msgstr "Vous pouvez désactiver la surcouche de page et le bouton d'enregistreme
 msgid "List members"
 msgstr "Membres de la liste"
 
+#: src/components/onboarding/step-friends.tsx
+msgid "{remaining, plural, one {# more publication from people you follow — find it under Discover once you're set up.} other {# more publications from people you follow — find them under Discover once you're set up.}}"
+msgstr ""
+
 #. placeholder {0}: pub.name
 #: src/components/reader/article-below-fold.tsx
 msgid "More from <0>{0}</0>"
@@ -1690,8 +1694,8 @@ msgid "See all trending"
 msgstr "Voir toutes les tendances"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "All selected"
-msgstr ""
+#~ msgid "All selected"
+#~ msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Fonts"
@@ -1828,8 +1832,8 @@ msgid "Matching articles"
 msgstr "Articles correspondants"
 
 #: src/routes/_layout.friends.tsx
-msgid "Writers"
-msgstr ""
+#~ msgid "Writers"
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A quiet place to read"
@@ -2291,6 +2295,10 @@ msgstr "Continuer la lecture"
 #: src/routes/_layout.latest.tsx
 msgid "All"
 msgstr "Tout"
+
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky."
+msgstr ""
 
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
@@ -2961,8 +2969,8 @@ msgid "Example record"
 msgstr "Exemple d'enregistrement"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
-msgstr ""
+#~ msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
+#~ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "No articles yet — use “Add an article” to get started."
@@ -3274,8 +3282,8 @@ msgid "Tag"
 msgstr "Mot-clé"
 
 #: src/routes/_layout.friends.tsx
-msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
-msgstr ""
+#~ msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Wander the directory"
@@ -3550,8 +3558,8 @@ msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {# vote} other {# votes}} — connectez-vous pour voter"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "Select all"
-msgstr ""
+#~ msgid "Select all"
+#~ msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
@@ -3708,6 +3716,7 @@ msgid "We do not post to your account except when you take an explicit action th
 msgstr "Nous ne publions rien depuis votre compte, sauf lorsque vous effectuez une action explicite qui l'exige (par exemple suivre une publication, aimer ou enregistrer un article, ou vous abonner via le parcours d'abonnement dédié). Nous ne vendons pas vos informations personnelles."
 
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
@@ -3863,8 +3872,8 @@ msgid "Save from anywhere you browse"
 msgstr "Enregistrez depuis n'importe où sur le web"
 
 #: src/components/reader/friend-publishers.tsx
-msgid "Loading"
-msgstr ""
+#~ msgid "Loading"
+#~ msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Not on Standard Reader yet"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -261,6 +261,10 @@ msgstr "この発行物からインデックスされた投稿はまだありま
 msgid "Subscribing…"
 msgstr "購読しています…"
 
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "List"
 msgstr "リスト"
@@ -946,6 +950,7 @@ msgstr "拡張機能の内部で独自の分析パイプラインを運用する
 msgid "Remove list"
 msgstr "リストを削除"
 
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Loading articles"
@@ -1780,6 +1785,10 @@ msgstr "一時停止"
 msgid "Back"
 msgstr "戻る"
 
+#: src/routes/_layout.friends.tsx
+msgid "None of these publications have posted anything yet. Subscribe from the Publications tab and their writing will land on your Home feed."
+msgstr ""
+
 #: src/components/reader/link-share-menu.tsx
 #: src/components/reader/share-menu.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -1886,8 +1895,8 @@ msgid "Finish"
 msgstr "完了"
 
 #: src/routes/_layout.friends.tsx
-msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
-msgstr ""
+#~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
@@ -2297,8 +2306,8 @@ msgid "All"
 msgstr "すべて"
 
 #: src/routes/_layout.friends.tsx
-msgid "Publications written by the people you follow on Bluesky."
-msgstr ""
+#~ msgid "Publications written by the people you follow on Bluesky."
+#~ msgstr ""
 
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
@@ -2678,6 +2687,10 @@ msgstr "{name} はまだここで読んだり公開したりしていません�
 msgid "Accent on background"
 msgstr "背景上のアクセント色"
 
+#: src/routes/_layout.friends.tsx
+msgid "Either no one you follow on Bluesky publishes here yet, or you're already subscribed to everyone who does. As more of them start publishing, they'll show up here."
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection"
 msgstr "コレクション"
@@ -2829,8 +2842,8 @@ msgid "Preview"
 msgstr "プレビュー"
 
 #: src/routes/_layout.friends.tsx
-msgid "No one you follow publishes here yet"
-msgstr ""
+#~ msgid "No one you follow publishes here yet"
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Standard Reader knows about every publication on the network. Find a few worth your mornings."
@@ -2996,6 +3009,10 @@ msgstr "見出しフォント"
 msgid "You may be asked to grant permission the first time."
 msgstr "初回は許可を求められる場合があります。"
 
+#: src/routes/_layout.friends.tsx
+msgid "Friends views"
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/routes/login.tsx
 msgid "Log in"
@@ -3111,6 +3128,10 @@ msgstr "your.handle.com"
 msgid "Open collections in magazine"
 msgstr "コレクションを雑誌形式で開く"
 
+#: src/routes/_layout.friends.tsx
+msgid "Nothing new from the people you follow"
+msgstr ""
+
 #: src/components/reader/reader-queue-rows.tsx
 msgid "Article unavailable"
 msgstr "記事を表示できません"
@@ -3160,6 +3181,7 @@ msgid "Your Home feed is empty for now — head to Discover whenever you're read
 msgstr "ホームフィードは今のところ空です。準備ができたら発見ページへどうぞ。購読したものがすべてここに集まり始めます。"
 
 #: src/components/reader/collection-builder.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -90,6 +90,7 @@ msgstr "記事を追加"
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/article-below-fold.tsx
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.friends.tsx
 msgid "Discover"
 msgstr "見つける"
 
@@ -593,6 +594,10 @@ msgstr "リストを並べ替え"
 msgid "Publication lists"
 msgstr "発行物リスト"
 
+#: src/components/onboarding/welcome-wizard.tsx
+msgid "These accounts you follow on Bluesky publish on standard.site. Subscribing puts their writing on your Home feed."
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Optional: add context, steps to reproduce, or what you'd like to see"
 msgstr "任意: 背景、再現手順、希望する挙動などを書いてください"
@@ -662,6 +667,10 @@ msgstr "{userCount, plural, one {ユーザー} other {ユーザー}}"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>Reading activity.</0> When reading history is enabled, articles you open are recorded as public AT Protocol records in <1>your</1> repository — not as private app-only data. You can turn this off in Settings; existing records remain in your repo until you delete them from the Personal data section."
 msgstr "<0>閲覧履歴。</0> 閲覧履歴を有効にすると、開いた記事は<1>あなた自身の</1>リポジトリに公開の AT Protocol レコードとして記録されます。アプリ内だけの非公開データではありません。設定からオフにできますが、既存のレコードは「個人データ」セクションから削除するまでリポジトリに残ります。"
+
+#: src/routes/_layout.friends.tsx
+msgid "Browse the directory"
+msgstr ""
 
 #: src/components/reader/article-view.tsx
 msgid "Did you enjoy this article?"
@@ -1300,6 +1309,10 @@ msgstr "PDSLS で表示"
 msgid "Subscribe to a few publications to unlock recommendations."
 msgstr "発行物をいくつか購読すると、おすすめが表示されます。"
 
+#: src/routes/_layout.discover.tsx
+msgid "See publications from the people you follow"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "{shown}+ matches"
 msgstr "{shown}+ 件の一致"
@@ -1353,6 +1366,11 @@ msgstr "ログアウト"
 msgid "The top articles from publications you subscribe to."
 msgstr ""
 
+#. placeholder {0}: data?.publicationCount ?? 0
+#: src/routes/_layout.discover.tsx
+msgid "{0, plural, one {# publication from your Bluesky follows} other {# publications from your Bluesky follows}}"
+msgstr ""
+
 #: src/routes/review.thanks.tsx
 msgid "Return to the app"
 msgstr "アプリに戻る"
@@ -1400,6 +1418,10 @@ msgstr "その著者は見つかりませんでした。"
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "A few preferences"
 msgstr "いくつかの設定"
+
+#: src/routes/_layout.friends.tsx
+msgid "We couldn't reach Bluesky to look up who you follow. Reload in a moment, or browse the directory in the meantime."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "All articles you have marked as read."
@@ -1453,6 +1475,10 @@ msgstr "ディレクトリを開く"
 #: src/routes/_layout.feedback.index.tsx
 msgid "Answered"
 msgstr "回答済み"
+
+#: src/routes/_layout.friends.tsx
+msgid "Couldn't check right now"
+msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "Reorder {itemTitle}"
@@ -1638,6 +1664,10 @@ msgstr "最終更新: 2026年6月13日"
 msgid "{shown, plural, one {# match} other {# matches}}"
 msgstr "{shown, plural, one {# 件の一致} other {# 件の一致}}"
 
+#: src/components/onboarding/welcome-wizard.tsx
+msgid "People you follow write here"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "Original"
 msgstr "オリジナル"
@@ -1658,6 +1688,10 @@ msgstr "作成"
 #: src/routes/_layout.index.tsx
 msgid "See all trending"
 msgstr "急上昇をすべて見る"
+
+#: src/components/onboarding/step-friends.tsx
+msgid "All selected"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Fonts"
@@ -1761,6 +1795,10 @@ msgstr "購読する価値のある発行物"
 msgid "Subscription list actions"
 msgstr "購読リストの操作"
 
+#: src/components/reader/friend-publishers.tsx
+msgid "{people, plural, one {# person you follow} other {# people you follow}}"
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "You don't have any lists to reorder yet."
 msgstr "並べ替えできるリストはまだありません。"
@@ -1788,6 +1826,10 @@ msgstr "ネットワーク上"
 #: src/components/reader/collection-builder.tsx
 msgid "Matching articles"
 msgstr "一致する記事"
+
+#: src/routes/_layout.friends.tsx
+msgid "Writers"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A quiet place to read"
@@ -1838,6 +1880,10 @@ msgstr "ライト、ダーク、またはシステム設定に合わせるかを
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Finish"
 msgstr "完了"
+
+#: src/routes/_layout.friends.tsx
+msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
@@ -2342,6 +2388,10 @@ msgstr "このリストにユーザーがいません。編集ダイアログか
 msgid "Description"
 msgstr "説明"
 
+#: src/routes/_layout.discover.tsx
+msgid "{totalPeople, plural, one {# person you follow writes here} other {# people you follow write here}}"
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
 msgstr "問題が発生しました"
@@ -2377,6 +2427,10 @@ msgstr "雑誌を閉じる"
 #: src/components/reader/collection-builder.tsx
 msgid "Introduce the collection… (markdown supported)"
 msgstr "コレクションの紹介文…（markdown 対応）"
+
+#: src/components/reader/friend-publishers.tsx
+msgid "Bluesky didn't answer in time, so this list may be incomplete. Reload to try again."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Cited in"
@@ -2595,6 +2649,7 @@ msgstr "購読するには Bluesky でサインインしてください。アカ
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/reader/about-view.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.recommended.tsx
@@ -2765,6 +2820,10 @@ msgstr "Standard Reader は、読む場所に寄り添います"
 msgid "Preview"
 msgstr "プレビュー"
 
+#: src/routes/_layout.friends.tsx
+msgid "No one you follow publishes here yet"
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Standard Reader knows about every publication on the network. Find a few worth your mornings."
 msgstr "Standard Reader はネットワーク上のすべての発行物を把握しています。朝の時間にふさわしいものを見つけましょう。"
@@ -2781,6 +2840,10 @@ msgstr "プライバシー"
 #: src/components/reader/privacy-view.tsx
 msgid "Last updated June 11, 2026"
 msgstr "最終更新: 2026年6月11日"
+
+#: src/routes/_layout.friends.tsx
+msgid "People you follow"
+msgstr ""
 
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Standard Reader needs write access to your site.standard publications and documents, plus your collection records, to author Collections. You'll be asked to approve this on your PDS login."
@@ -2897,6 +2960,10 @@ msgstr "記事をタップしたときに Standard Reader 内でそのまま開�
 msgid "Example record"
 msgstr "レコードの例"
 
+#: src/components/onboarding/step-friends.tsx
+msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "No articles yet — use “Add an article” to get started."
 msgstr "記事はまだありません。「記事を追加」から始めましょう。"
@@ -2933,6 +3000,10 @@ msgstr "閲覧履歴を保持"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Other markdown shapes (avoid).</0> <1>site.standard.content.markdown</1> and a scattering of third-party <2>#markdown</2> shapes — e.g. <3>site.standard.document#markdown</3> — carry a raw markdown string under a format-specific key. Don't add another one — publish Markpub instead."
 msgstr "<0>その他の markdown 形式（非推奨）。</0><1>site.standard.content.markdown</1> や、点在するサードパーティの <2>#markdown</2> 形式（例: <3>site.standard.document#markdown</3>）は、形式ごとのキーの下に生の markdown 文字列を持ちます。新たに追加せず、Markpub で公開してください。"
+
+#: src/routes/_layout.discover.tsx
+msgid "Find your friends"
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "Save list"
@@ -3202,6 +3273,10 @@ msgstr "読み上げの音声"
 msgid "Tag"
 msgstr "タグ"
 
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Wander the directory"
 msgstr "ディレクトリを見て回る"
@@ -3308,6 +3383,10 @@ msgstr "編集部"
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Click Run example to fetch a live response with your session."
 msgstr "「例を実行」をクリックすると、セッションを使って実際のレスポンスを取得します。"
+
+#: src/components/reader/friend-publishers.tsx
+msgid "{publicationCount, plural, one {# publication} other {# publications}}"
+msgstr ""
 
 #. placeholder {0}: selected.size
 #: src/components/onboarding/welcome-wizard.tsx
@@ -3469,6 +3548,10 @@ msgstr "この発行物はディスカバリーへの掲載を停止している
 #: src/routes/_layout.feedback.index.tsx
 msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {# 件の高評価} other {# 件の高評価}} — 高評価するにはサインイン"
+
+#: src/components/onboarding/step-friends.tsx
+msgid "Select all"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
@@ -3778,6 +3861,10 @@ msgstr "Powered by <0>Standard Reader</0>"
 #: src/components/reader/about-view.tsx
 msgid "Save from anywhere you browse"
 msgstr "どこで見ていても保存できる"
+
+#: src/components/reader/friend-publishers.tsx
+msgid "Loading"
+msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Not on Standard Reader yet"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -967,6 +967,10 @@ msgstr "ページのオーバーレイと Bluesky 埋め込みの保存ボタン
 msgid "List members"
 msgstr "リストのメンバー"
 
+#: src/components/onboarding/step-friends.tsx
+msgid "{remaining, plural, one {# more publication from people you follow — find it under Discover once you're set up.} other {# more publications from people you follow — find them under Discover once you're set up.}}"
+msgstr ""
+
 #. placeholder {0}: pub.name
 #: src/components/reader/article-below-fold.tsx
 msgid "More from <0>{0}</0>"
@@ -1690,8 +1694,8 @@ msgid "See all trending"
 msgstr "急上昇をすべて見る"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "All selected"
-msgstr ""
+#~ msgid "All selected"
+#~ msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Fonts"
@@ -1828,8 +1832,8 @@ msgid "Matching articles"
 msgstr "一致する記事"
 
 #: src/routes/_layout.friends.tsx
-msgid "Writers"
-msgstr ""
+#~ msgid "Writers"
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A quiet place to read"
@@ -2291,6 +2295,10 @@ msgstr "読み続ける"
 #: src/routes/_layout.latest.tsx
 msgid "All"
 msgstr "すべて"
+
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky."
+msgstr ""
 
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
@@ -2961,8 +2969,8 @@ msgid "Example record"
 msgstr "レコードの例"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
-msgstr ""
+#~ msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
+#~ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "No articles yet — use “Add an article” to get started."
@@ -3274,8 +3282,8 @@ msgid "Tag"
 msgstr "タグ"
 
 #: src/routes/_layout.friends.tsx
-msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
-msgstr ""
+#~ msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Wander the directory"
@@ -3550,8 +3558,8 @@ msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {# 件の高評価} other {# 件の高評価}} — 高評価するにはサインイン"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "Select all"
-msgstr ""
+#~ msgid "Select all"
+#~ msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
@@ -3708,6 +3716,7 @@ msgid "We do not post to your account except when you take an explicit action th
 msgstr "明示的な操作（発行物のフォロー、記事への高評価や保存、専用の購読フローでの購読など）が必要な場合を除き、あなたのアカウントで投稿することはありません。個人情報を販売することもありません。"
 
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
@@ -3863,8 +3872,8 @@ msgid "Save from anywhere you browse"
 msgstr "どこで見ていても保存できる"
 
 #: src/components/reader/friend-publishers.tsx
-msgid "Loading"
-msgstr ""
+#~ msgid "Loading"
+#~ msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Not on Standard Reader yet"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -967,6 +967,10 @@ msgstr "확장 프로그램 옵션 페이지에서 페이지 오버레이와 Blu
 msgid "List members"
 msgstr "목록 멤버"
 
+#: src/components/onboarding/step-friends.tsx
+msgid "{remaining, plural, one {# more publication from people you follow — find it under Discover once you're set up.} other {# more publications from people you follow — find them under Discover once you're set up.}}"
+msgstr ""
+
 #. placeholder {0}: pub.name
 #: src/components/reader/article-below-fold.tsx
 msgid "More from <0>{0}</0>"
@@ -1690,8 +1694,8 @@ msgid "See all trending"
 msgstr "인기 글 전체 보기"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "All selected"
-msgstr ""
+#~ msgid "All selected"
+#~ msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Fonts"
@@ -1828,8 +1832,8 @@ msgid "Matching articles"
 msgstr "일치하는 글"
 
 #: src/routes/_layout.friends.tsx
-msgid "Writers"
-msgstr ""
+#~ msgid "Writers"
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A quiet place to read"
@@ -2291,6 +2295,10 @@ msgstr "계속 읽기"
 #: src/routes/_layout.latest.tsx
 msgid "All"
 msgstr "전체"
+
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky."
+msgstr ""
 
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
@@ -2961,8 +2969,8 @@ msgid "Example record"
 msgstr "예시 레코드"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
-msgstr ""
+#~ msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
+#~ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "No articles yet — use “Add an article” to get started."
@@ -3274,8 +3282,8 @@ msgid "Tag"
 msgstr "태그"
 
 #: src/routes/_layout.friends.tsx
-msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
-msgstr ""
+#~ msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Wander the directory"
@@ -3550,8 +3558,8 @@ msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {추천 #개} other {추천 #개}} — 추천하려면 로그인하세요"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "Select all"
-msgstr ""
+#~ msgid "Select all"
+#~ msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
@@ -3708,6 +3716,7 @@ msgid "We do not post to your account except when you take an explicit action th
 msgstr "발행물 팔로우, 글 좋아요나 저장, 전용 구독 흐름을 통한 구독처럼 이용자가 직접 수행한 동작에 필요한 경우를 제외하고는 계정에 게시하지 않습니다. 개인정보를 판매하지 않습니다."
 
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
@@ -3863,8 +3872,8 @@ msgid "Save from anywhere you browse"
 msgstr "어디서 둘러보든 저장하기"
 
 #: src/components/reader/friend-publishers.tsx
-msgid "Loading"
-msgstr ""
+#~ msgid "Loading"
+#~ msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Not on Standard Reader yet"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -261,6 +261,10 @@ msgstr "이 발행물에서 색인된 글이 아직 없습니다."
 msgid "Subscribing…"
 msgstr "구독하는 중…"
 
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "List"
 msgstr "목록"
@@ -946,6 +950,7 @@ msgstr "확장 프로그램 내부에서 별도의 분석 파이프라인을 운
 msgid "Remove list"
 msgstr "목록 제거"
 
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Loading articles"
@@ -1780,6 +1785,10 @@ msgstr "일시정지"
 msgid "Back"
 msgstr "뒤로"
 
+#: src/routes/_layout.friends.tsx
+msgid "None of these publications have posted anything yet. Subscribe from the Publications tab and their writing will land on your Home feed."
+msgstr ""
+
 #: src/components/reader/link-share-menu.tsx
 #: src/components/reader/share-menu.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -1886,8 +1895,8 @@ msgid "Finish"
 msgstr "완료"
 
 #: src/routes/_layout.friends.tsx
-msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
-msgstr ""
+#~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
@@ -2297,8 +2306,8 @@ msgid "All"
 msgstr "전체"
 
 #: src/routes/_layout.friends.tsx
-msgid "Publications written by the people you follow on Bluesky."
-msgstr ""
+#~ msgid "Publications written by the people you follow on Bluesky."
+#~ msgstr ""
 
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
@@ -2678,6 +2687,10 @@ msgstr "{name}님은 아직 여기서 읽거나 발행하지 않았습니다. Bl
 msgid "Accent on background"
 msgstr "배경 위 강조색"
 
+#: src/routes/_layout.friends.tsx
+msgid "Either no one you follow on Bluesky publishes here yet, or you're already subscribed to everyone who does. As more of them start publishing, they'll show up here."
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection"
 msgstr "컬렉션"
@@ -2829,8 +2842,8 @@ msgid "Preview"
 msgstr "미리보기"
 
 #: src/routes/_layout.friends.tsx
-msgid "No one you follow publishes here yet"
-msgstr ""
+#~ msgid "No one you follow publishes here yet"
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Standard Reader knows about every publication on the network. Find a few worth your mornings."
@@ -2996,6 +3009,10 @@ msgstr "제목 글꼴"
 msgid "You may be asked to grant permission the first time."
 msgstr "처음에는 권한 부여를 요청받을 수 있습니다."
 
+#: src/routes/_layout.friends.tsx
+msgid "Friends views"
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/routes/login.tsx
 msgid "Log in"
@@ -3111,6 +3128,10 @@ msgstr "your.handle.com"
 msgid "Open collections in magazine"
 msgstr "매거진에서 컬렉션 열기"
 
+#: src/routes/_layout.friends.tsx
+msgid "Nothing new from the people you follow"
+msgstr ""
+
 #: src/components/reader/reader-queue-rows.tsx
 msgid "Article unavailable"
 msgstr "글을 볼 수 없음"
@@ -3160,6 +3181,7 @@ msgid "Your Home feed is empty for now — head to Discover whenever you're read
 msgstr "홈 피드가 아직 비어 있습니다. 준비되면 언제든 탐색으로 가 보세요. 구독한 글이 모두 여기에 모입니다."
 
 #: src/components/reader/collection-builder.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -90,6 +90,7 @@ msgstr "글 추가"
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/article-below-fold.tsx
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.friends.tsx
 msgid "Discover"
 msgstr "둘러보기"
 
@@ -593,6 +594,10 @@ msgstr "목록 순서 변경"
 msgid "Publication lists"
 msgstr "발행물 목록"
 
+#: src/components/onboarding/welcome-wizard.tsx
+msgid "These accounts you follow on Bluesky publish on standard.site. Subscribing puts their writing on your Home feed."
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Optional: add context, steps to reproduce, or what you'd like to see"
 msgstr "선택 사항: 배경 설명, 재현 단계, 원하는 개선점을 적어 주세요"
@@ -662,6 +667,10 @@ msgstr "{userCount, plural, one {사용자} other {사용자}}"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>Reading activity.</0> When reading history is enabled, articles you open are recorded as public AT Protocol records in <1>your</1> repository — not as private app-only data. You can turn this off in Settings; existing records remain in your repo until you delete them from the Personal data section."
 msgstr "<0>읽기 활동.</0> 읽기 기록을 켜면 열어 본 글이 앱 전용 비공개 데이터가 아니라 <1>내</1> 저장소의 공개 AT Protocol 레코드로 기록됩니다. 설정에서 끌 수 있으며, 기존 레코드는 개인 데이터 섹션에서 삭제하기 전까지 저장소에 남아 있습니다."
+
+#: src/routes/_layout.friends.tsx
+msgid "Browse the directory"
+msgstr ""
 
 #: src/components/reader/article-view.tsx
 msgid "Did you enjoy this article?"
@@ -1300,6 +1309,10 @@ msgstr "PDSLS에서 보기"
 msgid "Subscribe to a few publications to unlock recommendations."
 msgstr "추천을 받으려면 발행물을 몇 개 구독하세요."
 
+#: src/routes/_layout.discover.tsx
+msgid "See publications from the people you follow"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "{shown}+ matches"
 msgstr "{shown}개 이상 일치"
@@ -1353,6 +1366,11 @@ msgstr "로그아웃"
 msgid "The top articles from publications you subscribe to."
 msgstr ""
 
+#. placeholder {0}: data?.publicationCount ?? 0
+#: src/routes/_layout.discover.tsx
+msgid "{0, plural, one {# publication from your Bluesky follows} other {# publications from your Bluesky follows}}"
+msgstr ""
+
 #: src/routes/review.thanks.tsx
 msgid "Return to the app"
 msgstr "앱으로 돌아가기"
@@ -1400,6 +1418,10 @@ msgstr "해당 작가를 찾을 수 없습니다."
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "A few preferences"
 msgstr "몇 가지 설정"
+
+#: src/routes/_layout.friends.tsx
+msgid "We couldn't reach Bluesky to look up who you follow. Reload in a moment, or browse the directory in the meantime."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "All articles you have marked as read."
@@ -1453,6 +1475,10 @@ msgstr "디렉터리 열기"
 #: src/routes/_layout.feedback.index.tsx
 msgid "Answered"
 msgstr "답변 완료"
+
+#: src/routes/_layout.friends.tsx
+msgid "Couldn't check right now"
+msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "Reorder {itemTitle}"
@@ -1638,6 +1664,10 @@ msgstr "2026년 6월 13일 최종 업데이트"
 msgid "{shown, plural, one {# match} other {# matches}}"
 msgstr "{shown, plural, one {#개 일치} other {#개 일치}}"
 
+#: src/components/onboarding/welcome-wizard.tsx
+msgid "People you follow write here"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "Original"
 msgstr "원본"
@@ -1658,6 +1688,10 @@ msgstr "만들기"
 #: src/routes/_layout.index.tsx
 msgid "See all trending"
 msgstr "인기 글 전체 보기"
+
+#: src/components/onboarding/step-friends.tsx
+msgid "All selected"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Fonts"
@@ -1761,6 +1795,10 @@ msgstr "구독할 만한 곳"
 msgid "Subscription list actions"
 msgstr "구독 리스트 작업"
 
+#: src/components/reader/friend-publishers.tsx
+msgid "{people, plural, one {# person you follow} other {# people you follow}}"
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "You don't have any lists to reorder yet."
 msgstr "아직 순서를 바꿀 리스트가 없습니다."
@@ -1788,6 +1826,10 @@ msgstr "네트워크에서"
 #: src/components/reader/collection-builder.tsx
 msgid "Matching articles"
 msgstr "일치하는 글"
+
+#: src/routes/_layout.friends.tsx
+msgid "Writers"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A quiet place to read"
@@ -1838,6 +1880,10 @@ msgstr "라이트, 다크 또는 시스템 설정 따르기 중에서 선택하�
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Finish"
 msgstr "완료"
+
+#: src/routes/_layout.friends.tsx
+msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
@@ -2342,6 +2388,10 @@ msgstr "이 목록에 사람이 없습니다 — 편집 대화상자에서 추�
 msgid "Description"
 msgstr "설명"
 
+#: src/routes/_layout.discover.tsx
+msgid "{totalPeople, plural, one {# person you follow writes here} other {# people you follow write here}}"
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
 msgstr "문제가 발생했습니다"
@@ -2377,6 +2427,10 @@ msgstr "매거진 닫기"
 #: src/components/reader/collection-builder.tsx
 msgid "Introduce the collection… (markdown supported)"
 msgstr "컬렉션을 소개해 주세요… (마크다운 지원)"
+
+#: src/components/reader/friend-publishers.tsx
+msgid "Bluesky didn't answer in time, so this list may be incomplete. Reload to try again."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Cited in"
@@ -2595,6 +2649,7 @@ msgstr "구독하려면 Bluesky로 로그인하세요. 계정에 이 팔로우�
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/reader/about-view.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.recommended.tsx
@@ -2765,6 +2820,10 @@ msgstr "Standard Reader는 당신이 읽는 곳으로 찾아갑니다"
 msgid "Preview"
 msgstr "미리보기"
 
+#: src/routes/_layout.friends.tsx
+msgid "No one you follow publishes here yet"
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Standard Reader knows about every publication on the network. Find a few worth your mornings."
 msgstr "Standard Reader는 네트워크의 모든 발행물을 알고 있습니다. 당신의 아침을 채울 만한 몇 곳을 찾아보세요."
@@ -2781,6 +2840,10 @@ msgstr "개인정보"
 #: src/components/reader/privacy-view.tsx
 msgid "Last updated June 11, 2026"
 msgstr "2026년 6월 11일 최종 수정"
+
+#: src/routes/_layout.friends.tsx
+msgid "People you follow"
+msgstr ""
 
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Standard Reader needs write access to your site.standard publications and documents, plus your collection records, to author Collections. You'll be asked to approve this on your PDS login."
@@ -2897,6 +2960,10 @@ msgstr "글을 탭했을 때 Standard Reader 안에서 바로 열릴지, 아니�
 msgid "Example record"
 msgstr "예시 레코드"
 
+#: src/components/onboarding/step-friends.tsx
+msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "No articles yet — use “Add an article” to get started."
 msgstr "아직 글이 없습니다 — “글 추가”로 시작해 보세요."
@@ -2933,6 +3000,10 @@ msgstr "읽기 기록 유지"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Other markdown shapes (avoid).</0> <1>site.standard.content.markdown</1> and a scattering of third-party <2>#markdown</2> shapes — e.g. <3>site.standard.document#markdown</3> — carry a raw markdown string under a format-specific key. Don't add another one — publish Markpub instead."
 msgstr "<0>다른 마크다운 형태(권장하지 않음).</0> <1>site.standard.content.markdown</1>과 여기저기 흩어진 서드파티 <2>#markdown</2> 형태들 — 예: <3>site.standard.document#markdown</3> — 은 형식별 키 아래에 원시 마크다운 문자열을 담습니다. 새로 하나 더 만들지 말고 Markpub으로 발행하세요."
+
+#: src/routes/_layout.discover.tsx
+msgid "Find your friends"
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "Save list"
@@ -3202,6 +3273,10 @@ msgstr "소리내어 읽기 음성"
 msgid "Tag"
 msgstr "태그"
 
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Wander the directory"
 msgstr "디렉터리 거닐기"
@@ -3308,6 +3383,10 @@ msgstr "에디토리얼"
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Click Run example to fetch a live response with your session."
 msgstr "예제 실행을 누르면 내 세션으로 실시간 응답을 가져옵니다."
+
+#: src/components/reader/friend-publishers.tsx
+msgid "{publicationCount, plural, one {# publication} other {# publications}}"
+msgstr ""
 
 #. placeholder {0}: selected.size
 #: src/components/onboarding/welcome-wizard.tsx
@@ -3469,6 +3548,10 @@ msgstr "이 발행물은 둘러보기 노출을 해제했기 때문에 내 프�
 #: src/routes/_layout.feedback.index.tsx
 msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {추천 #개} other {추천 #개}} — 추천하려면 로그인하세요"
+
+#: src/components/onboarding/step-friends.tsx
+msgid "Select all"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
@@ -3778,6 +3861,10 @@ msgstr "<0>Standard Reader</0> 제공"
 #: src/components/reader/about-view.tsx
 msgid "Save from anywhere you browse"
 msgstr "어디서 둘러보든 저장하기"
+
+#: src/components/reader/friend-publishers.tsx
+msgid "Loading"
+msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Not on Standard Reader yet"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -90,6 +90,7 @@ msgstr "Adicionar um artigo"
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/article-below-fold.tsx
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.friends.tsx
 msgid "Discover"
 msgstr "Descobrir"
 
@@ -593,6 +594,10 @@ msgstr "Reordenar listas"
 msgid "Publication lists"
 msgstr "Listas de publicações"
 
+#: src/components/onboarding/welcome-wizard.tsx
+msgid "These accounts you follow on Bluesky publish on standard.site. Subscribing puts their writing on your Home feed."
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Optional: add context, steps to reproduce, or what you'd like to see"
 msgstr "Opcional: acrescente contexto, passos para reproduzir ou o que gostaria de ver"
@@ -662,6 +667,10 @@ msgstr "{userCount, plural, one {utilizador} other {utilizadores}}"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>Reading activity.</0> When reading history is enabled, articles you open are recorded as public AT Protocol records in <1>your</1> repository — not as private app-only data. You can turn this off in Settings; existing records remain in your repo until you delete them from the Personal data section."
 msgstr "<0>Atividade de leitura.</0> Quando o histórico de leitura está ativo, os artigos que abrir são registados como registos públicos AT Protocol no <1>seu</1> repositório — e não como dados privados só da aplicação. Pode desativar isto nas Definições; os registos existentes permanecem no seu repositório até que os elimine na secção Dados pessoais."
+
+#: src/routes/_layout.friends.tsx
+msgid "Browse the directory"
+msgstr ""
 
 #: src/components/reader/article-view.tsx
 msgid "Did you enjoy this article?"
@@ -1300,6 +1309,10 @@ msgstr "Ver no PDSLS"
 msgid "Subscribe to a few publications to unlock recommendations."
 msgstr "Subscreva algumas publicações para desbloquear recomendações."
 
+#: src/routes/_layout.discover.tsx
+msgid "See publications from the people you follow"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "{shown}+ matches"
 msgstr "{shown}+ resultados"
@@ -1353,6 +1366,11 @@ msgstr "Terminar sessão"
 msgid "The top articles from publications you subscribe to."
 msgstr ""
 
+#. placeholder {0}: data?.publicationCount ?? 0
+#: src/routes/_layout.discover.tsx
+msgid "{0, plural, one {# publication from your Bluesky follows} other {# publications from your Bluesky follows}}"
+msgstr ""
+
 #: src/routes/review.thanks.tsx
 msgid "Return to the app"
 msgstr "Voltar à aplicação"
@@ -1400,6 +1418,10 @@ msgstr "Não conseguimos encontrar esse autor."
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "A few preferences"
 msgstr "Algumas preferências"
+
+#: src/routes/_layout.friends.tsx
+msgid "We couldn't reach Bluesky to look up who you follow. Reload in a moment, or browse the directory in the meantime."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "All articles you have marked as read."
@@ -1453,6 +1475,10 @@ msgstr "Abrir o diretório"
 #: src/routes/_layout.feedback.index.tsx
 msgid "Answered"
 msgstr "Respondido"
+
+#: src/routes/_layout.friends.tsx
+msgid "Couldn't check right now"
+msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "Reorder {itemTitle}"
@@ -1638,6 +1664,10 @@ msgstr "Última atualização a 13 de junho de 2026"
 msgid "{shown, plural, one {# match} other {# matches}}"
 msgstr "{shown, plural, one {# correspondência} other {# correspondências}}"
 
+#: src/components/onboarding/welcome-wizard.tsx
+msgid "People you follow write here"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "Original"
 msgstr "Original"
@@ -1658,6 +1688,10 @@ msgstr "Criar"
 #: src/routes/_layout.index.tsx
 msgid "See all trending"
 msgstr "Ver tudo em tendência"
+
+#: src/components/onboarding/step-friends.tsx
+msgid "All selected"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Fonts"
@@ -1761,6 +1795,10 @@ msgstr "Vale a pena subscrever"
 msgid "Subscription list actions"
 msgstr "Ações da lista de subscrições"
 
+#: src/components/reader/friend-publishers.tsx
+msgid "{people, plural, one {# person you follow} other {# people you follow}}"
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "You don't have any lists to reorder yet."
 msgstr "Ainda não tem listas para reordenar."
@@ -1788,6 +1826,10 @@ msgstr "Na rede"
 #: src/components/reader/collection-builder.tsx
 msgid "Matching articles"
 msgstr "Artigos correspondentes"
+
+#: src/routes/_layout.friends.tsx
+msgid "Writers"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A quiet place to read"
@@ -1838,6 +1880,10 @@ msgstr "Escolha claro, escuro ou igual à definição do sistema."
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Finish"
 msgstr "Concluir"
+
+#: src/routes/_layout.friends.tsx
+msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
@@ -2342,6 +2388,10 @@ msgstr "Sem pessoas nesta lista — adicione algumas na janela de edição."
 msgid "Description"
 msgstr "Descrição"
 
+#: src/routes/_layout.discover.tsx
+msgid "{totalPeople, plural, one {# person you follow writes here} other {# people you follow write here}}"
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
 msgstr "Algo correu mal"
@@ -2377,6 +2427,10 @@ msgstr "Fechar revista"
 #: src/components/reader/collection-builder.tsx
 msgid "Introduce the collection… (markdown supported)"
 msgstr "Apresente a coleção… (com suporte para markdown)"
+
+#: src/components/reader/friend-publishers.tsx
+msgid "Bluesky didn't answer in time, so this list may be incomplete. Reload to try again."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Cited in"
@@ -2595,6 +2649,7 @@ msgstr "Inicie sessão com o Bluesky para subscrever. Apenas pedimos permissão 
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/reader/about-view.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.recommended.tsx
@@ -2765,6 +2820,10 @@ msgstr "O Standard Reader vai ter consigo onde quer que leia"
 msgid "Preview"
 msgstr "Pré-visualizar"
 
+#: src/routes/_layout.friends.tsx
+msgid "No one you follow publishes here yet"
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Standard Reader knows about every publication on the network. Find a few worth your mornings."
 msgstr "O Standard Reader conhece todas as publicações da rede. Encontre algumas que valham as suas manhãs."
@@ -2781,6 +2840,10 @@ msgstr "Privacidade"
 #: src/components/reader/privacy-view.tsx
 msgid "Last updated June 11, 2026"
 msgstr "Última atualização a 11 de junho de 2026"
+
+#: src/routes/_layout.friends.tsx
+msgid "People you follow"
+msgstr ""
 
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Standard Reader needs write access to your site.standard publications and documents, plus your collection records, to author Collections. You'll be asked to approve this on your PDS login."
@@ -2897,6 +2960,10 @@ msgstr "Se tocar num artigo o abre dentro do Standard Reader, ou leva o leitor d
 msgid "Example record"
 msgstr "Registo de exemplo"
 
+#: src/components/onboarding/step-friends.tsx
+msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "No articles yet — use “Add an article” to get started."
 msgstr "Ainda não há artigos — use “Adicionar um artigo” para começar."
@@ -2933,6 +3000,10 @@ msgstr "Manter histórico de leitura"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Other markdown shapes (avoid).</0> <1>site.standard.content.markdown</1> and a scattering of third-party <2>#markdown</2> shapes — e.g. <3>site.standard.document#markdown</3> — carry a raw markdown string under a format-specific key. Don't add another one — publish Markpub instead."
 msgstr "<0>Outros formatos de markdown (a evitar).</0> <1>site.standard.content.markdown</1> e uma dispersão de formatos <2>#markdown</2> de terceiros — por exemplo <3>site.standard.document#markdown</3> — guardam uma cadeia de markdown em bruto sob uma chave específica do formato. Não acrescente mais um — publique antes em Markpub."
+
+#: src/routes/_layout.discover.tsx
+msgid "Find your friends"
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "Save list"
@@ -3202,6 +3273,10 @@ msgstr "Voz da leitura em voz alta"
 msgid "Tag"
 msgstr "Tag"
 
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Wander the directory"
 msgstr "Explorar o diretório"
@@ -3308,6 +3383,10 @@ msgstr "Editorial"
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Click Run example to fetch a live response with your session."
 msgstr "Clique em Executar exemplo para obter uma resposta em direto com a sua sessão."
+
+#: src/components/reader/friend-publishers.tsx
+msgid "{publicationCount, plural, one {# publication} other {# publications}}"
+msgstr ""
 
 #. placeholder {0}: selected.size
 #: src/components/onboarding/welcome-wizard.tsx
@@ -3469,6 +3548,10 @@ msgstr "Esta publicação optou por não aparecer na descoberta, pelo que está 
 #: src/routes/_layout.feedback.index.tsx
 msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {# voto positivo} other {# votos positivos}} — inicie sessão para votar"
+
+#: src/components/onboarding/step-friends.tsx
+msgid "Select all"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
@@ -3778,6 +3861,10 @@ msgstr "Com tecnologia <0>Standard Reader</0>"
 #: src/components/reader/about-view.tsx
 msgid "Save from anywhere you browse"
 msgstr "Guarde a partir de onde quer que navegue"
+
+#: src/components/reader/friend-publishers.tsx
+msgid "Loading"
+msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Not on Standard Reader yet"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -967,6 +967,10 @@ msgstr "Pode desativar a sobreposição na página e o botão de guardar nas inc
 msgid "List members"
 msgstr "Membros da lista"
 
+#: src/components/onboarding/step-friends.tsx
+msgid "{remaining, plural, one {# more publication from people you follow — find it under Discover once you're set up.} other {# more publications from people you follow — find them under Discover once you're set up.}}"
+msgstr ""
+
 #. placeholder {0}: pub.name
 #: src/components/reader/article-below-fold.tsx
 msgid "More from <0>{0}</0>"
@@ -1690,8 +1694,8 @@ msgid "See all trending"
 msgstr "Ver tudo em tendência"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "All selected"
-msgstr ""
+#~ msgid "All selected"
+#~ msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Fonts"
@@ -1828,8 +1832,8 @@ msgid "Matching articles"
 msgstr "Artigos correspondentes"
 
 #: src/routes/_layout.friends.tsx
-msgid "Writers"
-msgstr ""
+#~ msgid "Writers"
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A quiet place to read"
@@ -2291,6 +2295,10 @@ msgstr "Continuar a ler"
 #: src/routes/_layout.latest.tsx
 msgid "All"
 msgstr "Tudo"
+
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky."
+msgstr ""
 
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
@@ -2961,8 +2969,8 @@ msgid "Example record"
 msgstr "Registo de exemplo"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
-msgstr ""
+#~ msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
+#~ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "No articles yet — use “Add an article” to get started."
@@ -3274,8 +3282,8 @@ msgid "Tag"
 msgstr "Tag"
 
 #: src/routes/_layout.friends.tsx
-msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
-msgstr ""
+#~ msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Wander the directory"
@@ -3550,8 +3558,8 @@ msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {# voto positivo} other {# votos positivos}} — inicie sessão para votar"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "Select all"
-msgstr ""
+#~ msgid "Select all"
+#~ msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
@@ -3708,6 +3716,7 @@ msgid "We do not post to your account except when you take an explicit action th
 msgstr "Não publicamos na sua conta exceto quando realiza uma ação explícita que o exija (por exemplo seguir uma publicação, gostar ou guardar um artigo, ou subscrever através do fluxo de subscrição dedicado). Não vendemos as suas informações pessoais."
 
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
@@ -3863,8 +3872,8 @@ msgid "Save from anywhere you browse"
 msgstr "Guarde a partir de onde quer que navegue"
 
 #: src/components/reader/friend-publishers.tsx
-msgid "Loading"
-msgstr ""
+#~ msgid "Loading"
+#~ msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Not on Standard Reader yet"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -261,6 +261,10 @@ msgstr "Ainda não há publicações indexadas desta publicação."
 msgid "Subscribing…"
 msgstr "A subscrever…"
 
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "List"
 msgstr "Lista"
@@ -946,6 +950,7 @@ msgstr "Não mantemos um pipeline de análise separado dentro da extensão."
 msgid "Remove list"
 msgstr "Remover lista"
 
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Loading articles"
@@ -1780,6 +1785,10 @@ msgstr "Pausa"
 msgid "Back"
 msgstr "Voltar"
 
+#: src/routes/_layout.friends.tsx
+msgid "None of these publications have posted anything yet. Subscribe from the Publications tab and their writing will land on your Home feed."
+msgstr ""
+
 #: src/components/reader/link-share-menu.tsx
 #: src/components/reader/share-menu.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -1886,8 +1895,8 @@ msgid "Finish"
 msgstr "Concluir"
 
 #: src/routes/_layout.friends.tsx
-msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
-msgstr ""
+#~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
@@ -2297,8 +2306,8 @@ msgid "All"
 msgstr "Tudo"
 
 #: src/routes/_layout.friends.tsx
-msgid "Publications written by the people you follow on Bluesky."
-msgstr ""
+#~ msgid "Publications written by the people you follow on Bluesky."
+#~ msgstr ""
 
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
@@ -2678,6 +2687,10 @@ msgstr "{name} ainda não começou a ler nem a publicar aqui. Pode encontrá-lo 
 msgid "Accent on background"
 msgstr "Destaque sobre o fundo"
 
+#: src/routes/_layout.friends.tsx
+msgid "Either no one you follow on Bluesky publishes here yet, or you're already subscribed to everyone who does. As more of them start publishing, they'll show up here."
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection"
 msgstr "Coleção"
@@ -2829,8 +2842,8 @@ msgid "Preview"
 msgstr "Pré-visualizar"
 
 #: src/routes/_layout.friends.tsx
-msgid "No one you follow publishes here yet"
-msgstr ""
+#~ msgid "No one you follow publishes here yet"
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Standard Reader knows about every publication on the network. Find a few worth your mornings."
@@ -2996,6 +3009,10 @@ msgstr "Tipo de letra dos títulos"
 msgid "You may be asked to grant permission the first time."
 msgstr "Poderá ser-lhe pedida permissão da primeira vez."
 
+#: src/routes/_layout.friends.tsx
+msgid "Friends views"
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/routes/login.tsx
 msgid "Log in"
@@ -3111,6 +3128,10 @@ msgstr "o.seu.identificador.com"
 msgid "Open collections in magazine"
 msgstr "Abrir coleções em revista"
 
+#: src/routes/_layout.friends.tsx
+msgid "Nothing new from the people you follow"
+msgstr ""
+
 #: src/components/reader/reader-queue-rows.tsx
 msgid "Article unavailable"
 msgstr "Artigo indisponível"
@@ -3160,6 +3181,7 @@ msgid "Your Home feed is empty for now — head to Discover whenever you're read
 msgstr "O seu feed Início está vazio por agora — passe por Descobrir quando quiser, e tudo o que subscrever começará a juntar-se aqui."
 
 #: src/components/reader/collection-builder.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -261,6 +261,10 @@ msgstr "此刊物尚无已索引的文章。"
 msgid "Subscribing…"
 msgstr "正在订阅…"
 
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "List"
 msgstr "列表"
@@ -946,6 +950,7 @@ msgstr "我们不在扩展内运行独立的分析管道。"
 msgid "Remove list"
 msgstr "移除列表"
 
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Loading articles"
@@ -1780,6 +1785,10 @@ msgstr "暂停"
 msgid "Back"
 msgstr "返回"
 
+#: src/routes/_layout.friends.tsx
+msgid "None of these publications have posted anything yet. Subscribe from the Publications tab and their writing will land on your Home feed."
+msgstr ""
+
 #: src/components/reader/link-share-menu.tsx
 #: src/components/reader/share-menu.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -1886,8 +1895,8 @@ msgid "Finish"
 msgstr "完成"
 
 #: src/routes/_layout.friends.tsx
-msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
-msgstr ""
+#~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
@@ -2297,8 +2306,8 @@ msgid "All"
 msgstr "全部"
 
 #: src/routes/_layout.friends.tsx
-msgid "Publications written by the people you follow on Bluesky."
-msgstr ""
+#~ msgid "Publications written by the people you follow on Bluesky."
+#~ msgstr ""
 
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
@@ -2678,6 +2687,10 @@ msgstr "{name} 还没有在这里阅读或发布过内容。你可以在 Bluesky
 msgid "Accent on background"
 msgstr "背景上的强调色"
 
+#: src/routes/_layout.friends.tsx
+msgid "Either no one you follow on Bluesky publishes here yet, or you're already subscribed to everyone who does. As more of them start publishing, they'll show up here."
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection"
 msgstr "合集"
@@ -2829,8 +2842,8 @@ msgid "Preview"
 msgstr "预览"
 
 #: src/routes/_layout.friends.tsx
-msgid "No one you follow publishes here yet"
-msgstr ""
+#~ msgid "No one you follow publishes here yet"
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Standard Reader knows about every publication on the network. Find a few worth your mornings."
@@ -2996,6 +3009,10 @@ msgstr "标题字体"
 msgid "You may be asked to grant permission the first time."
 msgstr "首次使用时可能需要你授权。"
 
+#: src/routes/_layout.friends.tsx
+msgid "Friends views"
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/routes/login.tsx
 msgid "Log in"
@@ -3111,6 +3128,10 @@ msgstr "your.handle.com"
 msgid "Open collections in magazine"
 msgstr "在杂志中打开合集"
 
+#: src/routes/_layout.friends.tsx
+msgid "Nothing new from the people you follow"
+msgstr ""
+
 #: src/components/reader/reader-queue-rows.tsx
 msgid "Article unavailable"
 msgstr "文章不可用"
@@ -3160,6 +3181,7 @@ msgid "Your Home feed is empty for now — head to Discover whenever you're read
 msgstr "你的首页信息流暂时是空的——随时可以去「发现」看看，你订阅的一切都会在这里汇集起来。"
 
 #: src/components/reader/collection-builder.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -90,6 +90,7 @@ msgstr "添加文章"
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/article-below-fold.tsx
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.friends.tsx
 msgid "Discover"
 msgstr "发现"
 
@@ -593,6 +594,10 @@ msgstr "重新排序列表"
 msgid "Publication lists"
 msgstr "刊物列表"
 
+#: src/components/onboarding/welcome-wizard.tsx
+msgid "These accounts you follow on Bluesky publish on standard.site. Subscribing puts their writing on your Home feed."
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Optional: add context, steps to reproduce, or what you'd like to see"
 msgstr "可选：补充背景、复现步骤，或你希望看到的效果"
@@ -662,6 +667,10 @@ msgstr "{userCount, plural, one {用户} other {用户}}"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>Reading activity.</0> When reading history is enabled, articles you open are recorded as public AT Protocol records in <1>your</1> repository — not as private app-only data. You can turn this off in Settings; existing records remain in your repo until you delete them from the Personal data section."
 msgstr "<0>阅读活动。</0>启用阅读历史后，你打开的文章会作为公开的 AT Protocol 记录存入<1>你的</1> repo——而非仅限应用的私有数据。你可以在「设置」中关闭；已有记录会保留在你的 repo 中，直到你在「个人数据」部分将其删除。"
+
+#: src/routes/_layout.friends.tsx
+msgid "Browse the directory"
+msgstr ""
 
 #: src/components/reader/article-view.tsx
 msgid "Did you enjoy this article?"
@@ -1300,6 +1309,10 @@ msgstr "在 PDSLS 中查看"
 msgid "Subscribe to a few publications to unlock recommendations."
 msgstr "订阅几个刊物即可解锁推荐。"
 
+#: src/routes/_layout.discover.tsx
+msgid "See publications from the people you follow"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "{shown}+ matches"
 msgstr "{shown}+ 条匹配"
@@ -1353,6 +1366,11 @@ msgstr "退出登录"
 msgid "The top articles from publications you subscribe to."
 msgstr ""
 
+#. placeholder {0}: data?.publicationCount ?? 0
+#: src/routes/_layout.discover.tsx
+msgid "{0, plural, one {# publication from your Bluesky follows} other {# publications from your Bluesky follows}}"
+msgstr ""
+
 #: src/routes/review.thanks.tsx
 msgid "Return to the app"
 msgstr "返回应用"
@@ -1400,6 +1418,10 @@ msgstr "找不到该作者。"
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "A few preferences"
 msgstr "几项偏好设置"
+
+#: src/routes/_layout.friends.tsx
+msgid "We couldn't reach Bluesky to look up who you follow. Reload in a moment, or browse the directory in the meantime."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "All articles you have marked as read."
@@ -1453,6 +1475,10 @@ msgstr "打开目录"
 #: src/routes/_layout.feedback.index.tsx
 msgid "Answered"
 msgstr "已回答"
+
+#: src/routes/_layout.friends.tsx
+msgid "Couldn't check right now"
+msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "Reorder {itemTitle}"
@@ -1638,6 +1664,10 @@ msgstr "最后更新于 2026 年 6 月 13 日"
 msgid "{shown, plural, one {# match} other {# matches}}"
 msgstr "{shown, plural, one {# 个匹配项} other {# 个匹配项}}"
 
+#: src/components/onboarding/welcome-wizard.tsx
+msgid "People you follow write here"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "Original"
 msgstr "原文"
@@ -1658,6 +1688,10 @@ msgstr "创建"
 #: src/routes/_layout.index.tsx
 msgid "See all trending"
 msgstr "查看全部热门"
+
+#: src/components/onboarding/step-friends.tsx
+msgid "All selected"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Fonts"
@@ -1761,6 +1795,10 @@ msgstr "值得订阅"
 msgid "Subscription list actions"
 msgstr "订阅列表操作"
 
+#: src/components/reader/friend-publishers.tsx
+msgid "{people, plural, one {# person you follow} other {# people you follow}}"
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "You don't have any lists to reorder yet."
 msgstr "你还没有可以重新排序的列表。"
@@ -1788,6 +1826,10 @@ msgstr "网络上"
 #: src/components/reader/collection-builder.tsx
 msgid "Matching articles"
 msgstr "匹配的文章"
+
+#: src/routes/_layout.friends.tsx
+msgid "Writers"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A quiet place to read"
@@ -1838,6 +1880,10 @@ msgstr "选择浅色、深色，或跟随系统设置。"
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Finish"
 msgstr "完成"
+
+#: src/routes/_layout.friends.tsx
+msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
@@ -2342,6 +2388,10 @@ msgstr "此列表中没有人——可在编辑对话框中添加。"
 msgid "Description"
 msgstr "描述"
 
+#: src/routes/_layout.discover.tsx
+msgid "{totalPeople, plural, one {# person you follow writes here} other {# people you follow write here}}"
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
 msgstr "出错了"
@@ -2377,6 +2427,10 @@ msgstr "关闭杂志"
 #: src/components/reader/collection-builder.tsx
 msgid "Introduce the collection… (markdown supported)"
 msgstr "介绍一下这个合集……（支持 markdown）"
+
+#: src/components/reader/friend-publishers.tsx
+msgid "Bluesky didn't answer in time, so this list may be incomplete. Reload to try again."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Cited in"
@@ -2595,6 +2649,7 @@ msgstr "使用 Bluesky 登录以订阅。我们仅请求向你的账号添加此
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/reader/about-view.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.recommended.tsx
@@ -2765,6 +2820,10 @@ msgstr "Standard Reader 随你所读之处而至"
 msgid "Preview"
 msgstr "预览"
 
+#: src/routes/_layout.friends.tsx
+msgid "No one you follow publishes here yet"
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Standard Reader knows about every publication on the network. Find a few worth your mornings."
 msgstr "Standard Reader 收录了网络上的每一个刊物。找几个值得你清晨阅读的吧。"
@@ -2781,6 +2840,10 @@ msgstr "隐私"
 #: src/components/reader/privacy-view.tsx
 msgid "Last updated June 11, 2026"
 msgstr "最后更新于 2026 年 6 月 11 日"
+
+#: src/routes/_layout.friends.tsx
+msgid "People you follow"
+msgstr ""
 
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Standard Reader needs write access to your site.standard publications and documents, plus your collection records, to author Collections. You'll be asked to approve this on your PDS login."
@@ -2897,6 +2960,10 @@ msgstr "点击一篇文章后，是在 Standard Reader 内直接打开，还是�
 msgid "Example record"
 msgstr "示例记录"
 
+#: src/components/onboarding/step-friends.tsx
+msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "No articles yet — use “Add an article” to get started."
 msgstr "还没有文章——使用「添加文章」开始吧。"
@@ -2933,6 +3000,10 @@ msgstr "保留阅读历史"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Other markdown shapes (avoid).</0> <1>site.standard.content.markdown</1> and a scattering of third-party <2>#markdown</2> shapes — e.g. <3>site.standard.document#markdown</3> — carry a raw markdown string under a format-specific key. Don't add another one — publish Markpub instead."
 msgstr "<0>其他 markdown 形态（应避免）。</0><1>site.standard.content.markdown</1> 以及零散的第三方 <2>#markdown</2> 形态——例如 <3>site.standard.document#markdown</3>——都在各自特定的键下存放原始 markdown 字符串。不要再新增一种——请改用 Markpub 发布。"
+
+#: src/routes/_layout.discover.tsx
+msgid "Find your friends"
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "Save list"
@@ -3202,6 +3273,10 @@ msgstr "朗读语音"
 msgid "Tag"
 msgstr "标签"
 
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Wander the directory"
 msgstr "随意逛逛目录"
@@ -3308,6 +3383,10 @@ msgstr "编辑部"
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Click Run example to fetch a live response with your session."
 msgstr "点击「运行示例」，用你的会话获取实时响应。"
+
+#: src/components/reader/friend-publishers.tsx
+msgid "{publicationCount, plural, one {# publication} other {# publications}}"
+msgstr ""
 
 #. placeholder {0}: selected.size
 #: src/components/onboarding/welcome-wizard.tsx
@@ -3469,6 +3548,10 @@ msgstr "该刊物已选择不出现在发现页，因此除了你自己的主页
 #: src/routes/_layout.feedback.index.tsx
 msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {# 个赞} other {# 个赞}}——登录后可点赞"
+
+#: src/components/onboarding/step-friends.tsx
+msgid "Select all"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
@@ -3778,6 +3861,10 @@ msgstr "由 <0>Standard Reader</0> 提供支持"
 #: src/components/reader/about-view.tsx
 msgid "Save from anywhere you browse"
 msgstr "在任何浏览的地方随手保存"
+
+#: src/components/reader/friend-publishers.tsx
+msgid "Loading"
+msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Not on Standard Reader yet"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -967,6 +967,10 @@ msgstr "你可以在扩展的选项页面中关闭页面浮层和 Bluesky 嵌入
 msgid "List members"
 msgstr "列表成员"
 
+#: src/components/onboarding/step-friends.tsx
+msgid "{remaining, plural, one {# more publication from people you follow — find it under Discover once you're set up.} other {# more publications from people you follow — find them under Discover once you're set up.}}"
+msgstr ""
+
 #. placeholder {0}: pub.name
 #: src/components/reader/article-below-fold.tsx
 msgid "More from <0>{0}</0>"
@@ -1690,8 +1694,8 @@ msgid "See all trending"
 msgstr "查看全部热门"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "All selected"
-msgstr ""
+#~ msgid "All selected"
+#~ msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Fonts"
@@ -1828,8 +1832,8 @@ msgid "Matching articles"
 msgstr "匹配的文章"
 
 #: src/routes/_layout.friends.tsx
-msgid "Writers"
-msgstr ""
+#~ msgid "Writers"
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A quiet place to read"
@@ -2291,6 +2295,10 @@ msgstr "继续阅读"
 #: src/routes/_layout.latest.tsx
 msgid "All"
 msgstr "全部"
+
+#: src/routes/_layout.friends.tsx
+msgid "Publications written by the people you follow on Bluesky."
+msgstr ""
 
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
@@ -2961,8 +2969,8 @@ msgid "Example record"
 msgstr "示例记录"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
-msgstr ""
+#~ msgid "{remaining, plural, one {# more person you follow writes here — find them under Discover once you're set up.} other {# more people you follow write here — find them under Discover once you're set up.}}"
+#~ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "No articles yet — use “Add an article” to get started."
@@ -3274,8 +3282,8 @@ msgid "Tag"
 msgstr "标签"
 
 #: src/routes/_layout.friends.tsx
-msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
-msgstr ""
+#~ msgid "Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed."
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Wander the directory"
@@ -3550,8 +3558,8 @@ msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {# 个赞} other {# 个赞}}——登录后可点赞"
 
 #: src/components/onboarding/step-friends.tsx
-msgid "Select all"
-msgstr ""
+#~ msgid "Select all"
+#~ msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
@@ -3708,6 +3716,7 @@ msgid "We do not post to your account except when you take an explicit action th
 msgstr "除非你主动执行需要写入的操作（例如关注刊物、点赞或保存文章，或通过专门的订阅流程订阅），我们不会以你的账户发帖。我们不会出售你的个人信息。"
 
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
@@ -3863,8 +3872,8 @@ msgid "Save from anywhere you browse"
 msgstr "在任何浏览的地方随手保存"
 
 #: src/components/reader/friend-publishers.tsx
-msgid "Loading"
-msgstr ""
+#~ msgid "Loading"
+#~ msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Not on Standard Reader yet"

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as LayoutIndexRouteImport } from './routes/_layout.index'
 import { Route as LayoutAboutRouteImport } from './routes/_layout.about'
 import { Route as LayoutCollectionsRouteImport } from './routes/_layout.collections'
 import { Route as LayoutDiscoverRouteImport } from './routes/_layout.discover'
+import { Route as LayoutFriendsRouteImport } from './routes/_layout.friends'
 import { Route as LayoutHistoryRouteImport } from './routes/_layout.history'
 import { Route as LayoutLatestRouteImport } from './routes/_layout.latest'
 import { Route as LayoutLikesRouteImport } from './routes/_layout.likes'
@@ -121,6 +122,11 @@ const LayoutCollectionsRoute = LayoutCollectionsRouteImport.update({
 const LayoutDiscoverRoute = LayoutDiscoverRouteImport.update({
   id: '/discover',
   path: '/discover',
+  getParentRoute: () => LayoutRoute,
+} as any)
+const LayoutFriendsRoute = LayoutFriendsRouteImport.update({
+  id: '/friends',
+  path: '/friends',
   getParentRoute: () => LayoutRoute,
 } as any)
 const LayoutHistoryRoute = LayoutHistoryRouteImport.update({
@@ -473,6 +479,7 @@ export interface FileRoutesByFullPath {
   '/about': typeof LayoutAboutRoute
   '/collections': typeof LayoutCollectionsRouteWithChildren
   '/discover': typeof LayoutDiscoverRoute
+  '/friends': typeof LayoutFriendsRoute
   '/history': typeof LayoutHistoryRoute
   '/latest': typeof LayoutLatestRoute
   '/likes': typeof LayoutLikesRoute
@@ -547,6 +554,7 @@ export interface FileRoutesByTo {
   '/welcome': typeof WelcomeRoute
   '/about': typeof LayoutAboutRoute
   '/discover': typeof LayoutDiscoverRoute
+  '/friends': typeof LayoutFriendsRoute
   '/history': typeof LayoutHistoryRoute
   '/latest': typeof LayoutLatestRoute
   '/likes': typeof LayoutLikesRoute
@@ -624,6 +632,7 @@ export interface FileRoutesById {
   '/_layout/about': typeof LayoutAboutRoute
   '/_layout/collections': typeof LayoutCollectionsRouteWithChildren
   '/_layout/discover': typeof LayoutDiscoverRoute
+  '/_layout/friends': typeof LayoutFriendsRoute
   '/_layout/history': typeof LayoutHistoryRoute
   '/_layout/latest': typeof LayoutLatestRoute
   '/_layout/likes': typeof LayoutLikesRoute
@@ -702,6 +711,7 @@ export interface FileRouteTypes {
     | '/about'
     | '/collections'
     | '/discover'
+    | '/friends'
     | '/history'
     | '/latest'
     | '/likes'
@@ -776,6 +786,7 @@ export interface FileRouteTypes {
     | '/welcome'
     | '/about'
     | '/discover'
+    | '/friends'
     | '/history'
     | '/latest'
     | '/likes'
@@ -852,6 +863,7 @@ export interface FileRouteTypes {
     | '/_layout/about'
     | '/_layout/collections'
     | '/_layout/discover'
+    | '/_layout/friends'
     | '/_layout/history'
     | '/_layout/latest'
     | '/_layout/likes'
@@ -1028,6 +1040,13 @@ declare module '@tanstack/react-router' {
       path: '/discover'
       fullPath: '/discover'
       preLoaderRoute: typeof LayoutDiscoverRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/friends': {
+      id: '/_layout/friends'
+      path: '/friends'
+      fullPath: '/friends'
+      preLoaderRoute: typeof LayoutFriendsRouteImport
       parentRoute: typeof LayoutRoute
     }
     '/_layout/history': {
@@ -1548,6 +1567,7 @@ interface LayoutRouteChildren {
   LayoutAboutRoute: typeof LayoutAboutRoute
   LayoutCollectionsRoute: typeof LayoutCollectionsRouteWithChildren
   LayoutDiscoverRoute: typeof LayoutDiscoverRoute
+  LayoutFriendsRoute: typeof LayoutFriendsRoute
   LayoutHistoryRoute: typeof LayoutHistoryRoute
   LayoutLatestRoute: typeof LayoutLatestRoute
   LayoutLikesRoute: typeof LayoutLikesRoute
@@ -1572,6 +1592,7 @@ const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutAboutRoute: LayoutAboutRoute,
   LayoutCollectionsRoute: LayoutCollectionsRouteWithChildren,
   LayoutDiscoverRoute: LayoutDiscoverRoute,
+  LayoutFriendsRoute: LayoutFriendsRoute,
   LayoutHistoryRoute: LayoutHistoryRoute,
   LayoutLatestRoute: LayoutLatestRoute,
   LayoutLikesRoute: LayoutLikesRoute,

--- a/src/routes/_layout.discover.tsx
+++ b/src/routes/_layout.discover.tsx
@@ -30,6 +30,7 @@ import { user } from "#/integrations/tanstack-query/api-user.functions";
 import { getPublicUrlClient } from "#/lib/public-url";
 import { pageSocialMeta } from "#/lib/site-metadata";
 import { useFormatters } from "#/lib/use-formatters";
+import { useHasMounted } from "#/lib/use-has-mounted";
 
 import {
   PubCardSkeleton,
@@ -451,6 +452,10 @@ const FRIENDS_PROMPT_PAGE = 4;
  */
 function DiscoverFriendsPrompt() {
   const { t } = useLingui();
+  // The friends lookup is prefetched without blocking the loader, so SSR can
+  // finish it mid-render while the client hydrates without it. Rendering
+  // nothing until mount keeps both sides in agreement.
+  const mounted = useHasMounted();
   const { data } = useQuery(
     discoverApi.getFriendPublishersQueryOptions({
       limit: FRIENDS_PROMPT_PAGE,
@@ -458,7 +463,7 @@ function DiscoverFriendsPrompt() {
   );
   const totalPeople = data?.totalPeople ?? 0;
 
-  if (totalPeople === 0) return null;
+  if (!mounted || totalPeople === 0) return null;
 
   const shown = data?.previewAuthors.slice(0, FRIENDS_PROMPT_AVATARS) ?? [];
 

--- a/src/routes/_layout.discover.tsx
+++ b/src/routes/_layout.discover.tsx
@@ -37,7 +37,7 @@ import {
 } from "../components/reader/cards";
 import { DiscoverTopicFilters } from "../components/reader/discover-topic-filters";
 import { sortDiscoverTopics } from "../components/reader/discover-topics";
-import { friendDisplayName, initials } from "../components/reader/format";
+import { initials } from "../components/reader/format";
 import {
   Masthead,
   ReaderContent,
@@ -460,25 +460,22 @@ function DiscoverFriendsPrompt() {
 
   if (totalPeople === 0) return null;
 
-  const shown = data?.people.slice(0, FRIENDS_PROMPT_AVATARS) ?? [];
+  const shown = data?.previewAuthors.slice(0, FRIENDS_PROMPT_AVATARS) ?? [];
 
   return (
     <div {...stylex.props(styles.friendsPrompt)}>
       <div {...stylex.props(styles.friendsPromptMain)}>
         <div {...stylex.props(styles.friendsAvatars)} aria-hidden>
-          {shown.map((person) => {
-            const name = friendDisplayName(person);
-            return (
-              <Avatar
-                key={person.did}
-                src={person.avatarUrl ?? undefined}
-                alt=""
-                size="md"
-                fallback={initials(name)}
-                style={styles.friendsAvatar}
-              />
-            );
-          })}
+          {shown.map((author) => (
+            <Avatar
+              key={author.did}
+              src={author.avatarUrl ?? undefined}
+              alt=""
+              size="md"
+              fallback={initials(author.handle ?? author.did)}
+              style={styles.friendsAvatar}
+            />
+          ))}
         </div>
         <p {...stylex.props(styles.friendsPromptText)}>
           <Plural

--- a/src/routes/_layout.discover.tsx
+++ b/src/routes/_layout.discover.tsx
@@ -30,7 +30,6 @@ import { user } from "#/integrations/tanstack-query/api-user.functions";
 import { getPublicUrlClient } from "#/lib/public-url";
 import { pageSocialMeta } from "#/lib/site-metadata";
 import { useFormatters } from "#/lib/use-formatters";
-import { useHasMounted } from "#/lib/use-has-mounted";
 
 import {
   PubCardSkeleton,
@@ -75,6 +74,17 @@ const RAIL_LIMIT = 10;
 const TRENDING_LIMIT_OPTIONS = [5, 10, 20, 50, 100] as const;
 const DEFAULT_TRENDING_LIMIT = 5;
 const SOCIAL_PROOF_MAX = 60;
+/**
+ * How long the loader will wait for the "people you follow" lookup before
+ * giving up and letting it stream in.
+ *
+ * The wait doubles as the warmth test: the reader's Bluesky graph is cached
+ * server-side for ten minutes, and a warm lookup comes back in ~400ms while a
+ * cold sweep of the whole author set can't. So a warm hit lands inside the
+ * budget and the prompt is in the first paint; a cold one loses the race and
+ * costs the page nothing.
+ */
+const FRIENDS_PROMPT_BUDGET_MS = 700;
 
 const discoverSearchSchema = z.object({
   topic: z.string().optional(),
@@ -131,7 +141,15 @@ export const Route = createFileRoute("/_layout/discover")({
     void context.queryClient.prefetchQuery(extrasOptions);
     void context.queryClient.prefetchQuery(topicsOptions);
     void context.queryClient.prefetchQuery(directoryOptions);
-    void context.queryClient.prefetchQuery(friendsOptions);
+
+    // Block on the friends lookup only if it can be answered from the warm
+    // server-side cache. `prefetchQuery` never rejects, so the race is safe;
+    // whichever side wins, the query is in flight and the prompt renders as
+    // soon as it resolves.
+    await Promise.race([
+      context.queryClient.prefetchQuery(friendsOptions),
+      new Promise((resolve) => setTimeout(resolve, FRIENDS_PROMPT_BUDGET_MS)),
+    ]);
   },
   head: () => ({
     meta: pageSocialMeta("discover", getPublicUrlClient()),
@@ -452,10 +470,6 @@ const FRIENDS_PROMPT_PAGE = 4;
  */
 function DiscoverFriendsPrompt() {
   const { t } = useLingui();
-  // The friends lookup is prefetched without blocking the loader, so SSR can
-  // finish it mid-render while the client hydrates without it. Rendering
-  // nothing until mount keeps both sides in agreement.
-  const mounted = useHasMounted();
   const { data } = useQuery(
     discoverApi.getFriendPublishersQueryOptions({
       limit: FRIENDS_PROMPT_PAGE,
@@ -463,7 +477,7 @@ function DiscoverFriendsPrompt() {
   );
   const totalPeople = data?.totalPeople ?? 0;
 
-  if (!mounted || totalPeople === 0) return null;
+  if (totalPeople === 0) return null;
 
   const shown = data?.previewAuthors.slice(0, FRIENDS_PROMPT_AVATARS) ?? [];
 
@@ -580,6 +594,10 @@ function DiscoverTrendingSection() {
     <div {...stylex.props(styles.section)}>
       <SectionHead
         title={trendingTitle}
+        // The limit chooser is a compact control, not a full-width mobile
+        // action — stacking it under the heading wasted a row and read as a
+        // second, unrelated element. Keep it on the heading line at every width.
+        stackOnMobile={false}
         action={
           <Select
             aria-label={t`Publications shown`}

--- a/src/routes/_layout.discover.tsx
+++ b/src/routes/_layout.discover.tsx
@@ -2,7 +2,7 @@
 
 import type { MessageDescriptor } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
-import { Trans, useLingui } from "@lingui/react/macro";
+import { Plural, Trans, useLingui } from "@lingui/react/macro";
 import * as stylex from "@stylexjs/stylex";
 import {
   keepPreviousData,
@@ -10,7 +10,7 @@ import {
   useSuspenseQuery,
 } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { LayoutGrid, List } from "lucide-react";
+import { LayoutGrid, List, Users } from "lucide-react";
 import {
   Suspense,
   useCallback,
@@ -21,6 +21,7 @@ import {
 } from "react";
 import { z } from "zod";
 
+import { ButtonLink } from "#/components/router-links";
 import {
   DISCOVER_TOPICS_LIMIT,
   discoverApi,
@@ -36,6 +37,7 @@ import {
 } from "../components/reader/cards";
 import { DiscoverTopicFilters } from "../components/reader/discover-topic-filters";
 import { sortDiscoverTopics } from "../components/reader/discover-topics";
+import { friendDisplayName, initials } from "../components/reader/format";
 import {
   Masthead,
   ReaderContent,
@@ -43,6 +45,7 @@ import {
   SectionHead,
 } from "../components/reader/primitives";
 import { PubGridList } from "../components/reader/pub-grid-list";
+import { Avatar } from "../design-system/avatar";
 import { Flex } from "../design-system/flex";
 import { Grid } from "../design-system/grid";
 import { SearchField } from "../design-system/search-field";
@@ -53,6 +56,7 @@ import {
 import { Select, SelectItem } from "../design-system/select";
 import { Skeleton } from "../design-system/skeleton";
 import { uiColor } from "../design-system/theme/color.stylex";
+import { radius } from "../design-system/theme/radius.stylex";
 import { spacing } from "../design-system/theme/spacing.stylex";
 import {
   fontFamily,
@@ -99,6 +103,10 @@ export const Route = createFileRoute("/_layout/discover")({
       limit: DIRECTORY_PAGE_SIZE,
       offset: 0,
     });
+    // Shared with /friends, so following the prompt is a cache hit.
+    const friendsOptions = discoverApi.getFriendPublishersQueryOptions({
+      limit: FRIENDS_PROMPT_PAGE,
+    });
 
     if (preload) {
       void context.queryClient.prefetchQuery(knownCountOptions);
@@ -106,6 +114,7 @@ export const Route = createFileRoute("/_layout/discover")({
       void context.queryClient.prefetchQuery(trendingOptions);
       void context.queryClient.prefetchQuery(topicsOptions);
       void context.queryClient.prefetchQuery(directoryOptions);
+      void context.queryClient.prefetchQuery(friendsOptions);
       return;
     }
 
@@ -121,6 +130,7 @@ export const Route = createFileRoute("/_layout/discover")({
     void context.queryClient.prefetchQuery(extrasOptions);
     void context.queryClient.prefetchQuery(topicsOptions);
     void context.queryClient.prefetchQuery(directoryOptions);
+    void context.queryClient.prefetchQuery(friendsOptions);
   },
   head: () => ({
     meta: pageSocialMeta("discover", getPublicUrlClient()),
@@ -131,6 +141,65 @@ export const Route = createFileRoute("/_layout/discover")({
 const styles = stylex.create({
   section: {
     marginBottom: spacing["12"],
+  },
+  friendsPrompt: {
+    alignItems: {
+      default: "stretch",
+      "@media (min-width: 40rem)": "center",
+    },
+    borderColor: uiColor.border1,
+    borderRadius: radius.md,
+    borderStyle: "solid",
+    borderWidth: 1,
+    columnGap: spacing["5"],
+    display: "flex",
+    flexDirection: {
+      default: "column",
+      "@media (min-width: 40rem)": "row",
+    },
+    justifyContent: "space-between",
+    marginBottom: spacing["12"],
+    paddingBottom: spacing["4"],
+    paddingInlineEnd: spacing["5"],
+    paddingInlineStart: spacing["5"],
+    paddingTop: spacing["4"],
+    rowGap: spacing["4"],
+  },
+  friendsPromptMain: {
+    alignItems: "center",
+    columnGap: spacing["4"],
+    display: "flex",
+    minWidth: 0,
+  },
+  friendsAvatars: {
+    display: "flex",
+    flexShrink: 0,
+    // Overlap the stack, first avatar on top, so it reads as a group of people
+    // rather than a row of unrelated icons.
+    paddingInlineStart: spacing["2"],
+  },
+  friendsAvatar: {
+    borderColor: uiColor.bg,
+    borderStyle: "solid",
+    borderWidth: 2,
+    marginInlineStart: `calc(-1 * ${spacing["2"]})`,
+  },
+  friendsPromptText: {
+    color: uiColor.text2,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.base,
+    lineHeight: lineHeight.sm,
+    marginBottom: spacing["0"],
+    marginTop: spacing["0"],
+    minWidth: 0,
+  },
+  friendsPromptDek: {
+    color: uiColor.text1,
+    display: "block",
+    fontSize: fontSize.sm,
+  },
+  friendsPromptAction: {
+    flexShrink: 0,
   },
   railWrap: {
     marginTop: spacing["5"],
@@ -366,6 +435,76 @@ function DiscoverDirectorySectionSkeleton({ view }: { view: "grid" | "list" }) {
       />
       <DiscoverDirectoryToolbarSkeleton />
       <DiscoverDirectorySkeleton view={view} />
+    </div>
+  );
+}
+
+const FRIENDS_PROMPT_AVATARS = 4;
+/** The prompt only needs the headline counts and a few faces. */
+const FRIENDS_PROMPT_PAGE = 4;
+
+/**
+ * Entry point to `/friends` — publications written by the people the reader
+ * follows on Bluesky. Renders only once we know there's someone to show, so it
+ * never occupies the top of Discover with an empty promise (the surrounding
+ * rails behave the same way).
+ */
+function DiscoverFriendsPrompt() {
+  const { t } = useLingui();
+  const { data } = useQuery(
+    discoverApi.getFriendPublishersQueryOptions({
+      limit: FRIENDS_PROMPT_PAGE,
+    }),
+  );
+  const totalPeople = data?.totalPeople ?? 0;
+
+  if (totalPeople === 0) return null;
+
+  const shown = data?.people.slice(0, FRIENDS_PROMPT_AVATARS) ?? [];
+
+  return (
+    <div {...stylex.props(styles.friendsPrompt)}>
+      <div {...stylex.props(styles.friendsPromptMain)}>
+        <div {...stylex.props(styles.friendsAvatars)} aria-hidden>
+          {shown.map((person) => {
+            const name = friendDisplayName(person);
+            return (
+              <Avatar
+                key={person.did}
+                src={person.avatarUrl ?? undefined}
+                alt=""
+                size="md"
+                fallback={initials(name)}
+                style={styles.friendsAvatar}
+              />
+            );
+          })}
+        </div>
+        <p {...stylex.props(styles.friendsPromptText)}>
+          <Plural
+            value={totalPeople}
+            one="# person you follow writes here"
+            other="# people you follow write here"
+          />
+          <span {...stylex.props(styles.friendsPromptDek)}>
+            <Plural
+              value={data?.publicationCount ?? 0}
+              one="# publication from your Bluesky follows"
+              other="# publications from your Bluesky follows"
+            />
+          </span>
+        </p>
+      </div>
+      <ButtonLink
+        to="/friends"
+        variant="secondary"
+        size="md"
+        style={styles.friendsPromptAction}
+        aria-label={t`See publications from the people you follow`}
+      >
+        <Users size={16} aria-hidden />
+        <Trans>Find your friends</Trans>
+      </ButtonLink>
     </div>
   );
 }
@@ -840,6 +979,8 @@ function Discover() {
             : undefined
         }
       />
+
+      {signedIn ? <DiscoverFriendsPrompt /> : null}
 
       <DiscoverTrendingSection />
 

--- a/src/routes/_layout.friends.tsx
+++ b/src/routes/_layout.friends.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { Trans, useLingui } from "@lingui/react/macro";
+import * as stylex from "@stylexjs/stylex";
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { useCallback, useEffect, useMemo } from "react";
+
+import { ButtonLink } from "#/components/router-links";
+import { discoverApi } from "#/integrations/tanstack-query/api-discover.functions";
+import type { FriendPublisher } from "#/integrations/tanstack-query/api-discover.functions";
+import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
+import { user } from "#/integrations/tanstack-query/api-user.functions";
+import { getPublicUrlClient } from "#/lib/public-url";
+import { pageSocialMeta } from "#/lib/site-metadata";
+import { buildAuthRedirectPath } from "#/utils/auth-redirect";
+
+import { PubDirectoryRow } from "../components/reader/cards";
+import { FollowUserButton } from "../components/reader/follow-user-button";
+import {
+  FriendPublisherGroup,
+  FriendPublishersDegradedNote,
+  FriendPublishersSkeleton,
+  FriendPublishersSummary,
+} from "../components/reader/friend-publishers";
+import { Masthead, ReaderContent } from "../components/reader/primitives";
+import { useInfiniteScrollSentinel } from "../components/reader/use-infinite-scroll-sentinel";
+import { Flex } from "../design-system/flex";
+import { uiColor } from "../design-system/theme/color.stylex";
+import { radius } from "../design-system/theme/radius.stylex";
+import { spacing } from "../design-system/theme/spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+} from "../design-system/theme/typography.stylex";
+
+export const Route = createFileRoute("/_layout/friends")({
+  beforeLoad: async ({ context }) => {
+    const session = await context.queryClient.ensureQueryData(
+      user.getSessionQueryOptions,
+    );
+    if (!session?.user) {
+      throw redirect({
+        to: "/login",
+        search: { redirect: buildAuthRedirectPath("/friends") },
+      });
+    }
+  },
+  loader: ({ context }) => {
+    // The Bluesky round trip is the slow part (batched `getRelationships`), so
+    // it streams into the skeleton rather than gating first paint.
+    void context.queryClient.prefetchInfiniteQuery(
+      discoverApi.getFriendPublishersInfiniteQueryOptions(),
+    );
+  },
+  head: () => ({
+    meta: pageSocialMeta("friends", getPublicUrlClient()),
+  }),
+  component: FriendsPage,
+});
+
+const styles = stylex.create({
+  groups: {
+    display: "flex",
+    flexDirection: "column",
+    marginTop: spacing["8"],
+    rowGap: spacing["12"],
+  },
+  summary: {
+    marginTop: spacing["6"],
+  },
+  emptyCard: {
+    borderColor: uiColor.border1,
+    borderRadius: radius.md,
+    borderStyle: "solid",
+    borderWidth: 1,
+    boxSizing: "border-box",
+    marginTop: spacing["6"],
+    maxWidth: "100%",
+    paddingBottom: spacing["10"],
+    paddingInlineStart: spacing["8"],
+    paddingInlineEnd: spacing["8"],
+    paddingTop: spacing["10"],
+    width: "100%",
+  },
+  emptyInner: {
+    minWidth: 0,
+    width: "100%",
+  },
+  emptyTitle: {
+    color: uiColor.text2,
+    fontFamily: fontFamily.serif,
+    fontSize: fontSize["2xl"],
+    fontWeight: fontWeight.medium,
+    lineHeight: lineHeight.sm,
+  },
+  emptyDek: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.serif,
+    fontSize: fontSize.lg,
+    lineHeight: lineHeight.sm,
+    maxWidth: "52ch",
+    minWidth: 0,
+    overflowWrap: "anywhere",
+  },
+  loading: {
+    marginTop: spacing["8"],
+  },
+  loadSentinel: {
+    height: 1,
+    marginTop: spacing["6"],
+    width: "100%",
+  },
+  loadingNote: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.sm,
+    marginTop: spacing["6"],
+    textAlign: "center",
+  },
+});
+
+/**
+ * Seed the per-publication and per-person follow-status caches from the payload
+ * we already have, so a page of ten people doesn't fire twenty status requests.
+ * Only fills gaps (`prev ?? next`) — an optimistic update from a button press
+ * must always win over this snapshot.
+ */
+function useSeededFollowStatus(
+  people: Array<FriendPublisher> | undefined,
+  subscribedUris: Array<string> | undefined,
+) {
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    if (!people) return;
+    const subscribed = new Set(subscribedUris ?? []);
+    for (const person of people) {
+      queryClient.setQueryData(
+        readerApi.getUserFollowStatusQueryOptions(person.did).queryKey,
+        (prev) => prev ?? { isFollowing: person.followedInApp },
+      );
+      for (const pub of person.publications) {
+        queryClient.setQueryData(
+          readerApi.getFollowStatusQueryOptions(pub.uri).queryKey,
+          (prev) => prev ?? { isFollowing: subscribed.has(pub.uri) },
+        );
+      }
+    }
+  }, [people, subscribedUris, queryClient]);
+}
+
+function FriendsPage() {
+  const { t } = useLingui();
+  const {
+    data,
+    isPending,
+    isError,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery(discoverApi.getFriendPublishersInfiniteQueryOptions());
+
+  const first = data?.pages[0];
+  // A failed request and a partial Bluesky sweep get the same treatment: say we
+  // couldn't check, never "nobody you follow publishes here".
+  const couldNotCheck = isError || (first?.degraded ?? false);
+  const people = useMemo(
+    () => data?.pages.flatMap((page) => page.people) ?? [],
+    [data],
+  );
+  const subscribedUris = useMemo(
+    () => data?.pages.flatMap((page) => page.subscribedUris) ?? [],
+    [data],
+  );
+
+  useSeededFollowStatus(people, subscribedUris);
+
+  const loadMore = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
+    }
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  const loadMoreRef = useInfiniteScrollSentinel(
+    loadMore,
+    hasNextPage,
+    people.length,
+  );
+
+  return (
+    <ReaderContent>
+      <Masthead
+        kicker={t`Discover`}
+        title={t`People you follow`}
+        dek={t`Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed.`}
+        metaLabel={t`Writers`}
+        metaValue={first ? String(first.totalPeople) : undefined}
+      />
+
+      {isPending ? (
+        <div {...stylex.props(styles.loading)}>
+          <FriendPublishersSkeleton />
+        </div>
+      ) : people.length === 0 ? (
+        <div {...stylex.props(styles.emptyCard)}>
+          <Flex
+            direction="column"
+            gap="lg"
+            align="start"
+            style={styles.emptyInner}
+          >
+            <span {...stylex.props(styles.emptyTitle)}>
+              {couldNotCheck ? (
+                <Trans>Couldn't check right now</Trans>
+              ) : (
+                <Trans>No one you follow publishes here yet</Trans>
+              )}
+            </span>
+            <p {...stylex.props(styles.emptyDek)}>
+              {couldNotCheck ? (
+                <Trans>
+                  We couldn't reach Bluesky to look up who you follow. Reload in
+                  a moment, or browse the directory in the meantime.
+                </Trans>
+              ) : (
+                <Trans>
+                  We checked the people you follow on Bluesky against every
+                  publication on the network and didn't find a match. As more of
+                  them start publishing, they'll show up here.
+                </Trans>
+              )}
+            </p>
+            <ButtonLink to="/discover" variant="secondary" size="lg">
+              <Trans>Browse the directory</Trans>
+            </ButtonLink>
+          </Flex>
+        </div>
+      ) : (
+        <>
+          <div {...stylex.props(styles.summary)}>
+            <FriendPublishersSummary
+              people={first?.totalPeople ?? people.length}
+              publicationCount={first?.publicationCount ?? 0}
+            />
+            {couldNotCheck ? <FriendPublishersDegradedNote /> : null}
+          </div>
+          <div {...stylex.props(styles.groups)}>
+            {people.map((person) => (
+              <FriendPublisherGroup
+                key={person.did}
+                person={person}
+                action={
+                  <FollowUserButton
+                    did={person.did}
+                    signedIn
+                    size="sm"
+                    user={{
+                      did: person.did,
+                      handle: person.handle,
+                      displayName: person.displayName,
+                      avatarUrl: person.avatarUrl,
+                    }}
+                  />
+                }
+              >
+                {person.publications.map((pub, index) => (
+                  <PubDirectoryRow
+                    key={pub.uri}
+                    pub={pub}
+                    hideOwner
+                    isFirstInSection={index === 0}
+                    isLast={index === person.publications.length - 1}
+                  />
+                ))}
+              </FriendPublisherGroup>
+            ))}
+          </div>
+          {isFetchingNextPage ? (
+            <p {...stylex.props(styles.loadingNote)}>
+              <Trans>Loading…</Trans>
+            </p>
+          ) : null}
+          {hasNextPage ? (
+            <div
+              ref={loadMoreRef}
+              aria-hidden
+              {...stylex.props(styles.loadSentinel)}
+            />
+          ) : null}
+        </>
+      )}
+    </ReaderContent>
+  );
+}

--- a/src/routes/_layout.friends.tsx
+++ b/src/routes/_layout.friends.tsx
@@ -2,19 +2,29 @@
 
 import { Trans, useLingui } from "@lingui/react/macro";
 import * as stylex from "@stylexjs/stylex";
-import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo } from "react";
+import { z } from "zod";
 
+import { isArticleUnreadForReader } from "#/components/reader/read-optimistic";
 import { ButtonLink } from "#/components/router-links";
+import { Tab, TabList, TabPanel, Tabs } from "#/design-system/tabs";
 import { discoverApi } from "#/integrations/tanstack-query/api-discover.functions";
 import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
 import { user } from "#/integrations/tanstack-query/api-user.functions";
 import { getPublicUrlClient } from "#/lib/public-url";
 import { pageSocialMeta } from "#/lib/site-metadata";
+import { useHasMounted } from "#/lib/use-has-mounted";
+import { useTrackReadingHistory } from "#/lib/use-track-reading-history";
 import { buildAuthRedirectPath } from "#/utils/auth-redirect";
 
 import {
+  ArticleRow,
   PubDirectoryRow,
   PubDirectoryRowSkeleton,
 } from "../components/reader/cards";
@@ -38,7 +48,16 @@ import type { PublicationCard } from "../integrations/tanstack-query/api-shapes"
 
 const SKELETON_ROWS = 6;
 
+const friendsSearchSchema = z.object({
+  // Publications lead: the page exists to get the reader subscribed, and the
+  // articles are what those publications happen to have published lately.
+  view: z.enum(["publications", "articles"]).default("publications"),
+});
+
+type FriendsView = z.infer<typeof friendsSearchSchema>["view"];
+
 export const Route = createFileRoute("/_layout/friends")({
+  validateSearch: friendsSearchSchema,
   beforeLoad: async ({ context }) => {
     const session = await context.queryClient.ensureQueryData(
       user.getSessionQueryOptions,
@@ -52,7 +71,8 @@ export const Route = createFileRoute("/_layout/friends")({
   },
   loader: ({ context }) => {
     // The Bluesky round trip is the slow part (batched `getRelationships`), so
-    // it streams into the skeleton rather than gating first paint.
+    // it streams into the skeleton rather than gating first paint. Both tabs
+    // share the server-side graph cache, so warming one warms the other.
     void context.queryClient.prefetchInfiniteQuery(
       discoverApi.getFriendPublishersInfiniteQueryOptions(),
     );
@@ -67,8 +87,16 @@ const styles = stylex.create({
   summary: {
     marginTop: spacing["6"],
   },
-  list: {
+  tabList: {
     marginTop: spacing["6"],
+  },
+  tabPanel: {
+    paddingInlineEnd: spacing["0"],
+    paddingInlineStart: spacing["0"],
+    paddingTop: spacing["2"],
+  },
+  list: {
+    marginTop: spacing["4"],
   },
   emptyCard: {
     borderColor: uiColor.border1,
@@ -104,6 +132,14 @@ const styles = stylex.create({
     minWidth: 0,
     overflowWrap: "anywhere",
   },
+  emptyNote: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.sm,
+    marginTop: spacing["8"],
+    maxWidth: "60ch",
+    overflowWrap: "anywhere",
+  },
   loadSentinel: {
     height: 1,
     marginTop: spacing["6"],
@@ -121,27 +157,30 @@ const styles = stylex.create({
 /**
  * Seed the per-publication follow-status cache from the payload we already
  * have, so a page of two dozen rows doesn't fire two dozen status requests.
- * Only fills gaps (`prev ?? next`) — an optimistic update from a Subscribe
- * press must always win over this snapshot.
+ * Every row here is unsubscribed by construction; `prev ?? next` means an
+ * optimistic update from a Subscribe press still wins.
  */
-function useSeededFollowStatus(
-  publications: Array<PublicationCard>,
-  subscribedUris: Array<string>,
-) {
+function useSeededFollowStatus(publications: Array<PublicationCard>) {
   const queryClient = useQueryClient();
   useEffect(() => {
-    const subscribed = new Set(subscribedUris);
     for (const pub of publications) {
       queryClient.setQueryData(
         readerApi.getFollowStatusQueryOptions(pub.uri).queryKey,
-        (prev) => prev ?? { isFollowing: subscribed.has(pub.uri) },
+        (prev) => prev ?? { isFollowing: false },
       );
     }
-  }, [publications, subscribedUris, queryClient]);
+  }, [publications, queryClient]);
 }
 
 function FriendsPage() {
   const { t } = useLingui();
+  const { view } = Route.useSearch();
+  const navigate = Route.useNavigate();
+  // See `useHasMounted`: the list is prefetched off the critical path, so SSR
+  // must render the skeleton rather than whatever the server happened to
+  // resolve mid-render.
+  const mounted = useHasMounted();
+
   const {
     data,
     isPending,
@@ -151,20 +190,17 @@ function FriendsPage() {
     isFetchingNextPage,
   } = useInfiniteQuery(discoverApi.getFriendPublishersInfiniteQueryOptions());
 
-  const first = data?.pages[0];
+  const first = mounted ? data?.pages[0] : undefined;
   // A failed request and a partial Bluesky sweep get the same treatment: say we
   // couldn't check, never "nobody you follow publishes here".
   const couldNotCheck = isError || (first?.degraded ?? false);
   const publications = useMemo(
-    () => data?.pages.flatMap((page) => page.publications) ?? [],
-    [data],
-  );
-  const subscribedUris = useMemo(
-    () => data?.pages.flatMap((page) => page.subscribedUris) ?? [],
-    [data],
+    () =>
+      mounted ? (data?.pages.flatMap((page) => page.publications) ?? []) : [],
+    [data, mounted],
   );
 
-  useSeededFollowStatus(publications, subscribedUris);
+  useSeededFollowStatus(publications);
 
   const loadMore = useCallback(() => {
     if (hasNextPage && !isFetchingNextPage) {
@@ -178,17 +214,23 @@ function FriendsPage() {
     publications.length,
   );
 
+  const onViewChange = (key: React.Key) => {
+    void navigate({ search: { view: key as FriendsView }, replace: true });
+  };
+
+  const showEmpty = mounted && !isPending && publications.length === 0;
+
   return (
     <ReaderContent>
       <Masthead
         kicker={t`Discover`}
         title={t`People you follow`}
-        dek={t`Publications written by the people you follow on Bluesky.`}
+        dek={t`Publications written by the people you follow on Bluesky, minus the ones you already subscribe to.`}
         metaLabel={t`Publications`}
         metaValue={first ? String(first.publicationCount) : undefined}
       />
 
-      {isPending ? (
+      {!mounted || isPending ? (
         <div {...stylex.props(styles.list)}>
           {Array.from({ length: SKELETON_ROWS }, (_, index) => (
             <PubDirectoryRowSkeleton
@@ -198,7 +240,7 @@ function FriendsPage() {
             />
           ))}
         </div>
-      ) : publications.length === 0 ? (
+      ) : showEmpty ? (
         <div {...stylex.props(styles.emptyCard)}>
           <Flex
             direction="column"
@@ -210,7 +252,7 @@ function FriendsPage() {
               {couldNotCheck ? (
                 <Trans>Couldn't check right now</Trans>
               ) : (
-                <Trans>No one you follow publishes here yet</Trans>
+                <Trans>Nothing new from the people you follow</Trans>
               )}
             </span>
             <p {...stylex.props(styles.emptyDek)}>
@@ -221,8 +263,8 @@ function FriendsPage() {
                 </Trans>
               ) : (
                 <Trans>
-                  We checked the people you follow on Bluesky against every
-                  publication on the network and didn't find a match. As more of
+                  Either no one you follow on Bluesky publishes here yet, or
+                  you're already subscribed to everyone who does. As more of
                   them start publishing, they'll show up here.
                 </Trans>
               )}
@@ -241,30 +283,141 @@ function FriendsPage() {
             />
             {couldNotCheck ? <FriendPublishersDegradedNote /> : null}
           </div>
-          <div {...stylex.props(styles.list)}>
-            {publications.map((pub, index) => (
-              <PubDirectoryRow
-                key={pub.uri}
-                pub={pub}
-                isFirstInSection={index === 0}
-                isLast={index === publications.length - 1}
-              />
-            ))}
-          </div>
-          {isFetchingNextPage ? (
-            <p {...stylex.props(styles.loadingNote)}>
-              <Trans>Loading…</Trans>
-            </p>
-          ) : null}
-          {hasNextPage ? (
-            <div
-              ref={loadMoreRef}
-              aria-hidden
-              {...stylex.props(styles.loadSentinel)}
-            />
-          ) : null}
+
+          <Tabs selectedKey={view} onSelectionChange={onViewChange}>
+            <TabList aria-label={t`Friends views`} style={styles.tabList}>
+              <Tab id="publications">
+                <Trans>Publications</Trans>
+              </Tab>
+              <Tab id="articles">
+                <Trans>Articles</Trans>
+              </Tab>
+            </TabList>
+
+            <TabPanel id="publications" style={styles.tabPanel}>
+              <div {...stylex.props(styles.list)}>
+                {publications.map((pub, index) => (
+                  <PubDirectoryRow
+                    key={pub.uri}
+                    pub={pub}
+                    isFirstInSection={index === 0}
+                    isLast={index === publications.length - 1}
+                  />
+                ))}
+              </div>
+              {isFetchingNextPage ? (
+                <p {...stylex.props(styles.loadingNote)}>
+                  <Trans>Loading…</Trans>
+                </p>
+              ) : null}
+              {hasNextPage ? (
+                <div
+                  ref={loadMoreRef}
+                  aria-hidden
+                  {...stylex.props(styles.loadSentinel)}
+                />
+              ) : null}
+            </TabPanel>
+
+            <TabPanel id="articles" style={styles.tabPanel}>
+              {view === "articles" ? <FriendArticlesPanel /> : null}
+            </TabPanel>
+          </Tabs>
         </>
       )}
     </ReaderContent>
+  );
+}
+
+/**
+ * Chronological writing from the same publications the other tab lists. Mounted
+ * only while its tab is selected, so an unvisited tab costs no request.
+ */
+function FriendArticlesPanel() {
+  const { t } = useLingui();
+  const mounted = useHasMounted();
+  const queryClient = useQueryClient();
+  const { data: session } = useQuery(user.getSessionQueryOptions);
+  const signedIn = Boolean(session?.user);
+  const { enabled: trackReading } = useTrackReadingHistory();
+
+  const { data, isPending, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery(discoverApi.getFriendArticlesInfiniteQueryOptions());
+
+  const items = useMemo(
+    () => (mounted ? (data?.pages.flatMap((page) => page.items) ?? []) : []),
+    [data, mounted],
+  );
+
+  const loadMore = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
+    }
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  const loadMoreRef = useInfiniteScrollSentinel(
+    loadMore,
+    hasNextPage,
+    items.length,
+  );
+
+  if (!mounted || isPending) {
+    return (
+      <div
+        {...stylex.props(styles.list)}
+        aria-busy="true"
+        aria-label={t`Loading articles`}
+      >
+        {Array.from({ length: SKELETON_ROWS }, (_, index) => (
+          <PubDirectoryRowSkeleton
+            key={index}
+            isFirstInSection={index === 0}
+            isLast={index === SKELETON_ROWS - 1}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <p {...stylex.props(styles.emptyNote)}>
+        <Trans>
+          None of these publications have posted anything yet. Subscribe from
+          the Publications tab and their writing will land on your Home feed.
+        </Trans>
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <div {...stylex.props(styles.list)}>
+        {items.map((article, index) => (
+          <ArticleRow
+            key={article.uri}
+            article={article}
+            isFirstInSection={index === 0}
+            unread={isArticleUnreadForReader(queryClient, article, {
+              trackReading,
+              signedIn,
+            })}
+            showSaveButton={false}
+          />
+        ))}
+      </div>
+      {isFetchingNextPage ? (
+        <p {...stylex.props(styles.loadingNote)}>
+          <Trans>Loading…</Trans>
+        </p>
+      ) : null}
+      {hasNextPage ? (
+        <div
+          ref={loadMoreRef}
+          aria-hidden
+          {...stylex.props(styles.loadSentinel)}
+        />
+      ) : null}
+    </>
   );
 }

--- a/src/routes/_layout.friends.tsx
+++ b/src/routes/_layout.friends.tsx
@@ -8,19 +8,18 @@ import { useCallback, useEffect, useMemo } from "react";
 
 import { ButtonLink } from "#/components/router-links";
 import { discoverApi } from "#/integrations/tanstack-query/api-discover.functions";
-import type { FriendPublisher } from "#/integrations/tanstack-query/api-discover.functions";
 import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
 import { user } from "#/integrations/tanstack-query/api-user.functions";
 import { getPublicUrlClient } from "#/lib/public-url";
 import { pageSocialMeta } from "#/lib/site-metadata";
 import { buildAuthRedirectPath } from "#/utils/auth-redirect";
 
-import { PubDirectoryRow } from "../components/reader/cards";
-import { FollowUserButton } from "../components/reader/follow-user-button";
 import {
-  FriendPublisherGroup,
+  PubDirectoryRow,
+  PubDirectoryRowSkeleton,
+} from "../components/reader/cards";
+import {
   FriendPublishersDegradedNote,
-  FriendPublishersSkeleton,
   FriendPublishersSummary,
 } from "../components/reader/friend-publishers";
 import { Masthead, ReaderContent } from "../components/reader/primitives";
@@ -35,6 +34,9 @@ import {
   fontWeight,
   lineHeight,
 } from "../design-system/theme/typography.stylex";
+import type { PublicationCard } from "../integrations/tanstack-query/api-shapes";
+
+const SKELETON_ROWS = 6;
 
 export const Route = createFileRoute("/_layout/friends")({
   beforeLoad: async ({ context }) => {
@@ -62,13 +64,10 @@ export const Route = createFileRoute("/_layout/friends")({
 });
 
 const styles = stylex.create({
-  groups: {
-    display: "flex",
-    flexDirection: "column",
-    marginTop: spacing["8"],
-    rowGap: spacing["12"],
-  },
   summary: {
+    marginTop: spacing["6"],
+  },
+  list: {
     marginTop: spacing["6"],
   },
   emptyCard: {
@@ -105,9 +104,6 @@ const styles = stylex.create({
     minWidth: 0,
     overflowWrap: "anywhere",
   },
-  loading: {
-    marginTop: spacing["8"],
-  },
   loadSentinel: {
     height: 1,
     marginTop: spacing["6"],
@@ -123,32 +119,25 @@ const styles = stylex.create({
 });
 
 /**
- * Seed the per-publication and per-person follow-status caches from the payload
- * we already have, so a page of ten people doesn't fire twenty status requests.
- * Only fills gaps (`prev ?? next`) — an optimistic update from a button press
- * must always win over this snapshot.
+ * Seed the per-publication follow-status cache from the payload we already
+ * have, so a page of two dozen rows doesn't fire two dozen status requests.
+ * Only fills gaps (`prev ?? next`) — an optimistic update from a Subscribe
+ * press must always win over this snapshot.
  */
 function useSeededFollowStatus(
-  people: Array<FriendPublisher> | undefined,
-  subscribedUris: Array<string> | undefined,
+  publications: Array<PublicationCard>,
+  subscribedUris: Array<string>,
 ) {
   const queryClient = useQueryClient();
   useEffect(() => {
-    if (!people) return;
-    const subscribed = new Set(subscribedUris ?? []);
-    for (const person of people) {
+    const subscribed = new Set(subscribedUris);
+    for (const pub of publications) {
       queryClient.setQueryData(
-        readerApi.getUserFollowStatusQueryOptions(person.did).queryKey,
-        (prev) => prev ?? { isFollowing: person.followedInApp },
+        readerApi.getFollowStatusQueryOptions(pub.uri).queryKey,
+        (prev) => prev ?? { isFollowing: subscribed.has(pub.uri) },
       );
-      for (const pub of person.publications) {
-        queryClient.setQueryData(
-          readerApi.getFollowStatusQueryOptions(pub.uri).queryKey,
-          (prev) => prev ?? { isFollowing: subscribed.has(pub.uri) },
-        );
-      }
     }
-  }, [people, subscribedUris, queryClient]);
+  }, [publications, subscribedUris, queryClient]);
 }
 
 function FriendsPage() {
@@ -166,8 +155,8 @@ function FriendsPage() {
   // A failed request and a partial Bluesky sweep get the same treatment: say we
   // couldn't check, never "nobody you follow publishes here".
   const couldNotCheck = isError || (first?.degraded ?? false);
-  const people = useMemo(
-    () => data?.pages.flatMap((page) => page.people) ?? [],
+  const publications = useMemo(
+    () => data?.pages.flatMap((page) => page.publications) ?? [],
     [data],
   );
   const subscribedUris = useMemo(
@@ -175,7 +164,7 @@ function FriendsPage() {
     [data],
   );
 
-  useSeededFollowStatus(people, subscribedUris);
+  useSeededFollowStatus(publications, subscribedUris);
 
   const loadMore = useCallback(() => {
     if (hasNextPage && !isFetchingNextPage) {
@@ -186,7 +175,7 @@ function FriendsPage() {
   const loadMoreRef = useInfiniteScrollSentinel(
     loadMore,
     hasNextPage,
-    people.length,
+    publications.length,
   );
 
   return (
@@ -194,16 +183,22 @@ function FriendsPage() {
       <Masthead
         kicker={t`Discover`}
         title={t`People you follow`}
-        dek={t`Publications written by the people you follow on Bluesky. Follow someone here and every publication they write lands on your Home feed.`}
-        metaLabel={t`Writers`}
-        metaValue={first ? String(first.totalPeople) : undefined}
+        dek={t`Publications written by the people you follow on Bluesky.`}
+        metaLabel={t`Publications`}
+        metaValue={first ? String(first.publicationCount) : undefined}
       />
 
       {isPending ? (
-        <div {...stylex.props(styles.loading)}>
-          <FriendPublishersSkeleton />
+        <div {...stylex.props(styles.list)}>
+          {Array.from({ length: SKELETON_ROWS }, (_, index) => (
+            <PubDirectoryRowSkeleton
+              key={index}
+              isFirstInSection={index === 0}
+              isLast={index === SKELETON_ROWS - 1}
+            />
+          ))}
         </div>
-      ) : people.length === 0 ? (
+      ) : publications.length === 0 ? (
         <div {...stylex.props(styles.emptyCard)}>
           <Flex
             direction="column"
@@ -241,40 +236,19 @@ function FriendsPage() {
         <>
           <div {...stylex.props(styles.summary)}>
             <FriendPublishersSummary
-              people={first?.totalPeople ?? people.length}
+              people={first?.totalPeople ?? 0}
               publicationCount={first?.publicationCount ?? 0}
             />
             {couldNotCheck ? <FriendPublishersDegradedNote /> : null}
           </div>
-          <div {...stylex.props(styles.groups)}>
-            {people.map((person) => (
-              <FriendPublisherGroup
-                key={person.did}
-                person={person}
-                action={
-                  <FollowUserButton
-                    did={person.did}
-                    signedIn
-                    size="sm"
-                    user={{
-                      did: person.did,
-                      handle: person.handle,
-                      displayName: person.displayName,
-                      avatarUrl: person.avatarUrl,
-                    }}
-                  />
-                }
-              >
-                {person.publications.map((pub, index) => (
-                  <PubDirectoryRow
-                    key={pub.uri}
-                    pub={pub}
-                    hideOwner
-                    isFirstInSection={index === 0}
-                    isLast={index === person.publications.length - 1}
-                  />
-                ))}
-              </FriendPublisherGroup>
+          <div {...stylex.props(styles.list)}>
+            {publications.map((pub, index) => (
+              <PubDirectoryRow
+                key={pub.uri}
+                pub={pub}
+                isFirstInSection={index === 0}
+                isLast={index === publications.length - 1}
+              />
             ))}
           </div>
           {isFetchingNextPage ? (

--- a/src/routes/welcome.tsx
+++ b/src/routes/welcome.tsx
@@ -5,10 +5,13 @@ import type { OnboardingStep } from "#/components/onboarding/welcome-wizard";
 import { WelcomeWizard } from "#/components/onboarding/welcome-wizard";
 import { discoverApi } from "#/integrations/tanstack-query/api-discover.functions";
 import { user } from "#/integrations/tanstack-query/api-user.functions";
+import { ONBOARDING_FRIENDS_LIMIT } from "#/lib/onboarding";
 import { siteSocialMeta } from "#/lib/site-metadata";
 
 const searchSchema = z.object({
-  step: z.enum(["intro", "topics", "follow", "settings", "done"]).optional(),
+  step: z
+    .enum(["intro", "topics", "friends", "follow", "settings", "done"])
+    .optional(),
   topics: z.array(z.string().min(1).max(60)).max(5).optional(),
 });
 
@@ -39,6 +42,13 @@ export const Route = createFileRoute("/welcome")({
     );
     void context.queryClient.prefetchQuery(
       discoverApi.getTrendingPublicationsQueryOptions({ limit: 6 }),
+    );
+    // Kicked off at the intro step: the Bluesky lookup decides whether the
+    // "people you follow" step exists at all, so it needs a head start.
+    void context.queryClient.prefetchQuery(
+      discoverApi.getFriendPublishersQueryOptions({
+        limit: ONBOARDING_FRIENDS_LIMIT,
+      }),
     );
     await Promise.all([
       context.queryClient.ensureQueryData(user.getThemePreferenceQueryOptions),

--- a/src/server/atproto/bsky-relationships.ts
+++ b/src/server/atproto/bsky-relationships.ts
@@ -5,6 +5,8 @@
 const PUBLIC_APPVIEW = "https://public.api.bsky.app";
 const FETCH_TIMEOUT_MS = 8000;
 const RELATIONSHIPS_BATCH = 30;
+/** In-flight `getRelationships` requests. Bounded to stay a polite client. */
+const RELATIONSHIPS_CONCURRENCY = 8;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -32,6 +34,15 @@ function parseRelationshipDid(value: unknown): {
   };
 }
 
+export interface FollowedDidsResult {
+  /** The subset of the candidates that the actor follows. */
+  followed: Set<string>;
+  /** Batches the AppView never answered (timeout, network, non-2xx). */
+  failedBatches: number;
+  /** Batches attempted. `failedBatches === batches` means we learned nothing. */
+  batches: number;
+}
+
 /**
  * Return the subset of `candidateDids` that `actorDid` follows on Bluesky.
  * Uses `app.bsky.graph.getRelationships` (30 DIDs per request).
@@ -40,15 +51,47 @@ export async function filterDidsFollowedByActor(
   actorDid: string,
   candidateDids: ReadonlyArray<string>,
 ): Promise<Set<string>> {
+  const { followed } = await followedDidsForActor(actorDid, candidateDids);
+  return followed;
+}
+
+/**
+ * {@link filterDidsFollowedByActor} with batch-failure counts retained.
+ *
+ * Callers that render "we found nobody" need to tell a genuine empty result
+ * apart from an unreachable AppView — an empty `followed` with
+ * `failedBatches > 0` is "couldn't check", not "no results".
+ */
+export async function followedDidsForActor(
+  actorDid: string,
+  candidateDids: ReadonlyArray<string>,
+): Promise<FollowedDidsResult> {
   const unique = [
     ...new Set(
       candidateDids.filter((did) => did.startsWith("did:") && did !== actorDid),
     ),
   ];
-  if (unique.length === 0) return new Set();
+  if (unique.length === 0) {
+    return { followed: new Set(), failedBatches: 0, batches: 0 };
+  }
 
   const followed = new Set<string>();
-  for (const batch of chunk(unique, RELATIONSHIPS_BATCH)) {
+  const allBatches = chunk(unique, RELATIONSHIPS_BATCH);
+  let failedBatches = 0;
+
+  // Batches run concurrently: a full candidate sweep is dozens of requests, and
+  // serially they add up to tens of seconds. The cap keeps us a polite client.
+  const queue = [...allBatches];
+  const workers = Array.from(
+    { length: Math.min(RELATIONSHIPS_CONCURRENCY, queue.length) },
+    async () => {
+      for (let batch = queue.shift(); batch; batch = queue.shift()) {
+        await runBatch(batch);
+      }
+    },
+  );
+
+  async function runBatch(batch: Array<string>): Promise<void> {
     try {
       const url = new URL(
         "/xrpc/app.bsky.graph.getRelationships",
@@ -63,11 +106,15 @@ export async function filterDidsFollowedByActor(
         signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
         headers: { Accept: "application/json" },
       });
-      if (!response.ok) continue;
+      if (!response.ok) {
+        failedBatches += 1;
+        return;
+      }
 
       const payload: unknown = await response.json();
       if (!isRecord(payload) || !Array.isArray(payload.relationships)) {
-        continue;
+        failedBatches += 1;
+        return;
       }
 
       for (const relationship of payload.relationships) {
@@ -78,8 +125,11 @@ export async function filterDidsFollowedByActor(
       }
     } catch {
       // Best-effort — omit this batch on timeout/network failure.
+      failedBatches += 1;
     }
   }
 
-  return followed;
+  await Promise.all(workers);
+
+  return { followed, failedBatches, batches: allBatches.length };
 }

--- a/src/server/reader/bsky-friends.test.ts
+++ b/src/server/reader/bsky-friends.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { PublicationCard } from "#/integrations/tanstack-query/api-shapes";
 
-import type { FriendProfileRow } from "./bsky-friends";
-import { buildFriendPublishers } from "./bsky-friends";
+import { friendAuthors, rankFriendPublications } from "./bsky-friends";
 
 function pub(
   did: string,
@@ -30,130 +29,88 @@ function pub(
   };
 }
 
-function profile(did: string, over: Partial<FriendProfileRow> = {}) {
-  return {
-    did,
-    handle: `${did}.example`,
-    displayName: null,
-    avatarUrl: null,
-    ...over,
-  } satisfies FriendProfileRow;
-}
-
-describe("buildFriendPublishers", () => {
-  it("drops followed accounts that publish nothing", () => {
-    const people = buildFriendPublishers({
-      followedDids: ["did:a", "did:silent"],
-      publicationsByDid: new Map([["did:a", [pub("did:a", "a1", 5)]]]),
-      profiles: new Map([
-        ["did:a", profile("did:a")],
-        ["did:silent", profile("did:silent")],
+describe("rankFriendPublications", () => {
+  it("ranks by readership across every writer", () => {
+    const ranked = rankFriendPublications(
+      ["did:a", "did:b"],
+      new Map([
+        ["did:a", [pub("did:a", "a-small", 5), pub("did:a", "a-big", 90)]],
+        ["did:b", [pub("did:b", "b-mid", 40)]],
       ]),
-      appFollowedDids: new Set(),
-    });
+    );
 
-    expect(people.map((p) => p.did)).toEqual(["did:a"]);
+    expect(ranked.map((p) => p.uri)).toEqual(["a-big", "b-mid", "a-small"]);
   });
 
-  it("ranks people by combined readership across their publications", () => {
-    const people = buildFriendPublishers({
-      followedDids: ["did:small", "did:split", "did:big"],
-      publicationsByDid: new Map([
-        ["did:small", [pub("did:small", "s1", 40)]],
-        // Two modest publications outrank one mid-sized one.
-        ["did:split", [pub("did:split", "p1", 30), pub("did:split", "p2", 30)]],
-        ["did:big", [pub("did:big", "b1", 100)]],
+  it("breaks ties on name then URI so paging stays stable", () => {
+    const ranked = rankFriendPublications(
+      ["did:a", "did:b"],
+      new Map([
+        ["did:a", [pub("did:a", "z-uri", 10, { name: "Same" })]],
+        ["did:b", [pub("did:b", "a-uri", 10, { name: "Same" })]],
       ]),
-      profiles: new Map(),
-      appFollowedDids: new Set(),
-    });
+    );
 
-    expect(people.map((p) => p.did)).toEqual([
-      "did:big",
-      "did:split",
-      "did:small",
+    expect(ranked.map((p) => p.uri)).toEqual(["a-uri", "z-uri"]);
+  });
+
+  it("drops publications the reader already subscribes to", () => {
+    const ranked = rankFriendPublications(
+      ["did:a"],
+      new Map([
+        ["did:a", [pub("did:a", "known", 90), pub("did:a", "new", 10)]],
+      ]),
+      new Set(["known"]),
+    );
+
+    expect(ranked.map((p) => p.uri)).toEqual(["new"]);
+  });
+
+  it("ignores followed accounts that publish nothing", () => {
+    const ranked = rankFriendPublications(
+      ["did:silent", "did:a"],
+      new Map([["did:a", [pub("did:a", "a1", 1)]]]),
+    );
+
+    expect(ranked.map((p) => p.uri)).toEqual(["a1"]);
+  });
+});
+
+describe("friendAuthors", () => {
+  it("dedupes writers, keeping rank order", () => {
+    const ranked = rankFriendPublications(
+      ["did:a", "did:b"],
+      new Map([
+        [
+          "did:a",
+          [
+            pub("did:a", "a1", 90, { ownerHandle: "ana.example" }),
+            pub("did:a", "a2", 5, { ownerHandle: "ana.example" }),
+          ],
+        ],
+        ["did:b", [pub("did:b", "b1", 40, { ownerHandle: "bo.example" })]],
+      ]),
+    );
+
+    expect(friendAuthors(ranked).map((a) => a.handle)).toEqual([
+      "ana.example",
+      "bo.example",
     ]);
   });
 
-  it("breaks readership ties on handle so ordering is stable", () => {
-    const people = buildFriendPublishers({
-      followedDids: ["did:z", "did:a"],
-      publicationsByDid: new Map([
-        ["did:z", [pub("did:z", "z1", 10)]],
-        ["did:a", [pub("did:a", "a1", 10)]],
+  it("honours the preview limit", () => {
+    const ranked = rankFriendPublications(
+      ["did:a", "did:b", "did:c"],
+      new Map([
+        ["did:a", [pub("did:a", "a1", 30)]],
+        ["did:b", [pub("did:b", "b1", 20)]],
+        ["did:c", [pub("did:c", "c1", 10)]],
       ]),
-      profiles: new Map([
-        ["did:z", profile("did:z", { handle: "zoe.example" })],
-        ["did:a", profile("did:a", { handle: "ana.example" })],
-      ]),
-      appFollowedDids: new Set(),
-    });
+    );
 
-    expect(people.map((p) => p.handle)).toEqual(["ana.example", "zoe.example"]);
-  });
-
-  it("prefers the profile row for identity and falls back to the publication", () => {
-    const people = buildFriendPublishers({
-      followedDids: ["did:withprofile", "did:noprofile"],
-      publicationsByDid: new Map([
-        [
-          "did:withprofile",
-          [
-            pub("did:withprofile", "w1", 2, {
-              ownerHandle: "stale.example",
-              ownerAvatarUrl: "https://cdn.example/stale.jpg",
-            }),
-          ],
-        ],
-        [
-          "did:noprofile",
-          [
-            pub("did:noprofile", "n1", 1, {
-              ownerHandle: "fallback.example",
-              ownerAvatarUrl: "https://cdn.example/fallback.jpg",
-            }),
-          ],
-        ],
-      ]),
-      profiles: new Map([
-        [
-          "did:withprofile",
-          profile("did:withprofile", {
-            handle: "current.example",
-            displayName: "Current Name",
-            avatarUrl: "https://cdn.example/current.jpg",
-          }),
-        ],
-      ]),
-      appFollowedDids: new Set(),
-    });
-
-    const [withProfile, noProfile] = people;
-    expect(withProfile).toMatchObject({
-      handle: "current.example",
-      displayName: "Current Name",
-      avatarUrl: "https://cdn.example/current.jpg",
-    });
-    expect(noProfile).toMatchObject({
-      handle: "fallback.example",
-      displayName: null,
-      avatarUrl: "https://cdn.example/fallback.jpg",
-    });
-  });
-
-  it("marks people the reader already follows in-app", () => {
-    const people = buildFriendPublishers({
-      followedDids: ["did:a", "did:b"],
-      publicationsByDid: new Map([
-        ["did:a", [pub("did:a", "a1", 5)]],
-        ["did:b", [pub("did:b", "b1", 4)]],
-      ]),
-      profiles: new Map(),
-      appFollowedDids: new Set(["did:b"]),
-    });
-
-    expect(
-      Object.fromEntries(people.map((p) => [p.did, p.followedInApp])),
-    ).toEqual({ "did:a": false, "did:b": true });
+    expect(friendAuthors(ranked, 2).map((a) => a.did)).toEqual([
+      "did:a",
+      "did:b",
+    ]);
   });
 });

--- a/src/server/reader/bsky-friends.test.ts
+++ b/src/server/reader/bsky-friends.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+
+import type { PublicationCard } from "#/integrations/tanstack-query/api-shapes";
+
+import type { FriendProfileRow } from "./bsky-friends";
+import { buildFriendPublishers } from "./bsky-friends";
+
+function pub(
+  did: string,
+  uri: string,
+  subscriberCount: number,
+  over: Partial<PublicationCard> = {},
+): PublicationCard {
+  return {
+    uri,
+    did,
+    name: uri,
+    url: `https://${uri}.example`,
+    description: null,
+    iconUrl: null,
+    ownerAvatarUrl: null,
+    ownerHandle: null,
+    topic: null,
+    verified: false,
+    hiddenFromDiscover: false,
+    subscriberCount,
+    documentCount: 1,
+    lastDocumentAt: null,
+    ...over,
+  };
+}
+
+function profile(did: string, over: Partial<FriendProfileRow> = {}) {
+  return {
+    did,
+    handle: `${did}.example`,
+    displayName: null,
+    avatarUrl: null,
+    ...over,
+  } satisfies FriendProfileRow;
+}
+
+describe("buildFriendPublishers", () => {
+  it("drops followed accounts that publish nothing", () => {
+    const people = buildFriendPublishers({
+      followedDids: ["did:a", "did:silent"],
+      publicationsByDid: new Map([["did:a", [pub("did:a", "a1", 5)]]]),
+      profiles: new Map([
+        ["did:a", profile("did:a")],
+        ["did:silent", profile("did:silent")],
+      ]),
+      appFollowedDids: new Set(),
+    });
+
+    expect(people.map((p) => p.did)).toEqual(["did:a"]);
+  });
+
+  it("ranks people by combined readership across their publications", () => {
+    const people = buildFriendPublishers({
+      followedDids: ["did:small", "did:split", "did:big"],
+      publicationsByDid: new Map([
+        ["did:small", [pub("did:small", "s1", 40)]],
+        // Two modest publications outrank one mid-sized one.
+        ["did:split", [pub("did:split", "p1", 30), pub("did:split", "p2", 30)]],
+        ["did:big", [pub("did:big", "b1", 100)]],
+      ]),
+      profiles: new Map(),
+      appFollowedDids: new Set(),
+    });
+
+    expect(people.map((p) => p.did)).toEqual([
+      "did:big",
+      "did:split",
+      "did:small",
+    ]);
+  });
+
+  it("breaks readership ties on handle so ordering is stable", () => {
+    const people = buildFriendPublishers({
+      followedDids: ["did:z", "did:a"],
+      publicationsByDid: new Map([
+        ["did:z", [pub("did:z", "z1", 10)]],
+        ["did:a", [pub("did:a", "a1", 10)]],
+      ]),
+      profiles: new Map([
+        ["did:z", profile("did:z", { handle: "zoe.example" })],
+        ["did:a", profile("did:a", { handle: "ana.example" })],
+      ]),
+      appFollowedDids: new Set(),
+    });
+
+    expect(people.map((p) => p.handle)).toEqual(["ana.example", "zoe.example"]);
+  });
+
+  it("prefers the profile row for identity and falls back to the publication", () => {
+    const people = buildFriendPublishers({
+      followedDids: ["did:withprofile", "did:noprofile"],
+      publicationsByDid: new Map([
+        [
+          "did:withprofile",
+          [
+            pub("did:withprofile", "w1", 2, {
+              ownerHandle: "stale.example",
+              ownerAvatarUrl: "https://cdn.example/stale.jpg",
+            }),
+          ],
+        ],
+        [
+          "did:noprofile",
+          [
+            pub("did:noprofile", "n1", 1, {
+              ownerHandle: "fallback.example",
+              ownerAvatarUrl: "https://cdn.example/fallback.jpg",
+            }),
+          ],
+        ],
+      ]),
+      profiles: new Map([
+        [
+          "did:withprofile",
+          profile("did:withprofile", {
+            handle: "current.example",
+            displayName: "Current Name",
+            avatarUrl: "https://cdn.example/current.jpg",
+          }),
+        ],
+      ]),
+      appFollowedDids: new Set(),
+    });
+
+    const [withProfile, noProfile] = people;
+    expect(withProfile).toMatchObject({
+      handle: "current.example",
+      displayName: "Current Name",
+      avatarUrl: "https://cdn.example/current.jpg",
+    });
+    expect(noProfile).toMatchObject({
+      handle: "fallback.example",
+      displayName: null,
+      avatarUrl: "https://cdn.example/fallback.jpg",
+    });
+  });
+
+  it("marks people the reader already follows in-app", () => {
+    const people = buildFriendPublishers({
+      followedDids: ["did:a", "did:b"],
+      publicationsByDid: new Map([
+        ["did:a", [pub("did:a", "a1", 5)]],
+        ["did:b", [pub("did:b", "b1", 4)]],
+      ]),
+      profiles: new Map(),
+      appFollowedDids: new Set(["did:b"]),
+    });
+
+    expect(
+      Object.fromEntries(people.map((p) => [p.did, p.followedInApp])),
+    ).toEqual({ "did:a": false, "did:b": true });
+  });
+});

--- a/src/server/reader/bsky-friends.ts
+++ b/src/server/reader/bsky-friends.ts
@@ -1,0 +1,399 @@
+/**
+ * "Publications by people you follow" — the bridge between a reader's Bluesky
+ * social graph and the standard.site publications indexed in the read-model.
+ *
+ * The join runs candidate-first: the read-model knows every DID that publishes
+ * (a bounded, network-wide set), so we ask the Bluesky AppView "of these, which
+ * do I follow?" via `app.bsky.graph.getRelationships` (30 DIDs per request)
+ * rather than paginating the reader's follow list. That keeps the cost tied to
+ * the size of the author set instead of the reader's follow count, and needs no
+ * stored mirror of the Bluesky graph.
+ *
+ * If the author set ever outgrows {@link FRIEND_CANDIDATE_LIMIT} the trade
+ * inverts and the reverse direction (paginate `app.bsky.graph.getFollows`, cache
+ * per reader) becomes the cheaper one; `truncated` on the result marks when
+ * we've hit that ceiling.
+ */
+
+import { and, asc, desc, eq, exists, inArray, sql } from "drizzle-orm";
+
+import type {
+  Db,
+  PublicationCard,
+  Schema,
+} from "#/integrations/tanstack-query/api-shapes";
+import {
+  publicationCardColumns,
+  toPublicationCard,
+} from "#/integrations/tanstack-query/api-shapes";
+import { followedDidsForActor } from "#/server/atproto/bsky-relationships";
+import { discoverEligiblePublicationWhere } from "#/server/reader/publication-filters";
+
+/**
+ * Ceiling on candidate author DIDs checked against the Bluesky graph.
+ *
+ * Sized to cover the whole network with room to grow: batches of 30 run
+ * concurrently, so ~2,800 authors is ~95 requests and measures under a second
+ * against the public AppView. Candidates are ordered by readership, so if the
+ * network ever outgrows this the check still covers the authors a reader is
+ * most likely to follow — and the result is flagged `truncated`.
+ */
+export const FRIEND_CANDIDATE_LIMIT = 5000;
+
+export interface FriendPublisher {
+  did: string;
+  handle: string | null;
+  displayName: string | null;
+  avatarUrl: string | null;
+  /** True when the reader already follows this person *in Standard Reader*. */
+  followedInApp: boolean;
+  publications: Array<PublicationCard>;
+}
+
+export interface FriendPublishers {
+  /** This page of people. */
+  people: Array<FriendPublisher>;
+  /** Every matching person, not just this page — the headline count. */
+  totalPeople: number;
+  /** Total publications across every match — the headline count. */
+  publicationCount: number;
+  /** Offset for the next page, or `null` at the end. */
+  nextOffset: number | null;
+  /** Publication URIs on this page the reader already subscribes to. */
+  subscribedUris: Array<string>;
+  /**
+   * The Bluesky AppView didn't answer for at least one batch, so the result is
+   * incomplete. The UI must say "couldn't check" rather than "nobody found".
+   */
+  degraded: boolean;
+  /** Candidate authors exceeded {@link FRIEND_CANDIDATE_LIMIT}. */
+  truncated: boolean;
+}
+
+export const EMPTY_FRIEND_PUBLISHERS: FriendPublishers = {
+  people: [],
+  totalPeople: 0,
+  publicationCount: 0,
+  nextOffset: null,
+  subscribedUris: [],
+  degraded: false,
+  truncated: false,
+};
+
+/** Default page size for `/friends`. */
+export const FRIEND_PAGE_SIZE = 12;
+
+interface CachedGraph {
+  followedDids: Array<string>;
+  degraded: boolean;
+  truncated: boolean;
+  at: number;
+}
+
+/**
+ * The Bluesky sweep (dozens of `getRelationships` requests) is far too
+ * expensive to repeat for page two. Results are held per reader for a few
+ * minutes so paging is DB-only; the graph doesn't move fast enough for the
+ * staleness to matter, and losing the cache on restart is harmless.
+ */
+const GRAPH_CACHE_TTL_MS = 10 * 60_000;
+const GRAPH_CACHE_MAX = 500;
+const graphCache = new Map<string, CachedGraph>();
+
+function readGraphCache(readerDid: string): CachedGraph | null {
+  const hit = graphCache.get(readerDid);
+  if (!hit) return null;
+  if (Date.now() - hit.at > GRAPH_CACHE_TTL_MS) {
+    graphCache.delete(readerDid);
+    return null;
+  }
+  return hit;
+}
+
+function writeGraphCache(readerDid: string, value: CachedGraph): void {
+  if (graphCache.size >= GRAPH_CACHE_MAX) {
+    // Map preserves insertion order, so the first key is the oldest write.
+    const oldest = graphCache.keys().next().value;
+    if (oldest !== undefined) graphCache.delete(oldest);
+  }
+  graphCache.set(readerDid, value);
+}
+
+/**
+ * The candidate list is identical for every reader and costs ~900ms, so it's
+ * memoized process-wide rather than per reader. A new publication showing up a
+ * few minutes late is invisible to the reader.
+ */
+const CANDIDATE_CACHE_TTL_MS = 10 * 60_000;
+let candidateCache: { dids: Array<string>; limit: number; at: number } | null =
+  null;
+
+/**
+ * Author DIDs worth checking against the reader's Bluesky follows: owners of
+ * discover-eligible publications that actually have indexed documents, ordered
+ * by readership so the cap (if hit) keeps the most notable authors.
+ */
+async function candidateAuthorDids(
+  db: Db,
+  schema: Schema,
+  limit: number,
+): Promise<Array<string>> {
+  const cached = candidateCache;
+  if (
+    cached &&
+    cached.limit === limit &&
+    Date.now() - cached.at < CANDIDATE_CACHE_TTL_MS
+  ) {
+    return cached.dids;
+  }
+  const p = schema.publications;
+  const st = schema.publicationStats;
+  const doc = schema.documents;
+
+  const rows = await db
+    .select({
+      did: p.did,
+      score: sql<number>`sum(coalesce(${st.subscriberCount}, 0))`.mapWith(
+        Number,
+      ),
+    })
+    .from(p)
+    .leftJoin(st, eq(st.publicationUri, p.uri))
+    .where(
+      and(
+        discoverEligiblePublicationWhere(p),
+        exists(
+          db
+            .select({ one: sql`1` })
+            .from(doc)
+            .where(and(eq(doc.publicationUri, p.uri), eq(doc.deleted, false))),
+        ),
+      ),
+    )
+    .groupBy(p.did)
+    .orderBy(desc(sql`sum(coalesce(${st.subscriberCount}, 0))`), asc(p.did))
+    .limit(limit);
+
+  const dids = rows.map((row) => row.did);
+  candidateCache = { dids, limit, at: Date.now() };
+  return dids;
+}
+
+/** Every publication owned by `dids`, as cards, newest-first within an owner. */
+async function publicationsByAuthors(
+  db: Db,
+  schema: Schema,
+  dids: Array<string>,
+): Promise<Map<string, Array<PublicationCard>>> {
+  const grouped = new Map<string, Array<PublicationCard>>();
+  if (dids.length === 0) return grouped;
+
+  const p = schema.publications;
+  const st = schema.publicationStats;
+  const pr = schema.profiles;
+  const doc = schema.documents;
+
+  const rows = await db
+    .select(publicationCardColumns(schema))
+    .from(p)
+    .leftJoin(st, eq(st.publicationUri, p.uri))
+    .leftJoin(pr, eq(pr.did, p.did))
+    .where(
+      and(
+        inArray(p.did, dids),
+        discoverEligiblePublicationWhere(p),
+        exists(
+          db
+            .select({ one: sql`1` })
+            .from(doc)
+            .where(and(eq(doc.publicationUri, p.uri), eq(doc.deleted, false))),
+        ),
+      ),
+    )
+    .orderBy(sql`${st.lastDocumentAt} desc nulls last`, asc(p.name));
+
+  for (const row of rows) {
+    const card = toPublicationCard(row);
+    const list = grouped.get(card.did);
+    if (list) list.push(card);
+    else grouped.set(card.did, [card]);
+  }
+  return grouped;
+}
+
+/** Combined readership across everything a person publishes. */
+function totalReaders(person: FriendPublisher): number {
+  return person.publications.reduce((n, pub) => n + pub.subscriberCount, 0);
+}
+
+export interface FriendProfileRow {
+  did: string;
+  handle: string | null;
+  displayName: string | null;
+  avatarUrl: string | null;
+}
+
+/**
+ * Assemble the person-grouped result from the pieces the DB returned: drop
+ * followed DIDs that publish nothing, prefer the profile row for identity and
+ * fall back to whatever the publication carries, and rank by combined
+ * readership (handle breaks ties, so the order is stable between requests).
+ * Pure so it can be unit-tested without a DB.
+ */
+export function buildFriendPublishers({
+  followedDids,
+  publicationsByDid,
+  profiles,
+  appFollowedDids,
+}: {
+  followedDids: ReadonlyArray<string>;
+  publicationsByDid: ReadonlyMap<string, Array<PublicationCard>>;
+  profiles: ReadonlyMap<string, FriendProfileRow>;
+  appFollowedDids: ReadonlySet<string>;
+}): Array<FriendPublisher> {
+  const people: Array<FriendPublisher> = [];
+  for (const did of followedDids) {
+    const publications = publicationsByDid.get(did);
+    if (!publications || publications.length === 0) continue;
+    const profile = profiles.get(did);
+    people.push({
+      did,
+      handle: profile?.handle ?? publications[0]?.ownerHandle ?? null,
+      displayName: profile?.displayName ?? null,
+      avatarUrl: profile?.avatarUrl ?? publications[0]?.ownerAvatarUrl ?? null,
+      followedInApp: appFollowedDids.has(did),
+      publications,
+    });
+  }
+
+  people.sort((a, b) => {
+    const diff = totalReaders(b) - totalReaders(a);
+    if (diff !== 0) return diff;
+    return (a.handle ?? a.did).localeCompare(b.handle ?? b.did);
+  });
+
+  return people;
+}
+
+/**
+ * Publications authored by the Bluesky accounts `readerDid` follows.
+ *
+ * Grouped by person, because that's the unit the reader thinks in: "Anna
+ * writes here" rather than "here is a publication that happens to be Anna's".
+ * People are ordered by total readership across their publications.
+ */
+export async function friendPublishers(
+  db: Db,
+  schema: Schema,
+  readerDid: string,
+  opts: { candidateLimit?: number; limit?: number; offset?: number } = {},
+): Promise<FriendPublishers> {
+  const limit = opts.limit ?? FRIEND_PAGE_SIZE;
+  const offset = opts.offset ?? 0;
+
+  const graph =
+    readGraphCache(readerDid) ??
+    (await (async (): Promise<CachedGraph> => {
+      const candidateLimit = opts.candidateLimit ?? FRIEND_CANDIDATE_LIMIT;
+      // One past the cap, so "exactly full" is distinguishable from "overflowing".
+      const candidates = await candidateAuthorDids(
+        db,
+        schema,
+        candidateLimit + 1,
+      );
+      const truncated = candidates.length > candidateLimit;
+      const checked = truncated
+        ? candidates.slice(0, candidateLimit)
+        : candidates;
+
+      const { followed, failedBatches, batches } = await followedDidsForActor(
+        readerDid,
+        checked,
+      );
+      const fresh: CachedGraph = {
+        followedDids: [...followed],
+        degraded: failedBatches > 0 && batches > 0,
+        truncated,
+        at: Date.now(),
+      };
+      // A degraded sweep is a partial answer; don't pin it for ten minutes.
+      if (!fresh.degraded) writeGraphCache(readerDid, fresh);
+      return fresh;
+    })());
+
+  const { followedDids, degraded, truncated } = graph;
+  if (followedDids.length === 0) {
+    return { ...EMPTY_FRIEND_PUBLISHERS, degraded, truncated };
+  }
+
+  const uf = schema.userFollows;
+  const sub = schema.subscriptions;
+  const pr = schema.profiles;
+
+  const [byAuthor, appFollowRows, profileRows] = await Promise.all([
+    publicationsByAuthors(db, schema, followedDids),
+    db
+      .select({ did: uf.subjectDid })
+      .from(uf)
+      .where(
+        and(
+          eq(uf.followerDid, readerDid),
+          eq(uf.deleted, false),
+          inArray(uf.subjectDid, followedDids),
+        ),
+      ),
+    db
+      .select({
+        did: pr.did,
+        handle: pr.handle,
+        displayName: pr.displayName,
+        avatarUrl: pr.avatarUrl,
+      })
+      .from(pr)
+      .where(inArray(pr.did, followedDids)),
+  ]);
+
+  const people = buildFriendPublishers({
+    followedDids,
+    publicationsByDid: byAuthor,
+    profiles: new Map(profileRows.map((row) => [row.did, row])),
+    appFollowedDids: new Set(appFollowRows.map((row) => row.did)),
+  });
+
+  // Headline counts describe the whole match; only a page is serialized. 240
+  // people with their publication cards is half a megabyte of JSON otherwise.
+  const totalPeople = people.length;
+  const publicationCount = people.reduce(
+    (n, person) => n + person.publications.length,
+    0,
+  );
+  const page = people.slice(offset, offset + limit);
+  const nextOffset = offset + limit < totalPeople ? offset + limit : null;
+
+  const publicationUris = page.flatMap((person) =>
+    person.publications.map((pub) => pub.uri),
+  );
+  const subscribedRows =
+    publicationUris.length > 0
+      ? await db
+          .select({ uri: sub.publicationUri })
+          .from(sub)
+          .where(
+            and(
+              eq(sub.subscriberDid, readerDid),
+              eq(sub.deleted, false),
+              inArray(sub.publicationUri, publicationUris),
+            ),
+          )
+      : [];
+
+  return {
+    people: page,
+    totalPeople,
+    publicationCount,
+    nextOffset,
+    subscribedUris: [...new Set(subscribedRows.map((row) => row.uri))],
+    degraded,
+    truncated,
+  };
+}

--- a/src/server/reader/bsky-friends.ts
+++ b/src/server/reader/bsky-friends.ts
@@ -40,26 +40,29 @@ import { discoverEligiblePublicationWhere } from "#/server/reader/publication-fi
  */
 export const FRIEND_CANDIDATE_LIMIT = 5000;
 
-export interface FriendPublisher {
+/** A writer you follow, for the Discover prompt's avatar stack. */
+export interface FriendAuthor {
   did: string;
   handle: string | null;
-  displayName: string | null;
   avatarUrl: string | null;
-  /** True when the reader already follows this person *in Standard Reader*. */
-  followedInApp: boolean;
-  publications: Array<PublicationCard>;
 }
 
 export interface FriendPublishers {
-  /** This page of people. */
-  people: Array<FriendPublisher>;
-  /** Every matching person, not just this page — the headline count. */
-  totalPeople: number;
-  /** Total publications across every match — the headline count. */
+  /** This page of publications, ranked by readership. */
+  publications: Array<PublicationCard>;
+  /** Every matching publication, not just this page — the headline count. */
   publicationCount: number;
+  /** Distinct writers behind those publications — the headline count. */
+  totalPeople: number;
+  /** A few writers for the Discover prompt's avatar stack. */
+  previewAuthors: Array<FriendAuthor>;
   /** Offset for the next page, or `null` at the end. */
   nextOffset: number | null;
-  /** Publication URIs on this page the reader already subscribes to. */
+  /**
+   * Publications on this page the reader already subscribes to. Normally empty
+   * — subscriptions are filtered out server-side — but a row subscribed to
+   * during this visit stays put, so the client seeds its state from here.
+   */
   subscribedUris: Array<string>;
   /**
    * The Bluesky AppView didn't answer for at least one batch, so the result is
@@ -71,17 +74,21 @@ export interface FriendPublishers {
 }
 
 export const EMPTY_FRIEND_PUBLISHERS: FriendPublishers = {
-  people: [],
-  totalPeople: 0,
+  publications: [],
   publicationCount: 0,
+  totalPeople: 0,
+  previewAuthors: [],
   nextOffset: null,
   subscribedUris: [],
   degraded: false,
   truncated: false,
 };
 
-/** Default page size for `/friends`. */
-export const FRIEND_PAGE_SIZE = 12;
+/** Writers shown in the Discover prompt's avatar stack. */
+export const FRIEND_PREVIEW_AUTHORS = 4;
+
+/** Default page size for `/friends`. Matches the Discover directory. */
+export const FRIEND_PAGE_SIZE = 24;
 
 interface CachedGraph {
   followedDids: Array<string>;
@@ -221,66 +228,67 @@ async function publicationsByAuthors(
   return grouped;
 }
 
-/** Combined readership across everything a person publishes. */
-function totalReaders(person: FriendPublisher): number {
-  return person.publications.reduce((n, pub) => n + pub.subscriberCount, 0);
-}
-
-export interface FriendProfileRow {
-  did: string;
-  handle: string | null;
-  displayName: string | null;
-  avatarUrl: string | null;
-}
-
 /**
- * Assemble the person-grouped result from the pieces the DB returned: drop
- * followed DIDs that publish nothing, prefer the profile row for identity and
- * fall back to whatever the publication carries, and rank by combined
- * readership (handle breaks ties, so the order is stable between requests).
- * Pure so it can be unit-tested without a DB.
+ * Rank the publications written by people you follow. Ordered by readership so
+ * the best-known writing leads, with name and URI breaking ties so the order is
+ * stable between requests (and therefore between pages).
+ *
+ * Publications the reader already subscribes to are dropped: this is a page of
+ * things to discover, and a list of rows already marked "Subscribed" is just
+ * noise between the reader and what's new to them.
+ *
+ * A flat list, not a per-person grouping: the reader is picking publications to
+ * subscribe to, and every row already names its author. Pure so it can be
+ * unit-tested without a DB.
  */
-export function buildFriendPublishers({
-  followedDids,
-  publicationsByDid,
-  profiles,
-  appFollowedDids,
-}: {
-  followedDids: ReadonlyArray<string>;
-  publicationsByDid: ReadonlyMap<string, Array<PublicationCard>>;
-  profiles: ReadonlyMap<string, FriendProfileRow>;
-  appFollowedDids: ReadonlySet<string>;
-}): Array<FriendPublisher> {
-  const people: Array<FriendPublisher> = [];
+export function rankFriendPublications(
+  followedDids: ReadonlyArray<string>,
+  publicationsByDid: ReadonlyMap<string, Array<PublicationCard>>,
+  subscribedUris: ReadonlySet<string> = new Set(),
+): Array<PublicationCard> {
+  const publications: Array<PublicationCard> = [];
   for (const did of followedDids) {
-    const publications = publicationsByDid.get(did);
-    if (!publications || publications.length === 0) continue;
-    const profile = profiles.get(did);
-    people.push({
-      did,
-      handle: profile?.handle ?? publications[0]?.ownerHandle ?? null,
-      displayName: profile?.displayName ?? null,
-      avatarUrl: profile?.avatarUrl ?? publications[0]?.ownerAvatarUrl ?? null,
-      followedInApp: appFollowedDids.has(did),
-      publications,
-    });
+    const owned = publicationsByDid.get(did);
+    if (!owned) continue;
+    for (const pub of owned) {
+      if (subscribedUris.has(pub.uri)) continue;
+      publications.push(pub);
+    }
   }
 
-  people.sort((a, b) => {
-    const diff = totalReaders(b) - totalReaders(a);
-    if (diff !== 0) return diff;
-    return (a.handle ?? a.did).localeCompare(b.handle ?? b.did);
+  return publications.toSorted((a, b) => {
+    const readers = b.subscriberCount - a.subscriberCount;
+    if (readers !== 0) return readers;
+    const name = a.name.localeCompare(b.name);
+    if (name !== 0) return name;
+    return a.uri.localeCompare(b.uri);
   });
+}
 
-  return people;
+/** Distinct writers behind a ranked list, in the order they first appear. */
+export function friendAuthors(
+  publications: ReadonlyArray<PublicationCard>,
+  limit?: number,
+): Array<FriendAuthor> {
+  const seen = new Set<string>();
+  const authors: Array<FriendAuthor> = [];
+  for (const pub of publications) {
+    if (seen.has(pub.did)) continue;
+    seen.add(pub.did);
+    authors.push({
+      did: pub.did,
+      handle: pub.ownerHandle,
+      avatarUrl: pub.ownerAvatarUrl,
+    });
+    if (limit != null && authors.length >= limit) break;
+  }
+  return authors;
 }
 
 /**
- * Publications authored by the Bluesky accounts `readerDid` follows.
- *
- * Grouped by person, because that's the unit the reader thinks in: "Anna
- * writes here" rather than "here is a publication that happens to be Anna's".
- * People are ordered by total readership across their publications.
+ * Publications authored by the Bluesky accounts `readerDid` follows, ranked by
+ * readership and paged. Every card carries its owner's handle and avatar, so
+ * the author stays visible without grouping the list by person.
  */
 export async function friendPublishers(
   db: Db,
@@ -326,73 +334,34 @@ export async function friendPublishers(
     return { ...EMPTY_FRIEND_PUBLISHERS, degraded, truncated };
   }
 
-  const uf = schema.userFollows;
   const sub = schema.subscriptions;
-  const pr = schema.profiles;
 
-  const [byAuthor, appFollowRows, profileRows] = await Promise.all([
+  const [byAuthor, subscribedRows] = await Promise.all([
     publicationsByAuthors(db, schema, followedDids),
     db
-      .select({ did: uf.subjectDid })
-      .from(uf)
-      .where(
-        and(
-          eq(uf.followerDid, readerDid),
-          eq(uf.deleted, false),
-          inArray(uf.subjectDid, followedDids),
-        ),
-      ),
-    db
-      .select({
-        did: pr.did,
-        handle: pr.handle,
-        displayName: pr.displayName,
-        avatarUrl: pr.avatarUrl,
-      })
-      .from(pr)
-      .where(inArray(pr.did, followedDids)),
+      .select({ uri: sub.publicationUri })
+      .from(sub)
+      .where(and(eq(sub.subscriberDid, readerDid), eq(sub.deleted, false))),
   ]);
+  const subscribed = new Set(subscribedRows.map((row) => row.uri));
+  const ranked = rankFriendPublications(followedDids, byAuthor, subscribed);
 
-  const people = buildFriendPublishers({
-    followedDids,
-    publicationsByDid: byAuthor,
-    profiles: new Map(profileRows.map((row) => [row.did, row])),
-    appFollowedDids: new Set(appFollowRows.map((row) => row.did)),
-  });
-
-  // Headline counts describe the whole match; only a page is serialized. 240
-  // people with their publication cards is half a megabyte of JSON otherwise.
-  const totalPeople = people.length;
-  const publicationCount = people.reduce(
-    (n, person) => n + person.publications.length,
-    0,
-  );
-  const page = people.slice(offset, offset + limit);
-  const nextOffset = offset + limit < totalPeople ? offset + limit : null;
-
-  const publicationUris = page.flatMap((person) =>
-    person.publications.map((pub) => pub.uri),
-  );
-  const subscribedRows =
-    publicationUris.length > 0
-      ? await db
-          .select({ uri: sub.publicationUri })
-          .from(sub)
-          .where(
-            and(
-              eq(sub.subscriberDid, readerDid),
-              eq(sub.deleted, false),
-              inArray(sub.publicationUri, publicationUris),
-            ),
-          )
-      : [];
+  // Headline counts describe the whole match; only a page is serialized —
+  // 362 publication cards at once is half a megabyte of JSON otherwise.
+  const publicationCount = ranked.length;
+  const page = ranked.slice(offset, offset + limit);
+  const nextOffset = offset + limit < publicationCount ? offset + limit : null;
 
   return {
-    people: page,
-    totalPeople,
+    publications: page,
     publicationCount,
+    totalPeople: friendAuthors(ranked).length,
+    previewAuthors: friendAuthors(ranked, FRIEND_PREVIEW_AUTHORS),
     nextOffset,
-    subscribedUris: [...new Set(subscribedRows.map((row) => row.uri))],
+    // Every row on the page is unsubscribed by construction; the client seeds
+    // its follow-status cache from this so a page of rows costs no extra
+    // requests, and its own optimistic updates still win.
+    subscribedUris: [],
     degraded,
     truncated,
   };

--- a/src/server/reader/bsky-friends.ts
+++ b/src/server/reader/bsky-friends.ts
@@ -16,17 +16,22 @@
  */
 
 import { and, asc, desc, eq, exists, inArray, sql } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 
 import type {
+  ArticleCard,
   Db,
   PublicationCard,
   Schema,
 } from "#/integrations/tanstack-query/api-shapes";
 import {
+  articleCardColumns,
   publicationCardColumns,
+  toArticleCard,
   toPublicationCard,
 } from "#/integrations/tanstack-query/api-shapes";
 import { followedDidsForActor } from "#/server/atproto/bsky-relationships";
+import { documentPublishedNotInFuture } from "#/server/reader/document-filters";
 import { discoverEligiblePublicationWhere } from "#/server/reader/publication-filters";
 
 /**
@@ -89,6 +94,23 @@ export const FRIEND_PREVIEW_AUTHORS = 4;
 
 /** Default page size for `/friends`. Matches the Discover directory. */
 export const FRIEND_PAGE_SIZE = 24;
+
+/** Page size for the Articles tab. Matches the other chronological feeds. */
+export const FRIEND_ARTICLE_PAGE_SIZE = 20;
+
+export interface FriendArticles {
+  items: Array<ArticleCard>;
+  /** Offset for the next page, or `null` at the end. */
+  nextOffset: number | null;
+  /** See {@link FriendPublishers.degraded}. */
+  degraded: boolean;
+}
+
+export const EMPTY_FRIEND_ARTICLES: FriendArticles = {
+  items: [],
+  nextOffset: null,
+  degraded: false,
+};
 
 interface CachedGraph {
   followedDids: Array<string>;
@@ -286,19 +308,21 @@ export function friendAuthors(
 }
 
 /**
- * Publications authored by the Bluesky accounts `readerDid` follows, ranked by
- * readership and paged. Every card carries its owner's handle and avatar, so
- * the author stays visible without grouping the list by person.
+ * The publications behind both tabs of `/friends`: written by someone the
+ * reader follows on Bluesky, not already subscribed to, ranked by readership.
+ * Shared so the Articles tab describes exactly the same set as the
+ * Publications tab rather than a subtly different one.
  */
-export async function friendPublishers(
+async function resolveFriendPublications(
   db: Db,
   schema: Schema,
   readerDid: string,
-  opts: { candidateLimit?: number; limit?: number; offset?: number } = {},
-): Promise<FriendPublishers> {
-  const limit = opts.limit ?? FRIEND_PAGE_SIZE;
-  const offset = opts.offset ?? 0;
-
+  opts: { candidateLimit?: number } = {},
+): Promise<{
+  publications: Array<PublicationCard>;
+  degraded: boolean;
+  truncated: boolean;
+}> {
   const graph =
     readGraphCache(readerDid) ??
     (await (async (): Promise<CachedGraph> => {
@@ -331,7 +355,7 @@ export async function friendPublishers(
 
   const { followedDids, degraded, truncated } = graph;
   if (followedDids.length === 0) {
-    return { ...EMPTY_FRIEND_PUBLISHERS, degraded, truncated };
+    return { publications: [], degraded, truncated };
   }
 
   const sub = schema.subscriptions;
@@ -344,7 +368,36 @@ export async function friendPublishers(
       .where(and(eq(sub.subscriberDid, readerDid), eq(sub.deleted, false))),
   ]);
   const subscribed = new Set(subscribedRows.map((row) => row.uri));
-  const ranked = rankFriendPublications(followedDids, byAuthor, subscribed);
+
+  return {
+    publications: rankFriendPublications(followedDids, byAuthor, subscribed),
+    degraded,
+    truncated,
+  };
+}
+
+/**
+ * Publications authored by the Bluesky accounts `readerDid` follows, ranked by
+ * readership and paged. Every card carries its owner's handle and avatar, so
+ * the author stays visible without grouping the list by person.
+ */
+export async function friendPublishers(
+  db: Db,
+  schema: Schema,
+  readerDid: string,
+  opts: { candidateLimit?: number; limit?: number; offset?: number } = {},
+): Promise<FriendPublishers> {
+  const limit = opts.limit ?? FRIEND_PAGE_SIZE;
+  const offset = opts.offset ?? 0;
+
+  const {
+    publications: ranked,
+    degraded,
+    truncated,
+  } = await resolveFriendPublications(db, schema, readerDid, opts);
+  if (ranked.length === 0) {
+    return { ...EMPTY_FRIEND_PUBLISHERS, degraded, truncated };
+  }
 
   // Headline counts describe the whole match; only a page is serialized —
   // 362 publication cards at once is half a megabyte of JSON otherwise.
@@ -364,5 +417,79 @@ export async function friendPublishers(
     subscribedUris: [],
     degraded,
     truncated,
+  };
+}
+
+/**
+ * Recent articles from the same publications the Publications tab lists:
+ * written by people the reader follows on Bluesky, minus anything already
+ * subscribed to (those already arrive on Home). Chronological, newest first.
+ */
+export async function friendArticles(
+  db: Db,
+  schema: Schema,
+  readerDid: string,
+  opts: { candidateLimit?: number; limit?: number; offset?: number } = {},
+): Promise<FriendArticles> {
+  const limit = opts.limit ?? FRIEND_ARTICLE_PAGE_SIZE;
+  const offset = opts.offset ?? 0;
+
+  const { publications, degraded } = await resolveFriendPublications(
+    db,
+    schema,
+    readerDid,
+    opts,
+  );
+  if (publications.length === 0) {
+    return { ...EMPTY_FRIEND_ARTICLES, degraded };
+  }
+
+  const publicationUris = publications.map((pub) => pub.uri);
+  const d = schema.documents;
+  const p = schema.publications;
+  const pr = schema.profiles;
+  const pa = alias(schema.profiles, "pa");
+
+  const rows = await db
+    .select(articleCardColumns(schema))
+    .from(d)
+    .leftJoin(p, eq(p.uri, d.publicationUri))
+    .leftJoin(pr, eq(pr.did, p.did))
+    .leftJoin(pa, eq(pa.did, d.did))
+    .where(
+      and(
+        inArray(d.publicationUri, publicationUris),
+        eq(d.deleted, false),
+        documentPublishedNotInFuture(d),
+      ),
+    )
+    .orderBy(desc(d.publishedAt), desc(d.uri))
+    // One past the page so `nextOffset` never promises an empty page.
+    .limit(limit + 1)
+    .offset(offset);
+
+  const hasMore = rows.length > limit;
+  const items = rows
+    .slice(0, limit)
+    .filter(
+      (
+        row,
+      ): row is typeof row & {
+        uri: string;
+        did: string;
+        title: string;
+        publishedAt: Date;
+      } =>
+        row.uri != null &&
+        row.did != null &&
+        row.title != null &&
+        row.publishedAt != null,
+    )
+    .map((row) => toArticleCard({ ...row, featured: row.featured ?? false }));
+
+  return {
+    items,
+    nextOffset: hasMore ? offset + limit : null,
+    degraded,
   };
 }


### PR DESCRIPTION
Readers sign in with Bluesky already following people who publish on standard.site — and the app never told them. On my own account that's **240 people I follow, writing 362 publications**, none of which were surfaced anywhere.

## Surfaces

1. **Discover entry point** — a "Find your friends" strip above Trending with an overlapping avatar stack and a live count. Renders only when there's someone to show, matching how the neighbouring rails behave.
2. **`/friends`** — the destination. Person heading (avatar, name, handle, Follow) with their publications in a quieter well beneath, each carrying its own Subscribe state. Paginated at 12 people with infinite scroll.
3. **Onboarding** — a new `friends` step between topics and follow, showing the top 6 with a "N more…" line. Selection stays in-memory like the rest of the wizard; people running several publications get a "Select all".

## How the join works

Candidate-first: the read-model already knows every DID that publishes, so we ask the Bluesky AppView *"of these, which do I follow?"* via `app.bsky.graph.getRelationships` rather than paginating the reader's follow list. Cost tracks the size of the author set instead of the reader's follow count, and nothing about the Bluesky graph is stored.

Results group by person, because that's the unit the reader thinks in — "Anna writes here", not "here is a publication that happens to be Anna's". Following a person also auto-subscribes their future publications, which is what the person-level action is for.

## Sizing came from measurement

The first working version was **20s load, 556KB payload, 45,795px tall, 11,698 DOM nodes** — and carried a correctness bug: a 900-DID cap meant to bound the AppView calls was silently hiding two thirds of the network's **2,754** publishing authors.

Benchmarking showed the cap was solving a problem that didn't exist — 30 batched `getRelationships` calls take **260ms**. So:

- batches now run **concurrently** (8 at a time) instead of serially
- cap raised to **5,000** — full network coverage, `truncated: false`
- response **paginated**, with the per-reader graph sweep cached server-side so page two is DB-only
- candidate list **memoized process-wide** (identical for every reader, cost ~900ms)
- follow-status caches **seeded from the payload**, so a page of ten people doesn't fire twenty status requests

Result: **3.1s cold, 399ms warm, 36KB, 1,620 nodes.**

## Edge cases

- A dedicated wizard step rendering nobody would be a dead screen, so the welcome loader prefetches the lookup and the flow **skips the step when it's empty**, progress dots adjusting to match. A deep link to `?step=friends` with nothing to show moves on by itself.
- An unreachable AppView and a failed request both report **"couldn't check"** — never "nobody you follow publishes here". Partial sweeps aren't cached.
- Signed-out, long handles/display names, people with one vs. many publications, and the truncation ceiling all handled.

## Drive-by fix

`OnboardingPubRow` descriptions were clipped mid-word on a single line. The row is a `<button>` (inheriting `white-space: nowrap`) and StyleX doesn't emit the `-webkit-box-orient` the line clamp depended on. **Pre-existing on the current follow step** — this repairs both.

## Verification

Screenshotted signed-in at desktop light, desktop dark, and 390px mobile, plus both onboarding steps. Typecheck clean, oxlint clean, oxfmt applied, **276 tests pass** (5 new, covering ranking, tie-breaking, identity fallback, and dropping followed accounts that publish nothing), production build passes, i18n catalogs extracted (30 new messages × 9 locales).

## Worth a look

- **"Follow" vs "Subscribed"** reads a little oddly on a person whose only publication you already subscribe to. They are genuinely different records and the masthead dek explains it, but the labels sit close together.
- Route is `/friends`, copy is "Find your friends" — easy to swap for `/following` if you'd rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)