### PR TITLE
Remove saved count from sidebar navigation

### DIFF
--- a/src/components/reader/app-shell.tsx
+++ b/src/components/reader/app-shell.tsx
@@ -1148,7 +1148,6 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const following = sidebar?.following ?? [];
   const followingUsers = sidebar?.followingUsers ?? [];
   const unreadCount = sidebar?.unreadCount ?? null;
-  const savedCount = sidebar?.savedCount ?? null;
   const hasUnread = unreadCount != null && unreadCount > 0;
   const primaryNav = navWithSaved(signedIn);
   const [subsSheetOpen, setSubsSheetOpen] = useState(false);
@@ -1268,13 +1267,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
                   <SidebarNavItem
                     key={item.to}
                     {...item}
-                    count={
-                      item.to === "/latest"
-                        ? unreadCount
-                        : item.to === "/saved"
-                          ? savedCount
-                          : null
-                    }
+                    count={item.to === "/latest" ? unreadCount : null}
                     compactCount={item.to === "/latest"}
                   />
                 ))}


### PR DESCRIPTION
## Summary
Removes the `savedCount` variable and its associated conditional logic from the sidebar navigation item rendering in the AppShell component. The `/saved` route no longer displays a count badge.

## Changes
- Removed `savedCount` variable declaration that was extracted from the sidebar data
- Simplified the `count` prop logic for `SidebarNavItem` to only show unread count for the `/latest` route
- Removed the ternary condition that previously displayed `savedCount` for the `/saved` route

## Details
The change streamlines the navigation item rendering by eliminating unused state and simplifying the conditional logic. The `/saved` route will now render without a count indicator, while the `/latest` route continues to display the unread count as before.

https://claude.ai/code/session_01Je69jZVq37JAuV5AhqVjiB