### PR TITLE
ci: publish lexicon updates (not just new) on merge to main

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "db:studio": "drizzle-kit studio",
     "lex:lint": "node scripts/goat-lex.mjs lex lint lexicons/app/standard-reader",
     "lex:status": "node scripts/goat-lex.mjs lex status",
-    "atproto:publish-lexicons": "node scripts/goat-lex.mjs lex publish",
+    "atproto:publish-lexicons": "node scripts/goat-lex.mjs lex publish --update",
     "lexicons:generate": "pnpm --filter @standard-reader/lexicons generate",
     "lexicons:build": "pnpm --filter @standard-reader/lexicons build",
     "extension:dev": "pnpm --filter standard-reader-extension dev",


### PR DESCRIPTION
## What

Adds `--update` to the `atproto:publish-lexicons` script:

```json
"atproto:publish-lexicons": "node scripts/goat-lex.mjs lex publish --update",
```

## Why

`goat lex publish` **skips changed schemas by default** — it only publishes brand-new NSIDs and treats existing schemas as no-ops even when they've changed. That meant the merge-to-main publish step added in #68 would never propagate edits to already-published `app.standard-reader.*` lexicons to the network.

From goat's own command description:
> Checks schema status against live network and will not re-publish identical schemas, or update schemas by default (use `--update` to skip this check).

With `--update`, the publish step now covers all cases:

| Local schema state | Behavior |
|---|---|
| Brand-new NSID | publishes |
| Changed vs network | **updates** |
| Identical to network | no-op (still skipped) |

## Note

`--update` overwrites live records for changed schemas, which is the intended behavior for a main-branch publish. The `lex:lint` CI gate and PR review remain the guardrails against a bad edit reaching the network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDiiThfxhKehVbBHjX8XhF)_