### PR TITLE
Add app-wide accent color preference (presets + custom)

### DIFF
--- a/APP_VISION.md
+++ b/APP_VISION.md
@@ -187,6 +187,17 @@ Sections, top to bottom:
   bottom of the page. The sidebar and mobile bar stay Standard Reader chrome.
   Signed-in only (`user.use_publication_theme`, `null` = off); publications with
   no colors of their own always keep the editorial theme.
+- **Accent color (preference):** settings-page control (Appearance) that repaints the
+  app's own accent token — not a publication's — from 6 curated presets (camel, the
+  existing default; moss; teal; slate; plum; rust) or any custom color, via the
+  design system's color picker. A preset is just a curated seed color run through the
+  same light+dark accent-scale derivation built for publication theming
+  (`buildLightAccentScale` / `buildDarkAccentScale`), so no per-option token set is
+  hand-tuned. A new `appAccentPrimary` StyleX theme reads `--app-accent-*` CSS vars set
+  via inline style, mirroring how `publicationPrimary` reads `--pub-accent-*`; the root
+  layout swaps it in for `editorialPrimary` only once a preference is set, so a reader
+  who never opens the setting sees the exact hand-tuned default. Signed-in only
+  (`user.accent_color`, `null` = the default camel accent).
 - **Publisher-native themes.** `site.standard.theme.basic` is the interop
   baseline (four opaque colors, light only), but records also carry the
   publishing platform's own theme under `theme`, discriminated by `$type`.

--- a/TODO.md
+++ b/TODO.md
@@ -477,6 +477,21 @@ Build each on hip-ui components + StyleX tokens (no raw HTML/inline styles).
       Theme colors ride along on the existing header query (`selectPublicationHeader`) and on
       `article.collectionTheme` — no extra round trips (`#/lib/publication-theme-preference`,
       `usePublicationThemePreference`).
+- [x] **App-wide accent color preference** — Settings → Appearance row lets a signed-in reader
+      repaint the app's own accent token (not a publication's) from 6 curated presets (camel —
+      the existing default, moss, teal, slate, plum, rust) or any custom color, via the
+      design system's `ColorPicker` + `DefaultColorEditor` preset swatches. Reuses the
+      per-publication accent-scale derivation (`buildLightAccentScale` / `buildDarkAccentScale`,
+      exported from `publication-theme-scale.ts`) instead of hand-tuning a token set per option —
+      a preset is just a curated seed color run through the same generator
+      (`#/lib/accent-color-scale`, `#/lib/accent-color-presets`). A new `appAccentPrimary` StyleX
+      theme (`#/components/reader/theme`) reads `--app-accent-*` CSS vars, mirroring how
+      `publicationPrimary` reads `--pub-accent-*`; the root layout swaps it in for
+      `editorialPrimary` only when a preference is set, so a reader who never opens the setting
+      sees the exact hand-tuned default (unchanged pixels, including its P3 gamut variants).
+      Signed-in only, no cookie mirror: `user.accent_color` (`drizzle/0021_greedy_venom`,
+      preset id or `#rrggbb`), served through `getShellBootstrap`
+      (`#/lib/accent-color-preference`, `useAccentColorPreference`).
 - [x] **Publisher-native themes beyond `basicTheme`** — ingest now keeps the platform's own
       theme block as `theme_json.nativeTheme`, and `resolvePublicationTheme`
       (`#/lib/publication-theme-source`, unit-tested against real Leaflet/PCKT/Offprint records)

--- a/drizzle/0021_greedy_venom.sql
+++ b/drizzle/0021_greedy_venom.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "accent_color" text;

--- a/drizzle/meta/0021_snapshot.json
+++ b/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,3833 @@
+{
+  "id": "8e26bc62-0a64-4b7f-9ee5-11b35f675a9e",
+  "prevId": "4c3052f9-39ed-4493-8399-ceb2c024e14f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_mode": {
+          "name": "theme_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale_hint_seen": {
+          "name": "locale_hint_seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reader_voice": {
+          "name": "reader_voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_links_externally": {
+          "name": "open_links_externally",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_collections_in_magazine": {
+          "name": "open_collections_in_magazine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reading_typography": {
+          "name": "reading_typography",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_reading_history": {
+          "name": "track_reading_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count_old_posts_as_unread": {
+          "name": "count_old_posts_as_unread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_publication_theme": {
+          "name": "use_publication_theme",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accent_color": {
+          "name": "accent_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_scope": {
+          "name": "home_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_hidden_tabs": {
+          "name": "profile_hidden_tabs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_show_likes": {
+          "name": "profile_show_likes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_authoring_enabled": {
+          "name": "collections_authoring_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userinput_feedback_enabled": {
+          "name": "userinput_feedback_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "margin_save_enabled": {
+          "name": "margin_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semble_save_enabled": {
+          "name": "semble_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "atstore_review_prompt_dismissed": {
+          "name": "atstore_review_prompt_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_enabled": {
+          "name": "weekly_digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_subscriptions": {
+          "name": "weekly_digest_section_subscriptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_network": {
+          "name": "weekly_digest_section_network",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_saved": {
+          "name": "weekly_digest_section_saved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_recommendations": {
+          "name": "weekly_digest_section_recommendations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_last_sent_at": {
+          "name": "weekly_digest_last_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_welcome_sent_at": {
+          "name": "weekly_digest_welcome_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_did_unique": {
+          "name": "user_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "did"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pds": {
+          "name": "pds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_url": {
+          "name": "banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_uri": {
+          "name": "bsky_profile_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_cid": {
+          "name": "bsky_profile_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_fetched_at": {
+          "name": "profile_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_handle_idx": {
+          "name": "profiles_handle_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_handle_trgm_idx": {
+          "name": "profiles_handle_trgm_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "profiles_display_name_trgm_idx": {
+          "name": "profiles_display_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publications": {
+      "name": "publications",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_cid": {
+          "name": "icon_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_mime": {
+          "name": "icon_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent": {
+          "name": "theme_accent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_background": {
+          "name": "theme_background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_foreground": {
+          "name": "theme_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent_foreground": {
+          "name": "theme_accent_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_json": {
+          "name": "theme_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_in_discover": {
+          "name": "show_in_discover",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "collections_publication": {
+          "name": "collections_publication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_checked_at": {
+          "name": "verification_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(name, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(topic, '')), 'B')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publications_did_idx": {
+          "name": "publications_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_name_idx": {
+          "name": "publications_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_discover_idx": {
+          "name": "publications_discover_idx",
+          "columns": [
+            {
+              "expression": "show_in_discover",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_topic_idx": {
+          "name": "publications_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_url_idx": {
+          "name": "publications_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_search_idx": {
+          "name": "publications_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_contributors": {
+      "name": "document_contributors",
+      "schema": "",
+      "columns": {
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "document_contributors_did_idx": {
+          "name": "document_contributors_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_contributors_document_uri_documents_uri_fk": {
+          "name": "document_contributors_document_uri_documents_uri_fk",
+          "tableFrom": "document_contributors",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_contributors_document_uri_did_pk": {
+          "name": "document_contributors_document_uri_did_pk",
+          "columns": [
+            "document_uri",
+            "did"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_uri": {
+          "name": "site_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_json": {
+          "name": "collection_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_renderable_body": {
+          "name": "has_renderable_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cover_image_cid": {
+          "name": "cover_image_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_mime": {
+          "name": "cover_image_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backlink_count": {
+          "name": "backlink_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_count_prev": {
+          "name": "backlink_count_prev",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_synced_at": {
+          "name": "backlink_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_recomputed_at": {
+          "name": "trending_recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_recommender_count": {
+          "name": "distinct_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bsky_post_uri": {
+          "name": "bsky_post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_post_cid": {
+          "name": "bsky_post_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_updated_at": {
+          "name": "record_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(title, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(immutable_array_to_string(tags), '')), 'B') || setweight(to_tsvector('english', coalesce(text_content, '')), 'C')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documents_did_idx": {
+          "name": "documents_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_did_published_idx": {
+          "name": "documents_did_published_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"published_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_publication_published_idx": {
+          "name": "documents_publication_published_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_published_idx": {
+          "name": "documents_published_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_featured_idx": {
+          "name": "documents_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_site_idx": {
+          "name": "documents_site_idx",
+          "columns": [
+            {
+              "expression": "site_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_search_idx": {
+          "name": "documents_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "documents_trending_idx": {
+          "name": "documents_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_idx": {
+          "name": "documents_canonical_url_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_trgm_idx": {
+          "name": "documents_canonical_url_trgm_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommends": {
+      "name": "recommends",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommender_did": {
+          "name": "recommender_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recommends_document_idx": {
+          "name": "recommends_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_recommender_idx": {
+          "name": "recommends_recommender_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_edge_idx": {
+          "name": "recommends_edge_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_doc_recommender_created_idx": {
+          "name": "recommends_doc_recommender_created_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recommends\".\"deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_did": {
+          "name": "publication_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_publication_idx": {
+          "name": "subscriptions_publication_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_subscriber_idx": {
+          "name": "subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_edge_idx": {
+          "name": "subscriptions_edge_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follower_did": {
+          "name": "follower_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excluded_publications": {
+          "name": "excluded_publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_subject_idx": {
+          "name": "user_follows_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_edge_idx": {
+          "name": "user_follows_edge_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_owner_idx": {
+          "name": "bookmarks_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_document_idx": {
+          "name": "bookmarks_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_edge_idx": {
+          "name": "bookmarks_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reads": {
+      "name": "reads",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reads_owner_idx": {
+          "name": "reads_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_document_idx": {
+          "name": "reads_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_edge_idx": {
+          "name": "reads_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidebar_prefs": {
+      "name": "sidebar_prefs",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_order": {
+          "name": "list_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customize_nav": {
+          "name": "customize_nav",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_nav": {
+          "name": "hidden_nav",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_saves": {
+      "name": "list_saves",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saver_did": {
+          "name": "saver_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_owner_did": {
+          "name": "list_owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "list_saves_saver_idx": {
+          "name": "list_saves_saver_idx",
+          "columns": [
+            {
+              "expression": "saver_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "list_saves_list_uri_idx": {
+          "name": "list_saves_list_uri_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lists": {
+      "name": "lists",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publications": {
+          "name": "publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "users": {
+          "name": "users",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lists_owner_idx": {
+          "name": "lists_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rkey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_corecommends": {
+      "name": "publication_corecommends",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_recommender_count": {
+          "name": "co_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_corecomm_rank_idx": {
+          "name": "publication_corecomm_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_corecommends_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_corecommends_related_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_corecommends_publication_uri_related_publication_uri_pk": {
+          "name": "publication_corecommends_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_cosubscriptions": {
+      "name": "publication_cosubscriptions",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_subscriber_count": {
+          "name": "co_subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_cosub_rank_idx": {
+          "name": "publication_cosub_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_cosubscriptions_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_cosubscriptions_related_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_cosubscriptions_publication_uri_related_publication_uri_pk": {
+          "name": "publication_cosubscriptions_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_stats": {
+      "name": "publication_stats",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommend_count": {
+          "name": "recommend_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_document_at": {
+          "name": "last_document_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documents_7d": {
+          "name": "documents_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_7d": {
+          "name": "subscribers_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_7d": {
+          "name": "recommends_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "documents_prev_7d": {
+          "name": "documents_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_prev_7d": {
+          "name": "subscribers_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_prev_7d": {
+          "name": "recommends_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlinks_7d": {
+          "name": "backlinks_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_velocity": {
+          "name": "trending_velocity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_window_start": {
+          "name": "trending_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_stats_subscribers_idx": {
+          "name": "publication_stats_subscribers_idx",
+          "columns": [
+            {
+              "expression": "subscriber_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_active_idx": {
+          "name": "publication_stats_active_idx",
+          "columns": [
+            {
+              "expression": "last_document_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_trending_idx": {
+          "name": "publication_stats_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_stats_publication_uri_publications_uri_fk": {
+          "name": "publication_stats_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_stats",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discover_topic_counts": {
+      "name": "discover_topic_counts",
+      "schema": "",
+      "columns": {
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discover_topic_counts_count_idx": {
+          "name": "discover_topic_counts_count_idx",
+          "columns": [
+            {
+              "expression": "publication_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discover_topic_counts_topic_trgm_idx": {
+          "name": "discover_topic_counts_topic_trgm_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_dead_letter": {
+      "name": "ingest_dead_letter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retries": {
+          "name": "retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingest_dead_letter_collection_idx": {
+          "name": "ingest_dead_letter_collection_idx",
+          "columns": [
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_state": {
+      "name": "ingest_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_processed": {
+          "name": "events_processed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_repos": {
+      "name": "tracked_repos",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_to_tap_at": {
+          "name": "added_to_tap_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_state": {
+          "name": "backfill_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_seen_rev": {
+          "name": "last_seen_rev",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_fail_count": {
+          "name": "reconcile_fail_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconcile_retry_after": {
+          "name": "reconcile_retry_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tracked_repos_state_idx": {
+          "name": "tracked_repos_state_idx",
+          "columns": [
+            {
+              "expression": "backfill_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_labels": {
+      "name": "document_labels",
+      "schema": "",
+      "columns": {
+        "src": {
+          "name": "src",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "val": {
+          "name": "val",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cts": {
+          "name": "cts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_labels_uri_idx": {
+          "name": "document_labels_uri_idx",
+          "columns": [
+            {
+              "expression": "uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_labels_src_idx": {
+          "name": "document_labels_src_idx",
+          "columns": [
+            {
+              "expression": "src",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "document_labels_src_uri_val_pk": {
+          "name": "document_labels_src_uri_val_pk",
+          "columns": [
+            "src",
+            "uri",
+            "val"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_sync_state": {
+      "name": "label_sync_state",
+      "schema": "",
+      "columns": {
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_services": {
+      "name": "labeler_services",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_endpoint": {
+          "name": "service_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_value_definitions": {
+          "name": "label_value_definitions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_services_labeler_idx": {
+          "name": "labeler_services_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_subscriptions": {
+      "name": "labeler_subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefs": {
+          "name": "prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_subscriptions_subscriber_idx": {
+          "name": "labeler_subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labeler_subscriptions_labeler_idx": {
+          "name": "labeler_subscriptions_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_shares": {
+      "name": "quote_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_text": {
+          "name": "quote_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quote_shares_document_uri_idx": {
+          "name": "quote_shares_document_uri_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_draft": {
+      "name": "feedback_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feedback_draft_user_idx": {
+          "name": "feedback_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_draft_expires_idx": {
+          "name": "feedback_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_draft_user_id_user_id_fk": {
+          "name": "feedback_draft_user_id_user_id_fk",
+          "tableFrom": "feedback_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upvote_draft": {
+      "name": "upvote_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "upvote_draft_user_idx": {
+          "name": "upvote_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upvote_draft_expires_idx": {
+          "name": "upvote_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upvote_draft_user_id_user_id_fk": {
+          "name": "upvote_draft_user_id_user_id_fk",
+          "tableFrom": "upvote_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.save_draft": {
+      "name": "save_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_app": {
+          "name": "target_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_uri": {
+          "name": "collection_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_cid": {
+          "name": "collection_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_collection_name": {
+          "name": "new_collection_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motivation": {
+          "name": "motivation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passage": {
+          "name": "passage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "save_draft_user_idx": {
+          "name": "save_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "save_draft_expires_idx": {
+          "name": "save_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "save_draft_user_id_user_id_fk": {
+          "name": "save_draft_user_id_user_id_fk",
+          "tableFrom": "save_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1784956568171,
       "tag": "0020_use_publication_theme",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1784967833785,
+      "tag": "0021_greedy_venom",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/reader/publication-theme-scale.ts
+++ b/src/components/reader/publication-theme-scale.ts
@@ -168,7 +168,7 @@ export function hasPublicationThemeColors(
   );
 }
 
-interface Rgb {
+export interface Rgb {
   r: number;
   g: number;
   b: number;
@@ -181,7 +181,7 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
-function parseHex(hex: string): Rgb | null {
+export function parseHex(hex: string): Rgb | null {
   const m = /^#([\da-f]{3}|[\da-f]{6})$/i.exec(hex.trim());
   if (!m) return null;
   const h = m[1];
@@ -199,7 +199,7 @@ function parseHex(hex: string): Rgb | null {
   };
 }
 
-function toHex(c: Rgb): string {
+export function toHex(c: Rgb): string {
   const ch = (v: number) =>
     clamp(Math.round(v), 0, 255).toString(16).padStart(2, "0");
   return `#${ch(c.r)}${ch(c.g)}${ch(c.b)}`;
@@ -365,7 +365,7 @@ function lighten(c: Rgb, amount: number): Rgb {
  * Light mode: tints of the accent on a light surface.
  * Dark mode: dark accent-tinted surfaces with bright text.
  */
-interface ColorScale {
+export interface ColorScale {
   bg: string;
   bgSubtle: string;
   component1: string;
@@ -532,7 +532,7 @@ function buildLightUiScale(background: Rgb, foreground: Rgb): ColorScale {
  * reason as {@link buildDarkUiScale} — so a publisher's own dark palette drives
  * it rather than one derived from their light colors.
  */
-function buildDarkAccentScale(accent: Rgb, darkPageBg: Rgb): ColorScale {
+export function buildDarkAccentScale(accent: Rgb, darkPageBg: Rgb): ColorScale {
   const darkAccentBg = darken(accent, 0.78);
   return {
     bg: toHex(darkAccentBg),
@@ -555,7 +555,7 @@ function buildDarkAccentScale(accent: Rgb, darkPageBg: Rgb): ColorScale {
  * Build the accent (primary) scale from the publication's accent color.
  * Light: accent tints on light bg; Dark: dark accent-tinted surfaces.
  */
-function buildLightAccentScale(accent: Rgb): ColorScale {
+export function buildLightAccentScale(accent: Rgb): ColorScale {
   const lightBg = lighten(accent, 0.86);
   return {
     bg: toHex(lightBg),

--- a/src/components/reader/theme.ts
+++ b/src/components/reader/theme.ts
@@ -92,6 +92,44 @@ export const editorialPrimary = stylex.createTheme(primaryColor, {
   },
 });
 
+/**
+ * App-wide accent color preference override — applied instead of
+ * `editorialPrimary` when a reader has chosen a preset or custom accent color
+ * (`#/lib/accent-color-scale`, Settings → Appearance). Values reference
+ * `--app-accent-*` CSS custom properties set at runtime via inline `style` on
+ * the same element, mirroring how `publicationPrimary`
+ * (`publication-theme-tokens.ts`) routes per-publication colors through
+ * `--pub-accent-*`. `linkColor`'s default already aliases `primaryColor.text2`,
+ * so links pick this up with no separate override.
+ */
+export const appAccentPrimary = stylex.createTheme(primaryColor, {
+  bg: "light-dark(var(--app-accent-bg-light), var(--app-accent-bg-dark))",
+  bgSubtle:
+    "light-dark(var(--app-accent-bgSubtle-light), var(--app-accent-bgSubtle-dark))",
+  component1:
+    "light-dark(var(--app-accent-component1-light), var(--app-accent-component1-dark))",
+  component2:
+    "light-dark(var(--app-accent-component2-light), var(--app-accent-component2-dark))",
+  component3:
+    "light-dark(var(--app-accent-component3-light), var(--app-accent-component3-dark))",
+  border1:
+    "light-dark(var(--app-accent-border1-light), var(--app-accent-border1-dark))",
+  border2:
+    "light-dark(var(--app-accent-border2-light), var(--app-accent-border2-dark))",
+  border3:
+    "light-dark(var(--app-accent-border3-light), var(--app-accent-border3-dark))",
+  solid1:
+    "light-dark(var(--app-accent-solid1-light), var(--app-accent-solid1-dark))",
+  solid2:
+    "light-dark(var(--app-accent-solid2-light), var(--app-accent-solid2-dark))",
+  text1:
+    "light-dark(var(--app-accent-text1-light), var(--app-accent-text1-dark))",
+  text2:
+    "light-dark(var(--app-accent-text2-light), var(--app-accent-text2-dark))",
+  textContrast:
+    "light-dark(var(--app-accent-textContrast-light), var(--app-accent-textContrast-dark))",
+});
+
 /** Newsreader (serif/display), Atkinson Hyperlegible Next (sans/UI), Spline Sans Mono (mono). */
 export const editorialFonts = stylex.createTheme(fontFamily, {
   // The `* Fallback: *` families are metric-adjusted @font-face rules generated

--- a/src/components/user-settings-view.tsx
+++ b/src/components/user-settings-view.tsx
@@ -20,6 +20,11 @@ import { listApi } from "#/integrations/tanstack-query/api-lists.functions";
 import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
 import type { DigestSectionKey } from "#/integrations/tanstack-query/api-user.functions";
 import { user } from "#/integrations/tanstack-query/api-user.functions";
+import {
+  ACCENT_COLOR_PRESETS,
+  accentColorPresetById,
+} from "#/lib/accent-color-presets";
+import { resolveAccentSeedHex } from "#/lib/accent-color-scale";
 import { DEFAULT_CUSTOM_GOOGLE_FONT } from "#/lib/google-fonts";
 import type { Locale } from "#/lib/locale";
 import { LOCALE_LABELS, LOCALES, PSEUDO_LOCALE, isLocale } from "#/lib/locale";
@@ -37,6 +42,7 @@ import {
 import { CUSTOMIZABLE_SIDEBAR_NAV } from "#/lib/sidebar-nav";
 import type { ThemeMode } from "#/lib/theme";
 import { isThemeMode } from "#/lib/theme";
+import { useAccentColorPreference } from "#/lib/use-accent-color-preference";
 import { useCountOldPostsAsUnread } from "#/lib/use-count-old-posts-as-unread";
 import { useLocale } from "#/lib/use-locale";
 import { useOpenCollectionsInMagazine } from "#/lib/use-open-collections-in-magazine";
@@ -57,6 +63,7 @@ import {
 } from "../design-system/alert-dialog";
 import { Avatar } from "../design-system/avatar";
 import { Button } from "../design-system/button";
+import { ColorPicker, DefaultColorEditor } from "../design-system/color-picker";
 import { Dialog, DialogBody, DialogHeader } from "../design-system/dialog";
 import { Flex } from "../design-system/flex";
 import { ProgressCircle } from "../design-system/progress-circle";
@@ -98,6 +105,16 @@ const THEME_OPTIONS: Array<{
   { id: "dark", label: msg`Dark`, icon: Moon },
   { id: "system", label: msg`System`, icon: Monitor },
 ];
+
+/** Display names for `ACCENT_COLOR_PRESETS` — see `#/lib/accent-color-presets`. */
+const ACCENT_COLOR_PRESET_LABELS: Record<string, MessageDescriptor> = {
+  camel: msg`Camel`,
+  moss: msg`Moss`,
+  teal: msg`Teal`,
+  slate: msg`Slate`,
+  plum: msg`Plum`,
+  rust: msg`Rust`,
+};
 
 /** The pseudo-locale is a translation-coverage tool, not a language to ship. */
 const LOCALE_OPTIONS: ReadonlyArray<Locale> = LOCALES.filter(
@@ -440,6 +457,8 @@ export function UserSettingsView() {
     useCountOldPostsAsUnread();
   const { enabled: usePublicationTheme, setEnabled: setUsePublicationTheme } =
     usePublicationThemePreference();
+  const { color: accentColor, setColor: setAccentColor } =
+    useAccentColorPreference();
 
   const { data: session } = useQuery(user.getSessionQueryOptions);
   const signedIn = Boolean(session?.user);
@@ -583,6 +602,19 @@ export function UserSettingsView() {
     });
   };
 
+  const accentColorPreset = accentColor
+    ? accentColorPresetById(accentColor)
+    : null;
+  // No preference stored yet → the trigger still shows the effective default
+  // (the "Camel" preset seed, matching `editorialPrimary`'s hand-tuned accent).
+  const accentColorSwatchValue =
+    resolveAccentSeedHex(accentColor) ?? ACCENT_COLOR_PRESETS[0].seed;
+  const accentColorLabel = accentColorPreset
+    ? i18n._(ACCENT_COLOR_PRESET_LABELS[accentColorPreset.id])
+    : accentColor
+      ? t`Custom`
+      : i18n._(ACCENT_COLOR_PRESET_LABELS.camel);
+
   return (
     <ReaderContent>
       <Masthead
@@ -628,6 +660,37 @@ export function UserSettingsView() {
               onChange={setUsePublicationTheme}
               aria-label={t`Use publication themes`}
             />
+          </SettingRow>
+          <Separator />
+          <SettingRow
+            label={t`Accent color`}
+            description={t`Choose a preset or pick your own.`}
+          >
+            <ColorPicker
+              label={accentColorLabel}
+              value={accentColorSwatchValue}
+              onChange={(color) => {
+                const hex = color.toString("hex");
+                const preset = ACCENT_COLOR_PRESETS.find(
+                  (candidate) =>
+                    candidate.seed.toLowerCase() === hex.toLowerCase(),
+                );
+                setAccentColor(preset ? preset.id : hex);
+              }}
+            >
+              <DefaultColorEditor
+                hasAlpha={false}
+                swatches={ACCENT_COLOR_PRESETS.map((preset) => preset.seed)}
+                onSwatchChange={(color) => {
+                  const hex = color.toString("hex");
+                  const preset = ACCENT_COLOR_PRESETS.find(
+                    (candidate) =>
+                      candidate.seed.toLowerCase() === hex.toLowerCase(),
+                  );
+                  setAccentColor(preset ? preset.id : hex);
+                }}
+              />
+            </ColorPicker>
           </SettingRow>
           <Separator />
           <SettingRow

--- a/src/db/schema/auth.ts
+++ b/src/db/schema/auth.ts
@@ -66,6 +66,11 @@ export const user = pgTable("user", {
    * theme colors keep the editorial theme either way. See
    * `src/lib/publication-theme-preference.ts`. */
   usePublicationTheme: boolean("use_publication_theme"),
+  /** App-wide accent color preference: either an `#/lib/accent-color-presets`
+   * id or a literal `#rrggbb` hex; `null` = the default editorial "camel"
+   * accent (`editorialPrimary` in `#/components/reader/theme`). See
+   * `#/lib/accent-color-scale`. */
+  accentColor: text("accent_color"),
   /** `network` shows the whole-network home feed; `null` = follows (default). */
   homeScope: text("home_scope"),
   /** Comma-separated author-profile tab ids the owner has hidden from their

--- a/src/integrations/tanstack-query/api-user.functions.ts
+++ b/src/integrations/tanstack-query/api-user.functions.ts
@@ -10,6 +10,11 @@ import { revokeAtprotoSession } from "#/integrations/auth/atproto";
 import { AUTH_SESSION_TOKEN_COOKIE } from "#/integrations/auth/constants";
 import { hasEmailScope } from "#/integrations/auth/scope";
 import {
+  DEFAULT_ACCENT_COLOR,
+  accentColorToDbValue,
+  dbValueToAccentColor,
+} from "#/lib/accent-color-preference";
+import {
   COUNT_OLD_POSTS_AS_UNREAD_COOKIE,
   COUNT_OLD_POSTS_AS_UNREAD_COOKIE_MAX_AGE_SECONDS,
   countOldPostsAsUnreadToCookieValue,
@@ -289,6 +294,7 @@ const getShellBootstrap = createServerFn({ method: "GET" }).handler(
         ),
       },
       usePublicationTheme: { enabled: DEFAULT_USE_PUBLICATION_THEME },
+      accentColor: { color: DEFAULT_ACCENT_COLOR },
       collectionsAuthoring: { enabled: false },
       shell: null,
     };
@@ -329,6 +335,7 @@ const getShellBootstrap = createServerFn({ method: "GET" }).handler(
             openCollectionsInMagazine: true,
             readingTypography: true,
             usePublicationTheme: true,
+            accentColor: true,
             collectionsAuthoringEnabled: true,
             atstoreReviewPromptDismissed: true,
             userinputFeedbackEnabled: true,
@@ -464,6 +471,9 @@ const getShellBootstrap = createServerFn({ method: "GET" }).handler(
       },
       usePublicationTheme: {
         enabled: dbValueToUsePublicationTheme(userRow.usePublicationTheme),
+      },
+      accentColor: {
+        color: dbValueToAccentColor(userRow.accentColor),
       },
       collectionsAuthoring: {
         enabled: userRow.collectionsAuthoringEnabled === true,
@@ -1100,6 +1110,43 @@ const setUsePublicationThemePreference = createServerFn({ method: "POST" })
     return { enabled: data.enabled };
   });
 
+// Signed-in only — same reasoning as `getUsePublicationThemePreference` above.
+const getAccentColorPreference = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware, maybeAuthMiddleware])
+  .handler(async ({ context }): Promise<{ color: string | null }> => {
+    const session = context?.session;
+    if (!session?.user) return { color: DEFAULT_ACCENT_COLOR };
+
+    const row = await context.db.query.user.findFirst({
+      where: eq(context.schema.user.id, session.user.id),
+      columns: { accentColor: true },
+    });
+    return { color: dbValueToAccentColor(row?.accentColor ?? null) };
+  });
+
+const getAccentColorPreferenceQueryOptions = queryOptions({
+  queryKey: ["accentColorPreference"] as const,
+  queryFn: () => getAccentColorPreference(),
+  staleTime: Number.POSITIVE_INFINITY,
+});
+
+const setAccentColorPreference = createServerFn({ method: "POST" })
+  .middleware([dbMiddleware, maybeAuthMiddleware])
+  .validator(z.object({ color: z.string().nullable() }))
+  .handler(async ({ data, context }): Promise<{ color: string | null }> => {
+    if (!context?.session?.user) {
+      return { color: DEFAULT_ACCENT_COLOR };
+    }
+
+    const color = accentColorToDbValue(data.color);
+    await context.db
+      .update(context.schema.user)
+      .set({ accentColor: color })
+      .where(eq(context.schema.user.id, context.session.user.id));
+
+    return { color };
+  });
+
 const homeScopeInput = z.object({
   scope: z.enum(["follows", "trending"]),
 });
@@ -1402,6 +1449,9 @@ export const user = {
   getUsePublicationThemePreference,
   getUsePublicationThemePreferenceQueryOptions,
   setUsePublicationThemePreference,
+  getAccentColorPreference,
+  getAccentColorPreferenceQueryOptions,
+  setAccentColorPreference,
   getHomeScopePreference,
   getHomeScopePreferenceQueryOptions,
   setHomeScopePreference,

--- a/src/lib/accent-color-preference.ts
+++ b/src/lib/accent-color-preference.ts
@@ -1,0 +1,38 @@
+/**
+ * App-wide accent color preference — lets a signed-in reader repaint the
+ * app's accent token from a curated preset (`#/lib/accent-color-presets`) or
+ * any custom color, instead of the default editorial "camel" accent.
+ *
+ * Stores either a preset id or a literal `#rrggbb` hex on
+ * `user.accent_color`. `null` = unset, the default (renders exactly as the
+ * hand-tuned `editorialPrimary` theme always has — see
+ * `#/components/reader/theme` and `#/lib/accent-color-scale`).
+ *
+ * Signed-in only (the setting lives on the settings page, which guests can't
+ * reach), so this is stored on `user.accent_color` with no cookie mirror —
+ * same as `#/lib/publication-theme-preference`.
+ */
+import { accentColorPresetById } from "./accent-color-presets";
+import { isValidCustomAccentColor } from "./accent-color-scale";
+
+export const DEFAULT_ACCENT_COLOR: string | null = null;
+
+/** A valid preference value is a known preset id or a `#rrggbb` hex; anything
+ * else (a stale/garbage DB value) is treated as unset. */
+export function isValidAccentColorValue(value: string): boolean {
+  return (
+    accentColorPresetById(value) !== null || isValidCustomAccentColor(value)
+  );
+}
+
+export function accentColorToDbValue(value: string | null): string | null {
+  if (!value) return null;
+  return isValidAccentColorValue(value) ? value : null;
+}
+
+export function dbValueToAccentColor(
+  value: string | null | undefined,
+): string | null {
+  if (!value) return DEFAULT_ACCENT_COLOR;
+  return isValidAccentColorValue(value) ? value : DEFAULT_ACCENT_COLOR;
+}

--- a/src/lib/accent-color-presets.ts
+++ b/src/lib/accent-color-presets.ts
@@ -1,0 +1,27 @@
+/**
+ * Curated app-wide accent color presets — see `#/lib/accent-color-scale` for
+ * how a preset (or a custom `#rrggbb`) turns into the app's actual theme.
+ *
+ * `camel` is the app's current hand-tuned "terracotta" accent
+ * (`editorialPrimary` in `#/components/reader/theme`) restated as a single
+ * seed color, so picking it explicitly renders the same hue as the default —
+ * only a reader who has never set a preference sees the exact hand-tuned
+ * values (including the P3 gamut variants this derived scale doesn't have).
+ */
+export interface AccentColorPreset {
+  id: string;
+  seed: string;
+}
+
+export const ACCENT_COLOR_PRESETS: ReadonlyArray<AccentColorPreset> = [
+  { id: "camel", seed: "#ad7f58" },
+  { id: "moss", seed: "#6f8f5b" },
+  { id: "teal", seed: "#4f8f86" },
+  { id: "slate", seed: "#5f7fa3" },
+  { id: "plum", seed: "#8f6693" },
+  { id: "rust", seed: "#b3573f" },
+];
+
+export function accentColorPresetById(id: string): AccentColorPreset | null {
+  return ACCENT_COLOR_PRESETS.find((preset) => preset.id === id) ?? null;
+}

--- a/src/lib/accent-color-scale.ts
+++ b/src/lib/accent-color-scale.ts
@@ -1,0 +1,86 @@
+/**
+ * App-wide accent color preference — lets a signed-in reader repaint the
+ * app's single accent token (`primaryColor`) from a curated preset
+ * (`#/lib/accent-color-presets`) or any custom color, reusing the same
+ * light+dark scale derivation built for per-publication theming
+ * (`buildLightAccentScale` / `buildDarkAccentScale` in
+ * `#/components/reader/publication-theme-scale`) rather than hand-tuning a
+ * token set per option.
+ *
+ * A stored preference value is either a preset id or a literal `#rrggbb` hex.
+ * `null` means "no preference" — the caller keeps the hand-tuned
+ * `editorialPrimary` theme untouched (`#/components/reader/theme`), so a
+ * reader who never opens this setting sees zero visual change.
+ */
+import type { CSSProperties } from "react";
+
+import type {
+  ColorScale,
+  Rgb,
+} from "#/components/reader/publication-theme-scale";
+import {
+  buildDarkAccentScale,
+  buildLightAccentScale,
+  parseHex,
+} from "#/components/reader/publication-theme-scale";
+
+import { accentColorPresetById } from "./accent-color-presets";
+
+/** Hex equivalent of the editorial dark page background (`editorialUi.bg`
+ * dark value in `theme.ts`, `oklch(0.16 0.012 60)`) — the accent scale only
+ * uses this as the "text sitting directly on the page" fallback color. */
+const DARK_PAGE_BG: Rgb = { r: 17, g: 12, b: 8 }; // #110c08
+
+const SCALE_KEYS: ReadonlyArray<keyof ColorScale> = [
+  "bg",
+  "bgSubtle",
+  "component1",
+  "component2",
+  "component3",
+  "border1",
+  "border2",
+  "border3",
+  "solid1",
+  "solid2",
+  "text1",
+  "text2",
+  "textContrast",
+];
+
+const CUSTOM_HEX_PATTERN = /^#[\da-f]{6}$/i;
+
+export function isValidCustomAccentColor(value: string): boolean {
+  return CUSTOM_HEX_PATTERN.test(value.trim());
+}
+
+/**
+ * Resolve a stored preference value (preset id or `#rrggbb`) to a seed hex,
+ * or `null` when it's neither a known preset nor a valid hex — callers treat
+ * that the same as "no preference".
+ */
+export function resolveAccentSeedHex(value: string | null): string | null {
+  if (!value) return null;
+  const preset = accentColorPresetById(value);
+  if (preset) return preset.seed;
+  return isValidCustomAccentColor(value) ? value.trim().toLowerCase() : null;
+}
+
+/**
+ * `--app-accent-{key}-{light|dark}` CSS custom properties for the
+ * `appAccentPrimary` theme (`#/components/reader/theme`) to apply, via inline
+ * `style`, on the element that wears that theme class.
+ */
+export function accentColorScaleVars(seedHex: string): CSSProperties | null {
+  const seed = parseHex(seedHex);
+  if (!seed) return null;
+
+  const light = buildLightAccentScale(seed);
+  const dark = buildDarkAccentScale(seed, DARK_PAGE_BG);
+
+  const vars: Record<string, string> = {};
+  for (const key of SCALE_KEYS) {
+    vars[`--app-accent-${key}-light`] = light[key];
+    vars[`--app-accent-${key}-dark`] = dark[key];
+  }
+  return vars as CSSProperties;
+}

--- a/src/lib/use-accent-color-preference.ts
+++ b/src/lib/use-accent-color-preference.ts
@@ -1,0 +1,72 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+
+import { user } from "#/integrations/tanstack-query/api-user.functions";
+
+import { DEFAULT_ACCENT_COLOR } from "./accent-color-preference";
+
+export interface AccentColorContextValue {
+  /** A preset id, a `#rrggbb` hex, or `null` for the default editorial accent. */
+  color: string | null;
+  setColor: (next: string | null) => void;
+  isPending: boolean;
+}
+
+/** App-wide accent color preference — see `#/lib/accent-color-preference`. */
+export function useAccentColorPreference(): AccentColorContextValue {
+  const queryClient = useQueryClient();
+
+  const { data } = useQuery({
+    ...user.getAccentColorPreferenceQueryOptions,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+  });
+  const color = data?.color ?? DEFAULT_ACCENT_COLOR;
+
+  const setMutation = useMutation({
+    mutationFn: async (next: string | null) => {
+      return await user.setAccentColorPreference({ data: { color: next } });
+    },
+    onMutate: async (next) => {
+      await queryClient.cancelQueries({
+        queryKey: user.getAccentColorPreferenceQueryOptions.queryKey,
+      });
+      const previous = queryClient.getQueryData(
+        user.getAccentColorPreferenceQueryOptions.queryKey,
+      );
+      queryClient.setQueryData(
+        user.getAccentColorPreferenceQueryOptions.queryKey,
+        { color: next },
+      );
+      return { previous };
+    },
+    onError: (_error, _next, ctx) => {
+      if (ctx?.previous) {
+        queryClient.setQueryData(
+          user.getAccentColorPreferenceQueryOptions.queryKey,
+          ctx.previous,
+        );
+      }
+    },
+    onSuccess: (result) => {
+      queryClient.setQueryData(
+        user.getAccentColorPreferenceQueryOptions.queryKey,
+        result,
+      );
+    },
+  });
+
+  const setColor = useCallback(
+    (next: string | null) => {
+      if (next === color) return;
+      setMutation.mutate(next);
+    },
+    [color, setMutation],
+  );
+
+  return {
+    color,
+    setColor,
+    isPending: setMutation.isPending,
+  };
+}

--- a/src/locales/ar/messages.po
+++ b/src/locales/ar/messages.po
@@ -833,6 +833,10 @@ msgstr "لا توجد منشورات مفهرسة بعد."
 msgid "{0} added to {listName}."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Custom"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Read the API docs"
 msgstr "اقرأ وثائق API"
@@ -892,6 +896,10 @@ msgstr "استبدال صورة الغلاف"
 #: src/lib/sidebar-nav.ts
 msgid "Search"
 msgstr "بحث"
+
+#: src/components/user-settings-view.tsx
+msgid "Camel"
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "Nothing trending yet"
@@ -2098,6 +2106,10 @@ msgstr ""
 msgid "Share elsewhere"
 msgstr "المشاركة في مكان آخر"
 
+#: src/components/user-settings-view.tsx
+msgid "Plum"
+msgstr ""
+
 #: src/components/docs/docs-publishing-nav.tsx
 #~ msgid "Publishing guide"
 #~ msgstr "دليل النشر"
@@ -2472,6 +2484,10 @@ msgstr "كن أول من يشارك خللًا أو فكرة أو سؤالًا."
 msgid "Browse the publication directory to find new writers."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Accent color"
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "الأكثر قراءة عبر الشبكة الآن."
@@ -2648,6 +2664,10 @@ msgstr "متابعة"
 #: src/components/reader/collection-builder.tsx
 msgid "Colophon"
 msgstr "بيان الإصدار"
+
+#: src/components/user-settings-view.tsx
+msgid "Choose a preset or pick your own."
+msgstr ""
 
 #: src/components/ReaderVoiceMenu.tsx
 #: src/components/user-settings-view.tsx
@@ -2989,6 +3009,10 @@ msgstr "تعذّر تشغيل عيّنة الصوت."
 msgid "{0, plural, one {# publication} other {{1} publications}}"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Moss"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Person"
 msgstr ""
@@ -3244,6 +3268,10 @@ msgstr "تُحَل صلاحية <0>app.standard-reader</0> عبر سجلات DNS
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Margin"
 msgstr "على Margin"
+
+#: src/components/user-settings-view.tsx
+msgid "Slate"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Everything by one author"
@@ -3503,6 +3531,10 @@ msgstr "لا شيء بعد — ابدأ الاستكشاف."
 #: src/routes/_layout.search.tsx
 msgid "Searching…"
 msgstr "جارٍ البحث…"
+
+#: src/components/user-settings-view.tsx
+msgid "Rust"
+msgstr ""
 
 #: src/components/reader/app-shell.tsx
 msgid "Toggle list {name}"
@@ -4193,6 +4225,10 @@ msgstr "إجراءات تحديد النص"
 #: src/routes/_layout.recommended.tsx
 msgid "Recommended"
 msgstr "موصى به"
+
+#: src/components/user-settings-view.tsx
+msgid "Teal"
+msgstr ""
 
 #: src/components/reader/cards.tsx
 msgid "This publication opted out of discovery, so it's hidden everywhere except here on your own profile."

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -833,6 +833,10 @@ msgstr "Noch keine Beiträge indexiert."
 msgid "{0} added to {listName}."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Custom"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Read the API docs"
 msgstr "API-Doku lesen"
@@ -892,6 +896,10 @@ msgstr "Titelbild ersetzen"
 #: src/lib/sidebar-nav.ts
 msgid "Search"
 msgstr "Suchen"
+
+#: src/components/user-settings-view.tsx
+msgid "Camel"
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "Nothing trending yet"
@@ -2098,6 +2106,10 @@ msgstr ""
 msgid "Share elsewhere"
 msgstr "Woanders teilen"
 
+#: src/components/user-settings-view.tsx
+msgid "Plum"
+msgstr ""
+
 #: src/components/docs/docs-publishing-nav.tsx
 #~ msgid "Publishing guide"
 #~ msgstr "Leitfaden zum Veröffentlichen"
@@ -2472,6 +2484,10 @@ msgstr "Teilen Sie als Erste(r) einen Fehler, eine Idee oder eine Frage."
 msgid "Browse the publication directory to find new writers."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Accent color"
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "Die meistgelesenen Texte im Netzwerk gerade jetzt."
@@ -2648,6 +2664,10 @@ msgstr "Folgen"
 #: src/components/reader/collection-builder.tsx
 msgid "Colophon"
 msgstr "Impressum"
+
+#: src/components/user-settings-view.tsx
+msgid "Choose a preset or pick your own."
+msgstr ""
 
 #: src/components/ReaderVoiceMenu.tsx
 #: src/components/user-settings-view.tsx
@@ -2989,6 +3009,10 @@ msgstr "Die Stimmprobe konnte nicht abgespielt werden."
 msgid "{0, plural, one {# publication} other {{1} publications}}"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Moss"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Person"
 msgstr ""
@@ -3244,6 +3268,10 @@ msgstr "Die Autorität für <0>app.standard-reader</0> wird über DNS-TXT-Eintr�
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Margin"
 msgstr "auf Margin"
+
+#: src/components/user-settings-view.tsx
+msgid "Slate"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Everything by one author"
@@ -3503,6 +3531,10 @@ msgstr "Noch nichts – auf zum Entdecken."
 #: src/routes/_layout.search.tsx
 msgid "Searching…"
 msgstr "Wird gesucht …"
+
+#: src/components/user-settings-view.tsx
+msgid "Rust"
+msgstr ""
 
 #: src/components/reader/app-shell.tsx
 msgid "Toggle list {name}"
@@ -4193,6 +4225,10 @@ msgstr "Aktionen für markierten Text"
 #: src/routes/_layout.recommended.tsx
 msgid "Recommended"
 msgstr "Empfohlen"
+
+#: src/components/user-settings-view.tsx
+msgid "Teal"
+msgstr ""
 
 #: src/components/reader/cards.tsx
 msgid "This publication opted out of discovery, so it's hidden everywhere except here on your own profile."

--- a/src/locales/en-XA/messages.po
+++ b/src/locales/en-XA/messages.po
@@ -833,6 +833,10 @@ msgstr ""
 msgid "{0} added to {listName}."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Custom"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Read the API docs"
 msgstr ""
@@ -891,6 +895,10 @@ msgstr ""
 #: src/components/reader/app-shell.tsx
 #: src/lib/sidebar-nav.ts
 msgid "Search"
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Camel"
 msgstr ""
 
 #: src/routes/_layout.latest.tsx
@@ -2098,6 +2106,10 @@ msgstr ""
 msgid "Share elsewhere"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Plum"
+msgstr ""
+
 #: src/components/docs/docs-publishing-nav.tsx
 #~ msgid "Publishing guide"
 #~ msgstr ""
@@ -2472,6 +2484,10 @@ msgstr ""
 msgid "Browse the publication directory to find new writers."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Accent color"
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr ""
@@ -2647,6 +2663,10 @@ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "Colophon"
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Choose a preset or pick your own."
 msgstr ""
 
 #: src/components/ReaderVoiceMenu.tsx
@@ -2989,6 +3009,10 @@ msgstr ""
 msgid "{0, plural, one {# publication} other {{1} publications}}"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Moss"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Person"
 msgstr ""
@@ -3243,6 +3267,10 @@ msgstr ""
 
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Margin"
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Slate"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -3502,6 +3530,10 @@ msgstr ""
 #: src/components/reader/collection-builder.tsx
 #: src/routes/_layout.search.tsx
 msgid "Searching…"
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Rust"
 msgstr ""
 
 #: src/components/reader/app-shell.tsx
@@ -4192,6 +4224,10 @@ msgstr ""
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.recommended.tsx
 msgid "Recommended"
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Teal"
 msgstr ""
 
 #: src/components/reader/cards.tsx

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -833,6 +833,10 @@ msgstr "No posts indexed yet."
 msgid "{0} added to {listName}."
 msgstr "{0} added to {listName}."
 
+#: src/components/user-settings-view.tsx
+msgid "Custom"
+msgstr "Custom"
+
 #: src/components/reader/about-view.tsx
 msgid "Read the API docs"
 msgstr "Read the API docs"
@@ -892,6 +896,10 @@ msgstr "Replace cover image"
 #: src/lib/sidebar-nav.ts
 msgid "Search"
 msgstr "Search"
+
+#: src/components/user-settings-view.tsx
+msgid "Camel"
+msgstr "Camel"
 
 #: src/routes/_layout.latest.tsx
 msgid "Nothing trending yet"
@@ -2098,6 +2106,10 @@ msgstr "None of these publications have posted anything yet. Subscribe from the 
 msgid "Share elsewhere"
 msgstr "Share elsewhere"
 
+#: src/components/user-settings-view.tsx
+msgid "Plum"
+msgstr "Plum"
+
 #: src/components/docs/docs-publishing-nav.tsx
 #~ msgid "Publishing guide"
 #~ msgstr "Publishing guide"
@@ -2472,6 +2484,10 @@ msgstr "Be the first to share a bug, idea, or question."
 msgid "Browse the publication directory to find new writers."
 msgstr "Browse the publication directory to find new writers."
 
+#: src/components/user-settings-view.tsx
+msgid "Accent color"
+msgstr "Accent color"
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "The most-read writing across the network right now."
@@ -2648,6 +2664,10 @@ msgstr "Follow"
 #: src/components/reader/collection-builder.tsx
 msgid "Colophon"
 msgstr "Colophon"
+
+#: src/components/user-settings-view.tsx
+msgid "Choose a preset or pick your own."
+msgstr "Choose a preset or pick your own."
 
 #: src/components/ReaderVoiceMenu.tsx
 #: src/components/user-settings-view.tsx
@@ -2989,6 +3009,10 @@ msgstr "Couldn’t play the voice sample."
 msgid "{0, plural, one {# publication} other {{1} publications}}"
 msgstr "{0, plural, one {# publication} other {{1} publications}}"
 
+#: src/components/user-settings-view.tsx
+msgid "Moss"
+msgstr "Moss"
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Person"
 msgstr "Person"
@@ -3244,6 +3268,10 @@ msgstr "Authority for <0>app.standard-reader</0> resolves via DNS <1>_lexicon.*<
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Margin"
 msgstr "on Margin"
+
+#: src/components/user-settings-view.tsx
+msgid "Slate"
+msgstr "Slate"
 
 #: src/components/reader/about-view.tsx
 msgid "Everything by one author"
@@ -3503,6 +3531,10 @@ msgstr "Nothing yet — go discover."
 #: src/routes/_layout.search.tsx
 msgid "Searching…"
 msgstr "Searching…"
+
+#: src/components/user-settings-view.tsx
+msgid "Rust"
+msgstr "Rust"
 
 #: src/components/reader/app-shell.tsx
 msgid "Toggle list {name}"
@@ -4193,6 +4225,10 @@ msgstr "Text selection actions"
 #: src/routes/_layout.recommended.tsx
 msgid "Recommended"
 msgstr "Recommended"
+
+#: src/components/user-settings-view.tsx
+msgid "Teal"
+msgstr "Teal"
 
 #: src/components/reader/cards.tsx
 msgid "This publication opted out of discovery, so it's hidden everywhere except here on your own profile."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -833,6 +833,10 @@ msgstr "Todavía no hay posts indexados."
 msgid "{0} added to {listName}."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Custom"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Read the API docs"
 msgstr "Leer la documentación de la API"
@@ -892,6 +896,10 @@ msgstr "Reemplazar la imagen de portada"
 #: src/lib/sidebar-nav.ts
 msgid "Search"
 msgstr "Buscar"
+
+#: src/components/user-settings-view.tsx
+msgid "Camel"
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "Nothing trending yet"
@@ -2098,6 +2106,10 @@ msgstr ""
 msgid "Share elsewhere"
 msgstr "Compartir en otro sitio"
 
+#: src/components/user-settings-view.tsx
+msgid "Plum"
+msgstr ""
+
 #: src/components/docs/docs-publishing-nav.tsx
 #~ msgid "Publishing guide"
 #~ msgstr "Guía de publicación"
@@ -2472,6 +2484,10 @@ msgstr "Sea la primera persona en compartir un error, una idea o una pregunta."
 msgid "Browse the publication directory to find new writers."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Accent color"
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "Los textos más leídos de toda la red en este momento."
@@ -2648,6 +2664,10 @@ msgstr "Seguir"
 #: src/components/reader/collection-builder.tsx
 msgid "Colophon"
 msgstr "Colofón"
+
+#: src/components/user-settings-view.tsx
+msgid "Choose a preset or pick your own."
+msgstr ""
 
 #: src/components/ReaderVoiceMenu.tsx
 #: src/components/user-settings-view.tsx
@@ -2989,6 +3009,10 @@ msgstr "No se pudo reproducir la muestra de voz."
 msgid "{0, plural, one {# publication} other {{1} publications}}"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Moss"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Person"
 msgstr ""
@@ -3244,6 +3268,10 @@ msgstr "La autoridad de <0>app.standard-reader</0> se resuelve mediante registro
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Margin"
 msgstr "en Margin"
+
+#: src/components/user-settings-view.tsx
+msgid "Slate"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Everything by one author"
@@ -3503,6 +3531,10 @@ msgstr "Nada todavía — vaya a descubrir."
 #: src/routes/_layout.search.tsx
 msgid "Searching…"
 msgstr "Buscando…"
+
+#: src/components/user-settings-view.tsx
+msgid "Rust"
+msgstr ""
 
 #: src/components/reader/app-shell.tsx
 msgid "Toggle list {name}"
@@ -4193,6 +4225,10 @@ msgstr "Acciones de selección de texto"
 #: src/routes/_layout.recommended.tsx
 msgid "Recommended"
 msgstr "Recomendado"
+
+#: src/components/user-settings-view.tsx
+msgid "Teal"
+msgstr ""
 
 #: src/components/reader/cards.tsx
 msgid "This publication opted out of discovery, so it's hidden everywhere except here on your own profile."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -833,6 +833,10 @@ msgstr "Aucun article indexé pour l’instant."
 msgid "{0} added to {listName}."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Custom"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Read the API docs"
 msgstr "Lire la documentation de l’API"
@@ -892,6 +896,10 @@ msgstr "Remplacer l’image de couverture"
 #: src/lib/sidebar-nav.ts
 msgid "Search"
 msgstr "Rechercher"
+
+#: src/components/user-settings-view.tsx
+msgid "Camel"
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "Nothing trending yet"
@@ -2098,6 +2106,10 @@ msgstr ""
 msgid "Share elsewhere"
 msgstr "Partager ailleurs"
 
+#: src/components/user-settings-view.tsx
+msgid "Plum"
+msgstr ""
+
 #: src/components/docs/docs-publishing-nav.tsx
 #~ msgid "Publishing guide"
 #~ msgstr "Guide de publication"
@@ -2472,6 +2484,10 @@ msgstr "Soyez le premier à signaler un bug, une idée ou une question."
 msgid "Browse the publication directory to find new writers."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Accent color"
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "Les textes les plus lus du réseau en ce moment."
@@ -2648,6 +2664,10 @@ msgstr "Suivre"
 #: src/components/reader/collection-builder.tsx
 msgid "Colophon"
 msgstr "Colophon"
+
+#: src/components/user-settings-view.tsx
+msgid "Choose a preset or pick your own."
+msgstr ""
 
 #: src/components/ReaderVoiceMenu.tsx
 #: src/components/user-settings-view.tsx
@@ -2989,6 +3009,10 @@ msgstr "Impossible de lire l'extrait vocal."
 msgid "{0, plural, one {# publication} other {{1} publications}}"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Moss"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Person"
 msgstr ""
@@ -3244,6 +3268,10 @@ msgstr "L'autorité pour <0>app.standard-reader</0> se résout via les enregistr
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Margin"
 msgstr "sur Margin"
+
+#: src/components/user-settings-view.tsx
+msgid "Slate"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Everything by one author"
@@ -3503,6 +3531,10 @@ msgstr "Rien pour l'instant — allez découvrir."
 #: src/routes/_layout.search.tsx
 msgid "Searching…"
 msgstr "Recherche…"
+
+#: src/components/user-settings-view.tsx
+msgid "Rust"
+msgstr ""
 
 #: src/components/reader/app-shell.tsx
 msgid "Toggle list {name}"
@@ -4193,6 +4225,10 @@ msgstr "Actions sur la sélection de texte"
 #: src/routes/_layout.recommended.tsx
 msgid "Recommended"
 msgstr "Recommandé"
+
+#: src/components/user-settings-view.tsx
+msgid "Teal"
+msgstr ""
 
 #: src/components/reader/cards.tsx
 msgid "This publication opted out of discovery, so it's hidden everywhere except here on your own profile."

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -833,6 +833,10 @@ msgstr "インデックスされた投稿はまだありません。"
 msgid "{0} added to {listName}."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Custom"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Read the API docs"
 msgstr "API ドキュメントを読む"
@@ -892,6 +896,10 @@ msgstr "カバー画像を差し替え"
 #: src/lib/sidebar-nav.ts
 msgid "Search"
 msgstr "検索"
+
+#: src/components/user-settings-view.tsx
+msgid "Camel"
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "Nothing trending yet"
@@ -2098,6 +2106,10 @@ msgstr ""
 msgid "Share elsewhere"
 msgstr "他のサービスで共有"
 
+#: src/components/user-settings-view.tsx
+msgid "Plum"
+msgstr ""
+
 #: src/components/docs/docs-publishing-nav.tsx
 #~ msgid "Publishing guide"
 #~ msgstr "公開ガイド"
@@ -2472,6 +2484,10 @@ msgstr "最初にバグ・アイデア・質問を投稿しましょう。"
 msgid "Browse the publication directory to find new writers."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Accent color"
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "いまネットワークで最も読まれている記事です。"
@@ -2648,6 +2664,10 @@ msgstr "フォロー"
 #: src/components/reader/collection-builder.tsx
 msgid "Colophon"
 msgstr "奥付"
+
+#: src/components/user-settings-view.tsx
+msgid "Choose a preset or pick your own."
+msgstr ""
 
 #: src/components/ReaderVoiceMenu.tsx
 #: src/components/user-settings-view.tsx
@@ -2989,6 +3009,10 @@ msgstr "音声サンプルを再生できませんでした。"
 msgid "{0, plural, one {# publication} other {{1} publications}}"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Moss"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Person"
 msgstr ""
@@ -3244,6 +3268,10 @@ msgstr "<0>app.standard-reader</0> の権限は、DNS の <1>_lexicon.*</1> TXT 
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Margin"
 msgstr "Margin で"
+
+#: src/components/user-settings-view.tsx
+msgid "Slate"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Everything by one author"
@@ -3503,6 +3531,10 @@ msgstr "まだ何もありません。発見ページへどうぞ。"
 #: src/routes/_layout.search.tsx
 msgid "Searching…"
 msgstr "検索中…"
+
+#: src/components/user-settings-view.tsx
+msgid "Rust"
+msgstr ""
 
 #: src/components/reader/app-shell.tsx
 msgid "Toggle list {name}"
@@ -4193,6 +4225,10 @@ msgstr "テキスト選択時の操作"
 #: src/routes/_layout.recommended.tsx
 msgid "Recommended"
 msgstr "おすすめ"
+
+#: src/components/user-settings-view.tsx
+msgid "Teal"
+msgstr ""
 
 #: src/components/reader/cards.tsx
 msgid "This publication opted out of discovery, so it's hidden everywhere except here on your own profile."

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -833,6 +833,10 @@ msgstr "아직 색인된 글이 없습니다."
 msgid "{0} added to {listName}."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Custom"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Read the API docs"
 msgstr "API 문서 보기"
@@ -892,6 +896,10 @@ msgstr "커버 이미지 교체"
 #: src/lib/sidebar-nav.ts
 msgid "Search"
 msgstr "검색"
+
+#: src/components/user-settings-view.tsx
+msgid "Camel"
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "Nothing trending yet"
@@ -2098,6 +2106,10 @@ msgstr ""
 msgid "Share elsewhere"
 msgstr "다른 곳에 공유"
 
+#: src/components/user-settings-view.tsx
+msgid "Plum"
+msgstr ""
+
 #: src/components/docs/docs-publishing-nav.tsx
 #~ msgid "Publishing guide"
 #~ msgstr "발행 가이드"
@@ -2472,6 +2484,10 @@ msgstr "버그, 아이디어, 질문을 가장 먼저 남겨보세요."
 msgid "Browse the publication directory to find new writers."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Accent color"
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "지금 네트워크에서 가장 많이 읽히는 글입니다."
@@ -2648,6 +2664,10 @@ msgstr "팔로우"
 #: src/components/reader/collection-builder.tsx
 msgid "Colophon"
 msgstr "콜로폰"
+
+#: src/components/user-settings-view.tsx
+msgid "Choose a preset or pick your own."
+msgstr ""
 
 #: src/components/ReaderVoiceMenu.tsx
 #: src/components/user-settings-view.tsx
@@ -2989,6 +3009,10 @@ msgstr "음성 샘플을 재생하지 못했습니다."
 msgid "{0, plural, one {# publication} other {{1} publications}}"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Moss"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Person"
 msgstr ""
@@ -3244,6 +3268,10 @@ msgstr "<0>app.standard-reader</0>의 권한은 DNS <1>_lexicon.*</1> TXT 레코
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Margin"
 msgstr "Margin에서"
+
+#: src/components/user-settings-view.tsx
+msgid "Slate"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Everything by one author"
@@ -3503,6 +3531,10 @@ msgstr "아직 없습니다 — 둘러보러 가볼까요."
 #: src/routes/_layout.search.tsx
 msgid "Searching…"
 msgstr "검색 중…"
+
+#: src/components/user-settings-view.tsx
+msgid "Rust"
+msgstr ""
 
 #: src/components/reader/app-shell.tsx
 msgid "Toggle list {name}"
@@ -4193,6 +4225,10 @@ msgstr "텍스트 선택 동작"
 #: src/routes/_layout.recommended.tsx
 msgid "Recommended"
 msgstr "추천"
+
+#: src/components/user-settings-view.tsx
+msgid "Teal"
+msgstr ""
 
 #: src/components/reader/cards.tsx
 msgid "This publication opted out of discovery, so it's hidden everywhere except here on your own profile."

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -833,6 +833,10 @@ msgstr "Ainda não há publicações indexadas."
 msgid "{0} added to {listName}."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Custom"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Read the API docs"
 msgstr "Ler a documentação da API"
@@ -892,6 +896,10 @@ msgstr "Substituir imagem de capa"
 #: src/lib/sidebar-nav.ts
 msgid "Search"
 msgstr "Pesquisar"
+
+#: src/components/user-settings-view.tsx
+msgid "Camel"
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "Nothing trending yet"
@@ -2098,6 +2106,10 @@ msgstr "Nenhuma destas publicações publicou algo. Inscreva-se através da aba 
 msgid "Share elsewhere"
 msgstr "Compartilhar em outro lugar"
 
+#: src/components/user-settings-view.tsx
+msgid "Plum"
+msgstr ""
+
 #: src/components/docs/docs-publishing-nav.tsx
 #~ msgid "Publishing guide"
 #~ msgstr "Guia de publicação"
@@ -2472,6 +2484,10 @@ msgstr "Seja o primeiro a compartilhar um erro, uma ideia ou uma pergunta."
 msgid "Browse the publication directory to find new writers."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Accent color"
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "Os textos mais lidos em toda a rede neste momento."
@@ -2648,6 +2664,10 @@ msgstr "Seguir"
 #: src/components/reader/collection-builder.tsx
 msgid "Colophon"
 msgstr "Colofão"
+
+#: src/components/user-settings-view.tsx
+msgid "Choose a preset or pick your own."
+msgstr ""
 
 #: src/components/ReaderVoiceMenu.tsx
 #: src/components/user-settings-view.tsx
@@ -2989,6 +3009,10 @@ msgstr "Não foi possível reproduzir a amostra de voz."
 msgid "{0, plural, one {# publication} other {{1} publications}}"
 msgstr "{0, plural, one {# publicação} other {{1} publicações}}"
 
+#: src/components/user-settings-view.tsx
+msgid "Moss"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Person"
 msgstr ""
@@ -3244,6 +3268,10 @@ msgstr "A autoridade de <0>app.standard-reader</0> resolve-se através de regist
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Margin"
 msgstr "no Margin"
+
+#: src/components/user-settings-view.tsx
+msgid "Slate"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Everything by one author"
@@ -3503,6 +3531,10 @@ msgstr "Nada ainda — vá descobrir."
 #: src/routes/_layout.search.tsx
 msgid "Searching…"
 msgstr "Pesquisando…"
+
+#: src/components/user-settings-view.tsx
+msgid "Rust"
+msgstr ""
 
 #: src/components/reader/app-shell.tsx
 msgid "Toggle list {name}"
@@ -4193,6 +4225,10 @@ msgstr "Ações de seleção de texto"
 #: src/routes/_layout.recommended.tsx
 msgid "Recommended"
 msgstr "Recomendado"
+
+#: src/components/user-settings-view.tsx
+msgid "Teal"
+msgstr ""
 
 #: src/components/reader/cards.tsx
 msgid "This publication opted out of discovery, so it's hidden everywhere except here on your own profile."

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -833,6 +833,10 @@ msgstr "尚无已索引的文章。"
 msgid "{0} added to {listName}."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Custom"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Read the API docs"
 msgstr "阅读 API 文档"
@@ -892,6 +896,10 @@ msgstr "替换封面图"
 #: src/lib/sidebar-nav.ts
 msgid "Search"
 msgstr "搜索"
+
+#: src/components/user-settings-view.tsx
+msgid "Camel"
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "Nothing trending yet"
@@ -2098,6 +2106,10 @@ msgstr ""
 msgid "Share elsewhere"
 msgstr "分享到其他平台"
 
+#: src/components/user-settings-view.tsx
+msgid "Plum"
+msgstr ""
+
 #: src/components/docs/docs-publishing-nav.tsx
 #~ msgid "Publishing guide"
 #~ msgstr "发布指南"
@@ -2472,6 +2484,10 @@ msgstr "来做第一个提交缺陷、想法或问题的人。"
 msgid "Browse the publication directory to find new writers."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Accent color"
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "当下整个网络阅读量最高的文章。"
@@ -2648,6 +2664,10 @@ msgstr "关注"
 #: src/components/reader/collection-builder.tsx
 msgid "Colophon"
 msgstr "版本记录"
+
+#: src/components/user-settings-view.tsx
+msgid "Choose a preset or pick your own."
+msgstr ""
 
 #: src/components/ReaderVoiceMenu.tsx
 #: src/components/user-settings-view.tsx
@@ -2989,6 +3009,10 @@ msgstr "无法播放语音示例。"
 msgid "{0, plural, one {# publication} other {{1} publications}}"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Moss"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Person"
 msgstr ""
@@ -3244,6 +3268,10 @@ msgstr "<0>app.standard-reader</0> 的权威通过 DNS <1>_lexicon.*</1> TXT 记
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Margin"
 msgstr "在 Margin 上"
+
+#: src/components/user-settings-view.tsx
+msgid "Slate"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Everything by one author"
@@ -3503,6 +3531,10 @@ msgstr "还没有内容——去发现看看吧。"
 #: src/routes/_layout.search.tsx
 msgid "Searching…"
 msgstr "搜索中……"
+
+#: src/components/user-settings-view.tsx
+msgid "Rust"
+msgstr ""
 
 #: src/components/reader/app-shell.tsx
 msgid "Toggle list {name}"
@@ -4193,6 +4225,10 @@ msgstr "选中文本操作"
 #: src/routes/_layout.recommended.tsx
 msgid "Recommended"
 msgstr "推荐"
+
+#: src/components/user-settings-view.tsx
+msgid "Teal"
+msgstr ""
 
 #: src/components/reader/cards.tsx
 msgid "This publication opted out of discovery, so it's hidden everywhere except here on your own profile."

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -16,6 +16,7 @@ import { I18nProvider as AriaI18nProvider } from "react-aria-components";
 
 import { NavTelemetry } from "../components/nav-telemetry";
 import {
+  appAccentPrimary,
   editorialFonts,
   editorialPrimary,
   editorialShadow,
@@ -30,6 +31,10 @@ import {
   savedListsQueryOptions,
   sidebarQueryOptions,
 } from "../integrations/tanstack-query/shell-queries";
+import {
+  accentColorScaleVars,
+  resolveAccentSeedHex,
+} from "../lib/accent-color-scale";
 import { i18nForLocale } from "../lib/i18n";
 import { intlLocale } from "../lib/locale";
 import { getPublicUrlClient } from "../lib/public-url";
@@ -178,6 +183,10 @@ export const Route = createRootRouteWithContext<RouterContext>()({
       user.getUsePublicationThemePreferenceQueryOptions.queryKey,
       bootstrap.usePublicationTheme,
     );
+    context.queryClient.setQueryData(
+      user.getAccentColorPreferenceQueryOptions.queryKey,
+      bootstrap.accentColor,
+    );
     if (bootstrap.shell) {
       context.queryClient.setQueryData(
         sidebarQueryOptions().queryKey,
@@ -263,6 +272,17 @@ function RootDocument({ children }: { children: React.ReactNode }) {
     refetchOnWindowFocus: false,
   });
   const themeMode = themePreference?.mode ?? DEFAULT_THEME_MODE;
+  // Accent color preference (Settings → Appearance, `#/lib/accent-color-scale`):
+  // `null` — the common case — keeps the hand-tuned `editorialPrimary` theme
+  // untouched below; only a resolved preset/custom seed swaps in
+  // `appAccentPrimary` and its `--app-accent-*` vars.
+  const { data: accentColorPreference } = useQuery({
+    ...user.getAccentColorPreferenceQueryOptions,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+  });
+  const accentSeed = resolveAccentSeedHex(accentColorPreference?.color ?? null);
+  const accentVars = accentSeed ? accentColorScaleVars(accentSeed) : null;
   // Resolved server-side (DB -> cookie -> Accept-Language) and hydrated with
   // the shell bootstrap, so `lang`/`dir` are correct on the first paint and
   // there is no flash of mis-directed layout.
@@ -322,7 +342,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
             ? rootStyles.embedShellBody
             : [
                 editorialUi,
-                editorialPrimary,
+                accentVars ? appAccentPrimary : editorialPrimary,
                 editorialFonts,
                 editorialShadow,
                 ui.bg,
@@ -330,6 +350,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
                 rootStyles.standaloneTitlebarBorder,
               ],
         )}
+        style={accentVars ?? undefined}
       >
         <PersistOAuthSavedHandle />
         <NavTelemetry />


### PR DESCRIPTION
Discussion: at://did:plc:f4os2wz5fjl56xpwcvtnqu7m/app.userinput.discussion/3mrg7vmzwq32e

## Original request

> Title: Ability to theme the app
>
> Let users choose from a few different color combos or completely custom

## What I found

The app already has two separate theming systems, and neither did what this request asks for:

- **Light/dark/system** (`user.theme_mode`, `#/lib/theme`) — controls only the neutral surface, not any accent color.
- **"Use publication themes"** (`user.use_publication_theme`, `#/lib/publication-theme-preference`) — repaints a *publication's own* page in *that publication's* colors when reading it. It's not an app-wide preference; it's per-publication and only applies on `/p/$did/$rkey` and `/a/$did/$rkey`.

Neither lets a reader pick their own accent color for the app chrome itself. The app's single accent token (`primaryColor`) is a hardcoded "terracotta" (`editorialPrimary` in `#/components/reader/theme.ts`) applied globally on `<body>` — there was no reader-facing control for it anywhere.

The publication-theme system did already contain everything needed to build this properly: `buildLightAccentScale` / `buildDarkAccentScale` (`publication-theme-scale.ts`) derive a full light+dark 10-step accent scale from a single seed color, and `publicationPrimary` (`publication-theme-tokens.ts`) shows the exact pattern for routing an StyleX `createTheme` override through runtime CSS custom properties. So rather than hand-tuning a token set per color option (which the request's "few different color combos" could have implied), this reuses that generator — a "preset" is just a curated seed color run through the same math a custom color goes through.

**What ships:**

- **Settings → Appearance → "Accent color"** — a `ColorPicker` (the same design-system component already used for the collection theme editor) showing the current accent as a swatch. Opening it shows 6 preset swatches (Camel — the existing default, Moss, Teal, Slate, Plum, Rust) plus the full color area/sliders/hex field for anything custom.
- Picking a preset stores its id; picking a custom color stores `#rrggbb`; `null` (untouched) renders **exactly** as before — the hand-tuned `editorialPrimary` theme (including its Display-P3 gamut variants, which the generic derivation doesn't have) is left completely alone unless a preference is actually set.
- New `appAccentPrimary` StyleX theme reads `--app-accent-*` CSS vars, mirroring how `publicationPrimary` reads `--pub-accent-*`. The root layout swaps it in for `editorialPrimary` only when a preference resolves to a seed color.
- `linkColor` needs no separate override — its default already aliases `primaryColor.text2`, so links follow the chosen accent automatically.
- Signed-in only, no cookie mirror — same reasoning as "Use publication themes" (Settings is behind auth): `user.accent_color` (`drizzle/0021_greedy_venom.sql`), served through `getShellBootstrap` so first paint is already correct.

**Divergence from the literal request:** "a few different color combos" could be read as full palette themes (background + accent together, like the publication theme system). I scoped this to the app's single accent token instead, because (a) that's the one hardcoded value in the app today, (b) the app's neutral/editorial surface (warm paper/ink) is a deliberate brand choice per `PRODUCT.md` ("editorial warmth over utilitarian density"), not something publication theming or this request asked to make user-selectable, and (c) it keeps the feature to one well-scoped preference rather than a much larger surface-recoloring system. Happy to expand if that's not what was wanted.

**Pre-existing bug, not touched here:** `src/components/ThemeToggle.tsx` (wired into `Header.tsx`) is a dead/duplicate light-dark toggle that fights with the real `theme_mode` system (`__root.tsx` / `user-settings-view.tsx`) — separate `localStorage` key, separate `data-theme` writes, no DB/cookie sync. Unrelated to accent color; flagging it since I ran into it while reading the theming code.

## Shape brief

This didn't need the full mock/palette flow — the visual direction, scope, and content were already answered by the existing product register (`PRODUCT.md`: warm, calm, editorial; "color earns its place or is removed") and the existing sibling `SettingRow`s in the same section. No native image generation is available in this environment, so per the standing instructions for this agent, the palette/mock gates collapse into this brief:

- **Control:** one `SettingRow` ("Accent color" / "Choose a preset or pick your own."), consistent with the `Switch`/`SegmentedControl`/`Select` rows already in Appearance — no new panel, no dedicated preview card.
- **Presets:** 6 seeds tuned to the same muted, editorial character as the existing terracotta accent (not saturated/neon primaries), so picking one doesn't make the app suddenly read as a color-picker demo: Camel `#ad7f58` (today's default, unchanged), Moss `#6f8f5b`, Teal `#4f8f86`, Slate `#5f7fa3`, Plum `#8f6693`, Rust `#b3573f`.
- **Custom:** the same `ColorPicker` popover's full color area/sliders/hex field, already an established pattern in this codebase (collection theme editor) — no new picker UI invented.

## Verification

- `pnpm build && pnpm lint && pnpm format:check && pnpm typecheck && pnpm test` — all green.
- `pnpm i18n:extract` — new copy ("Accent color", preset names, "Custom") extracted cleanly across all locale catalogs.
- **Could not visually verify in-browser.** This sandboxed environment has no reachable Neon database or `PUBLIC_URL`, so `pnpm dev` 500s on any route that queries the read-model, and the Settings route itself is auth-gated (AT Proto OAuth, also unavailable here). I relied instead on: reusing the exact same `ColorPicker` + `DefaultColorEditor` composition already shipped for the collection theme editor (`collection-theme-editor.tsx`), reusing the exact `SettingRow`/preference-hook/`getShellBootstrap` wiring pattern already shipped for every sibling Appearance row, and typecheck/lint passing clean on the full component tree. Screenshots aren't included because I can't produce a real one — flagging this explicitly rather than faking it.

## Follow-ups noted, not done here

- Live/in-browser visual QA of the new Settings row (needs a real DB + signed-in session).
- The `ThemeToggle.tsx` dead-code bug above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XfwcDAbqNTnF5oebm2ZgWV)_