### PR TITLE
Center image alt text captions

### DIFF
--- a/src/components/reader/content/body-styles.ts
+++ b/src/components/reader/content/body-styles.ts
@@ -496,6 +496,7 @@ export const articleBodyStyles = stylex.create({
     lineHeight: 1.2,
     marginBottom: spacing["0"],
     marginTop: gap.md,
+    textAlign: "center",
   },
   gallery: {
     marginBottom: spacing["6"],


### PR DESCRIPTION
## Summary

Alt text rendered as a caption under images in the article body was left-aligned. This centers it.

## Details

Images in the article body are rendered by `ImageFigureView`, which places the alt text in a `<figcaption>` styled by `articleBodyStyles.imageCaption` in `body-styles.ts`. That style had no `textAlign`, so captions defaulted to left-aligned. Added `textAlign: "center"` so alt-text captions center under every image using this shared renderer.

Reported via the post at https://standard-reader.app/a/did:plc:d6qtcdrko52u3xicksm56igj/3mqvuqwfsy2on

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFnqyaR8CDG7AVrgPf47NF)_