### PR TITLE
Stop inferring wrong announcement posts for Discussion

### DIFF
--- a/src/server/atproto/bsky-posts.test.ts
+++ b/src/server/atproto/bsky-posts.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { inferAuthorAnnouncementPostUri } from "./bsky-posts";
+
+const DID = "did:plc:fip3nyk6tjo3senpq4ei2cxw";
+const ARTICLE_URL = "https://example.com/some-article";
+const PUBLISHED_AT = new Date("2026-07-15T12:00:00.000Z");
+
+function feedPost({
+  rkey,
+  createdAt,
+  replyCount = 0,
+  linkUri,
+}: {
+  rkey: string;
+  createdAt: string;
+  replyCount?: number;
+  linkUri?: string;
+}) {
+  return {
+    post: {
+      uri: `at://${DID}/app.bsky.feed.post/${rkey}`,
+      cid: `cid-${rkey}`,
+      author: { did: DID, handle: "author.example", displayName: null },
+      record: {
+        text: "hello",
+        createdAt,
+        ...(linkUri
+          ? {
+              facets: [
+                {
+                  features: [
+                    { $type: "app.bsky.richtext.facet#link", uri: linkUri },
+                  ],
+                },
+              ],
+            }
+          : {}),
+      },
+      replyCount,
+      likeCount: 0,
+      indexedAt: createdAt,
+    },
+  };
+}
+
+function mockFeedResponse(feed: Array<unknown>) {
+  return {
+    ok: true,
+    json: async () => ({ feed }),
+  } as Response;
+}
+
+describe("inferAuthorAnnouncementPostUri", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Regression test: a linkblog entry with no matching announcement post
+  // previously fell back to the author's most-replied unrelated post in the
+  // publish window, surfacing that post's replies as the document's
+  // Discussion.
+  it("does not fall back to an unrelated post just because it has many replies", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockFeedResponse([
+          feedPost({
+            rkey: "unrelated-popular",
+            createdAt: "2026-07-14T12:00:00.000Z",
+            replyCount: 200,
+          }),
+        ]),
+      ),
+    );
+
+    const uri = await inferAuthorAnnouncementPostUri(DID, PUBLISHED_AT, [
+      ARTICLE_URL,
+    ]);
+
+    expect(uri).toBeNull();
+  });
+
+  it("picks the post that actually links the article URL", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockFeedResponse([
+          feedPost({
+            rkey: "unrelated-popular",
+            createdAt: "2026-07-14T12:00:00.000Z",
+            replyCount: 200,
+          }),
+          feedPost({
+            rkey: "the-announcement",
+            createdAt: "2026-07-15T13:00:00.000Z",
+            replyCount: 1,
+            linkUri: ARTICLE_URL,
+          }),
+        ]),
+      ),
+    );
+
+    const uri = await inferAuthorAnnouncementPostUri(DID, PUBLISHED_AT, [
+      ARTICLE_URL,
+    ]);
+
+    expect(uri).toBe(`at://${DID}/app.bsky.feed.post/the-announcement`);
+  });
+});

--- a/src/server/atproto/bsky-posts.ts
+++ b/src/server/atproto/bsky-posts.ts
@@ -176,7 +176,6 @@ const AUTHOR_FEED_PAGE_SIZE = 100;
 const AUTHOR_FEED_MAX_PAGES = 40;
 const ANNOUNCEMENT_WINDOW_BEFORE_MS = 14 * 24 * 60 * 60 * 1000;
 const ANNOUNCEMENT_WINDOW_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
-const MIN_INFERRED_ANNOUNCEMENT_REPLIES = 5;
 
 function normalizeLinkTarget(url: string): string {
   try {
@@ -308,8 +307,12 @@ async function fetchAuthorFeedPage(
 
 /**
  * When a document has no `bskyPostRef`, infer the author's announcement post
- * by scanning their top-level feed around `publishedAt`. Prefer posts that link
- * the article URL; otherwise pick the highest-reply post in the window.
+ * by scanning their top-level feed around `publishedAt` for a post that
+ * actually links the article URL (via facet or embed). We deliberately do
+ * *not* fall back to "most-replied post in the window" when no post links
+ * the URL — that heuristic surfaces a prolific author's unrelated popular
+ * post (and its replies) as the document's Discussion, which is worse than
+ * showing no inferred announcement at all.
  */
 export async function inferAuthorAnnouncementPostUri(
   did: string,
@@ -325,7 +328,6 @@ export async function inferAuthorAnnouncementPostUri(
   const windowEnd = publishedAt.getTime() + ANNOUNCEMENT_WINDOW_AFTER_MS;
 
   let urlLinkedBest: AuthorFeedPostCandidate | null = null;
-  let replyBest: AuthorFeedPostCandidate | null = null;
   let cursor: string | undefined;
   let reachedWindowStart = false;
 
@@ -350,18 +352,11 @@ export async function inferAuthorAnnouncementPostUri(
       ) {
         urlLinkedBest = candidate;
       }
-
-      if (
-        candidate.replyCount >= MIN_INFERRED_ANNOUNCEMENT_REPLIES &&
-        (!replyBest || candidate.replyCount > replyBest.replyCount)
-      ) {
-        replyBest = candidate;
-      }
     }
 
     cursor = feedPage.cursor;
     if (!cursor) break;
   }
 
-  return urlLinkedBest?.uri ?? replyBest?.uri ?? null;
+  return urlLinkedBest?.uri ?? null;
 }


### PR DESCRIPTION
Discussion: at://did:plc:fip3nyk6tjo3senpq4ei2cxw/app.userinput.discussion/3mqztfieemi2s

## Original request (quoted verbatim)

> Title: Linkblog from Skyreader having wrong Bluesky posts as Discussions
>
> You can se it happening here as example: https://standard-reader.app/a/did:plc:fip3nyk6tjo3senpq4ei2cxw/mrqfnc0k6jvkp9kly3
>
> The posts are all replies to this (completely unrelated) post of mine: https://bsky.app/profile/did:plc:fip3nyk6tjo3senpq4ei2cxw/post/3mqltqn6dr22i
>
> More Linkblogs from other people that have the same problem to help investigate the reason:
> - https://standard-reader.app/p/did:plc:6ayddqghxhciedbaofoxkcbs/skyreader-links
> - https://standard-reader.app/p/did:plc:2cxgdrgtsmrbqnjkwyplmp43/skyreader-links

## What I found

The document's Discussion feed is built in `fetchDocumentComments` (`src/server/reader/document-comments.ts`). When a `site.standard.document` has no stored `bskyPostRef`, it falls back to `inferAuthorAnnouncementPostUri` (`src/server/atproto/bsky-posts.ts`), which scans the author's Bluesky feed in a ±(14 days before / 7 days after) window around `publishedAt` looking for the post that announced the article.

That inference had two tiers:
1. Prefer a post in the window whose facets/embed actually link the article's URL.
2. **Fall back to whichever post in the window had the most replies (≥5), even if it had no relation to the article at all.**

Skyreader linkblog entries are batch-published (`site.standard.document` records with no per-entry `bskyPostRef` — there's no individual tweet per link), so tier 1 never finds a match. For a prolific poster, tier 2 then latches onto whatever unrelated post in that ~3-week window happened to get the most replies, and every reply to that post gets shown as the document's "Discussion." Since several linkblog entries publish close together in time, they land in the same window and all show the *same* wrong post — which matches the reporter's "more linkblogs have the same problem" observation.

The reporter's guess didn't name a mechanism, so there's nothing to diverge from — but the fix follows directly from the code: the reply-count fallback is the actual bug, not a case of a real announcement post being mismatched. It's not just wrong for linkblogs; it's fundamentally unsound (a popular post has no logical connection to an unrelated article just because it happened to be posted nearby in time).

## Fix

Removed the reply-count fallback in `inferAuthorAnnouncementPostUri`. Only a post that actually links the article's URL (via link facet or external embed) is ever treated as its announcement post now. When no such post exists — which is the normal case for linkblog entries — the document simply shows no inferred Bluesky discussion, instead of someone else's unrelated thread.

Not a visual/layout change (wrong data being fetched, not wrong rendering), so this skipped the `craft` flow per the routine's gating rules.

## Testing

- Added `src/server/atproto/bsky-posts.test.ts`: regression test asserting an unrelated high-reply-count post is never returned, plus a test that a genuinely link-matching post is still found.
- `pnpm build && pnpm lint && pnpm typecheck && pnpm test` all green locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hqodp9v5yQQ9eQPV3SjF3o)_