### PR TITLE
Fix over-tall iframe embeds declared with a percentage width

### DIFF
--- a/src/components/reader/content/renderers/shared/iframe-dimensions.test.ts
+++ b/src/components/reader/content/renderers/shared/iframe-dimensions.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { parsePixelDimension } from "./iframe-dimensions";
+
+describe("parsePixelDimension", () => {
+  it("accepts positive numbers", () => {
+    expect(parsePixelDimension(200)).toBe(200);
+    expect(parsePixelDimension(315.5)).toBe(315.5);
+  });
+
+  it("rejects non-positive and non-finite numbers", () => {
+    expect(parsePixelDimension(0)).toBeUndefined();
+    expect(parsePixelDimension(-10)).toBeUndefined();
+    expect(parsePixelDimension(Number.NaN)).toBeUndefined();
+    expect(parsePixelDimension(Number.POSITIVE_INFINITY)).toBeUndefined();
+  });
+
+  it("accepts unitless and px strings", () => {
+    expect(parsePixelDimension("560")).toBe(560);
+    expect(parsePixelDimension(" 315 ")).toBe(315);
+    expect(parsePixelDimension("200px")).toBe(200);
+    expect(parsePixelDimension("200PX")).toBe(200);
+    expect(parsePixelDimension("12.5px")).toBe(12.5);
+  });
+
+  it("rejects relative units so responsive embeds keep their pixel height", () => {
+    expect(parsePixelDimension("100%")).toBeUndefined();
+    expect(parsePixelDimension("50%")).toBeUndefined();
+    expect(parsePixelDimension("10em")).toBeUndefined();
+    expect(parsePixelDimension("100vw")).toBeUndefined();
+    expect(parsePixelDimension("auto")).toBeUndefined();
+  });
+
+  it("rejects empty and missing values", () => {
+    const missing: string | undefined = undefined;
+
+    expect(parsePixelDimension("")).toBeUndefined();
+    expect(parsePixelDimension("   ")).toBeUndefined();
+    expect(parsePixelDimension(missing)).toBeUndefined();
+    expect(parsePixelDimension(null)).toBeUndefined();
+  });
+});

--- a/src/components/reader/content/renderers/shared/iframe-dimensions.ts
+++ b/src/components/reader/content/renderers/shared/iframe-dimensions.ts
@@ -1,0 +1,27 @@
+/**
+ * HTML `width`/`height` attributes are only meaningful as layout numbers when
+ * they are unitless or `px`. Publishers routinely ship `width="100%"` on
+ * responsive embeds; parsing that as `100` and pairing it with `height="200"`
+ * would produce a 1:2 aspect ratio and render the embed at twice the column
+ * width tall.
+ */
+const PIXEL_DIMENSION = /^\s*(\d+(?:\.\d+)?)\s*(?:px)?\s*$/i;
+
+/**
+ * Parse a dimension into pixels, rejecting relative units (`%`, `em`, `vw`, …)
+ * and non-positive values.
+ */
+export function parsePixelDimension(
+  value: string | number | undefined | null,
+): number | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value > 0 ? value : undefined;
+  }
+  if (typeof value !== "string") return undefined;
+
+  const match = PIXEL_DIMENSION.exec(value);
+  if (!match) return undefined;
+
+  const parsed = Number.parseFloat(match[1]);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}

--- a/src/components/reader/content/renderers/shared/iframe-embed.tsx
+++ b/src/components/reader/content/renderers/shared/iframe-embed.tsx
@@ -7,6 +7,7 @@ import {
   articleBodyStyles,
   IFRAME_FRAME_BORDER_WIDTH,
 } from "../../body-styles";
+import { parsePixelDimension } from "./iframe-dimensions";
 
 const DEFAULT_ASPECT_RATIO = "16 / 9";
 
@@ -26,17 +27,6 @@ function iframeReferrerPolicy(url: string): React.HTMLAttributeReferrerPolicy {
   return needsReferrer ? "strict-origin-when-cross-origin" : "no-referrer";
 }
 
-function parseDimension(
-  value: string | number | undefined,
-): number | undefined {
-  if (typeof value === "number" && value > 0) return value;
-  if (typeof value === "string") {
-    const parsed = Number.parseFloat(value);
-    if (Number.isFinite(parsed) && parsed > 0) return parsed;
-  }
-  return undefined;
-}
-
 export function IframeEmbedView({
   url,
   height,
@@ -50,10 +40,10 @@ export function IframeEmbedView({
 
   if (!url.trim()) return null;
 
-  const ratioWidth = parseDimension(aspectRatio?.width);
-  const ratioHeight = parseDimension(aspectRatio?.height);
+  const ratioWidth = parsePixelDimension(aspectRatio?.width);
+  const ratioHeight = parsePixelDimension(aspectRatio?.height);
   const hasRatio = ratioWidth != null && ratioHeight != null;
-  const fixedHeight = parseDimension(height);
+  const fixedHeight = parsePixelDimension(height);
 
   // A declared aspect ratio means the embed should scale with the fluid
   // column width (e.g. a 16:9 video); a bare height with no ratio means the
@@ -106,8 +96,11 @@ export function MarkdownIframeEmbed({
   width?: string | number | null;
   height?: string | number | null;
 }) {
-  const embedWidth = parseDimension(width ?? undefined);
-  const embedHeight = parseDimension(height ?? undefined);
+  // Only a pixel width pairs with the height to form a real aspect ratio.
+  // `width="100%"` is a fluid-width hint, not a ratio numerator — treating it
+  // as one renders e.g. `width="100%" height="200"` at 2x the column width.
+  const embedWidth = parsePixelDimension(width);
+  const embedHeight = parsePixelDimension(height);
 
   return (
     <IframeEmbedView


### PR DESCRIPTION
## The bug

Podcast/audio embeds render absurdly tall. Repro: [Ctrl-Alt-Speech: Live At TrustCon 2026](https://standard-reader.app/a/did:plc:l4edfel22exejp7mewt6f3ky/3mrg5swlllxrl), whose body contains a Buzzsprout player:

```html
<iframe src="https://www.buzzsprout.com/…" width="100%" height="200" …>
```

`parseDimension` in `iframe-embed.tsx` used a bare `Number.parseFloat`, so `"100%"` parsed to `100`. With both a width and a height present, `MarkdownIframeEmbed` handed them to `IframeEmbedView` as an **aspect ratio of 100 : 200** — so the iframe rendered at *twice the column width* tall (~1400px on desktop) instead of the 200px the embed asked for.

## The fix

- New `iframe-dimensions.ts` — `parsePixelDimension` accepts only unitless or `px` values, rejecting `%`, `em`, `vw`, `auto`, and non-positive/non-finite numbers.
- `iframe-embed.tsx` uses it everywhere the old parser was used. A percentage width now yields no ratio, so the existing "bare height ⇒ fixed pixel height" branch takes over and the player renders 200px tall at full column width — what a responsive audio widget wants.
- Colocated unit tests covering the `100%` case and the units matrix.

Unchanged: `width="560" height="315"` still gives a fluid 16:9 video, and a dimensionless iframe still falls back to the 16:9 default.

## Verification

`pnpm test` (323 passed), `pnpm typecheck`, `pnpm lint`, `pnpm format:check` all pass.

Not verified by rendering the page locally — there's no `.env` in the worktree, so the app can't reach the DB. Verification is via unit tests at the boundary that broke; worth a look on the preview deploy against the linked article.

🤖 Generated with [Claude Code](https://claude.com/claude-code)