### PR TITLE
Fix Offprint content gaps: `#webMention` facets and `component` blocks

### DIFF
--- a/src/components/reader/content/renderers/offprint-component.tsx
+++ b/src/components/reader/content/renderers/offprint-component.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { createContext, use, useMemo } from "react";
+
+import { fetchOffprintComponent } from "#/lib/offprint/component";
+
+import type { ContentBlobContext } from "../types";
+// Recursive block renderer: a component's body is arbitrary Offprint content,
+// so it renders through the same switch that dispatched to it. The resulting
+// import cycle is safe — `StructuredBlockView` is a hoisted function
+// declaration and is only referenced at render time, never at module eval.
+import { StructuredBlockView } from "./structured-block-view";
+
+/**
+ * AT-URIs of the components currently being rendered, outermost first.
+ *
+ * Components are referenced by URI, so a publication can (accidentally) author
+ * one that embeds itself, or a pair that embed each other. Rendering those
+ * would recurse until the browser dies, so each level refuses to expand a URI
+ * already on the stack.
+ */
+const OffprintComponentStack = createContext<ReadonlyArray<string>>([]);
+
+/** Hard ceiling on nesting, independent of the cycle check — a deep but acyclic
+ * chain is still far more than any real newsletter footer needs. */
+const MAX_COMPONENT_DEPTH = 3;
+
+/**
+ * Renders `app.offprint.block.component` — a reusable snippet (newsletter
+ * footer, content warning) stored as its own `app.offprint.component` record
+ * and inlined by AT-URI.
+ *
+ * Fetched client-side rather than resolved at ingest because Offprint
+ * references components by URI specifically so edits cascade to every document
+ * embedding them; pinning the body into `content_json` would freeze that.
+ * Renders nothing until it resolves, and nothing if it can't — the snippet is
+ * supplementary, so a failed fetch should leave the article intact rather than
+ * show an error.
+ */
+export function OffprintComponentBlockView({
+  componentUri,
+}: {
+  componentUri: string;
+}) {
+  const stack = use(OffprintComponentStack);
+  const isCycle = stack.includes(componentUri);
+  const atDepthLimit = stack.length >= MAX_COMPONENT_DEPTH;
+  const enabled = Boolean(componentUri) && !isCycle && !atDepthLimit;
+
+  const { data: component } = useQuery({
+    queryKey: ["offprint-component", componentUri] as const,
+    queryFn: () => fetchOffprintComponent(componentUri),
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const nestedStack = useMemo(
+    () => [...stack, componentUri],
+    [stack, componentUri],
+  );
+
+  if (!enabled || !component) return null;
+
+  // Blobs inside the component live in the component's repo, which is not
+  // necessarily the document author's (a publication may embed a shared one).
+  const componentBlobContext: ContentBlobContext = { authorDid: component.did };
+
+  return (
+    <OffprintComponentStack.Provider value={nestedStack}>
+      {component.blocks.map((block, index) => (
+        <StructuredBlockView
+          key={index}
+          block={block}
+          blobContext={componentBlobContext}
+        />
+      ))}
+    </OffprintComponentStack.Provider>
+  );
+}

--- a/src/components/reader/content/renderers/shared/faceted-text.tsx
+++ b/src/components/reader/content/renderers/shared/faceted-text.tsx
@@ -348,7 +348,12 @@ function FacetSegment({
   const isUnderline = hasFacetKind(features, "underline");
   const isStrikethrough = hasFacetKind(features, "strikethrough");
   const isHighlight = hasFacetKind(features, "highlight");
-  const link = findFacetFeature(features, "link");
+  // Offprint's `#webMention` is a `#link` enriched with page metadata (`title`,
+  // `siteName`). Authors use it both inline and as a whole-paragraph label, and
+  // the plaintext already carries that metadata, so render it as a plain link.
+  const link =
+    findFacetFeature(features, "link") ??
+    findFacetFeature(features, "webMention");
   const didMention =
     findFacetFeature(features, "didMention") ??
     findFacetFeature(features, "mention");

--- a/src/components/reader/content/renderers/structured-block-view.tsx
+++ b/src/components/reader/content/renderers/structured-block-view.tsx
@@ -10,6 +10,7 @@ import type { StructuredRenderableBlock } from "#/lib/document/structured-conten
 import type { CodeHighlightsByScheme } from "#/lib/theme";
 
 import type { ContentBlobContext } from "../types";
+import { OffprintComponentBlockView } from "./offprint-component";
 import { PcktGalleryBlockView } from "./pckt-gallery";
 import { BlockquoteBlockView } from "./shared/blockquote-block";
 import { BskyPostEmbedView } from "./shared/bsky-post-embed";
@@ -172,6 +173,9 @@ export function StructuredBlockView({
           blobContext={blobContext}
         />
       );
+    }
+    case "offprintComponent": {
+      return <OffprintComponentBlockView componentUri={block.componentUri} />;
     }
     case "button": {
       return (

--- a/src/lib/document/structured-content/plaintext.ts
+++ b/src/lib/document/structured-content/plaintext.ts
@@ -72,6 +72,7 @@ export function plaintextLinesFromStructuredBlock(
     case "blueskyEmbed":
     case "iframe":
     case "gallery":
+    case "offprintComponent":
     case "unknown": {
       return [];
     }

--- a/src/lib/document/structured-content/types.ts
+++ b/src/lib/document/structured-content/types.ts
@@ -74,6 +74,13 @@ export type StructuredRenderableBlock =
       labels?: [string?, string?];
       alignment?: string;
     }
+  /**
+   * An `app.offprint.component` record inlined by AT-URI. Offprint references
+   * it by URI rather than strongRef so publication-wide edits (a newsletter
+   * footer, a content warning) cascade to every document embedding it — so it
+   * is resolved when read, not pinned at ingest.
+   */
+  | { kind: "offprintComponent"; componentUri: string }
   | { kind: "unknown"; blockType: string };
 
 export interface StructuredTableCell {

--- a/src/lib/offprint/blocks.test.ts
+++ b/src/lib/offprint/blocks.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { offprintBlocks } from "./blocks";
+import { OFFPRINT_BLOCK, OFFPRINT_CONTENT } from "./types";
+
+function content(items: Array<unknown>) {
+  return { $type: OFFPRINT_CONTENT, items };
+}
+
+const COMPONENT_URI =
+  "at://did:plc:vahtz72vqgetnz3cf4xsa7iv/app.offprint.component/3mqkdhog4nn2k";
+
+describe("offprintBlocks — component blocks", () => {
+  it("parses a component block into its AT-URI", () => {
+    const blocks = offprintBlocks(
+      content([{ $type: OFFPRINT_BLOCK.component, component: COMPONENT_URI }]),
+    );
+
+    expect(blocks).toEqual([
+      { kind: "offprintComponent", componentUri: COMPONENT_URI },
+    ]);
+  });
+
+  it("keeps components in document order alongside other blocks", () => {
+    const blocks = offprintBlocks(
+      content([
+        { $type: OFFPRINT_BLOCK.component, component: COMPONENT_URI },
+        { $type: OFFPRINT_BLOCK.heading, level: 1, plaintext: "Devlog" },
+        { $type: OFFPRINT_BLOCK.text, plaintext: "Body" },
+      ]),
+    );
+
+    expect(blocks.map((block) => block.kind)).toEqual([
+      "offprintComponent",
+      "heading",
+      "text",
+    ]);
+  });
+
+  // Rendering nothing beats an "unsupported block" placeholder: the reference
+  // is unusable either way, and the snippet is supplementary to the article.
+  it("drops a component block with a missing or blank reference", () => {
+    expect(
+      offprintBlocks(content([{ $type: OFFPRINT_BLOCK.component }])),
+    ).toEqual([]);
+    expect(
+      offprintBlocks(
+        content([{ $type: OFFPRINT_BLOCK.component, component: "   " }]),
+      ),
+    ).toEqual([]);
+  });
+
+  it("no longer reports components as an unsupported block type", () => {
+    const blocks = offprintBlocks(
+      content([{ $type: OFFPRINT_BLOCK.component, component: COMPONENT_URI }]),
+    );
+
+    expect(blocks.some((block) => block.kind === "unknown")).toBe(false);
+  });
+});

--- a/src/lib/offprint/blocks.ts
+++ b/src/lib/offprint/blocks.ts
@@ -266,6 +266,12 @@ function asRenderableBlock(value: unknown): StructuredRenderableBlock | null {
     };
   }
 
+  if (value.$type === OFFPRINT_BLOCK.component) {
+    const componentUri =
+      typeof value.component === "string" ? value.component.trim() : "";
+    return componentUri ? { kind: "offprintComponent", componentUri } : null;
+  }
+
   const blockType =
     typeof value.$type === "string" ? value.$type : "unknown block";
   return { kind: "unknown", blockType };

--- a/src/lib/offprint/component.ts
+++ b/src/lib/offprint/component.ts
@@ -1,0 +1,52 @@
+/**
+ * Offprint "components" — the `app.offprint.component` lexicon: a reusable
+ * block of content (a newsletter footer, a mature-content warning) that a
+ * publication authors once and inlines into many documents.
+ *
+ * Documents reference a component by AT-URI rather than strongRef, so edits
+ * cascade to every document embedding it. That means the record is resolved
+ * when the article is read — never pinned into `content_json` at ingest.
+ */
+
+import type { StructuredRenderableBlock } from "#/lib/document/structured-content/types";
+import { fetchRepoRecordWithFallback } from "#/server/atproto/fetch-record";
+import { parseAtUri } from "#/server/atproto/uri";
+
+import { offprintBlocks } from "./blocks";
+import { OFFPRINT_COMPONENT_COLLECTION } from "./types";
+
+export interface OffprintComponent {
+  /** The component body, parsed into the shared renderable block union. */
+  blocks: Array<StructuredRenderableBlock>;
+  /** Repo the component lives in — blob URLs in its body resolve against it. */
+  did: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Fetch and parse an `app.offprint.component` by AT-URI.
+ *
+ * Routes through `fetchRepoRecordWithFallback` (Slingshot first, PDS fallback)
+ * so it is safe to call from the browser, mirroring `fetchPcktGallery` and
+ * `fetchMiniPost`. Returns null for anything that isn't a component record, or
+ * whose body has no renderable blocks.
+ */
+export async function fetchOffprintComponent(
+  componentUri: string,
+): Promise<OffprintComponent | null> {
+  const parsed = parseAtUri(componentUri);
+  if (!parsed || parsed.collection !== OFFPRINT_COMPONENT_COLLECTION) {
+    return null;
+  }
+
+  const result = await fetchRepoRecordWithFallback(componentUri);
+  if (!isRecord(result?.value)) return null;
+
+  const blocks = offprintBlocks(result.value.content);
+  if (blocks.length === 0) return null;
+
+  return { blocks, did: parsed.did };
+}

--- a/src/lib/offprint/types.ts
+++ b/src/lib/offprint/types.ts
@@ -19,4 +19,8 @@ export const OFFPRINT_BLOCK = {
   imageCarousel: "app.offprint.block.imageCarousel",
   imageDiff: "app.offprint.block.imageDiff",
   mathBlock: "app.offprint.block.mathBlock",
+  component: "app.offprint.block.component",
 } as const;
+
+/** Reusable snippet record inlined by `app.offprint.block.component`. */
+export const OFFPRINT_COMPONENT_COLLECTION = "app.offprint.component";

--- a/src/lib/quote-highlight-text.ts
+++ b/src/lib/quote-highlight-text.ts
@@ -364,6 +364,7 @@ function appendStructuredRenderedText(
     case "image":
     case "iframe":
     case "gallery":
+    case "offprintComponent":
     case "unknown": {
       return;
     }

--- a/src/server/atproto/constellation.ts
+++ b/src/server/atproto/constellation.ts
@@ -120,6 +120,7 @@ export const CITATION_URL_PATHS = [
   ".content.pages[pub.leaflet.pages.linearDocument].blocks[pub.leaflet.pages.linearDocument#block].block.facets[].features[pub.leaflet.richtext.facet#link].uri",
   ".content.pages[pub.leaflet.pages.linearDocument].blocks[pub.leaflet.pages.linearDocument#block].block.children[pub.leaflet.blocks.unorderedList#listItem].content.facets[].features[pub.leaflet.richtext.facet#link].uri",
   ".content.items[app.offprint.block.text].facets[].features[app.offprint.richtext.facet#link].uri",
+  ".content.items[app.offprint.block.text].facets[].features[app.offprint.richtext.facet#webMention].uri",
   ".content.items[blog.pckt.block.text].facets[].features[blog.pckt.richtext.facet#link].uri",
   ".pages[pub.leaflet.pages.linearDocument].blocks[].block.facets[].features[pub.leaflet.richtext.facet#link].uri",
 ] as const;


### PR DESCRIPTION
Two kinds of Offprint content were silently disappearing from articles. Found by diffing Offprint's published lexicon (`did:plc:pgjkomf37an4czloay5zeth6`, 28 schemas) against our support, then surveying all **895 Offprint documents** in the DB:

| Gap | Uses | Symptom |
|---|---|---|
| `richtext.facet#webMention` | 46 across 12 docs | Links rendered as dead plain text |
| `block.component` | 5 across 3 docs | "Unsupported block" placeholder |

Everything else Offprint publishes was already supported.

---

## 1. `#webMention` facets rendered as dead text

[Reported example](https://standard-reader.app/a/did:plc:stznz7qsokto2345qtdzogjb/3mqhmom3dau23) — every item in the "Discovery" checklist should be a link.

**Cause:** facet features are matched by their `#suffix` (`shared/facets.ts`), which is namespace-agnostic — so Offprint's `#link`, `#bold`, `#italic`, and `#mention` all worked by accident of shared naming. `#webMention` matched nothing and fell through to the plain-text path.

**Fix:** a `#webMention` is a `#link` plus page metadata (`uri`, `title`, `siteName`). 17 of the 46 are used mid-sentence, so rendering them as preview cards would break those — and the plaintext already embeds the title and site name. So they render as plain links, reusing the existing `#link` path (which also gets them `SmartArticleLink` handling for free). Also added the matching constellation citation path so these count as backlinks.

## 2. `component` blocks dropped

`app.offprint.block.component` references an `app.offprint.component` record by AT-URI — a reusable snippet a publication authors once and embeds in many documents.

In one real case that snippet is a **mature-content warning**, so readers were missing a content advisory the author deliberately attached.

**Fix:** resolved client-side via Slingshot, mirroring pckt galleries/notes and leaflet polls. Deliberately *not* at ingest: Offprint references components by URI specifically so edits cascade to every embedding document, and pinning the body into `content_json` would freeze that.

A component's body is arbitrary Offprint content, so it renders through the same block switch that dispatched to it. Components can therefore reference each other, so each level refuses to expand a URI already on the render stack, with a depth ceiling as a backstop. Blobs resolve against the component's own repo, which isn't necessarily the document author's.

---

## Verification

Both driven end-to-end in a real browser against a local dev server, not just typechecked.

**webMention** — on the reported article, external links in the body went **3 → 12**; all 9 checklist items now resolve (`embedbsky.com`, `cheeseburger.world`, `juttu.app`, …). Prod still renders them as dead text, confirming the before state.

**component** — on [`3mpju4vorgq23`](https://standard-reader.app/a/did:plc:vahtz72vqgetnz3cf4xsa7iv/3mpju4vorgq23) (uses all 3 distinct components), confirmed all three `com.atproto.repo.getRecord` calls to Slingshot and all three snippets rendering in document order: the 🔞 content warning, the intro, and the closing note. Article text grew 3771 → 4508 chars. No console errors.

`oxfmt`, `oxlint`, `tsc --noEmit`, and `vitest run src/lib` (19 files / 125 tests) all clean. Added `src/lib/offprint/blocks.test.ts` covering component parsing.

## Notes / follow-ups

- The added constellation path only matches facets on top-level `text` blocks. The links in the reported article live inside `taskList` children, so they still won't be indexed as citations — this already applied to `#link`, and fixing it needs list-child path variants I'd want to confirm against constellation's path syntax first.
- Component bodies aren't in `text_content`, so they're not searchable and don't count toward reading time. Same tradeoff as pckt galleries and leaflet polls.
- **Bluesky embeds were also reported broken; they aren't.** `blueskyPost` parses and renders fine (verified on prod with a doc containing 3). But `bsky-post-embed.tsx` passes `components={{ PostNotFound: () => <></> }}`, so a deleted or unavailable post renders as *nothing at all* — indistinguishable from a bug. That's the likely source of the report. Left alone here; worth a follow-up to show a fallback link instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)