### PR TITLE
Fix Discussion missing posts that link app article URLs

### DIFF
--- a/src/lib/public-url.test.ts
+++ b/src/lib/public-url.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getCanonicalPublicUrl, getPublicUrl } from "./public-url.ts";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("public URL resolution", () => {
+  it("getPublicUrl returns the preview railway domain on non-prod deploys", () => {
+    vi.stubEnv("PUBLIC_URL", "https://standard-reader.app");
+    vi.stubEnv("RAILWAY_PUBLIC_DOMAIN", "web-pr-62.up.railway.app");
+    vi.stubEnv("RAILWAY_ENVIRONMENT_NAME", "pr-62");
+    expect(getPublicUrl()).toBe("https://web-pr-62.up.railway.app");
+  });
+
+  it("getCanonicalPublicUrl ignores the railway override — prod domain even on a preview", () => {
+    vi.stubEnv("PUBLIC_URL", "https://standard-reader.app");
+    vi.stubEnv("RAILWAY_PUBLIC_DOMAIN", "web-pr-62.up.railway.app");
+    vi.stubEnv("RAILWAY_ENVIRONMENT_NAME", "pr-62");
+    expect(getCanonicalPublicUrl()).toBe("https://standard-reader.app");
+  });
+
+  it("both resolve to PUBLIC_URL in the production environment", () => {
+    vi.stubEnv("PUBLIC_URL", "https://standard-reader.app");
+    vi.stubEnv("RAILWAY_PUBLIC_DOMAIN", "web.up.railway.app");
+    vi.stubEnv("RAILWAY_ENVIRONMENT_NAME", "production");
+    expect(getPublicUrl()).toBe("https://standard-reader.app");
+    expect(getCanonicalPublicUrl()).toBe("https://standard-reader.app");
+  });
+
+  it("strips a trailing slash and rewrites localhost", () => {
+    vi.stubEnv("PUBLIC_URL", "http://localhost:3000/");
+    vi.stubEnv("RAILWAY_PUBLIC_DOMAIN", "");
+    vi.stubEnv("RAILWAY_ENVIRONMENT_NAME", "");
+    expect(getCanonicalPublicUrl()).toBe("http://127.0.0.1:3000");
+  });
+});

--- a/src/lib/public-url.ts
+++ b/src/lib/public-url.ts
@@ -24,6 +24,22 @@ export function getPublicUrl(): string {
     return `https://${railwayDomain}`;
   }
 
+  return getCanonicalPublicUrl();
+}
+
+/**
+ * Canonical public base URL — the production custom domain, ignoring the
+ * per-deployment `RAILWAY_PUBLIC_DOMAIN` override that {@link getPublicUrl}
+ * applies for OAuth. Previews inherit prod's `PUBLIC_URL` from shared
+ * variables, so this resolves to `standard-reader.app` on prod AND previews.
+ *
+ * Use this for anything that must match strings that exist in the wild — most
+ * importantly the `/a/<did>/<rkey>` app-article URLs that Bluesky posts embed,
+ * which the Discussion backlink lookup resolves against Constellation by exact
+ * string match. Building those targets from the preview domain would match no
+ * real post.
+ */
+export function getCanonicalPublicUrl(): string {
   const url =
     process.env.PUBLIC_URL ||
     process.env.BETTER_AUTH_URL ||

--- a/src/lib/quote-share.test.ts
+++ b/src/lib/quote-share.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { articleSharePath, buildQuoteShareUrl } from "./quote-share.ts";
+
+const DID = "did:plc:7ztoas5m6664r5bwab56byec";
+const RKEY = "3mqfxjkfbjuas";
+
+describe("articleSharePath", () => {
+  // Discussion looks these URLs up in Constellation by exact string match, so
+  // they have to be byte-identical to what the router emits. Percent-encoding
+  // the DID's colons builds a URL no real post ever contains.
+  it("leaves the DID's colons literal", () => {
+    expect(articleSharePath(DID, RKEY)).toBe(`/a/${DID}/${RKEY}`);
+  });
+
+  it("survives URL resolution against a base", () => {
+    const url = new URL(
+      articleSharePath(DID, RKEY),
+      "https://standard-reader.app",
+    ).toString();
+    expect(url).toBe(`https://standard-reader.app/a/${DID}/${RKEY}`);
+  });
+});
+
+describe("buildQuoteShareUrl", () => {
+  it("keeps the DID literal and appends the quote id", () => {
+    expect(
+      buildQuoteShareUrl(DID, RKEY, "abc", "https://standard-reader.app"),
+    ).toBe(`https://standard-reader.app/a/${DID}/${RKEY}?q=abc`);
+  });
+});

--- a/src/lib/quote-share.ts
+++ b/src/lib/quote-share.ts
@@ -40,8 +40,13 @@ export function decodeQuoteParam(encoded: string | undefined): string | null {
   return normalized || null;
 }
 
+/**
+ * Article path exactly as the router emits it — `:` in the DID stays literal.
+ * Percent-encoding it yields a URL that never appears in the wild, so
+ * Constellation backlink lookups (Discussion) miss every real share.
+ */
 export function articleSharePath(did: string, rkey: string): string {
-  return `/a/${encodeURIComponent(did)}/${encodeURIComponent(rkey)}`;
+  return `/a/${did}/${rkey}`;
 }
 
 /** Share URL for a highlighted quote on an article. */

--- a/src/server/reader/document-comments.ts
+++ b/src/server/reader/document-comments.ts
@@ -9,7 +9,7 @@ import type {
 import { bskyPostUrl } from "#/lib/leaflet/bsky";
 import { shiftFacets } from "#/lib/leaflet/facets";
 import { utf8ByteLength } from "#/lib/leaflet/utf8";
-import { getPublicUrl } from "#/lib/public-url";
+import { getCanonicalPublicUrl } from "#/lib/public-url";
 import {
   articleSharePath,
   buildQuoteShareUrl,
@@ -454,7 +454,10 @@ async function loadDocumentCommentTargets(
   const canonicalUrl =
     doc.canonicalUrl ?? buildCanonicalUrl(doc.publicationUrl, doc.path);
 
-  const baseUrl = getPublicUrl();
+  // Canonical (not per-deployment) origin: posts in the wild embed the prod
+  // `standard-reader.app/a/...` URL, so a preview must look that up, not its
+  // own railway.app subdomain.
+  const baseUrl = getCanonicalPublicUrl();
   const quoteShares = await listQuoteSharesForDocument(documentUri);
   const targets = buildCommentTargets(
     doc.did,


### PR DESCRIPTION
A Bluesky post embedding an app article URL wasn't appearing in that article's Discussion section. Two separate bugs were involved — the second is why it still didn't show on the PR-62 preview after the first fix.

## Bug 1 — the app-article target URL was percent-encoded

The app-internal `/a/<did>/<rkey>` URL is a first-class discussion target: `buildCommentTargets` adds it *before* the publication's canonical URL (`src/server/reader/document-comments.ts:204-208`). But `articleSharePath` encoded the DID:

```ts
return `/a/${encodeURIComponent(did)}/${encodeURIComponent(rkey)}`;
```

That yields `/a/did%3Aplc%3A…/rkey`, whereas every link the app actually emits comes from the TanStack router (`to="/a/$did/$rkey"`), which leaves the colons literal. The encoded form appears in no real post, and Discussion resolves Bluesky backlinks by **exact string match** against Constellation. Confirmed against the live index for a real post:

```
did:plc:7ztoas5m6664r5bwab56byec   -> {"total":1}
did%3Aplc%3A7ztoas5m6664r5bwab56byec -> {"total":0}
```

Quote-share URLs (`?q=`) share the helper and had the same defect. Navigation was never affected — the router decodes either form.

## Bug 2 — previews look up the per-deployment domain

The app-article target was built from `getPublicUrl()`, which on non-production Railway deployments returns the per-deploy `RAILWAY_PUBLIC_DOMAIN` (`src/lib/public-url.ts:19-25`, an override that exists only so OAuth redirects land on the right deployment). So the PR-62 preview looked up `web-standard-reader-pr-62.up.railway.app/a/…` — a URL no real post embeds — and Discussion stayed empty even after Bug 1 was fixed. Production was unaffected (there `getPublicUrl()` is `standard-reader.app`), so this only bit previews/staging.

Fix: add `getCanonicalPublicUrl()`, which skips the Railway-domain branch and reads the shared `PUBLIC_URL` (which previews inherit from prod = `standard-reader.app`). `buildCommentTargets` now resolves against it, so previews and prod look up the same real URLs.

## Tests

- `src/lib/quote-share.test.ts` — path keeps the DID's colons literal; resolves correctly against a base; quote-share variant.
- `src/lib/public-url.test.ts` — `getPublicUrl` still returns the preview domain on non-prod; `getCanonicalPublicUrl` returns the prod domain on prod *and* previews; trailing-slash / localhost handling.

7 tests pass; `tsc --noEmit`, `oxfmt`, `oxlint` clean on the touched files.

## Still out of scope (worth a follow-up)

- **Existing quote-share posts won't backfill** — any `?q=` link shared before Bug 1 carries the encoded DID and stays indexed under the old string; only new shares match.
- **Canonical-URL targets still aren't normalized** — `buildCommentTargets` only does `url.trim()`, so a post linking the canonical URL with a trailing slash, `utm_*` params, or `http://` also silently misses. The repo already has `linkTargetVariants` (`src/lib/link-target-variants.ts`) for this, but `document-comments.ts` doesn't import it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)