### PR TITLE
Show "Recommended by you" on document items across the app

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -408,6 +408,13 @@ Build each on hip-ui components + StyleX tokens (no raw HTML/inline styles).
 - [x] **Search result snippets** — `ts_headline` excerpts in `searchArticles` /
       `searchPublications`; highlighted `<mark>` terms in `ArticleRow` and
       `PubDirectoryRow` on `/search`.
+- [x] **"Recommended by you" indicator** — document cards across every surface (home, latest,
+      discover, tag, publication, author, search, saved, and history feeds) show a red heart +
+      "Recommended by you" eyebrow when the signed-in reader has recommended that document. Attached
+      server-side in one batched, index-served query (`attachViewerRecommendedToArticles` →
+      `viewerHasRecommended` on `ArticleCard`), toggled optimistically alongside the recommend
+      action (`recommend-optimistic.ts`), and rendered by `RecommendedByLine` (the viewer's own
+      signal takes precedence over the followed-user "@handle and N others" attribution).
 - [x] **Article** (reading view) — ~680px measure, drop-cap, pull quotes, hero, sticky bar (back/byline/follow/save/share), reading-progress bar, footer pub card + "More from {publication}". Route `/a/$did/$rkey` (`_layout.a.$did.$rkey.tsx`); feed/profile cards link here; `publicationApi.getArticle` returns core content + stale-while-revalidate `commentCount`; below-the-fold rails (`moreFrom`, `readersAlsoFollow`) and discussion load client-side via `getArticleExtras` + `commentsApi.getDocumentComments`. Save toggle writes `site.standard.graph.recommend`; like counts on cards + article byline.
 - [x] **Article discussion** — Bluesky comment section on documents: Constellation backlink discovery for external + app quote-share URLs, direct replies to the author's `bskyPostRef` (excluded from the list itself), hydrated via public AppView, facet-rendered commentary, reply counts linking to bsky threads (`commentsApi.getDocumentComments`).
 - [x] **Article discussion — margin.at** — merge `at.margin.note` / `at.margin.annotation` / `at.margin.highlight` and `network.cosmik.card` NOTE cards on the document's canonical URL into the same Discussion feed via Constellation (`at.margin.*` at `.target.source`, cosmik at `.url` / `.content.url`); hydrate from author PDS + Bluesky/margin profile; quote-style cards for `TextQuoteSelector` passages; reply counts via `at.margin.reply`; margin notes link to margin.at; cosmik NOTE cards link to Semble (`semble.so/url?id=…`); cosmik URL bookmarks excluded from counts.

--- a/src/components/reader/cards.tsx
+++ b/src/components/reader/cards.tsx
@@ -1027,12 +1027,31 @@ function OwnerHandleLink({
 
 /* ── Recommended-by attribution ─────────────────────────────────────────── */
 
+/** Whether {@link RecommendedByLine} would render anything for this card. */
+function hasRecommendedByLine(article: ArticleCard): boolean {
+  return (
+    article.viewerHasRecommended || (article.recommendedBy?.length ?? 0) > 0
+  );
+}
+
 /**
- * "Recommended by @handle" line shown above the byline in the home/latest feed
- * when an article surfaced because followed users recommended it. A single line
- * covers all recommenders ("+N others") — the article is one collapsed card.
+ * Recommend attribution shown above the byline on document items. When the
+ * viewer recommended the article themselves it reads "Recommended by you" (the
+ * personal signal takes precedence); otherwise it collapses the followed users
+ * who recommended it into one line ("@handle and N others"). Either way a red
+ * heart marks it as a recommendation at a glance.
  */
 function RecommendedByLine({ article }: { article: ArticleCard }) {
+  if (article.viewerHasRecommended) {
+    return (
+      <Flex align="center" gap="sm" style={styles.recommendedByLine}>
+        <span {...stylex.props(styles.recommendedByHeart)}>
+          <Heart size={13} aria-hidden fill="currentColor" />
+        </span>
+        <span>Recommended by you</span>
+      </Flex>
+    );
+  }
   const recommenders = article.recommendedBy;
   if (!recommenders || recommenders.length === 0) {
     return null;
@@ -1646,10 +1665,11 @@ export function FeatureArticle({
     );
   }
 
-  // Byline-less (publication page): the "Recommended by @follow" line still
-  // applies. Lift it out of the card link — it holds its own profile links —
-  // and let the shell own the row's border so the grid inside stays border-free.
-  if (article.recommendedBy && article.recommendedBy.length > 0) {
+  // Byline-less (publication page): the recommend attribution still applies —
+  // "Recommended by you" or the followed-user line. Lift it out of the card link
+  // (it holds its own profile links) and let the shell own the row's border so
+  // the grid inside stays border-free.
+  if (hasRecommendedByLine(article)) {
     return (
       <div {...stylex.props(styles.featureShell)}>
         <RecommendedByLine article={article} />
@@ -1909,6 +1929,7 @@ export function CompactRow({
         {String(rank).padStart(2, "0")}
       </span>
       <Flex direction="column" gap="sm" style={styles.grow}>
+        <RecommendedByLine article={article} />
         <span {...stylex.props(styles.compactTitle)}>{article.title}</span>
         <MetaLine>
           {showCollection ? <CollectionMagazineMeta /> : null}

--- a/src/components/reader/read-optimistic.test.ts
+++ b/src/components/reader/read-optimistic.test.ts
@@ -53,6 +53,7 @@ function makeCard(uri: string, isRead: boolean): ArticleCard {
     hasRenderableBody: true,
     isRead,
     isCollection: false,
+    viewerHasRecommended: false,
   };
 }
 

--- a/src/components/reader/recommend-optimistic.ts
+++ b/src/components/reader/recommend-optimistic.ts
@@ -40,32 +40,44 @@ function bumpCard(
   card: ArticleCard,
   documentUri: string,
   delta: number,
+  recommended: boolean,
 ): ArticleCard {
-  if (card.uri !== documentUri || delta === 0) return card;
-  return { ...card, recommendCount: bumpCount(card.recommendCount, delta) };
+  if (card.uri !== documentUri) return card;
+  // Also flip the viewer's own recommend flag so the "Recommended by you"
+  // indicator toggles instantly, even when the count is unchanged (delta 0).
+  return {
+    ...card,
+    recommendCount: bumpCount(card.recommendCount, delta),
+    viewerHasRecommended: recommended,
+  };
 }
 
 function updateFeedCache(
   data: unknown,
   documentUri: string,
   delta: number,
+  recommended: boolean,
 ): unknown {
   if (isLatestFeed(data)) {
     return {
       ...data,
-      items: data.items.map((item) => bumpCard(item, documentUri, delta)),
+      items: data.items.map((item) =>
+        bumpCard(item, documentUri, delta, recommended),
+      ),
     };
   }
   if (isHomeFeed(data)) {
     return {
       ...data,
       featured: data.featured
-        ? bumpCard(data.featured, documentUri, delta)
+        ? bumpCard(data.featured, documentUri, delta, recommended)
         : data.featured,
       latestUnread: data.latestUnread.map((item) =>
-        bumpCard(item, documentUri, delta),
+        bumpCard(item, documentUri, delta, recommended),
       ),
-      trending: data.trending.map((item) => bumpCard(item, documentUri, delta)),
+      trending: data.trending.map((item) =>
+        bumpCard(item, documentUri, delta, recommended),
+      ),
     };
   }
   return data;
@@ -120,7 +132,7 @@ export function applyRecommendOptimisticUpdate(
   });
 
   queryClient.setQueriesData({ queryKey: ["feed"] }, (data) =>
-    updateFeedCache(data, documentUri, delta),
+    updateFeedCache(data, documentUri, delta, recommended),
   );
 
   return { prevStatus, prevArticle, prevFeedEntries };

--- a/src/integrations/tanstack-query/api-author.functions.ts
+++ b/src/integrations/tanstack-query/api-author.functions.ts
@@ -21,7 +21,10 @@ import {
   authorSubscriptions,
 } from "#/server/reader/queries";
 import type { AuthorProfileStats, AuthorReader } from "#/server/reader/queries";
-import { attachRecommendedByToArticles } from "#/server/reader/recommended-by";
+import {
+  attachRecommendedByToArticles,
+  attachViewerRecommendedToArticles,
+} from "#/server/reader/recommended-by";
 import { effectiveFollowSets } from "#/server/reader/saved-lists";
 
 import type {
@@ -316,14 +319,35 @@ const getAuthorProfile = createServerFn({ method: "GET" })
         // posts (self-recommends are already excluded by the helper); Likes =
         // posts this author recommended, so drop the author from the attribution
         // to avoid the redundant "Recommended by <this profile>".
+        const [documentsAttributed, recommendationsAttributed] =
+          await Promise.all([
+            attachViewerRecommendedBy(
+              db,
+              schema,
+              viewerDid,
+              documentsPage.items,
+            ),
+            attachViewerRecommendedBy(
+              db,
+              schema,
+              viewerDid,
+              recommendationsPage.items,
+              did,
+            ),
+          ]);
+        // Flag the viewer's own recommends so cards show "Recommended by you".
         const [documentsWithRecs, recommendationsWithRecs] = await Promise.all([
-          attachViewerRecommendedBy(db, schema, viewerDid, documentsPage.items),
-          attachViewerRecommendedBy(
+          attachViewerRecommendedToArticles(
             db,
             schema,
             viewerDid,
-            recommendationsPage.items,
-            did,
+            documentsAttributed,
+          ),
+          attachViewerRecommendedToArticles(
+            db,
+            schema,
+            viewerDid,
+            recommendationsAttributed,
           ),
         ]);
 
@@ -544,12 +568,18 @@ const getAuthorRecommendations = createServerFn({ method: "GET" })
 
         // Likes tab: exclude the profile owner from the attribution (see
         // {@link attachViewerRecommendedBy}).
-        const items = await attachViewerRecommendedBy(
+        const attributed = await attachViewerRecommendedBy(
           db,
           schema,
           viewerDid,
           page.items,
           did,
+        );
+        const items = await attachViewerRecommendedToArticles(
+          db,
+          schema,
+          viewerDid,
+          attributed,
         );
 
         return {
@@ -587,11 +617,17 @@ const getAuthorDocuments = createServerFn({ method: "GET" })
 
         // Writing tab: this author's own posts — the helper already drops
         // self-recommends, so no owner exclusion needed here.
-        const items = await attachViewerRecommendedBy(
+        const attributed = await attachViewerRecommendedBy(
           db,
           schema,
           viewerDid,
           page.items,
+        );
+        const items = await attachViewerRecommendedToArticles(
+          db,
+          schema,
+          viewerDid,
+          attributed,
         );
 
         return {

--- a/src/integrations/tanstack-query/api-discover.functions.ts
+++ b/src/integrations/tanstack-query/api-discover.functions.ts
@@ -29,7 +29,10 @@ import {
   trendingPublications,
 } from "#/server/reader/queries";
 import { rotationSeed } from "#/server/reader/rail-rotation";
-import { attachRecommendedByToArticles } from "#/server/reader/recommended-by";
+import {
+  attachRecommendedByToArticles,
+  attachViewerRecommendedToArticles,
+} from "#/server/reader/recommended-by";
 import {
   effectiveFollowSets,
   effectiveFollowUris,
@@ -273,11 +276,17 @@ const getFriendArticles = createServerFn({ method: "GET" })
       ]);
       // "Recommended by @follow" attribution — the same follows signal as the
       // feeds; a no-op (no query) when the reader follows no one.
-      const items = await attachRecommendedByToArticles(
+      const withRecs = await attachRecommendedByToArticles(
         db,
         schema,
         followSets.userDids,
         result.items,
+      );
+      const items = await attachViewerRecommendedToArticles(
+        db,
+        schema,
+        did,
+        withRecs,
       );
       span.set("count", items.length);
       span.set("degraded", result.degraded);

--- a/src/integrations/tanstack-query/api-feed.functions.ts
+++ b/src/integrations/tanstack-query/api-feed.functions.ts
@@ -38,7 +38,10 @@ import {
   trendingPublications,
 } from "#/server/reader/queries";
 import { rotationSeed } from "#/server/reader/rail-rotation";
-import { attachRecommendedByToArticles } from "#/server/reader/recommended-by";
+import {
+  attachRecommendedByToArticles,
+  attachViewerRecommendedToArticles,
+} from "#/server/reader/recommended-by";
 import {
   effectiveFollowSets,
   effectiveFollowUris,
@@ -332,7 +335,7 @@ async function buildHomeFeedCritical(
       0,
       HOME_TRENDING_ROW_LIMIT + 1,
     );
-    const trendingCards = await attachSubscribedLabels(
+    const trendingLabeled = await attachSubscribedLabels(
       db,
       schema,
       ctx.did,
@@ -341,6 +344,12 @@ async function buildHomeFeedCritical(
         schema,
         trackReading ? trendingVisible : articleCardsAsAllRead(trendingVisible),
       ),
+    );
+    const trendingCards = await attachViewerRecommendedToArticles(
+      db,
+      schema,
+      ctx.did,
+      trendingLabeled,
     );
     span.set("trending", trendingCards.length);
 
@@ -399,6 +408,13 @@ async function buildHomeFeedCritical(
       ? attachRecommendedByToArticles(db, schema, ctx.followedUserDids, cards)
       : Promise.resolve(cards),
   ]);
+  // Flag the viewer's own recommends so cards show "Recommended by you".
+  const withViewerRecs = await attachViewerRecommendedToArticles(
+    db,
+    schema,
+    ctx.did,
+    withRecs,
+  );
 
   // Drop anything the reader hid via a subscribed labeler's label.
   const hidden = hiddenUrisFromLabels(labelsByUri);
@@ -413,7 +429,7 @@ async function buildHomeFeedCritical(
   const withCounts = await attachCommentCountsToArticles(
     db,
     schema,
-    withRecs.filter((article) => !hidden.has(article.uri)),
+    withViewerRecs.filter((article) => !hidden.has(article.uri)),
   );
   const enrichedWithRecs = attachLabelsFromMap(withCounts, labelsByUri);
   const byUri = new Map(
@@ -689,7 +705,13 @@ async function loadLatestFeedCritical(
     schema,
     trackReading ? visibleItems : articleCardsAsAllRead(visibleItems),
   );
-  const attributedItems = attachLabelsFromMap(enrichedItems, labelsByUri);
+  const withViewerRecs = await attachViewerRecommendedToArticles(
+    db,
+    schema,
+    did,
+    enrichedItems,
+  );
+  const attributedItems = attachLabelsFromMap(withViewerRecs, labelsByUri);
 
   return {
     items: attributedItems,

--- a/src/integrations/tanstack-query/api-lists.functions.ts
+++ b/src/integrations/tanstack-query/api-lists.functions.ts
@@ -30,7 +30,10 @@ import {
   followedPublications,
   selectArticleCards,
 } from "#/server/reader/queries";
-import { attachRecommendedByToArticles } from "#/server/reader/recommended-by";
+import {
+  attachRecommendedByToArticles,
+  attachViewerRecommendedToArticles,
+} from "#/server/reader/recommended-by";
 import type { SubscriptionList } from "#/server/reader/saved-lists";
 import {
   hasSavedListDb,
@@ -564,9 +567,15 @@ const getListFeed = createServerFn({ method: "GET" })
               enriched,
             )
           : enriched;
+      const withViewerRecs = await attachViewerRecommendedToArticles(
+        db,
+        schema,
+        session?.did,
+        attributed,
+      );
 
       return {
-        items: attributed,
+        items: withViewerRecs,
         nextOffset:
           items.length === data.limit ? data.offset + data.limit : null,
       } satisfies ListFeed;

--- a/src/integrations/tanstack-query/api-publication.functions.ts
+++ b/src/integrations/tanstack-query/api-publication.functions.ts
@@ -40,7 +40,10 @@ import {
   selectArticleCardsByUris,
   selectPublicationArticleCards,
 } from "#/server/reader/queries";
-import { attachRecommendedByToArticles } from "#/server/reader/recommended-by";
+import {
+  attachRecommendedByToArticles,
+  attachViewerRecommendedToArticles,
+} from "#/server/reader/recommended-by";
 import { effectiveFollowSets } from "#/server/reader/saved-lists";
 import { themeModeForRequest } from "#/server/theme-preference";
 
@@ -343,11 +346,17 @@ const getPublicationDocuments = createServerFn({ method: "GET" })
                 documents,
               )
             : documents;
+        const withViewerRecs = await attachViewerRecommendedToArticles(
+          db,
+          schema,
+          did,
+          withRecommendedBy,
+        );
         // No DB round trip: reads cached counts + schedules background refresh.
         const items = await attachCommentCountsToArticles(
           db,
           schema,
-          withRecommendedBy,
+          withViewerRecs,
         );
 
         span.set("count", items.length);

--- a/src/integrations/tanstack-query/api-reader.functions.ts
+++ b/src/integrations/tanstack-query/api-reader.functions.ts
@@ -34,6 +34,7 @@ import { observe } from "#/server/observability/log";
 import { syncFollowedPublications } from "#/server/reader/followed-publications-sync.server";
 import { markDocumentsRead } from "#/server/reader/mark-documents-read";
 import { selectUnreadDocumentUris } from "#/server/reader/queries";
+import { attachViewerRecommendedToArticles } from "#/server/reader/recommended-by";
 import { effectiveFollowSets } from "#/server/reader/saved-lists";
 import {
   unfollowPublicationForSession,
@@ -168,6 +169,41 @@ function buildReaderListPage<T>(
         ? offset + items.length
         : null,
   };
+}
+
+/**
+ * Flag the queue items (saved / history) whose article the viewer recommended,
+ * so the rows show the "Recommended by you" indicator. One batched query over
+ * the page's cards; a no-op when nothing on the page is recommended.
+ */
+async function flagViewerRecommendedItems<
+  T extends { article: ArticleCard | null },
+>(
+  db: Parameters<typeof attachViewerRecommendedToArticles>[0],
+  schema: Parameters<typeof attachViewerRecommendedToArticles>[1],
+  viewerDid: string | null | undefined,
+  items: Array<T>,
+): Promise<Array<T>> {
+  const articles = items
+    .map((item) => item.article)
+    .filter((article): article is ArticleCard => article != null);
+  const flagged = await attachViewerRecommendedToArticles(
+    db,
+    schema,
+    viewerDid,
+    articles,
+  );
+  const recommendedUris = new Set(
+    flagged
+      .filter((article) => article.viewerHasRecommended)
+      .map((article) => article.uri),
+  );
+  if (recommendedUris.size === 0) return items;
+  return items.map((item) =>
+    item.article && recommendedUris.has(item.article.uri)
+      ? { ...item, article: { ...item.article, viewerHasRecommended: true } }
+      : item,
+  );
 }
 
 export interface FollowStatus {
@@ -889,7 +925,14 @@ const getReadingHistory = createServerFn({ method: "GET" })
         article: hydrateArticleFromRow(row, { isRead: true }),
       })) satisfies Array<ReadHistoryItem>;
 
-      return buildReaderListPage(items, data.offset, total);
+      const withViewerRecs = await flagViewerRecommendedItems(
+        context.db,
+        context.schema,
+        did,
+        items,
+      );
+
+      return buildReaderListPage(withViewerRecs, data.offset, total);
     }),
   );
 
@@ -981,7 +1024,14 @@ const getSaved = createServerFn({ method: "GET" })
         article: hydrateArticleFromRow(row),
       })) satisfies Array<SavedArticleItem>;
 
-      return buildReaderListPage(items, data.offset, total);
+      const withViewerRecs = await flagViewerRecommendedItems(
+        context.db,
+        context.schema,
+        did,
+        items,
+      );
+
+      return buildReaderListPage(withViewerRecs, data.offset, total);
     }),
   );
 

--- a/src/integrations/tanstack-query/api-search.functions.ts
+++ b/src/integrations/tanstack-query/api-search.functions.ts
@@ -22,6 +22,7 @@ import {
   discoverEligiblePublicationWhere,
   notExcludedPublicationArticleWhere,
 } from "#/server/reader/publication-filters";
+import { attachViewerRecommendedToArticles } from "#/server/reader/recommended-by";
 import {
   documentSearchSnippetHeadline,
   documentSearchTitleHeadline,
@@ -153,7 +154,7 @@ const searchArticles = createServerFn({ method: "GET" })
       const pa = alias(schema.profiles, "pa");
       span.set("q", data.q);
       span.set("offset", data.offset);
-      await attachReaderSpanContext(span, getRequest());
+      const did = await attachReaderSpanContext(span, getRequest());
 
       const tsq = sql`websearch_to_tsquery('english', ${data.q})`;
       const hints = documentQueryHints(data.q);
@@ -220,10 +221,16 @@ const searchArticles = createServerFn({ method: "GET" })
       const hasMore = pageRows.length > data.limit;
       const articleRows = hasMore ? pageRows.slice(0, data.limit) : pageRows;
 
+      const withViewerRecs = await attachViewerRecommendedToArticles(
+        db,
+        schema,
+        did,
+        articleRows.map((row) => toArticleCard(row)),
+      );
       const items = await attachCommentCountsToArticles(
         db,
         schema,
-        articleRows.map((row) => toArticleCard(row)),
+        withViewerRecs,
       );
       span.set("count", items.length);
 

--- a/src/integrations/tanstack-query/api-shapes.ts
+++ b/src/integrations/tanstack-query/api-shapes.ts
@@ -145,6 +145,14 @@ export interface ArticleCard {
    * reached the feed as an author's own post or a subscribed publication's.
    */
   recommendedBy?: Array<ArticleCardRecommender>;
+  /**
+   * Whether the requesting reader has recommended this article themselves.
+   * Drives the "Recommended by you" indicator (red heart) shown on document
+   * items across the app. Attached server-side (see
+   * `attachViewerRecommendedToArticles`); only meaningful when the query ran for
+   * a signed-in reader, otherwise defaults to `false`.
+   */
+  viewerHasRecommended: boolean;
 }
 
 /** A followed user who recommended an article (for feed attribution). */
@@ -458,6 +466,9 @@ export function toArticleCard(row: ArticleCardRow): ArticleCard {
     recommendCount: row.recommendCount ?? 0,
     commentCount: 0,
     isRead: row.isRead ?? false,
+    // Defaults to false; `attachViewerRecommendedToArticles` flips it to true
+    // for the signed-in reader's own recommends after the card is built.
+    viewerHasRecommended: false,
     searchTitleHtml: row.searchTitleHtml ?? undefined,
     searchSnippetHtml: row.searchSnippetHtml ?? undefined,
   };

--- a/src/integrations/tanstack-query/api-tag.functions.ts
+++ b/src/integrations/tanstack-query/api-tag.functions.ts
@@ -25,7 +25,10 @@ import {
   selectTagPublicationUris,
   tagDirectoryPublications,
 } from "#/server/reader/queries";
-import { attachRecommendedByToArticles } from "#/server/reader/recommended-by";
+import {
+  attachRecommendedByToArticles,
+  attachViewerRecommendedToArticles,
+} from "#/server/reader/recommended-by";
 import { effectiveFollowSets } from "#/server/reader/saved-lists";
 
 import type { ArticleCard, PublicationCard } from "./api-shapes";
@@ -131,10 +134,16 @@ const getArticles = createServerFn({ method: "GET" })
         followSets?.userDids ?? [],
         rows,
       );
+      const withViewerRecs = await attachViewerRecommendedToArticles(
+        db,
+        schema,
+        did,
+        withRecs,
+      );
       const withCounts = await attachCommentCountsToArticles(
         db,
         schema,
-        withRecs,
+        withViewerRecs,
       );
       const items = await attachSubscribedLabels(db, schema, did, withCounts);
       span.set("count", items.length);
@@ -249,11 +258,17 @@ const getTagPage = createServerFn({ method: "GET" })
       if (data.view === "feed") {
         // "Recommended by @follow" attribution — no-op (no query) for signed-out
         // readers and readers who follow no one.
-        const items = await attachRecommendedByToArticles(
+        const withRecs = await attachRecommendedByToArticles(
           db,
           schema,
           followSets?.userDids ?? [],
           content as Array<ArticleCard>,
+        );
+        const items = await attachViewerRecommendedToArticles(
+          db,
+          schema,
+          did,
+          withRecs,
         );
         span.set("count", items.length);
         return {

--- a/src/server/reader/recommended-by.ts
+++ b/src/server/reader/recommended-by.ts
@@ -76,3 +76,53 @@ export async function attachRecommendedByToArticles<
       : article;
   });
 }
+
+/**
+ * Flag the cards the requesting reader has recommended themselves, so document
+ * items across the app can show the "Recommended by you" indicator. One batched,
+ * index-served query (rides the `(recommender_did, document_uri)` composite
+ * index) sets `viewerHasRecommended: true` on matching cards; the rest keep the
+ * `false` default from {@link toArticleCard}.
+ *
+ * A no-op (no query) for signed-out readers (`viewerDid` null/empty) and empty
+ * card lists — those keep `viewerHasRecommended: false`. Unlike
+ * {@link attachRecommendedByToArticles}, this is the viewer's *own* recommend
+ * state, so it is independent of who they follow and never excludes self.
+ */
+export async function attachViewerRecommendedToArticles<
+  T extends Pick<ArticleCard, "uri" | "viewerHasRecommended">,
+>(
+  dbClient: typeof db,
+  schemaModule: typeof schema,
+  viewerDid: string | null | undefined,
+  articles: Array<T>,
+): Promise<Array<T>> {
+  if (!viewerDid || articles.length === 0) {
+    return articles;
+  }
+
+  const uris = [...new Set(articles.map((article) => article.uri))];
+  const rec = schemaModule.recommends;
+
+  const rows = await dbClient
+    .select({ documentUri: rec.documentUri })
+    .from(rec)
+    .where(
+      and(
+        inArray(rec.documentUri, uris),
+        eq(rec.recommenderDid, viewerDid),
+        eq(rec.deleted, false),
+      ),
+    );
+
+  if (rows.length === 0) {
+    return articles;
+  }
+
+  const recommended = new Set(rows.map((row) => row.documentUri));
+  return articles.map((article) =>
+    recommended.has(article.uri)
+      ? { ...article, viewerHasRecommended: true }
+      : article,
+  );
+}


### PR DESCRIPTION
When the signed-in reader has recommended a document, its cards now show a
red heart + "Recommended by you" eyebrow — the same social affordance every
platform gives you after you like something.

- Add `viewerHasRecommended` to the `ArticleCard` shape (defaults false in
  `toArticleCard`).
- Add `attachViewerRecommendedToArticles` — one batched, index-served query
  (rides the `(recommender_did, document_uri)` composite index) that flags the
  viewer's own recommends. Wired into every card-producing surface: home,
  latest, discover/friends, tag, publication, author (writing + likes tabs),
  search, and the saved / reading-history queues. No-op for signed-out readers.
- `RecommendedByLine` renders "Recommended by you" (taking precedence over the
  followed-user "@handle and N others" attribution) and now also drives the
  compact trending row; the feature card's byline-less branch shows it too.
- Flip `viewerHasRecommended` optimistically alongside the recommend toggle so
  the indicator updates instantly in feed caches.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MoRChjtrX9FxVbd2edAFrC