### PR TITLE
Let readers view publications in the publisher's own theme

### DIFF
--- a/APP_VISION.md
+++ b/APP_VISION.md
@@ -175,6 +175,53 @@ Sections, top to bottom:
   everyone; `user.reading_typography` when signed in (`fontSize:measure:bodyFont`
   encoding, with optional `:customFont` when body font is custom).
 
+- **Use publication themes (preference):** settings-page toggle (Appearance) that
+  repaints `/p/$did/$rkey` and `/a/$did/$rkey` in the publication's own
+  `site.standard.theme.basic` colors. The four flat colors are expanded into full
+  light + dark UI/accent scales (`publicationThemeScaleVars`) that the
+  `publicationUi` / `publicationPrimary` StyleX themes read to override the
+  design-system `uiColor` / `primaryColor` tokens — the same machinery the themed
+  subscribe login already used. A route opts in by returning `publicationTheme`
+  from its loader; the app shell reads it off the deepest match and wraps the
+  content column **and the site footer**, so the publication's colors run to the
+  bottom of the page. The sidebar and mobile bar stay Standard Reader chrome.
+  Signed-in only (`user.use_publication_theme`, `null` = off); publications with
+  no colors of their own always keep the editorial theme.
+- **Publisher-native themes.** `site.standard.theme.basic` is the interop
+  baseline (four opaque colors, light only), but records also carry the
+  publishing platform's own theme under `theme`, discriminated by `$type`.
+  Ingest keeps it in `publications.theme_json` as `nativeTheme`, and
+  `resolvePublicationTheme` (`#/lib/publication-theme-source`) narrows it:
+  **Leaflet** (`pub.leaflet.publication#theme`) paints a page over a canvas, so
+  `pageBackground` composited over `backgroundColor` — not `basicTheme.background`,
+  which mirrors the canvas — is the surface the reader actually sees;
+  **PCKT** (`blog.pckt.theme`) and **Offprint** (`app.offprint.theme`, a
+  DaisyUI-shaped `base100`/`baseContent`/`primary` palette whose `colorScheme`
+  says which mode it is) can supply a real **dark** palette, which we use verbatim
+  instead of deriving one by darkening their light colors. Unknown `$type`s fall
+  back to `basicTheme`, so a new platform degrades rather than losing its colors.
+  Publishers who state **neutral scale steps** (Offprint `base200`/`base300`,
+  PCKT `surfaceHover`) get them pinned onto the matching token — `component1`,
+  `component2`, `border1` — with the steps between anchors interpolated, instead
+  of the whole ramp being derived by darkening the background. A theme states one
+  background, so it is **routed to the mode its own luminance matches** — a dark
+  publication supplies the dark page, and the mode they didn't author is
+  **synthesized by mirroring their colour through OKLCH** (`invertLightness`):
+  hue preserved, lightness moved to the other end (0.975 / 0.17, matching the
+  app's own editorial backgrounds), chroma damped because the same chroma reads
+  far more saturated at high lightness. A warm near-black page becomes warm cream
+  rather than generic near-white, and the ink is mirrored from their text colour
+  instead of dropping to flat black. Without this routing, a dark background
+  painted a dark page for a reader in light mode _and_ produced a ramp derived by
+  darkening near-black, collapsing every step into the same colour. **Fonts** are read
+  the same way (`#/lib/publication-fonts`): each platform's key format is resolved
+  against the Google Fonts catalog by normalized key, loaded via a scoped
+  stylesheet link, and layered over the editorial stack so anything that doesn't
+  resolve leaves the reader's own typography in place. Overlays (hover cards,
+  menus, dialogs) are re-pointed into the themed container with react-aria's
+  `UNSAFE_PortalProvider` so they inherit the palette instead of portalling to
+  `document.body` and reverting to app tokens.
+
 ### Publication profile
 
 - Banner + **inline header** (avatar, topic, name, description, stats, Share, Follow).

--- a/TODO.md
+++ b/TODO.md
@@ -456,6 +456,89 @@ Build each on hip-ui components + StyleX tokens (no raw HTML/inline styles).
 - [x] Global follow toggle reflects everywhere instantly (optimistic).
 - [x] Theme picker (light / dark / system) + editorial dark tokens + Shiki `standard-reader-dark`.
 - [x] Theme tokens / dark mode parity with prototype (remaining hardcoded surfaces).
+- [x] **"Use publication themes" preference** — Settings → Appearance toggle that repaints
+      `/p/$did/$rkey` and `/a/$did/$rkey` in the publication's own `basicTheme` colors.
+      `publicationThemeScaleVars` expands the four flat colors into light + dark UI/accent
+      scales; the `publicationUi` / `publicationPrimary` StyleX themes (previously used only by
+      the themed subscribe login) override the design-system `uiColor` / `primaryColor` tokens
+      on a `PublicationThemeScope` wrapper. A route opts in by returning `publicationTheme`
+      from its loader; `AppShell` reads it off the deepest match (no apply-on-effect flash) and
+      wraps the content column **plus `SiteFooter`**, so the palette runs to the bottom of the
+      page. Sidebar and mobile bar stay Standard Reader chrome. Signed-in only:
+      `user.use_publication_theme` (`drizzle/0019_use_publication_theme`), served through
+      `getShellBootstrap` so the first paint is already themed. Gated on
+      `hasPublicationThemeColors`, so publications with no colors keep the editorial theme.
+      Theme colors ride along on the existing header query (`selectPublicationHeader`) and on
+      `article.collectionTheme` — no extra round trips (`#/lib/publication-theme-preference`,
+      `usePublicationThemePreference`).
+- [x] **Publisher-native themes beyond `basicTheme`** — ingest now keeps the platform's own
+      theme block as `theme_json.nativeTheme`, and `resolvePublicationTheme`
+      (`#/lib/publication-theme-source`, unit-tested against real Leaflet/PCKT/Offprint records)
+      narrows it per `$type`: Leaflet's `pageBackground`-over-`backgroundColor` page surface
+      (`basicTheme.background` only mirrors the canvas), and PCKT/Offprint **authored dark
+      palettes** used verbatim instead of darkening their light colors
+      (`buildDarkUiScale` / `buildDarkAccentScale`). Unknown `$type`s fall back to `basicTheme`.
+      **Existing rows only pick this up on re-ingest** — `theme_json.nativeTheme` is written by
+      `upsertPublication`, so a repo resync (`src/server/ingest/repo-sync.ts`) or the publisher's
+      next record update is needed to backfill it.
+- [x] **Stated neutral scale steps instead of derived ones** — `ThemePalette` carries optional
+      `surface` / `surfaceHover` / `border` anchors, and `applyNeutralAnchors`
+      (`publication-theme-scale.ts`) re-lays the neutral ramp as a piecewise-linear curve through
+      whatever the publisher actually stated, interpolating only between anchors. Offprint's
+      `base200` → `component1` and `base300` → `border1`; PCKT's `surfaceHover` → `component2`
+      (a hover fill, so it must not become the resting card surface). Publications stating nothing
+      keep the derived scale byte-for-byte. Light and dark anchor independently — light-mode
+      anchors never leak onto a derived dark ramp.
+- [x] **Route a stated background to the mode its luminance matches** — dark publications
+      (Leaflet on a black canvas, dark-scheme Offprint themes) were painting a dark page in
+      light mode, and the light ramp then _darkened_ from near-black so all eight neutral steps
+      landed within ~10 RGB units — invisible borders, cards indistinguishable from the page.
+      `isDarkColor` now decides which mode the stated background serves; the other mode is
+      synthesized by `invertLightness` — an OKLCH mirror that keeps the hue, moves lightness to
+      the opposite end (0.975 / 0.17, calibrated against the app's own editorial backgrounds),
+      and damps chroma so a dark plum inverts to pale paper rather than a lurid pink. The ink is
+      mirrored from the publisher's own text colour too, so a warm palette keeps warm ink.
+      Achromatic and unparseable colours fall back to neutral defaults.
+      `buildUiScale`/`buildAccentScale`
+      split into explicit `buildLight*`/`buildDark*` pairs so the caller supplies each mode's
+      background, and stated neutral anchors only apply to the ramp actually using the surface
+      they were authored against. Light publications are unaffected.
+- [x] **Fonts from native themes** — `#/lib/publication-fonts` reads each platform's font format
+      (Leaflet's self-describing `custom:<Family>:…` plus built-in keys, PCKT's single squashed
+      `font`, Offprint's `typography.headingFont`/`bodyFont` slugs) and resolves them against the
+      Google Fonts catalog by normalized key (lowercase, alphanumerics only) — no hand-maintained
+      per-platform table. `PLATFORM_FONT_ALIASES` covers the three keys that don't normalize onto
+      their family (`source-sans` → Source Sans 3, `cactusserif`, `anon`). Unresolved keys are
+      deliberately left alone so the reader keeps their own typography: PCKT's `legible` / `sans`
+      are generic slots, and `quattro` / `iawritermono` are iA Writer faces Google doesn't serve.
+      The catalog cache moved to `#/server/fonts/google-catalog.server` and is shared with the
+      reading-typography picker; a Google Fonts outage degrades to "no publisher fonts".
+      `publicationFonts` (a `createTheme` over `fontFamily`) layers `--pub-font-title` /
+      `--pub-font-body` over the editorial stack, so each slot falls back to the app's own family
+      when nothing resolved.
+      **Open:** how publication fonts should interact with the reader's explicit
+      **reading-typography** body-font choice — right now the publication's font wins inside the
+      themed scope. Arguably an explicit reader preference should take precedence.
+- [x] **Code blocks match the publication theme** — rather than synthesizing syntax colours from
+      four theme colours (inventing a whole colour system per publication, which reads as noise
+      next to hand-designed ones), `pickCodeTheme` (`#/server/shiki/match-theme`) scores Shiki's
+      65 bundled themes against the publication's background/text/accent by perceptual ΔE in
+      OKLab, weighted toward the accent, and filtered to the requested light/dark type. The
+      chosen theme is loaded on demand by the highlighter, falling back to the editorial theme
+      if it can't be registered. Gated per-reader: `usePublicationThemeForRequest` is resolved
+      alongside `themeModeForRequest`, so a reader with the preference off keeps editorial code
+      blocks. Two corrections after the first pass: scoring uses the **rendered** surface for
+      each scheme (`publicationRenderedSurfaces`) rather than the stated background, which can
+      belong to the other mode entirely and was being reused for both; and the background is a
+      **gate** (ΔE ≤ 0.035) rather than just a weighted term, because a code block is mostly
+      background — a cream `gruvbox-light-hard` panel was winning on accent alone against a
+      near-white page. Character still tracks the accent within the gate: magenta → `dracula`,
+      gold → `gruvbox-dark-hard`, teal → `min-light` / `vitesse-dark`.
+- [ ] **Decorative parts of native themes** — Leaflet `backgroundImage` (20%) / `wordmark` (2%) /
+      `pageWidth` (67%), PCKT `tileBackground` (71%) / `transparency` (95%) / `highlightShape` /
+      `corners`, Offprint `sizing` (85%) / `effects` (84%), plus PCKT's `link` colour (we have no
+      distinct link token). Deferred pending a product call on how far a publication's styling
+      should reach into reader chrome — these change shape and texture, not just palette.
 - [x] **"Open on original site" preference** — user-menu toggle that bypasses the in-app reader:
       document links (feed/search cards, "More from", embedded standard.site post cards) open the
       article's canonical URL in a new tab (marking it read), and `/a/$did/$rkey` redirects to the

--- a/drizzle/0020_use_publication_theme.sql
+++ b/drizzle/0020_use_publication_theme.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "use_publication_theme" boolean;

--- a/drizzle/0020_use_publication_theme.sql
+++ b/drizzle/0020_use_publication_theme.sql
@@ -1,1 +1,7 @@
-ALTER TABLE "user" ADD COLUMN "use_publication_theme" boolean;
+-- `IF NOT EXISTS` because this column was applied to production by hand before
+-- the migration was renumbered from 0019 to 0020 (0019 went to `big_payback` on
+-- main). Production — and every preview branch cut from it — therefore already
+-- has the column but has not recorded *this* migration, and drizzle decides what
+-- to run by comparing the journal's `when` against the last applied
+-- `created_at`. Without this guard the run fails with "column already exists".
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "use_publication_theme" boolean;

--- a/drizzle/meta/0020_snapshot.json
+++ b/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,3827 @@
+{
+  "id": "4c3052f9-39ed-4493-8399-ceb2c024e14f",
+  "prevId": "d7a32a50-d042-4ce7-8af8-a5e1878492f9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_mode": {
+          "name": "theme_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale_hint_seen": {
+          "name": "locale_hint_seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reader_voice": {
+          "name": "reader_voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_links_externally": {
+          "name": "open_links_externally",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_collections_in_magazine": {
+          "name": "open_collections_in_magazine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reading_typography": {
+          "name": "reading_typography",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_reading_history": {
+          "name": "track_reading_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count_old_posts_as_unread": {
+          "name": "count_old_posts_as_unread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_publication_theme": {
+          "name": "use_publication_theme",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_scope": {
+          "name": "home_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_hidden_tabs": {
+          "name": "profile_hidden_tabs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_show_likes": {
+          "name": "profile_show_likes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_authoring_enabled": {
+          "name": "collections_authoring_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userinput_feedback_enabled": {
+          "name": "userinput_feedback_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "margin_save_enabled": {
+          "name": "margin_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semble_save_enabled": {
+          "name": "semble_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "atstore_review_prompt_dismissed": {
+          "name": "atstore_review_prompt_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_enabled": {
+          "name": "weekly_digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_subscriptions": {
+          "name": "weekly_digest_section_subscriptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_network": {
+          "name": "weekly_digest_section_network",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_saved": {
+          "name": "weekly_digest_section_saved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_recommendations": {
+          "name": "weekly_digest_section_recommendations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_last_sent_at": {
+          "name": "weekly_digest_last_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_welcome_sent_at": {
+          "name": "weekly_digest_welcome_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_did_unique": {
+          "name": "user_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "did"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pds": {
+          "name": "pds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_url": {
+          "name": "banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_uri": {
+          "name": "bsky_profile_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_cid": {
+          "name": "bsky_profile_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_fetched_at": {
+          "name": "profile_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_handle_idx": {
+          "name": "profiles_handle_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_handle_trgm_idx": {
+          "name": "profiles_handle_trgm_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "profiles_display_name_trgm_idx": {
+          "name": "profiles_display_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publications": {
+      "name": "publications",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_cid": {
+          "name": "icon_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_mime": {
+          "name": "icon_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent": {
+          "name": "theme_accent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_background": {
+          "name": "theme_background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_foreground": {
+          "name": "theme_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent_foreground": {
+          "name": "theme_accent_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_json": {
+          "name": "theme_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_in_discover": {
+          "name": "show_in_discover",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "collections_publication": {
+          "name": "collections_publication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_checked_at": {
+          "name": "verification_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(name, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(topic, '')), 'B')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publications_did_idx": {
+          "name": "publications_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_name_idx": {
+          "name": "publications_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_discover_idx": {
+          "name": "publications_discover_idx",
+          "columns": [
+            {
+              "expression": "show_in_discover",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_topic_idx": {
+          "name": "publications_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_url_idx": {
+          "name": "publications_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_search_idx": {
+          "name": "publications_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_contributors": {
+      "name": "document_contributors",
+      "schema": "",
+      "columns": {
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "document_contributors_did_idx": {
+          "name": "document_contributors_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_contributors_document_uri_documents_uri_fk": {
+          "name": "document_contributors_document_uri_documents_uri_fk",
+          "tableFrom": "document_contributors",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_contributors_document_uri_did_pk": {
+          "name": "document_contributors_document_uri_did_pk",
+          "columns": [
+            "document_uri",
+            "did"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_uri": {
+          "name": "site_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_json": {
+          "name": "collection_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_renderable_body": {
+          "name": "has_renderable_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cover_image_cid": {
+          "name": "cover_image_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_mime": {
+          "name": "cover_image_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backlink_count": {
+          "name": "backlink_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_count_prev": {
+          "name": "backlink_count_prev",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_synced_at": {
+          "name": "backlink_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_recomputed_at": {
+          "name": "trending_recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_recommender_count": {
+          "name": "distinct_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bsky_post_uri": {
+          "name": "bsky_post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_post_cid": {
+          "name": "bsky_post_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_updated_at": {
+          "name": "record_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(title, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(immutable_array_to_string(tags), '')), 'B') || setweight(to_tsvector('english', coalesce(text_content, '')), 'C')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documents_did_idx": {
+          "name": "documents_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_did_published_idx": {
+          "name": "documents_did_published_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"published_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_publication_published_idx": {
+          "name": "documents_publication_published_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_published_idx": {
+          "name": "documents_published_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_featured_idx": {
+          "name": "documents_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_site_idx": {
+          "name": "documents_site_idx",
+          "columns": [
+            {
+              "expression": "site_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_search_idx": {
+          "name": "documents_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "documents_trending_idx": {
+          "name": "documents_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_idx": {
+          "name": "documents_canonical_url_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_trgm_idx": {
+          "name": "documents_canonical_url_trgm_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommends": {
+      "name": "recommends",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommender_did": {
+          "name": "recommender_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recommends_document_idx": {
+          "name": "recommends_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_recommender_idx": {
+          "name": "recommends_recommender_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_edge_idx": {
+          "name": "recommends_edge_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_doc_recommender_created_idx": {
+          "name": "recommends_doc_recommender_created_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recommends\".\"deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_did": {
+          "name": "publication_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_publication_idx": {
+          "name": "subscriptions_publication_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_subscriber_idx": {
+          "name": "subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_edge_idx": {
+          "name": "subscriptions_edge_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follower_did": {
+          "name": "follower_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excluded_publications": {
+          "name": "excluded_publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_subject_idx": {
+          "name": "user_follows_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_edge_idx": {
+          "name": "user_follows_edge_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_owner_idx": {
+          "name": "bookmarks_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_document_idx": {
+          "name": "bookmarks_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_edge_idx": {
+          "name": "bookmarks_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reads": {
+      "name": "reads",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reads_owner_idx": {
+          "name": "reads_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_document_idx": {
+          "name": "reads_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_edge_idx": {
+          "name": "reads_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidebar_prefs": {
+      "name": "sidebar_prefs",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_order": {
+          "name": "list_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customize_nav": {
+          "name": "customize_nav",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_nav": {
+          "name": "hidden_nav",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_saves": {
+      "name": "list_saves",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saver_did": {
+          "name": "saver_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_owner_did": {
+          "name": "list_owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "list_saves_saver_idx": {
+          "name": "list_saves_saver_idx",
+          "columns": [
+            {
+              "expression": "saver_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "list_saves_list_uri_idx": {
+          "name": "list_saves_list_uri_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lists": {
+      "name": "lists",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publications": {
+          "name": "publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "users": {
+          "name": "users",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lists_owner_idx": {
+          "name": "lists_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rkey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_corecommends": {
+      "name": "publication_corecommends",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_recommender_count": {
+          "name": "co_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_corecomm_rank_idx": {
+          "name": "publication_corecomm_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_corecommends_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_corecommends_related_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_corecommends_publication_uri_related_publication_uri_pk": {
+          "name": "publication_corecommends_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_cosubscriptions": {
+      "name": "publication_cosubscriptions",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_subscriber_count": {
+          "name": "co_subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_cosub_rank_idx": {
+          "name": "publication_cosub_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_cosubscriptions_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_cosubscriptions_related_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_cosubscriptions_publication_uri_related_publication_uri_pk": {
+          "name": "publication_cosubscriptions_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_stats": {
+      "name": "publication_stats",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommend_count": {
+          "name": "recommend_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_document_at": {
+          "name": "last_document_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documents_7d": {
+          "name": "documents_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_7d": {
+          "name": "subscribers_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_7d": {
+          "name": "recommends_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "documents_prev_7d": {
+          "name": "documents_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_prev_7d": {
+          "name": "subscribers_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_prev_7d": {
+          "name": "recommends_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlinks_7d": {
+          "name": "backlinks_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_velocity": {
+          "name": "trending_velocity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_window_start": {
+          "name": "trending_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_stats_subscribers_idx": {
+          "name": "publication_stats_subscribers_idx",
+          "columns": [
+            {
+              "expression": "subscriber_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_active_idx": {
+          "name": "publication_stats_active_idx",
+          "columns": [
+            {
+              "expression": "last_document_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_trending_idx": {
+          "name": "publication_stats_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_stats_publication_uri_publications_uri_fk": {
+          "name": "publication_stats_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_stats",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discover_topic_counts": {
+      "name": "discover_topic_counts",
+      "schema": "",
+      "columns": {
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discover_topic_counts_count_idx": {
+          "name": "discover_topic_counts_count_idx",
+          "columns": [
+            {
+              "expression": "publication_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discover_topic_counts_topic_trgm_idx": {
+          "name": "discover_topic_counts_topic_trgm_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_dead_letter": {
+      "name": "ingest_dead_letter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retries": {
+          "name": "retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingest_dead_letter_collection_idx": {
+          "name": "ingest_dead_letter_collection_idx",
+          "columns": [
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_state": {
+      "name": "ingest_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_processed": {
+          "name": "events_processed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_repos": {
+      "name": "tracked_repos",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_to_tap_at": {
+          "name": "added_to_tap_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_state": {
+          "name": "backfill_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_seen_rev": {
+          "name": "last_seen_rev",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_fail_count": {
+          "name": "reconcile_fail_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconcile_retry_after": {
+          "name": "reconcile_retry_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tracked_repos_state_idx": {
+          "name": "tracked_repos_state_idx",
+          "columns": [
+            {
+              "expression": "backfill_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_labels": {
+      "name": "document_labels",
+      "schema": "",
+      "columns": {
+        "src": {
+          "name": "src",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "val": {
+          "name": "val",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cts": {
+          "name": "cts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_labels_uri_idx": {
+          "name": "document_labels_uri_idx",
+          "columns": [
+            {
+              "expression": "uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_labels_src_idx": {
+          "name": "document_labels_src_idx",
+          "columns": [
+            {
+              "expression": "src",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "document_labels_src_uri_val_pk": {
+          "name": "document_labels_src_uri_val_pk",
+          "columns": [
+            "src",
+            "uri",
+            "val"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_sync_state": {
+      "name": "label_sync_state",
+      "schema": "",
+      "columns": {
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_services": {
+      "name": "labeler_services",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_endpoint": {
+          "name": "service_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_value_definitions": {
+          "name": "label_value_definitions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_services_labeler_idx": {
+          "name": "labeler_services_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_subscriptions": {
+      "name": "labeler_subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefs": {
+          "name": "prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_subscriptions_subscriber_idx": {
+          "name": "labeler_subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labeler_subscriptions_labeler_idx": {
+          "name": "labeler_subscriptions_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_shares": {
+      "name": "quote_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_text": {
+          "name": "quote_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quote_shares_document_uri_idx": {
+          "name": "quote_shares_document_uri_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_draft": {
+      "name": "feedback_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feedback_draft_user_idx": {
+          "name": "feedback_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_draft_expires_idx": {
+          "name": "feedback_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_draft_user_id_user_id_fk": {
+          "name": "feedback_draft_user_id_user_id_fk",
+          "tableFrom": "feedback_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upvote_draft": {
+      "name": "upvote_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "upvote_draft_user_idx": {
+          "name": "upvote_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upvote_draft_expires_idx": {
+          "name": "upvote_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upvote_draft_user_id_user_id_fk": {
+          "name": "upvote_draft_user_id_user_id_fk",
+          "tableFrom": "upvote_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.save_draft": {
+      "name": "save_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_app": {
+          "name": "target_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_uri": {
+          "name": "collection_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_cid": {
+          "name": "collection_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_collection_name": {
+          "name": "new_collection_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motivation": {
+          "name": "motivation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passage": {
+          "name": "passage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "save_draft_user_idx": {
+          "name": "save_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "save_draft_expires_idx": {
+          "name": "save_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "save_draft_user_id_user_id_fk": {
+          "name": "save_draft_user_id_user_id_fk",
+          "tableFrom": "save_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1784936864607,
       "tag": "0019_big_payback",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1784956568171,
+      "tag": "0020_use_publication_theme",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/onboarding/step-settings.tsx
+++ b/src/components/onboarding/step-settings.tsx
@@ -6,6 +6,7 @@ import { Pressable } from "react-aria";
 import { user } from "#/integrations/tanstack-query/api-user.functions";
 import { useCountOldPostsAsUnread } from "#/lib/use-count-old-posts-as-unread";
 import { useOpenLinks } from "#/lib/use-open-links";
+import { usePublicationThemePreference } from "#/lib/use-publication-theme-preference";
 import { useTrackReadingHistory } from "#/lib/use-track-reading-history";
 
 import { Flex } from "../../design-system/flex";
@@ -119,6 +120,8 @@ export function StepSettings() {
     useTrackReadingHistory();
   const { enabled: countOldAsUnread, setEnabled: setCountOldAsUnread } =
     useCountOldPostsAsUnread();
+  const { enabled: usePublicationTheme, setEnabled: setUsePublicationTheme } =
+    usePublicationThemePreference();
 
   const digestStatusQuery = useQuery(user.getWeeklyDigestStatusQueryOptions);
   const digestEnabled = Boolean(
@@ -162,6 +165,17 @@ export function StepSettings() {
               isSelected={countOldAsUnread}
               onChange={setCountOldAsUnread}
               aria-label={t`Mark old posts as unread`}
+            />
+          </Row>
+          <Separator />
+          <Row
+            label={t`Use publication themes`}
+            description={t`When on, a publication's page and its posts are shown in that publication's own colors and fonts. Publications that haven't set any keep the Standard Reader theme.`}
+          >
+            <Switch
+              isSelected={usePublicationTheme}
+              onChange={setUsePublicationTheme}
+              aria-label={t`Use publication themes`}
             />
           </Row>
         </div>

--- a/src/components/reader/app-shell.tsx
+++ b/src/components/reader/app-shell.tsx
@@ -90,6 +90,7 @@ import { initials, listLinkParams, publicationLinkParams } from "./format";
 import { LanguageHintPrompt } from "./language-hint-prompt";
 import { ListEditModal } from "./list-edit-modal";
 import { PageReaderBar } from "./page-reader-bar";
+import { PublicationThemeScope } from "./publication-theme-scope";
 import { ReorderListsModal } from "./reorder-lists-modal";
 import {
   SelectionDockProvider,
@@ -1473,8 +1474,12 @@ export function AppShell({ children }: { children: React.ReactNode }) {
                 </Flex>
               )}
 
-              {children}
-              <SiteFooter />
+              {/* The footer sits inside the themed region so a publication's
+                  colors run to the bottom of the content column. */}
+              <PublicationThemeScope>
+                {children}
+                <SiteFooter />
+              </PublicationThemeScope>
             </div>
 
             <div {...stylex.props(styles.dock)}>

--- a/src/components/reader/app-shell.tsx
+++ b/src/components/reader/app-shell.tsx
@@ -1476,9 +1476,8 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
               {/* The footer sits inside the themed region so a publication's
                   colors run to the bottom of the content column. */}
-              <PublicationThemeScope>
+              <PublicationThemeScope footer={<SiteFooter />}>
                 {children}
-                <SiteFooter />
               </PublicationThemeScope>
             </div>
 

--- a/src/components/reader/article-below-fold.tsx
+++ b/src/components/reader/article-below-fold.tsx
@@ -39,7 +39,8 @@ const styles = stylex.create({
     boxSizing: "border-box",
     marginInlineStart: "auto",
     marginInlineEnd: "auto",
-    paddingBottom: spacing["20"],
+    // Trimmed inside a publication page card, which supplies its own margin.
+    paddingBottom: `var(--pub-page-content-bottom, ${spacing["20"]})`,
     paddingInlineStart: spacing["6"],
     paddingInlineEnd: spacing["6"],
     width: "100%",

--- a/src/components/reader/article-view.tsx
+++ b/src/components/reader/article-view.tsx
@@ -100,6 +100,7 @@ import {
   PublicationAvatar,
   Topic,
 } from "./primitives";
+import { publicationPageCard } from "./publication-theme-tokens";
 import { QuoteShareLayer } from "./quote-share-layer";
 import { ReadOnPlatformButton } from "./read-on-platform";
 import { applyMarkReadOptimisticUpdate } from "./read-optimistic";
@@ -281,10 +282,12 @@ const styles = stylex.create({
     marginInlineEnd: "auto",
     maxWidth: "100%",
     minWidth: 0,
-    paddingBottom: spacing["24"],
+    paddingBottom: `var(--pub-page-content-bottom, ${spacing["24"]})`,
     paddingInlineStart: spacing["6"],
     paddingInlineEnd: spacing["6"],
-    paddingTop: spacing["14"],
+    // The page card already floats the content off the chrome above it, so the
+    // article needs less of its own lead-in there; unchanged without a canvas.
+    paddingTop: `var(--pub-page-content-top, ${spacing["14"]})`,
     width: "100%",
   },
   kicker: {
@@ -1175,223 +1178,235 @@ function ArticleViewBody({
 
       <ReaderWordHighlighter rootRef={articleRef} articleUri={article.uri} />
       <SaveDraftConsumer />
-      <article
-        ref={articleRef}
+      {/* The page card — the sticky chrome above stays outside it, so it reads
+          as app furniture rather than part of the publication's page. */}
+      <div
         {...stylex.props(
-          styles.article,
+          publicationPageCard.card,
           articleMeasureStyle(readingTypography),
         )}
       >
-        {showMagazineIntro ? (
-          <div {...stylex.props(styles.magazineIntro)}>
-            <Alert
-              title={t`There’s a magazine edition of this collection.`}
-              action={
-                <Button variant="primary" onPress={dismissMagazineIntro}>
-                  <Trans>OK</Trans>
-                </Button>
-              }
-            >
-              <Trans>
-                Nine pieces, laid out as spreads — made to be read slowly. Click
-                the book icon in the header.
-              </Trans>
-            </Alert>
-          </div>
-        ) : null}
+        <article
+          ref={articleRef}
+          {...stylex.props(
+            styles.article,
+            articleMeasureStyle(readingTypography),
+          )}
+        >
+          {showMagazineIntro ? (
+            <div {...stylex.props(styles.magazineIntro)}>
+              <Alert
+                title={t`There’s a magazine edition of this collection.`}
+                action={
+                  <Button variant="primary" onPress={dismissMagazineIntro}>
+                    <Trans>OK</Trans>
+                  </Button>
+                }
+              >
+                <Trans>
+                  Nine pieces, laid out as spreads — made to be read slowly.
+                  Click the book icon in the header.
+                </Trans>
+              </Alert>
+            </div>
+          ) : null}
 
-        {topic || labelRefs.length > 0 ? (
-          <div {...stylex.props(styles.kicker)}>
-            {labelRefs.length > 0 ? (
-              <div {...stylex.props(styles.labelBadges)}>
-                {labelRefs.map((ref) => (
-                  <LabelerPill
-                    key={`${ref.src}:${ref.val}`}
-                    src={ref.src}
-                    val={ref.val}
-                  />
-                ))}
-              </div>
-            ) : null}
-            {topic ? (
-              <Kicker>
-                <Topic name={topic} />
-              </Kicker>
-            ) : null}
-          </div>
-        ) : null}
-
-        {hero ? (
-          <button
-            aria-label={t`Open image`}
-            type="button"
-            onClick={() => {
-              flushSync(() => setHeroTransitionActive(true));
-              startLightboxViewTransition(() => setHeroLightboxOpen(true));
-            }}
-            style={
-              heroTransitionActive && !heroLightboxOpen
-                ? { viewTransitionName: LIGHTBOX_IMAGE_TRANSITION_NAME }
-                : undefined
-            }
-            {...stylex.props(styles.hero)}
-          >
-            <img
-              src={hero.url}
-              alt=""
-              referrerPolicy="no-referrer"
-              {...stylex.props(styles.heroImg)}
-            />
-          </button>
-        ) : null}
-        {hero ? (
-          <Lightbox
-            alt={t`Article header image`}
-            images={[
-              {
-                src: hero.url,
-                alt: "",
-                transitionName: heroTransitionActive
-                  ? LIGHTBOX_IMAGE_TRANSITION_NAME
-                  : undefined,
-              },
-            ]}
-            isOpen={heroLightboxOpen}
-            onOpenChange={(open) => {
-              setHeroLightboxOpen(open);
-              if (!open) setHeroTransitionActive(false);
-            }}
-          />
-        ) : null}
-
-        {/* dir="auto" for the same reason as the article body: this is author
-            content, not UI chrome, so it must not inherit the UI direction. */}
-        <h1 dir="auto" {...stylex.props(styles.title)}>
-          {article.title}
-        </h1>
-
-        {article.description && !articleDescriptionIsBodyExcerpt(article) ? (
-          <p dir="auto" {...stylex.props(styles.dek)}>
-            {article.description}
-          </p>
-        ) : null}
-
-        <div {...stylex.props(styles.byline)}>
-          <Avatar
-            size="lg"
-            src={authorAvatarUrl(article) ?? undefined}
-            fallback={initials(authorName)}
-            alt={authorName}
-          />
-          <div {...stylex.props(styles.bylineWho)}>
-            <div {...stylex.props(styles.bylineName)}>
-              {bylineDid ? (
-                <Link
-                  to="/u/$did"
-                  params={{ did: bylineDid }}
-                  {...stylex.props(styles.bylineNameLink)}
-                >
-                  {authorName}
-                </Link>
-              ) : (
-                authorName
-              )}
-
-              {showHandle && bylineDid ? (
-                <Link
-                  to="/u/$did"
-                  params={{ did: bylineDid }}
-                  {...stylex.props(
-                    styles.bylineNameLink,
-                    styles.bylineHandleLink,
-                  )}
-                >
-                  <Handle>@{handle}</Handle>
-                </Link>
-              ) : showHandle ? (
-                <Handle>@{handle}</Handle>
+          {topic || labelRefs.length > 0 ? (
+            <div {...stylex.props(styles.kicker)}>
+              {labelRefs.length > 0 ? (
+                <div {...stylex.props(styles.labelBadges)}>
+                  {labelRefs.map((ref) => (
+                    <LabelerPill
+                      key={`${ref.src}:${ref.val}`}
+                      src={ref.src}
+                      val={ref.val}
+                    />
+                  ))}
+                </div>
+              ) : null}
+              {topic ? (
+                <Kicker>
+                  <Topic name={topic} />
+                </Kicker>
               ) : null}
             </div>
-            <Flex align="center" gap="md" wrap style={styles.bylineMeta}>
-              <span>
-                <span {...stylex.props(styles.bylineMetaItem)}>{date}</span>
-                {readingLabel ? (
-                  <>
-                    <span aria-hidden> · </span>
-                    <span {...stylex.props(styles.bylineMetaItem)}>
-                      {readingLabel}
-                    </span>
-                  </>
-                ) : null}
-                {readStats ? (
-                  <>
-                    <span aria-hidden> · </span>
-                    <span {...stylex.props(styles.bylineMetaItem)}>
-                      {readStats}
-                    </span>
-                  </>
-                ) : null}
-              </span>
-              {hasEngagement ? (
-                <>
-                  <span aria-hidden>·</span>
-                  <ArticleEngagement
-                    recommendCount={article.recommendCount}
-                    commentCount={article.commentCount}
-                    size="sm"
-                  />
-                </>
-              ) : null}
-            </Flex>
-          </div>
-        </div>
+          ) : null}
 
-        {linkParams ? (
-          <QuoteShareLayer article={article} sharedQuote={sharedQuote}>
-            <ArticleContent article={article} />
-          </QuoteShareLayer>
-        ) : (
-          <ArticleContent article={article} />
-        )}
-
-        {article.collection?.colophon?.body ? (
-          <CollectionColophon body={article.collection.colophon.body} />
-        ) : null}
-
-        <ArticleLikePrompt
-          recommended={recommended}
-          onToggle={toggleRecommend}
-          recommendCount={recommendCount}
-        />
-
-        {pub ? (
-          <div {...stylex.props(styles.foot)}>
-            <PublicationAvatar pub={pub} size="lg" />
-            <Flex direction="column" gap="xs" style={styles.footGrow}>
-              <PublicationNameLink
-                publicationUri={article.publicationUri}
-                url={pub.url}
-                linkStyle={styles.footName}
-              >
-                {pub.name}
-              </PublicationNameLink>
-              {article.publicationOwnerHandle && bylineDid ? (
-                <AuthorProfileLink authorRef={bylineDid}>
-                  <Handle>@{article.publicationOwnerHandle}</Handle>
-                </AuthorProfileLink>
-              ) : null}
-            </Flex>
-            {article.publicationUri ? (
-              <FollowButton
-                publicationUri={article.publicationUri}
-                signedIn={signedIn}
+          {hero ? (
+            <button
+              aria-label={t`Open image`}
+              type="button"
+              onClick={() => {
+                flushSync(() => setHeroTransitionActive(true));
+                startLightboxViewTransition(() => setHeroLightboxOpen(true));
+              }}
+              style={
+                heroTransitionActive && !heroLightboxOpen
+                  ? { viewTransitionName: LIGHTBOX_IMAGE_TRANSITION_NAME }
+                  : undefined
+              }
+              {...stylex.props(styles.hero)}
+            >
+              <img
+                src={hero.url}
+                alt=""
+                referrerPolicy="no-referrer"
+                {...stylex.props(styles.heroImg)}
               />
-            ) : null}
-          </div>
-        ) : null}
-      </article>
+            </button>
+          ) : null}
+          {hero ? (
+            <Lightbox
+              alt={t`Article header image`}
+              images={[
+                {
+                  src: hero.url,
+                  alt: "",
+                  transitionName: heroTransitionActive
+                    ? LIGHTBOX_IMAGE_TRANSITION_NAME
+                    : undefined,
+                },
+              ]}
+              isOpen={heroLightboxOpen}
+              onOpenChange={(open) => {
+                setHeroLightboxOpen(open);
+                if (!open) setHeroTransitionActive(false);
+              }}
+            />
+          ) : null}
 
-      <ArticleBelowFold article={article} showComments={Boolean(linkParams)} />
+          {/* dir="auto" for the same reason as the article body: this is author
+            content, not UI chrome, so it must not inherit the UI direction. */}
+          <h1 dir="auto" {...stylex.props(styles.title)}>
+            {article.title}
+          </h1>
+
+          {article.description && !articleDescriptionIsBodyExcerpt(article) ? (
+            <p dir="auto" {...stylex.props(styles.dek)}>
+              {article.description}
+            </p>
+          ) : null}
+
+          <div {...stylex.props(styles.byline)}>
+            <Avatar
+              size="lg"
+              src={authorAvatarUrl(article) ?? undefined}
+              fallback={initials(authorName)}
+              alt={authorName}
+            />
+            <div {...stylex.props(styles.bylineWho)}>
+              <div {...stylex.props(styles.bylineName)}>
+                {bylineDid ? (
+                  <Link
+                    to="/u/$did"
+                    params={{ did: bylineDid }}
+                    {...stylex.props(styles.bylineNameLink)}
+                  >
+                    {authorName}
+                  </Link>
+                ) : (
+                  authorName
+                )}
+
+                {showHandle && bylineDid ? (
+                  <Link
+                    to="/u/$did"
+                    params={{ did: bylineDid }}
+                    {...stylex.props(
+                      styles.bylineNameLink,
+                      styles.bylineHandleLink,
+                    )}
+                  >
+                    <Handle>@{handle}</Handle>
+                  </Link>
+                ) : showHandle ? (
+                  <Handle>@{handle}</Handle>
+                ) : null}
+              </div>
+              <Flex align="center" gap="md" wrap style={styles.bylineMeta}>
+                <span>
+                  <span {...stylex.props(styles.bylineMetaItem)}>{date}</span>
+                  {readingLabel ? (
+                    <>
+                      <span aria-hidden> · </span>
+                      <span {...stylex.props(styles.bylineMetaItem)}>
+                        {readingLabel}
+                      </span>
+                    </>
+                  ) : null}
+                  {readStats ? (
+                    <>
+                      <span aria-hidden> · </span>
+                      <span {...stylex.props(styles.bylineMetaItem)}>
+                        {readStats}
+                      </span>
+                    </>
+                  ) : null}
+                </span>
+                {hasEngagement ? (
+                  <>
+                    <span aria-hidden>·</span>
+                    <ArticleEngagement
+                      recommendCount={article.recommendCount}
+                      commentCount={article.commentCount}
+                      size="sm"
+                    />
+                  </>
+                ) : null}
+              </Flex>
+            </div>
+          </div>
+
+          {linkParams ? (
+            <QuoteShareLayer article={article} sharedQuote={sharedQuote}>
+              <ArticleContent article={article} />
+            </QuoteShareLayer>
+          ) : (
+            <ArticleContent article={article} />
+          )}
+
+          {article.collection?.colophon?.body ? (
+            <CollectionColophon body={article.collection.colophon.body} />
+          ) : null}
+
+          <ArticleLikePrompt
+            recommended={recommended}
+            onToggle={toggleRecommend}
+            recommendCount={recommendCount}
+          />
+
+          {pub ? (
+            <div {...stylex.props(styles.foot)}>
+              <PublicationAvatar pub={pub} size="lg" />
+              <Flex direction="column" gap="xs" style={styles.footGrow}>
+                <PublicationNameLink
+                  publicationUri={article.publicationUri}
+                  url={pub.url}
+                  linkStyle={styles.footName}
+                >
+                  {pub.name}
+                </PublicationNameLink>
+                {article.publicationOwnerHandle && bylineDid ? (
+                  <AuthorProfileLink authorRef={bylineDid}>
+                    <Handle>@{article.publicationOwnerHandle}</Handle>
+                  </AuthorProfileLink>
+                ) : null}
+              </Flex>
+              {article.publicationUri ? (
+                <FollowButton
+                  publicationUri={article.publicationUri}
+                  signedIn={signedIn}
+                />
+              ) : null}
+            </div>
+          ) : null}
+        </article>
+
+        <ArticleBelowFold
+          article={article}
+          showComments={Boolean(linkParams)}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/reader/content/body-styles.ts
+++ b/src/components/reader/content/body-styles.ts
@@ -2,6 +2,7 @@ import * as stylex from "@stylexjs/stylex";
 import type { CSSProperties } from "react";
 
 import {
+  linkColor,
   primaryColor,
   uiColor,
   warningColor,
@@ -137,14 +138,14 @@ export const articleBodyStyles = stylex.create({
   },
   facetLink: {
     textDecoration: { default: "underline", ":hover": "none" },
-    color: primaryColor.text2,
+    color: linkColor.text,
     textUnderlineOffset: spacing["1.5"],
   },
   publicationBylineLink: {
     cornerShape: "squircle",
     borderRadius: radius.xs,
     textDecoration: { default: "underline", ":hover": "none" },
-    color: primaryColor.text2,
+    color: linkColor.text,
     textDecorationColor: "currentColor",
     textUnderlineOffset: spacing["1.5"],
     fontWeight: fontWeight.semibold,
@@ -185,7 +186,7 @@ export const articleBodyStyles = stylex.create({
     cornerShape: "squircle",
     borderRadius: radius.xs,
     textDecoration: "none",
-    color: primaryColor.text2,
+    color: linkColor.text,
     fontWeight: fontWeight.medium,
     paddingInline: spacing["0.5"],
   },
@@ -218,7 +219,7 @@ export const articleBodyStyles = stylex.create({
   },
   footnoteBackLink: {
     textDecoration: "none",
-    color: primaryColor.text2,
+    color: linkColor.text,
     marginInlineStart: spacing["1"],
   },
   codeBlock: {

--- a/src/components/reader/primitives.tsx
+++ b/src/components/reader/primitives.tsx
@@ -100,7 +100,7 @@ const styles = stylex.create({
     marginInlineStart: "auto",
     marginInlineEnd: "auto",
     maxWidth: "1320px",
-    paddingBottom: spacing["20"],
+    paddingBottom: `var(--pub-page-content-bottom, ${spacing["20"]})`,
     paddingInlineStart: {
       default: spacing["5"],
       "@media (min-width: 40rem)": spacing["10"],

--- a/src/components/reader/publication-theme-scale.test.ts
+++ b/src/components/reader/publication-theme-scale.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+
+import { publicationThemeScaleVars } from "./publication-theme-scale";
+
+const BASE = {
+  themeBackground: "#ffffff",
+  themeForeground: "#0d0d0d",
+  themeAccent: "#2b52ff",
+  themeAccentForeground: "#ffffff",
+};
+
+function vars(input: Parameters<typeof publicationThemeScaleVars>[0]) {
+  return publicationThemeScaleVars(input) as unknown as Record<string, string>;
+}
+
+describe("publicationThemeScaleVars neutral anchors", () => {
+  it("leaves the derived scale untouched when the publisher states nothing", () => {
+    // The `basicTheme`-only path must not shift — most publications are here.
+    const withoutAnchors = vars(BASE);
+    const withNullAnchors = vars({
+      ...BASE,
+      surface: null,
+      surfaceHover: null,
+      border: null,
+    });
+    expect(withNullAnchors).toEqual(withoutAnchors);
+  });
+
+  it("pins a stated surface and border exactly onto their steps", () => {
+    const v = vars({ ...BASE, surface: "#fafafa", border: "#e5e5e5" });
+    // Offprint's base200 -> component1, base300 -> border1, verbatim.
+    expect(v["--pub-component1-light"]).toBe("#fafafa");
+    expect(v["--pub-border1-light"]).toBe("#e5e5e5");
+  });
+
+  it("pins a stated hover fill onto the hover step, not the resting one", () => {
+    const v = vars({ ...BASE, surfaceHover: "#a7f3d0" });
+    expect(v["--pub-component2-light"]).toBe("#a7f3d0");
+    // The resting surface stays a subtle derivation off the background.
+    expect(v["--pub-component1-light"]).not.toBe("#a7f3d0");
+  });
+
+  it("interpolates the steps between two anchors", () => {
+    const v = vars({ ...BASE, surface: "#f0f0f0", border: "#d0d0d0" });
+    const between = v["--pub-component3-light"];
+    // component3 sits between component1 (#f0f0f0) and border1 (#d0d0d0).
+    expect(between < "#f0f0f0").toBe(true);
+    expect(between > "#d0d0d0").toBe(true);
+  });
+
+  it("keeps the ramp monotonic across anchored and derived steps", () => {
+    const v = vars({ ...BASE, surface: "#fafafa", border: "#e5e5e5" });
+    const order = [
+      "--pub-bgSubtle-light",
+      "--pub-component1-light",
+      "--pub-component2-light",
+      "--pub-component3-light",
+      "--pub-border1-light",
+      "--pub-border2-light",
+      "--pub-border3-light",
+    ].map((k) => Number.parseInt(v[k].slice(1, 3), 16));
+    // On a light background each step must get progressively darker.
+    for (let i = 1; i < order.length; i += 1) {
+      expect(order[i]).toBeLessThanOrEqual(order[i - 1]);
+    }
+  });
+
+  it("routes a dark stated background to dark mode, not light", () => {
+    // A publication authored on black (Leaflet on a black canvas, a dark-scheme
+    // Offprint theme). Painting that into light mode gave the reader a dark page
+    // *and* a ramp derived by darkening near-black, which collapsed every step.
+    const v = vars({
+      ...BASE,
+      themeBackground: "#1f150c",
+      themeForeground: "#e1dcc9",
+    });
+    expect(v["--pub-bg-dark"]).toBe("#1f150c");
+    // Light mode is synthesized by mirroring their colour through OKLCH, so it
+    // keeps the warm hue rather than dropping to generic near-white.
+    const lightBg = v["--pub-bg-light"];
+    expect(lightBg).not.toBe("#1f150c");
+    const [r, g, b] = [1, 3, 5].map((i) =>
+      Number.parseInt(lightBg.slice(i, i + 2), 16),
+    );
+    expect(r).toBeGreaterThan(230); // light…
+    expect(r).toBeGreaterThan(b); // …and still warm, like their own palette.
+    expect(g).toBeGreaterThan(b);
+    // Ink is mirrored from their text colour: dark enough to read, not flat black.
+    const ink = v["--pub-text2-light"];
+    expect(Number.parseInt(ink.slice(1, 3), 16)).toBeLessThan(80);
+  });
+
+  it("keeps the neutral steps separated for a dark publication", () => {
+    const v = vars({
+      ...BASE,
+      themeBackground: "#1f150c",
+      themeForeground: "#e1dcc9",
+    });
+    for (const mode of ["light", "dark"]) {
+      const channel = (key: string) =>
+        Number.parseInt(v[`--pub-${key}-${mode}`].slice(1, 3), 16);
+      // Borders must be visibly distinct from the page, not the ~1-unit
+      // difference the collapsed ramp used to produce.
+      expect(Math.abs(channel("border1") - channel("bg"))).toBeGreaterThan(16);
+      expect(Math.abs(channel("component1") - channel("bg"))).toBeGreaterThan(
+        4,
+      );
+    }
+  });
+
+  it("leaves a light publication's own background in light mode", () => {
+    const v = vars({ ...BASE, themeBackground: "#f0f2f2" });
+    expect(v["--pub-bg-light"]).toBe("#f0f2f2");
+  });
+
+  it("ignores stated light anchors when the background is dark", () => {
+    // Those anchors describe dark surfaces; applying them to the substituted
+    // light page would reintroduce the unreadable ramp.
+    const v = vars({
+      ...BASE,
+      themeBackground: "#0a0a0a",
+      themeForeground: "#fafafa",
+      surface: "#171717",
+      border: "#262626",
+    });
+    expect(v["--pub-component1-light"]).not.toBe("#171717");
+    expect(v["--pub-border1-light"]).not.toBe("#262626");
+    // They anchor the dark ramp instead, where they belong.
+    expect(v["--pub-component1-dark"]).toBe("#171717");
+    expect(v["--pub-border1-dark"]).toBe("#262626");
+  });
+
+  it("anchors the dark ramp from the authored dark palette", () => {
+    const v = vars({
+      ...BASE,
+      dark: {
+        background: "#022c22",
+        foreground: "#d1fae5",
+        accent: "#84cc16",
+        accentForeground: null,
+        surface: null,
+        surfaceHover: "#064e3b",
+        border: null,
+        link: null,
+        neutral: null,
+        secondary: null,
+      },
+    });
+    expect(v["--pub-bg-dark"]).toBe("#022c22");
+    expect(v["--pub-component2-dark"]).toBe("#064e3b");
+  });
+
+  it("emits no link var when the publisher states none", () => {
+    // `publicationLink` then falls back to the accent's text step, which is what
+    // links used before the token existed.
+    const v = vars(BASE);
+    expect(v["--pub-link-light"]).toBeUndefined();
+    expect(v["--pub-link-dark"]).toBeUndefined();
+  });
+
+  it("uses a stated link colour instead of the accent", () => {
+    const v = vars({ ...BASE, link: "#0d9488" });
+    // Teal is kept (a nudge darker to clear AA on white), and is nowhere near
+    // the blue accent — the two are genuinely separate.
+    const link = v["--pub-link-light"];
+    const [r, g, b] = [1, 3, 5].map((i) =>
+      Number.parseInt(link.slice(i, i + 2), 16),
+    );
+    expect(g).toBeGreaterThan(r);
+    expect(b).toBeGreaterThan(r);
+    expect(g).toBeGreaterThan(b); // teal, not blue
+    expect(v["--pub-accent-solid1-light"]).toBe("#2b52ff");
+  });
+
+  it("forces a stated link to stay readable on the page", () => {
+    // A link colour chosen for the publisher's own surface can be unreadable on
+    // a synthesized one; contrast wins over fidelity.
+    const v = vars({ ...BASE, themeBackground: "#ffffff", link: "#fbfbfb" });
+    expect(v["--pub-link-light"]).not.toBe("#fbfbfb");
+  });
+
+  it("takes the link from the authored dark palette in dark mode", () => {
+    const v = vars({
+      ...BASE,
+      link: "#0d9488",
+      dark: {
+        background: "#022c22",
+        foreground: "#d1fae5",
+        accent: "#84cc16",
+        accentForeground: null,
+        surface: null,
+        surfaceHover: null,
+        border: null,
+        link: "#5eead4",
+        neutral: null,
+        secondary: null,
+      },
+    });
+    // Light keeps the light palette's teal; dark takes the authored one.
+    expect(v["--pub-link-light"]).not.toBe(v["--pub-link-dark"]);
+    expect(v["--pub-link-dark"]).toBe("#5eead4");
+  });
+
+  it("uses a stated neutral for the solid fill", () => {
+    const derived = vars(BASE);
+    const v = vars({ ...BASE, neutral: "#0d0d0d" });
+    expect(v["--pub-solid1-light"]).toBe("#0d0d0d");
+    expect(v["--pub-solid1-light"]).not.toBe(derived["--pub-solid1-light"]);
+  });
+
+  it("ignores light-mode anchors when building a derived dark scale", () => {
+    // Light anchors describe light surfaces; reusing them on a dark ramp would
+    // wash it out. Only an authored dark palette may anchor dark.
+    const anchored = vars({ ...BASE, surface: "#fafafa", border: "#e5e5e5" });
+    const plain = vars(BASE);
+    expect(anchored["--pub-component1-dark"]).toBe(
+      plain["--pub-component1-dark"],
+    );
+  });
+});

--- a/src/components/reader/publication-theme-scale.test.ts
+++ b/src/components/reader/publication-theme-scale.test.ts
@@ -144,6 +144,8 @@ describe("publicationThemeScaleVars neutral anchors", () => {
         link: null,
         neutral: null,
         secondary: null,
+        canvas: null,
+        backgroundImage: null,
       },
     });
     expect(v["--pub-bg-dark"]).toBe("#022c22");
@@ -194,6 +196,8 @@ describe("publicationThemeScaleVars neutral anchors", () => {
         link: "#5eead4",
         neutral: null,
         secondary: null,
+        canvas: null,
+        backgroundImage: null,
       },
     });
     // Light keeps the light palette's teal; dark takes the authored one.

--- a/src/components/reader/publication-theme-scale.ts
+++ b/src/components/reader/publication-theme-scale.ts
@@ -1,7 +1,159 @@
+import Color from "colorjs.io";
 import type { CSSProperties } from "react";
 
-import type { PublicationEmbedMeta } from "#/integrations/tanstack-query/api-publication.functions";
+import type { PublicationFonts } from "#/lib/publication-fonts";
 import { resolveQuoteOgColors } from "#/lib/publication-theme";
+import type {
+  ResolvedPublicationTheme,
+  ThemePalette,
+} from "#/lib/publication-theme-source";
+import { resolvePublicationTheme } from "#/lib/publication-theme-source";
+
+/**
+ * The four flat theme colors every themed surface starts from — the publication
+ * record's `basicTheme`, flattened onto the `publications` row. Structurally a
+ * subset of `PublicationEmbedMeta`, so that type can be passed directly.
+ */
+export interface PublicationThemeColors {
+  themeBackground: string | null;
+  themeForeground: string | null;
+  themeAccent: string | null;
+  themeAccentForeground: string | null;
+  /**
+   * The publisher's own dark palette, when their native theme carries one (see
+   * `#/lib/publication-theme-source`). Absent means "derive dark from the light
+   * colors", which is all `basicTheme` alone can support.
+   */
+  dark?: ThemePalette | null;
+  /** Stated light-mode neutral steps; absent slots stay derived. */
+  surface?: string | null;
+  surfaceHover?: string | null;
+  border?: string | null;
+  /** Stated link colour for light mode; dark comes from the dark palette. */
+  link?: string | null;
+  /** Stated neutral solid fill (Offprint `neutral`). */
+  neutral?: string | null;
+  /**
+   * Google Fonts families the publisher chose, already resolved from their
+   * platform's key format (see `#/lib/publication-fonts`). Unresolved fonts stay
+   * `null` so the reader keeps their own typography.
+   */
+  fonts?: PublicationFonts | null;
+}
+
+/** Pull the neutral anchors out of a palette, or null when it states none. */
+function anchorsOf(palette: {
+  surface?: string | null;
+  surfaceHover?: string | null;
+  border?: string | null;
+}): NeutralAnchors | null {
+  if (!palette.surface && !palette.surfaceHover && !palette.border) return null;
+  return {
+    surface: palette.surface ?? null,
+    surfaceHover: palette.surfaceHover ?? null,
+    border: palette.border ?? null,
+  };
+}
+
+/**
+ * The page surface and body text a reader actually sees in each mode — the
+ * *generated* values, which differ from the stated theme colours whenever a mode
+ * had to be synthesized. Anything matching against the rendered page (the code
+ * theme picker) must score on these, not on the stated background.
+ */
+export function publicationRenderedSurfaces(meta: PublicationThemeColors): {
+  light: { background: string; foreground: string };
+  dark: { background: string; foreground: string };
+} {
+  const vars = publicationThemeScaleVars(meta) as Record<string, string>;
+  return {
+    light: {
+      background: vars["--pub-bg-light"],
+      foreground: vars["--pub-text2-light"],
+    },
+    dark: {
+      background: vars["--pub-bg-dark"],
+      foreground: vars["--pub-text2-dark"],
+    },
+  };
+}
+
+/**
+ * Adapt a resolved publisher theme (`resolvePublicationTheme`) into the shape
+ * the scale generator and the flat `theme_*` columns share.
+ */
+export function themeColorsFromResolved(
+  theme: ResolvedPublicationTheme,
+): PublicationThemeColors {
+  return {
+    themeBackground: theme.light.background,
+    themeForeground: theme.light.foreground,
+    themeAccent: theme.light.accent,
+    themeAccentForeground: theme.light.accentForeground,
+    dark: theme.dark,
+    surface: theme.light.surface,
+    surfaceHover: theme.light.surfaceHover,
+    border: theme.light.border,
+    link: theme.light.link,
+    neutral: theme.light.neutral,
+  };
+}
+
+/**
+ * Build the theme for a `publications` row. The flat `theme_*` columns hold the
+ * flattened `basicTheme` baseline; `theme_json` additionally carries the
+ * publisher's native theme under `nativeTheme`, which wins per-slot when it
+ * expresses something the baseline can't (Leaflet's real page surface, an
+ * authored dark palette).
+ */
+export function publicationThemeFromRow(row: {
+  themeBackground: string | null;
+  themeForeground: string | null;
+  themeAccent: string | null;
+  themeAccentForeground: string | null;
+  themeJson: unknown;
+}): PublicationThemeColors {
+  const json =
+    row.themeJson && typeof row.themeJson === "object"
+      ? (row.themeJson as Record<string, unknown>)
+      : null;
+  const resolved = resolvePublicationTheme(json, json?.nativeTheme);
+  return {
+    themeBackground: resolved.light.background ?? row.themeBackground,
+    themeForeground: resolved.light.foreground ?? row.themeForeground,
+    themeAccent: resolved.light.accent ?? row.themeAccent,
+    themeAccentForeground:
+      resolved.light.accentForeground ?? row.themeAccentForeground,
+    dark: resolved.dark,
+    surface: resolved.light.surface,
+    surfaceHover: resolved.light.surfaceHover,
+    border: resolved.light.border,
+    link: resolved.light.link,
+    neutral: resolved.light.neutral,
+  };
+}
+
+/**
+ * Whether a publication actually carries theme colors of its own.
+ *
+ * `publicationThemeScaleVars` always produces a full palette — it falls back to
+ * the site's editorial-ish defaults when colors are missing. That fallback is
+ * right for surfaces that are inherently the publication's (OG cards, subscribe
+ * embeds), but on in-app pages it would swap the real design-system tokens for a
+ * hand-rolled approximation of them for no visual gain. Gate on this first and
+ * leave unthemed publications on the editorial theme.
+ */
+export function hasPublicationThemeColors(
+  colors: PublicationThemeColors | null | undefined,
+): colors is PublicationThemeColors {
+  if (!colors) return false;
+  return Boolean(
+    colors.themeBackground?.trim() ||
+    colors.themeForeground?.trim() ||
+    colors.themeAccent?.trim() ||
+    colors.themeAccentForeground?.trim(),
+  );
+}
 
 interface Rgb {
   r: number;
@@ -69,8 +221,118 @@ function highContrastFallback(bg: Rgb): Rgb {
   return contrastRatio(BLACK, bg) >= contrastRatio(WHITE, bg) ? BLACK : WHITE;
 }
 
+/**
+ * Whether a surface reads as dark — i.e. white text contrasts better than black
+ * against it. Drives which mode a publisher's stated background belongs to, and
+ * therefore which way the neutral ramp has to travel to stay visible.
+ */
+function isDarkColor(color: Rgb): boolean {
+  return contrastRatio(WHITE, color) > contrastRatio(BLACK, color);
+}
+
+/**
+ * Neutral stand-in used only when a colour can't be inverted (unparseable, or
+ * an achromatic value whose hue carries no information to preserve).
+ */
+const DEFAULT_LIGHT_BG: Rgb = { r: 253, g: 253, b: 252 };
+const DEFAULT_DARK_BG: Rgb = { r: 17, g: 17, b: 17 };
+
+/** Target lightness for a synthesized page background, in OKLCH terms. */
+const SYNTH_LIGHT_L = 0.975;
+const SYNTH_DARK_L = 0.17;
+/**
+ * How much of the source chroma a synthesized background keeps. The same chroma
+ * reads far more saturated at high lightness than at low, so a dark plum
+ * inverted at full chroma becomes a lurid pink rather than the pale, warm paper
+ * the publisher's palette implies.
+ */
+const SYNTH_LIGHT_CHROMA = 0.28;
+const SYNTH_DARK_CHROMA = 0.5;
+/** Ink for a synthesized mode: near the opposite end, keeping the hue. */
+const SYNTH_LIGHT_INK_L = 0.25;
+const SYNTH_DARK_INK_L = 0.92;
+
+/**
+ * A theme states one background. Rather than dropping the publisher's character
+ * on the mode they didn't author, mirror the colour through OKLCH: keep its hue,
+ * move lightness to the other end, and damp chroma so the result reads as paper
+ * or ink rather than a saturated wash. A warm near-black page becomes a warm
+ * cream one; a deep green becomes pale mint.
+ *
+ * Returns `null` when the colour can't be parsed, so callers fall back to a
+ * neutral default.
+ */
+function invertLightness(
+  color: Rgb,
+  target: "light" | "dark",
+  kind: "background" | "ink" = "background",
+): Rgb | null {
+  const toLight = target === "light";
+  try {
+    const oklch = new Color(toHex(color)).to("oklch");
+    const [, chroma, hue] = oklch.coords;
+    const lightness =
+      kind === "ink"
+        ? toLight
+          ? SYNTH_LIGHT_INK_L
+          : SYNTH_DARK_INK_L
+        : toLight
+          ? SYNTH_LIGHT_L
+          : SYNTH_DARK_L;
+    const damped =
+      (chroma ?? 0) * (toLight ? SYNTH_LIGHT_CHROMA : SYNTH_DARK_CHROMA);
+    const next = new Color("oklch", [lightness, damped, hue ?? 0]).to("srgb");
+    // `toGamut` keeps the hue while pulling chroma back into sRGB.
+    next.toGamut({ space: "srgb", method: "clip" });
+    return {
+      r: (next.coords[0] ?? 0) * 255,
+      g: (next.coords[1] ?? 0) * 255,
+      b: (next.coords[2] ?? 0) * 255,
+    };
+  } catch {
+    return null;
+  }
+}
+
 function ensureContrast(fg: Rgb, bg: Rgb, minRatio: number): Rgb {
   return contrastRatio(fg, bg) >= minRatio ? fg : highContrastFallback(bg);
+}
+
+/**
+ * Bring a colour up to a contrast ratio by moving its OKLCH lightness away from
+ * the background, keeping hue and chroma.
+ *
+ * Unlike {@link ensureContrast}, which flips to black or white, this preserves
+ * the colour's identity — essential for a publisher's stated link colour, where
+ * snapping to black would discard the very distinction we adopted it for. Plenty
+ * of real link colours (a teal `#0d9488` on white is ~3.9:1) sit just under AA
+ * and only need a nudge.
+ */
+function ensureReadable(color: Rgb, bg: Rgb, minRatio: number): Rgb {
+  if (contrastRatio(color, bg) >= minRatio) return color;
+  try {
+    const oklch = new Color(toHex(color)).to("oklch");
+    const [lightness, chroma, hue] = oklch.coords;
+    const towardsDark = !isDarkColor(bg);
+    let current = lightness ?? 0.5;
+    for (let step = 0; step < 50; step += 1) {
+      current += towardsDark ? -0.02 : 0.02;
+      if (current <= 0 || current >= 1) break;
+      const next = new Color("oklch", [current, chroma ?? 0, hue ?? 0]).to(
+        "srgb",
+      );
+      next.toGamut({ space: "srgb", method: "clip" });
+      const candidate = {
+        r: (next.coords[0] ?? 0) * 255,
+        g: (next.coords[1] ?? 0) * 255,
+        b: (next.coords[2] ?? 0) * 255,
+      };
+      if (contrastRatio(candidate, bg) >= minRatio) return candidate;
+    }
+  } catch {
+    // Fall through to the hard fallback below.
+  }
+  return highContrastFallback(bg);
 }
 
 /** Darken a color toward black by `amount` (0–1). */
@@ -107,33 +369,134 @@ interface ColorScale {
 }
 
 /**
- * Build the neutral (ui) scale from the publication's background + foreground.
- * Light: background tints; Dark: inverted dark surfaces with the same hue.
+ * A stated neutral solid (Offprint `neutral`) replaces the neutral fill we
+ * otherwise derive from the foreground. `solid2` is the lighter companion step.
  */
-function buildUiScale(
-  background: Rgb,
-  foreground: Rgb,
-  isDark: boolean,
+function applyNeutralSolid(
+  scale: ColorScale,
+  stated: string | null | undefined,
+  towards: Rgb,
 ): ColorScale {
-  if (isDark) {
-    const darkBg = darken(background, 0.82);
-    return {
-      bg: toHex(darkBg),
-      bgSubtle: toHex(lighten(darkBg, 0.03)),
-      component1: toHex(lighten(darkBg, 0.06)),
-      component2: toHex(lighten(darkBg, 0.1)),
-      component3: toHex(lighten(darkBg, 0.16)),
-      border1: toHex(lighten(darkBg, 0.18)),
-      border2: toHex(lighten(darkBg, 0.26)),
-      border3: toHex(lighten(darkBg, 0.36)),
-      solid1: toHex(lighten(darkBg, 0.72)),
-      solid2: toHex(lighten(darkBg, 0.6)),
-      text1: toHex(ensureContrast(lighten(foreground, 0.3), darkBg, 3)),
-      text2: toHex(ensureContrast(lighten(foreground, 0.75), darkBg, 4.5)),
-      textContrast: toHex(darkBg),
-    };
-  }
+  const parsed = stated ? parseHex(stated) : null;
+  if (!parsed) return scale;
+  return {
+    ...scale,
+    solid1: toHex(parsed),
+    solid2: toHex(mix(parsed, towards, 0.18)),
+  };
+}
 
+/**
+ * Where each neutral step sits on a 0→1 ramp from the page background (0) to the
+ * strongest border (1). Publisher-supplied colors are pinned at the step whose
+ * semantics they match, and the steps between anchors are interpolated — so a
+ * stated `base200` lands on `component1` exactly, rather than near it.
+ */
+const NEUTRAL_ELEVATION: Readonly<Record<string, number>> = {
+  bgSubtle: 0.1,
+  component1: 0.22,
+  component2: 0.34,
+  component3: 0.48,
+  border1: 0.58,
+  border2: 0.75,
+  border3: 1,
+};
+
+export interface NeutralAnchors {
+  /** Resting secondary surface — cards, sidebars (`component1`). */
+  surface: string | null;
+  /** Hover state of that surface (`component2`). */
+  surfaceHover: string | null;
+  /** Borders and dividers (`border1`). */
+  border: string | null;
+}
+
+const ANCHOR_ELEVATION = {
+  surface: NEUTRAL_ELEVATION.component1,
+  surfaceHover: NEUTRAL_ELEVATION.component2,
+  border: NEUTRAL_ELEVATION.border1,
+} as const;
+
+/**
+ * Re-lay the neutral steps along a piecewise-linear ramp through whatever the
+ * publisher actually stated, keeping the derived scale everywhere they said
+ * nothing. Returns the scale unchanged when there are no anchors, so
+ * publications that only carry a `basicTheme` render exactly as before.
+ */
+function applyNeutralAnchors(
+  derived: ColorScale,
+  background: Rgb,
+  anchors: NeutralAnchors | null,
+): ColorScale {
+  if (!anchors) return derived;
+
+  const points: Array<{ elevation: number; color: Rgb }> = [];
+  for (const key of ["surface", "surfaceHover", "border"] as const) {
+    const parsed = anchors[key] ? parseHex(anchors[key]) : null;
+    if (parsed)
+      points.push({ elevation: ANCHOR_ELEVATION[key], color: parsed });
+  }
+  if (points.length === 0) return derived;
+
+  const ramp = [
+    { elevation: 0, color: background },
+    ...points.toSorted((a, b) => a.elevation - b.elevation),
+    // The far end stays wherever the derived scale put it, so an anchored ramp
+    // still terminates at a border strong enough to read as one.
+    { elevation: 1, color: parseHex(derived.border3) ?? background },
+  ];
+
+  const next: ColorScale = { ...derived };
+  for (const [key, elevation] of Object.entries(NEUTRAL_ELEVATION)) {
+    let lo = ramp[0];
+    let hi = ramp.at(-1) as { elevation: number; color: Rgb };
+    for (let i = 0; i < ramp.length - 1; i += 1) {
+      if (
+        elevation >= ramp[i].elevation &&
+        elevation <= ramp[i + 1].elevation
+      ) {
+        lo = ramp[i];
+        hi = ramp[i + 1];
+        break;
+      }
+    }
+    const span = hi.elevation - lo.elevation;
+    const t = span === 0 ? 0 : (elevation - lo.elevation) / span;
+    next[key as keyof ColorScale] = toHex(mix(lo.color, hi.color, t));
+  }
+  return next;
+}
+
+/**
+ * Build the neutral (ui) scale from an already-dark background + foreground.
+ * Split out from {@link buildUiScale} so a publisher-authored dark palette can
+ * be used verbatim instead of one derived by darkening their light background.
+ */
+function buildDarkUiScale(darkBg: Rgb, foreground: Rgb): ColorScale {
+  return {
+    bg: toHex(darkBg),
+    bgSubtle: toHex(lighten(darkBg, 0.03)),
+    component1: toHex(lighten(darkBg, 0.06)),
+    component2: toHex(lighten(darkBg, 0.1)),
+    component3: toHex(lighten(darkBg, 0.16)),
+    border1: toHex(lighten(darkBg, 0.18)),
+    border2: toHex(lighten(darkBg, 0.26)),
+    border3: toHex(lighten(darkBg, 0.36)),
+    solid1: toHex(lighten(darkBg, 0.72)),
+    solid2: toHex(lighten(darkBg, 0.6)),
+    text1: toHex(ensureContrast(lighten(foreground, 0.3), darkBg, 3)),
+    text2: toHex(ensureContrast(lighten(foreground, 0.75), darkBg, 4.5)),
+    textContrast: toHex(darkBg),
+  };
+}
+
+/**
+ * Build the neutral (ui) scale for a light page background, tinting *downward*
+ * from it. Only valid when `background` really is light — a dark background
+ * darkened further collapses every step into the same near-black, which is what
+ * {@link isDarkColor} routing exists to prevent.
+ */
+function buildLightUiScale(background: Rgb, foreground: Rgb): ColorScale {
   return {
     bg: toHex(background),
     bgSubtle: toHex(darken(background, 0.02)),
@@ -152,33 +515,34 @@ function buildUiScale(
 }
 
 /**
+ * Accent scale against an already-dark page background. Split out for the same
+ * reason as {@link buildDarkUiScale} — so a publisher's own dark palette drives
+ * it rather than one derived from their light colors.
+ */
+function buildDarkAccentScale(accent: Rgb, darkPageBg: Rgb): ColorScale {
+  const darkAccentBg = darken(accent, 0.78);
+  return {
+    bg: toHex(darkAccentBg),
+    bgSubtle: toHex(lighten(darkAccentBg, 0.04)),
+    component1: toHex(lighten(darkAccentBg, 0.08)),
+    component2: toHex(lighten(darkAccentBg, 0.14)),
+    component3: toHex(lighten(darkAccentBg, 0.22)),
+    border1: toHex(lighten(darkAccentBg, 0.24)),
+    border2: toHex(lighten(darkAccentBg, 0.34)),
+    border3: toHex(lighten(darkAccentBg, 0.46)),
+    solid1: toHex(lighten(accent, 0.12)),
+    solid2: toHex(lighten(accent, 0.24)),
+    text1: toHex(ensureContrast(lighten(accent, 0.3), darkAccentBg, 3)),
+    text2: toHex(ensureContrast(lighten(accent, 0.55), darkAccentBg, 4.5)),
+    textContrast: toHex(darkPageBg),
+  };
+}
+
+/**
  * Build the accent (primary) scale from the publication's accent color.
  * Light: accent tints on light bg; Dark: dark accent-tinted surfaces.
  */
-function buildAccentScale(
-  accent: Rgb,
-  background: Rgb,
-  isDark: boolean,
-): ColorScale {
-  if (isDark) {
-    const darkAccentBg = darken(accent, 0.78);
-    return {
-      bg: toHex(darkAccentBg),
-      bgSubtle: toHex(lighten(darkAccentBg, 0.04)),
-      component1: toHex(lighten(darkAccentBg, 0.08)),
-      component2: toHex(lighten(darkAccentBg, 0.14)),
-      component3: toHex(lighten(darkAccentBg, 0.22)),
-      border1: toHex(lighten(darkAccentBg, 0.24)),
-      border2: toHex(lighten(darkAccentBg, 0.34)),
-      border3: toHex(lighten(darkAccentBg, 0.46)),
-      solid1: toHex(lighten(accent, 0.12)),
-      solid2: toHex(lighten(accent, 0.24)),
-      text1: toHex(ensureContrast(lighten(accent, 0.3), darkAccentBg, 3)),
-      text2: toHex(ensureContrast(lighten(accent, 0.55), darkAccentBg, 4.5)),
-      textContrast: toHex(darken(background, 0.82)),
-    };
-  }
-
+function buildLightAccentScale(accent: Rgb): ColorScale {
   const lightBg = lighten(accent, 0.86);
   return {
     bg: toHex(lightBg),
@@ -239,7 +603,7 @@ function scaleKeyToVarName(
  * these vars via `light-dark(var(--pub-...-light), var(--pub-...-dark))`.
  */
 export function publicationThemeScaleVars(
-  meta: PublicationEmbedMeta,
+  meta: PublicationThemeColors,
 ): CSSProperties {
   const colors = resolveQuoteOgColors({
     themeBackground: meta.themeBackground,
@@ -256,10 +620,76 @@ export function publicationThemeScaleVars(
   const foreground = parseHex(colors.foreground) ?? fallbackFg;
   const accent = parseHex(colors.accent) ?? fallbackAccent;
 
-  const uiLight = buildUiScale(background, foreground, false);
-  const uiDark = buildUiScale(background, foreground, true);
-  const accentLight = buildAccentScale(accent, background, false);
-  const accentDark = buildAccentScale(accent, background, true);
+  // A theme states one background. Route it to the mode its own luminance
+  // matches: a dark publication (Leaflet on black, a dark-scheme Offprint theme)
+  // supplies the *dark* page and light mode falls back to a neutral light one —
+  // rather than painting a dark page for a reader in light mode and deriving a
+  // ramp with nowhere to travel.
+  const statedBgIsDark = isDarkColor(background);
+  const lightBg = statedBgIsDark
+    ? (invertLightness(background, "light") ?? DEFAULT_LIGHT_BG)
+    : background;
+  // Ink for the synthesized mode is mirrored from their own text colour, so a
+  // warm palette keeps warm ink rather than falling back to flat black.
+  const lightFg = statedBgIsDark
+    ? (invertLightness(foreground, "light", "ink") ?? foreground)
+    : foreground;
+
+  // Stated neutral steps describe the surface they were authored against, so
+  // they may only anchor the ramp that actually uses that background.
+  const uiLight = applyNeutralSolid(
+    applyNeutralAnchors(
+      buildLightUiScale(lightBg, lightFg),
+      lightBg,
+      statedBgIsDark ? null : anchorsOf(meta),
+    ),
+    statedBgIsDark ? null : meta.neutral,
+    lightBg,
+  );
+  const accentLight = buildLightAccentScale(accent);
+
+  // Prefer the publisher's own dark palette (PCKT ships light+dark, Offprint
+  // may ship a dark-scheme theme); otherwise use their stated background when it
+  // is already dark, and only darken their light one as a last resort.
+  const authoredDark = meta.dark ?? null;
+  const authoredDarkBg = authoredDark?.background
+    ? parseHex(authoredDark.background)
+    : null;
+  const darkFg = authoredDark?.foreground
+    ? parseHex(authoredDark.foreground)
+    : null;
+  const darkAccent = authoredDark?.accent
+    ? parseHex(authoredDark.accent)
+    : null;
+
+  const darkBg =
+    authoredDarkBg ??
+    (statedBgIsDark
+      ? background
+      : (invertLightness(background, "dark") ?? DEFAULT_DARK_BG));
+  const derivedDarkFg =
+    darkFg ??
+    (statedBgIsDark
+      ? foreground
+      : (invertLightness(foreground, "dark", "ink") ?? foreground));
+  // The stated palette *is* the dark one when its background is dark, so its
+  // anchors belong here.
+  const darkAnchors = authoredDarkBg
+    ? anchorsOf(authoredDark ?? {})
+    : statedBgIsDark
+      ? anchorsOf(meta)
+      : null;
+
+  const uiDark = applyNeutralSolid(
+    applyNeutralAnchors(
+      buildDarkUiScale(darkBg, derivedDarkFg),
+      darkBg,
+      darkAnchors,
+    ),
+    authoredDark ? authoredDark.neutral : statedBgIsDark ? meta.neutral : null,
+    WHITE,
+  );
+  const accentDark = buildDarkAccentScale(darkAccent ?? accent, darkBg);
 
   const vars: Record<string, string> = {};
 
@@ -275,6 +705,25 @@ export function publicationThemeScaleVars(
   // Overlay backdrop — derived from foreground hue.
   vars["--pub-overlay-light"] = toHex(darken(foreground, 0.6));
   vars["--pub-overlay-dark"] = toHex(darken(BLACK, 0.2));
+
+  // Stated link colour, per mode. Left unset when the publisher states none, so
+  // `publicationLink` falls back to the accent's text step. Contrast is enforced
+  // against the page the link sits on — a publisher's link colour chosen for
+  // their own surface can be unreadable on a synthesized one.
+  const linkFor = (
+    stated: string | null | undefined,
+    pageBg: Rgb,
+  ): string | null => {
+    const parsed = stated ? parseHex(stated) : null;
+    return parsed ? toHex(ensureReadable(parsed, pageBg, 4.5)) : null;
+  };
+  const lightLink = linkFor(statedBgIsDark ? null : meta.link, lightBg);
+  const darkLink = linkFor(
+    authoredDark ? authoredDark.link : meta.link,
+    darkBg,
+  );
+  if (lightLink) vars["--pub-link-light"] = lightLink;
+  if (darkLink) vars["--pub-link-dark"] = darkLink;
 
   return vars as CSSProperties;
 }

--- a/src/components/reader/publication-theme-scale.ts
+++ b/src/components/reader/publication-theme-scale.ts
@@ -33,6 +33,17 @@ export interface PublicationThemeColors {
   link?: string | null;
   /** Stated neutral solid fill (Offprint `neutral`). */
   neutral?: string | null;
+  /** Canvas the page card sits on, when distinct from the page surface. */
+  canvas?: string | null;
+  /**
+   * Fixed canvas background image, already resolved to a URL server-side (the
+   * blob CID alone can't be turned into one without the publication's DID).
+   */
+  backgroundImage?: {
+    url: string;
+    repeat: boolean;
+    width: number | null;
+  } | null;
   /**
    * Google Fonts families the publisher chose, already resolved from their
    * platform's key format (see `#/lib/publication-fonts`). Unresolved fonts stay
@@ -96,6 +107,7 @@ export function themeColorsFromResolved(
     border: theme.light.border,
     link: theme.light.link,
     neutral: theme.light.neutral,
+    canvas: theme.light.canvas,
   };
 }
 
@@ -130,6 +142,7 @@ export function publicationThemeFromRow(row: {
     border: resolved.light.border,
     link: resolved.light.link,
     neutral: resolved.light.neutral,
+    canvas: resolved.light.canvas,
   };
 }
 

--- a/src/components/reader/publication-theme-scope.tsx
+++ b/src/components/reader/publication-theme-scope.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { useRouterState } from "@tanstack/react-router";
+import type { ReactNode } from "react";
+import { useCallback, useMemo, useRef } from "react";
+import { UNSAFE_PortalProvider } from "react-aria";
+
+import { publicationFontsHref } from "#/lib/publication-fonts";
+import { usePublicationThemePreference } from "#/lib/use-publication-theme-preference";
+
+import { uiColor } from "../../design-system/theme/color.stylex";
+import type { PublicationThemeColors } from "./publication-theme-scale";
+import {
+  hasPublicationThemeColors,
+  publicationThemeScaleVars,
+} from "./publication-theme-scale";
+import {
+  publicationFonts,
+  publicationLink,
+  publicationPrimary,
+  publicationUi,
+} from "./publication-theme-tokens";
+
+/**
+ * The loader-data key a route sets to opt its page into publication theming.
+ * Any route that returns `publicationTheme` from its loader gets repainted in
+ * those colors — the shell reads it off the deepest match rather than the route
+ * passing it down, so the theme is known before the page renders (no
+ * apply-on-effect flash) and the site footer can sit inside the themed region.
+ */
+export interface PublicationThemedLoaderData {
+  publicationTheme?: PublicationThemeColors | null;
+}
+
+function usePublicationThemeColors(): PublicationThemeColors | null {
+  return useRouterState({
+    select: (state) => {
+      const data = state.matches.at(-1)?.loaderData as
+        | PublicationThemedLoaderData
+        | undefined;
+      return data?.publicationTheme ?? null;
+    },
+  });
+}
+
+/**
+ * Repaints the page in a publication's own colors when the reader has opted
+ * into publication themes (`user.use_publication_theme`).
+ *
+ * The wrapper carries the `publicationUi` / `publicationPrimary` StyleX themes —
+ * which override the design-system `uiColor` / `primaryColor` tokens — plus the
+ * `--pub-*` custom properties those themes read. Everything inside therefore
+ * picks up the publication's palette without knowing anything about theming.
+ *
+ * Only the content column is themed; the sidebar and mobile bar stay Standard
+ * Reader chrome. When the preference is off, or the route published no colors,
+ * this renders its children untouched so the DOM matches the unthemed page.
+ *
+ * Overlays (hover cards, popovers, menus, tooltips, modals) portal to
+ * `document.body` by default, which would drop them right back onto the app's
+ * own tokens. `UNSAFE_PortalProvider` re-points that portal at this container
+ * instead, so they inherit the publication's palette the same way inline content
+ * does — no per-component theming.
+ */
+export function PublicationThemeScope({ children }: { children: ReactNode }) {
+  const { enabled } = usePublicationThemePreference();
+  const colors = usePublicationThemeColors();
+  const scopeRef = useRef<HTMLDivElement | null>(null);
+  const getContainer = useCallback(() => scopeRef.current, []);
+
+  const scaleVars = useMemo(
+    () =>
+      hasPublicationThemeColors(colors)
+        ? publicationThemeScaleVars(colors)
+        : null,
+    [colors],
+  );
+
+  // Only the families that actually resolved get a variable; the rest fall back
+  // to the editorial stack baked into `publicationFonts`.
+  const fonts = colors?.fonts ?? null;
+  const fontVars = useMemo(() => {
+    const vars: Record<string, string> = {};
+    if (fonts?.heading) vars["--pub-font-title"] = `'${fonts.heading}'`;
+    if (fonts?.body) vars["--pub-font-body"] = `'${fonts.body}'`;
+    return vars;
+  }, [fonts]);
+  const fontsHref = useMemo(() => publicationFontsHref(fonts), [fonts]);
+
+  if (!enabled || !scaleVars) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div
+      ref={scopeRef}
+      {...stylex.props(
+        publicationUi,
+        publicationPrimary,
+        publicationLink,
+        publicationFonts,
+        styles.scope,
+      )}
+      style={{ ...scaleVars, ...fontVars }}
+    >
+      {fontsHref ? (
+        <link rel="stylesheet" href={fontsHref} referrerPolicy="no-referrer" />
+      ) : null}
+      <UNSAFE_PortalProvider getContainer={getContainer}>
+        {children}
+      </UNSAFE_PortalProvider>
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  scope: {
+    // Stand in for the content column this replaces as a flex child of the app
+    // shell's scroller, so wrapping doesn't shift the page's layout…
+    display: "flex",
+    flexDirection: "column",
+    flexGrow: 1,
+    minWidth: 0,
+    // …and paint the publication's background across the whole column, since
+    // the shell behind it is still painted in the app's own theme.
+    backgroundColor: uiColor.bg,
+    color: uiColor.text2,
+  },
+});

--- a/src/components/reader/publication-theme-scope.tsx
+++ b/src/components/reader/publication-theme-scope.tsx
@@ -10,6 +10,8 @@ import { publicationFontsHref } from "#/lib/publication-fonts";
 import { usePublicationThemePreference } from "#/lib/use-publication-theme-preference";
 
 import { uiColor } from "../../design-system/theme/color.stylex";
+import { radius } from "../../design-system/theme/radius.stylex";
+import { verticalSpace } from "../../design-system/theme/semantic-spacing.stylex";
 import type { PublicationThemeColors } from "./publication-theme-scale";
 import {
   hasPublicationThemeColors,
@@ -63,7 +65,18 @@ function usePublicationThemeColors(): PublicationThemeColors | null {
  * instead, so they inherit the publication's palette the same way inline content
  * does — no per-component theming.
  */
-export function PublicationThemeScope({ children }: { children: ReactNode }) {
+export function PublicationThemeScope({
+  children,
+  footer,
+}: {
+  children: ReactNode;
+  /**
+   * Site chrome that must sit *outside* the page card but still inside the
+   * themed region — it gets its own opaque surface so the canvas image never
+   * shows behind it.
+   */
+  footer?: ReactNode;
+}) {
   const { enabled } = usePublicationThemePreference();
   const colors = usePublicationThemeColors();
   const scopeRef = useRef<HTMLDivElement | null>(null);
@@ -88,8 +101,34 @@ export function PublicationThemeScope({ children }: { children: ReactNode }) {
   }, [fonts]);
   const fontsHref = useMemo(() => publicationFontsHref(fonts), [fonts]);
 
+  // Leaflet paints a page over a canvas; with a background image the canvas is
+  // what shows around the page. Rather than restructure the column, the scope
+  // takes the image (fixed to the viewport, so it doesn't scroll with content)
+  // and hands the opaque page colour inward via `--pub-page-surface`, which
+  // `ReaderContent` picks up. Everything else stays exactly where it was.
+  const image = colors?.backgroundImage ?? null;
+  const imageVars = useMemo(() => {
+    if (!image) return {};
+    const vars: Record<string, string> = {
+      "--pub-canvas-image": `url("${image.url}")`,
+      "--pub-canvas-repeat": image.repeat ? "repeat" : "no-repeat",
+      "--pub-canvas-size": image.repeat
+        ? image.width
+          ? `${image.width}px auto`
+          : "auto"
+        : "cover",
+    };
+    if (colors?.canvas) vars["--pub-canvas-color"] = colors.canvas;
+    return vars;
+  }, [image, colors?.canvas]);
+
   if (!enabled || !scaleVars) {
-    return <>{children}</>;
+    return (
+      <>
+        {children}
+        {footer}
+      </>
+    );
   }
 
   return (
@@ -101,14 +140,20 @@ export function PublicationThemeScope({ children }: { children: ReactNode }) {
         publicationLink,
         publicationFonts,
         styles.scope,
+        image ? styles.scopeWithCanvasImage : styles.scopeFlat,
       )}
-      style={{ ...scaleVars, ...fontVars }}
+      style={{ ...scaleVars, ...fontVars, ...imageVars }}
     >
       {fontsHref ? (
         <link rel="stylesheet" href={fontsHref} referrerPolicy="no-referrer" />
       ) : null}
       <UNSAFE_PortalProvider getContainer={getContainer}>
         {children}
+        {footer && image ? (
+          <div {...stylex.props(styles.footerSurface)}>{footer}</div>
+        ) : (
+          footer
+        )}
       </UNSAFE_PortalProvider>
     </div>
   );
@@ -117,14 +162,45 @@ export function PublicationThemeScope({ children }: { children: ReactNode }) {
 const styles = stylex.create({
   scope: {
     // Stand in for the content column this replaces as a flex child of the app
-    // shell's scroller, so wrapping doesn't shift the page's layout…
+    // shell's scroller, so wrapping doesn't shift the page's layout.
     display: "flex",
     flexDirection: "column",
     flexGrow: 1,
     minWidth: 0,
-    // …and paint the publication's background across the whole column, since
-    // the shell behind it is still painted in the app's own theme.
-    backgroundColor: uiColor.bg,
     color: uiColor.text2,
+  },
+  /** No canvas image: the column is simply the publication's page colour. */
+  scopeFlat: {
+    backgroundColor: uiColor.bg,
+  },
+  /**
+   * With a canvas image the column becomes the canvas, and `ReaderContent` takes
+   * the page colour instead (via `--pub-page-surface`) so the image shows around
+   * it. `background-attachment: fixed` pins the image to the viewport, so it
+   * stays put while the page scrolls.
+   */
+  scopeWithCanvasImage: {
+    backgroundAttachment: "fixed",
+    backgroundColor: `var(--pub-canvas-color, ${uiColor.bg})`,
+    backgroundImage: "var(--pub-canvas-image)",
+    backgroundPosition: "center center",
+    backgroundRepeat: "var(--pub-canvas-repeat)",
+    backgroundSize: "var(--pub-canvas-size)",
+    // Published for `publicationPageCard` below. Only set in this branch, so a
+    // page card is inert unless there's actually a canvas to frame it against.
+    "--pub-page-surface": uiColor.bg,
+    "--pub-page-radius": radius.lg,
+    "--pub-page-inset": verticalSpace["10xl"],
+    "--pub-page-border": uiColor.border1,
+    "--pub-page-border-width": "1px",
+    "--pub-page-content-top": verticalSpace["8xl"],
+    "--pub-page-content-bottom": verticalSpace["10xl"],
+    // Narrower than the 1320px reading shell so the canvas frames the page on
+    // desktop instead of being squeezed to a sliver at the very edges.
+    "--pub-page-max-width": "1080px",
+  },
+  /** Footer sits on the page colour, not the canvas image. */
+  footerSurface: {
+    backgroundColor: uiColor.bg,
   },
 });

--- a/src/components/reader/publication-theme-tokens.ts
+++ b/src/components/reader/publication-theme-tokens.ts
@@ -102,3 +102,42 @@ export const publicationLink = stylex.createTheme(linkColor, {
   hover:
     "light-dark(var(--pub-link-hover-light, var(--pub-accent-text1-light)), var(--pub-link-hover-dark, var(--pub-accent-text1-dark)))",
 });
+
+/**
+ * The page card: a route's own content, floated on the canvas image a
+ * publication's theme may supply.
+ *
+ * Applied by each page around the part that is *content* — the article's sticky
+ * reading chrome and the site footer are app furniture and stay outside it.
+ * Every value falls back to a no-op, so a page wearing this style is visually
+ * unchanged unless `PublicationThemeScope` is painting a canvas behind it (only
+ * then does it publish `--pub-page-*`).
+ *
+ * Deliberately no `overflow` — clipping here would break the sticky reading
+ * chrome, and the content already has its own padding.
+ */
+export const publicationPageCard = stylex.create({
+  card: {
+    backgroundColor: "var(--pub-page-surface, transparent)",
+    // Squircle corners, matching the app's other rounded surfaces.
+    cornerShape: "squircle",
+    borderRadius: "var(--pub-page-radius, 0)",
+    // Border width is variable too, so the card adds no box in the default
+    // no-canvas case — a transparent 1px border would still eat inner width.
+    borderColor: "var(--pub-page-border, transparent)",
+    borderStyle: "solid",
+    borderWidth: "var(--pub-page-border-width, 0)",
+    boxSizing: "border-box",
+    marginBlockEnd: "var(--pub-page-inset, 0)",
+    marginBlockStart: "var(--pub-page-inset, 0)",
+    // Centred at the reading measure, which the caller supplies — the content
+    // inside already sat at exactly this width, so without a canvas behind it
+    // this changes nothing.
+    marginInlineEnd: "auto",
+    marginInlineStart: "auto",
+    // Callers with their own measure (the article) override this by applying
+    // their width style after the card's.
+    maxWidth: "var(--pub-page-max-width, none)",
+    width: "100%",
+  },
+});

--- a/src/components/reader/publication-theme-tokens.ts
+++ b/src/components/reader/publication-theme-tokens.ts
@@ -1,6 +1,11 @@
 import * as stylex from "@stylexjs/stylex";
 
-import { primaryColor, uiColor } from "../../design-system/theme/color.stylex";
+import {
+  linkColor,
+  primaryColor,
+  uiColor,
+} from "../../design-system/theme/color.stylex";
+import { fontFamily } from "../../design-system/theme/typography.stylex";
 
 /**
  * Publication-themed overrides for the design-system color tokens.
@@ -65,4 +70,35 @@ export const publicationPrimary = stylex.createTheme(primaryColor, {
     "light-dark(var(--pub-accent-text2-light), var(--pub-accent-text2-dark))",
   textContrast:
     "light-dark(var(--pub-accent-textContrast-light), var(--pub-accent-textContrast-dark))",
+});
+
+/**
+ * Publisher-chosen typefaces, layered over the editorial stack rather than
+ * replacing it: `--pub-font-title` / `--pub-font-body` are set at runtime only
+ * when a font actually resolved, and each falls back to the editorial family
+ * (and its Capsize metric-adjusted fallbacks) when it didn't. So a publication
+ * that states no fonts — or one whose font Google doesn't serve — renders in
+ * exactly the app's own typography.
+ */
+const EDITORIAL_TITLE =
+  "'Newsreader', 'Newsreader Fallback: Georgia', 'Newsreader Fallback: Times New Roman', Georgia, 'Times New Roman', serif";
+const EDITORIAL_SANS =
+  "'Atkinson Hyperlegible Next', 'Atkinson Hyperlegible Next Fallback: -apple-system', 'Atkinson Hyperlegible Next Fallback: Arial', system-ui, -apple-system, sans-serif";
+
+export const publicationFonts = stylex.createTheme(fontFamily, {
+  title: `var(--pub-font-title, ${EDITORIAL_TITLE})`,
+  serif: `var(--pub-font-body, ${EDITORIAL_TITLE})`,
+  sans: `var(--pub-font-body, ${EDITORIAL_SANS})`,
+  mono: "'Spline Sans Mono', 'Spline Sans Mono Fallback', ui-monospace, 'SFMono-Regular', monospace",
+});
+
+/**
+ * Publisher-stated link colour. Falls back to the accent's text step, which is
+ * exactly what links used before this token existed — so a publication that
+ * states no link colour renders identically.
+ */
+export const publicationLink = stylex.createTheme(linkColor, {
+  text: "light-dark(var(--pub-link-light, var(--pub-accent-text2-light)), var(--pub-link-dark, var(--pub-accent-text2-dark)))",
+  hover:
+    "light-dark(var(--pub-link-hover-light, var(--pub-accent-text1-light)), var(--pub-link-hover-dark, var(--pub-accent-text1-dark)))",
 });

--- a/src/components/user-settings-view.tsx
+++ b/src/components/user-settings-view.tsx
@@ -41,6 +41,7 @@ import { useCountOldPostsAsUnread } from "#/lib/use-count-old-posts-as-unread";
 import { useLocale } from "#/lib/use-locale";
 import { useOpenCollectionsInMagazine } from "#/lib/use-open-collections-in-magazine";
 import { useOpenLinks } from "#/lib/use-open-links";
+import { usePublicationThemePreference } from "#/lib/use-publication-theme-preference";
 import { useReaderVoice } from "#/lib/use-reader-voice";
 import { useReadingTypography } from "#/lib/use-reading-typography";
 import { useTheme } from "#/lib/use-theme";
@@ -437,6 +438,8 @@ export function UserSettingsView() {
     useTrackReadingHistory();
   const { enabled: countOldAsUnread, setEnabled: setCountOldAsUnread } =
     useCountOldPostsAsUnread();
+  const { enabled: usePublicationTheme, setEnabled: setUsePublicationTheme } =
+    usePublicationThemePreference();
 
   const { data: session } = useQuery(user.getSessionQueryOptions);
   const signedIn = Boolean(session?.user);
@@ -614,6 +617,17 @@ export function UserSettingsView() {
                 </SegmentedControlItem>
               ))}
             </SegmentedControl>
+          </SettingRow>
+          <Separator />
+          <SettingRow
+            label={t`Use publication themes`}
+            description={t`When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme.`}
+          >
+            <Switch
+              isSelected={usePublicationTheme}
+              onChange={setUsePublicationTheme}
+              aria-label={t`Use publication themes`}
+            />
           </SettingRow>
           <Separator />
           <SettingRow

--- a/src/db/schema/auth.ts
+++ b/src/db/schema/auth.ts
@@ -60,6 +60,12 @@ export const user = pgTable("user", {
    * users that existed before this preference shipped, to preserve their current
    * behaviour. */
   countOldPostsAsUnread: boolean("count_old_posts_as_unread"),
+  /** `true` paints publication pages and their documents in the publication's
+   * own `site.standard.theme.basic` colors; `null`/`false` = off (default), so
+   * the app's editorial theme is used everywhere. Publications that carry no
+   * theme colors keep the editorial theme either way. See
+   * `src/lib/publication-theme-preference.ts`. */
+  usePublicationTheme: boolean("use_publication_theme"),
   /** `network` shows the whole-network home feed; `null` = follows (default). */
   homeScope: text("home_scope"),
   /** Comma-separated author-profile tab ids the owner has hidden from their

--- a/src/design-system/theme/color.stylex.tsx
+++ b/src/design-system/theme/color.stylex.tsx
@@ -66,6 +66,23 @@ export const primaryColor = stylex.defineVars({
   textContrast: "white",
 });
 
+/**
+ * Link colour, separate from the accent.
+ *
+ * Body links used `primaryColor.text2` directly, which conflates "this is a
+ * link" with "this is the brand accent". Publishers distinguish the two — every
+ * PCKT theme states a `link` colour alongside its accent — so links need a token
+ * of their own to carry that.
+ *
+ * The defaults reference `primaryColor`, so the app looks exactly as before and
+ * any `createTheme` over `primaryColor` (e.g. `editorialPrimary`) still flows
+ * through; only a theme that overrides `linkColor` itself diverges.
+ */
+export const linkColor = stylex.defineVars({
+  text: primaryColor.text2,
+  hover: primaryColor.text1,
+});
+
 export const criticalColor = stylex.defineVars({
   bg: red.bg,
   bgSubtle: red.bgSubtle,

--- a/src/integrations/tanstack-query/api-google-fonts.functions.ts
+++ b/src/integrations/tanstack-query/api-google-fonts.functions.ts
@@ -2,50 +2,9 @@ import { queryOptions } from "@tanstack/react-query";
 import { createServerFn } from "@tanstack/react-start";
 
 import {
-  isValidGoogleFontFamily,
-  normalizeGoogleFontFamily,
-} from "#/lib/google-fonts";
-
-const GOOGLE_FONTS_METADATA_URL = "https://fonts.google.com/metadata/fonts";
-const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
-
-let cachedFamilies: ReadonlyArray<string> | null = null;
-let cachedAt = 0;
-
-type GoogleFontsMetadata = {
-  familyMetadataList?: ReadonlyArray<{ family?: string }>;
-};
-
-async function loadGoogleFontFamilies(): Promise<ReadonlyArray<string>> {
-  if (cachedFamilies && Date.now() - cachedAt < CACHE_TTL_MS) {
-    return cachedFamilies;
-  }
-
-  const response = await fetch(GOOGLE_FONTS_METADATA_URL, {
-    headers: {
-      Accept: "application/json",
-      "User-Agent": "standard-reader/1.0",
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error("Could not load Google Fonts catalog.");
-  }
-
-  const raw = await response.text();
-  const json = JSON.parse(
-    raw.replace(/^\)\]\}'\n?/, ""),
-  ) as GoogleFontsMetadata;
-  const families = (json.familyMetadataList ?? [])
-    .map((entry) => normalizeGoogleFontFamily(entry.family ?? ""))
-    .filter((family) => isValidGoogleFontFamily(family));
-
-  cachedFamilies = [...new Set(families)].toSorted((a, b) =>
-    a.localeCompare(b),
-  );
-  cachedAt = Date.now();
-  return cachedFamilies;
-}
+  GOOGLE_FONTS_CACHE_TTL_MS,
+  loadGoogleFontFamilies,
+} from "#/server/fonts/google-catalog.server";
 
 const getGoogleFontFamilies = createServerFn({ method: "GET" }).handler(
   async () => {
@@ -57,7 +16,7 @@ const getGoogleFontFamilies = createServerFn({ method: "GET" }).handler(
 const getGoogleFontFamiliesQueryOptions = queryOptions({
   queryKey: ["googleFonts", "families"] as const,
   queryFn: () => getGoogleFontFamilies(),
-  staleTime: CACHE_TTL_MS,
+  staleTime: GOOGLE_FONTS_CACHE_TTL_MS,
 });
 
 export const googleFontsApi = {

--- a/src/integrations/tanstack-query/api-google-fonts.functions.ts
+++ b/src/integrations/tanstack-query/api-google-fonts.functions.ts
@@ -1,10 +1,8 @@
 import { queryOptions } from "@tanstack/react-query";
 import { createServerFn } from "@tanstack/react-start";
 
-import {
-  GOOGLE_FONTS_CACHE_TTL_MS,
-  loadGoogleFontFamilies,
-} from "#/server/fonts/google-catalog.server";
+import { GOOGLE_FONTS_CACHE_TTL_MS } from "#/lib/google-fonts";
+import { loadGoogleFontFamilies } from "#/server/fonts/google-catalog.server";
 
 const getGoogleFontFamilies = createServerFn({ method: "GET" }).handler(
   async () => {

--- a/src/integrations/tanstack-query/api-publication.functions.ts
+++ b/src/integrations/tanstack-query/api-publication.functions.ts
@@ -30,6 +30,7 @@ import { loadCollectionMagazine } from "#/server/reader/collection-magazine";
 import type { ContentLinkTargets } from "#/server/reader/content-links";
 import { resolveContentLinkTargets } from "#/server/reader/content-links";
 import { attachCommentCountsToArticles } from "#/server/reader/document-comments";
+import type { PublicationHeader } from "#/server/reader/publication-header";
 import { selectPublicationHeader } from "#/server/reader/publication-header";
 import { resolveInlineMentions } from "#/server/reader/publication-mentions";
 import {
@@ -45,7 +46,10 @@ import {
   attachViewerRecommendedToArticles,
 } from "#/server/reader/recommended-by";
 import { effectiveFollowSets } from "#/server/reader/saved-lists";
-import { themeModeForRequest } from "#/server/theme-preference";
+import {
+  themeModeForRequest,
+  usePublicationThemeForRequest,
+} from "#/server/theme-preference";
 
 import type {
   ArticleCard,
@@ -119,11 +123,11 @@ const contentLinksInput = z.object({
   hrefs: z.array(z.string()).default([]),
 });
 
-/** Publication identity + stats for the profile hero (no document list). */
-export interface PublicationHeader {
-  publication: PublicationCard;
-  owner: ProfileSummary;
-}
+/**
+ * Publication identity + stats + theme colors for the profile hero (no document
+ * list). Re-exported from the query that builds it so the two can't drift.
+ */
+export type { PublicationHeader } from "#/server/reader/publication-header";
 
 export interface PublicationProfile {
   publication: PublicationCard;
@@ -498,7 +502,12 @@ const getArticle = createServerFn({ method: "GET" })
           }),
         );
 
-        const themeMode = await themeModeForRequest(db, schema, reader?.userId);
+        // Resolved per-reader alongside the theme mode: the code theme may only
+        // follow the publication when this reader opted into publication themes.
+        const [themeMode, usePublicationTheme] = await Promise.all([
+          themeModeForRequest(db, schema, reader?.userId),
+          usePublicationThemeForRequest(db, schema, reader?.userId),
+        ]);
 
         return buildArticleDetail(
           db,
@@ -507,6 +516,7 @@ const getArticle = createServerFn({ method: "GET" })
           contributors,
           themeMode,
           {
+            usePublicationTheme,
             readCount: readRows[0]?.count ?? 0,
             recommendCount: recommendRows[0]?.count ?? 0,
           },

--- a/src/integrations/tanstack-query/api-user.functions.ts
+++ b/src/integrations/tanstack-query/api-user.functions.ts
@@ -67,6 +67,11 @@ import {
   parseHiddenTabs,
 } from "#/lib/profile-tabs";
 import {
+  DEFAULT_USE_PUBLICATION_THEME,
+  dbValueToUsePublicationTheme,
+  usePublicationThemeToDbValue,
+} from "#/lib/publication-theme-preference";
+import {
   READER_VOICE_COOKIE,
   READER_VOICE_COOKIE_MAX_AGE_SECONDS,
   READER_VOICE_PREFERENCES,
@@ -283,6 +288,7 @@ const getShellBootstrap = createServerFn({ method: "GET" }).handler(
           cookies[READING_TYPOGRAPHY_COOKIE],
         ),
       },
+      usePublicationTheme: { enabled: DEFAULT_USE_PUBLICATION_THEME },
       collectionsAuthoring: { enabled: false },
       shell: null,
     };
@@ -322,6 +328,7 @@ const getShellBootstrap = createServerFn({ method: "GET" }).handler(
             openLinksExternally: true,
             openCollectionsInMagazine: true,
             readingTypography: true,
+            usePublicationTheme: true,
             collectionsAuthoringEnabled: true,
             atstoreReviewPromptDismissed: true,
             userinputFeedbackEnabled: true,
@@ -454,6 +461,9 @@ const getShellBootstrap = createServerFn({ method: "GET" }).handler(
       },
       readingTypography: {
         preference: dbValueToReadingTypography(userRow.readingTypography),
+      },
+      usePublicationTheme: {
+        enabled: dbValueToUsePublicationTheme(userRow.usePublicationTheme),
       },
       collectionsAuthoring: {
         enabled: userRow.collectionsAuthoringEnabled === true,
@@ -1051,6 +1061,45 @@ const setCountOldPostsAsUnreadPreference = createServerFn({ method: "POST" })
     return { enabled: data.enabled };
   });
 
+// Signed-in only — the settings page is behind auth, so there is no cookie
+// mirror to keep in sync for guests (unlike the preferences above).
+const getUsePublicationThemePreference = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware, maybeAuthMiddleware])
+  .handler(async ({ context }): Promise<{ enabled: boolean }> => {
+    const session = context?.session;
+    if (!session?.user) return { enabled: DEFAULT_USE_PUBLICATION_THEME };
+
+    const row = await context.db.query.user.findFirst({
+      where: eq(context.schema.user.id, session.user.id),
+      columns: { usePublicationTheme: true },
+    });
+    return {
+      enabled: dbValueToUsePublicationTheme(row?.usePublicationTheme ?? null),
+    };
+  });
+
+const getUsePublicationThemePreferenceQueryOptions = queryOptions({
+  queryKey: ["usePublicationThemePreference"] as const,
+  queryFn: () => getUsePublicationThemePreference(),
+  staleTime: Number.POSITIVE_INFINITY,
+});
+
+const setUsePublicationThemePreference = createServerFn({ method: "POST" })
+  .middleware([dbMiddleware, maybeAuthMiddleware])
+  .validator(z.object({ enabled: z.boolean() }))
+  .handler(async ({ data, context }): Promise<{ enabled: boolean }> => {
+    if (!context?.session?.user) {
+      return { enabled: DEFAULT_USE_PUBLICATION_THEME };
+    }
+
+    await context.db
+      .update(context.schema.user)
+      .set({ usePublicationTheme: usePublicationThemeToDbValue(data.enabled) })
+      .where(eq(context.schema.user.id, context.session.user.id));
+
+    return { enabled: data.enabled };
+  });
+
 const homeScopeInput = z.object({
   scope: z.enum(["follows", "trending"]),
 });
@@ -1350,6 +1399,9 @@ export const user = {
   getCountOldPostsAsUnreadPreference,
   getCountOldPostsAsUnreadPreferenceQueryOptions,
   setCountOldPostsAsUnreadPreference,
+  getUsePublicationThemePreference,
+  getUsePublicationThemePreferenceQueryOptions,
+  setUsePublicationThemePreference,
   getHomeScopePreference,
   getHomeScopePreferenceQueryOptions,
   setHomeScopePreference,

--- a/src/lib/collections/theme.ts
+++ b/src/lib/collections/theme.ts
@@ -4,6 +4,9 @@
  * `app.standard-reader.publicationTheme` (merged into `themeJson` on ingest).
  * Shared across all of a user's collections. Client-safe.
  */
+import type { PublicationFonts } from "../publication-fonts";
+import type { ThemePalette } from "../publication-theme-source";
+
 export interface CollectionTheme {
   background: string | null;
   foreground: string | null;
@@ -11,6 +14,18 @@ export interface CollectionTheme {
   accentForeground: string | null;
   fontTitle: string | null;
   fontBody: string | null;
+  /** Publisher-authored dark palette, when their native theme ships one. */
+  dark?: ThemePalette | null;
+  /** Publisher-authored neutral scale steps, when stated. */
+  surface?: string | null;
+  surfaceHover?: string | null;
+  border?: string | null;
+  /**
+   * Google Fonts families from the platform-native theme, resolved server-side.
+   * Distinct from `fontTitle`/`fontBody`, which come from the
+   * `app.standard-reader.publicationTheme` sidecar and drive magazine rendering.
+   */
+  publicationFonts?: PublicationFonts | null;
 }
 
 function cleanFont(value: unknown): string | null {

--- a/src/lib/collections/theme.ts
+++ b/src/lib/collections/theme.ts
@@ -26,6 +26,14 @@ export interface CollectionTheme {
    * `app.standard-reader.publicationTheme` sidecar and drive magazine rendering.
    */
   publicationFonts?: PublicationFonts | null;
+  /** Canvas the page sits on, when Leaflet states one distinct from the page. */
+  canvas?: string | null;
+  /** Fixed canvas background image, resolved to a CDN URL server-side. */
+  publicationBackgroundImage?: {
+    url: string;
+    repeat: boolean;
+    width: number | null;
+  } | null;
 }
 
 function cleanFont(value: unknown): string | null {

--- a/src/lib/google-fonts.ts
+++ b/src/lib/google-fonts.ts
@@ -1,3 +1,11 @@
+/**
+ * How long the fetched Google Fonts family catalog stays fresh — shared by the
+ * server-side cache and the client query, so it lives here rather than in the
+ * `.server` module (importing it from there would pull server-only code into
+ * the client bundle).
+ */
+export const GOOGLE_FONTS_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
 /** Default Google Font when the user first picks Custom body font. */
 export const DEFAULT_CUSTOM_GOOGLE_FONT = "Lora";
 

--- a/src/lib/publication-fonts.test.ts
+++ b/src/lib/publication-fonts.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  hasPublicationFonts,
+  normalizeFontKey,
+  publicationFontRequests,
+  publicationFontsHref,
+  resolvePublicationFonts,
+} from "./publication-fonts";
+
+/**
+ * Stands in for the Google Fonts catalog index. Entries are real families,
+ * keyed the way `normalizeFontKey` produces.
+ */
+const CATALOG = new Map([
+  ["dmsans", "DM Sans"],
+  ["jetbrainsmono", "JetBrains Mono"],
+  ["sourceserif4", "Source Serif 4"],
+  ["spacemono", "Space Mono"],
+  ["ibmplexserif", "IBM Plex Serif"],
+  ["lora", "Lora"],
+  ["montserrat", "Montserrat"],
+]);
+const lookup = (key: string) => CATALOG.get(key) ?? null;
+
+describe("publicationFontRequests", () => {
+  it("reads Offprint's heading/body slugs", () => {
+    expect(
+      publicationFontRequests({
+        $type: "app.offprint.theme",
+        typography: { headingFont: "playfair-display", bodyFont: "dm-sans" },
+      }),
+    ).toEqual({
+      heading: { family: null, key: "playfair-display" },
+      body: { family: null, key: "dm-sans" },
+    });
+  });
+
+  it("uses PCKT's single font for both heading and body", () => {
+    const requests = publicationFontRequests({
+      $type: "blog.pckt.theme",
+      font: "spacemono",
+    });
+    expect(requests.heading).toEqual({ family: null, key: "spacemono" });
+    expect(requests.body).toEqual(requests.heading);
+  });
+
+  it("takes the family straight out of Leaflet's `custom:` form", () => {
+    const requests = publicationFontRequests({
+      $type: "pub.leaflet.publication#theme",
+      headingFont: "custom:Source Serif 4:Source+Serif+4:ital,wght@0,400;0,700",
+      bodyFont: "montserrat",
+    });
+    // Family is stated outright — no catalog lookup required.
+    expect(requests.heading).toEqual({ family: "Source Serif 4", key: null });
+    expect(requests.body).toEqual({ family: null, key: "montserrat" });
+  });
+
+  it("returns nothing for an unknown platform or a missing theme", () => {
+    expect(publicationFontRequests({ $type: "com.example.theme" })).toEqual({
+      heading: null,
+      body: null,
+    });
+    expect(publicationFontRequests(null)).toEqual({
+      heading: null,
+      body: null,
+    });
+  });
+});
+
+describe("resolvePublicationFonts", () => {
+  it("normalizes slugs and squashed keys onto catalog families", () => {
+    expect(
+      resolvePublicationFonts(
+        publicationFontRequests({
+          $type: "app.offprint.theme",
+          typography: { headingFont: "jetbrains-mono", bodyFont: "dm-sans" },
+        }),
+        lookup,
+      ),
+    ).toEqual({ heading: "JetBrains Mono", body: "DM Sans" });
+
+    expect(
+      resolvePublicationFonts(
+        publicationFontRequests({
+          $type: "blog.pckt.theme",
+          font: "ibmplexserif",
+        }),
+        lookup,
+      ),
+    ).toEqual({ heading: "IBM Plex Serif", body: "IBM Plex Serif" });
+  });
+
+  it("applies the alias table for keys that don't normalize onto a family", () => {
+    // `source-sans` predates Adobe's rename to Source Sans 3.
+    const fonts = resolvePublicationFonts(
+      publicationFontRequests({
+        $type: "pub.leaflet.publication#theme",
+        bodyFont: "source-sans",
+      }),
+      lookup,
+    );
+    expect(fonts.body).toBe("Source Sans 3");
+  });
+
+  it("leaves platform defaults and non-Google faces unresolved", () => {
+    // PCKT `legible` is a generic slot, Leaflet `quattro` is iA Writer — both
+    // must fall through so the reader keeps their own typography.
+    for (const key of ["legible", "sans", "quattro", "iawritermono"]) {
+      const fonts = resolvePublicationFonts(
+        publicationFontRequests({ $type: "blog.pckt.theme", font: key }),
+        lookup,
+      );
+      expect(fonts).toEqual({ heading: null, body: null });
+      expect(hasPublicationFonts(fonts)).toBe(false);
+    }
+  });
+});
+
+describe("publicationFontsHref", () => {
+  it("builds a CSS2 URL with no weight axis and no duplicates", () => {
+    expect(publicationFontsHref({ heading: "DM Sans", body: "DM Sans" })).toBe(
+      "https://fonts.googleapis.com/css2?family=DM+Sans&display=swap",
+    );
+    expect(
+      publicationFontsHref({ heading: "Source Serif 4", body: "Lora" }),
+    ).toBe(
+      "https://fonts.googleapis.com/css2?family=Source+Serif+4&family=Lora&display=swap",
+    );
+  });
+
+  it("is null when nothing resolved", () => {
+    expect(publicationFontsHref({ heading: null, body: null })).toBeNull();
+    expect(publicationFontsHref(null)).toBeNull();
+  });
+});
+
+describe("normalizeFontKey", () => {
+  it("collapses separators and case", () => {
+    expect(normalizeFontKey("DM Sans")).toBe("dmsans");
+    expect(normalizeFontKey("dm-sans")).toBe("dmsans");
+    expect(normalizeFontKey("Source Serif 4")).toBe("sourceserif4");
+  });
+});

--- a/src/lib/publication-fonts.ts
+++ b/src/lib/publication-fonts.ts
@@ -1,0 +1,179 @@
+/**
+ * Reads the fonts a publisher chose out of their native theme
+ * (see `#/lib/publication-theme-source` for the colour half).
+ *
+ * Each platform states fonts differently:
+ *
+ * - **Leaflet** — either a built-in key (`source-sans`, `quattro`) or a
+ *   self-describing `custom:<Family>:<url-spec>:<axes>` string, which already
+ *   contains the exact family name and needs no lookup.
+ * - **PCKT** — squashed lowercase keys with no separators (`spacemono`,
+ *   `ibmplexserif`), under a single `font` used for both headings and body.
+ * - **Offprint** — standard Google Fonts slugs (`dm-sans`, `source-serif-4`)
+ *   split across `typography.headingFont` / `bodyFont`.
+ *
+ * Rather than hand-maintaining a table per platform, keys are normalized
+ * (lowercased, non-alphanumerics stripped) and matched against the Google Fonts
+ * catalog we already fetch for the reading-typography picker — that alone
+ * resolves every Offprint slug and most PCKT keys. {@link PLATFORM_FONT_ALIASES}
+ * covers the handful whose key doesn't normalize onto its family name.
+ *
+ * Anything that doesn't resolve is left alone rather than guessed at: an unknown
+ * key means the reader keeps their own typography, which is the right outcome
+ * for the platform *defaults* that make up most of the misses — PCKT's
+ * `legible` / `sans` are generic slots rather than named faces, and Leaflet's
+ * `quattro` (and PCKT's `iawritermono`) are iA Writer fonts that Google Fonts
+ * does not serve.
+ *
+ * Client-safe: pure string handling, no catalog access.
+ */
+
+/** Lowercase, alphanumerics only — `DM Sans` and `dm-sans` both become `dmsans`. */
+export function normalizeFontKey(value: string): string {
+  return value.toLowerCase().replaceAll(/[^a-z0-9]/g, "");
+}
+
+/**
+ * Keys whose normalized form doesn't match their Google Fonts family. Verified
+ * against the live catalog; each target is a real family.
+ */
+export const PLATFORM_FONT_ALIASES: Readonly<Record<string, string>> = {
+  // Adobe renamed Source Sans Pro to Source Sans 3; Leaflet still says
+  // `source-sans`, and it's their most-used body font.
+  sourcesans: "Source Sans 3",
+  // PCKT's key drops the middle word.
+  cactusserif: "Cactus Classical Serif",
+  anon: "Anonymous Pro",
+};
+
+export interface PublicationFontRequest {
+  /** Family stated outright by the record — no catalog lookup needed. */
+  family: string | null;
+  /** Platform key or slug to resolve against the catalog. */
+  key: string | null;
+}
+
+export interface PublicationFontRequests {
+  heading: PublicationFontRequest | null;
+  body: PublicationFontRequest | null;
+}
+
+const EMPTY: PublicationFontRequests = { heading: null, body: null };
+
+/**
+ * Leaflet's `custom:` form, e.g.
+ * `custom:Source Serif 4:Source+Serif+4:ital,wght@0,400;0,700;1,400;1,700` —
+ * the second segment is the family name as Google Fonts spells it.
+ */
+function parseFontValue(value: unknown): PublicationFontRequest | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+
+  if (trimmed.startsWith("custom:")) {
+    const rest = trimmed.slice("custom:".length);
+    const family = (rest.split(":")[0] ?? "").trim();
+    return family.length > 0 ? { family, key: null } : null;
+  }
+
+  return { family: null, key: trimmed };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/** Pull the heading/body font requests out of a publisher's native theme. */
+export function publicationFontRequests(
+  nativeTheme: unknown,
+): PublicationFontRequests {
+  const theme = asRecord(nativeTheme);
+  const type = typeof theme?.$type === "string" ? theme.$type : null;
+  if (!theme || !type) return EMPTY;
+
+  if (type === "blog.pckt.theme") {
+    // One font for the whole publication.
+    const font = parseFontValue(theme.font);
+    return { heading: font, body: font };
+  }
+
+  if (type === "app.offprint.theme") {
+    const typography = asRecord(theme.typography);
+    if (!typography) return EMPTY;
+    return {
+      heading: parseFontValue(typography.headingFont),
+      body: parseFontValue(typography.bodyFont),
+    };
+  }
+
+  if (type.startsWith("pub.leaflet.")) {
+    return {
+      heading: parseFontValue(theme.headingFont),
+      body: parseFontValue(theme.bodyFont),
+    };
+  }
+
+  return EMPTY;
+}
+
+export interface PublicationFonts {
+  heading: string | null;
+  body: string | null;
+}
+
+export const NO_PUBLICATION_FONTS: PublicationFonts = {
+  heading: null,
+  body: null,
+};
+
+/**
+ * Turn font requests into Google Fonts family names, given a lookup built from
+ * the catalog (normalized key → family). Unresolved requests stay `null`.
+ */
+export function resolvePublicationFonts(
+  requests: PublicationFontRequests,
+  lookup: (normalizedKey: string) => string | null,
+): PublicationFonts {
+  const resolve = (request: PublicationFontRequest | null): string | null => {
+    if (!request) return null;
+    if (request.family) return request.family;
+    if (!request.key) return null;
+    const normalized = normalizeFontKey(request.key);
+    if (normalized.length === 0) return null;
+    return PLATFORM_FONT_ALIASES[normalized] ?? lookup(normalized);
+  };
+  return { heading: resolve(requests.heading), body: resolve(requests.body) };
+}
+
+/** Whether a resolved pair carries anything worth loading. */
+export function hasPublicationFonts(
+  fonts: PublicationFonts | null | undefined,
+): fonts is PublicationFonts {
+  return Boolean(fonts && (fonts.heading || fonts.body));
+}
+
+/**
+ * Google Fonts stylesheet URL for the resolved families, or null.
+ *
+ * Deliberately requests no `wght` axis: Google Fonts CSS2 fails the *whole*
+ * request when any family lacks a requested weight, which would silently drop
+ * every font on the page. Bold falls back to synthetic bold. Same reasoning as
+ * `googleFontsHref` in the magazine.
+ */
+export function publicationFontsHref(
+  fonts: PublicationFonts | null | undefined,
+): string | null {
+  if (!fonts) return null;
+  const families = [fonts.heading, fonts.body].filter(
+    (family) => family !== null,
+  );
+  if (families.length === 0) return null;
+  const params = [...new Set(families)]
+    .map(
+      (family) => `family=${encodeURIComponent(family).replaceAll("%20", "+")}`,
+    )
+    .join("&");
+  return `https://fonts.googleapis.com/css2?${params}&display=swap`;
+}

--- a/src/lib/publication-theme-preference.ts
+++ b/src/lib/publication-theme-preference.ts
@@ -1,0 +1,34 @@
+/**
+ * "Use publication themes" preference — controls whether publication pages and
+ * their documents are painted in the publication's own colors.
+ *
+ * Every publication carries a `site.standard.theme.basic` record with up to four
+ * colors (background, foreground, accent, accent foreground). Those flat colors
+ * are expanded into full light + dark UI/accent scales by
+ * `publicationThemeScaleVars`, which the `publicationUi` / `publicationPrimary`
+ * StyleX themes read to override the design-system color tokens.
+ *
+ * When this preference is off (the default) the app's editorial theme is used
+ * everywhere and a publication's colors only ever appear in the places that are
+ * intrinsically the publication's own surface (OG cards, subscribe embeds, the
+ * themed subscribe login, magazine editions). When it is on, `/p/$did/$rkey` and
+ * `/a/$did/$rkey` adopt the publication's palette. Publications with no theme
+ * colors of their own always keep the editorial theme — see
+ * `hasPublicationThemeColors`.
+ *
+ * Signed-in only (the setting lives on the settings page, which guests can't
+ * reach), so this is stored on `user.use_publication_theme` with no cookie
+ * mirror. `null` = off, the default.
+ */
+
+export const DEFAULT_USE_PUBLICATION_THEME = false;
+
+export function usePublicationThemeToDbValue(enabled: boolean): true | null {
+  return enabled ? true : null;
+}
+
+export function dbValueToUsePublicationTheme(
+  value: boolean | null | undefined,
+): boolean {
+  return value === true;
+}

--- a/src/lib/publication-theme-source.test.ts
+++ b/src/lib/publication-theme-source.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+
+import { resolvePublicationTheme } from "./publication-theme-source";
+
+/** `site.standard.theme.basic` as every publisher writes it (0–255 channels). */
+const BASIC_THEME = {
+  $type: "site.standard.theme.basic",
+  background: { r: 253, g: 252, b: 250 },
+  foreground: { r: 39, g: 39, b: 39 },
+  accent: { r: 43, g: 82, b: 255 },
+  accentForeground: { r: 255, g: 255, b: 255 },
+};
+
+describe("resolvePublicationTheme", () => {
+  it("falls back to basicTheme when there is no native theme", () => {
+    const theme = resolvePublicationTheme(BASIC_THEME, null);
+    expect(theme.light).toEqual({
+      background: "#fdfcfa",
+      foreground: "#272727",
+      accent: "#2b52ff",
+      accentForeground: "#ffffff",
+      // The baseline states no scale steps, so they stay derived.
+      surface: null,
+      surfaceHover: null,
+      border: null,
+      link: null,
+      neutral: null,
+      secondary: null,
+    });
+    expect(theme.dark).toBeNull();
+  });
+
+  it("falls back to basicTheme for an unknown platform $type", () => {
+    const theme = resolvePublicationTheme(BASIC_THEME, {
+      $type: "com.example.someFutureTheme",
+      background: { r: 1, g: 2, b: 3 },
+    });
+    expect(theme.light.background).toBe("#fdfcfa");
+  });
+
+  describe("pub.leaflet.publication#theme", () => {
+    // Real shape from at://did:plc:pqerwmnouevyltxyoayhholf/…/3m52m2q72qs2a
+    const LEAFLET = {
+      $type: "pub.leaflet.publication#theme",
+      backgroundColor: { $type: "…#rgba", r: 253, g: 252, b: 250, a: 100 },
+      pageBackground: { $type: "…#rgba", r: 224, g: 239, b: 255, a: 95 },
+      showPageBackground: true,
+      primary: { r: 39, g: 39, b: 39 },
+      accentBackground: { r: 43, g: 82, b: 255 },
+      accentText: { r: 255, g: 255, b: 255 },
+    };
+
+    it("uses the page surface, not the canvas, when showPageBackground is on", () => {
+      const theme = resolvePublicationTheme(BASIC_THEME, LEAFLET);
+      // basicTheme reports the canvas (#fdfcfa); the reader actually sees the
+      // page background composited over it at 95% alpha.
+      expect(theme.light.background).not.toBe("#fdfcfa");
+      // 224,239,255 at 95% over the 253,252,250 canvas.
+      expect(theme.light.background).toBe("#e1f0ff");
+    });
+
+    it("uses the canvas when showPageBackground is off", () => {
+      const theme = resolvePublicationTheme(BASIC_THEME, {
+        ...LEAFLET,
+        showPageBackground: false,
+      });
+      expect(theme.light.background).toBe("#fdfcfa");
+    });
+
+    it("maps primary/accent and derives no dark palette", () => {
+      const theme = resolvePublicationTheme(BASIC_THEME, LEAFLET);
+      expect(theme.light.foreground).toBe("#272727");
+      expect(theme.light.accent).toBe("#2b52ff");
+      expect(theme.light.accentForeground).toBe("#ffffff");
+      expect(theme.dark).toBeNull();
+    });
+  });
+
+  describe("blog.pckt.theme", () => {
+    // Real shape from at://did:plc:v46ojbiop5ebs5h7gaomixcc/…/3m57zfsq3a2fo
+    const PCKT = {
+      $type: "blog.pckt.theme",
+      light: {
+        background: "#ecfdf5",
+        text: "#064e3b",
+        accent: "#65a30d",
+        link: "#0d9488",
+        surfaceHover: "#a7f3d0",
+      },
+      dark: {
+        background: "#022c22",
+        text: "#d1fae5",
+        accent: "#84cc16",
+        link: "#5eead4",
+        surfaceHover: "#064e3b",
+      },
+    };
+
+    it("uses the authored light palette", () => {
+      const theme = resolvePublicationTheme(BASIC_THEME, PCKT);
+      expect(theme.light.background).toBe("#ecfdf5");
+      expect(theme.light.foreground).toBe("#064e3b");
+      expect(theme.light.accent).toBe("#65a30d");
+    });
+
+    it("surfaces the authored dark palette instead of deriving one", () => {
+      const theme = resolvePublicationTheme(BASIC_THEME, PCKT);
+      expect(theme.dark).toStrictEqual({
+        background: "#022c22",
+        foreground: "#d1fae5",
+        accent: "#84cc16",
+        // PCKT authors no accent-foreground; the scale generator picks a
+        // WCAG-safe one against the accent.
+        accentForeground: null,
+        // A hover fill anchors the hover step, not the resting surface.
+        surface: null,
+        surfaceHover: "#064e3b",
+        border: null,
+        // PCKT always states a link colour, distinct from the accent.
+        link: "#5eead4",
+        neutral: null,
+        secondary: null,
+      });
+    });
+  });
+
+  describe("app.offprint.theme", () => {
+    const OFFPRINT_LIGHT = {
+      $type: "app.offprint.theme",
+      colorScheme: "light",
+      colors: {
+        base100: { r: 255, g: 255, b: 255 },
+        base200: { r: 250, g: 250, b: 250 },
+        base300: { r: 229, g: 229, b: 229 },
+        baseContent: { r: 13, g: 13, b: 13 },
+        primary: { r: 13, g: 13, b: 13 },
+        primaryContent: { r: 250, g: 250, b: 250 },
+      },
+    };
+
+    it("maps base100/baseContent/primary and the base200/300 scale steps", () => {
+      const theme = resolvePublicationTheme(BASIC_THEME, OFFPRINT_LIGHT);
+      expect(theme.light).toEqual({
+        background: "#ffffff",
+        foreground: "#0d0d0d",
+        accent: "#0d0d0d",
+        accentForeground: "#fafafa",
+        surface: "#fafafa",
+        surfaceHover: null,
+        border: "#e5e5e5",
+        link: null,
+        neutral: null,
+        secondary: null,
+      });
+      expect(theme.dark).toBeNull();
+    });
+
+    it("slots a dark-scheme theme as the dark palette, leaving light on basicTheme", () => {
+      const theme = resolvePublicationTheme(BASIC_THEME, {
+        ...OFFPRINT_LIGHT,
+        colorScheme: "dark",
+        colors: {
+          base100: { r: 2, g: 44, b: 34 },
+          baseContent: { r: 209, g: 250, b: 229 },
+          primary: { r: 132, g: 204, b: 22 },
+          primaryContent: { r: 0, g: 0, b: 0 },
+        },
+      });
+      expect(theme.light.background).toBe("#fdfcfa");
+      expect(theme.dark?.background).toBe("#022c22");
+      expect(theme.dark?.accent).toBe("#84cc16");
+    });
+  });
+});

--- a/src/lib/publication-theme-source.test.ts
+++ b/src/lib/publication-theme-source.test.ts
@@ -26,6 +26,8 @@ describe("resolvePublicationTheme", () => {
       link: null,
       neutral: null,
       secondary: null,
+      canvas: null,
+      backgroundImage: null,
     });
     expect(theme.dark).toBeNull();
   });
@@ -120,6 +122,8 @@ describe("resolvePublicationTheme", () => {
         link: "#5eead4",
         neutral: null,
         secondary: null,
+        canvas: null,
+        backgroundImage: null,
       });
     });
   });
@@ -151,6 +155,8 @@ describe("resolvePublicationTheme", () => {
         link: null,
         neutral: null,
         secondary: null,
+        canvas: null,
+        backgroundImage: null,
       });
       expect(theme.dark).toBeNull();
     });

--- a/src/lib/publication-theme-source.ts
+++ b/src/lib/publication-theme-source.ts
@@ -49,6 +49,23 @@ export interface ThemePalette {
   neutral: string | null;
   /** Secondary action colour (Offprint `secondary`). */
   secondary: string | null;
+  /**
+   * The canvas the page sits on, when it differs from the page surface. Leaflet
+   * paints a page card over a canvas; `background` is the card, this is what
+   * shows around it — and what a background image tiles across.
+   */
+  canvas: string | null;
+  /** Canvas background image (Leaflet `backgroundImage`). */
+  backgroundImage: PublicationBackgroundImage | null;
+}
+
+export interface PublicationBackgroundImage {
+  /** Blob CID; the URL needs the publication's DID, so it's built server-side. */
+  cid: string;
+  /** Tile rather than cover. */
+  repeat: boolean;
+  /** Tile width in px when repeating. */
+  width: number | null;
 }
 
 export interface ResolvedPublicationTheme {
@@ -68,6 +85,8 @@ export const EMPTY_PALETTE: ThemePalette = {
   link: null,
   neutral: null,
   secondary: null,
+  canvas: null,
+  backgroundImage: null,
 };
 
 interface Rgb {
@@ -194,6 +213,28 @@ function paletteFromBasicTheme(basicTheme: unknown): ThemePalette {
     link: null,
     neutral: null,
     secondary: null,
+    canvas: null,
+    backgroundImage: null,
+  };
+}
+
+/** `pub.leaflet.theme.backgroundImage` — a blob plus tiling hints. */
+function backgroundImageOf(value: unknown): PublicationBackgroundImage | null {
+  const image = asRecord(value);
+  if (!image) return null;
+  const blob = asRecord(image.image);
+  const ref = blob ? asRecord(blob.ref) : null;
+  const cid =
+    typeof ref?.$link === "string"
+      ? ref.$link
+      : typeof blob?.ref === "string"
+        ? blob.ref
+        : null;
+  if (!cid) return null;
+  return {
+    cid,
+    repeat: image.repeat === true,
+    width: typeof image.width === "number" ? image.width : null,
   };
 }
 
@@ -222,6 +263,9 @@ function paletteFromLeafletTheme(theme: Record<string, unknown>): ThemePalette {
     link: null,
     neutral: null,
     secondary: null,
+    // Only meaningful when the page sits on a distinct canvas.
+    canvas: showPage ? flattenColor(theme.backgroundColor, null) : null,
+    backgroundImage: backgroundImageOf(theme.backgroundImage),
   };
 }
 
@@ -254,6 +298,8 @@ function paletteFromOffprintTheme(
     link: null,
     neutral: flattenColor(colors.neutral, null),
     secondary: flattenColor(colors.secondary, null),
+    canvas: null,
+    backgroundImage: null,
   };
 }
 
@@ -276,6 +322,8 @@ function paletteFromPcktVariant(variant: unknown): ThemePalette {
     link: flattenColor(v.link, null),
     neutral: null,
     secondary: null,
+    canvas: null,
+    backgroundImage: null,
   };
 }
 
@@ -326,6 +374,8 @@ export function resolvePublicationTheme(
       link: light.link,
       neutral: light.neutral,
       secondary: light.secondary,
+      canvas: light.canvas,
+      backgroundImage: light.backgroundImage,
     },
     dark,
   };

--- a/src/lib/publication-theme-source.ts
+++ b/src/lib/publication-theme-source.ts
@@ -1,0 +1,339 @@
+/**
+ * Normalizes the publisher-authored theme carried on a `site.standard.publication`
+ * record into the light (and, when supplied, dark) palettes our UI themes from.
+ *
+ * `basicTheme` (`site.standard.theme.basic`) is the interop baseline every
+ * publisher writes: four opaque colors, light mode only. Alongside it, records
+ * keep the richer native theme of whichever platform published them, under
+ * `theme`, discriminated by `$type`:
+ *
+ * - **`pub.leaflet.publication#theme`** — Leaflet paints a *page* on top of a
+ *   *canvas*. `basicTheme.background` mirrors the canvas (`backgroundColor`), so
+ *   for publications with `showPageBackground` the baseline reports a background
+ *   the reader never actually sees behind the text. `pageBackground` is the real
+ *   surface, and it may be translucent over the canvas.
+ * - **`blog.pckt.theme`** — PCKT authors a full light *and* dark palette. That
+ *   dark palette is worth far more than the one we derive by darkening the light
+ *   background, so we use it verbatim when present.
+ *
+ * Unknown `$type`s fall back to `basicTheme`, so a new publishing platform
+ * degrades to the interop baseline rather than losing its colors.
+ *
+ * Client-safe: pure functions over already-fetched JSON, no server imports.
+ */
+
+export interface ThemePalette {
+  background: string | null;
+  foreground: string | null;
+  accent: string | null;
+  accentForeground: string | null;
+  /**
+   * Optional anchors on the neutral ramp between the page background and the
+   * strongest border. We otherwise *derive* these steps by darkening the
+   * background by fixed ratios; when a publisher states them outright we pin
+   * their value at the matching step instead of guessing.
+   *
+   * `surface` is a resting secondary background (cards, sidebars),
+   * `surfaceHover` its hover state, and `border` the borders/dividers color.
+   */
+  surface: string | null;
+  surfaceHover: string | null;
+  border: string | null;
+  /**
+   * Link colour, stated separately from the accent. Publishers routinely choose
+   * a different hue for links than for accents (PCKT states both, always), and
+   * collapsing links into the accent throws that distinction away.
+   */
+  link: string | null;
+  /** Neutral solid fill for muted UI (Offprint `neutral`). */
+  neutral: string | null;
+  /** Secondary action colour (Offprint `secondary`). */
+  secondary: string | null;
+}
+
+export interface ResolvedPublicationTheme {
+  light: ThemePalette;
+  /** Publisher-authored dark palette; `null` means "derive one from `light`". */
+  dark: ThemePalette | null;
+}
+
+export const EMPTY_PALETTE: ThemePalette = {
+  background: null,
+  foreground: null,
+  accent: null,
+  accentForeground: null,
+  surface: null,
+  surfaceHover: null,
+  border: null,
+  link: null,
+  neutral: null,
+  secondary: null,
+};
+
+interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+function clampChannel(value: number): number {
+  return Math.min(255, Math.max(0, Math.round(value)));
+}
+
+function toHex(c: Rgb): string {
+  const ch = (v: number) => clampChannel(v).toString(16).padStart(2, "0");
+  return `#${ch(c.r)}${ch(c.g)}${ch(c.b)}`;
+}
+
+function parseHexString(value: string): Rgb | null {
+  const m = /^#?([\da-f]{3}|[\da-f]{6})$/i.exec(value.trim());
+  if (!m) return null;
+  const h = m[1];
+  if (h.length === 3) {
+    return {
+      r: Number.parseInt(h[0] + h[0], 16),
+      g: Number.parseInt(h[1] + h[1], 16),
+      b: Number.parseInt(h[2] + h[2], 16),
+    };
+  }
+  return {
+    r: Number.parseInt(h.slice(0, 2), 16),
+    g: Number.parseInt(h.slice(2, 4), 16),
+    b: Number.parseInt(h.slice(4, 6), 16),
+  };
+}
+
+function parseRgbFunction(value: string): { rgb: Rgb; alpha: number } | null {
+  const m = /^rgba?\(([^)]+)\)$/i.exec(value.trim());
+  if (!m) return null;
+  const parts = m[1]
+    .split(/[\s,/]+/)
+    .filter(Boolean)
+    .map(Number);
+  if (parts.length < 3 || parts.slice(0, 3).some((n) => Number.isNaN(n))) {
+    return null;
+  }
+  const alpha = parts.length > 3 && !Number.isNaN(parts[3]) ? parts[3] : 1;
+  return { rgb: { r: parts[0], g: parts[1], b: parts[2] }, alpha };
+}
+
+/**
+ * A color as any of the shapes these records use: a hex or `rgb()` string, or a
+ * `{r,g,b}` / `{r,g,b,a}` object. Lexicon alpha is a 0–100 percentage
+ * (`pub.leaflet.theme.color#rgba`), not a 0–255 channel or a 0–1 fraction.
+ */
+function parseColor(value: unknown): { rgb: Rgb; alpha: number } | null {
+  if (typeof value === "string") {
+    const hex = parseHexString(value);
+    if (hex) return { rgb: hex, alpha: 1 };
+    return parseRgbFunction(value);
+  }
+  if (!value || typeof value !== "object") return null;
+  const o = value as Record<string, unknown>;
+  if (
+    typeof o.r !== "number" ||
+    typeof o.g !== "number" ||
+    typeof o.b !== "number"
+  ) {
+    return null;
+  }
+  const alpha =
+    typeof o.a === "number" ? Math.min(1, Math.max(0, o.a / 100)) : 1;
+  return { rgb: { r: o.r, g: o.g, b: o.b }, alpha };
+}
+
+/**
+ * Flatten a possibly-translucent color to an opaque hex by compositing it over
+ * `backdrop`. Our tokens are opaque, and a translucent page background is only
+ * meaningful against the canvas it sits on, so we resolve it here.
+ */
+function flattenColor(value: unknown, backdrop: Rgb | null): string | null {
+  const parsed = parseColor(value);
+  if (!parsed) return null;
+  if (parsed.alpha >= 1 || !backdrop) return toHex(parsed.rgb);
+  const t = parsed.alpha;
+  return toHex({
+    r: backdrop.r + (parsed.rgb.r - backdrop.r) * t,
+    g: backdrop.g + (parsed.rgb.g - backdrop.g) * t,
+    b: backdrop.b + (parsed.rgb.b - backdrop.b) * t,
+  });
+}
+
+function opaqueRgb(value: unknown): Rgb | null {
+  return parseColor(value)?.rgb ?? null;
+}
+
+function isPalettePopulated(palette: ThemePalette): boolean {
+  return Boolean(
+    palette.background ||
+    palette.foreground ||
+    palette.accent ||
+    palette.accentForeground,
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/** `site.standard.theme.basic` — the interop baseline (light only). */
+function paletteFromBasicTheme(basicTheme: unknown): ThemePalette {
+  const t = asRecord(basicTheme);
+  if (!t) return EMPTY_PALETTE;
+  return {
+    background: flattenColor(t.background, null),
+    foreground: flattenColor(t.foreground, null),
+    accent: flattenColor(t.accent, null),
+    accentForeground: flattenColor(t.accentForeground, null),
+    // The interop baseline has no scale steps — they stay derived.
+    surface: null,
+    surfaceHover: null,
+    border: null,
+    link: null,
+    neutral: null,
+    secondary: null,
+  };
+}
+
+/**
+ * `pub.leaflet.publication#theme`. The surface a reader actually sees is
+ * `pageBackground` over `backgroundColor` when `showPageBackground` is on,
+ * otherwise the canvas itself.
+ */
+function paletteFromLeafletTheme(theme: Record<string, unknown>): ThemePalette {
+  const canvas = opaqueRgb(theme.backgroundColor);
+  const showPage = theme.showPageBackground === true;
+  const surface = showPage
+    ? (flattenColor(theme.pageBackground, canvas) ??
+      flattenColor(theme.backgroundColor, null))
+    : flattenColor(theme.backgroundColor, null);
+
+  return {
+    background: surface,
+    foreground: flattenColor(theme.primary, null),
+    accent: flattenColor(theme.accentBackground, null),
+    accentForeground: flattenColor(theme.accentText, null),
+    // Leaflet states no component, border, link or neutral colors of its own.
+    surface: null,
+    surfaceHover: null,
+    border: null,
+    link: null,
+    neutral: null,
+    secondary: null,
+  };
+}
+
+/**
+ * `app.offprint.theme` — a DaisyUI-shaped palette that maps almost 1:1 onto our
+ * tokens: `base100` is the page, `baseContent` the text, and `primary` /
+ * `primaryContent` the action pair. Its `colorScheme` declares whether the
+ * palette *is* the light or the dark one, so it slots accordingly rather than
+ * always being treated as light.
+ */
+function paletteFromOffprintTheme(
+  theme: Record<string, unknown>,
+): ThemePalette {
+  const colors = asRecord(theme.colors);
+  if (!colors) return EMPTY_PALETTE;
+  return {
+    background: flattenColor(colors.base100, null),
+    foreground: flattenColor(colors.baseContent, null),
+    accent:
+      flattenColor(colors.primary, null) ?? flattenColor(colors.accent, null),
+    accentForeground:
+      flattenColor(colors.primaryContent, null) ??
+      flattenColor(colors.accentContent, null),
+    // `base200` is Offprint's "cards, sidebars" surface and `base300` its
+    // "borders, dividers" — exactly the steps we would otherwise approximate.
+    surface: flattenColor(colors.base200, null),
+    surfaceHover: null,
+    border: flattenColor(colors.base300, null),
+    // Offprint has no distinct link colour; links follow the accent.
+    link: null,
+    neutral: flattenColor(colors.neutral, null),
+    secondary: flattenColor(colors.secondary, null),
+  };
+}
+
+/** One half of a `blog.pckt.theme` (`light` / `dark`), hex strings throughout. */
+function paletteFromPcktVariant(variant: unknown): ThemePalette {
+  const v = asRecord(variant);
+  if (!v) return EMPTY_PALETTE;
+  return {
+    background: flattenColor(v.background, null),
+    foreground: flattenColor(v.text, null),
+    accent: flattenColor(v.accent, null),
+    // PCKT has no accent-foreground; the scale generator picks a WCAG-safe one.
+    accentForeground: null,
+    // `surfaceHover` is a hover fill, so it anchors the hover step rather than
+    // the resting one — using it for resting cards would be far louder than the
+    // publisher intends.
+    surface: null,
+    surfaceHover: flattenColor(v.surfaceHover, null),
+    border: null,
+    link: flattenColor(v.link, null),
+    neutral: null,
+    secondary: null,
+  };
+}
+
+/**
+ * Resolve the palettes to theme from, preferring the publisher's native theme
+ * and falling back to `basicTheme` per-slot so a partial native theme still
+ * benefits from the baseline.
+ */
+export function resolvePublicationTheme(
+  basicTheme: unknown,
+  nativeTheme: unknown,
+): ResolvedPublicationTheme {
+  const base = paletteFromBasicTheme(basicTheme);
+  const theme = asRecord(nativeTheme);
+  const type = typeof theme?.$type === "string" ? theme.$type : null;
+
+  let light = EMPTY_PALETTE;
+  let dark: ThemePalette | null = null;
+
+  if (theme) {
+    if (type === "blog.pckt.theme") {
+      light = paletteFromPcktVariant(theme.light);
+      const darkPalette = paletteFromPcktVariant(theme.dark);
+      dark = isPalettePopulated(darkPalette) ? darkPalette : null;
+    } else if (type === "app.offprint.theme") {
+      const palette = paletteFromOffprintTheme(theme);
+      if (theme.colorScheme === "dark") {
+        // A dark-scheme Offprint theme is the publisher's dark palette; the
+        // light side stays on `basicTheme` rather than being darkened from it.
+        dark = isPalettePopulated(palette) ? palette : null;
+      } else {
+        light = palette;
+      }
+    } else if (type?.startsWith("pub.leaflet.")) {
+      light = paletteFromLeafletTheme(theme);
+    }
+  }
+
+  return {
+    light: {
+      background: light.background ?? base.background,
+      foreground: light.foreground ?? base.foreground,
+      accent: light.accent ?? base.accent,
+      accentForeground: light.accentForeground ?? base.accentForeground,
+      surface: light.surface,
+      surfaceHover: light.surfaceHover,
+      border: light.border,
+      link: light.link,
+      neutral: light.neutral,
+      secondary: light.secondary,
+    },
+    dark,
+  };
+}
+
+/** Whether a resolved theme carries anything worth painting with. */
+export function hasResolvedTheme(
+  theme: ResolvedPublicationTheme | null | undefined,
+): boolean {
+  return Boolean(theme && isPalettePopulated(theme.light));
+}

--- a/src/lib/use-publication-theme-preference.ts
+++ b/src/lib/use-publication-theme-preference.ts
@@ -1,0 +1,73 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+
+import { user } from "#/integrations/tanstack-query/api-user.functions";
+
+import { DEFAULT_USE_PUBLICATION_THEME } from "./publication-theme-preference";
+
+export interface UsePublicationThemeContextValue {
+  enabled: boolean;
+  setEnabled: (next: boolean) => void;
+  isPending: boolean;
+}
+
+/** "Use publication themes" preference — see `#/lib/publication-theme-preference`. */
+export function usePublicationThemePreference(): UsePublicationThemeContextValue {
+  const queryClient = useQueryClient();
+
+  const { data } = useQuery({
+    ...user.getUsePublicationThemePreferenceQueryOptions,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+  });
+  const enabled = data?.enabled ?? DEFAULT_USE_PUBLICATION_THEME;
+
+  const setMutation = useMutation({
+    mutationFn: async (next: boolean) => {
+      return await user.setUsePublicationThemePreference({
+        data: { enabled: next },
+      });
+    },
+    onMutate: async (next) => {
+      await queryClient.cancelQueries({
+        queryKey: user.getUsePublicationThemePreferenceQueryOptions.queryKey,
+      });
+      const previous = queryClient.getQueryData(
+        user.getUsePublicationThemePreferenceQueryOptions.queryKey,
+      );
+      queryClient.setQueryData(
+        user.getUsePublicationThemePreferenceQueryOptions.queryKey,
+        { enabled: next },
+      );
+      return { previous };
+    },
+    onError: (_error, _next, ctx) => {
+      if (ctx?.previous) {
+        queryClient.setQueryData(
+          user.getUsePublicationThemePreferenceQueryOptions.queryKey,
+          ctx.previous,
+        );
+      }
+    },
+    onSuccess: (result) => {
+      queryClient.setQueryData(
+        user.getUsePublicationThemePreferenceQueryOptions.queryKey,
+        result,
+      );
+    },
+  });
+
+  const setEnabled = useCallback(
+    (next: boolean) => {
+      if (next === enabled) return;
+      setMutation.mutate(next);
+    },
+    [enabled, setMutation],
+  );
+
+  return {
+    enabled,
+    setEnabled,
+    isPending: setMutation.isPending,
+  };
+}

--- a/src/locales/ar/messages.po
+++ b/src/locales/ar/messages.po
@@ -3422,6 +3422,10 @@ msgstr "ابحث في جهات التصنيف"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · تغذيتك"
 
+#: src/components/user-settings-view.tsx
+msgid "Use publication themes"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "e.g. The Spring Reading Issue"
 msgstr "مثال: عدد قراءات الربيع"
@@ -4113,6 +4117,10 @@ msgstr "منسجم مع الويب المفتوح"
 #: src/components/reader/privacy-view.tsx
 msgid "What we collect"
 msgstr "ما نجمعه"
+
+#: src/components/user-settings-view.tsx
+msgid "When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme."
+msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Do you like Standard Reader?"

--- a/src/locales/ar/messages.po
+++ b/src/locales/ar/messages.po
@@ -2823,6 +2823,10 @@ msgstr ""
 msgid "Something went wrong"
 msgstr "حدث خطأ ما"
 
+#: src/components/onboarding/step-settings.tsx
+msgid "When on, a publication's page and its posts are shown in that publication's own colors and fonts. Publications that haven't set any keep the Standard Reader theme."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Browse publications"
 msgstr "تصفّح المنشورات"
@@ -3422,6 +3426,7 @@ msgstr "ابحث في جهات التصنيف"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · تغذيتك"
 
+#: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Use publication themes"
 msgstr ""

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -2823,6 +2823,10 @@ msgstr ""
 msgid "Something went wrong"
 msgstr "Etwas ist schiefgelaufen"
 
+#: src/components/onboarding/step-settings.tsx
+msgid "When on, a publication's page and its posts are shown in that publication's own colors and fonts. Publications that haven't set any keep the Standard Reader theme."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Browse publications"
 msgstr "Publikationen durchstöbern"
@@ -3422,6 +3426,7 @@ msgstr "Labeler suchen"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · Ihr Feed"
 
+#: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Use publication themes"
 msgstr ""

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -3422,6 +3422,10 @@ msgstr "Labeler suchen"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · Ihr Feed"
 
+#: src/components/user-settings-view.tsx
+msgid "Use publication themes"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "e.g. The Spring Reading Issue"
 msgstr "z. B. Die Frühlings-Leseausgabe"
@@ -4113,6 +4117,10 @@ msgstr "Versteht sich mit dem offenen Web"
 #: src/components/reader/privacy-view.tsx
 msgid "What we collect"
 msgstr "Was wir erheben"
+
+#: src/components/user-settings-view.tsx
+msgid "When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme."
+msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Do you like Standard Reader?"

--- a/src/locales/en-XA/messages.po
+++ b/src/locales/en-XA/messages.po
@@ -2823,6 +2823,10 @@ msgstr ""
 msgid "Something went wrong"
 msgstr ""
 
+#: src/components/onboarding/step-settings.tsx
+msgid "When on, a publication's page and its posts are shown in that publication's own colors and fonts. Publications that haven't set any keep the Standard Reader theme."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Browse publications"
 msgstr ""
@@ -3422,6 +3426,7 @@ msgstr ""
 msgid "{weekday} · Your feed"
 msgstr ""
 
+#: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Use publication themes"
 msgstr ""

--- a/src/locales/en-XA/messages.po
+++ b/src/locales/en-XA/messages.po
@@ -3422,6 +3422,10 @@ msgstr ""
 msgid "{weekday} · Your feed"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Use publication themes"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "e.g. The Spring Reading Issue"
 msgstr ""
@@ -4112,6 +4116,10 @@ msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "What we collect"
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme."
 msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -2823,6 +2823,10 @@ msgstr "{totalPeople, plural, one {# person you follow writes here} other {# peo
 msgid "Something went wrong"
 msgstr "Something went wrong"
 
+#: src/components/onboarding/step-settings.tsx
+msgid "When on, a publication's page and its posts are shown in that publication's own colors and fonts. Publications that haven't set any keep the Standard Reader theme."
+msgstr "When on, a publication's page and its posts are shown in that publication's own colors and fonts. Publications that haven't set any keep the Standard Reader theme."
+
 #: src/components/reader/about-view.tsx
 msgid "Browse publications"
 msgstr "Browse publications"
@@ -3422,6 +3426,7 @@ msgstr "Search labelers"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · Your feed"
 
+#: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Use publication themes"
 msgstr "Use publication themes"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -3422,6 +3422,10 @@ msgstr "Search labelers"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · Your feed"
 
+#: src/components/user-settings-view.tsx
+msgid "Use publication themes"
+msgstr "Use publication themes"
+
 #: src/components/reader/collection-builder.tsx
 msgid "e.g. The Spring Reading Issue"
 msgstr "e.g. The Spring Reading Issue"
@@ -4113,6 +4117,10 @@ msgstr "Plays nice with the open web"
 #: src/components/reader/privacy-view.tsx
 msgid "What we collect"
 msgstr "What we collect"
+
+#: src/components/user-settings-view.tsx
+msgid "When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme."
+msgstr "When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme."
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Do you like Standard Reader?"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -3422,6 +3422,10 @@ msgstr "Buscar etiquetadores"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · Su feed"
 
+#: src/components/user-settings-view.tsx
+msgid "Use publication themes"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "e.g. The Spring Reading Issue"
 msgstr "p. ej. El número de lecturas de primavera"
@@ -4113,6 +4117,10 @@ msgstr "Se lleva bien con la web abierta"
 #: src/components/reader/privacy-view.tsx
 msgid "What we collect"
 msgstr "Qué recopilamos"
+
+#: src/components/user-settings-view.tsx
+msgid "When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme."
+msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Do you like Standard Reader?"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -2823,6 +2823,10 @@ msgstr ""
 msgid "Something went wrong"
 msgstr "Algo salió mal"
 
+#: src/components/onboarding/step-settings.tsx
+msgid "When on, a publication's page and its posts are shown in that publication's own colors and fonts. Publications that haven't set any keep the Standard Reader theme."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Browse publications"
 msgstr "Explorar publicaciones"
@@ -3422,6 +3426,7 @@ msgstr "Buscar etiquetadores"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · Su feed"
 
+#: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Use publication themes"
 msgstr ""

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -3422,6 +3422,10 @@ msgstr "Rechercher des services d'étiquetage"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · Votre flux"
 
+#: src/components/user-settings-view.tsx
+msgid "Use publication themes"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "e.g. The Spring Reading Issue"
 msgstr "ex. Le numéro de printemps"
@@ -4113,6 +4117,10 @@ msgstr "En bonne entente avec le web ouvert"
 #: src/components/reader/privacy-view.tsx
 msgid "What we collect"
 msgstr "Ce que nous collectons"
+
+#: src/components/user-settings-view.tsx
+msgid "When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme."
+msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Do you like Standard Reader?"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -2823,6 +2823,10 @@ msgstr ""
 msgid "Something went wrong"
 msgstr "Une erreur s’est produite"
 
+#: src/components/onboarding/step-settings.tsx
+msgid "When on, a publication's page and its posts are shown in that publication's own colors and fonts. Publications that haven't set any keep the Standard Reader theme."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Browse publications"
 msgstr "Parcourir les publications"
@@ -3422,6 +3426,7 @@ msgstr "Rechercher des services d'étiquetage"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · Votre flux"
 
+#: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Use publication themes"
 msgstr ""

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -3422,6 +3422,10 @@ msgstr "ラベラーを検索"
 msgid "{weekday} · Your feed"
 msgstr "{weekday}・フィード"
 
+#: src/components/user-settings-view.tsx
+msgid "Use publication themes"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "e.g. The Spring Reading Issue"
 msgstr "例: 春の読書特集号"
@@ -4113,6 +4117,10 @@ msgstr "オープンな Web と相性よく"
 #: src/components/reader/privacy-view.tsx
 msgid "What we collect"
 msgstr "収集する情報"
+
+#: src/components/user-settings-view.tsx
+msgid "When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme."
+msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Do you like Standard Reader?"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -2823,6 +2823,10 @@ msgstr ""
 msgid "Something went wrong"
 msgstr "問題が発生しました"
 
+#: src/components/onboarding/step-settings.tsx
+msgid "When on, a publication's page and its posts are shown in that publication's own colors and fonts. Publications that haven't set any keep the Standard Reader theme."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Browse publications"
 msgstr "発行物を見る"
@@ -3422,6 +3426,7 @@ msgstr "ラベラーを検索"
 msgid "{weekday} · Your feed"
 msgstr "{weekday}・フィード"
 
+#: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Use publication themes"
 msgstr ""

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -2823,6 +2823,10 @@ msgstr ""
 msgid "Something went wrong"
 msgstr "문제가 발생했습니다"
 
+#: src/components/onboarding/step-settings.tsx
+msgid "When on, a publication's page and its posts are shown in that publication's own colors and fonts. Publications that haven't set any keep the Standard Reader theme."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Browse publications"
 msgstr "발행물 둘러보기"
@@ -3422,6 +3426,7 @@ msgstr "라벨러 검색"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · 내 피드"
 
+#: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Use publication themes"
 msgstr ""

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -3422,6 +3422,10 @@ msgstr "라벨러 검색"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · 내 피드"
 
+#: src/components/user-settings-view.tsx
+msgid "Use publication themes"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "e.g. The Spring Reading Issue"
 msgstr "예: 봄 독서 특집호"
@@ -4113,6 +4117,10 @@ msgstr "열린 웹과 잘 어울립니다"
 #: src/components/reader/privacy-view.tsx
 msgid "What we collect"
 msgstr "저희가 수집하는 정보"
+
+#: src/components/user-settings-view.tsx
+msgid "When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme."
+msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Do you like Standard Reader?"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -3422,6 +3422,10 @@ msgstr "Pesquisar rotuladores"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · O seu feed"
 
+#: src/components/user-settings-view.tsx
+msgid "Use publication themes"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "e.g. The Spring Reading Issue"
 msgstr "por exemplo, A Edição de Leituras de Primavera"
@@ -4113,6 +4117,10 @@ msgstr "Dá-se bem com a web aberta"
 #: src/components/reader/privacy-view.tsx
 msgid "What we collect"
 msgstr "O que recolhemos"
+
+#: src/components/user-settings-view.tsx
+msgid "When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme."
+msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Do you like Standard Reader?"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -2823,6 +2823,10 @@ msgstr "{totalPeople, plural, one {# pessoa que você segue escreve aqui} other 
 msgid "Something went wrong"
 msgstr "Algo deu errado"
 
+#: src/components/onboarding/step-settings.tsx
+msgid "When on, a publication's page and its posts are shown in that publication's own colors and fonts. Publications that haven't set any keep the Standard Reader theme."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Browse publications"
 msgstr "Explorar publicações"
@@ -3422,6 +3426,7 @@ msgstr "Pesquisar rotuladores"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · O seu feed"
 
+#: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Use publication themes"
 msgstr ""

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -3422,6 +3422,10 @@ msgstr "搜索标注服务"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · 你的信息流"
 
+#: src/components/user-settings-view.tsx
+msgid "Use publication themes"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "e.g. The Spring Reading Issue"
 msgstr "例如：春季阅读特辑"
@@ -4113,6 +4117,10 @@ msgstr "与开放网络友好共处"
 #: src/components/reader/privacy-view.tsx
 msgid "What we collect"
 msgstr "我们收集哪些信息"
+
+#: src/components/user-settings-view.tsx
+msgid "When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme."
+msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Do you like Standard Reader?"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -2823,6 +2823,10 @@ msgstr ""
 msgid "Something went wrong"
 msgstr "出错了"
 
+#: src/components/onboarding/step-settings.tsx
+msgid "When on, a publication's page and its posts are shown in that publication's own colors and fonts. Publications that haven't set any keep the Standard Reader theme."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Browse publications"
 msgstr "浏览刊物"
@@ -3422,6 +3426,7 @@ msgstr "搜索标注服务"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · 你的信息流"
 
+#: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Use publication themes"
 msgstr ""

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -174,6 +174,10 @@ export const Route = createRootRouteWithContext<RouterContext>()({
       user.getReadingTypographyPreferenceQueryOptions.queryKey,
       bootstrap.readingTypography,
     );
+    context.queryClient.setQueryData(
+      user.getUsePublicationThemePreferenceQueryOptions.queryKey,
+      bootstrap.usePublicationTheme,
+    );
     if (bootstrap.shell) {
       context.queryClient.setQueryData(
         sidebarQueryOptions().queryKey,

--- a/src/routes/_layout.a.$did.$rkey.tsx
+++ b/src/routes/_layout.a.$did.$rkey.tsx
@@ -262,5 +262,7 @@ function articleThemeColors(
     surfaceHover: theme?.surfaceHover ?? null,
     border: theme?.border ?? null,
     fonts: theme?.publicationFonts ?? null,
+    canvas: theme?.canvas ?? null,
+    backgroundImage: theme?.publicationBackgroundImage ?? null,
   };
 }

--- a/src/routes/_layout.a.$did.$rkey.tsx
+++ b/src/routes/_layout.a.$did.$rkey.tsx
@@ -27,6 +27,7 @@ import {
   articlePublicationUrl,
   documentUriFromParams,
 } from "../components/reader/format";
+import type { PublicationThemeColors } from "../components/reader/publication-theme-scale";
 import { prefetchCollectionMagazine } from "../magazine/load-magazine-data";
 
 const articleSearchSchema = z.object({
@@ -123,7 +124,13 @@ export const Route = createFileRoute("/_layout/a/$did/$rkey")({
       });
     }
 
-    return { article, sharedQuote };
+    // `publicationTheme` is read by `PublicationThemeScope` in the app shell —
+    // see its doc comment.
+    return {
+      article,
+      sharedQuote,
+      publicationTheme: articleThemeColors(article),
+    };
   },
   head: ({ loaderData, match }) => {
     const article = loaderData?.article as ArticleDetail | null | undefined;
@@ -234,4 +241,26 @@ function ArticleRoute() {
       sharedQuote={sharedQuote}
     />
   );
+}
+
+/**
+ * The owning publication's theme colors, as carried on the article itself.
+ * `collectionTheme` is populated for every article with a publication (not just
+ * collections), so the palette is already on the page — no extra round trip.
+ */
+function articleThemeColors(
+  article: ArticleDetail | null | undefined,
+): PublicationThemeColors {
+  const theme = article?.collectionTheme;
+  return {
+    themeBackground: theme?.background ?? null,
+    themeForeground: theme?.foreground ?? null,
+    themeAccent: theme?.accent ?? null,
+    themeAccentForeground: theme?.accentForeground ?? null,
+    dark: theme?.dark ?? null,
+    surface: theme?.surface ?? null,
+    surfaceHover: theme?.surfaceHover ?? null,
+    border: theme?.border ?? null,
+    fonts: theme?.publicationFonts ?? null,
+  };
 }

--- a/src/routes/_layout.p.$did.$rkey.tsx
+++ b/src/routes/_layout.p.$did.$rkey.tsx
@@ -46,6 +46,7 @@ import {
 import { PublicationLatestNote } from "../components/reader/publication-latest-note";
 import { PublicationSocialProofLine } from "../components/reader/publication-social-proof";
 import type { PublicationThemeColors } from "../components/reader/publication-theme-scale";
+import { publicationPageCard } from "../components/reader/publication-theme-tokens";
 import {
   applyMarkReadManyOptimisticUpdate,
   invalidateReadQueries,
@@ -740,7 +741,9 @@ function PublicationProfileContent({
   const rest = documents.slice(1);
 
   return (
-    <div>
+    // The publication's own header is page content, unlike an article's sticky
+    // reading chrome, so the hero sits inside the card.
+    <div {...stylex.props(publicationPageCard.card)}>
       <div {...stylex.props(styles.hero)}>
         <div {...stylex.props(styles.heroInner)}>
           <div {...stylex.props(styles.heroTop)}>

--- a/src/routes/_layout.p.$did.$rkey.tsx
+++ b/src/routes/_layout.p.$did.$rkey.tsx
@@ -45,6 +45,7 @@ import {
 } from "../components/reader/primitives";
 import { PublicationLatestNote } from "../components/reader/publication-latest-note";
 import { PublicationSocialProofLine } from "../components/reader/publication-social-proof";
+import type { PublicationThemeColors } from "../components/reader/publication-theme-scale";
 import {
   applyMarkReadManyOptimisticUpdate,
   invalidateReadQueries,
@@ -124,6 +125,7 @@ export const Route = createFileRoute("/_layout/p/$did/$rkey")({
       return {
         publicationName: null,
         publicationDescription: null,
+        publicationTheme: null,
       };
     }
 
@@ -142,6 +144,7 @@ export const Route = createFileRoute("/_layout/p/$did/$rkey")({
     const header = results[0] as {
       publication: { name: string; description: string };
       owner: { did: string; handle: string };
+      theme: PublicationThemeColors;
     } | null;
 
     if (header) {
@@ -155,6 +158,8 @@ export const Route = createFileRoute("/_layout/p/$did/$rkey")({
     return {
       publicationName: header?.publication.name ?? null,
       publicationDescription: header?.publication.description ?? null,
+      // Read by `PublicationThemeScope` in the app shell — see its doc comment.
+      publicationTheme: header?.theme ?? null,
     };
   },
   head: ({ loaderData, match }) => {

--- a/src/routes/_layout.settings.index.tsx
+++ b/src/routes/_layout.settings.index.tsx
@@ -40,6 +40,9 @@ export const Route = createFileRoute("/_layout/settings/")({
       context.queryClient.ensureQueryData(
         user.getCountOldPostsAsUnreadPreferenceQueryOptions,
       ),
+      context.queryClient.ensureQueryData(
+        user.getUsePublicationThemePreferenceQueryOptions,
+      ),
       context.queryClient.prefetchQuery(
         googleFontsApi.getGoogleFontFamiliesQueryOptions,
       ),

--- a/src/routes/welcome.tsx
+++ b/src/routes/welcome.tsx
@@ -62,6 +62,9 @@ export const Route = createFileRoute("/welcome")({
         user.getCountOldPostsAsUnreadPreferenceQueryOptions,
       ),
       context.queryClient.ensureQueryData(
+        user.getUsePublicationThemePreferenceQueryOptions,
+      ),
+      context.queryClient.ensureQueryData(
         user.getOpenLinksPreferenceQueryOptions,
       ),
       context.queryClient.ensureQueryData(

--- a/src/server/atproto/types.ts
+++ b/src/server/atproto/types.ts
@@ -50,6 +50,14 @@ export interface PublicationRecord {
   description?: string;
   icon?: BlobRef;
   basicTheme?: BasicTheme;
+  /**
+   * The publishing platform's own richer theme, kept alongside the `basicTheme`
+   * interop baseline and discriminated by `$type` (`pub.leaflet.publication#theme`,
+   * `blog.pckt.theme`, `app.offprint.theme`, …). Left untyped on purpose — it is
+   * third-party and open-ended; `resolvePublicationTheme`
+   * (`#/lib/publication-theme-source`) narrows it per `$type`.
+   */
+  theme?: unknown;
   preferences?: { showInDiscover?: boolean };
 }
 

--- a/src/server/fonts/google-catalog.server.ts
+++ b/src/server/fonts/google-catalog.server.ts
@@ -1,4 +1,5 @@
 import {
+  GOOGLE_FONTS_CACHE_TTL_MS,
   isValidGoogleFontFamily,
   normalizeGoogleFontFamily,
 } from "#/lib/google-fonts";
@@ -13,7 +14,6 @@ import {
 import { normalizeFontKey } from "#/lib/publication-fonts";
 
 const GOOGLE_FONTS_METADATA_URL = "https://fonts.google.com/metadata/fonts";
-export const GOOGLE_FONTS_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
 let cachedFamilies: ReadonlyArray<string> | null = null;
 let cachedIndex: ReadonlyMap<string, string> | null = null;

--- a/src/server/fonts/google-catalog.server.ts
+++ b/src/server/fonts/google-catalog.server.ts
@@ -1,0 +1,75 @@
+import {
+  isValidGoogleFontFamily,
+  normalizeGoogleFontFamily,
+} from "#/lib/google-fonts";
+/**
+ * The Google Fonts family catalog, fetched once and cached in memory.
+ *
+ * Two consumers share this cache: the reading-typography font picker (via
+ * `googleFontsApi`) and publication theming, which matches the font keys
+ * publishers write — Offprint slugs, PCKT's squashed keys — onto real family
+ * names (see `#/lib/publication-fonts`).
+ */
+import { normalizeFontKey } from "#/lib/publication-fonts";
+
+const GOOGLE_FONTS_METADATA_URL = "https://fonts.google.com/metadata/fonts";
+export const GOOGLE_FONTS_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+let cachedFamilies: ReadonlyArray<string> | null = null;
+let cachedIndex: ReadonlyMap<string, string> | null = null;
+let cachedAt = 0;
+
+type GoogleFontsMetadata = {
+  familyMetadataList?: ReadonlyArray<{ family?: string }>;
+};
+
+export async function loadGoogleFontFamilies(): Promise<ReadonlyArray<string>> {
+  if (cachedFamilies && Date.now() - cachedAt < GOOGLE_FONTS_CACHE_TTL_MS) {
+    return cachedFamilies;
+  }
+
+  const response = await fetch(GOOGLE_FONTS_METADATA_URL, {
+    headers: {
+      Accept: "application/json",
+      "User-Agent": "standard-reader/1.0",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error("Could not load Google Fonts catalog.");
+  }
+
+  const raw = await response.text();
+  const json = JSON.parse(
+    raw.replace(/^\)\]\}'\n?/, ""),
+  ) as GoogleFontsMetadata;
+  const families = (json.familyMetadataList ?? [])
+    .map((entry) => normalizeGoogleFontFamily(entry.family ?? ""))
+    .filter((family) => isValidGoogleFontFamily(family));
+
+  cachedFamilies = [...new Set(families)].toSorted((a, b) =>
+    a.localeCompare(b),
+  );
+  cachedIndex = new Map(
+    cachedFamilies.map((family) => [normalizeFontKey(family), family]),
+  );
+  cachedAt = Date.now();
+  return cachedFamilies;
+}
+
+/**
+ * Normalized-key → family lookup. Returns a lookup that always misses when the
+ * catalog can't be fetched, so a Google Fonts outage degrades to "no publisher
+ * fonts" rather than failing the page.
+ */
+export async function googleFontLookup(): Promise<
+  (normalizedKey: string) => string | null
+> {
+  try {
+    await loadGoogleFontFamilies();
+  } catch {
+    return () => null;
+  }
+  const index = cachedIndex;
+  return (normalizedKey: string) => index?.get(normalizedKey) ?? null;
+}

--- a/src/server/fonts/publication-fonts.server.ts
+++ b/src/server/fonts/publication-fonts.server.ts
@@ -1,0 +1,31 @@
+/**
+ * Resolves the fonts stated in a publication's native theme into Google Fonts
+ * families, using the shared catalog cache.
+ *
+ * Kept off the synchronous `publicationThemeFromRow` colour path because the
+ * catalog is fetched (and cached) asynchronously — the two call sites that need
+ * fonts are already async.
+ */
+import type { PublicationFonts } from "#/lib/publication-fonts";
+import {
+  NO_PUBLICATION_FONTS,
+  publicationFontRequests,
+  resolvePublicationFonts,
+} from "#/lib/publication-fonts";
+
+import { googleFontLookup } from "./google-catalog.server";
+
+/** Pull `nativeTheme` out of a `publications.theme_json` blob. */
+function nativeThemeOf(themeJson: unknown): unknown {
+  if (!themeJson || typeof themeJson !== "object") return null;
+  return (themeJson as Record<string, unknown>).nativeTheme ?? null;
+}
+
+export async function publicationFontsFromThemeJson(
+  themeJson: unknown,
+): Promise<PublicationFonts> {
+  const requests = publicationFontRequests(nativeThemeOf(themeJson));
+  if (!requests.heading && !requests.body) return NO_PUBLICATION_FONTS;
+  const lookup = await googleFontLookup();
+  return resolvePublicationFonts(requests, lookup);
+}

--- a/src/server/ingest/handlers.ts
+++ b/src/server/ingest/handlers.ts
@@ -230,7 +230,16 @@ export async function upsertPublication(
     iconCid,
     iconMime: record.icon?.mimeType ?? null,
     ...theme,
-    themeJson: sanitizeJson(record.basicTheme),
+    // Keep the publisher's native theme next to the `basicTheme` baseline —
+    // Leaflet/PCKT/Offprint carry colors (and real dark palettes) the four
+    // flattened columns can't express. See `#/lib/publication-theme-source`.
+    themeJson:
+      record.basicTheme || record.theme
+        ? sanitizeJson({
+            ...record.basicTheme,
+            ...(record.theme ? { nativeTheme: record.theme } : {}),
+          })
+        : sanitizeJson(record.basicTheme),
     showInDiscover:
       (record.preferences?.showInDiscover ?? true) &&
       !isExcludedPublicationUrl(url),

--- a/src/server/reader/article-detail-build.ts
+++ b/src/server/reader/article-detail-build.ts
@@ -1,3 +1,7 @@
+import {
+  publicationRenderedSurfaces,
+  publicationThemeFromRow,
+} from "#/components/reader/publication-theme-scale";
 import type {
   ArticleContributor,
   ArticleDetail,
@@ -26,9 +30,11 @@ import { getPublicUrl } from "#/lib/public-url";
 import type { CodeHighlightsByScheme, ThemeMode } from "#/lib/theme";
 import { EMPTY_CODE_HIGHLIGHTS } from "#/lib/theme";
 import { cdnImageUrl } from "#/server/atproto/blob";
+import { publicationFontsFromThemeJson } from "#/server/fonts/publication-fonts.server";
 import { countDocumentComments } from "#/server/reader/document-comments";
 import { selectArticleCardsByUris } from "#/server/reader/queries";
 import { highlightLeafletCodeBlocks } from "#/server/shiki/highlighter";
+import { pickCodeTheme } from "#/server/shiki/match-theme";
 
 /** Row shape shared by single-article and collection bundle queries. */
 export interface ArticleDetailSourceRow {
@@ -72,6 +78,12 @@ export interface ArticleDetailSourceRow {
 }
 
 export interface BuildArticleDetailOptions {
+  /**
+   * Match the code theme to the publication's palette. Only set when the reader
+   * opted into publication themes — otherwise their code blocks would take a
+   * publication's colours while the rest of the page stayed editorial.
+   */
+  usePublicationTheme?: boolean;
   /** Skip recommend/read/comment counts (magazine bundle). */
   skipSocialCounts?: boolean;
   /** Skip newsletter compose for collection manifests (unused for magazine). */
@@ -83,18 +95,46 @@ export interface BuildArticleDetailOptions {
 async function codeHighlightsForThemeMode(
   blocks: Array<Pick<LeafletCodeBlock, "language" | "plaintext">>,
   themeMode: ThemeMode,
+  codeTheme: {
+    accent: string | null;
+    surfaces: ReturnType<typeof publicationRenderedSurfaces>;
+  } | null,
 ): Promise<CodeHighlightsByScheme> {
   if (blocks.length === 0) return EMPTY_CODE_HIGHLIGHTS;
 
+  // Match a bundled Shiki theme to the publication's palette so code blocks read
+  // as part of the page rather than a foreign panel dropped into it. Scored
+  // against the *rendered* surface for that scheme — the stated background can
+  // belong to the other mode entirely. Null keeps the editorial theme.
+  const themeFor = async (scheme: "light" | "dark") =>
+    codeTheme
+      ? ((await pickCodeTheme(
+          {
+            background: codeTheme.surfaces[scheme].background,
+            foreground: codeTheme.surfaces[scheme].foreground,
+            accent: codeTheme.accent,
+          },
+          scheme,
+        )) ?? undefined)
+      : undefined;
+
   if (themeMode === "system") {
+    const [lightTheme, darkTheme] = await Promise.all([
+      themeFor("light"),
+      themeFor("dark"),
+    ]);
     const [light, dark] = await Promise.all([
-      highlightLeafletCodeBlocks(blocks, "light"),
-      highlightLeafletCodeBlocks(blocks, "dark"),
+      highlightLeafletCodeBlocks(blocks, "light", lightTheme),
+      highlightLeafletCodeBlocks(blocks, "dark", darkTheme),
     ]);
     return { light, dark };
   }
 
-  const single = await highlightLeafletCodeBlocks(blocks, themeMode);
+  const single = await highlightLeafletCodeBlocks(
+    blocks,
+    themeMode,
+    await themeFor(themeMode),
+  );
   return themeMode === "dark"
     ? { light: {}, dark: single }
     : { light: single, dark: {} };
@@ -200,12 +240,36 @@ export async function buildArticleDetail(
     resolvedContentJson,
   );
 
+  // Resolved through the publisher's native theme so Leaflet/PCKT/Offprint
+  // publications contribute their real surface colors (and authored dark
+  // palette), not just the flattened `basicTheme` baseline. Resolved before the
+  // highlight pass because it also picks the code theme.
+  const publicationTheme = publicationThemeFromRow({
+    themeBackground: row.pubThemeBackground,
+    themeForeground: row.pubThemeForeground,
+    themeAccent: row.pubThemeAccent,
+    themeAccentForeground: row.pubThemeAccentForeground,
+    themeJson: row.pubThemeJson,
+  });
+
   const [codeHighlights, commentCount] = await Promise.all([
-    codeHighlightsForThemeMode(codeBlocks, themeMode),
+    codeHighlightsForThemeMode(
+      codeBlocks,
+      themeMode,
+      options.usePublicationTheme
+        ? {
+            accent: publicationTheme.themeAccent,
+            surfaces: publicationRenderedSurfaces(publicationTheme),
+          }
+        : null,
+    ),
     options.skipSocialCounts
       ? Promise.resolve(0)
       : countDocumentComments(db, schema, row.uri),
   ]);
+  const publicationFonts = await publicationFontsFromThemeJson(
+    row.pubThemeJson,
+  );
 
   return {
     uri: row.uri,
@@ -232,10 +296,18 @@ export async function buildArticleDetail(
     collection,
     collectionTheme: row.pubUri
       ? {
-          background: row.pubThemeBackground,
-          foreground: row.pubThemeForeground,
-          accent: row.pubThemeAccent,
-          accentForeground: row.pubThemeAccentForeground,
+          background: publicationTheme.themeBackground,
+          foreground: publicationTheme.themeForeground,
+          accent: publicationTheme.themeAccent,
+          accentForeground: publicationTheme.themeAccentForeground,
+          dark: publicationTheme.dark ?? null,
+          surface: publicationTheme.surface ?? null,
+          surfaceHover: publicationTheme.surfaceHover ?? null,
+          border: publicationTheme.border ?? null,
+          publicationFonts,
+          // The sidecar `app.standard-reader.publicationTheme` fonts still win
+          // for collections/magazine rendering; `publicationFonts` is the
+          // platform-native pair used by the reader's publication theming.
           fontTitle: themeFontsFromJson(row.pubThemeJson).title,
           fontBody: themeFontsFromJson(row.pubThemeJson).body,
         }

--- a/src/server/reader/article-detail-build.ts
+++ b/src/server/reader/article-detail-build.ts
@@ -32,6 +32,7 @@ import { EMPTY_CODE_HIGHLIGHTS } from "#/lib/theme";
 import { cdnImageUrl } from "#/server/atproto/blob";
 import { publicationFontsFromThemeJson } from "#/server/fonts/publication-fonts.server";
 import { countDocumentComments } from "#/server/reader/document-comments";
+import { publicationBackgroundImage } from "#/server/reader/publication-background";
 import { selectArticleCardsByUris } from "#/server/reader/queries";
 import { highlightLeafletCodeBlocks } from "#/server/shiki/highlighter";
 import { pickCodeTheme } from "#/server/shiki/match-theme";
@@ -304,7 +305,12 @@ export async function buildArticleDetail(
           surface: publicationTheme.surface ?? null,
           surfaceHover: publicationTheme.surfaceHover ?? null,
           border: publicationTheme.border ?? null,
+          canvas: publicationTheme.canvas ?? null,
           publicationFonts,
+          publicationBackgroundImage: publicationBackgroundImage(
+            row.pubThemeJson,
+            row.pubDid ?? row.did,
+          ),
           // The sidecar `app.standard-reader.publicationTheme` fonts still win
           // for collections/magazine rendering; `publicationFonts` is the
           // platform-native pair used by the reader's publication theming.

--- a/src/server/reader/publication-background.ts
+++ b/src/server/reader/publication-background.ts
@@ -1,0 +1,35 @@
+/**
+ * Resolves a publication's canvas background image to a CDN URL.
+ *
+ * The record stores a blob ref; turning it into a URL needs the publication's
+ * DID, which only the server has to hand — so the client-safe adapter stops at
+ * the CID and this fills in the rest.
+ */
+import { resolvePublicationTheme } from "#/lib/publication-theme-source";
+import { cdnImageUrl } from "#/server/atproto/blob";
+
+export interface PublicationBackgroundImageUrl {
+  url: string;
+  repeat: boolean;
+  width: number | null;
+}
+
+export function publicationBackgroundImage(
+  themeJson: unknown,
+  did: string | null,
+): PublicationBackgroundImageUrl | null {
+  if (!did) return null;
+  const json =
+    themeJson && typeof themeJson === "object"
+      ? (themeJson as Record<string, unknown>)
+      : null;
+  if (!json) return null;
+  const image = resolvePublicationTheme(json, json.nativeTheme).light
+    .backgroundImage;
+  if (!image) return null;
+  return {
+    url: cdnImageUrl(did, image.cid),
+    repeat: image.repeat,
+    width: image.width,
+  };
+}

--- a/src/server/reader/publication-header.ts
+++ b/src/server/reader/publication-header.ts
@@ -13,6 +13,7 @@ import {
   toPublicationCard,
 } from "#/integrations/tanstack-query/api-shapes";
 import { publicationFontsFromThemeJson } from "#/server/fonts/publication-fonts.server";
+import { publicationBackgroundImage } from "#/server/reader/publication-background";
 
 export interface PublicationHeader {
   publication: PublicationCard;
@@ -70,6 +71,7 @@ export async function selectPublicationHeader(
     theme: {
       ...publicationThemeFromRow(row),
       fonts: await publicationFontsFromThemeJson(row.themeJson),
+      backgroundImage: publicationBackgroundImage(row.themeJson, row.did),
     },
   };
 }

--- a/src/server/reader/publication-header.ts
+++ b/src/server/reader/publication-header.ts
@@ -1,5 +1,7 @@
 import { eq } from "drizzle-orm";
 
+import type { PublicationThemeColors } from "#/components/reader/publication-theme-scale";
+import { publicationThemeFromRow } from "#/components/reader/publication-theme-scale";
 import type {
   Db,
   ProfileSummary,
@@ -10,10 +12,19 @@ import {
   publicationCardColumns,
   toPublicationCard,
 } from "#/integrations/tanstack-query/api-shapes";
+import { publicationFontsFromThemeJson } from "#/server/fonts/publication-fonts.server";
 
 export interface PublicationHeader {
   publication: PublicationCard;
   owner: ProfileSummary;
+  /**
+   * The publication's own `site.standard.theme.basic` colors, flattened. Only
+   * used to repaint the profile page when the reader opted into publication
+   * themes (`user.use_publication_theme`); selected here rather than through
+   * `getPublicationEmbedMeta` so the palette lands in the same round trip as
+   * the header and the page paints themed on the first frame.
+   */
+  theme: PublicationThemeColors;
 }
 
 export async function selectPublicationHeader(
@@ -32,6 +43,11 @@ export async function selectPublicationHeader(
       ownerDisplayName: pr.displayName,
       ownerDescription: pr.description,
       ownerBannerUrl: pr.bannerUrl,
+      themeBackground: p.themeBackground,
+      themeForeground: p.themeForeground,
+      themeAccent: p.themeAccent,
+      themeAccentForeground: p.themeAccentForeground,
+      themeJson: p.themeJson,
     })
     .from(p)
     .leftJoin(st, eq(st.publicationUri, p.uri))
@@ -50,6 +66,10 @@ export async function selectPublicationHeader(
       description: row.ownerDescription,
       avatarUrl: row.ownerAvatarUrl,
       bannerUrl: row.ownerBannerUrl,
+    },
+    theme: {
+      ...publicationThemeFromRow(row),
+      fonts: await publicationFontsFromThemeJson(row.themeJson),
     },
   };
 }

--- a/src/server/shiki/highlighter.ts
+++ b/src/server/shiki/highlighter.ts
@@ -1,4 +1,4 @@
-import type { BundledLanguage, Highlighter } from "shiki";
+import type { BundledLanguage, BundledTheme, Highlighter } from "shiki";
 import { createHighlighter } from "shiki";
 
 import { codeBlockKey, normalizeLanguage } from "#/lib/code-highlight";
@@ -64,12 +64,38 @@ async function resolveLanguage(
   }
 }
 
+/**
+ * Ensure a bundled theme is registered, returning the editorial theme's name if
+ * it can't be loaded — a missing theme must never cost us the highlight.
+ */
+async function resolveTheme(
+  highlighter: Highlighter,
+  requested: string | undefined,
+  scheme: ResolvedThemeScheme,
+): Promise<string> {
+  const fallback = codeThemeNameForScheme(scheme);
+  if (!requested || requested === fallback) return fallback;
+  if (highlighter.getLoadedThemes().includes(requested)) return requested;
+  try {
+    await highlighter.loadTheme(requested as BundledTheme);
+    return requested;
+  } catch {
+    return fallback;
+  }
+}
+
 export async function highlightCodeBlock(
   plaintext: string,
   language: string | undefined,
   scheme: ResolvedThemeScheme = "light",
+  requestedTheme?: string,
 ): Promise<string> {
-  const themeName = codeThemeNameForScheme(scheme);
+  const highlighterForTheme = await getHighlighter();
+  const themeName = await resolveTheme(
+    highlighterForTheme,
+    requestedTheme,
+    scheme,
+  );
   const key = `${themeName}:${codeBlockKey({ language, plaintext })}`;
   const cached = htmlCache.get(key);
   if (cached) return cached;
@@ -92,6 +118,7 @@ export async function highlightCodeBlock(
 export async function highlightLeafletCodeBlocks(
   blocks: Array<LeafletCodeBlock>,
   scheme: ResolvedThemeScheme = "light",
+  requestedTheme?: string,
 ): Promise<Record<string, string>> {
   const unique = new Map<string, LeafletCodeBlock>();
   for (const block of blocks) {
@@ -108,6 +135,7 @@ export async function highlightLeafletCodeBlocks(
         block.plaintext,
         block.language,
         scheme,
+        requestedTheme,
       );
       return [key, html] as const;
     }),

--- a/src/server/shiki/match-theme.test.ts
+++ b/src/server/shiki/match-theme.test.ts
@@ -1,0 +1,79 @@
+import Color from "colorjs.io";
+import type { ThemeRegistrationAny } from "shiki";
+import { bundledThemes, bundledThemesInfo } from "shiki";
+import { describe, expect, it } from "vitest";
+
+import { pickCodeTheme } from "./match-theme";
+
+const typeById = new Map(bundledThemesInfo.map((t) => [t.id, t.type]));
+
+describe("pickCodeTheme", () => {
+  it("returns null without an accent to match on", async () => {
+    // The accent carries the publication's character; without it any theme is
+    // as good as the editorial one we already ship.
+    await expect(
+      pickCodeTheme(
+        { background: "#ffffff", foreground: "#111111", accent: null },
+        "light",
+      ),
+    ).resolves.toBeNull();
+  });
+
+  it("only ever picks a theme matching the requested scheme", async () => {
+    const target = {
+      background: "#1f150c",
+      foreground: "#e1dcc9",
+      accent: "#412d15",
+    };
+    for (const scheme of ["light", "dark"] as const) {
+      const picked = await pickCodeTheme(target, scheme);
+      expect(picked).toBeTruthy();
+      expect(typeById.get(picked as string)).toBe(scheme);
+    }
+  });
+
+  it("picks different themes for meaningfully different accents", async () => {
+    const warm = await pickCodeTheme(
+      { background: "#1f150c", foreground: "#e1dcc9", accent: "#412d15" },
+      "dark",
+    );
+    const cool = await pickCodeTheme(
+      { background: "#eef5ff", foreground: "#1a3a5c", accent: "#5eb5ec" },
+      "dark",
+    );
+    expect(warm).not.toBe(cool);
+  });
+
+  it("keeps the code panel close to the page background", async () => {
+    // A code block is mostly background, so a theme whose surface disagrees with
+    // the page reads as a foreign panel however well its accent matches. This
+    // regressed once: a teal accent on a near-white page picked cream
+    // `gruvbox-light-hard` (#f9f5d7) purely on accent similarity.
+    const pageBackground = "#fdfcfa";
+    const picked = await pickCodeTheme(
+      { background: pageBackground, foreground: "#292929", accent: "#2b7882" },
+      "light",
+    );
+    expect(picked).toBeTruthy();
+    const loaded = await bundledThemes[picked as keyof typeof bundledThemes]();
+    const theme =
+      (loaded as { default?: ThemeRegistrationAny }).default ?? loaded;
+    const themeBackground = (theme as ThemeRegistrationAny).colors?.[
+      "editor.background"
+    ];
+    expect(themeBackground).toBeTruthy();
+    const delta = new Color(pageBackground).deltaEOK(
+      new Color(themeBackground as string),
+    );
+    expect(delta).toBeLessThanOrEqual(0.035);
+  });
+
+  it("survives an unparseable colour rather than throwing", async () => {
+    await expect(
+      pickCodeTheme(
+        { background: "not-a-color", foreground: null, accent: "#65a30d" },
+        "light",
+      ),
+    ).resolves.toBeTruthy();
+  });
+});

--- a/src/server/shiki/match-theme.ts
+++ b/src/server/shiki/match-theme.ts
@@ -1,0 +1,186 @@
+/**
+ * Picks the bundled Shiki theme that best matches a publication's palette.
+ *
+ * Synthesizing syntax colours from a publication's four theme colours would mean
+ * inventing a whole colour system per publication — keywords, strings, comments,
+ * numbers — and algorithmic palettes read as noise next to hand-designed ones.
+ * Shiki already ships 65 themes that *are* designed systems, so we score them
+ * against the publication's background, text and accent and use the closest.
+ *
+ * Scoring is perceptual (ΔE in OKLab) and weighted toward the accent, since that
+ * is what gives a theme its character; background and text mostly decide whether
+ * it sits calmly on the page.
+ */
+import Color from "colorjs.io";
+import type { ThemeRegistrationAny } from "shiki";
+import { bundledThemes, bundledThemesInfo } from "shiki";
+
+import type { ResolvedThemeScheme } from "#/lib/theme";
+
+export interface CodeThemeTarget {
+  /** The surface the code block sits on. */
+  background: string | null;
+  /** Body text colour. */
+  foreground: string | null;
+  /** The publication's accent — the strongest signal of its character. */
+  accent: string | null;
+}
+
+interface ThemeFingerprint {
+  id: string;
+  type: "light" | "dark";
+  background: string;
+  foreground: string;
+  /** The token colour covering the most scopes — keywords, in practice. */
+  accent: string;
+}
+
+/**
+ * A code block is mostly background: the panel is a large flat area, while the
+ * accent shows up as a few keywords. So the background is a **gate**, not just a
+ * weighted term — a theme whose surface visibly disagrees with the page reads as
+ * a foreign panel no matter how well its keyword colour echoes the accent (a
+ * cream `gruvbox-light-hard` on a near-white page was the case that prompted
+ * this). Among themes that do sit calmly, we then pick the most characterful.
+ *
+ * Threshold is ΔE in OKLab; ~0.02 is roughly "just noticeable", so 0.035 allows
+ * a panel that reads as a distinct surface without clashing.
+ */
+const MAX_BACKGROUND_DELTA = 0.035;
+
+const WEIGHT = { background: 1, foreground: 0.6, accent: 1.4 } as const;
+
+/** Themes whose palette is a novelty rather than a reading surface. */
+const EXCLUDED = new Set(["red", "vitesse-black", "andromeeda"]);
+
+function accentOf(theme: ThemeRegistrationAny): string | null {
+  const byColor = new Map<string, number>();
+  for (const entry of theme.tokenColors ?? []) {
+    const fg = entry.settings?.foreground;
+    if (!fg) continue;
+    const scopes = Array.isArray(entry.scope)
+      ? entry.scope.length
+      : entry.scope
+        ? 1
+        : 0;
+    byColor.set(fg, (byColor.get(fg) ?? 0) + scopes);
+  }
+  let best: string | null = null;
+  let bestCount = -1;
+  for (const [color, count] of byColor) {
+    // Skip the body text colour; it is the foreground, not the accent.
+    if (
+      color.toLowerCase() === theme.colors?.["editor.foreground"]?.toLowerCase()
+    ) {
+      continue;
+    }
+    if (count > bestCount) {
+      best = color;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+let fingerprintsPromise: Promise<ReadonlyArray<ThemeFingerprint>> | null = null;
+
+async function loadFingerprints(): Promise<ReadonlyArray<ThemeFingerprint>> {
+  fingerprintsPromise ??= (async () => {
+    const out: Array<ThemeFingerprint> = [];
+    await Promise.all(
+      bundledThemesInfo.map(async (info) => {
+        if (EXCLUDED.has(info.id)) return;
+        try {
+          const loaded =
+            await bundledThemes[info.id as keyof typeof bundledThemes]();
+          const theme = (loaded.default ?? loaded) as ThemeRegistrationAny;
+          const background = theme.colors?.["editor.background"];
+          const foreground = theme.colors?.["editor.foreground"];
+          const accent = accentOf(theme);
+          if (!background || !foreground || !accent) return;
+          out.push({
+            id: info.id,
+            type: info.type,
+            background,
+            foreground,
+            accent,
+          });
+        } catch {
+          // A theme that won't load simply isn't a candidate.
+        }
+      }),
+    );
+    return out;
+  })();
+  return fingerprintsPromise;
+}
+
+function parse(value: string | null): Color | null {
+  if (!value) return null;
+  try {
+    return new Color(value);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The bundled theme closest to `target`, or `null` when the target carries too
+ * little colour to choose on (the caller then keeps the editorial theme).
+ */
+export async function pickCodeTheme(
+  target: CodeThemeTarget,
+  scheme: ResolvedThemeScheme,
+): Promise<string | null> {
+  const accent = parse(target.accent);
+  const background = parse(target.background);
+  const foreground = parse(target.foreground);
+  // The accent is what makes a match meaningful; without it, any theme is as
+  // good as the editorial one we already have.
+  if (!accent) return null;
+
+  const fingerprints = await loadFingerprints();
+  const ofScheme = fingerprints.filter((f) => f.type === scheme);
+  if (ofScheme.length === 0) return null;
+
+  // Gate on background agreement first; fall back to the full field if nothing
+  // sits closely enough, so we always return a usable theme.
+  const nearBackground = background
+    ? ofScheme.filter((f) => {
+        try {
+          return (
+            background.deltaEOK(new Color(f.background)) <= MAX_BACKGROUND_DELTA
+          );
+        } catch {
+          return false;
+        }
+      })
+    : ofScheme;
+  const candidates = nearBackground.length > 0 ? nearBackground : ofScheme;
+
+  let best: string | null = null;
+  let bestScore = Number.POSITIVE_INFINITY;
+  for (const candidate of candidates) {
+    let score = 0;
+    try {
+      score += WEIGHT.accent * accent.deltaEOK(new Color(candidate.accent));
+      if (background) {
+        score +=
+          WEIGHT.background *
+          background.deltaEOK(new Color(candidate.background));
+      }
+      if (foreground) {
+        score +=
+          WEIGHT.foreground *
+          foreground.deltaEOK(new Color(candidate.foreground));
+      }
+    } catch {
+      continue;
+    }
+    if (score < bestScore) {
+      bestScore = score;
+      best = candidate.id;
+    }
+  }
+  return best;
+}

--- a/src/server/theme-preference.ts
+++ b/src/server/theme-preference.ts
@@ -2,6 +2,10 @@ import { getCookie, getRequest } from "@tanstack/react-start/server";
 import { eq } from "drizzle-orm";
 
 import type { Db, Schema } from "#/integrations/tanstack-query/api-shapes";
+import {
+  DEFAULT_USE_PUBLICATION_THEME,
+  dbValueToUsePublicationTheme,
+} from "#/lib/publication-theme-preference";
 import type { ResolvedThemeScheme, ThemeMode } from "#/lib/theme";
 import {
   THEME_COOKIE,
@@ -24,6 +28,24 @@ export async function themeModeForRequest(
   }
 
   return parseThemeMode(getCookie(THEME_COOKIE));
+}
+
+/**
+ * Whether this reader opted into publication themes. Signed-in only, mirroring
+ * `getUsePublicationThemePreference` — guests never see publication colours, so
+ * their code blocks stay editorial too.
+ */
+export async function usePublicationThemeForRequest(
+  db: Db,
+  schema: Schema,
+  sessionUserId?: string | null,
+): Promise<boolean> {
+  if (!sessionUserId) return DEFAULT_USE_PUBLICATION_THEME;
+  const row = await db.query.user.findFirst({
+    where: eq(schema.user.id, sessionUserId),
+    columns: { usePublicationTheme: true },
+  });
+  return dbValueToUsePublicationTheme(row?.usePublicationTheme ?? null);
 }
 
 export function resolvedThemeSchemeForRequest(


### PR DESCRIPTION
Adds an account-level opt-in (**Settings → Appearance → Use publication themes**, also offered during onboarding) that repaints `/p/$did/$rkey` and `/a/$did/$rkey` in the publication's own colours, fonts and code theme.

The machinery mostly already existed — `publicationThemeScaleVars` expands a publication's `basicTheme` into light + dark UI/accent scales that the `publicationUi` / `publicationPrimary` StyleX themes read. It was wired to exactly one route (the themed subscribe login). This puts it behind a preference and extends it to the reader.

Off by default; `null` = off. Publications with no colours of their own always keep the editorial theme, so nothing changes for them.

## Reading more than `basicTheme`

`site.standard.theme.basic` is the interop baseline — four opaque colours, light only. Records also carry the publishing platform's *native* theme under `theme`, discriminated by `$type`, which ingest was discarding. It's now kept as `theme_json.nativeTheme` and narrowed per platform by `resolvePublicationTheme`:

| | Leaflet | PCKT | Offprint |
|---|---|---|---|
| Publications | 959 | 557 | 260 |
| Page surface | `pageBackground` over `backgroundColor` | — | `base100` |
| Authored dark palette | — | ✅ | ✅ (`colorScheme: dark`) |
| Scale steps | — | `surfaceHover` | `base200` / `base300` |
| Link colour | — | ✅ | — |
| Fonts | ✅ | ✅ | ✅ |
| Canvas image | ✅ | — | — |

Unknown `$type`s fall back to `basicTheme`, so a new publishing platform degrades rather than losing its colours.

Three findings worth calling out:

- **Leaflet's `basicTheme.background` mirrors its *canvas*, not its page.** For the 461 publications with `showPageBackground`, we were painting a background the reader never actually sees behind the text.
- **PCKT and Offprint ship real dark palettes** (625 publications). We were deriving dark mode by darkening their light background; now theirs is used verbatim.
- **Offprint's `base200`/`base300` and PCKT's `surfaceHover` are exactly the steps we approximate.** They're now pinned onto `component1`/`component2`/`border1`, with the steps between anchors interpolated.

## Palette generation fixes

- **A stated background is routed to the mode its own luminance matches.** A dark publication was painting a dark page for a reader in *light* mode, and the light ramp then derived its steps by darkening near-black — collapsing all eight neutral steps into ~10 RGB units, so borders vanished and cards were indistinguishable from the page.
- **The mode a publisher didn't author is synthesized by mirroring their colour through OKLCH** — hue preserved, lightness moved to the other end (calibrated against the app's own editorial backgrounds), chroma damped because the same chroma reads far more saturated at high lightness. A warm near-black page becomes warm cream rather than generic near-white.
- **Stated link colours keep their hue when they fail contrast.** Snapping to black would discard the distinction we adopted them for, and plenty of real link colours sit just under AA (`#0d9488` on white is ~3.9:1).

## Fonts

Each platform states fonts differently — Leaflet's self-describing `custom:<Family>:…` plus built-in keys, PCKT's squashed single `font`, Offprint's Google slugs. Rather than a per-platform table, keys are normalised (lowercase, alphanumerics only) and matched against the Google Fonts catalogue already fetched for the reading-typography picker. That resolves every Offprint slug, including ones a naive de-slug gets wrong (`dm-sans` → DM Sans, `jetbrains-mono` → JetBrains Mono).

Unresolved keys are deliberately left alone rather than guessed at: PCKT's `legible`/`sans` are generic slots, and `quattro`/`iawritermono` are iA Writer faces Google doesn't serve. The reader keeps their own typography in those cases.

## Code blocks

`pickCodeTheme` scores Shiki's 65 bundled themes against the publication's palette by perceptual ΔE in OKLab and uses the closest. Synthesising syntax colours from four values would mean inventing a whole colour system per publication, and algorithmic palettes read as noise beside hand-designed ones.

Background is a **gate** (ΔE ≤ 0.035), not just a weighted term — a code block is mostly background, so a theme whose surface disagrees with the page reads as a foreign panel however well its accent matches. Within the gate, character still tracks the accent: magenta → `dracula`, gold → `gruvbox-dark-hard`.

Scoring uses the *rendered* surface per scheme, not the stated background, which can belong to the other mode entirely.

## Canvas backgrounds

Leaflet publications (196) can carry a background image. The scope becomes the canvas — image fixed to the viewport — and the route's content floats above it in a squircle card with a themed border. Only in this mode; every card value is a CSS variable falling back to a no-op, so pages without a canvas are untouched.

The article's sticky reading chrome and the site footer stay *outside* the card (the footer gets its own opaque surface), since they're app furniture rather than the publication's page.

## Notes for review

- **Overlays** are re-pointed into the themed container with react-aria's `UNSAFE_PortalProvider`, so hover cards, menus and dialogs inherit the palette instead of portalling to `document.body` and reverting to app tokens.
- **New `linkColor` token** in the design system, defaulting to `primaryColor.text2` — body links previously conflated "this is a link" with "this is the brand accent". No visual change without a publication theme.
- **`0020_use_publication_theme`** adds one nullable column. It was `0019` before the rebase; regenerated rather than renamed so the snapshot reflects the merged schema. `drizzle-kit check` passes.
- **Backfill required.** `theme_json.nativeTheme` is only written by `upsertPublication`, so existing rows need a repo resync (or the publisher's next record update) before any of the native-theme work applies to them.
- Gated per-reader server-side too: `usePublicationThemeForRequest` resolves alongside `themeModeForRequest`, so a reader with the preference off keeps editorial code blocks.

Adapters and palette generation are unit-tested against real record payloads from all three platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
