### PR TITLE
Release extension v0.4.0

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "standard-reader-extension",
   "description": "Save articles and follow publications on the standard.site network.",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "wxt",


### PR DESCRIPTION
Automated release PR — bumps `extension/package.json` to **v0.4.0**.

Merging this PR builds the production Chrome and Firefox packages,
uploads them to the Chrome Web Store and Firefox AMO, tags
`extension-v0.4.0`, and cuts a GitHub Release.

Do not merge until you're ready to ship a store release.