### PR TITLE
Highlight the whole discussion post card on hover

### DIFF
--- a/src/components/reader/comments/comment-card.tsx
+++ b/src/components/reader/comments/comment-card.tsx
@@ -224,7 +224,24 @@ export function CommentCard({ comment }: { comment: DocumentComment }) {
   );
 
   return (
-    <div {...stylex.props(commentStyles.card)}>
+    <div
+      {...stylex.props(
+        commentStyles.card,
+        hasLink && commentStyles.cardLinked,
+      )}
+    >
+      {hasLink ? (
+        // Stretched overlay link — a sibling of the header and facet links,
+        // not their ancestor, so no nested <a>. Covers the whole card so the
+        // hover highlight (`cardLinked`, above) matches the click target.
+        <a
+          href={comment.postUrl}
+          target="_blank"
+          rel="noreferrer"
+          aria-label={t`Open this reply on Bluesky`}
+          {...stylex.props(commentStyles.cardBodyOverlay)}
+        />
+      ) : null}
       <div {...stylex.props(commentStyles.cardHeader)}>
         <AuthorProfileLink
           authorRef={comment.author.did}
@@ -253,22 +270,7 @@ export function CommentCard({ comment }: { comment: DocumentComment }) {
         </time>
       </div>
 
-      {hasLink ? (
-        <div {...stylex.props(commentStyles.cardBody)}>
-          {/* Stretched overlay link — a sibling of the facet links, not their
-              ancestor, so no nested <a>. */}
-          <a
-            href={comment.postUrl}
-            target="_blank"
-            rel="noreferrer"
-            aria-label={t`Open this reply on Bluesky`}
-            {...stylex.props(commentStyles.cardBodyOverlay)}
-          />
-          {body}
-        </div>
-      ) : (
-        <div {...stylex.props(commentStyles.cardBody)}>{body}</div>
-      )}
+      <div {...stylex.props(commentStyles.cardBody)}>{body}</div>
     </div>
   );
 }

--- a/src/components/reader/comments/comment-card.tsx
+++ b/src/components/reader/comments/comment-card.tsx
@@ -225,10 +225,7 @@ export function CommentCard({ comment }: { comment: DocumentComment }) {
 
   return (
     <div
-      {...stylex.props(
-        commentStyles.card,
-        hasLink && commentStyles.cardLinked,
-      )}
+      {...stylex.props(commentStyles.card, hasLink && commentStyles.cardLinked)}
     >
       {hasLink ? (
         // Stretched overlay link — a sibling of the header and facet links,

--- a/src/components/reader/comments/comments-styles.ts
+++ b/src/components/reader/comments/comments-styles.ts
@@ -34,6 +34,7 @@ export const commentStyles = stylex.create({
     marginTop: verticalSpace.lg,
   },
   card: {
+    position: "relative",
     borderColor: uiColor.border1,
     borderRadius: radius.sm,
     borderStyle: "solid",
@@ -47,39 +48,32 @@ export const commentStyles = stylex.create({
     paddingInlineEnd: horizontalSpace.lg,
     paddingTop: verticalSpace.lg,
   },
-  // A plain container (not a link) with a stretched overlay link below. The
-  // "open post" affordance must not wrap the in-body facet links — a nested
-  // <a> is invalid HTML and breaks hydration.
-  cardBody: {
-    position: "relative",
-    borderRadius: radius.sm,
+  // Only comments that link out to the original post get the hover affordance
+  // — the stretched overlay link covers the whole card, so the highlight
+  // should too, not just the text below the byline.
+  cardLinked: {
     backgroundColor: {
-      default: "transparent",
+      default: uiColor.component1,
       ":hover": uiColor.component2,
     },
-    color: "inherit",
-    display: "block",
     transitionDuration: animationDuration.fast,
     transitionProperty: "background-color",
-    marginInlineStart: `calc(-1 * ${horizontalSpace.lg})`,
-    marginInlineEnd: `calc(-1 * ${horizontalSpace.lg})`,
-    paddingBottom: verticalSpace.lg,
-    paddingInlineStart: horizontalSpace.lg,
-    paddingInlineEnd: horizontalSpace.lg,
-    paddingTop: verticalSpace.md,
   },
-  // Full-card "open the post" link. Sits above the body text (a click anywhere
-  // opens the post) but below the facet links, which lift themselves above it.
+  cardBody: {
+    color: "inherit",
+    display: "block",
+  },
+  // Full-card "open the post" link. Sits above the card background but below
+  // the header and facet links, which lift themselves above it.
   cardBodyOverlay: {
     position: "absolute",
-    top: 0,
-    insetInlineEnd: 0,
-    bottom: 0,
-    insetInlineStart: 0,
-    borderRadius: radius.sm,
+    inset: 0,
+    borderRadius: "inherit",
     zIndex: 0,
   },
   cardHeader: {
+    position: "relative",
+    zIndex: 1,
     alignItems: "center",
     columnGap: gap.md,
     display: "flex",


### PR DESCRIPTION
Discussion: at://did:plc:f4os2wz5fjl56xpwcvtnqu7m/app.userinput.discussion/3mqzrcyajll2e

## Original request

> Title: The hover bg on posts doesnt make sense
>
> see in the pic how its just some random area. i would expect the whole card to have the bg, not just the content area

## What I found

The "posts" the reporter means are the Bluesky reply cards in the article discussion section (`CommentCard` in `src/components/reader/comments/comment-card.tsx` — the cards that show "on Bluesky", replies, etc. under an article).

That card is split into two DOM regions: a header (avatar/name/timestamp, linking to the author's profile) and a body (quote/commentary/footer, with a stretched overlay `<a>` that opens the post on Bluesky). The hover background was only ever applied to the body — via a negative-margin bleed trick meant to make the highlight reach the card's edges — so hovering anywhere in the top third of the card (the avatar/name row) showed no highlight at all, and the highlighted rectangle looked like it started at an arbitrary point partway down the card. That's the "random area" in the screenshot.

The reporter's fix ("whole card should have the bg") is correct and is what I implemented: the hover background and the stretched "open post" link now both live on the outer card container, with the header lifted above the overlay via `z-index` so the author-profile link stays independently clickable. I scoped the hover affordance to comments that actually have an outbound post link (`hasLink`) — previously the body's hover style fired even when there was nothing to click, which was its own small pre-existing inconsistency.

## Testing

- `pnpm build && pnpm lint && pnpm typecheck && pnpm test` all pass.
- Verified against the actual compiled StyleX output (not just source) that the card gets `position: relative` + a hover `background-color`, the overlay link is `position: absolute; inset: 0` at `z-index: 0`, and the header sits at `z-index: 1` above it — confirming the whole-card highlight and click target line up. Couldn't exercise this in a live browser since the sandbox has no `DATABASE_URL`/seed data to render real discussion comments.


---
_Generated by [Claude Code](https://claude.ai/code/session_018zpxb55dqjgfC4kGmnoDdJ)_