### PR TITLE
Align task-list checkboxes with the text they label

### DIFF
--- a/src/components/reader/content/body-styles.ts
+++ b/src/components/reader/content/body-styles.ts
@@ -26,12 +26,23 @@ import { readingCustomFontFamily } from "#/lib/reading-typography";
  */
 export const IFRAME_FRAME_BORDER_WIDTH = 1;
 
+/**
+ * Line height of the article reading column. Shared so that anything which
+ * has to align to a line of body copy — task-list checkboxes, hanging
+ * markers — can do the arithmetic against the same number instead of
+ * hard-coding a second copy that silently drifts.
+ */
+const READING_LINE_HEIGHT = 1.68;
+
+/** Edge length of a task-list checkbox, relative to the reading font size. */
+const TASK_CHECKBOX_SIZE = "0.75em";
+
 export const articleBodyStyles = stylex.create({
   body: {
     color: uiColor.text2,
     fontFamily: fontFamily.serif,
     fontSize: { default: "1.1875rem", "@media (min-width: 40rem)": "1.25rem" },
-    lineHeight: 1.68,
+    lineHeight: READING_LINE_HEIGHT,
     marginTop: spacing["9"],
     minWidth: 0,
   },
@@ -649,7 +660,7 @@ export const articleBodyStyles = stylex.create({
     flexDirection: "column",
     fontFamily: fontFamily.serif,
     fontSize: { default: "1.1875rem", "@media (min-width: 40rem)": "1.25rem" },
-    lineHeight: 1.68,
+    lineHeight: READING_LINE_HEIGHT,
     paddingBottom: spacing["4"],
     paddingInlineStart: spacing["4"],
     paddingInlineEnd: spacing["4"],
@@ -716,15 +727,39 @@ export const articleBodyStyles = stylex.create({
     paddingInlineStart: spacing["0"],
   },
   taskItem: {
-    gap: gap.sm,
+    gap: gap.md,
     alignItems: "flex-start",
     display: "flex",
     marginBottom: gap.sm,
     marginTop: spacing["0"],
   },
+  /**
+   * Sized and centred against the reading type rather than the browser
+   * default. A bare checkbox is ~13px at whatever font-size the UA gives an
+   * `input`, so at the article's reading rhythm the old fixed `margin-top`
+   * left it floating near the top of the line box, well above the letterforms
+   * it labels. `font-size: inherit` makes `em` and `lh` resolve against the
+   * reading size, so the box scales with the reader's type preference and
+   * centres on its item's first line at any size. `lh` is the accurate unit
+   * but is unsupported in older Safari, hence the `em` fallback computed from
+   * the same line height the body uses.
+   *
+   * `line-height: inherit` is load-bearing, not tidiness: the UA sets
+   * `line-height: normal` on `input`, so without it `1lh` resolves against the
+   * control's own ~1.2 normal rather than the reading column's, and the box
+   * lands 7px high — the original bug.
+   */
   taskCheckbox: {
+    accentColor: primaryColor.solid1,
     flexShrink: 0,
-    marginTop: spacing["1"],
+    fontSize: "inherit",
+    lineHeight: "inherit",
+    blockSize: TASK_CHECKBOX_SIZE,
+    inlineSize: TASK_CHECKBOX_SIZE,
+    marginTop: stylex.firstThatWorks(
+      `calc((1lh - ${TASK_CHECKBOX_SIZE}) / 2)`,
+      `calc((${READING_LINE_HEIGHT}em - ${TASK_CHECKBOX_SIZE}) / 2)`,
+    ),
   },
   unknownBlock: {
     borderColor: uiColor.border1,


### PR DESCRIPTION
Task-list indicators sat ~7px above their own text, reading as detached from the item rather than as its marker.

Spotted on [this article](https://standard-reader.app/a/did:plc:stznz7qsokto2345qtdzogjb/3mqhmom3dau23).

## What was wrong

- The checkbox carried a hardcoded `margin-top: 4px`, but the reading column runs at line-height 1.68 — a 20px item has a **33.6px line box** and needs ~9.3px to centre.
- The control was stuck at the browser-default **12px** against 20px serif body copy, so it neither aligned nor scaled with the reader's typography preference.

The root cause only surfaced in the browser: the UA sets `line-height: normal` on `input`, which **breaks inheritance**. A first pass at `calc((1lh - 0.75em) / 2)` still computed wrong because `1lh` resolved against the control's own ~1.2 normal instead of the reading column's 1.68 — landing the box back within a pixel of where it started. `line-height: inherit` is what makes the math work, so it's called out in the comment to keep it from being tidied away later.

## The fix

One shared style, so this corrects both the Offprint (`structured-views.tsx`) and Pocket (`pckt-list.tsx`) renderers:

- Centre on the item's first line via `calc((1lh - 0.75em) / 2)`, with an `em` fallback for older Safari, which lacks `lh`.
- Size at `0.75em` with `font-size: inherit`, so the box scales with the reader's type preference.
- Extract `READING_LINE_HEIGHT` so that fallback can't drift from the body it aligns to, and point the two existing body definitions at it.
- Item gap 6px → 8px, landing the text flush with the 312px indent bullet and ordered lists already use.
- `accent-color` on the brand camel, so checked items stop rendering in system blue on a warm editorial page.

## Verification

`tsc` clean, oxlint 0 errors, oxfmt clean.

Geometry confirmed in-browser: checkbox centre at **16.797px** against the **16.8px** line-box centre.

One caveat: I verified by injecting the equivalent CSS onto prod rather than rendering a local build of the compiled StyleX output — the declarations are identical, but the compiled result itself is unconfirmed. Worth a glance on the preview deploy.

Unrelated: the design hook flags `pullquote`'s `font-size: 1.6875rem` as off the DESIGN.md type ramp. Pre-existing and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
