### PR TITLE
Extend "Recommended by @follow" to profiles, tags, and friends

### DIFF
--- a/src/integrations/tanstack-query/api-author.functions.ts
+++ b/src/integrations/tanstack-query/api-author.functions.ts
@@ -21,11 +21,15 @@ import {
   authorSubscriptions,
 } from "#/server/reader/queries";
 import type { AuthorProfileStats, AuthorReader } from "#/server/reader/queries";
+import { attachRecommendedByToArticles } from "#/server/reader/recommended-by";
+import { effectiveFollowSets } from "#/server/reader/saved-lists";
 
 import type {
   ArticleCard,
+  Db,
   ProfileSummary,
   PublicationCard,
+  Schema,
 } from "./api-shapes";
 import { dbMiddleware } from "./db-middleware";
 
@@ -194,6 +198,30 @@ function nextOffsetForPage(
   return next < total && fetched === limit ? next : null;
 }
 
+/**
+ * "Recommended by @follow" attribution for the *viewing* reader — the same
+ * signal shown on the feeds. Resolves the viewer's effective follow set and
+ * attaches it to the cards; a no-op (no query) when signed out or following no
+ * one. `excludeDid` drops one recommender: on a profile's Likes tab the cards
+ * are already framed as that profile's recommendations, so surfacing
+ * "Recommended by <that profile>" would be redundant — pass the profile owner
+ * to keep only *other* follows.
+ */
+async function attachViewerRecommendedBy(
+  db: Db,
+  schema: Schema,
+  viewerDid: string | null | undefined,
+  articles: Array<ArticleCard>,
+  excludeDid?: string | null,
+): Promise<Array<ArticleCard>> {
+  if (!viewerDid || articles.length === 0) return articles;
+  const { userDids } = await effectiveFollowSets(db, schema, viewerDid);
+  const followedUserDids = excludeDid
+    ? userDids.filter((recommender) => recommender !== excludeDid)
+    : userDids;
+  return attachRecommendedByToArticles(db, schema, followedUserDids, articles);
+}
+
 const getAuthorProfile = createServerFn({ method: "GET" })
   .middleware([dbMiddleware])
   .validator(authorInput)
@@ -278,6 +306,21 @@ const getAuthorProfile = createServerFn({ method: "GET" })
         span.set("recommendationCount", recommendationsPage.items.length);
         span.set("documentCount", documentsPage.items.length);
 
+        // "Recommended by @follow" for the viewer. Writing = this author's own
+        // posts (self-recommends are already excluded by the helper); Likes =
+        // posts this author recommended, so drop the author from the attribution
+        // to avoid the redundant "Recommended by <this profile>".
+        const [documentsWithRecs, recommendationsWithRecs] = await Promise.all([
+          attachViewerRecommendedBy(db, schema, viewerDid, documentsPage.items),
+          attachViewerRecommendedBy(
+            db,
+            schema,
+            viewerDid,
+            recommendationsPage.items,
+            did,
+          ),
+        ]);
+
         return {
           profile,
           stats,
@@ -300,14 +343,14 @@ const getAuthorProfile = createServerFn({ method: "GET" })
             readersPage.items.length,
             readersPage.total,
           ),
-          recommendations: recommendationsPage.items,
+          recommendations: recommendationsWithRecs,
           recommendationsNextOffset: nextOffsetForPage(
             0,
             data.activityLimit,
             recommendationsPage.items.length,
             recommendationsPage.total,
           ),
-          documents: documentsPage.items,
+          documents: documentsWithRecs,
           documentsNextOffset: nextOffsetForPage(
             0,
             data.activityLimit,
@@ -484,11 +527,26 @@ const getAuthorRecommendations = createServerFn({ method: "GET" })
         span.set("did", did);
         span.set("offset", data.offset);
 
-        const page = await authorRecommendations(db, schema, { ...data, did });
+        // Resolve the page and the viewer identity together — the follow-set
+        // lookup only needs the viewer's DID, not the page rows.
+        const [page, viewerDid] = await Promise.all([
+          authorRecommendations(db, schema, { ...data, did }),
+          getReaderDidForRequest(getRequest()),
+        ]);
         span.set("count", page.items.length);
 
+        // Likes tab: exclude the profile owner from the attribution (see
+        // {@link attachViewerRecommendedBy}).
+        const items = await attachViewerRecommendedBy(
+          db,
+          schema,
+          viewerDid,
+          page.items,
+          did,
+        );
+
         return {
-          items: page.items,
+          items,
           nextOffset: nextOffsetForPage(
             data.offset,
             data.limit,
@@ -512,11 +570,25 @@ const getAuthorDocuments = createServerFn({ method: "GET" })
         span.set("did", did);
         span.set("offset", data.offset);
 
-        const page = await authorDocuments(db, schema, { ...data, did });
+        // Resolve the page and the viewer identity together — the follow-set
+        // lookup only needs the viewer's DID, not the page rows.
+        const [page, viewerDid] = await Promise.all([
+          authorDocuments(db, schema, { ...data, did }),
+          getReaderDidForRequest(getRequest()),
+        ]);
         span.set("count", page.items.length);
 
+        // Writing tab: this author's own posts — the helper already drops
+        // self-recommends, so no owner exclusion needed here.
+        const items = await attachViewerRecommendedBy(
+          db,
+          schema,
+          viewerDid,
+          page.items,
+        );
+
         return {
-          items: page.items,
+          items,
           nextOffset: nextOffsetForPage(
             data.offset,
             data.limit,

--- a/src/integrations/tanstack-query/api-discover.functions.ts
+++ b/src/integrations/tanstack-query/api-discover.functions.ts
@@ -26,7 +26,11 @@ import {
   trendingPublications,
 } from "#/server/reader/queries";
 import { rotationSeed } from "#/server/reader/rail-rotation";
-import { effectiveFollowUris } from "#/server/reader/saved-lists";
+import { attachRecommendedByToArticles } from "#/server/reader/recommended-by";
+import {
+  effectiveFollowSets,
+  effectiveFollowUris,
+} from "#/server/reader/saved-lists";
 
 import type { Db, PublicationCard, Schema } from "./api-shapes";
 import { dbMiddleware } from "./db-middleware";
@@ -241,13 +245,26 @@ const getFriendArticles = createServerFn({ method: "GET" })
       span.set("signedIn", true);
       span.set("offset", data.offset);
 
-      const result = await friendArticles(db, schema, did, {
-        limit: data.limit,
-        offset: data.offset,
-      });
-      span.set("count", result.items.length);
+      // Fetch the friends' articles and the reader's follow set concurrently —
+      // the follow set only needs `did`, not the article rows.
+      const [result, followSets] = await Promise.all([
+        friendArticles(db, schema, did, {
+          limit: data.limit,
+          offset: data.offset,
+        }),
+        effectiveFollowSets(db, schema, did),
+      ]);
+      // "Recommended by @follow" attribution — the same follows signal as the
+      // feeds; a no-op (no query) when the reader follows no one.
+      const items = await attachRecommendedByToArticles(
+        db,
+        schema,
+        followSets.userDids,
+        result.items,
+      );
+      span.set("count", items.length);
       span.set("degraded", result.degraded);
-      return result;
+      return { ...result, items };
     }),
   );
 

--- a/src/integrations/tanstack-query/api-tag.functions.ts
+++ b/src/integrations/tanstack-query/api-tag.functions.ts
@@ -25,6 +25,8 @@ import {
   selectTagPublicationUris,
   tagDirectoryPublications,
 } from "#/server/reader/queries";
+import { attachRecommendedByToArticles } from "#/server/reader/recommended-by";
+import { effectiveFollowSets } from "#/server/reader/saved-lists";
 
 import type { ArticleCard, PublicationCard } from "./api-shapes";
 import { dbMiddleware } from "./db-middleware";
@@ -107,16 +109,33 @@ const getArticles = createServerFn({ method: "GET" })
       const countOldPostsAsUnread =
         did == null ? true : countOldPostsAsUnreadEnabled;
 
-      const rows = await selectArticleCards(db, schema, {
-        tag: data.tag,
-        discoverOnly: true,
-        limit: data.limit,
-        offset: data.offset,
-        readForDid: trackReading && did ? did : undefined,
-        countOldPostsAsUnread,
-      });
+      // The tag rows and the reader's follow set are independent reads (the
+      // follow set only needs `did`), so resolve them in one wave.
+      const [rows, followSets] = await Promise.all([
+        selectArticleCards(db, schema, {
+          tag: data.tag,
+          discoverOnly: true,
+          limit: data.limit,
+          offset: data.offset,
+          readForDid: trackReading && did ? did : undefined,
+          countOldPostsAsUnread,
+        }),
+        did ? effectiveFollowSets(db, schema, did) : Promise.resolve(null),
+      ]);
 
-      const withCounts = await attachCommentCountsToArticles(db, schema, rows);
+      // "Recommended by @follow" attribution — no-op (no query) for signed-out
+      // readers and readers who follow no one.
+      const withRecs = await attachRecommendedByToArticles(
+        db,
+        schema,
+        followSets?.userDids ?? [],
+        rows,
+      );
+      const withCounts = await attachCommentCountsToArticles(
+        db,
+        schema,
+        withRecs,
+      );
       const items = await attachSubscribedLabels(db, schema, did, withCounts);
       span.set("count", items.length);
 
@@ -200,31 +219,42 @@ const getTagPage = createServerFn({ method: "GET" })
       const countOldPostsAsUnread =
         did == null ? true : countOldPostsAsUnreadEnabled;
 
-      const [articleCount, publicationCount, content] = await Promise.all([
-        countTagArticles(db, schema, data.tag),
-        countTagPublications(db, schema, data.tag),
-        data.view === "feed"
-          ? selectArticleCards(db, schema, {
-              tag: data.tag,
-              discoverOnly: true,
-              limit: data.limit,
-              offset: data.offset,
-              readForDid: trackReading && did ? did : undefined,
-              countOldPostsAsUnread,
-            }).then((rows) => attachCommentCountsToArticles(db, schema, rows))
-          : tagDirectoryPublications(db, schema, {
-              tag: data.tag,
-              sort: data.sort,
-              limit: data.limit,
-              offset: data.offset,
-            }),
-      ]);
+      const [articleCount, publicationCount, content, followSets] =
+        await Promise.all([
+          countTagArticles(db, schema, data.tag),
+          countTagPublications(db, schema, data.tag),
+          data.view === "feed"
+            ? selectArticleCards(db, schema, {
+                tag: data.tag,
+                discoverOnly: true,
+                limit: data.limit,
+                offset: data.offset,
+                readForDid: trackReading && did ? did : undefined,
+                countOldPostsAsUnread,
+              }).then((rows) => attachCommentCountsToArticles(db, schema, rows))
+            : tagDirectoryPublications(db, schema, {
+                tag: data.tag,
+                sort: data.sort,
+                limit: data.limit,
+                offset: data.offset,
+              }),
+          data.view === "feed" && did
+            ? effectiveFollowSets(db, schema, did)
+            : Promise.resolve(null),
+        ]);
 
       span.set("articleCount", articleCount);
       span.set("publicationCount", publicationCount);
 
       if (data.view === "feed") {
-        const items = content as Array<ArticleCard>;
+        // "Recommended by @follow" attribution — no-op (no query) for signed-out
+        // readers and readers who follow no one.
+        const items = await attachRecommendedByToArticles(
+          db,
+          schema,
+          followSets?.userDids ?? [],
+          content as Array<ArticleCard>,
+        );
         span.set("count", items.length);
         return {
           articleCount,


### PR DESCRIPTION
Follow-up to #44. That PR surfaced the "Recommended by @follow" attribution on the home, latest, list, and publication feeds. This wires the same signal into the remaining article surfaces so it shows consistently wherever people you follow have recommended a post.

## Surfaces added

- **Profile pages** (`/u/$did`)
  - **Writing** tab — the author's own posts (the helper already drops self-recommends, so it only shows *other* follows).
  - **Likes** tab — posts that profile recommended. Since the tab is already framed as *their* recommendations, the profile owner is excluded from the attribution, so it only surfaces **other** follows who also recommended the post (never the redundant "Recommended by <this profile>").
  - Covers both the initial fan-out (`getAuthorProfile`) and pagination (`getAuthorDocuments`, `getAuthorRecommendations`).
- **Tag pages** (`/tag/$tag`) — the article feed (`getArticles`, `getTagPage` feed view).
- **Friends feed** (`/friends`) — the Articles tab (`getFriendArticles`).

## How

Each handler resolves the viewer's effective follow set (concurrently with the page query) and runs the existing single batched `attachRecommendedByToArticles` — the same helper and purpose-built partial `recommends (document_uri, recommender_did, created_at)` index the feeds already use. It's a no-op (no query) for signed-out readers and readers who follow no one, and the tag lookup is skipped on the publications tab.

No client changes: `ArticleRow` / `RecommendedByLine` already render the line when a card carries `recommendedBy`, so this is purely server-side data wiring.

## Intentionally left out

The reader's own queues (Saved / Likes / History — your own actions), Search (relevance-ranked, would be noise), digest emails / XRPC / feed-generator / extension (different render paths, would need schema/template work), and the collection editor.

## Verification

Typecheck, lint, and the full test suite (277 passing) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYb7APYcZcwqwPnphPEB2N

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYb7APYcZcwqwPnphPEB2N)_