### PR TITLE
Add "Show only mine" filter to feedback discussions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -453,6 +453,12 @@ Build each on hip-ui components + StyleX tokens (no raw HTML/inline styles).
       `/feedback/return?upvote=<id>` consumes it and creates the record. The
       card optimistically marks upvoted (+1) and reconciles on settle. Subject
       cid is re-resolved server-side at write time.
+- [x] **"Show only mine" feedback filter** — a toolbar toggle (next to the
+      show/hide implemented control) filters `/feedback` to the signed-in
+      reader's own discussions by matching `author.did` against the session DID,
+      so readers can quickly retrieve the bugs, feature requests, and questions
+      they've submitted. Signed-in only; empty state prompts them to submit
+      feedback when they have none.
 - [x] Global follow toggle reflects everywhere instantly (optimistic).
 - [x] Theme picker (light / dark / system) + editorial dark tokens + Shiki `standard-reader-dark`.
 - [x] Theme tokens / dark mode parity with prototype (remaining hardcoded surfaces).

--- a/src/locales/ar/messages.po
+++ b/src/locales/ar/messages.po
@@ -2372,6 +2372,10 @@ msgstr "لا يوجد أشخاص مطابقون."
 msgid "Empty list."
 msgstr "قائمة فارغة."
 
+#: src/routes/_layout.feedback.index.tsx
+msgid "Show only mine"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Preview mode"
 msgstr "وضع المعاينة"
@@ -2511,6 +2515,10 @@ msgstr "عرض المجموعة"
 #: src/components/reader/about-view.tsx
 msgid "Turn on in Settings"
 msgstr "فعّلها من الإعدادات"
+
+#: src/routes/_layout.feedback.index.tsx
+msgid "Share a bug, idea, or question to see it here."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler didn’t publish any label definitions."
@@ -3041,6 +3049,10 @@ msgstr ""
 msgid "Worth discovering"
 msgstr "يستحق الاستكشاف"
 
+#: src/routes/_layout.feedback.index.tsx
+msgid "You haven't submitted any feedback yet."
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 #: src/routes/_layout.collections.index.tsx
 msgid "Theme & fonts"
@@ -3252,6 +3264,10 @@ msgstr "ابحث في الملاحظات..."
 #: src/components/reader/page-reader-bar.tsx
 msgid "Follow along"
 msgstr "تابِع الجديد"
+
+#: src/routes/_layout.feedback.index.tsx
+msgid "Show all feedback"
+msgstr ""
 
 #: src/components/reader/add-publication-modal.tsx
 msgid "Couldn't resolve that handle."

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -2372,6 +2372,10 @@ msgstr "Keine passenden Personen."
 msgid "Empty list."
 msgstr "Leere Liste."
 
+#: src/routes/_layout.feedback.index.tsx
+msgid "Show only mine"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Preview mode"
 msgstr "Vorschaumodus"
@@ -2511,6 +2515,10 @@ msgstr "Sammlung ansehen"
 #: src/components/reader/about-view.tsx
 msgid "Turn on in Settings"
 msgstr "In den Einstellungen aktivieren"
+
+#: src/routes/_layout.feedback.index.tsx
+msgid "Share a bug, idea, or question to see it here."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler didn’t publish any label definitions."
@@ -3041,6 +3049,10 @@ msgstr ""
 msgid "Worth discovering"
 msgstr "Entdeckenswert"
 
+#: src/routes/_layout.feedback.index.tsx
+msgid "You haven't submitted any feedback yet."
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 #: src/routes/_layout.collections.index.tsx
 msgid "Theme & fonts"
@@ -3252,6 +3264,10 @@ msgstr "Feedback durchsuchen …"
 #: src/components/reader/page-reader-bar.tsx
 msgid "Follow along"
 msgstr "Mitlesen"
+
+#: src/routes/_layout.feedback.index.tsx
+msgid "Show all feedback"
+msgstr ""
 
 #: src/components/reader/add-publication-modal.tsx
 msgid "Couldn't resolve that handle."

--- a/src/locales/en-XA/messages.po
+++ b/src/locales/en-XA/messages.po
@@ -2372,6 +2372,10 @@ msgstr ""
 msgid "Empty list."
 msgstr ""
 
+#: src/routes/_layout.feedback.index.tsx
+msgid "Show only mine"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Preview mode"
 msgstr ""
@@ -2510,6 +2514,10 @@ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Turn on in Settings"
+msgstr ""
+
+#: src/routes/_layout.feedback.index.tsx
+msgid "Share a bug, idea, or question to see it here."
 msgstr ""
 
 #: src/components/labeler-detail-view.tsx
@@ -3041,6 +3049,10 @@ msgstr ""
 msgid "Worth discovering"
 msgstr ""
 
+#: src/routes/_layout.feedback.index.tsx
+msgid "You haven't submitted any feedback yet."
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 #: src/routes/_layout.collections.index.tsx
 msgid "Theme & fonts"
@@ -3251,6 +3263,10 @@ msgstr ""
 
 #: src/components/reader/page-reader-bar.tsx
 msgid "Follow along"
+msgstr ""
+
+#: src/routes/_layout.feedback.index.tsx
+msgid "Show all feedback"
 msgstr ""
 
 #: src/components/reader/add-publication-modal.tsx

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -2372,6 +2372,10 @@ msgstr "No matching people."
 msgid "Empty list."
 msgstr "Empty list."
 
+#: src/routes/_layout.feedback.index.tsx
+msgid "Show only mine"
+msgstr "Show only mine"
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Preview mode"
 msgstr "Preview mode"
@@ -2511,6 +2515,10 @@ msgstr "View collection"
 #: src/components/reader/about-view.tsx
 msgid "Turn on in Settings"
 msgstr "Turn on in Settings"
+
+#: src/routes/_layout.feedback.index.tsx
+msgid "Share a bug, idea, or question to see it here."
+msgstr "Share a bug, idea, or question to see it here."
 
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler didn’t publish any label definitions."
@@ -3041,6 +3049,10 @@ msgstr "Changes to these terms"
 msgid "Worth discovering"
 msgstr "Worth discovering"
 
+#: src/routes/_layout.feedback.index.tsx
+msgid "You haven't submitted any feedback yet."
+msgstr "You haven't submitted any feedback yet."
+
 #: src/components/reader/collection-theme-editor.tsx
 #: src/routes/_layout.collections.index.tsx
 msgid "Theme & fonts"
@@ -3252,6 +3264,10 @@ msgstr "Search feedback..."
 #: src/components/reader/page-reader-bar.tsx
 msgid "Follow along"
 msgstr "Follow along"
+
+#: src/routes/_layout.feedback.index.tsx
+msgid "Show all feedback"
+msgstr "Show all feedback"
 
 #: src/components/reader/add-publication-modal.tsx
 msgid "Couldn't resolve that handle."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -2372,6 +2372,10 @@ msgstr "No hay personas coincidentes."
 msgid "Empty list."
 msgstr "Lista vacía."
 
+#: src/routes/_layout.feedback.index.tsx
+msgid "Show only mine"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Preview mode"
 msgstr "Modo de vista previa"
@@ -2511,6 +2515,10 @@ msgstr "Ver la colección"
 #: src/components/reader/about-view.tsx
 msgid "Turn on in Settings"
 msgstr "Activar en Configuración"
+
+#: src/routes/_layout.feedback.index.tsx
+msgid "Share a bug, idea, or question to see it here."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler didn’t publish any label definitions."
@@ -3041,6 +3049,10 @@ msgstr ""
 msgid "Worth discovering"
 msgstr "Vale la pena descubrir"
 
+#: src/routes/_layout.feedback.index.tsx
+msgid "You haven't submitted any feedback yet."
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 #: src/routes/_layout.collections.index.tsx
 msgid "Theme & fonts"
@@ -3252,6 +3264,10 @@ msgstr "Buscar comentarios..."
 #: src/components/reader/page-reader-bar.tsx
 msgid "Follow along"
 msgstr "Seguir la lectura"
+
+#: src/routes/_layout.feedback.index.tsx
+msgid "Show all feedback"
+msgstr ""
 
 #: src/components/reader/add-publication-modal.tsx
 msgid "Couldn't resolve that handle."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -2372,6 +2372,10 @@ msgstr "Aucune personne correspondante."
 msgid "Empty list."
 msgstr "Liste vide."
 
+#: src/routes/_layout.feedback.index.tsx
+msgid "Show only mine"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Preview mode"
 msgstr "Mode aperçu"
@@ -2511,6 +2515,10 @@ msgstr "Voir la collection"
 #: src/components/reader/about-view.tsx
 msgid "Turn on in Settings"
 msgstr "Activer dans les réglages"
+
+#: src/routes/_layout.feedback.index.tsx
+msgid "Share a bug, idea, or question to see it here."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler didn’t publish any label definitions."
@@ -3041,6 +3049,10 @@ msgstr ""
 msgid "Worth discovering"
 msgstr "À découvrir"
 
+#: src/routes/_layout.feedback.index.tsx
+msgid "You haven't submitted any feedback yet."
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 #: src/routes/_layout.collections.index.tsx
 msgid "Theme & fonts"
@@ -3252,6 +3264,10 @@ msgstr "Rechercher dans les retours..."
 #: src/components/reader/page-reader-bar.tsx
 msgid "Follow along"
 msgstr "Suivre le fil"
+
+#: src/routes/_layout.feedback.index.tsx
+msgid "Show all feedback"
+msgstr ""
 
 #: src/components/reader/add-publication-modal.tsx
 msgid "Couldn't resolve that handle."

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -2372,6 +2372,10 @@ msgstr "一致するユーザーはいません。"
 msgid "Empty list."
 msgstr "リストは空です。"
 
+#: src/routes/_layout.feedback.index.tsx
+msgid "Show only mine"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Preview mode"
 msgstr "プレビューモード"
@@ -2511,6 +2515,10 @@ msgstr "コレクションを表示"
 #: src/components/reader/about-view.tsx
 msgid "Turn on in Settings"
 msgstr "設定でオンにする"
+
+#: src/routes/_layout.feedback.index.tsx
+msgid "Share a bug, idea, or question to see it here."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler didn’t publish any label definitions."
@@ -3041,6 +3049,10 @@ msgstr ""
 msgid "Worth discovering"
 msgstr "見つける価値のあるもの"
 
+#: src/routes/_layout.feedback.index.tsx
+msgid "You haven't submitted any feedback yet."
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 #: src/routes/_layout.collections.index.tsx
 msgid "Theme & fonts"
@@ -3252,6 +3264,10 @@ msgstr "フィードバックを検索..."
 #: src/components/reader/page-reader-bar.tsx
 msgid "Follow along"
 msgstr "追って読む"
+
+#: src/routes/_layout.feedback.index.tsx
+msgid "Show all feedback"
+msgstr ""
 
 #: src/components/reader/add-publication-modal.tsx
 msgid "Couldn't resolve that handle."

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -2372,6 +2372,10 @@ msgstr "일치하는 사람이 없습니다."
 msgid "Empty list."
 msgstr "빈 목록입니다."
 
+#: src/routes/_layout.feedback.index.tsx
+msgid "Show only mine"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Preview mode"
 msgstr "미리보기 모드"
@@ -2511,6 +2515,10 @@ msgstr "컬렉션 보기"
 #: src/components/reader/about-view.tsx
 msgid "Turn on in Settings"
 msgstr "설정에서 켜기"
+
+#: src/routes/_layout.feedback.index.tsx
+msgid "Share a bug, idea, or question to see it here."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler didn’t publish any label definitions."
@@ -3041,6 +3049,10 @@ msgstr ""
 msgid "Worth discovering"
 msgstr "발견할 만한 글"
 
+#: src/routes/_layout.feedback.index.tsx
+msgid "You haven't submitted any feedback yet."
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 #: src/routes/_layout.collections.index.tsx
 msgid "Theme & fonts"
@@ -3252,6 +3264,10 @@ msgstr "피드백 검색..."
 #: src/components/reader/page-reader-bar.tsx
 msgid "Follow along"
 msgstr "함께 보기"
+
+#: src/routes/_layout.feedback.index.tsx
+msgid "Show all feedback"
+msgstr ""
 
 #: src/components/reader/add-publication-modal.tsx
 msgid "Couldn't resolve that handle."

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -2372,6 +2372,10 @@ msgstr "Sem pessoas correspondentes."
 msgid "Empty list."
 msgstr "Lista vazia."
 
+#: src/routes/_layout.feedback.index.tsx
+msgid "Show only mine"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Preview mode"
 msgstr "Modo de pré-visualização"
@@ -2511,6 +2515,10 @@ msgstr "Ver coleção"
 #: src/components/reader/about-view.tsx
 msgid "Turn on in Settings"
 msgstr "Ativar nas Configurações"
+
+#: src/routes/_layout.feedback.index.tsx
+msgid "Share a bug, idea, or question to see it here."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler didn’t publish any label definitions."
@@ -3041,6 +3049,10 @@ msgstr "Alterações a estes termos"
 msgid "Worth discovering"
 msgstr "Vale a pena descobrir"
 
+#: src/routes/_layout.feedback.index.tsx
+msgid "You haven't submitted any feedback yet."
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 #: src/routes/_layout.collections.index.tsx
 msgid "Theme & fonts"
@@ -3252,6 +3264,10 @@ msgstr "Pesquisar feedback..."
 #: src/components/reader/page-reader-bar.tsx
 msgid "Follow along"
 msgstr "Acompanhar"
+
+#: src/routes/_layout.feedback.index.tsx
+msgid "Show all feedback"
+msgstr ""
 
 #: src/components/reader/add-publication-modal.tsx
 msgid "Couldn't resolve that handle."

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -2372,6 +2372,10 @@ msgstr "没有匹配的人。"
 msgid "Empty list."
 msgstr "空列表。"
 
+#: src/routes/_layout.feedback.index.tsx
+msgid "Show only mine"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Preview mode"
 msgstr "预览模式"
@@ -2511,6 +2515,10 @@ msgstr "查看合集"
 #: src/components/reader/about-view.tsx
 msgid "Turn on in Settings"
 msgstr "在设置中开启"
+
+#: src/routes/_layout.feedback.index.tsx
+msgid "Share a bug, idea, or question to see it here."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler didn’t publish any label definitions."
@@ -3041,6 +3049,10 @@ msgstr ""
 msgid "Worth discovering"
 msgstr "值得发现"
 
+#: src/routes/_layout.feedback.index.tsx
+msgid "You haven't submitted any feedback yet."
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 #: src/routes/_layout.collections.index.tsx
 msgid "Theme & fonts"
@@ -3252,6 +3264,10 @@ msgstr "搜索反馈……"
 #: src/components/reader/page-reader-bar.tsx
 msgid "Follow along"
 msgstr "跟随阅读"
+
+#: src/routes/_layout.feedback.index.tsx
+msgid "Show all feedback"
+msgstr ""
 
 #: src/components/reader/add-publication-modal.tsx
 msgid "Couldn't resolve that handle."

--- a/src/routes/_layout.feedback.index.tsx
+++ b/src/routes/_layout.feedback.index.tsx
@@ -22,6 +22,7 @@ import {
   HelpCircle,
   Lightbulb,
   MessageSquarePlus,
+  User,
 } from "lucide-react";
 import { Suspense, useEffect, useMemo, useState } from "react";
 
@@ -797,7 +798,13 @@ const TAG_FILTER_OPTIONS: Array<{ id: TagFilter; label: MessageDescriptor }> = [
  * unconditionally instead of waiting on this data (see the route's
  * non-blocking loader).
  */
-function FeedbackDiscussions({ signedIn }: { signedIn: boolean }) {
+function FeedbackDiscussions({
+  signedIn,
+  viewerDid,
+}: {
+  signedIn: boolean;
+  viewerDid: string | null;
+}) {
   const { t, i18n } = useLingui();
   const [tagFilter, setTagFilter] = useState<TagFilter>("all");
   const [sortMode, setSortMode] = useState<SortMode>("top");
@@ -805,6 +812,10 @@ function FeedbackDiscussions({ signedIn }: { signedIn: boolean }) {
   // Hide discussions the space owner has marked "implemented" by default so the
   // list surfaces open feedback first; the toolbar toggle reveals them.
   const [hideImplemented, setHideImplemented] = useState(true);
+  // Filter to just the viewer's own feedback so they can quickly find the bugs,
+  // feature requests, and questions they've submitted. Only offered to signed-in
+  // readers (a guest has no `viewerDid`, so nothing to match against).
+  const [onlyMine, setOnlyMine] = useState(false);
   const queryClient = useQueryClient();
   const { data } = useSuspenseQuery(
     userinputApi.getFeedbackDiscussionsQueryOptions({ limit: 50 }),
@@ -934,6 +945,9 @@ function FeedbackDiscussions({ signedIn }: { signedIn: boolean }) {
   if (tagFilter !== "all") {
     discussions = discussions.filter((d) => tagFor(d) === tagFilter);
   }
+  if (onlyMine && viewerDid) {
+    discussions = discussions.filter((d) => d.author.did === viewerDid);
+  }
   if (hideImplemented) {
     discussions = discussions.filter((d) => d.status !== "implemented");
   }
@@ -989,11 +1003,23 @@ function FeedbackDiscussions({ signedIn }: { signedIn: boolean }) {
       </Message>
     );
   } else if (discussions.length === 0) {
-    body = (
-      <Message>
-        <Trans>No feedback matches your filters.</Trans>
-      </Message>
-    );
+    body =
+      onlyMine && tagFilter === "all" && !search ? (
+        <Message>
+          <Flex direction="column" gap="md">
+            <span>
+              <Trans>You haven&apos;t submitted any feedback yet.</Trans>
+            </span>
+            <span {...stylex.props(styles.messageEm)}>
+              <Trans>Share a bug, idea, or question to see it here.</Trans>
+            </span>
+          </Flex>
+        </Message>
+      ) : (
+        <Message>
+          <Trans>No feedback matches your filters.</Trans>
+        </Message>
+      );
   } else if (showGroups) {
     body = (
       <div {...stylex.props(styles.list)}>
@@ -1101,6 +1127,18 @@ function FeedbackDiscussions({ signedIn }: { signedIn: boolean }) {
               <Trans>New</Trans>
             </SegmentedControlItem>
           </SegmentedControl>
+          {signedIn ? (
+            <IconButton
+              size="lg"
+              variant={onlyMine ? "primary" : "secondary"}
+              label={onlyMine ? t`Show all feedback` : t`Show only mine`}
+              style={styles.toolbarToggle}
+              aria-pressed={onlyMine}
+              onPress={() => setOnlyMine((v) => !v)}
+            >
+              <User size={16} strokeWidth={2} />
+            </IconButton>
+          ) : null}
           <IconButton
             size="lg"
             variant="secondary"
@@ -1126,6 +1164,7 @@ function FeedbackPage() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const { data: session } = useQuery(user.getSessionQueryOptions);
   const signedIn = Boolean(session?.user);
+  const viewerDid = session?.user?.did ?? null;
 
   return (
     <ReaderContent>
@@ -1167,7 +1206,7 @@ function FeedbackPage() {
         </header>
 
         <Suspense fallback={<DiscussionListSkeleton />}>
-          <FeedbackDiscussions signedIn={signedIn} />
+          <FeedbackDiscussions signedIn={signedIn} viewerDid={viewerDid} />
         </Suspense>
       </div>
 


### PR DESCRIPTION
## Summary

Adds a toolbar toggle to the feedback page that filters discussions to only those submitted by the signed-in reader, allowing them to quickly find their own bugs, feature requests, and questions.

## Changes

- **New filter state:** Added `onlyMine` state to `FeedbackDiscussions` component to track the filter toggle.
- **Viewer DID prop:** Updated `FeedbackDiscussions` to accept `viewerDid` (the signed-in user's DID) and pass it from the parent `FeedbackPage` component via the session data.
- **Filter logic:** Implemented filtering by matching `d.author.did` against `viewerDid` when `onlyMine` is active.
- **Toolbar button:** Added an `IconButton` with a `User` icon (from lucide-react) next to the sort controls; only visible to signed-in readers. Button toggles between "Show only mine" and "Show all feedback" labels and visual states.
- **Empty state messaging:** Updated the empty state to show a contextual message ("You haven't submitted any feedback yet") when the user has no feedback and the "only mine" filter is active, prompting them to submit feedback.
- **TODO.md:** Marked the "Show only mine" feedback filter task as complete.

## Implementation Details

- The filter respects other active filters (tag, search, implemented status) and only applies when `onlyMine && viewerDid` are both truthy.
- The button is conditionally rendered only for signed-in users (`signedIn` prop check).
- The empty state message is specific to the "only mine" view with no other filters applied, preserving the generic "No feedback matches your filters" message for other filter combinations.

https://claude.ai/code/session_01Qkvji5An13s8rRNBjAN5Yz