### PR TITLE
Batch and rate-limit "mark all as read" writes

### DIFF
--- a/src/integrations/auth/restore-client.server.ts
+++ b/src/integrations/auth/restore-client.server.ts
@@ -1,4 +1,5 @@
-import { Client } from "@atcute/client";
+import { Client, retryFetchHandler } from "@atcute/client";
+import type { FetchHandler, FetchHandlerObject } from "@atcute/client";
 import type { Did } from "@atcute/lexicons";
 
 import {
@@ -6,6 +7,7 @@ import {
   restoreAppPasswordClient,
 } from "#/integrations/auth/app-password-session.server";
 import { restoreAtprotoSession } from "#/integrations/auth/atproto";
+import { logEvent } from "#/server/observability/log";
 
 /**
  * How long a restored client stays cached. The client is a stateless
@@ -88,18 +90,55 @@ export async function restoreAuthenticatedClient(
   }
 }
 
+/**
+ * Longest we'll sit on a rate-limited request before giving up. Every PDS call
+ * here is inside a user-facing request, so this bounds the latency a retry can
+ * add. `retryFetchHandler` treats an authoritative `Retry-After` longer than
+ * this as "don't retry" rather than "retry early", so we back off to the
+ * caller instead of hammering a window that hasn't reset.
+ */
+const PDS_RETRY_MAX_DELAY_MS = 10_000;
+
+/**
+ * Wrap a session handler so rate-limited PDS writes back off instead of failing
+ * outright. Delay comes from the server's own `Retry-After` / `RateLimit-Reset`
+ * when present, falling back to jittered exponential backoff.
+ *
+ * This matters most for batched writes (marking a large backlog read), where a
+ * single 429 previously discarded the whole atomic batch with nothing written.
+ */
+function withRateLimitRetry(
+  handler: FetchHandler | FetchHandlerObject,
+  did: Did,
+): FetchHandler {
+  return retryFetchHandler({
+    handler,
+    maxDelay: PDS_RETRY_MAX_DELAY_MS,
+    onRetry: (response, attempt, delay) => {
+      logEvent("atproto.pdsRetry", {
+        did,
+        status: response.status,
+        attempt,
+        delayMs: Math.round(delay),
+      });
+    },
+  });
+}
+
 async function restoreUncached(did: Did): Promise<Client | null> {
   if (isAppPasswordAuthEnabled()) {
     const appPasswordClient = await restoreAppPasswordClient(did);
     if (appPasswordClient) {
-      return new Client({ handler: appPasswordClient });
+      return new Client({
+        handler: withRateLimitRetry(appPasswordClient, did),
+      });
     }
     // App-password session missing/expired — fall through to OAuth.
   }
 
   const oauthSession = await restoreAtprotoSession(did);
   if (oauthSession) {
-    return new Client({ handler: oauthSession });
+    return new Client({ handler: withRateLimitRetry(oauthSession, did) });
   }
 
   return null;

--- a/src/server/atproto/repo-records.ts
+++ b/src/server/atproto/repo-records.ts
@@ -162,6 +162,13 @@ interface ApplyWriteResult {
   cid: string;
 }
 
+/**
+ * Per-request write cap for `com.atproto.repo.applyWrites`. The reference PDS
+ * rejects anything larger with `InvalidRequest`, so batches must be chunked
+ * below this regardless of how many records a caller wants to write.
+ */
+export const APPLY_WRITES_MAX_BATCH = 200;
+
 /** Atomically apply one or more repo writes (create / update / delete). */
 export async function repoApplyWrites(
   client: Client,

--- a/src/server/reader/mark-documents-read.test.ts
+++ b/src/server/reader/mark-documents-read.test.ts
@@ -1,0 +1,141 @@
+import type { Client } from "@atcute/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { APPLY_WRITES_MAX_BATCH } from "#/server/atproto/repo-records";
+import { markDocumentsRead } from "#/server/reader/mark-documents-read";
+
+vi.mock("#/server/ingest/tap-client", () => ({
+  ensureTracked: vi.fn(async () => null),
+}));
+
+interface RecordedWrite {
+  collection: string;
+  rkey: string;
+  value: { subject: string; createdAt: string };
+}
+
+function fakeClient(): {
+  client: Client;
+  batches: Array<Array<RecordedWrite>>;
+} {
+  const batches: Array<Array<RecordedWrite>> = [];
+  const client = {
+    post: async (_nsid: string, options: { input: { writes: unknown } }) => {
+      const writes = options.input.writes as Array<RecordedWrite>;
+      batches.push(writes);
+      return { ok: true as const, data: { results: writes.map(() => ({})) } };
+    },
+  };
+  return { client: client as unknown as Client, batches };
+}
+
+function uris(count: number): Array<string> {
+  return Array.from(
+    { length: count },
+    (_, i) => `at://did:plc:pub/site.standard.document/doc${i}`,
+  );
+}
+
+describe("markDocumentsRead", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("splits a backlog into batches within the applyWrites cap", async () => {
+    const { client, batches } = fakeClient();
+    const documentUris = uris(450);
+
+    const result = await markDocumentsRead({
+      client,
+      did: "did:plc:reader",
+      documentUris,
+      trackReading: true,
+    });
+
+    expect(batches.map((batch) => batch.length)).toEqual([200, 200, 50]);
+    expect(result.markedCount).toBe(450);
+    expect(result.documentUris).toEqual(documentUris);
+  });
+
+  it("writes every document exactly once across batches", async () => {
+    const { client, batches } = fakeClient();
+    const documentUris = uris(450);
+
+    await markDocumentsRead({
+      client,
+      did: "did:plc:reader",
+      documentUris,
+      trackReading: true,
+    });
+
+    const subjects = batches.flat().map((write) => write.value.subject);
+    expect(subjects).toEqual(documentUris);
+    expect(new Set(subjects).size).toBe(documentUris.length);
+    // Deterministic subject-derived rkeys — a re-mark must collide, not duplicate.
+    expect(new Set(batches.flat().map((write) => write.rkey)).size).toBe(
+      documentUris.length,
+    );
+  });
+
+  it("sends a single batch when the backlog fits the cap", async () => {
+    const { client, batches } = fakeClient();
+
+    await markDocumentsRead({
+      client,
+      did: "did:plc:reader",
+      documentUris: uris(APPLY_WRITES_MAX_BATCH),
+      trackReading: true,
+    });
+
+    expect(batches).toHaveLength(1);
+  });
+
+  it("keeps a partial failure's earlier batches durable", async () => {
+    const batches: Array<number> = [];
+    const client = {
+      post: async (_nsid: string, options: { input: { writes: unknown } }) => {
+        const writes = options.input.writes as Array<RecordedWrite>;
+        batches.push(writes.length);
+        if (batches.length === 2) {
+          // Shape matches @atcute's ClientResponseError input, which `ok()` throws on.
+          return {
+            ok: false as const,
+            status: 429,
+            headers: new Headers(),
+            data: {
+              error: "RateLimitExceeded",
+              message: "Rate Limit Exceeded",
+            },
+          };
+        }
+        return { ok: true as const, data: { results: writes.map(() => ({})) } };
+      },
+    };
+
+    await expect(
+      markDocumentsRead({
+        client: client as unknown as Client,
+        did: "did:plc:reader",
+        documentUris: uris(450),
+        trackReading: true,
+      }),
+    ).rejects.toThrow(/RateLimitExceeded/);
+
+    // Stopped at the failing batch rather than pressing on into the rate limit.
+    expect(batches).toEqual([200, 200]);
+  });
+
+  it("writes nothing when read tracking is disabled", async () => {
+    const { client, batches } = fakeClient();
+
+    const result = await markDocumentsRead({
+      client,
+      did: "did:plc:reader",
+      documentUris: uris(10),
+      trackReading: false,
+    });
+
+    expect(batches).toHaveLength(0);
+    expect(result.markedCount).toBe(0);
+  });
+});

--- a/src/server/reader/mark-documents-read.ts
+++ b/src/server/reader/mark-documents-read.ts
@@ -1,7 +1,11 @@
 import type { Client } from "@atcute/client";
 
 import { COLLECTION } from "#/lib/atproto/nsids";
-import { repoApplyWrites, subjectRkey } from "#/server/atproto/repo-records";
+import {
+  APPLY_WRITES_MAX_BATCH,
+  repoApplyWrites,
+  subjectRkey,
+} from "#/server/atproto/repo-records";
 import { ensureTracked } from "#/server/ingest/tap-client";
 
 export interface MarkDocumentsReadResult {
@@ -30,19 +34,34 @@ export async function markDocumentsRead(options: {
   }
 
   const createdAt = new Date().toISOString();
-  await repoApplyWrites(client, {
-    repo: did,
-    writes: documentUris.map((documentUri) => ({
-      $type: "com.atproto.repo.applyWrites#create",
-      collection: COLLECTION.read,
-      rkey: subjectRkey(documentUri),
-      value: {
-        $type: COLLECTION.read,
-        subject: documentUri,
-        createdAt,
-      },
-    })),
-  });
+
+  // `applyWrites` is atomic per request and capped server-side, so a large
+  // backlog has to go out as several sequential batches. Sequential (not
+  // parallel) keeps us inside the PDS rate limit — the client retries 429s with
+  // the server's own `Retry-After`, and firing N batches at once would just
+  // burn those retries against a window we've already exhausted.
+  const marked: Array<string> = [];
+  for (let i = 0; i < documentUris.length; i += APPLY_WRITES_MAX_BATCH) {
+    const batch = documentUris.slice(i, i + APPLY_WRITES_MAX_BATCH);
+    // A failure here propagates, but earlier batches are already durable on the
+    // PDS — read records are additive and keyed by subject, so a retry re-marks
+    // only what's still unread rather than duplicating work.
+    await repoApplyWrites(client, {
+      repo: did,
+      writes: batch.map((documentUri) => ({
+        $type: "com.atproto.repo.applyWrites#create",
+        collection: COLLECTION.read,
+        rkey: subjectRkey(documentUri),
+        value: {
+          $type: COLLECTION.read,
+          subject: documentUri,
+          createdAt,
+        },
+      })),
+    });
+    marked.push(...batch);
+  }
+
   await trackReaderRepo(did);
-  return { markedCount: documentUris.length, documentUris };
+  return { markedCount: marked.length, documentUris: marked };
 }

--- a/src/server/reader/queries.ts
+++ b/src/server/reader/queries.ts
@@ -625,6 +625,14 @@ export async function selectPublicationArticleCards(
   );
 }
 
+/**
+ * How many unread URIs a single "mark all as read" pass will claim when the
+ * caller doesn't specify. Callers that write these to the PDS batch them, so
+ * this is a throughput/latency choice rather than a protocol limit — a reader
+ * with a backlog deeper than this still needs more than one pass.
+ */
+const DEFAULT_UNREAD_URI_LIMIT = 200;
+
 /** Unread document AT-URIs for a reader, optionally scoped to publications
  * and/or followed users (union — matches the follow feed). */
 export async function selectUnreadDocumentUris(
@@ -643,7 +651,7 @@ export async function selectUnreadDocumentUris(
     publicationUris,
     followedUserDids,
     countOldPostsAsUnread,
-    limit = 100,
+    limit = DEFAULT_UNREAD_URI_LIMIT,
   } = opts;
   const hasFollowedUsers = (followedUserDids?.length ?? 0) > 0;
   if (publicationUris && publicationUris.length === 0 && !hasFollowedUsers) {


### PR DESCRIPTION
## Problem

"Mark all as read" silently marked only the **100 newest** unread posts.

`selectUnreadDocumentUris` defaulted to `limit = 100` and none of its four callers overrode it (`markPublicationAllRead`, `markFollowsAllUnreadRead`, and the two XRPC handlers). A reader with a 500-post backlog had to click five times.

Two things made it worse than a plain truncation:

- The call returned **success** — no error, nothing to retry.
- The client's optimistic update zeroes *every* unread counter regardless of what was written (`read-optimistic.ts`, `clearAllFollowingUnread: true`), so the UI showed "all read" and only reverted on a later refetch. The dialog copy — *"Every unread article in your subscriptions will be marked read"* — was false above 100.

### Evidence

Honeycomb, for the reporting user: two `reader.markPublicationAllRead` calls 65s apart, both `count=100`, both `ok=true`. 2 × 100 = 200 marked of ~500 → ~300 left, exactly what they reported.

The fingerprint is visible on other users' PDS repos too — back-to-back 100-record batches as someone clicks repeatedly to chew through a backlog:

```
2026-07-13T17:09:57.571Z  100 records
2026-07-13T17:10:20.963Z   41
2026-07-13T17:10:38.600Z  100
2026-07-13T17:11:07.159Z   43
```

Separately, `applyWrites` was all-or-nothing with no backoff. Honeycomb shows **19 `RateLimitExceeded` + 12 `InternalServerError`** on `markFollowsAllUnreadRead` in 7 days, each discarding a full 100-record batch with nothing written.

## Changes

- **Raise the default unread-URI limit to 200.**
- **Chunk `applyWrites`** below the PDS's 200-write per-request cap, so the limit is a throughput choice rather than a protocol constraint. Batches go out sequentially — parallel would just burn retries against a rate-limit window we'd already exhausted. Earlier batches stay durable if a later one fails; read records are additive and keyed by subject, so a retry re-marks only what's still unread.
- **Respect rate limits** by wrapping the session fetch handler in `@atcute/client`'s `retryFetchHandler`. Delay comes from the server's own `Retry-After` / `RateLimit-Reset`, falling back to jittered exponential backoff. `maxDelay` is capped at 10s to bound added latency on user-facing requests; retries log as `atproto.pdsRetry`.

## Tests

First tests for this path — batch splitting, exactly-once writes across batches, deterministic rkeys, partial-failure behavior, and the tracking-disabled case.

`oxlint` 0/0, `tsc` 0 errors, 282 tests pass.

## Note on remaining scope

**This reduces clicks, it does not eliminate them.** A 500-post backlog now takes 3 passes instead of 5. Fully fixing it means looping server-side until drained — the chunking and backoff here are the prerequisites for that, so it's a small follow-up. I kept this PR to the requested scope; happy to add the loop.

There's also a **separate unresolved issue**: for the reporting user, both `count=100` calls returned `ok=true` but **zero** read records landed on their PDS for that publication (50 records total, all organic, all distinct timestamps). Their calls took 183ms/249ms versus 1522–1939ms for other users' successful 100-record batches. One other DID shows the same fast-and-empty pattern. Mechanism not yet identified — worth its own investigation, since a user hitting it gets silent no-op writes regardless of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)