### PR TITLE
Add "Customize sidebar" to hide primary nav items

### DIFF
--- a/APP_VISION.md
+++ b/APP_VISION.md
@@ -372,6 +372,14 @@ source of truth; Neon holds a derived view for speed and cross-network querying.
   `site.standard.graph.subscription` records are written. Both `list` and `listSave` records are
   **mirrored into Neon** (`lists` + `list_saves` tables) by the tap ingester so the shell snapshot
   never blocks on PDS I/O. A backfill from the PDS runs on first access when no rows exist yet.
+- **Sidebar personalization:** `app.standard-reader.sidebarPref` — a per-reader singleton (rkey
+  `self`, mirrored into `sidebar_prefs`) holding the reader's list-group order (`listOrder`),
+  collapsed groups (`collapsed`), and — via the **Customize sidebar** toggle in Settings —
+  which primary nav items are hidden (`customizeNav` gates the `hiddenNav` id set). The
+  customizable items are the top nav links only (Home, Latest, Saved for later, Collections,
+  Discover, Search); Subscriptions and its list groups are never hideable. When the toggle is
+  off, every nav item shows regardless of `hiddenNav`. Hidden items drop from both the desktop
+  sidebar and the mobile bottom-nav.
 - **Routing:** URL-backed routes (TanStack Router) for every view — home / latest / discover /
   search / article / publication — with real back/forward navigation and shareable links.
   _(The original prototype used an in-memory view stack; the port moves to real URLs.)_

--- a/TODO.md
+++ b/TODO.md
@@ -513,6 +513,13 @@ Build each on hip-ui components + StyleX tokens (no raw HTML/inline styles).
       readers get **Add list / Remove list**, which
       writes/deletes an `app.standard-reader.listSave` record — saved lists then render as
       extra sidebar groups (attributed `name · @owner`, label links to the list page).
+- [x] **Customize sidebar (hide nav items)** — a **Customize sidebar** toggle in Settings reveals a
+      per-item switch for each primary nav link (Home, Latest, Saved for later, Collections, Discover,
+      Search); turning one off hides it from both the desktop sidebar and the mobile bottom-nav.
+      Subscriptions and its list groups stay put (never hideable). Persisted on the
+      `app.standard-reader.sidebarPref` singleton (`customizeNav` gate + `hiddenNav` id set,
+      mirrored to `sidebar_prefs`); when the toggle is off every item shows regardless. Shared nav
+      metadata lives in `src/lib/sidebar-nav.ts`.
 - [x] **Saved lists act as virtual subscriptions** — feeds, the sidebar, unread counts, and
       mark-all-read operate on the reader's _effective_ follow set (subscriptions ∪ saved-list
       publications) via `effectiveFollowUris` in `src/server/reader/saved-lists.ts`; saved

--- a/drizzle/0019_big_payback.sql
+++ b/drizzle/0019_big_payback.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "sidebar_prefs" ADD COLUMN "customize_nav" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "sidebar_prefs" ADD COLUMN "hidden_nav" jsonb DEFAULT '[]'::jsonb NOT NULL;

--- a/drizzle/meta/0019_snapshot.json
+++ b/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,3821 @@
+{
+  "id": "d7a32a50-d042-4ce7-8af8-a5e1878492f9",
+  "prevId": "e1fdae60-36cd-44bb-8994-512888e000f9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_mode": {
+          "name": "theme_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale_hint_seen": {
+          "name": "locale_hint_seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reader_voice": {
+          "name": "reader_voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_links_externally": {
+          "name": "open_links_externally",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_collections_in_magazine": {
+          "name": "open_collections_in_magazine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reading_typography": {
+          "name": "reading_typography",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_reading_history": {
+          "name": "track_reading_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count_old_posts_as_unread": {
+          "name": "count_old_posts_as_unread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_scope": {
+          "name": "home_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_hidden_tabs": {
+          "name": "profile_hidden_tabs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_show_likes": {
+          "name": "profile_show_likes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_authoring_enabled": {
+          "name": "collections_authoring_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userinput_feedback_enabled": {
+          "name": "userinput_feedback_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "margin_save_enabled": {
+          "name": "margin_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semble_save_enabled": {
+          "name": "semble_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "atstore_review_prompt_dismissed": {
+          "name": "atstore_review_prompt_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_enabled": {
+          "name": "weekly_digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_subscriptions": {
+          "name": "weekly_digest_section_subscriptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_network": {
+          "name": "weekly_digest_section_network",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_saved": {
+          "name": "weekly_digest_section_saved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_recommendations": {
+          "name": "weekly_digest_section_recommendations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_last_sent_at": {
+          "name": "weekly_digest_last_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_welcome_sent_at": {
+          "name": "weekly_digest_welcome_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_did_unique": {
+          "name": "user_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "did"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pds": {
+          "name": "pds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_url": {
+          "name": "banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_uri": {
+          "name": "bsky_profile_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_cid": {
+          "name": "bsky_profile_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_fetched_at": {
+          "name": "profile_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_handle_idx": {
+          "name": "profiles_handle_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_handle_trgm_idx": {
+          "name": "profiles_handle_trgm_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "profiles_display_name_trgm_idx": {
+          "name": "profiles_display_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publications": {
+      "name": "publications",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_cid": {
+          "name": "icon_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_mime": {
+          "name": "icon_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent": {
+          "name": "theme_accent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_background": {
+          "name": "theme_background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_foreground": {
+          "name": "theme_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent_foreground": {
+          "name": "theme_accent_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_json": {
+          "name": "theme_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_in_discover": {
+          "name": "show_in_discover",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "collections_publication": {
+          "name": "collections_publication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_checked_at": {
+          "name": "verification_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(name, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(topic, '')), 'B')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publications_did_idx": {
+          "name": "publications_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_name_idx": {
+          "name": "publications_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_discover_idx": {
+          "name": "publications_discover_idx",
+          "columns": [
+            {
+              "expression": "show_in_discover",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_topic_idx": {
+          "name": "publications_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_url_idx": {
+          "name": "publications_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_search_idx": {
+          "name": "publications_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_contributors": {
+      "name": "document_contributors",
+      "schema": "",
+      "columns": {
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "document_contributors_did_idx": {
+          "name": "document_contributors_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_contributors_document_uri_documents_uri_fk": {
+          "name": "document_contributors_document_uri_documents_uri_fk",
+          "tableFrom": "document_contributors",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_contributors_document_uri_did_pk": {
+          "name": "document_contributors_document_uri_did_pk",
+          "columns": [
+            "document_uri",
+            "did"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_uri": {
+          "name": "site_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_json": {
+          "name": "collection_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_renderable_body": {
+          "name": "has_renderable_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cover_image_cid": {
+          "name": "cover_image_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_mime": {
+          "name": "cover_image_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backlink_count": {
+          "name": "backlink_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_count_prev": {
+          "name": "backlink_count_prev",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_synced_at": {
+          "name": "backlink_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_recomputed_at": {
+          "name": "trending_recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_recommender_count": {
+          "name": "distinct_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bsky_post_uri": {
+          "name": "bsky_post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_post_cid": {
+          "name": "bsky_post_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_updated_at": {
+          "name": "record_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(title, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(immutable_array_to_string(tags), '')), 'B') || setweight(to_tsvector('english', coalesce(text_content, '')), 'C')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documents_did_idx": {
+          "name": "documents_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_did_published_idx": {
+          "name": "documents_did_published_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"published_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_publication_published_idx": {
+          "name": "documents_publication_published_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_published_idx": {
+          "name": "documents_published_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_featured_idx": {
+          "name": "documents_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_site_idx": {
+          "name": "documents_site_idx",
+          "columns": [
+            {
+              "expression": "site_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_search_idx": {
+          "name": "documents_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "documents_trending_idx": {
+          "name": "documents_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_idx": {
+          "name": "documents_canonical_url_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_trgm_idx": {
+          "name": "documents_canonical_url_trgm_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommends": {
+      "name": "recommends",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommender_did": {
+          "name": "recommender_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recommends_document_idx": {
+          "name": "recommends_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_recommender_idx": {
+          "name": "recommends_recommender_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_edge_idx": {
+          "name": "recommends_edge_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_doc_recommender_created_idx": {
+          "name": "recommends_doc_recommender_created_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recommends\".\"deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_did": {
+          "name": "publication_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_publication_idx": {
+          "name": "subscriptions_publication_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_subscriber_idx": {
+          "name": "subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_edge_idx": {
+          "name": "subscriptions_edge_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follower_did": {
+          "name": "follower_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excluded_publications": {
+          "name": "excluded_publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_subject_idx": {
+          "name": "user_follows_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_edge_idx": {
+          "name": "user_follows_edge_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_owner_idx": {
+          "name": "bookmarks_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_document_idx": {
+          "name": "bookmarks_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_edge_idx": {
+          "name": "bookmarks_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reads": {
+      "name": "reads",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reads_owner_idx": {
+          "name": "reads_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_document_idx": {
+          "name": "reads_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_edge_idx": {
+          "name": "reads_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidebar_prefs": {
+      "name": "sidebar_prefs",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_order": {
+          "name": "list_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customize_nav": {
+          "name": "customize_nav",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_nav": {
+          "name": "hidden_nav",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_saves": {
+      "name": "list_saves",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saver_did": {
+          "name": "saver_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_owner_did": {
+          "name": "list_owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "list_saves_saver_idx": {
+          "name": "list_saves_saver_idx",
+          "columns": [
+            {
+              "expression": "saver_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "list_saves_list_uri_idx": {
+          "name": "list_saves_list_uri_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lists": {
+      "name": "lists",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publications": {
+          "name": "publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "users": {
+          "name": "users",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lists_owner_idx": {
+          "name": "lists_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rkey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_corecommends": {
+      "name": "publication_corecommends",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_recommender_count": {
+          "name": "co_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_corecomm_rank_idx": {
+          "name": "publication_corecomm_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_corecommends_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_corecommends_related_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_corecommends_publication_uri_related_publication_uri_pk": {
+          "name": "publication_corecommends_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_cosubscriptions": {
+      "name": "publication_cosubscriptions",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_subscriber_count": {
+          "name": "co_subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_cosub_rank_idx": {
+          "name": "publication_cosub_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_cosubscriptions_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_cosubscriptions_related_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_cosubscriptions_publication_uri_related_publication_uri_pk": {
+          "name": "publication_cosubscriptions_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_stats": {
+      "name": "publication_stats",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommend_count": {
+          "name": "recommend_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_document_at": {
+          "name": "last_document_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documents_7d": {
+          "name": "documents_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_7d": {
+          "name": "subscribers_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_7d": {
+          "name": "recommends_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "documents_prev_7d": {
+          "name": "documents_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_prev_7d": {
+          "name": "subscribers_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_prev_7d": {
+          "name": "recommends_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlinks_7d": {
+          "name": "backlinks_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_velocity": {
+          "name": "trending_velocity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_window_start": {
+          "name": "trending_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_stats_subscribers_idx": {
+          "name": "publication_stats_subscribers_idx",
+          "columns": [
+            {
+              "expression": "subscriber_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_active_idx": {
+          "name": "publication_stats_active_idx",
+          "columns": [
+            {
+              "expression": "last_document_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_trending_idx": {
+          "name": "publication_stats_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_stats_publication_uri_publications_uri_fk": {
+          "name": "publication_stats_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_stats",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discover_topic_counts": {
+      "name": "discover_topic_counts",
+      "schema": "",
+      "columns": {
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discover_topic_counts_count_idx": {
+          "name": "discover_topic_counts_count_idx",
+          "columns": [
+            {
+              "expression": "publication_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discover_topic_counts_topic_trgm_idx": {
+          "name": "discover_topic_counts_topic_trgm_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_dead_letter": {
+      "name": "ingest_dead_letter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retries": {
+          "name": "retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingest_dead_letter_collection_idx": {
+          "name": "ingest_dead_letter_collection_idx",
+          "columns": [
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_state": {
+      "name": "ingest_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_processed": {
+          "name": "events_processed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_repos": {
+      "name": "tracked_repos",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_to_tap_at": {
+          "name": "added_to_tap_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_state": {
+          "name": "backfill_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_seen_rev": {
+          "name": "last_seen_rev",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_fail_count": {
+          "name": "reconcile_fail_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconcile_retry_after": {
+          "name": "reconcile_retry_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tracked_repos_state_idx": {
+          "name": "tracked_repos_state_idx",
+          "columns": [
+            {
+              "expression": "backfill_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_labels": {
+      "name": "document_labels",
+      "schema": "",
+      "columns": {
+        "src": {
+          "name": "src",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "val": {
+          "name": "val",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cts": {
+          "name": "cts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_labels_uri_idx": {
+          "name": "document_labels_uri_idx",
+          "columns": [
+            {
+              "expression": "uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_labels_src_idx": {
+          "name": "document_labels_src_idx",
+          "columns": [
+            {
+              "expression": "src",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "document_labels_src_uri_val_pk": {
+          "name": "document_labels_src_uri_val_pk",
+          "columns": [
+            "src",
+            "uri",
+            "val"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_sync_state": {
+      "name": "label_sync_state",
+      "schema": "",
+      "columns": {
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_services": {
+      "name": "labeler_services",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_endpoint": {
+          "name": "service_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_value_definitions": {
+          "name": "label_value_definitions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_services_labeler_idx": {
+          "name": "labeler_services_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_subscriptions": {
+      "name": "labeler_subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefs": {
+          "name": "prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_subscriptions_subscriber_idx": {
+          "name": "labeler_subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labeler_subscriptions_labeler_idx": {
+          "name": "labeler_subscriptions_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_shares": {
+      "name": "quote_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_text": {
+          "name": "quote_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quote_shares_document_uri_idx": {
+          "name": "quote_shares_document_uri_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_draft": {
+      "name": "feedback_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feedback_draft_user_idx": {
+          "name": "feedback_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_draft_expires_idx": {
+          "name": "feedback_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_draft_user_id_user_id_fk": {
+          "name": "feedback_draft_user_id_user_id_fk",
+          "tableFrom": "feedback_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upvote_draft": {
+      "name": "upvote_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "upvote_draft_user_idx": {
+          "name": "upvote_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upvote_draft_expires_idx": {
+          "name": "upvote_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upvote_draft_user_id_user_id_fk": {
+          "name": "upvote_draft_user_id_user_id_fk",
+          "tableFrom": "upvote_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.save_draft": {
+      "name": "save_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_app": {
+          "name": "target_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_uri": {
+          "name": "collection_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_cid": {
+          "name": "collection_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_collection_name": {
+          "name": "new_collection_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motivation": {
+          "name": "motivation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passage": {
+          "name": "passage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "save_draft_user_idx": {
+          "name": "save_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "save_draft_expires_idx": {
+          "name": "save_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "save_draft_user_id_user_id_fk": {
+          "name": "save_draft_user_id_user_id_fk",
+          "tableFrom": "save_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1784603390663,
       "tag": "0018_discover_topic_counts",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1784936864607,
+      "tag": "0019_big_payback",
+      "breakpoints": true
     }
   ]
 }

--- a/lexicons/app/standard-reader/sidebarPref.json
+++ b/lexicons/app/standard-reader/sidebarPref.json
@@ -4,7 +4,7 @@
   "defs": {
     "main": {
       "type": "record",
-      "description": "A reader's personal sidebar preferences: the display order of their subscription list groups and which groups are collapsed. A singleton record (rkey `self`).",
+      "description": "A reader's personal sidebar preferences: the display order of their subscription list groups, which groups are collapsed, and which primary nav items are hidden. A singleton record (rkey `self`).",
       "key": "literal:self",
       "record": {
         "type": "object",
@@ -27,6 +27,19 @@
               "format": "at-uri"
             },
             "description": "AT URIs of the list groups the reader has collapsed in the sidebar."
+          },
+          "customizeNav": {
+            "type": "boolean",
+            "description": "Whether the reader has enabled 'Customize sidebar'. When true, the `hiddenNav` items are hidden; when false or absent, every primary nav item is shown regardless of `hiddenNav`."
+          },
+          "hiddenNav": {
+            "type": "array",
+            "maxLength": 32,
+            "items": {
+              "type": "string",
+              "maxLength": 64
+            },
+            "description": "Stable ids of the primary sidebar nav items the reader has hidden (e.g. 'home', 'latest', 'discover', 'search', 'saved', 'collections'). Subscriptions and its list groups are never hideable."
           },
           "updatedAt": {
             "type": "string",

--- a/packages/lexicons/src/lexicons/app/standard-reader/sidebarPref.defs.ts
+++ b/packages/lexicons/src/lexicons/app/standard-reader/sidebarPref.defs.ts
@@ -8,7 +8,7 @@ const $nsid = 'app.standard-reader.sidebarPref'
 
 export { $nsid }
 
-/** A reader's personal sidebar preferences: the display order of their subscription list groups and which groups are collapsed. A singleton record (rkey `self`). */
+/** A reader's personal sidebar preferences: the display order of their subscription list groups, which groups are collapsed, and which primary nav items are hidden. A singleton record (rkey `self`). */
 type Main = {
   $type: 'app.standard-reader.sidebarPref'
 
@@ -21,6 +21,16 @@ type Main = {
    * AT URIs of the list groups the reader has collapsed in the sidebar.
    */
   collapsed?: l.AtUriString[]
+
+  /**
+   * Whether the reader has enabled 'Customize sidebar'. When true, the `hiddenNav` items are hidden; when false or absent, every primary nav item is shown regardless of `hiddenNav`.
+   */
+  customizeNav?: boolean
+
+  /**
+   * Stable ids of the primary sidebar nav items the reader has hidden (e.g. 'home', 'latest', 'discover', 'search', 'saved', 'collections'). Subscriptions and its list groups are never hideable.
+   */
+  hiddenNav?: string[]
 
   /**
    * When these preferences were last changed.
@@ -43,6 +53,12 @@ const main = /*#__PURE__*/ l.record<'literal:self', Main>(
     collapsed: /*#__PURE__*/ l.optional(
       /*#__PURE__*/ l.array(/*#__PURE__*/ l.string({ format: 'at-uri' }), {
         maxLength: 1000,
+      }),
+    ),
+    customizeNav: /*#__PURE__*/ l.optional(/*#__PURE__*/ l.boolean()),
+    hiddenNav: /*#__PURE__*/ l.optional(
+      /*#__PURE__*/ l.array(/*#__PURE__*/ l.string({ maxLength: 64 }), {
+        maxLength: 32,
       }),
     ),
     updatedAt: /*#__PURE__*/ l.string({ format: 'datetime' }),

--- a/src/components/reader/app-shell.tsx
+++ b/src/components/reader/app-shell.tsx
@@ -39,6 +39,7 @@ import {
 import { formatSidebarUnreadCount } from "#/lib/format-count";
 import { parseInternalRoute } from "#/lib/internal-route";
 import { PageReaderProvider } from "#/lib/page-reader/page-reader-provider";
+import type { SidebarNavId } from "#/lib/sidebar-nav";
 import { useFormatters } from "#/lib/use-formatters";
 
 import { Avatar } from "../../design-system/avatar";
@@ -661,19 +662,37 @@ const styles = stylex.create({
 });
 
 interface NavLink {
+  /** Stable id used by "Customize sidebar" to hide the item. */
+  id: SidebarNavId;
   to: string;
   label: MessageDescriptor;
   icon: React.ReactNode;
 }
 
 const NAV: Array<NavLink> = [
-  { to: "/", label: msg`Home`, icon: <Home size={18} /> },
-  { to: "/latest", label: msg`Latest`, icon: <Newspaper size={18} /> },
-  { to: "/discover", label: msg`Discover`, icon: <Compass size={18} /> },
-  { to: "/search", label: msg`Search`, icon: <Search size={18} /> },
+  { id: "home", to: "/", label: msg`Home`, icon: <Home size={18} /> },
+  {
+    id: "latest",
+    to: "/latest",
+    label: msg`Latest`,
+    icon: <Newspaper size={18} />,
+  },
+  {
+    id: "discover",
+    to: "/discover",
+    label: msg`Discover`,
+    icon: <Compass size={18} />,
+  },
+  {
+    id: "search",
+    to: "/search",
+    label: msg`Search`,
+    icon: <Search size={18} />,
+  },
 ];
 
 const SAVED_NAV: NavLink = {
+  id: "saved",
   to: "/saved",
   label: msg`Saved for later`,
   icon: <Bookmark size={18} />,
@@ -683,6 +702,7 @@ const SAVED_NAV: NavLink = {
 const SAVED_SHORT_LABEL = msg`Saved`;
 
 const COLLECTIONS_NAV: NavLink = {
+  id: "collections",
   to: "/collections",
   label: msg`Collections`,
   icon: <Layers size={18} />,
@@ -1246,6 +1266,11 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   // Apply the reader's saved group order (own + saved interleaved); new lists
   // fall to the bottom until moved.
   const sidebarPref = useSidebarPref(signedIn);
+  // "Customize sidebar" hides selected primary nav items (Subscriptions and its
+  // list groups are never hideable). When the toggle is off, show everything.
+  const visibleNav = sidebarPref.customizeNav
+    ? primaryNav.filter((item) => !sidebarPref.isNavHidden(item.id))
+    : primaryNav;
   const orderedGroups = orderGroups(listGroups, sidebarPref.order);
   const groupUris = orderedGroups.map((group) => group.listUri);
   const allCollapsed =
@@ -1301,7 +1326,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
             <div {...stylex.props(styles.sidebarScroll)}>
               <Brand style={styles.brandSidebar} to="/about" />
               <nav {...stylex.props(styles.nav)}>
-                {primaryNav.map((item) => (
+                {visibleNav.map((item) => (
                   <SidebarNavItem
                     key={item.to}
                     {...item}
@@ -1454,7 +1479,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
             <div {...stylex.props(styles.dock)}>
               <PageReaderBar />
-              <BottomNavSlot items={primaryNav} hasUnread={hasUnread} />
+              <BottomNavSlot items={visibleNav} hasUnread={hasUnread} />
             </div>
           </main>
 

--- a/src/components/reader/use-sidebar-pref.ts
+++ b/src/components/reader/use-sidebar-pref.ts
@@ -7,7 +7,12 @@ import type { SidebarPref } from "#/integrations/tanstack-query/api-sidebar-pref
 import { sidebarPrefApi } from "#/integrations/tanstack-query/api-sidebar-prefs.functions";
 import { sidebarPrefQueryOptions } from "#/integrations/tanstack-query/shell-queries";
 
-const EMPTY: SidebarPref = { listOrder: [], collapsed: [] };
+const EMPTY: SidebarPref = {
+  listOrder: [],
+  collapsed: [],
+  customizeNav: false,
+  hiddenNav: [],
+};
 
 /** Debounce collapse writes: rapid chevron toggles coalesce into one PDS write. */
 const COLLAPSE_WRITE_DELAY_MS = 600;
@@ -45,6 +50,14 @@ export interface SidebarPrefController {
   setAllCollapsed: (listUris: Array<string>, collapsed: boolean) => void;
   /** Persist a new group order immediately. */
   saveOrder: (order: Array<string>) => void;
+  /** Whether "Customize sidebar" is enabled (gates `isNavHidden`). */
+  customizeNav: boolean;
+  /** Toggle the "Customize sidebar" master switch (immediate write-through). */
+  setCustomizeNav: (enabled: boolean) => void;
+  /** Whether a primary nav item is hidden (only meaningful when `customizeNav`). */
+  isNavHidden: (navId: string) => boolean;
+  /** Show/hide one primary nav item (immediate write-through). */
+  setNavHidden: (navId: string, hidden: boolean) => void;
 }
 
 /**
@@ -138,7 +151,32 @@ export function useSidebarPref(signedIn: boolean): SidebarPrefController {
     [queryClient, options.queryKey, write],
   );
 
+  const setCustomizeNav = useCallback(
+    (enabled: boolean) => {
+      const current =
+        queryClient.getQueryData<SidebarPref>(options.queryKey) ?? EMPTY;
+      write({ ...current, customizeNav: enabled }, true);
+    },
+    [queryClient, options.queryKey, write],
+  );
+
+  const setNavHidden = useCallback(
+    (navId: string, hidden: boolean) => {
+      const current =
+        queryClient.getQueryData<SidebarPref>(options.queryKey) ?? EMPTY;
+      const set = new Set(current.hiddenNav);
+      if (hidden) {
+        set.add(navId);
+      } else {
+        set.delete(navId);
+      }
+      write({ ...current, hiddenNav: [...set] }, true);
+    },
+    [queryClient, options.queryKey, write],
+  );
+
   const collapsedSet = new Set(pref.collapsed);
+  const hiddenNavSet = new Set(pref.hiddenNav);
 
   return {
     order: pref.listOrder,
@@ -146,5 +184,9 @@ export function useSidebarPref(signedIn: boolean): SidebarPrefController {
     setCollapsed,
     setAllCollapsed,
     saveOrder,
+    customizeNav: pref.customizeNav,
+    setCustomizeNav,
+    isNavHidden: (navId: string) => hiddenNavSet.has(navId),
+    setNavHidden,
   };
 }

--- a/src/components/user-settings-view.tsx
+++ b/src/components/user-settings-view.tsx
@@ -10,6 +10,7 @@ import { ChevronRight, Monitor, Moon, Sparkles, Sun } from "lucide-react";
 import { useCallback, useState } from "react";
 
 import { invalidateReadQueries } from "#/components/reader/read-optimistic";
+import { useSidebarPref } from "#/components/reader/use-sidebar-pref";
 import { ButtonLink } from "#/components/router-links";
 import { DirectionalIcon } from "#/design-system/directional-icon";
 import { auth } from "#/integrations/tanstack-query/api-auth.functions";
@@ -33,6 +34,7 @@ import {
   readingFontSizeLabel,
   readingMeasureLabel,
 } from "#/lib/reading-typography";
+import { CUSTOMIZABLE_SIDEBAR_NAV } from "#/lib/sidebar-nav";
 import type { ThemeMode } from "#/lib/theme";
 import { isThemeMode } from "#/lib/theme";
 import { useCountOldPostsAsUnread } from "#/lib/use-count-old-posts-as-unread";
@@ -436,6 +438,10 @@ export function UserSettingsView() {
   const { enabled: countOldAsUnread, setEnabled: setCountOldAsUnread } =
     useCountOldPostsAsUnread();
 
+  const { data: session } = useQuery(user.getSessionQueryOptions);
+  const signedIn = Boolean(session?.user);
+  const sidebarPref = useSidebarPref(signedIn);
+
   const deleteHistoryMutation = useMutation(
     readerApi.deleteAllReadHistoryMutationOptions(),
   );
@@ -688,6 +694,46 @@ export function UserSettingsView() {
           </SettingRow>
         </div>
       </section>
+
+      {signedIn ? (
+        <section {...stylex.props(styles.section)}>
+          <h2 {...stylex.props(styles.sectionHeading)}>
+            <Trans>Sidebar</Trans>
+          </h2>
+          <div {...stylex.props(styles.settingGroup)}>
+            <SettingRow
+              label={t`Customize sidebar`}
+              description={t`Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay.`}
+            >
+              <Switch
+                isSelected={sidebarPref.customizeNav}
+                onChange={sidebarPref.setCustomizeNav}
+                aria-label={t`Customize sidebar`}
+              />
+            </SettingRow>
+            {sidebarPref.customizeNav
+              ? CUSTOMIZABLE_SIDEBAR_NAV.map((item) => {
+                  const itemLabel = i18n._(item.label);
+                  const visible = !sidebarPref.isNavHidden(item.id);
+                  return (
+                    <div key={item.id}>
+                      <Separator />
+                      <SettingRow label={itemLabel}>
+                        <Switch
+                          isSelected={visible}
+                          onChange={(next) =>
+                            sidebarPref.setNavHidden(item.id, !next)
+                          }
+                          aria-label={t`Show ${itemLabel} in the sidebar`}
+                        />
+                      </SettingRow>
+                    </div>
+                  );
+                })
+              : null}
+          </div>
+        </section>
+      ) : null}
 
       <section {...stylex.props(styles.section)}>
         <h2 {...stylex.props(styles.sectionHeading)}>

--- a/src/components/user-settings-view.tsx
+++ b/src/components/user-settings-view.tsx
@@ -718,7 +718,10 @@ export function UserSettingsView() {
                   return (
                     <div key={item.id}>
                       <Separator />
-                      <SettingRow label={itemLabel}>
+                      <SettingRow
+                        label={itemLabel}
+                        description={i18n._(item.description)}
+                      >
                         <Switch
                           isSelected={visible}
                           onChange={(next) =>

--- a/src/db/schema/personal.ts
+++ b/src/db/schema/personal.ts
@@ -117,6 +117,11 @@ export const sidebarPrefs = pgTable("sidebar_prefs", {
   /** At-uris of the list groups the reader has collapsed. */
   collapsed: jsonb("collapsed").notNull().default([]),
 
+  /** Whether "Customize sidebar" is enabled (gates `hiddenNav`). */
+  customizeNav: boolean("customize_nav").notNull().default(false),
+  /** Stable ids of the primary nav items the reader has hidden. */
+  hiddenNav: jsonb("hidden_nav").notNull().default([]),
+
   /** `updatedAt` from the record. */
   updatedAt: timestamp("updated_at", { withTimezone: true }),
 

--- a/src/integrations/tanstack-query/api-sidebar-prefs.functions.ts
+++ b/src/integrations/tanstack-query/api-sidebar-prefs.functions.ts
@@ -22,17 +22,24 @@ import { loadSidebarPref } from "#/server/reader/shell-snapshot.server";
  * reads it without PDS I/O; writes go through to the mirror immediately.
  */
 
-/** Ordering + collapsed state for the sidebar's list groups. */
+/** Ordering + collapsed state for the sidebar's list groups, plus which primary
+ * nav items are hidden. */
 export interface SidebarPref {
   /** Ordered at-uris of the reader's list groups (own + saved). */
   listOrder: Array<string>;
   /** At-uris of the list groups the reader has collapsed. */
   collapsed: Array<string>;
+  /** Whether "Customize sidebar" is enabled (gates `hiddenNav`). */
+  customizeNav: boolean;
+  /** Stable ids of the primary nav items the reader has hidden. */
+  hiddenNav: Array<string>;
 }
 
 const putSidebarPrefInput = z.object({
   listOrder: z.array(z.string().min(1)).max(1000).default([]),
   collapsed: z.array(z.string().min(1)).max(1000).default([]),
+  customizeNav: z.boolean().default(false),
+  hiddenNav: z.array(z.string().min(1).max(64)).max(32).default([]),
 });
 
 const getSidebarPref = createServerFn({ method: "GET" }).handler(
@@ -40,7 +47,12 @@ const getSidebarPref = createServerFn({ method: "GET" }).handler(
     // DID-only lookup (no PDS client restore) — preferences are DB data.
     const did = await getReaderDidForRequest(getRequest());
     if (!did) {
-      return { listOrder: [], collapsed: [] } satisfies SidebarPref;
+      return {
+        listOrder: [],
+        collapsed: [],
+        customizeNav: false,
+        hiddenNav: [],
+      } satisfies SidebarPref;
     }
     span.set("did", did);
     const pref = await loadSidebarPref(did);
@@ -61,6 +73,8 @@ const putSidebarPref = createServerFn({ method: "POST" })
       span.set("did", session.did);
       span.set("order", data.listOrder.length);
       span.set("collapsed", data.collapsed.length);
+      span.set("customizeNav", data.customizeNav);
+      span.set("hiddenNav", data.hiddenNav.length);
 
       const updatedAt = new Date().toISOString();
       const { uri, cid } = await putSidebarPrefRecord(
@@ -69,6 +83,8 @@ const putSidebarPref = createServerFn({ method: "POST" })
         {
           listOrder: data.listOrder,
           collapsed: data.collapsed,
+          customizeNav: data.customizeNav,
+          hiddenNav: data.hiddenNav,
           updatedAt,
         },
       );
@@ -77,6 +93,8 @@ const putSidebarPref = createServerFn({ method: "POST" })
       await upsertSidebarPref(uri, session.did, SIDEBAR_PREF_RKEY, cid, {
         listOrder: data.listOrder,
         collapsed: data.collapsed,
+        customizeNav: data.customizeNav,
+        hiddenNav: data.hiddenNav,
         updatedAt,
       });
       return { ok: true as const };

--- a/src/lib/sidebar-nav.ts
+++ b/src/lib/sidebar-nav.ts
@@ -20,6 +20,8 @@ export interface SidebarNavMeta {
   /** Route the item links to. */
   to: string;
   label: MessageDescriptor;
+  /** One-line summary of what the tab is, shown in the customize UI. */
+  description: MessageDescriptor;
   /** Only rendered in the sidebar when the reader is signed in. */
   signedInOnly: boolean;
 }
@@ -30,27 +32,48 @@ export interface SidebarNavMeta {
  * The "Customize sidebar" settings UI iterates this list.
  */
 export const CUSTOMIZABLE_SIDEBAR_NAV: ReadonlyArray<SidebarNavMeta> = [
-  { id: "home", to: "/", label: msg`Home`, signedInOnly: false },
-  { id: "latest", to: "/latest", label: msg`Latest`, signedInOnly: false },
+  {
+    id: "home",
+    to: "/",
+    label: msg`Home`,
+    description: msg`Your day: a featured lead and the latest from your subscriptions.`,
+    signedInOnly: false,
+  },
+  {
+    id: "latest",
+    to: "/latest",
+    label: msg`Latest`,
+    description: msg`Everything newest first, with unread and all-network filters.`,
+    signedInOnly: false,
+  },
   {
     id: "saved",
     to: "/saved",
     label: msg`Saved for later`,
+    description: msg`Articles you've bookmarked to read later.`,
     signedInOnly: true,
   },
   {
     id: "collections",
     to: "/collections",
     label: msg`Collections`,
+    description: msg`Your own curated sets of articles.`,
     signedInOnly: true,
   },
   {
     id: "discover",
     to: "/discover",
     label: msg`Discover`,
+    description: msg`Browse the publication directory to find new writers.`,
     signedInOnly: false,
   },
-  { id: "search", to: "/search", label: msg`Search`, signedInOnly: false },
+  {
+    id: "search",
+    to: "/search",
+    label: msg`Search`,
+    description: msg`Find publications, people, topics, and headlines.`,
+    signedInOnly: false,
+  },
 ];
 
 /** Map a nav route to its stable customize id, if it is a hideable item. */

--- a/src/lib/sidebar-nav.ts
+++ b/src/lib/sidebar-nav.ts
@@ -1,0 +1,63 @@
+import type { MessageDescriptor } from "@lingui/core";
+import { msg } from "@lingui/core/macro";
+
+/**
+ * Stable ids for the primary sidebar nav items that "Customize sidebar" can
+ * hide. These strings are persisted in the reader's `sidebarPref` record, so
+ * they must stay stable even if a route path changes. Subscriptions and its
+ * list groups are intentionally not part of this set — they can't be hidden.
+ */
+export type SidebarNavId =
+  | "home"
+  | "latest"
+  | "saved"
+  | "collections"
+  | "discover"
+  | "search";
+
+export interface SidebarNavMeta {
+  id: SidebarNavId;
+  /** Route the item links to. */
+  to: string;
+  label: MessageDescriptor;
+  /** Only rendered in the sidebar when the reader is signed in. */
+  signedInOnly: boolean;
+}
+
+/**
+ * The hideable primary nav items, in the order they appear in the sidebar
+ * (Saved + Collections sit between Latest and Discover for signed-in readers).
+ * The "Customize sidebar" settings UI iterates this list.
+ */
+export const CUSTOMIZABLE_SIDEBAR_NAV: ReadonlyArray<SidebarNavMeta> = [
+  { id: "home", to: "/", label: msg`Home`, signedInOnly: false },
+  { id: "latest", to: "/latest", label: msg`Latest`, signedInOnly: false },
+  {
+    id: "saved",
+    to: "/saved",
+    label: msg`Saved for later`,
+    signedInOnly: true,
+  },
+  {
+    id: "collections",
+    to: "/collections",
+    label: msg`Collections`,
+    signedInOnly: true,
+  },
+  {
+    id: "discover",
+    to: "/discover",
+    label: msg`Discover`,
+    signedInOnly: false,
+  },
+  { id: "search", to: "/search", label: msg`Search`, signedInOnly: false },
+];
+
+/** Map a nav route to its stable customize id, if it is a hideable item. */
+const ID_BY_ROUTE = new Map<string, SidebarNavId>(
+  CUSTOMIZABLE_SIDEBAR_NAV.map((item) => [item.to, item.id]),
+);
+
+export function sidebarNavIdForRoute(to: string): SidebarNavId | undefined {
+  return ID_BY_ROUTE.get(to);
+}

--- a/src/locales/ar/messages.po
+++ b/src/locales/ar/messages.po
@@ -983,6 +983,10 @@ msgstr "تصفّح تغذيتك"
 msgid "RSS feed URL"
 msgstr "رابط تغذية RSS"
 
+#: src/lib/sidebar-nav.ts
+msgid "Your own curated sets of articles."
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
@@ -2460,6 +2464,10 @@ msgstr "قيد القراءة"
 msgid "Be the first to share a bug, idea, or question."
 msgstr "كن أول من يشارك خللًا أو فكرة أو سؤالًا."
 
+#: src/lib/sidebar-nav.ts
+msgid "Browse the publication directory to find new writers."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "الأكثر قراءة عبر الشبكة الآن."
@@ -3188,6 +3196,10 @@ msgstr "غرفة القراءة الخاصة بك"
 #: src/routes/_layout.index.tsx
 msgid "Fresh"
 msgstr "جديد"
+
+#: src/lib/sidebar-nav.ts
+msgid "Everything newest first, with unread and all-network filters."
+msgstr ""
 
 #: src/components/reader/mention-hover-card.tsx
 msgid "Verified"
@@ -4003,6 +4015,10 @@ msgstr "انقر على «تشغيل المثال» لجلب استجابة حي
 msgid "Legal"
 msgstr "قانوني"
 
+#: src/lib/sidebar-nav.ts
+msgid "Articles you've bookmarked to read later."
+msgstr ""
+
 #: src/components/reader/app-shell.tsx
 msgid "{unread} unread"
 msgstr "{unread} غير مقروءة"
@@ -4464,6 +4480,10 @@ msgstr "عروض القوائم"
 msgid "Drag to change the order your lists appear in the sidebar."
 msgstr "اسحب لتغيير ترتيب ظهور قوائمك في الشريط الجانبي."
 
+#: src/lib/sidebar-nav.ts
+msgid "Find publications, people, topics, and headlines."
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 msgid "Standard Reader indexes <0>site.standard.document</0> and <1>site.standard.publication</1> records out of AT Proto repos. Platforms like Leaflet, Pckt, and Offprint write these records for you as part of publishing, so their authors get the full reader treatment automatically. If you run your own site and hand-roll your own <2>site.standard</2> integration instead, you write those records yourself — this page covers what to add, including Markpub, the markdown format we recommend for a hand-rolled body."
 msgstr "يفهرس Standard Reader سجلات <0>site.standard.document</0> و<1>site.standard.publication</1> من مستودعات AT Proto. تكتب منصات مثل Leaflet وPckt وOffprint هذه السجلات نيابةً عنك ضمن عملية النشر، فيحصل مؤلفوها على تجربة القارئ الكاملة تلقائيًا. أما إن كنت تدير موقعك بنفسك وتبني تكاملك مع <2>site.standard</2> يدويًا، فعليك كتابة تلك السجلات بنفسك — وتغطي هذه الصفحة ما يلزم إضافته، بما في ذلك Markpub، وهي صيغة markdown التي نوصي بها لمتن مكتوب يدويًا."
@@ -4644,6 +4664,10 @@ msgstr "يمكنك إضافتها لاحقًا من صفحة الاكتشاف."
 #: src/routes/_layout.u.$did.tsx
 msgid "Reader"
 msgstr "قارئ"
+
+#: src/lib/sidebar-nav.ts
+msgid "Your day: a featured lead and the latest from your subscriptions."
+msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag views"

--- a/src/locales/ar/messages.po
+++ b/src/locales/ar/messages.po
@@ -92,6 +92,7 @@ msgstr "إضافة مقال"
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/article-below-fold.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
 msgid "Discover"
@@ -229,6 +230,10 @@ msgstr "{publicationCountText} · {articleCountText}"
 #: src/components/reader/collection-builder.tsx
 msgid "Search by title or author, or paste a URL or at:// URI"
 msgstr "ابحث بالعنوان أو الكاتب، أو الصق عنوان URL أو معرّف at://"
+
+#: src/components/user-settings-view.tsx
+msgid "Show {itemLabel} in the sidebar"
+msgstr ""
 
 #: src/routes/collection.$did.$rkey.tsx
 msgid "Opening the collection…"
@@ -623,6 +628,10 @@ msgstr "نظرة عامة"
 msgid "Nothing saved yet"
 msgstr "لا شيء محفوظ بعد"
 
+#: src/components/user-settings-view.tsx
+msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, zero {الاشتراك في {formattedUnfollowedCount} منشورة؟} one {الاشتراك في منشورة واحدة؟} two {الاشتراك في منشورتين؟} few {الاشتراك في {formattedUnfollowedCount} منشورات؟} many {الاشتراك في {formattedUnfollowedCount} منشورة؟} other {الاشتراك في {formattedUnfollowedCount} منشورة؟}}"
@@ -880,6 +889,7 @@ msgstr "استبدال صورة الغلاف"
 
 #: src/components/labelers-settings-view.tsx
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 msgid "Search"
 msgstr "بحث"
 
@@ -1348,6 +1358,7 @@ msgstr "لا تريد تطبيقًا آخر لتتفقّده؟ اشترك في �
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collections-upgrade-gate.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.collections.edit.$rkey.tsx
 #: src/routes/_layout.collections.index.tsx
 #: src/routes/_layout.collections.new.tsx
@@ -1960,6 +1971,10 @@ msgstr ""
 msgid "Original"
 msgstr "الأصلي"
 
+#: src/components/user-settings-view.tsx
+msgid "Customize sidebar"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Next"
 msgstr "التالي"
@@ -1987,6 +2002,7 @@ msgstr "الخطوط"
 
 #: src/components/Header.tsx
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 msgid "Home"
 msgstr "الرئيسية"
 
@@ -3881,6 +3897,10 @@ msgstr "عند الحفظ أو المتابعة من الامتداد، يكتب
 msgid "Create series"
 msgstr "إنشاء سلسلة"
 
+#: src/components/user-settings-view.tsx
+msgid "Sidebar"
+msgstr ""
+
 #: src/components/onboarding/step-settings.tsx
 msgid "Reading & privacy"
 msgstr "القراءة والخصوصية"
@@ -4163,6 +4183,7 @@ msgid "A quiet place to begin"
 msgstr "مكان هادئ للبداية"
 
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.latest.tsx
 msgid "Latest"
 msgstr "الأحدث"
@@ -4480,6 +4501,7 @@ msgstr "ليس على Standard Reader بعد"
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
 #: src/components/user-settings-view.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.saved.tsx
 msgid "Saved for later"
 msgstr "محفوظ لوقت لاحق"

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -983,6 +983,10 @@ msgstr "Feed durchstöbern"
 msgid "RSS feed URL"
 msgstr "RSS-Feed-URL"
 
+#: src/lib/sidebar-nav.ts
+msgid "Your own curated sets of articles."
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
@@ -2460,6 +2464,10 @@ msgstr "Lesen"
 msgid "Be the first to share a bug, idea, or question."
 msgstr "Teilen Sie als Erste(r) einen Fehler, eine Idee oder eine Frage."
 
+#: src/lib/sidebar-nav.ts
+msgid "Browse the publication directory to find new writers."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "Die meistgelesenen Texte im Netzwerk gerade jetzt."
@@ -3188,6 +3196,10 @@ msgstr "Ihr Lesezimmer"
 #: src/routes/_layout.index.tsx
 msgid "Fresh"
 msgstr "Neu"
+
+#: src/lib/sidebar-nav.ts
+msgid "Everything newest first, with unread and all-network filters."
+msgstr ""
 
 #: src/components/reader/mention-hover-card.tsx
 msgid "Verified"
@@ -4003,6 +4015,10 @@ msgstr "Klicken Sie auf „Beispiel ausführen“, um eine Live-Antwort abzurufe
 msgid "Legal"
 msgstr "Rechtliches"
 
+#: src/lib/sidebar-nav.ts
+msgid "Articles you've bookmarked to read later."
+msgstr ""
+
 #: src/components/reader/app-shell.tsx
 msgid "{unread} unread"
 msgstr "{unread} ungelesen"
@@ -4464,6 +4480,10 @@ msgstr "Listenansichten"
 msgid "Drag to change the order your lists appear in the sidebar."
 msgstr "Ziehen Sie, um die Reihenfolge Ihrer Listen in der Seitenleiste zu ändern."
 
+#: src/lib/sidebar-nav.ts
+msgid "Find publications, people, topics, and headlines."
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 msgid "Standard Reader indexes <0>site.standard.document</0> and <1>site.standard.publication</1> records out of AT Proto repos. Platforms like Leaflet, Pckt, and Offprint write these records for you as part of publishing, so their authors get the full reader treatment automatically. If you run your own site and hand-roll your own <2>site.standard</2> integration instead, you write those records yourself — this page covers what to add, including Markpub, the markdown format we recommend for a hand-rolled body."
 msgstr "Standard Reader indexiert <0>site.standard.document</0>- und <1>site.standard.publication</1>-Records aus AT-Proto-Repos. Plattformen wie Leaflet, Pckt und Offprint schreiben diese Records beim Veröffentlichen für Sie, sodass deren Autoren automatisch die volle Reader-Darstellung erhalten. Wenn Sie eine eigene Website betreiben und Ihre <2>site.standard</2>-Anbindung selbst bauen, schreiben Sie die Records selbst — diese Seite zeigt, was dazugehört, inklusive Markpub, dem Markdown-Format, das wir für selbst gebaute Inhalte empfehlen."
@@ -4644,6 +4664,10 @@ msgstr "Sie können sie später unter „Entdecken“ hinzufügen."
 #: src/routes/_layout.u.$did.tsx
 msgid "Reader"
 msgstr "Reader"
+
+#: src/lib/sidebar-nav.ts
+msgid "Your day: a featured lead and the latest from your subscriptions."
+msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag views"

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -92,6 +92,7 @@ msgstr "Artikel hinzufügen"
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/article-below-fold.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
 msgid "Discover"
@@ -229,6 +230,10 @@ msgstr "{publicationCountText} · {articleCountText}"
 #: src/components/reader/collection-builder.tsx
 msgid "Search by title or author, or paste a URL or at:// URI"
 msgstr "Nach Titel oder Autor suchen oder eine URL bzw. at://-URI einfügen"
+
+#: src/components/user-settings-view.tsx
+msgid "Show {itemLabel} in the sidebar"
+msgstr ""
 
 #: src/routes/collection.$did.$rkey.tsx
 msgid "Opening the collection…"
@@ -623,6 +628,10 @@ msgstr "Überblick"
 msgid "Nothing saved yet"
 msgstr "Noch nichts gespeichert"
 
+#: src/components/user-settings-view.tsx
+msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {{formattedUnfollowedCount} Publikation abonnieren?} other {{formattedUnfollowedCount} Publikationen abonnieren?}}"
@@ -880,6 +889,7 @@ msgstr "Titelbild ersetzen"
 
 #: src/components/labelers-settings-view.tsx
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 msgid "Search"
 msgstr "Suchen"
 
@@ -1348,6 +1358,7 @@ msgstr "Keine Lust, noch eine App zu prüfen? Abonnieren Sie eine wöchentliche 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collections-upgrade-gate.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.collections.edit.$rkey.tsx
 #: src/routes/_layout.collections.index.tsx
 #: src/routes/_layout.collections.new.tsx
@@ -1960,6 +1971,10 @@ msgstr ""
 msgid "Original"
 msgstr "Original"
 
+#: src/components/user-settings-view.tsx
+msgid "Customize sidebar"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Next"
 msgstr "Weiter"
@@ -1987,6 +2002,7 @@ msgstr "Schriften"
 
 #: src/components/Header.tsx
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 msgid "Home"
 msgstr "Start"
 
@@ -3881,6 +3897,10 @@ msgstr "Wenn Sie aus der Erweiterung heraus speichern oder folgen, schreibt {SIT
 msgid "Create series"
 msgstr "Reihe erstellen"
 
+#: src/components/user-settings-view.tsx
+msgid "Sidebar"
+msgstr ""
+
 #: src/components/onboarding/step-settings.tsx
 msgid "Reading & privacy"
 msgstr "Lesen & Datenschutz"
@@ -4163,6 +4183,7 @@ msgid "A quiet place to begin"
 msgstr "Ein ruhiger Ort zum Anfangen"
 
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.latest.tsx
 msgid "Latest"
 msgstr "Neueste"
@@ -4480,6 +4501,7 @@ msgstr "Noch nicht auf Standard Reader"
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
 #: src/components/user-settings-view.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.saved.tsx
 msgid "Saved for later"
 msgstr "Für später gespeichert"

--- a/src/locales/en-XA/messages.po
+++ b/src/locales/en-XA/messages.po
@@ -92,6 +92,7 @@ msgstr ""
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/article-below-fold.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
 msgid "Discover"
@@ -228,6 +229,10 @@ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "Search by title or author, or paste a URL or at:// URI"
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Show {itemLabel} in the sidebar"
 msgstr ""
 
 #: src/routes/collection.$did.$rkey.tsx
@@ -623,6 +628,10 @@ msgstr ""
 msgid "Nothing saved yet"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr ""
@@ -880,6 +889,7 @@ msgstr ""
 
 #: src/components/labelers-settings-view.tsx
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 msgid "Search"
 msgstr ""
 
@@ -1348,6 +1358,7 @@ msgstr ""
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collections-upgrade-gate.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.collections.edit.$rkey.tsx
 #: src/routes/_layout.collections.index.tsx
 #: src/routes/_layout.collections.new.tsx
@@ -1960,6 +1971,10 @@ msgstr ""
 msgid "Original"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Customize sidebar"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Next"
 msgstr ""
@@ -1987,6 +2002,7 @@ msgstr ""
 
 #: src/components/Header.tsx
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 msgid "Home"
 msgstr ""
 
@@ -3881,6 +3897,10 @@ msgstr ""
 msgid "Create series"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Sidebar"
+msgstr ""
+
 #: src/components/onboarding/step-settings.tsx
 msgid "Reading & privacy"
 msgstr ""
@@ -4163,6 +4183,7 @@ msgid "A quiet place to begin"
 msgstr ""
 
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.latest.tsx
 msgid "Latest"
 msgstr ""
@@ -4480,6 +4501,7 @@ msgstr ""
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
 #: src/components/user-settings-view.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.saved.tsx
 msgid "Saved for later"
 msgstr ""

--- a/src/locales/en-XA/messages.po
+++ b/src/locales/en-XA/messages.po
@@ -983,6 +983,10 @@ msgstr ""
 msgid "RSS feed URL"
 msgstr ""
 
+#: src/lib/sidebar-nav.ts
+msgid "Your own curated sets of articles."
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
@@ -2460,6 +2464,10 @@ msgstr ""
 msgid "Be the first to share a bug, idea, or question."
 msgstr ""
 
+#: src/lib/sidebar-nav.ts
+msgid "Browse the publication directory to find new writers."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr ""
@@ -3187,6 +3195,10 @@ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Fresh"
+msgstr ""
+
+#: src/lib/sidebar-nav.ts
+msgid "Everything newest first, with unread and all-network filters."
 msgstr ""
 
 #: src/components/reader/mention-hover-card.tsx
@@ -4003,6 +4015,10 @@ msgstr ""
 msgid "Legal"
 msgstr ""
 
+#: src/lib/sidebar-nav.ts
+msgid "Articles you've bookmarked to read later."
+msgstr ""
+
 #: src/components/reader/app-shell.tsx
 msgid "{unread} unread"
 msgstr ""
@@ -4464,6 +4480,10 @@ msgstr ""
 msgid "Drag to change the order your lists appear in the sidebar."
 msgstr ""
 
+#: src/lib/sidebar-nav.ts
+msgid "Find publications, people, topics, and headlines."
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 msgid "Standard Reader indexes <0>site.standard.document</0> and <1>site.standard.publication</1> records out of AT Proto repos. Platforms like Leaflet, Pckt, and Offprint write these records for you as part of publishing, so their authors get the full reader treatment automatically. If you run your own site and hand-roll your own <2>site.standard</2> integration instead, you write those records yourself — this page covers what to add, including Markpub, the markdown format we recommend for a hand-rolled body."
 msgstr ""
@@ -4643,6 +4663,10 @@ msgstr ""
 #: src/magazine/Magazine.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Reader"
+msgstr ""
+
+#: src/lib/sidebar-nav.ts
+msgid "Your day: a featured lead and the latest from your subscriptions."
 msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -92,6 +92,7 @@ msgstr "Add an article"
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/article-below-fold.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
 msgid "Discover"
@@ -229,6 +230,10 @@ msgstr "{publicationCountText} · {articleCountText}"
 #: src/components/reader/collection-builder.tsx
 msgid "Search by title or author, or paste a URL or at:// URI"
 msgstr "Search by title or author, or paste a URL or at:// URI"
+
+#: src/components/user-settings-view.tsx
+msgid "Show {itemLabel} in the sidebar"
+msgstr "Show {itemLabel} in the sidebar"
 
 #: src/routes/collection.$did.$rkey.tsx
 msgid "Opening the collection…"
@@ -623,6 +628,10 @@ msgstr "Overview"
 msgid "Nothing saved yet"
 msgstr "Nothing saved yet"
 
+#: src/components/user-settings-view.tsx
+msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
+msgstr "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
@@ -880,6 +889,7 @@ msgstr "Replace cover image"
 
 #: src/components/labelers-settings-view.tsx
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 msgid "Search"
 msgstr "Search"
 
@@ -1348,6 +1358,7 @@ msgstr "Don’t want another app to check? Opt into a weekly email with the best
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collections-upgrade-gate.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.collections.edit.$rkey.tsx
 #: src/routes/_layout.collections.index.tsx
 #: src/routes/_layout.collections.new.tsx
@@ -1960,6 +1971,10 @@ msgstr "People you follow write here"
 msgid "Original"
 msgstr "Original"
 
+#: src/components/user-settings-view.tsx
+msgid "Customize sidebar"
+msgstr "Customize sidebar"
+
 #: src/magazine/Magazine.tsx
 msgid "Next"
 msgstr "Next"
@@ -1987,6 +2002,7 @@ msgstr "Fonts"
 
 #: src/components/Header.tsx
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 msgid "Home"
 msgstr "Home"
 
@@ -3881,6 +3897,10 @@ msgstr "When you save or follow from the extension, {SITE_NAME} writes AT Protoc
 msgid "Create series"
 msgstr "Create series"
 
+#: src/components/user-settings-view.tsx
+msgid "Sidebar"
+msgstr "Sidebar"
+
 #: src/components/onboarding/step-settings.tsx
 msgid "Reading & privacy"
 msgstr "Reading & privacy"
@@ -4163,6 +4183,7 @@ msgid "A quiet place to begin"
 msgstr "A quiet place to begin"
 
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.latest.tsx
 msgid "Latest"
 msgstr "Latest"
@@ -4480,6 +4501,7 @@ msgstr "Not on Standard Reader yet"
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
 #: src/components/user-settings-view.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.saved.tsx
 msgid "Saved for later"
 msgstr "Saved for later"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -983,6 +983,10 @@ msgstr "Browse your feed"
 msgid "RSS feed URL"
 msgstr "RSS feed URL"
 
+#: src/lib/sidebar-nav.ts
+msgid "Your own curated sets of articles."
+msgstr "Your own curated sets of articles."
+
 #: src/components/reader/discover-topic-filters.tsx
 msgid "No topics match “{debouncedQuery}”."
 msgstr "No topics match “{debouncedQuery}”."
@@ -2460,6 +2464,10 @@ msgstr "Reading"
 msgid "Be the first to share a bug, idea, or question."
 msgstr "Be the first to share a bug, idea, or question."
 
+#: src/lib/sidebar-nav.ts
+msgid "Browse the publication directory to find new writers."
+msgstr "Browse the publication directory to find new writers."
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "The most-read writing across the network right now."
@@ -3188,6 +3196,10 @@ msgstr "Your reading room"
 #: src/routes/_layout.index.tsx
 msgid "Fresh"
 msgstr "Fresh"
+
+#: src/lib/sidebar-nav.ts
+msgid "Everything newest first, with unread and all-network filters."
+msgstr "Everything newest first, with unread and all-network filters."
 
 #: src/components/reader/mention-hover-card.tsx
 msgid "Verified"
@@ -4003,6 +4015,10 @@ msgstr "Click Run example to fetch a live response."
 msgid "Legal"
 msgstr "Legal"
 
+#: src/lib/sidebar-nav.ts
+msgid "Articles you've bookmarked to read later."
+msgstr "Articles you've bookmarked to read later."
+
 #: src/components/reader/app-shell.tsx
 msgid "{unread} unread"
 msgstr "{unread} unread"
@@ -4464,6 +4480,10 @@ msgstr "List views"
 msgid "Drag to change the order your lists appear in the sidebar."
 msgstr "Drag to change the order your lists appear in the sidebar."
 
+#: src/lib/sidebar-nav.ts
+msgid "Find publications, people, topics, and headlines."
+msgstr "Find publications, people, topics, and headlines."
+
 #: src/components/docs/publishing-docs-page.tsx
 msgid "Standard Reader indexes <0>site.standard.document</0> and <1>site.standard.publication</1> records out of AT Proto repos. Platforms like Leaflet, Pckt, and Offprint write these records for you as part of publishing, so their authors get the full reader treatment automatically. If you run your own site and hand-roll your own <2>site.standard</2> integration instead, you write those records yourself — this page covers what to add, including Markpub, the markdown format we recommend for a hand-rolled body."
 msgstr "Standard Reader indexes <0>site.standard.document</0> and <1>site.standard.publication</1> records out of AT Proto repos. Platforms like Leaflet, Pckt, and Offprint write these records for you as part of publishing, so their authors get the full reader treatment automatically. If you run your own site and hand-roll your own <2>site.standard</2> integration instead, you write those records yourself — this page covers what to add, including Markpub, the markdown format we recommend for a hand-rolled body."
@@ -4644,6 +4664,10 @@ msgstr "You can add them later from Discover."
 #: src/routes/_layout.u.$did.tsx
 msgid "Reader"
 msgstr "Reader"
+
+#: src/lib/sidebar-nav.ts
+msgid "Your day: a featured lead and the latest from your subscriptions."
+msgstr "Your day: a featured lead and the latest from your subscriptions."
 
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag views"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -983,6 +983,10 @@ msgstr "Explorar su feed"
 msgid "RSS feed URL"
 msgstr "URL del feed RSS"
 
+#: src/lib/sidebar-nav.ts
+msgid "Your own curated sets of articles."
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
@@ -2460,6 +2464,10 @@ msgstr "Lectura"
 msgid "Be the first to share a bug, idea, or question."
 msgstr "Sea la primera persona en compartir un error, una idea o una pregunta."
 
+#: src/lib/sidebar-nav.ts
+msgid "Browse the publication directory to find new writers."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "Los textos más leídos de toda la red en este momento."
@@ -3188,6 +3196,10 @@ msgstr "Su sala de lectura"
 #: src/routes/_layout.index.tsx
 msgid "Fresh"
 msgstr "Reciente"
+
+#: src/lib/sidebar-nav.ts
+msgid "Everything newest first, with unread and all-network filters."
+msgstr ""
 
 #: src/components/reader/mention-hover-card.tsx
 msgid "Verified"
@@ -4003,6 +4015,10 @@ msgstr "Haga clic en Ejecutar ejemplo para obtener una respuesta en vivo."
 msgid "Legal"
 msgstr "Legal"
 
+#: src/lib/sidebar-nav.ts
+msgid "Articles you've bookmarked to read later."
+msgstr ""
+
 #: src/components/reader/app-shell.tsx
 msgid "{unread} unread"
 msgstr "{unread} sin leer"
@@ -4464,6 +4480,10 @@ msgstr "Vistas de lista"
 msgid "Drag to change the order your lists appear in the sidebar."
 msgstr "Arrastre para cambiar el orden en que aparecen sus listas en la barra lateral."
 
+#: src/lib/sidebar-nav.ts
+msgid "Find publications, people, topics, and headlines."
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 msgid "Standard Reader indexes <0>site.standard.document</0> and <1>site.standard.publication</1> records out of AT Proto repos. Platforms like Leaflet, Pckt, and Offprint write these records for you as part of publishing, so their authors get the full reader treatment automatically. If you run your own site and hand-roll your own <2>site.standard</2> integration instead, you write those records yourself — this page covers what to add, including Markpub, the markdown format we recommend for a hand-rolled body."
 msgstr "Standard Reader indexa registros <0>site.standard.document</0> y <1>site.standard.publication</1> de repositorios de AT Proto. Plataformas como Leaflet, Pckt y Offprint escriben estos registros por usted como parte de la publicación, así que sus autores obtienen la experiencia de lectura completa automáticamente. Si gestiona su propio sitio y prefiere hacer a mano su integración con <2>site.standard</2>, tendrá que escribir esos registros usted mismo: esta página explica qué añadir, incluido Markpub, el formato markdown que recomendamos para un cuerpo hecho a mano."
@@ -4644,6 +4664,10 @@ msgstr "Puede añadirlas más tarde desde Descubrir."
 #: src/routes/_layout.u.$did.tsx
 msgid "Reader"
 msgstr "Lector"
+
+#: src/lib/sidebar-nav.ts
+msgid "Your day: a featured lead and the latest from your subscriptions."
+msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag views"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -92,6 +92,7 @@ msgstr "Añadir un artículo"
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/article-below-fold.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
 msgid "Discover"
@@ -229,6 +230,10 @@ msgstr "{publicationCountText} · {articleCountText}"
 #: src/components/reader/collection-builder.tsx
 msgid "Search by title or author, or paste a URL or at:// URI"
 msgstr "Busque por título o autor, o pegue una URL o un URI at://"
+
+#: src/components/user-settings-view.tsx
+msgid "Show {itemLabel} in the sidebar"
+msgstr ""
 
 #: src/routes/collection.$did.$rkey.tsx
 msgid "Opening the collection…"
@@ -623,6 +628,10 @@ msgstr "Resumen"
 msgid "Nothing saved yet"
 msgstr "Todavía no hay nada guardado"
 
+#: src/components/user-settings-view.tsx
+msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {¿Suscribirse a {formattedUnfollowedCount} publicación?} other {¿Suscribirse a {formattedUnfollowedCount} publicaciones?}}"
@@ -880,6 +889,7 @@ msgstr "Reemplazar la imagen de portada"
 
 #: src/components/labelers-settings-view.tsx
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 msgid "Search"
 msgstr "Buscar"
 
@@ -1348,6 +1358,7 @@ msgstr "¿No quiere otra aplicación más que revisar? Suscríbase a un correo s
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collections-upgrade-gate.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.collections.edit.$rkey.tsx
 #: src/routes/_layout.collections.index.tsx
 #: src/routes/_layout.collections.new.tsx
@@ -1960,6 +1971,10 @@ msgstr ""
 msgid "Original"
 msgstr "Original"
 
+#: src/components/user-settings-view.tsx
+msgid "Customize sidebar"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Next"
 msgstr "Siguiente"
@@ -1987,6 +2002,7 @@ msgstr "Fuentes tipográficas"
 
 #: src/components/Header.tsx
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 msgid "Home"
 msgstr "Inicio"
 
@@ -3881,6 +3897,10 @@ msgstr "Cuando guarda o sigue algo desde la extensión, {SITE_NAME} escribe regi
 msgid "Create series"
 msgstr "Crear serie"
 
+#: src/components/user-settings-view.tsx
+msgid "Sidebar"
+msgstr ""
+
 #: src/components/onboarding/step-settings.tsx
 msgid "Reading & privacy"
 msgstr "Lectura y privacidad"
@@ -4163,6 +4183,7 @@ msgid "A quiet place to begin"
 msgstr "Un lugar tranquilo para empezar"
 
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.latest.tsx
 msgid "Latest"
 msgstr "Lo último"
@@ -4480,6 +4501,7 @@ msgstr "Todavía no está en Standard Reader"
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
 #: src/components/user-settings-view.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.saved.tsx
 msgid "Saved for later"
 msgstr "Guardado para después"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -92,6 +92,7 @@ msgstr "Ajouter un article"
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/article-below-fold.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
 msgid "Discover"
@@ -229,6 +230,10 @@ msgstr "{publicationCountText} · {articleCountText}"
 #: src/components/reader/collection-builder.tsx
 msgid "Search by title or author, or paste a URL or at:// URI"
 msgstr "Recherchez par titre ou auteur, ou collez une URL ou une URI at://"
+
+#: src/components/user-settings-view.tsx
+msgid "Show {itemLabel} in the sidebar"
+msgstr ""
 
 #: src/routes/collection.$did.$rkey.tsx
 msgid "Opening the collection…"
@@ -623,6 +628,10 @@ msgstr "Vue d’ensemble"
 msgid "Nothing saved yet"
 msgstr "Rien d’enregistré pour l’instant"
 
+#: src/components/user-settings-view.tsx
+msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {S’abonner à {formattedUnfollowedCount} publication ?} other {S’abonner à {formattedUnfollowedCount} publications ?}}"
@@ -880,6 +889,7 @@ msgstr "Remplacer l’image de couverture"
 
 #: src/components/labelers-settings-view.tsx
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 msgid "Search"
 msgstr "Rechercher"
 
@@ -1348,6 +1358,7 @@ msgstr "Pas envie d'une application de plus à consulter ? Inscrivez-vous à un 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collections-upgrade-gate.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.collections.edit.$rkey.tsx
 #: src/routes/_layout.collections.index.tsx
 #: src/routes/_layout.collections.new.tsx
@@ -1960,6 +1971,10 @@ msgstr ""
 msgid "Original"
 msgstr "Original"
 
+#: src/components/user-settings-view.tsx
+msgid "Customize sidebar"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Next"
 msgstr "Suivant"
@@ -1987,6 +2002,7 @@ msgstr "Polices"
 
 #: src/components/Header.tsx
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 msgid "Home"
 msgstr "Accueil"
 
@@ -3881,6 +3897,10 @@ msgstr "Lorsque vous enregistrez ou suivez depuis l'extension, {SITE_NAME} écri
 msgid "Create series"
 msgstr "Créer une série"
 
+#: src/components/user-settings-view.tsx
+msgid "Sidebar"
+msgstr ""
+
 #: src/components/onboarding/step-settings.tsx
 msgid "Reading & privacy"
 msgstr "Lecture et confidentialité"
@@ -4163,6 +4183,7 @@ msgid "A quiet place to begin"
 msgstr "Un endroit paisible pour commencer"
 
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.latest.tsx
 msgid "Latest"
 msgstr "Derniers"
@@ -4480,6 +4501,7 @@ msgstr "Pas encore sur Standard Reader"
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
 #: src/components/user-settings-view.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.saved.tsx
 msgid "Saved for later"
 msgstr "Enregistré pour plus tard"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -983,6 +983,10 @@ msgstr "Parcourir votre flux"
 msgid "RSS feed URL"
 msgstr "URL du flux RSS"
 
+#: src/lib/sidebar-nav.ts
+msgid "Your own curated sets of articles."
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
@@ -2460,6 +2464,10 @@ msgstr "Lecture"
 msgid "Be the first to share a bug, idea, or question."
 msgstr "Soyez le premier à signaler un bug, une idée ou une question."
 
+#: src/lib/sidebar-nav.ts
+msgid "Browse the publication directory to find new writers."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "Les textes les plus lus du réseau en ce moment."
@@ -3188,6 +3196,10 @@ msgstr "Votre salon de lecture"
 #: src/routes/_layout.index.tsx
 msgid "Fresh"
 msgstr "Récent"
+
+#: src/lib/sidebar-nav.ts
+msgid "Everything newest first, with unread and all-network filters."
+msgstr ""
 
 #: src/components/reader/mention-hover-card.tsx
 msgid "Verified"
@@ -4003,6 +4015,10 @@ msgstr "Cliquez sur Exécuter l'exemple pour obtenir une réponse en direct."
 msgid "Legal"
 msgstr "Mentions légales"
 
+#: src/lib/sidebar-nav.ts
+msgid "Articles you've bookmarked to read later."
+msgstr ""
+
 #: src/components/reader/app-shell.tsx
 msgid "{unread} unread"
 msgstr "{unread} non lus"
@@ -4464,6 +4480,10 @@ msgstr "Vues de liste"
 msgid "Drag to change the order your lists appear in the sidebar."
 msgstr "Faites glisser pour modifier l'ordre d'affichage de vos listes dans la barre latérale."
 
+#: src/lib/sidebar-nav.ts
+msgid "Find publications, people, topics, and headlines."
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 msgid "Standard Reader indexes <0>site.standard.document</0> and <1>site.standard.publication</1> records out of AT Proto repos. Platforms like Leaflet, Pckt, and Offprint write these records for you as part of publishing, so their authors get the full reader treatment automatically. If you run your own site and hand-roll your own <2>site.standard</2> integration instead, you write those records yourself — this page covers what to add, including Markpub, the markdown format we recommend for a hand-rolled body."
 msgstr "Standard Reader indexe les enregistrements <0>site.standard.document</0> et <1>site.standard.publication</1> des dépôts AT Proto. Des plateformes comme Leaflet, Pckt et Offprint écrivent ces enregistrements pour vous dans le cadre de la publication, si bien que leurs auteurs bénéficient automatiquement de toute l'expérience de lecture. Si vous gérez votre propre site et réalisez vous-même votre intégration <2>site.standard</2>, c'est à vous d'écrire ces enregistrements — cette page détaille ce qu'il faut ajouter, y compris Markpub, le format markdown que nous recommandons pour un corps d'article fait main."
@@ -4644,6 +4664,10 @@ msgstr "Vous pourrez les ajouter plus tard depuis Découvrir."
 #: src/routes/_layout.u.$did.tsx
 msgid "Reader"
 msgstr "Lecteur"
+
+#: src/lib/sidebar-nav.ts
+msgid "Your day: a featured lead and the latest from your subscriptions."
+msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag views"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -92,6 +92,7 @@ msgstr "記事を追加"
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/article-below-fold.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
 msgid "Discover"
@@ -229,6 +230,10 @@ msgstr "{publicationCountText} · {articleCountText}"
 #: src/components/reader/collection-builder.tsx
 msgid "Search by title or author, or paste a URL or at:// URI"
 msgstr "タイトルや著者で検索、または URL や at:// URI を貼り付け"
+
+#: src/components/user-settings-view.tsx
+msgid "Show {itemLabel} in the sidebar"
+msgstr ""
 
 #: src/routes/collection.$did.$rkey.tsx
 msgid "Opening the collection…"
@@ -623,6 +628,10 @@ msgstr "概要"
 msgid "Nothing saved yet"
 msgstr "まだ何も保存されていません"
 
+#: src/components/user-settings-view.tsx
+msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {{formattedUnfollowedCount} 件の発行物を購読しますか？} other {{formattedUnfollowedCount} 件の発行物を購読しますか？}}"
@@ -880,6 +889,7 @@ msgstr "カバー画像を差し替え"
 
 #: src/components/labelers-settings-view.tsx
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 msgid "Search"
 msgstr "検索"
 
@@ -1348,6 +1358,7 @@ msgstr "もう一つアプリを開くのは面倒ですか？購読中の発行
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collections-upgrade-gate.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.collections.edit.$rkey.tsx
 #: src/routes/_layout.collections.index.tsx
 #: src/routes/_layout.collections.new.tsx
@@ -1960,6 +1971,10 @@ msgstr ""
 msgid "Original"
 msgstr "オリジナル"
 
+#: src/components/user-settings-view.tsx
+msgid "Customize sidebar"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Next"
 msgstr "次へ"
@@ -1987,6 +2002,7 @@ msgstr "フォント"
 
 #: src/components/Header.tsx
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 msgid "Home"
 msgstr "ホーム"
 
@@ -3881,6 +3897,10 @@ msgstr "拡張機能から保存やフォローをすると、{SITE_NAME} は We
 msgid "Create series"
 msgstr "シリーズを作成"
 
+#: src/components/user-settings-view.tsx
+msgid "Sidebar"
+msgstr ""
+
 #: src/components/onboarding/step-settings.tsx
 msgid "Reading & privacy"
 msgstr "読書とプライバシー"
@@ -4163,6 +4183,7 @@ msgid "A quiet place to begin"
 msgstr "静かに読みはじめる場所"
 
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.latest.tsx
 msgid "Latest"
 msgstr "最新"
@@ -4480,6 +4501,7 @@ msgstr "まだ Standard Reader にありません"
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
 #: src/components/user-settings-view.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.saved.tsx
 msgid "Saved for later"
 msgstr "あとで読む"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -983,6 +983,10 @@ msgstr "フィードを見る"
 msgid "RSS feed URL"
 msgstr "RSS フィード URL"
 
+#: src/lib/sidebar-nav.ts
+msgid "Your own curated sets of articles."
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
@@ -2460,6 +2464,10 @@ msgstr "読書"
 msgid "Be the first to share a bug, idea, or question."
 msgstr "最初にバグ・アイデア・質問を投稿しましょう。"
 
+#: src/lib/sidebar-nav.ts
+msgid "Browse the publication directory to find new writers."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "いまネットワークで最も読まれている記事です。"
@@ -3188,6 +3196,10 @@ msgstr "あなたの読書室"
 #: src/routes/_layout.index.tsx
 msgid "Fresh"
 msgstr "新着"
+
+#: src/lib/sidebar-nav.ts
+msgid "Everything newest first, with unread and all-network filters."
+msgstr ""
 
 #: src/components/reader/mention-hover-card.tsx
 msgid "Verified"
@@ -4003,6 +4015,10 @@ msgstr "「例を実行」をクリックすると、実際のレスポンスを
 msgid "Legal"
 msgstr "法的情報"
 
+#: src/lib/sidebar-nav.ts
+msgid "Articles you've bookmarked to read later."
+msgstr ""
+
 #: src/components/reader/app-shell.tsx
 msgid "{unread} unread"
 msgstr "未読 {unread} 件"
@@ -4464,6 +4480,10 @@ msgstr "リスト表示"
 msgid "Drag to change the order your lists appear in the sidebar."
 msgstr "ドラッグして、サイドバーでのリストの並び順を変更できます。"
 
+#: src/lib/sidebar-nav.ts
+msgid "Find publications, people, topics, and headlines."
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 msgid "Standard Reader indexes <0>site.standard.document</0> and <1>site.standard.publication</1> records out of AT Proto repos. Platforms like Leaflet, Pckt, and Offprint write these records for you as part of publishing, so their authors get the full reader treatment automatically. If you run your own site and hand-roll your own <2>site.standard</2> integration instead, you write those records yourself — this page covers what to add, including Markpub, the markdown format we recommend for a hand-rolled body."
 msgstr "Standard Reader は AT Proto リポジトリから <0>site.standard.document</0> と <1>site.standard.publication</1> のレコードをインデックスします。Leaflet、Pckt、Offprint などのプラットフォームは公開時にこれらのレコードを書き込むため、その著者は自動的にリーダーの機能をフルに使えます。自分でサイトを運営し、<2>site.standard</2> 連携を独自に実装する場合は、これらのレコードを自分で書き込むことになります。このページでは追加すべき内容を説明します。独自実装の本文には Markpub という markdown 形式をおすすめしており、それについても解説します。"
@@ -4644,6 +4664,10 @@ msgstr "あとから Discover で追加できます。"
 #: src/routes/_layout.u.$did.tsx
 msgid "Reader"
 msgstr "リーダー"
+
+#: src/lib/sidebar-nav.ts
+msgid "Your day: a featured lead and the latest from your subscriptions."
+msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag views"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -983,6 +983,10 @@ msgstr "내 피드 둘러보기"
 msgid "RSS feed URL"
 msgstr "RSS 피드 URL"
 
+#: src/lib/sidebar-nav.ts
+msgid "Your own curated sets of articles."
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
@@ -2460,6 +2464,10 @@ msgstr "읽는 중"
 msgid "Be the first to share a bug, idea, or question."
 msgstr "버그, 아이디어, 질문을 가장 먼저 남겨보세요."
 
+#: src/lib/sidebar-nav.ts
+msgid "Browse the publication directory to find new writers."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "지금 네트워크에서 가장 많이 읽히는 글입니다."
@@ -3188,6 +3196,10 @@ msgstr "나의 독서 공간"
 #: src/routes/_layout.index.tsx
 msgid "Fresh"
 msgstr "새 글"
+
+#: src/lib/sidebar-nav.ts
+msgid "Everything newest first, with unread and all-network filters."
+msgstr ""
 
 #: src/components/reader/mention-hover-card.tsx
 msgid "Verified"
@@ -4003,6 +4015,10 @@ msgstr "예제 실행을 누르면 실시간 응답을 가져옵니다."
 msgid "Legal"
 msgstr "법적 고지"
 
+#: src/lib/sidebar-nav.ts
+msgid "Articles you've bookmarked to read later."
+msgstr ""
+
 #: src/components/reader/app-shell.tsx
 msgid "{unread} unread"
 msgstr "안 읽음 {unread}"
@@ -4464,6 +4480,10 @@ msgstr "목록 보기"
 msgid "Drag to change the order your lists appear in the sidebar."
 msgstr "끌어서 사이드바에 목록이 표시되는 순서를 바꿉니다."
 
+#: src/lib/sidebar-nav.ts
+msgid "Find publications, people, topics, and headlines."
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 msgid "Standard Reader indexes <0>site.standard.document</0> and <1>site.standard.publication</1> records out of AT Proto repos. Platforms like Leaflet, Pckt, and Offprint write these records for you as part of publishing, so their authors get the full reader treatment automatically. If you run your own site and hand-roll your own <2>site.standard</2> integration instead, you write those records yourself — this page covers what to add, including Markpub, the markdown format we recommend for a hand-rolled body."
 msgstr "Standard Reader는 AT Proto 저장소에서 <0>site.standard.document</0>와 <1>site.standard.publication</1> 레코드를 색인합니다. Leaflet, Pckt, Offprint 같은 플랫폼은 발행 과정에서 이 레코드를 대신 작성해 주므로, 해당 저자들은 자동으로 완전한 리더 경험을 얻습니다. 직접 사이트를 운영하며 <2>site.standard</2> 연동을 직접 구현한다면 이 레코드를 스스로 작성해야 합니다 — 이 페이지에서는 무엇을 추가해야 하는지, 그리고 직접 작성하는 본문에 권장하는 마크다운 형식인 Markpub까지 다룹니다."
@@ -4644,6 +4664,10 @@ msgstr "나중에 탐색에서 추가할 수 있습니다."
 #: src/routes/_layout.u.$did.tsx
 msgid "Reader"
 msgstr "리더"
+
+#: src/lib/sidebar-nav.ts
+msgid "Your day: a featured lead and the latest from your subscriptions."
+msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag views"

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -92,6 +92,7 @@ msgstr "글 추가"
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/article-below-fold.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
 msgid "Discover"
@@ -229,6 +230,10 @@ msgstr "{publicationCountText} · {articleCountText}"
 #: src/components/reader/collection-builder.tsx
 msgid "Search by title or author, or paste a URL or at:// URI"
 msgstr "제목이나 저자로 검색하거나 URL 또는 at:// URI를 붙여넣으세요"
+
+#: src/components/user-settings-view.tsx
+msgid "Show {itemLabel} in the sidebar"
+msgstr ""
 
 #: src/routes/collection.$did.$rkey.tsx
 msgid "Opening the collection…"
@@ -623,6 +628,10 @@ msgstr "개요"
 msgid "Nothing saved yet"
 msgstr "아직 저장한 항목이 없습니다"
 
+#: src/components/user-settings-view.tsx
+msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {발행물 {formattedUnfollowedCount}개를 구독할까요?} other {발행물 {formattedUnfollowedCount}개를 구독할까요?}}"
@@ -880,6 +889,7 @@ msgstr "커버 이미지 교체"
 
 #: src/components/labelers-settings-view.tsx
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 msgid "Search"
 msgstr "검색"
 
@@ -1348,6 +1358,7 @@ msgstr "앱을 또 확인하기 번거롭나요? 구독한 발행물의 가장 �
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collections-upgrade-gate.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.collections.edit.$rkey.tsx
 #: src/routes/_layout.collections.index.tsx
 #: src/routes/_layout.collections.new.tsx
@@ -1960,6 +1971,10 @@ msgstr ""
 msgid "Original"
 msgstr "원본"
 
+#: src/components/user-settings-view.tsx
+msgid "Customize sidebar"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Next"
 msgstr "다음"
@@ -1987,6 +2002,7 @@ msgstr "글꼴"
 
 #: src/components/Header.tsx
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 msgid "Home"
 msgstr "홈"
 
@@ -3881,6 +3897,10 @@ msgstr "확장 프로그램에서 저장하거나 팔로우하면 {SITE_NAME}이
 msgid "Create series"
 msgstr "시리즈 만들기"
 
+#: src/components/user-settings-view.tsx
+msgid "Sidebar"
+msgstr ""
+
 #: src/components/onboarding/step-settings.tsx
 msgid "Reading & privacy"
 msgstr "읽기와 개인정보"
@@ -4163,6 +4183,7 @@ msgid "A quiet place to begin"
 msgstr "조용히 시작할 수 있는 곳"
 
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.latest.tsx
 msgid "Latest"
 msgstr "최신"
@@ -4480,6 +4501,7 @@ msgstr "아직 Standard Reader에 없음"
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
 #: src/components/user-settings-view.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.saved.tsx
 msgid "Saved for later"
 msgstr "나중에 볼 항목"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -983,6 +983,10 @@ msgstr "Explorar o seu feed"
 msgid "RSS feed URL"
 msgstr "URL do feed RSS"
 
+#: src/lib/sidebar-nav.ts
+msgid "Your own curated sets of articles."
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
@@ -2460,6 +2464,10 @@ msgstr "Leitura"
 msgid "Be the first to share a bug, idea, or question."
 msgstr "Seja o primeiro a compartilhar um erro, uma ideia ou uma pergunta."
 
+#: src/lib/sidebar-nav.ts
+msgid "Browse the publication directory to find new writers."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "Os textos mais lidos em toda a rede neste momento."
@@ -3188,6 +3196,10 @@ msgstr "A sua sala de leitura"
 #: src/routes/_layout.index.tsx
 msgid "Fresh"
 msgstr "Recente"
+
+#: src/lib/sidebar-nav.ts
+msgid "Everything newest first, with unread and all-network filters."
+msgstr ""
 
 #: src/components/reader/mention-hover-card.tsx
 msgid "Verified"
@@ -4003,6 +4015,10 @@ msgstr "Clique em Executar exemplo para obter uma resposta ao vivo."
 msgid "Legal"
 msgstr "Legal"
 
+#: src/lib/sidebar-nav.ts
+msgid "Articles you've bookmarked to read later."
+msgstr ""
+
 #: src/components/reader/app-shell.tsx
 msgid "{unread} unread"
 msgstr "{unread} por ler"
@@ -4464,6 +4480,10 @@ msgstr "Vistas de listas"
 msgid "Drag to change the order your lists appear in the sidebar."
 msgstr "Arraste para alterar a ordem por que as suas listas aparecem na barra lateral."
 
+#: src/lib/sidebar-nav.ts
+msgid "Find publications, people, topics, and headlines."
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 msgid "Standard Reader indexes <0>site.standard.document</0> and <1>site.standard.publication</1> records out of AT Proto repos. Platforms like Leaflet, Pckt, and Offprint write these records for you as part of publishing, so their authors get the full reader treatment automatically. If you run your own site and hand-roll your own <2>site.standard</2> integration instead, you write those records yourself — this page covers what to add, including Markpub, the markdown format we recommend for a hand-rolled body."
 msgstr "O Standard Reader indexa registos <0>site.standard.document</0> e <1>site.standard.publication</1> de repositórios AT Proto. Plataformas como o Leaflet, o Pckt e o Offprint escrevem estes registos por si como parte da publicação, pelo que os seus autores recebem automaticamente o tratamento completo no leitor. Se gere o seu próprio site e cria à mão a sua integração <2>site.standard</2>, é você que escreve esses registos — esta página explica o que adicionar, incluindo o Markpub, o formato markdown que recomendamos para um corpo feito à mão."
@@ -4644,6 +4664,10 @@ msgstr "Pode adicioná-las mais tarde a partir de Descobrir."
 #: src/routes/_layout.u.$did.tsx
 msgid "Reader"
 msgstr "Leitor"
+
+#: src/lib/sidebar-nav.ts
+msgid "Your day: a featured lead and the latest from your subscriptions."
+msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag views"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -92,6 +92,7 @@ msgstr "Adicionar um artigo"
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/article-below-fold.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
 msgid "Discover"
@@ -229,6 +230,10 @@ msgstr "{publicationCountText} · {articleCountText}"
 #: src/components/reader/collection-builder.tsx
 msgid "Search by title or author, or paste a URL or at:// URI"
 msgstr "Pesquise por título ou autor, ou cole um URL ou URI at://"
+
+#: src/components/user-settings-view.tsx
+msgid "Show {itemLabel} in the sidebar"
+msgstr ""
 
 #: src/routes/collection.$did.$rkey.tsx
 msgid "Opening the collection…"
@@ -623,6 +628,10 @@ msgstr "Resumo"
 msgid "Nothing saved yet"
 msgstr "Ainda não há nada salvo"
 
+#: src/components/user-settings-view.tsx
+msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {Se inscrever em {formattedUnfollowedCount} publicação?} other {Se inscrever em {formattedUnfollowedCount} publicações?}}"
@@ -880,6 +889,7 @@ msgstr "Substituir imagem de capa"
 
 #: src/components/labelers-settings-view.tsx
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 msgid "Search"
 msgstr "Pesquisar"
 
@@ -1348,6 +1358,7 @@ msgstr "Não quer mais um aplicativo para conferir? Opte por um e-mail semanal c
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collections-upgrade-gate.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.collections.edit.$rkey.tsx
 #: src/routes/_layout.collections.index.tsx
 #: src/routes/_layout.collections.new.tsx
@@ -1960,6 +1971,10 @@ msgstr "Pessoas que você segue escrevem aqui"
 msgid "Original"
 msgstr "Original"
 
+#: src/components/user-settings-view.tsx
+msgid "Customize sidebar"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Next"
 msgstr "Seguinte"
@@ -1987,6 +2002,7 @@ msgstr "Fontes"
 
 #: src/components/Header.tsx
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 msgid "Home"
 msgstr "Início"
 
@@ -3881,6 +3897,10 @@ msgstr "Quando você salva ou segue a partir da extensão, o {SITE_NAME} escreve
 msgid "Create series"
 msgstr "Criar série"
 
+#: src/components/user-settings-view.tsx
+msgid "Sidebar"
+msgstr ""
+
 #: src/components/onboarding/step-settings.tsx
 msgid "Reading & privacy"
 msgstr "Leitura e privacidade"
@@ -4163,6 +4183,7 @@ msgid "A quiet place to begin"
 msgstr "Um lugar calmo para começar"
 
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.latest.tsx
 msgid "Latest"
 msgstr "Recentes"
@@ -4480,6 +4501,7 @@ msgstr "Ainda não está no Standard Reader"
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
 #: src/components/user-settings-view.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.saved.tsx
 msgid "Saved for later"
 msgstr "Salvo para mais tarde"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -983,6 +983,10 @@ msgstr "浏览你的信息流"
 msgid "RSS feed URL"
 msgstr "RSS 源地址"
 
+#: src/lib/sidebar-nav.ts
+msgid "Your own curated sets of articles."
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
@@ -2460,6 +2464,10 @@ msgstr "正在阅读"
 msgid "Be the first to share a bug, idea, or question."
 msgstr "来做第一个提交缺陷、想法或问题的人。"
 
+#: src/lib/sidebar-nav.ts
+msgid "Browse the publication directory to find new writers."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "当下整个网络阅读量最高的文章。"
@@ -3188,6 +3196,10 @@ msgstr "你的阅读室"
 #: src/routes/_layout.index.tsx
 msgid "Fresh"
 msgstr "最新"
+
+#: src/lib/sidebar-nav.ts
+msgid "Everything newest first, with unread and all-network filters."
+msgstr ""
 
 #: src/components/reader/mention-hover-card.tsx
 msgid "Verified"
@@ -4003,6 +4015,10 @@ msgstr "点击「运行示例」获取实时响应。"
 msgid "Legal"
 msgstr "法律条款"
 
+#: src/lib/sidebar-nav.ts
+msgid "Articles you've bookmarked to read later."
+msgstr ""
+
 #: src/components/reader/app-shell.tsx
 msgid "{unread} unread"
 msgstr "{unread} 篇未读"
@@ -4464,6 +4480,10 @@ msgstr "列表视图"
 msgid "Drag to change the order your lists appear in the sidebar."
 msgstr "拖动以调整列表在侧边栏中的顺序。"
 
+#: src/lib/sidebar-nav.ts
+msgid "Find publications, people, topics, and headlines."
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 msgid "Standard Reader indexes <0>site.standard.document</0> and <1>site.standard.publication</1> records out of AT Proto repos. Platforms like Leaflet, Pckt, and Offprint write these records for you as part of publishing, so their authors get the full reader treatment automatically. If you run your own site and hand-roll your own <2>site.standard</2> integration instead, you write those records yourself — this page covers what to add, including Markpub, the markdown format we recommend for a hand-rolled body."
 msgstr "Standard Reader 从 AT Proto 仓库中收录 <0>site.standard.document</0> 和 <1>site.standard.publication</1> 记录。Leaflet、Pckt、Offprint 等平台会在发布时替你写入这些记录，因此其作者可自动获得完整的阅读体验。如果你运行自己的站点并手动实现 <2>site.standard</2> 集成，则需自行写入这些记录——本页说明需要添加的内容，包括 Markpub，即我们推荐用于手写正文的 markdown 格式。"
@@ -4644,6 +4664,10 @@ msgstr "你可以稍后在「发现」中添加它们。"
 #: src/routes/_layout.u.$did.tsx
 msgid "Reader"
 msgstr "阅读器"
+
+#: src/lib/sidebar-nav.ts
+msgid "Your day: a featured lead and the latest from your subscriptions."
+msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag views"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -92,6 +92,7 @@ msgstr "添加文章"
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/article-below-fold.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
 msgid "Discover"
@@ -229,6 +230,10 @@ msgstr "{publicationCountText} · {articleCountText}"
 #: src/components/reader/collection-builder.tsx
 msgid "Search by title or author, or paste a URL or at:// URI"
 msgstr "按标题或作者搜索，或粘贴 URL、at:// URI"
+
+#: src/components/user-settings-view.tsx
+msgid "Show {itemLabel} in the sidebar"
+msgstr ""
 
 #: src/routes/collection.$did.$rkey.tsx
 msgid "Opening the collection…"
@@ -623,6 +628,10 @@ msgstr "概览"
 msgid "Nothing saved yet"
 msgstr "尚未保存任何内容"
 
+#: src/components/user-settings-view.tsx
+msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {订阅 {formattedUnfollowedCount} 个刊物？} other {订阅 {formattedUnfollowedCount} 个刊物？}}"
@@ -880,6 +889,7 @@ msgstr "替换封面图"
 
 #: src/components/labelers-settings-view.tsx
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 msgid "Search"
 msgstr "搜索"
 
@@ -1348,6 +1358,7 @@ msgstr "不想再多装一个应用来查看？可以订阅每周邮件，收录
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collections-upgrade-gate.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.collections.edit.$rkey.tsx
 #: src/routes/_layout.collections.index.tsx
 #: src/routes/_layout.collections.new.tsx
@@ -1960,6 +1971,10 @@ msgstr ""
 msgid "Original"
 msgstr "原文"
 
+#: src/components/user-settings-view.tsx
+msgid "Customize sidebar"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Next"
 msgstr "下一个"
@@ -1987,6 +2002,7 @@ msgstr "字体"
 
 #: src/components/Header.tsx
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 msgid "Home"
 msgstr "首页"
 
@@ -3881,6 +3897,10 @@ msgstr "当你在扩展中保存或关注时，{SITE_NAME} 会通过与网页版
 msgid "Create series"
 msgstr "创建系列"
 
+#: src/components/user-settings-view.tsx
+msgid "Sidebar"
+msgstr ""
+
 #: src/components/onboarding/step-settings.tsx
 msgid "Reading & privacy"
 msgstr "阅读与隐私"
@@ -4163,6 +4183,7 @@ msgid "A quiet place to begin"
 msgstr "一个安静的起点"
 
 #: src/components/reader/app-shell.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.latest.tsx
 msgid "Latest"
 msgstr "最新"
@@ -4480,6 +4501,7 @@ msgstr "尚未加入 Standard Reader"
 #: src/components/reader/article-view.tsx
 #: src/components/reader/cards.tsx
 #: src/components/user-settings-view.tsx
+#: src/lib/sidebar-nav.ts
 #: src/routes/_layout.saved.tsx
 msgid "Saved for later"
 msgstr "稍后阅读"

--- a/src/server/atproto/repo-records.ts
+++ b/src/server/atproto/repo-records.ts
@@ -651,6 +651,8 @@ export async function putSidebarPrefRecord(
   pref: {
     listOrder: Array<string>;
     collapsed: Array<string>;
+    customizeNav: boolean;
+    hiddenNav: Array<string>;
     updatedAt: string;
   },
 ): Promise<{ uri: string; cid: string }> {
@@ -662,6 +664,8 @@ export async function putSidebarPrefRecord(
       $type: COLLECTION.sidebarPref,
       listOrder: pref.listOrder,
       collapsed: pref.collapsed,
+      customizeNav: pref.customizeNav,
+      hiddenNav: pref.hiddenNav,
       updatedAt: pref.updatedAt,
     },
   });

--- a/src/server/atproto/types.ts
+++ b/src/server/atproto/types.ts
@@ -221,6 +221,10 @@ export interface SidebarPrefRecord {
   listOrder?: Array<string>;
   /** At-uris of the list groups the reader has collapsed. */
   collapsed?: Array<string>;
+  /** Whether "Customize sidebar" is enabled (gates `hiddenNav`). */
+  customizeNav?: boolean;
+  /** Stable ids of the primary nav items the reader has hidden. */
+  hiddenNav?: Array<string>;
   updatedAt?: string;
 }
 

--- a/src/server/ingest/handlers.ts
+++ b/src/server/ingest/handlers.ts
@@ -873,6 +873,11 @@ export async function upsertSidebarPref(
         (item): item is string => typeof item === "string",
       )
     : [];
+  const hiddenNav = Array.isArray(record.hiddenNav)
+    ? record.hiddenNav.filter(
+        (item): item is string => typeof item === "string",
+      )
+    : [];
 
   const values = {
     ownerDid: did,
@@ -881,6 +886,8 @@ export async function upsertSidebarPref(
     rkey,
     listOrder,
     collapsed,
+    customizeNav: record.customizeNav === true,
+    hiddenNav,
     updatedAt: parseDate(record.updatedAt),
     deleted: false,
   };

--- a/src/server/reader/shell-snapshot.server.ts
+++ b/src/server/reader/shell-snapshot.server.ts
@@ -68,6 +68,8 @@ export async function loadSidebarPref(did: string): Promise<SidebarPref> {
   return {
     listOrder: (row?.listOrder as Array<string>) ?? [],
     collapsed: (row?.collapsed as Array<string>) ?? [],
+    customizeNav: row?.customizeNav ?? false,
+    hiddenNav: (row?.hiddenNav as Array<string>) ?? [],
   };
 }
 


### PR DESCRIPTION
Add a "Customize sidebar" toggle in Settings that reveals a per-item
switch for each primary sidebar nav link (Home, Latest, Saved for later,
Collections, Discover, Search). Turning one off hides it from both the
desktop sidebar and the mobile bottom-nav. Subscriptions and its list
groups are never hideable.

State persists on the app.standard-reader.sidebarPref singleton via two
new fields: customizeNav (gate) and hiddenNav (id set), mirrored into the
sidebar_prefs read-model table. When the toggle is off, every nav item
shows regardless of hiddenNav.

- Extend lexicon (json + generated defs), server record type, DB schema
  (+ migration), ingest upsert, PDS write, and shell-snapshot loader.
- Add shared nav metadata in src/lib/sidebar-nav.ts.
- Expand useSidebarPref controller with customizeNav/hiddenNav accessors
  and immediate write-through setters.
- Update APP_VISION.md and TODO.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B93hQVmbV2SZUDi5pJvWX5