### PR TITLE
Fail loudly when a PDS doesn't acknowledge applyWrites

### DIFF
--- a/src/server/atproto/repo-records.test.ts
+++ b/src/server/atproto/repo-records.test.ts
@@ -1,0 +1,98 @@
+import type { Client } from "@atcute/client";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ApplyWritesUnacknowledgedError,
+  repoApplyWrites,
+} from "#/server/atproto/repo-records";
+
+const logEvent = vi.hoisted(() => vi.fn());
+vi.mock("#/server/observability/log", () => ({ logEvent }));
+
+function clientReturning(data: unknown): Client {
+  return {
+    post: async () => ({ ok: true as const, data }),
+  } as unknown as Client;
+}
+
+function writes(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    $type: "com.atproto.repo.applyWrites#create" as const,
+    collection: "app.standard-reader.read",
+    rkey: `rkey${i}`,
+    value: { subject: `at://did:plc:pub/site.standard.document/doc${i}` },
+  }));
+}
+
+const result = (i: number) => ({
+  uri: `at://did:plc:reader/app.standard-reader.read/rkey${i}`,
+  cid: `cid${i}`,
+});
+
+describe("repoApplyWrites", () => {
+  it("returns a result per acknowledged write", async () => {
+    const client = clientReturning({
+      results: [0, 1, 2].map((i) => result(i)),
+    });
+
+    const results = await repoApplyWrites(client, {
+      repo: "did:plc:reader",
+      writes: writes(3),
+    });
+
+    expect(results).toHaveLength(3);
+    expect(results[0]).toEqual(result(0));
+  });
+
+  it("throws when the PDS acknowledges fewer writes than we sent", async () => {
+    // The observed failure: 2xx, no error, but nothing actually committed.
+    const client = clientReturning({ results: [] });
+
+    await expect(
+      repoApplyWrites(client, { repo: "did:plc:reader", writes: writes(100) }),
+    ).rejects.toThrow(ApplyWritesUnacknowledgedError);
+  });
+
+  it("reports how many writes went unacknowledged", async () => {
+    const client = clientReturning({ results: [0, 1].map((i) => result(i)) });
+
+    await repoApplyWrites(client, {
+      repo: "did:plc:reader",
+      writes: writes(5),
+    }).catch((error: unknown) => {
+      expect(error).toBeInstanceOf(ApplyWritesUnacknowledgedError);
+      const failure = error as ApplyWritesUnacknowledgedError;
+      expect(failure.requested).toBe(5);
+      expect(failure.acknowledged).toBe(2);
+    });
+
+    expect.assertions(3);
+  });
+
+  it("tolerates a PDS that omits results, but records it as unconfirmed", async () => {
+    logEvent.mockClear();
+    const client = clientReturning({});
+
+    const results = await repoApplyWrites(client, {
+      repo: "did:plc:reader",
+      writes: writes(10),
+    });
+
+    expect(results).toEqual([]);
+    expect(logEvent).toHaveBeenCalledWith("atproto.applyWritesUnconfirmed", {
+      repo: "did:plc:reader",
+      requested: 10,
+    });
+  });
+
+  it("maps malformed result rows to null without failing the batch", async () => {
+    const client = clientReturning({ results: [result(0), { bogus: true }] });
+
+    const results = await repoApplyWrites(client, {
+      repo: "did:plc:reader",
+      writes: writes(2),
+    });
+
+    expect(results).toEqual([result(0), null]);
+  });
+});

--- a/src/server/atproto/repo-records.ts
+++ b/src/server/atproto/repo-records.ts
@@ -22,6 +22,7 @@ import type { CollectionManifest } from "#/lib/collections/manifest";
 import { serializeCollectionManifestForRepo } from "#/lib/markpub/collection-fields.ts";
 import { listRepoRecords } from "#/server/atproto/fetch-record";
 import { buildAtUri } from "#/server/atproto/uri";
+import { logEvent } from "#/server/observability/log";
 
 export {
   collectionDocumentUri,
@@ -169,7 +170,30 @@ interface ApplyWriteResult {
  */
 export const APPLY_WRITES_MAX_BATCH = 200;
 
-/** Atomically apply one or more repo writes (create / update / delete). */
+/** Raised when a PDS returns success but acknowledges fewer writes than we sent. */
+export class ApplyWritesUnacknowledgedError extends Error {
+  readonly requested: number;
+  readonly acknowledged: number;
+
+  constructor(repo: string, requested: number, acknowledged: number) {
+    super(
+      `applyWrites acknowledged ${acknowledged} of ${requested} writes for ${repo}`,
+    );
+    this.name = "ApplyWritesUnacknowledgedError";
+    this.requested = requested;
+    this.acknowledged = acknowledged;
+  }
+}
+
+/**
+ * Atomically apply one or more repo writes (create / update / delete).
+ *
+ * A 2xx here is not by itself proof the writes committed: we have seen a PDS
+ * return success for a 100-record batch and commit nothing, with no error and
+ * no firehose event, which is indistinguishable from success to every caller
+ * downstream. So the response is checked against what we sent rather than
+ * assumed — see {@link ApplyWritesUnacknowledgedError}.
+ */
 export async function repoApplyWrites(
   client: Client,
   input: { repo: string; writes: Array<ApplyWriteOp> },
@@ -187,8 +211,32 @@ export async function repoApplyWrites(
     }),
   );
 
+  const rows = res.results;
+  if (rows == null) {
+    // `results` is optional in the lexicon and some PDS implementations omit it,
+    // so absence is not evidence of failure — but it does mean the write is
+    // unconfirmed. Record it so a PDS that silently drops writes is visible in
+    // telemetry instead of passing as success.
+    logEvent("atproto.applyWritesUnconfirmed", {
+      repo: input.repo,
+      requested: input.writes.length,
+    });
+    return [];
+  }
+
+  // A short `results` is the PDS telling us it did less than we asked. Fail
+  // loudly: the caller's retry is safe (writes are keyed by deterministic rkey)
+  // and a wrong "success" is worse than a visible error.
+  if (rows.length < input.writes.length) {
+    throw new ApplyWritesUnacknowledgedError(
+      input.repo,
+      input.writes.length,
+      rows.length,
+    );
+  }
+
   const results: Array<ApplyWriteResult | null> = [];
-  for (const row of res.results ?? []) {
+  for (const row of rows) {
     if (
       typeof row === "object" &&
       row !== null &&


### PR DESCRIPTION
Follow-up to #46 — the second issue found while investigating "Mark all as read".

## Problem

A 2xx from `applyWrites` was treated as proof the writes committed. It isn't.

One user's two 100-record batches returned `ok=true` and wrote **nothing**:

- `getRecord` probes on 40 deterministic rkeys: 0 found, 40 missing
- Their PDS holds 50 read records, all from single `putRecord` calls, `maxBatch=1` — no `applyWrites` has ever landed for them
- Postgres agrees exactly: 50 live reads, **0 deleted**, identical oldest/newest timestamps — so the firehose never saw a commit either

17 of 18 users who ran mark-all have healthy multi-record batches, across both Bluesky-hosted and self-hosted PDSes. This is one account on one host (`enoki.us-east.host.bsky.network`), and single-record `putRecord` works fine for them — so it isn't our batching logic.

## Why it stayed invisible

```ts
for (const row of res.results ?? []) { ... }
```

A response acknowledging nothing produced an empty array and no error. `markDocumentsRead` then reported `markedCount` as the count it *asked* for, never the count acknowledged. An accept-but-drop PDS was indistinguishable from success — which is why this sat in telemetry as `ok=true` rather than paging anyone.

## Changes

- **Throw `ApplyWritesUnacknowledgedError`** when `results` is present but shorter than the batch sent. Retrying is safe (writes are keyed by deterministic subject-derived rkeys), and a wrong "success" is worse than a visible error.
- **`results` is optional in the lexicon** and some PDS implementations legitimately omit it, so absence is logged as `atproto.applyWritesUnconfirmed` instead of failing. That distinction avoids false positives on conforming-but-terse PDSes — worth watching that event before tightening this further.

Scope is narrow: `repoApplyWrites` has exactly one caller.

## Tests

Acknowledged-write mapping, the short-`results` throw, the reported requested/acknowledged counts, the omitted-`results` path, and malformed rows.

`oxlint` 0/0, `tsc` 0 errors, 288 tests pass.

## What this does not do

**It detects the failure; it does not fix the PDS behaviour behind it.** The affected user will now get a visible error instead of a silent no-op — better, but they still can't mark that publication read. Root-causing `enoki` needs either a reproduction against that host or a retry from that account with the backoff from #46 in place, watching the response.

Worth noting the affected repo is unusually large (87 collections, 5100+ posts, 5100+ likes, 4027 blocks), which may or may not be related.

🤖 Generated with [Claude Code](https://claude.com/claude-code)