### PR TITLE
Handle Skyreader linkblogs in publishing platform detection

### DIFF
--- a/src/lib/publishing-platform.test.ts
+++ b/src/lib/publishing-platform.test.ts
@@ -58,6 +58,34 @@ describe("publishingPlatform", () => {
     ).toBe("leaflet");
   });
 
+  it("does not attribute Skyreader linkblogs to Leaflet", () => {
+    // Linkblogs are `site.standard.document` records whose body reuses Leaflet's
+    // content lexicon, so the content format claims Leaflet; the skyreader.app
+    // host must override it. See the example in the issue.
+    expect(
+      publishingPlatform({
+        contentFormat: "pub.leaflet.content",
+        canonicalUrl:
+          "https://linkblogs.skyreader.app/did:plc:fip3nyk6tjo3senpq4ei2cxw/mrq9kxj2ifmrino54w",
+      }),
+    ).toBe(null);
+    expect(
+      publishingPlatform({
+        contentFormat: "pub.leaflet.document",
+        canonicalUrl: "https://skyreader.app/some-post",
+      }),
+    ).toBe(null);
+  });
+
+  it("does not match a host that merely ends with skyreader.app", () => {
+    expect(
+      publishingPlatform({
+        contentFormat: "pub.leaflet.content",
+        canonicalUrl: "https://notskyreader.app/post",
+      }),
+    ).toBe("leaflet");
+  });
+
   it("does not treat offprint.net as Offprint", () => {
     // offprint.net redirects to offprint.cafe, an unrelated product.
     expect(

--- a/src/lib/publishing-platform.ts
+++ b/src/lib/publishing-platform.ts
@@ -58,9 +58,35 @@ function platformFromUrl(url: string): PublishingPlatform | null {
 }
 
 /**
+ * Skyreader publishes "linkblogs" — curated reshares of other people's posts —
+ * as `site.standard.document` records whose body reuses Leaflet's
+ * `pub.leaflet.content` lexicon. That makes `contentFormat` alone report them as
+ * Leaflet, so a linkblog would otherwise get a "Read on Leaflet" button linking
+ * to a `skyreader.app` URL — the platform mismatch behind this being a bug.
+ *
+ * Linkblogs always live on `skyreader.app` (each reader's on
+ * `linkblogs.skyreader.app`), never on Leaflet, so the canonical host is a
+ * reliable veto: a `skyreader.app` article is not one of the three platforms we
+ * attribute, whatever its content format claims.
+ */
+const SKYREADER_HOST = "skyreader.app";
+
+function isSkyreaderUrl(url: string): boolean {
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  return host === SKYREADER_HOST || host.endsWith(`.${SKYREADER_HOST}`);
+}
+
+/**
  * Which publishing platform an article came from, or null when it's from
  * somewhere else (or we can't tell). `contentFormat` wins over the URL because
- * custom domains are common on all three platforms.
+ * custom domains are common on all three platforms — the one exception is a
+ * Skyreader linkblog, whose host vetoes the reused Leaflet content format (see
+ * `isSkyreaderUrl`).
  */
 export function publishingPlatform({
   contentFormat,
@@ -69,6 +95,9 @@ export function publishingPlatform({
   contentFormat?: string | null;
   canonicalUrl?: string | null;
 }): PublishingPlatform | null {
+  // A Skyreader linkblog reuses Leaflet's content lexicon, so its host must veto
+  // the content-format check below before it reports the article as Leaflet.
+  if (canonicalUrl && isSkyreaderUrl(canonicalUrl)) return null;
   if (contentFormat) {
     const fromFormat = platformFromContentFormat(contentFormat);
     if (fromFormat) return fromFormat;


### PR DESCRIPTION
## Summary

Fixes a platform attribution bug where Skyreader linkblogs were incorrectly attributed to Leaflet. Skyreader publishes linkblogs as `site.standard.document` records that reuse Leaflet's `pub.leaflet.content` lexicon, causing the content format check to misidentify them as Leaflet articles. The canonical host is now used as a veto to correctly identify Skyreader URLs.

## Changes

- **Added `isSkyreaderUrl()` helper** — detects Skyreader URLs by checking if the hostname matches `skyreader.app` or a subdomain (e.g., `linkblogs.skyreader.app`)
- **Added `SKYREADER_HOST` constant** — centralizes the Skyreader domain for consistency
- **Updated `publishingPlatform()` logic** — checks the canonical URL against Skyreader before evaluating content format, ensuring linkblogs return `null` instead of `"leaflet"`
- **Updated JSDoc** — clarifies that the canonical host is an exception to the "content format wins" rule
- **Added test coverage** — verifies linkblogs are not attributed to Leaflet, and that hosts merely ending with `skyreader.app` don't trigger the veto

## Implementation Details

The fix prioritizes the canonical URL check for Skyreader before the content format evaluation. This is necessary because linkblogs legitimately reuse Leaflet's content lexicon (by design), so the content format alone cannot distinguish them. The hostname check is reliable because linkblogs always live on `skyreader.app` (never on Leaflet), making it a definitive signal.

https://claude.ai/code/session_01PqxY3mPair4jDQcCD5rj6Q