### PR TITLE
Support witchsky.app and mu.social in the Bluesky embed save button

### DIFF
--- a/APP_VISION.md
+++ b/APP_VISION.md
@@ -608,9 +608,9 @@ Standard Reader is a **port of an earlier no-build prototype** into this TanStac
 - **Browser extension:** pnpm workspace package [`extension/`](extension/) built with WXT + hip-ui
   (shared `#/*` → `src/design-system/`). Auth via HttpOnly session cookie; background worker calls
   `/api/extension/*` on the web app. Surfaces: popup, page overlay, context menu, Bluesky link
-  badges (bsky.app and its `social-app` forks — currently also Witchsky), options page, toolbar
-  badge. See [`extension/store/README.md`](extension/store/README.md) for Chrome Web Store publish
-  notes.
+  badges (bsky.app and its `social-app` forks — currently also Witchsky and Mu), options page,
+  toolbar badge. See [`extension/store/README.md`](extension/store/README.md) for Chrome Web Store
+  publish notes.
 
 ### Browser extension architecture
 

--- a/APP_VISION.md
+++ b/APP_VISION.md
@@ -608,8 +608,9 @@ Standard Reader is a **port of an earlier no-build prototype** into this TanStac
 - **Browser extension:** pnpm workspace package [`extension/`](extension/) built with WXT + hip-ui
   (shared `#/*` → `src/design-system/`). Auth via HttpOnly session cookie; background worker calls
   `/api/extension/*` on the web app. Surfaces: popup, page overlay, context menu, Bluesky link
-  badges, options page, toolbar badge. See [`extension/store/README.md`](extension/store/README.md)
-  for Chrome Web Store publish notes.
+  badges (bsky.app and its `social-app` forks — currently also Witchsky), options page, toolbar
+  badge. See [`extension/store/README.md`](extension/store/README.md) for Chrome Web Store publish
+  notes.
 
 ### Browser extension architecture
 

--- a/TODO.md
+++ b/TODO.md
@@ -610,7 +610,8 @@ After Tier 1–3, as appetite allows:
 ## 12. Browser extension (WXT)
 
 Full-featured MV3 extension in [`extension/`](extension/) — popup, page overlay, context menu,
-Bluesky badges, options page. Backend routes under [`src/routes/api/extension/`](src/routes/api/extension/).
+Bluesky badges (bsky.app + Witchsky), options page. Backend routes under
+[`src/routes/api/extension/`](src/routes/api/extension/).
 
 - [x] **Workspace scaffold** — `pnpm-workspace.yaml`, WXT + React + StyleX + hip-ui aliases,
       root scripts (`extension:dev`, `extension:build`, `extension:zip`), CI build step.
@@ -620,7 +621,8 @@ Bluesky badges, options page. Backend routes under [`src/routes/api/extension/`]
 - [x] **API routes** — `/api/extension/{session,resolve,bookmark,follow,recommend}`.
 - [x] **Connected landing** — [`/extension/connected`](src/routes/extension.connected.tsx) after OAuth.
 - [x] **Extension client** — background message router, hip-ui popup, unified content script
-      (page overlay + Bluesky badges), context menus, toolbar badge, options page.
+      (page overlay + Bluesky badges on bsky.app and Witchsky), context menus, toolbar badge,
+      options page.
 - [x] **Extension privacy URL** — [`/privacy/extension`](src/routes/_layout.privacy.extension.tsx) with
       [`ExtensionPrivacyView`](src/components/reader/extension-privacy-view.tsx); cross-linked from site privacy policy.
 - [ ] **Manual QA** — run checklist in [`extension/README.md`](extension/README.md) (dev + prod).

--- a/TODO.md
+++ b/TODO.md
@@ -610,7 +610,7 @@ After Tier 1–3, as appetite allows:
 ## 12. Browser extension (WXT)
 
 Full-featured MV3 extension in [`extension/`](extension/) — popup, page overlay, context menu,
-Bluesky badges (bsky.app + Witchsky), options page. Backend routes under
+Bluesky badges (bsky.app + `social-app` forks Witchsky, Mu), options page. Backend routes under
 [`src/routes/api/extension/`](src/routes/api/extension/).
 
 - [x] **Workspace scaffold** — `pnpm-workspace.yaml`, WXT + React + StyleX + hip-ui aliases,
@@ -621,8 +621,8 @@ Bluesky badges (bsky.app + Witchsky), options page. Backend routes under
 - [x] **API routes** — `/api/extension/{session,resolve,bookmark,follow,recommend}`.
 - [x] **Connected landing** — [`/extension/connected`](src/routes/extension.connected.tsx) after OAuth.
 - [x] **Extension client** — background message router, hip-ui popup, unified content script
-      (page overlay + Bluesky badges on bsky.app and Witchsky), context menus, toolbar badge,
-      options page.
+      (page overlay + Bluesky badges on bsky.app and its forks Witchsky, Mu), context menus,
+      toolbar badge, options page.
 - [x] **Extension privacy URL** — [`/privacy/extension`](src/routes/_layout.privacy.extension.tsx) with
       [`ExtensionPrivacyView`](src/components/reader/extension-privacy-view.tsx); cross-linked from site privacy policy.
 - [ ] **Manual QA** — run checklist in [`extension/README.md`](extension/README.md) (dev + prod).

--- a/extension/README.md
+++ b/extension/README.md
@@ -84,16 +84,16 @@ local API (`pnpm dev` + `pnpm extension:dev`).
 
 Load unpacked from `extension/.output/chrome-mv3/` after `pnpm extension:build`.
 
-| Case                    | Steps                                                               | Expected                                            |
-| ----------------------- | ------------------------------------------------------------------- | --------------------------------------------------- |
-| Popup — article         | Open indexed article URL → click extension icon                     | Title, Save, Follow, Open                           |
-| Popup — signed out save | Sign out → open popup on article → Save                             | Login tab opens; save completes after sign-in       |
-| Overlay                 | Visit publication article URL (not SR app)                          | Bottom-right chip; dismiss hides until page refresh |
-| Overlay off             | Disable in options → revisit site                                   | No chip                                             |
-| SR app excluded         | Visit `standard-reader.app` article                                 | No overlay                                          |
-| Context menu            | Right-click link to indexed article → Save                          | Bookmark created (or login → retry)                 |
-| Toolbar badge           | Switch tabs between article and other sites                         | Dot on indexed tabs only                            |
-| Bluesky embed save      | Post with a standard.site article embed on bsky.app or witchsky.app | Native Save button in embed footer                  |
-| Bluesky embed off       | Disable in options                                                  | Buttons removed                                     |
-| Options sync            | Toggle settings → restart browser                                   | Settings persist (`storage.sync`)                   |
-| Dev API                 | API origin blank or `http://127.0.0.1:3000` in options              | Extension hits local app                            |
+| Case                    | Steps                                                                           | Expected                                            |
+| ----------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------- |
+| Popup — article         | Open indexed article URL → click extension icon                                 | Title, Save, Follow, Open                           |
+| Popup — signed out save | Sign out → open popup on article → Save                                         | Login tab opens; save completes after sign-in       |
+| Overlay                 | Visit publication article URL (not SR app)                                      | Bottom-right chip; dismiss hides until page refresh |
+| Overlay off             | Disable in options → revisit site                                               | No chip                                             |
+| SR app excluded         | Visit `standard-reader.app` article                                             | No overlay                                          |
+| Context menu            | Right-click link to indexed article → Save                                      | Bookmark created (or login → retry)                 |
+| Toolbar badge           | Switch tabs between article and other sites                                     | Dot on indexed tabs only                            |
+| Bluesky embed save      | Post with a standard.site article embed on bsky.app, witchsky.app, or mu.social | Native Save button in embed footer                  |
+| Bluesky embed off       | Disable in options                                                              | Buttons removed                                     |
+| Options sync            | Toggle settings → restart browser                                               | Settings persist (`storage.sync`)                   |
+| Dev API                 | API origin blank or `http://127.0.0.1:3000` in options                          | Extension hits local app                            |

--- a/extension/README.md
+++ b/extension/README.md
@@ -84,16 +84,16 @@ local API (`pnpm dev` + `pnpm extension:dev`).
 
 Load unpacked from `extension/.output/chrome-mv3/` after `pnpm extension:build`.
 
-| Case                    | Steps                                                  | Expected                                            |
-| ----------------------- | ------------------------------------------------------ | --------------------------------------------------- |
-| Popup — article         | Open indexed article URL → click extension icon        | Title, Save, Follow, Open                           |
-| Popup — signed out save | Sign out → open popup on article → Save                | Login tab opens; save completes after sign-in       |
-| Overlay                 | Visit publication article URL (not SR app)             | Bottom-right chip; dismiss hides until page refresh |
-| Overlay off             | Disable in options → revisit site                      | No chip                                             |
-| SR app excluded         | Visit `standard-reader.app` article                    | No overlay                                          |
-| Context menu            | Right-click link to indexed article → Save             | Bookmark created (or login → retry)                 |
-| Toolbar badge           | Switch tabs between article and other sites            | Dot on indexed tabs only                            |
-| Bluesky embed save      | Post with a standard.site article embed on bsky.app    | Native Save button in embed footer                  |
-| Bluesky embed off       | Disable in options                                     | Buttons removed                                     |
-| Options sync            | Toggle settings → restart browser                      | Settings persist (`storage.sync`)                   |
-| Dev API                 | API origin blank or `http://127.0.0.1:3000` in options | Extension hits local app                            |
+| Case                    | Steps                                                               | Expected                                            |
+| ----------------------- | ------------------------------------------------------------------- | --------------------------------------------------- |
+| Popup — article         | Open indexed article URL → click extension icon                     | Title, Save, Follow, Open                           |
+| Popup — signed out save | Sign out → open popup on article → Save                             | Login tab opens; save completes after sign-in       |
+| Overlay                 | Visit publication article URL (not SR app)                          | Bottom-right chip; dismiss hides until page refresh |
+| Overlay off             | Disable in options → revisit site                                   | No chip                                             |
+| SR app excluded         | Visit `standard-reader.app` article                                 | No overlay                                          |
+| Context menu            | Right-click link to indexed article → Save                          | Bookmark created (or login → retry)                 |
+| Toolbar badge           | Switch tabs between article and other sites                         | Dot on indexed tabs only                            |
+| Bluesky embed save      | Post with a standard.site article embed on bsky.app or witchsky.app | Native Save button in embed footer                  |
+| Bluesky embed off       | Disable in options                                                  | Buttons removed                                     |
+| Options sync            | Toggle settings → restart browser                                   | Settings persist (`storage.sync`)                   |
+| Dev API                 | API origin blank or `http://127.0.0.1:3000` in options              | Extension hits local app                            |

--- a/extension/src/lib/manifest-hosts.ts
+++ b/extension/src/lib/manifest-hosts.ts
@@ -2,6 +2,7 @@
 export const PRODUCTION_HOST_PERMISSIONS = [
   "https://standard-reader.app/*",
   "https://bsky.app/*",
+  "https://witchsky.app/*",
   "<all_urls>",
 ] as const;
 
@@ -21,7 +22,9 @@ export function hostPermissions(includeDev: boolean): Array<string> {
 
 const APP_HOSTS = ["standard-reader.app"] as const;
 const DEV_APP_HOSTS = ["staging.standard-reader.app"] as const;
-const BSKY_HOSTS = ["bsky.app"] as const;
+// bsky.app and Bluesky-fork clients that share its post/embed DOM shape
+// (e.g. Witchsky) get the same in-embed "Save to Standard Reader" button.
+const BSKY_HOSTS = ["bsky.app", "witchsky.app"] as const;
 const DEV_BSKY_HOSTS = ["staging.bsky.app"] as const;
 const DEV_LOOPBACK_HOSTS = ["localhost", "127.0.0.1"] as const;
 
@@ -46,6 +49,7 @@ export function pageOverlayExcludeMatches(includeDev: boolean): Array<string> {
     "*://standard-reader.app/*",
     "*://*.standard-reader.app/*",
     "*://bsky.app/*",
+    "*://witchsky.app/*",
   ];
   if (includeDev) {
     excludes.push(
@@ -70,7 +74,7 @@ export function authCallbackMatches(includeDev: boolean): Array<string> {
 }
 
 export function bskyEmbedMatches(includeDev: boolean): Array<string> {
-  return includeDev
-    ? ["https://bsky.app/*", "https://staging.bsky.app/*"]
-    : ["https://bsky.app/*"];
+  const matches = ["https://bsky.app/*", "https://witchsky.app/*"];
+  if (includeDev) matches.push("https://staging.bsky.app/*");
+  return matches;
 }

--- a/extension/src/lib/manifest-hosts.ts
+++ b/extension/src/lib/manifest-hosts.ts
@@ -1,8 +1,14 @@
+// bsky.app and web clients forked from its `social-app` codebase share the
+// same post/embed DOM shape, so they all get the in-embed "Save to Standard
+// Reader" button. Add a fork's host here and every permission / content
+// script match / exclusion list below picks it up.
+const BSKY_HOSTS = ["bsky.app", "witchsky.app", "mu.social"] as const;
+const DEV_BSKY_HOSTS = ["staging.bsky.app"] as const;
+
 /** Production host permissions for store builds (build / zip). */
 export const PRODUCTION_HOST_PERMISSIONS = [
   "https://standard-reader.app/*",
-  "https://bsky.app/*",
-  "https://witchsky.app/*",
+  ...BSKY_HOSTS.map((host) => `https://${host}/*`),
   "<all_urls>",
 ] as const;
 
@@ -22,10 +28,6 @@ export function hostPermissions(includeDev: boolean): Array<string> {
 
 const APP_HOSTS = ["standard-reader.app"] as const;
 const DEV_APP_HOSTS = ["staging.standard-reader.app"] as const;
-// bsky.app and Bluesky-fork clients that share its post/embed DOM shape
-// (e.g. Witchsky) get the same in-embed "Save to Standard Reader" button.
-const BSKY_HOSTS = ["bsky.app", "witchsky.app"] as const;
-const DEV_BSKY_HOSTS = ["staging.bsky.app"] as const;
 const DEV_LOOPBACK_HOSTS = ["localhost", "127.0.0.1"] as const;
 
 export function appHosts(includeDev: boolean): ReadonlyArray<string> {
@@ -48,8 +50,7 @@ export function pageOverlayExcludeMatches(includeDev: boolean): Array<string> {
   const excludes = [
     "*://standard-reader.app/*",
     "*://*.standard-reader.app/*",
-    "*://bsky.app/*",
-    "*://witchsky.app/*",
+    ...BSKY_HOSTS.map((host) => `*://${host}/*`),
   ];
   if (includeDev) {
     excludes.push(
@@ -74,7 +75,7 @@ export function authCallbackMatches(includeDev: boolean): Array<string> {
 }
 
 export function bskyEmbedMatches(includeDev: boolean): Array<string> {
-  const matches = ["https://bsky.app/*", "https://witchsky.app/*"];
+  const matches = BSKY_HOSTS.map((host) => `https://${host}/*`);
   if (includeDev) matches.push("https://staging.bsky.app/*");
   return matches;
 }


### PR DESCRIPTION
Discussion: at://did:plc:fip3nyk6tjo3senpq4ei2cxw/app.userinput.discussion/3mqzcdx4msa2s

## Original request

> Standard Reader browser extension supporting Witchsky
>
> The request is for the browser extension button to save publications to read later directly from the Bluesky's embed to work on Witchsky too.

(Mu / mu.social was added on top of the original request, at the reviewer's request — see "Also added" below.)

## What I found

The extension already injects a native "Save to Standard Reader" bookmark button into `site.standard.document` embeds it finds inside posts (`extension/src/lib/bsky-embed-bookmark.ts`), but the content script that mounts it, and the host permissions that let it run, were scoped to `bsky.app` only (`extension/src/lib/manifest-hosts.ts`).

[Witchsky](https://witchsky.app/) is a fork of Bluesky's own `social-app` client (same codebase, same post/embed DOM shape, just reskinned), not a separate implementation. The bookmark-mount logic in `bsky-embed-bookmark.ts` is already written generically — it locates article links and text blocks by heuristics (link scoring, footer-CTA text matching, title-text matching), not bsky.app-specific selectors — so it needed no changes to work on Witchsky's DOM.

The reporter's suggested fix ("work on Witchsky too") matched what the code actually needed: this PR only widens the host-matching config in `manifest-hosts.ts`:

- `bskyEmbedMatches` — the embed content script (`bsky-embed.content.ts`) now also injects on the fork hosts.
- `PRODUCTION_HOST_PERMISSIONS` — added the fork hosts (mirrors the existing `bsky.app` entry; `<all_urls>` already technically covers it, but the explicit entry documents intent the same way the bsky.app one does).
- `BSKY_HOSTS` (→ `bskyHosts()`) — added the fork hosts so links back to a fork's own post are correctly excluded as "internal navigation" rather than mis-scored as the article link, same as bsky.app links already are.
- `pageOverlayExcludeMatches` — added the fork hosts so the generic page-overlay chip stays off them (they get the embed-badge UI instead, same split as bsky.app).

No new UI, component, or visual state — the button/icon/spinner are reused verbatim from the existing bsky.app implementation.

Also updated `TODO.md` / `APP_VISION.md` / `extension/README.md`'s extension sections, which described the badges as bsky.app-only.

### Also added: mu.social

While this PR was open, I was asked to also add [mu.social](https://mu.social) (Eurosky's "Mu"), which I confirmed is likewise a downstream fork of `bluesky-social/social-app` — same reasoning applies. Since this is now a second fork, I refactored `manifest-hosts.ts` so `BSKY_HOSTS` is a single source of truth (`["bsky.app", "witchsky.app", "mu.social"]`) that every permission list / content-script match / exclusion list derives from, instead of listing each host in four places. Adding another fork in the future is now a one-line change.

## Shape brief (impeccable craft)

Ran through `/impeccable craft` per the feature-tag rule even though this turned out to be config-only, no visual design:

- **What's being built:** widen the existing bsky.app "Save to Standard Reader" embed button to also mount on Bluesky `social-app` forks (Witchsky, Mu).
- **Visual lane:** none — button/icon/spinner/hover states are pulled verbatim from the existing component; no new copy, no new states.
- **Scope:** `extension/src/lib/manifest-hosts.ts` host-matching only.
- **Docs touch:** update the "bsky.app"-only wording in the living docs.

No mocks/screenshots to include — there's no new visual surface, and I don't have a live Witchsky or Mu post with a standard.site embed to screenshot against. The manual-QA checklist entry in `extension/README.md` now calls out testing the save button against real posts on all three hosts, the same way it already did for bsky.app.

## Verification

- `pnpm build` ✅
- `pnpm extension:build` ✅ (manifest.json confirmed to include `bsky.app`, `witchsky.app`, and `mu.social` in both `host_permissions` and the embed content script's `matches`)
- `pnpm --filter standard-reader-extension compile` ✅
- `pnpm exec oxlint extension/src src/server/extension src/routes/api/extension src/routes/extension.connected.tsx` ✅
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅ (294 passed, 2 skipped)
- `pnpm format:check` ✅
