### PR TITLE
Add a custom theme mode with palettes and appearance dials

### DIFF
--- a/APP_VISION.md
+++ b/APP_VISION.md
@@ -175,6 +175,44 @@ Sections, top to bottom:
   everyone; `user.reading_typography` when signed in (`fontSize:measure:bodyFont`
   encoding, with optional `:customFont` when body font is custom).
 
+- **Appearance (preference):** the theme control is light / dark / system /
+  **custom**. `custom` opens a palette picker: eight curated pairs — a Radix
+  accent with the gray Radix pairs it with (Almanac, Meadow, Press, Ink in light;
+  Almanac Night, Archive, Tide, Ember in dark) — plus the reader's own accent +
+  paper. A palette states its own scheme rather than following the OS: the paper
+  color decides light vs dark, and the shell pins `color-scheme` to it (which is
+  also what resolves `light-dark()` inside the Radix scales). Curated palettes are
+  static `createTheme`s over the vendored scales; the reader's own two colors go
+  through the same generator that paints publication themes, under an `--sr-*`
+  prefix, so ink, borders and every step in between are derived rather than asked
+  for. One deliberate difference from the publication path: a reader's stated
+  accent is **never substituted**. A publication whose accent can't clear 3:1
+  against its page gets that accent replaced by the page's ink, so a stranger's
+  site can't grey out our chrome; a reader theming their own app keeps exactly
+  the color they picked (choosing a primary color and being handed grey is a
+  worse answer), and the panel scores the generated ramp and warns instead.
+
+  Alongside the palette, four dials that apply in **every** theme mode because
+  none of them is color: interface font (editorial / sans / any Google family),
+  text size (XS–XL, 14→24px of interface text), roundness (sharp / soft /
+  default), and density (compact / default / relaxed). Text size scales the **root
+  font size**, so every rem in the app follows it — type, spacing, radii, control
+  boxes, the sidebar and the content shells — rather than only the tokens we
+  remembered to route through a multiplier; breakpoints are unaffected, since
+  media queries resolve against the initial font size. Roundness and density are
+  multipliers on the radius and spacing token scales, applied on the **root
+  element** — the semantic scales are declared as `--gap-md: var(--spacing-2)` at
+  `:root`, and a custom property resolves on the element that declares it, so an
+  override further down the tree moves padding that reads a spacing token
+  directly while every gap keeps the value it already computed. Density
+  deliberately stops
+  at the spacing _between_ things and leaves control geometry alone, because a
+  scale that stretched a switch's track but not its height distorts it. So a
+  single setting moves the chrome _and_ the article body — the Reading controls
+  above then override the article on top of that baseline. Cookie for everyone;
+  `user.appearance` when signed in (`null` = all defaults), seeded through
+  `getShellBootstrap` so the first paint is already themed.
+
 - **Use publication themes (preference):** settings-page toggle (Appearance) that
   repaints `/p/$did/$rkey` and `/a/$did/$rkey` in the publication's own
   `site.standard.theme.basic` colors. The four flat colors are expanded into full

--- a/TODO.md
+++ b/TODO.md
@@ -462,6 +462,27 @@ Build each on hip-ui components + StyleX tokens (no raw HTML/inline styles).
 - [x] Global follow toggle reflects everywhere instantly (optimistic).
 - [x] Theme picker (light / dark / system) + editorial dark tokens + Shiki `standard-reader-dark`.
 - [x] Theme tokens / dark mode parity with prototype (remaining hardcoded surfaces).
+- [x] **Custom theme mode (palette + shape/type dials)** — Theme becomes
+      light / dark / system / **custom**; custom opens a palette picker of eight curated
+      Radix pairs (Almanac, Meadow, Press, Ink / Almanac Night, Archive, Tide, Ember) plus the
+      reader's own accent + paper. A palette states its own scheme — the paper color decides
+      light vs dark — so `color-scheme` is pinned rather than tracking the OS. Curated palettes
+      are static `createTheme`s over the vendored Radix scales (`appearance-themes.ts`); the
+      reader's own two colors run through the _publication_ scale generator under an `--sr-*`
+      prefix (`appearance-vars.ts`), so ink, borders and all 26 steps are derived and
+      contrast-checked. Palette tiles wear the real theme, so the preview can't drift.
+      Alongside it, four dials that apply in **every** theme mode: interface font
+      (editorial / sans / any Google family), text size (XS–XL, 14→24px), roundness
+      (sharp / soft / default), density (compact / default / relaxed). Text size scales the root
+      font size so every rem follows it (chrome, sidebar width, content shells, article body);
+      roundness and density are multipliers on the radius / spacing token scales, with density
+      held out of control geometry. The Reading section still overrides the article on top.
+      Along the way: a global `font-family: inherit` for form controls (they never inherited it,
+      so the segmented control and friends sat outside the type system), a stated font size on
+      segmented-control items, and layout `px` dimensions converted to `rem`. Persisted as `user.appearance` + the
+      `standard-reader-appearance` cookie (`drizzle/0021_melodic_texas_twister`), seeded through
+      `getShellBootstrap` so the first paint is already themed
+      (`#/lib/appearance`, `useAppearance`, `AppearancePalettePanel`).
 - [x] **"Use publication themes" preference** — Settings → Appearance toggle that repaints
       `/p/$did/$rkey` and `/a/$did/$rkey` in the publication's own `basicTheme` colors.
       `publicationThemeScaleVars` expands the four flat colors into light + dark UI/accent

--- a/drizzle/0021_melodic_texas_twister.sql
+++ b/drizzle/0021_melodic_texas_twister.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "appearance" text;

--- a/drizzle/meta/0021_snapshot.json
+++ b/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,3833 @@
+{
+  "id": "d1593f8e-ed64-4e5f-a737-3653fd9a36bf",
+  "prevId": "4c3052f9-39ed-4493-8399-ceb2c024e14f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_mode": {
+          "name": "theme_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appearance": {
+          "name": "appearance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale_hint_seen": {
+          "name": "locale_hint_seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reader_voice": {
+          "name": "reader_voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_links_externally": {
+          "name": "open_links_externally",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_collections_in_magazine": {
+          "name": "open_collections_in_magazine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reading_typography": {
+          "name": "reading_typography",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_reading_history": {
+          "name": "track_reading_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count_old_posts_as_unread": {
+          "name": "count_old_posts_as_unread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_publication_theme": {
+          "name": "use_publication_theme",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_scope": {
+          "name": "home_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_hidden_tabs": {
+          "name": "profile_hidden_tabs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_show_likes": {
+          "name": "profile_show_likes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_authoring_enabled": {
+          "name": "collections_authoring_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userinput_feedback_enabled": {
+          "name": "userinput_feedback_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "margin_save_enabled": {
+          "name": "margin_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semble_save_enabled": {
+          "name": "semble_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "atstore_review_prompt_dismissed": {
+          "name": "atstore_review_prompt_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_enabled": {
+          "name": "weekly_digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_subscriptions": {
+          "name": "weekly_digest_section_subscriptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_network": {
+          "name": "weekly_digest_section_network",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_saved": {
+          "name": "weekly_digest_section_saved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_recommendations": {
+          "name": "weekly_digest_section_recommendations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_last_sent_at": {
+          "name": "weekly_digest_last_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_welcome_sent_at": {
+          "name": "weekly_digest_welcome_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_did_unique": {
+          "name": "user_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "did"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pds": {
+          "name": "pds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_url": {
+          "name": "banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_uri": {
+          "name": "bsky_profile_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_cid": {
+          "name": "bsky_profile_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_fetched_at": {
+          "name": "profile_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_handle_idx": {
+          "name": "profiles_handle_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_handle_trgm_idx": {
+          "name": "profiles_handle_trgm_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "profiles_display_name_trgm_idx": {
+          "name": "profiles_display_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publications": {
+      "name": "publications",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_cid": {
+          "name": "icon_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_mime": {
+          "name": "icon_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent": {
+          "name": "theme_accent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_background": {
+          "name": "theme_background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_foreground": {
+          "name": "theme_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent_foreground": {
+          "name": "theme_accent_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_json": {
+          "name": "theme_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_in_discover": {
+          "name": "show_in_discover",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "collections_publication": {
+          "name": "collections_publication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_checked_at": {
+          "name": "verification_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(name, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(topic, '')), 'B')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publications_did_idx": {
+          "name": "publications_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_name_idx": {
+          "name": "publications_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_discover_idx": {
+          "name": "publications_discover_idx",
+          "columns": [
+            {
+              "expression": "show_in_discover",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_topic_idx": {
+          "name": "publications_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_url_idx": {
+          "name": "publications_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_search_idx": {
+          "name": "publications_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_contributors": {
+      "name": "document_contributors",
+      "schema": "",
+      "columns": {
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "document_contributors_did_idx": {
+          "name": "document_contributors_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_contributors_document_uri_documents_uri_fk": {
+          "name": "document_contributors_document_uri_documents_uri_fk",
+          "tableFrom": "document_contributors",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_contributors_document_uri_did_pk": {
+          "name": "document_contributors_document_uri_did_pk",
+          "columns": [
+            "document_uri",
+            "did"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_uri": {
+          "name": "site_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_json": {
+          "name": "collection_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_renderable_body": {
+          "name": "has_renderable_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cover_image_cid": {
+          "name": "cover_image_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_mime": {
+          "name": "cover_image_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backlink_count": {
+          "name": "backlink_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_count_prev": {
+          "name": "backlink_count_prev",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_synced_at": {
+          "name": "backlink_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_recomputed_at": {
+          "name": "trending_recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_recommender_count": {
+          "name": "distinct_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bsky_post_uri": {
+          "name": "bsky_post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_post_cid": {
+          "name": "bsky_post_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_updated_at": {
+          "name": "record_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(title, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(immutable_array_to_string(tags), '')), 'B') || setweight(to_tsvector('english', coalesce(text_content, '')), 'C')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documents_did_idx": {
+          "name": "documents_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_did_published_idx": {
+          "name": "documents_did_published_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"published_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_publication_published_idx": {
+          "name": "documents_publication_published_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_published_idx": {
+          "name": "documents_published_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_featured_idx": {
+          "name": "documents_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_site_idx": {
+          "name": "documents_site_idx",
+          "columns": [
+            {
+              "expression": "site_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_search_idx": {
+          "name": "documents_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "documents_trending_idx": {
+          "name": "documents_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_idx": {
+          "name": "documents_canonical_url_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_trgm_idx": {
+          "name": "documents_canonical_url_trgm_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommends": {
+      "name": "recommends",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommender_did": {
+          "name": "recommender_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recommends_document_idx": {
+          "name": "recommends_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_recommender_idx": {
+          "name": "recommends_recommender_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_edge_idx": {
+          "name": "recommends_edge_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_doc_recommender_created_idx": {
+          "name": "recommends_doc_recommender_created_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recommends\".\"deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_did": {
+          "name": "publication_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_publication_idx": {
+          "name": "subscriptions_publication_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_subscriber_idx": {
+          "name": "subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_edge_idx": {
+          "name": "subscriptions_edge_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follower_did": {
+          "name": "follower_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excluded_publications": {
+          "name": "excluded_publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_subject_idx": {
+          "name": "user_follows_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_edge_idx": {
+          "name": "user_follows_edge_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_owner_idx": {
+          "name": "bookmarks_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_document_idx": {
+          "name": "bookmarks_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_edge_idx": {
+          "name": "bookmarks_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reads": {
+      "name": "reads",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reads_owner_idx": {
+          "name": "reads_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_document_idx": {
+          "name": "reads_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_edge_idx": {
+          "name": "reads_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidebar_prefs": {
+      "name": "sidebar_prefs",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_order": {
+          "name": "list_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customize_nav": {
+          "name": "customize_nav",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_nav": {
+          "name": "hidden_nav",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_saves": {
+      "name": "list_saves",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saver_did": {
+          "name": "saver_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_owner_did": {
+          "name": "list_owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "list_saves_saver_idx": {
+          "name": "list_saves_saver_idx",
+          "columns": [
+            {
+              "expression": "saver_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "list_saves_list_uri_idx": {
+          "name": "list_saves_list_uri_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lists": {
+      "name": "lists",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publications": {
+          "name": "publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "users": {
+          "name": "users",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lists_owner_idx": {
+          "name": "lists_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rkey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_corecommends": {
+      "name": "publication_corecommends",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_recommender_count": {
+          "name": "co_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_corecomm_rank_idx": {
+          "name": "publication_corecomm_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_corecommends_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_corecommends_related_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_corecommends_publication_uri_related_publication_uri_pk": {
+          "name": "publication_corecommends_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_cosubscriptions": {
+      "name": "publication_cosubscriptions",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_subscriber_count": {
+          "name": "co_subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_cosub_rank_idx": {
+          "name": "publication_cosub_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_cosubscriptions_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_cosubscriptions_related_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_cosubscriptions_publication_uri_related_publication_uri_pk": {
+          "name": "publication_cosubscriptions_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_stats": {
+      "name": "publication_stats",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommend_count": {
+          "name": "recommend_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_document_at": {
+          "name": "last_document_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documents_7d": {
+          "name": "documents_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_7d": {
+          "name": "subscribers_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_7d": {
+          "name": "recommends_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "documents_prev_7d": {
+          "name": "documents_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_prev_7d": {
+          "name": "subscribers_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_prev_7d": {
+          "name": "recommends_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlinks_7d": {
+          "name": "backlinks_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_velocity": {
+          "name": "trending_velocity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_window_start": {
+          "name": "trending_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_stats_subscribers_idx": {
+          "name": "publication_stats_subscribers_idx",
+          "columns": [
+            {
+              "expression": "subscriber_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_active_idx": {
+          "name": "publication_stats_active_idx",
+          "columns": [
+            {
+              "expression": "last_document_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_trending_idx": {
+          "name": "publication_stats_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_stats_publication_uri_publications_uri_fk": {
+          "name": "publication_stats_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_stats",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discover_topic_counts": {
+      "name": "discover_topic_counts",
+      "schema": "",
+      "columns": {
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discover_topic_counts_count_idx": {
+          "name": "discover_topic_counts_count_idx",
+          "columns": [
+            {
+              "expression": "publication_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discover_topic_counts_topic_trgm_idx": {
+          "name": "discover_topic_counts_topic_trgm_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_dead_letter": {
+      "name": "ingest_dead_letter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retries": {
+          "name": "retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingest_dead_letter_collection_idx": {
+          "name": "ingest_dead_letter_collection_idx",
+          "columns": [
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_state": {
+      "name": "ingest_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_processed": {
+          "name": "events_processed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_repos": {
+      "name": "tracked_repos",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_to_tap_at": {
+          "name": "added_to_tap_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_state": {
+          "name": "backfill_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_seen_rev": {
+          "name": "last_seen_rev",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_fail_count": {
+          "name": "reconcile_fail_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconcile_retry_after": {
+          "name": "reconcile_retry_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tracked_repos_state_idx": {
+          "name": "tracked_repos_state_idx",
+          "columns": [
+            {
+              "expression": "backfill_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_labels": {
+      "name": "document_labels",
+      "schema": "",
+      "columns": {
+        "src": {
+          "name": "src",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "val": {
+          "name": "val",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cts": {
+          "name": "cts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_labels_uri_idx": {
+          "name": "document_labels_uri_idx",
+          "columns": [
+            {
+              "expression": "uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_labels_src_idx": {
+          "name": "document_labels_src_idx",
+          "columns": [
+            {
+              "expression": "src",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "document_labels_src_uri_val_pk": {
+          "name": "document_labels_src_uri_val_pk",
+          "columns": [
+            "src",
+            "uri",
+            "val"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_sync_state": {
+      "name": "label_sync_state",
+      "schema": "",
+      "columns": {
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_services": {
+      "name": "labeler_services",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_endpoint": {
+          "name": "service_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_value_definitions": {
+          "name": "label_value_definitions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_services_labeler_idx": {
+          "name": "labeler_services_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_subscriptions": {
+      "name": "labeler_subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefs": {
+          "name": "prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_subscriptions_subscriber_idx": {
+          "name": "labeler_subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labeler_subscriptions_labeler_idx": {
+          "name": "labeler_subscriptions_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_shares": {
+      "name": "quote_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_text": {
+          "name": "quote_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quote_shares_document_uri_idx": {
+          "name": "quote_shares_document_uri_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_draft": {
+      "name": "feedback_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feedback_draft_user_idx": {
+          "name": "feedback_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_draft_expires_idx": {
+          "name": "feedback_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_draft_user_id_user_id_fk": {
+          "name": "feedback_draft_user_id_user_id_fk",
+          "tableFrom": "feedback_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upvote_draft": {
+      "name": "upvote_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "upvote_draft_user_idx": {
+          "name": "upvote_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upvote_draft_expires_idx": {
+          "name": "upvote_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upvote_draft_user_id_user_id_fk": {
+          "name": "upvote_draft_user_id_user_id_fk",
+          "tableFrom": "upvote_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.save_draft": {
+      "name": "save_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_app": {
+          "name": "target_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_uri": {
+          "name": "collection_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_cid": {
+          "name": "collection_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_collection_name": {
+          "name": "new_collection_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motivation": {
+          "name": "motivation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passage": {
+          "name": "passage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "save_draft_user_idx": {
+          "name": "save_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "save_draft_expires_idx": {
+          "name": "save_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "save_draft_user_id_user_id_fk": {
+          "name": "save_draft_user_id_user_id_fk",
+          "tableFrom": "save_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1784956568171,
       "tag": "0020_use_publication_theme",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1784961657747,
+      "tag": "0021_melodic_texas_twister",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/ThemeMenu.tsx
+++ b/src/components/ThemeMenu.tsx
@@ -1,5 +1,5 @@
 import * as stylex from "@stylexjs/stylex";
-import { Monitor, Moon, Sun } from "lucide-react";
+import { Monitor, Moon, Palette, Sun } from "lucide-react";
 
 import { MenuItem, SubMenu } from "#/design-system/menu";
 import { uiColor } from "#/design-system/theme/color.stylex";
@@ -21,6 +21,8 @@ const THEME_OPTIONS: Array<{
   { id: "light", label: "Light", icon: Sun },
   { id: "dark", label: "Dark", icon: Moon },
   { id: "system", label: "System", icon: Monitor },
+  // The palette itself is chosen in Settings → Appearance; this switches to it.
+  { id: "custom", label: "Custom", icon: Palette },
 ];
 
 function ThemeMenuItems({ onSelect }: { onSelect: (next: ThemeMode) => void }) {

--- a/src/components/appearance-settings.tsx
+++ b/src/components/appearance-settings.tsx
@@ -1,0 +1,784 @@
+"use client";
+
+import type { MessageDescriptor } from "@lingui/core";
+import { msg } from "@lingui/core/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
+import * as stylex from "@stylexjs/stylex";
+import { AlertTriangle, Check } from "lucide-react";
+import { useEffect, useState } from "react";
+import {
+  Radio as AriaRadio,
+  RadioGroup as AriaRadioGroup,
+} from "react-aria-components";
+
+import { contrastRatio } from "#/lib/collections/color";
+import { DEFAULT_CUSTOM_GOOGLE_FONT } from "#/lib/google-fonts";
+
+import { Button } from "../design-system/button";
+import { ColorPicker, DefaultColorEditor } from "../design-system/color-picker";
+import { Flex } from "../design-system/flex";
+import {
+  SegmentedControl,
+  SegmentedControlItem,
+} from "../design-system/segmented-control";
+import { Separator } from "../design-system/separator";
+import { animationDuration } from "../design-system/theme/animations.stylex";
+import {
+  focusColor,
+  primaryColor,
+  uiColor,
+} from "../design-system/theme/color.stylex";
+import { mediaQueries } from "../design-system/theme/media-queries.stylex";
+import { radius } from "../design-system/theme/radius.stylex";
+import {
+  gap,
+  horizontalSpace,
+  verticalSpace,
+} from "../design-system/theme/semantic-spacing.stylex";
+import { spacing } from "../design-system/theme/spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+  tracking,
+} from "../design-system/theme/typography.stylex";
+import type {
+  AppearanceDensity,
+  AppearanceFont,
+  AppearanceRoundness,
+  AppearanceTextSize,
+  PaletteId,
+} from "../lib/appearance";
+import {
+  APPEARANCE_DENSITIES,
+  APPEARANCE_FONTS,
+  APPEARANCE_ROUNDNESS,
+  APPEARANCE_TEXT_SIZES,
+  DEFAULT_APPEARANCE,
+  DEFAULT_CUSTOM_ACCENT,
+  DEFAULT_CUSTOM_PAPER,
+  PALETTES,
+  appearanceIsDefault,
+  appearanceScheme,
+} from "../lib/appearance";
+import { useAppearance } from "../lib/use-appearance";
+import { paletteThemes } from "./reader/appearance-themes";
+import { customPaletteVars } from "./reader/appearance-vars";
+import { ReadingCustomFontPicker } from "./reading-custom-font-picker";
+import { SettingRow } from "./settings-row";
+import { settingRowStyles } from "./settings-row-styles";
+
+const MOBILE = "@media (max-width: 47.5rem)";
+
+/** How long a color can be dragged before the whole app repaints to match. */
+const COLOR_COMMIT_DELAY_MS = 200;
+
+const FONT_LABELS: Record<AppearanceFont, MessageDescriptor> = {
+  editorial: msg`Editorial`,
+  sans: msg`Sans`,
+  custom: msg`Custom`,
+};
+
+/**
+ * Five steps need short labels to stay on one line on mobile, so the control
+ * shows the abbreviations and the accessible name says the whole word.
+ */
+const TEXT_SIZE_LABELS: Record<AppearanceTextSize, MessageDescriptor> = {
+  xs: msg`XS`,
+  small: msg`S`,
+  default: msg`M`,
+  large: msg`L`,
+  xl: msg`XL`,
+};
+
+const TEXT_SIZE_NAMES: Record<AppearanceTextSize, MessageDescriptor> = {
+  xs: msg`Extra small`,
+  small: msg`Small`,
+  default: msg`Default`,
+  large: msg`Large`,
+  xl: msg`Extra large`,
+};
+
+const ROUNDNESS_LABELS: Record<AppearanceRoundness, MessageDescriptor> = {
+  sharp: msg`Sharp`,
+  soft: msg`Soft`,
+  default: msg`Default`,
+};
+
+const DENSITY_LABELS: Record<AppearanceDensity, MessageDescriptor> = {
+  compact: msg`Compact`,
+  default: msg`Default`,
+  relaxed: msg`Relaxed`,
+};
+
+const styles = stylex.create({
+  block: {
+    paddingBottom: verticalSpace["3xl"],
+    paddingInlineStart: horizontalSpace["3xl"],
+    paddingInlineEnd: horizontalSpace["3xl"],
+    paddingTop: verticalSpace["3xl"],
+  },
+  groupLabel: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.xs,
+    fontWeight: fontWeight.medium,
+    lineHeight: lineHeight.sm,
+    marginBottom: verticalSpace.md,
+    marginTop: verticalSpace.none,
+  },
+  tileGrid: {
+    display: "grid",
+    gap: gap.xl,
+    gridTemplateColumns: {
+      default: "repeat(auto-fill, minmax(7.5rem, 1fr))",
+      [MOBILE]: "repeat(auto-fill, minmax(6.5rem, 1fr))",
+    },
+  },
+  radioGroup: {
+    display: "flex",
+    flexDirection: "column",
+    gap: gap["4xl"],
+    marginTop: verticalSpace["3xl"],
+  },
+  tile: {
+    cursor: "pointer",
+    display: "flex",
+    flexDirection: "column",
+    gap: gap.sm,
+  },
+  /**
+   * The miniature wears the palette's own StyleX theme, so what a reader sees
+   * here is the palette itself — same tokens the page will use, not a swatch
+   * approximating them.
+   */
+  tileSurface: {
+    backgroundColor: uiColor.bg,
+    borderColor: uiColor.border1,
+    borderRadius: radius.md,
+    borderStyle: "solid",
+    borderWidth: 1,
+    cornerShape: "squircle",
+    display: "flex",
+    flexDirection: "column",
+    gap: gap.sm,
+    justifyContent: "center",
+    outlineColor: {
+      default: "transparent",
+      ":is([data-selected])": primaryColor.solid1,
+    },
+    outlineOffset: 2,
+    outlineStyle: "solid",
+    outlineWidth: 2,
+    paddingBottom: verticalSpace.xl,
+    paddingInlineStart: horizontalSpace.xl,
+    paddingInlineEnd: horizontalSpace.xl,
+    paddingTop: verticalSpace.xl,
+    transform: {
+      default: "none",
+      ":is([data-hovered]):not([data-selected])": "translateY(-2px)",
+    },
+    transitionDuration: animationDuration.fast,
+    transitionProperty: {
+      default: "outline-color, transform, border-color",
+      [mediaQueries.reducedMotion]: "none",
+    },
+    transitionTimingFunction: "ease-out",
+  },
+  tileSurfaceFocused: {
+    outlineColor: focusColor.ring,
+  },
+  tileTitle: {
+    color: uiColor.text2,
+    fontFamily: fontFamily.title,
+    fontSize: fontSize.xl,
+    lineHeight: lineHeight.none,
+  },
+  tileLine: {
+    backgroundColor: uiColor.text1,
+    borderRadius: radius.full,
+    height: 2,
+    opacity: 0.5,
+    width: "100%",
+  },
+  tileLineShort: {
+    width: "60%",
+  },
+  tileAccent: {
+    backgroundColor: primaryColor.solid1,
+    borderRadius: radius.full,
+    height: spacing["2"],
+    marginTop: verticalSpace.xs,
+    width: spacing["6"],
+  },
+  tileMeta: {
+    alignItems: "center",
+    color: uiColor.text2,
+    display: "flex",
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.xs,
+    fontWeight: fontWeight.medium,
+    gap: gap.xs,
+    justifyContent: "space-between",
+  },
+  tileCheck: {
+    color: primaryColor.text2,
+    flexShrink: 0,
+  },
+  editor: {
+    display: "flex",
+    flexDirection: {
+      default: "row",
+      [MOBILE]: "column",
+    },
+    gap: gap["4xl"],
+    marginTop: verticalSpace["3xl"],
+  },
+  editorColumn: {
+    display: "flex",
+    flexBasis: "0",
+    flexDirection: "column",
+    flexGrow: 1,
+    gap: gap.xl,
+    minWidth: 0,
+  },
+  checkRow: {
+    alignItems: "center",
+    display: "flex",
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.xs,
+    gap: gap.sm,
+    lineHeight: lineHeight.sm,
+  },
+  checkOk: {
+    color: uiColor.text1,
+  },
+  checkWarn: {
+    color: primaryColor.text1,
+  },
+  note: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.xs,
+    lineHeight: lineHeight.sm,
+    marginBottom: verticalSpace.none,
+    marginTop: verticalSpace.none,
+    maxWidth: "46ch",
+  },
+  ratio: {
+    fontFamily: fontFamily.mono,
+    fontSize: fontSize.xs,
+    letterSpacing: tracking.normal,
+  },
+});
+
+/** The palette a tile paints itself in — real theme classes, real tokens. */
+function PaletteTile({
+  id,
+  name,
+  vars,
+  scheme,
+  isSelected,
+  isFocusVisible,
+}: {
+  id: PaletteId;
+  name: string;
+  vars?: React.CSSProperties;
+  scheme: "light" | "dark";
+  isSelected: boolean;
+  /** Keyboard focus outranks selection for the ring, so it stays visible. */
+  isFocusVisible: boolean;
+}) {
+  return (
+    <>
+      <div
+        data-selected={isSelected || undefined}
+        {...stylex.props(
+          ...paletteThemes(id),
+          styles.tileSurface,
+          isFocusVisible && styles.tileSurfaceFocused,
+        )}
+        // The palette states its scheme, so the miniature pins `color-scheme`
+        // the same way the shell does — that is what resolves `light-dark()`
+        // inside every Radix scale to the right half.
+        style={{ ...vars, colorScheme: scheme }}
+      >
+        <span {...stylex.props(styles.tileTitle)} aria-hidden>
+          Aa
+        </span>
+        <span {...stylex.props(styles.tileLine)} aria-hidden />
+        <span
+          {...stylex.props(styles.tileLine, styles.tileLineShort)}
+          aria-hidden
+        />
+        <span {...stylex.props(styles.tileAccent)} aria-hidden />
+      </div>
+      <span {...stylex.props(styles.tileMeta)}>
+        {name}
+        {isSelected ? (
+          <Check size={14} {...stylex.props(styles.tileCheck)} aria-hidden />
+        ) : null}
+      </span>
+    </>
+  );
+}
+
+function ContrastCheck({
+  label,
+  ratio,
+  min,
+}: {
+  label: string;
+  ratio: number;
+  min: number;
+}) {
+  const passes = ratio >= min;
+  return (
+    <span
+      {...stylex.props(
+        styles.checkRow,
+        passes ? styles.checkOk : styles.checkWarn,
+      )}
+    >
+      {passes ? (
+        <Check size={14} aria-hidden />
+      ) : (
+        <AlertTriangle size={14} aria-hidden />
+      )}
+      <span>
+        {label}{" "}
+        <span {...stylex.props(styles.ratio)}>{ratio.toFixed(1)}:1</span>
+      </span>
+    </span>
+  );
+}
+
+/**
+ * Accent + paper, with the contrast the *generated* palette actually renders —
+ * scored on the ramp's own text step rather than the raw pair, because that
+ * step is what the reader will be reading.
+ */
+function CustomColorEditor({
+  paper,
+  accent,
+  onChange,
+}: {
+  paper: string;
+  accent: string;
+  onChange: (next: { paper: string; accent: string }) => void;
+}) {
+  const { t } = useLingui();
+  const scheme = appearanceScheme({
+    ...DEFAULT_APPEARANCE,
+    palette: "custom",
+    customPaper: paper,
+    customAccent: accent,
+  });
+  const vars = customPaletteVars(paper, accent) as Record<string, string>;
+  const renderedPaper = vars[`--sr-bg-${scheme}`] ?? paper;
+  const renderedInk = vars[`--sr-text2-${scheme}`] ?? "#000000";
+  const renderedAccentText = vars[`--sr-accent-text2-${scheme}`] ?? accent;
+  const rawAccentRatio = contrastRatio(accent, renderedPaper);
+
+  return (
+    <div {...stylex.props(styles.editor)}>
+      <div {...stylex.props(styles.editorColumn)}>
+        <ColorPicker
+          label={t`Paper`}
+          value={paper}
+          onChange={(color) =>
+            onChange({ paper: color.toString("hex"), accent })
+          }
+        >
+          <DefaultColorEditor />
+        </ColorPicker>
+        <ColorPicker
+          label={t`Accent`}
+          value={accent}
+          onChange={(color) =>
+            onChange({ paper, accent: color.toString("hex") })
+          }
+        >
+          <DefaultColorEditor />
+        </ColorPicker>
+      </div>
+      <div {...stylex.props(styles.editorColumn)}>
+        <ContrastCheck
+          label={t`Body text on paper`}
+          ratio={contrastRatio(renderedInk, renderedPaper)}
+          min={4.5}
+        />
+        <ContrastCheck
+          label={t`Links and labels on paper`}
+          ratio={contrastRatio(renderedAccentText, renderedPaper)}
+          min={4.5}
+        />
+        <p {...stylex.props(styles.note)}>
+          {scheme === "dark" ? (
+            <Trans>
+              Your paper is dark, so the app reads as a dark theme. Text,
+              borders and every other step are derived from these two colors.
+            </Trans>
+          ) : (
+            <Trans>
+              Text, borders and every other step are derived from these two
+              colors.
+            </Trans>
+          )}
+          {rawAccentRatio < 3 ? (
+            <>
+              {" "}
+              {/* Stated, not corrected: the reader picked this color, so we keep
+                  it and tell them what it will cost to read. */}
+              <Trans>
+                Your accent sits close to the paper in tone — it stays exactly
+                as you picked it, but text and links set in it will be hard to
+                read.
+              </Trans>
+            </>
+          ) : null}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Palette picker for the `custom` theme mode: curated pairs grouped by the
+ * scheme they render in, then the reader's own two colors.
+ */
+export function AppearancePalettePanel() {
+  const { t } = useLingui();
+  const { preference, setPreference } = useAppearance();
+  const [draft, setDraft] = useState({
+    paper: preference.customPaper ?? DEFAULT_CUSTOM_PAPER,
+    accent: preference.customAccent ?? DEFAULT_CUSTOM_ACCENT,
+  });
+
+  const savedPaper = preference.customPaper;
+  const savedAccent = preference.customAccent;
+
+  // Adopt colors that changed elsewhere (another tab, a reset) without fighting
+  // the reader mid-drag: only when the saved pair differs from what we sent.
+  useEffect(() => {
+    if (!savedPaper || !savedAccent) return;
+    setDraft((current) =>
+      current.paper === savedPaper && current.accent === savedAccent
+        ? current
+        : { paper: savedPaper, accent: savedAccent },
+    );
+  }, [savedAccent, savedPaper]);
+
+  // A color wheel fires continuously while dragged; the tile follows every
+  // frame from local state, and the app itself repaints once the reader
+  // settles — one write, not a hundred.
+  useEffect(() => {
+    if (preference.palette !== "custom") return;
+    if (draft.paper === savedPaper && draft.accent === savedAccent) return;
+    const timer = globalThis.setTimeout(() => {
+      setPreference({
+        customPaper: draft.paper,
+        customAccent: draft.accent,
+      });
+    }, COLOR_COMMIT_DELAY_MS);
+    return () => globalThis.clearTimeout(timer);
+  }, [
+    draft.accent,
+    draft.paper,
+    preference.palette,
+    savedAccent,
+    savedPaper,
+    setPreference,
+  ]);
+
+  const lightPalettes = PALETTES.filter(
+    (palette) => palette.scheme === "light",
+  );
+  const darkPalettes = PALETTES.filter((palette) => palette.scheme === "dark");
+  const customScheme = appearanceScheme({
+    ...DEFAULT_APPEARANCE,
+    palette: "custom",
+    customPaper: draft.paper,
+    customAccent: draft.accent,
+  });
+  const customVars = customPaletteVars(
+    draft.paper,
+    draft.accent,
+  ) as React.CSSProperties;
+
+  const renderTile = (
+    id: PaletteId,
+    name: string,
+    scheme: "light" | "dark",
+    label: string,
+    vars?: React.CSSProperties,
+  ) => (
+    <AriaRadio
+      key={id}
+      value={id}
+      aria-label={label}
+      {...stylex.props(styles.tile)}
+    >
+      {({ isSelected, isFocusVisible }) => (
+        <PaletteTile
+          id={id}
+          name={name}
+          scheme={scheme}
+          vars={vars}
+          isSelected={isSelected}
+          isFocusVisible={isFocusVisible}
+        />
+      )}
+    </AriaRadio>
+  );
+
+  return (
+    <div {...stylex.props(styles.block)}>
+      <p {...stylex.props(settingRowStyles.label)}>
+        <Trans>Palette</Trans>
+      </p>
+      <p {...stylex.props(settingRowStyles.description)}>
+        <Trans>
+          Sets the app's colors — and, because the page color decides it,
+          whether the app reads light or dark.
+        </Trans>
+      </p>
+
+      <AriaRadioGroup
+        aria-label={t`Palette`}
+        value={preference.palette}
+        onChange={(value) => setPreference({ palette: value as PaletteId })}
+        {...stylex.props(styles.radioGroup)}
+      >
+        <div>
+          <p {...stylex.props(styles.groupLabel)}>
+            <Trans>Light</Trans>
+          </p>
+          <div {...stylex.props(styles.tileGrid)}>
+            {lightPalettes.map((palette) =>
+              renderTile(
+                palette.id,
+                palette.name,
+                palette.scheme,
+                t`${palette.name}, light`,
+              ),
+            )}
+          </div>
+        </div>
+
+        <div>
+          <p {...stylex.props(styles.groupLabel)}>
+            <Trans>Dark</Trans>
+          </p>
+          <div {...stylex.props(styles.tileGrid)}>
+            {darkPalettes.map((palette) =>
+              renderTile(
+                palette.id,
+                palette.name,
+                palette.scheme,
+                t`${palette.name}, dark`,
+              ),
+            )}
+          </div>
+        </div>
+
+        <div>
+          <p {...stylex.props(styles.groupLabel)}>
+            <Trans>Your own colors</Trans>
+          </p>
+          <div {...stylex.props(styles.tileGrid)}>
+            {renderTile(
+              "custom",
+              t`Custom`,
+              customScheme,
+              t`Your own colors`,
+              customVars,
+            )}
+          </div>
+        </div>
+      </AriaRadioGroup>
+
+      {preference.palette === "custom" ? (
+        <CustomColorEditor
+          paper={draft.paper}
+          accent={draft.accent}
+          onChange={setDraft}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Shape and type: applies in every theme mode, because none of it is color.
+ * The article inherits all of it as a baseline — the Reading section below
+ * still overrides the article on top.
+ */
+export function AppearanceAdvancedRows() {
+  const { t, i18n } = useLingui();
+  const { preference, setPreference, reset } = useAppearance();
+  const isDefault = appearanceIsDefault(preference);
+
+  return (
+    <>
+      <SettingRow
+        label={t`Interface font`}
+        description={t`The typeface used across the app. Article text follows this too, unless you set a reading font below.`}
+      >
+        <SegmentedControl
+          aria-label={t`Interface font`}
+          selectedKeys={new Set([preference.font])}
+          onSelectionChange={(keys: Set<React.Key> | "all") => {
+            const key = keys === "all" ? undefined : String([...keys][0]);
+            if (!key) return;
+            if (key === "custom") {
+              setPreference({
+                font: "custom",
+                customFontFamily:
+                  preference.customFontFamily ?? DEFAULT_CUSTOM_GOOGLE_FONT,
+              });
+              return;
+            }
+            if (isAppearanceFontKey(key)) {
+              setPreference({ font: key, customFontFamily: undefined });
+            }
+          }}
+          style={settingRowStyles.segmentedControl}
+        >
+          {APPEARANCE_FONTS.map((font) => (
+            <SegmentedControlItem key={font} id={font}>
+              {i18n._(FONT_LABELS[font])}
+            </SegmentedControlItem>
+          ))}
+        </SegmentedControl>
+      </SettingRow>
+
+      {preference.font === "custom" ? (
+        <>
+          <Separator />
+          <SettingRow
+            label={t`Google Font`}
+            description={t`Search and pick any family from the Google Fonts catalog.`}
+          >
+            <ReadingCustomFontPicker
+              value={preference.customFontFamily ?? DEFAULT_CUSTOM_GOOGLE_FONT}
+              onChange={(family) =>
+                setPreference({ font: "custom", customFontFamily: family })
+              }
+            />
+          </SettingRow>
+        </>
+      ) : null}
+
+      <Separator />
+      <SettingRow
+        label={t`Text size`}
+        description={t`Scales every size in the app, article text included — from 14px up to 24px of interface text.`}
+      >
+        <SegmentedControl
+          aria-label={t`Text size`}
+          selectedKeys={new Set([preference.textSize])}
+          onSelectionChange={(keys: Set<React.Key> | "all") => {
+            const key = keys === "all" ? undefined : String([...keys][0]);
+            if (isTextSizeKey(key)) setPreference({ textSize: key });
+          }}
+          style={settingRowStyles.segmentedControl}
+        >
+          {APPEARANCE_TEXT_SIZES.map((option) => (
+            <SegmentedControlItem
+              key={option}
+              id={option}
+              aria-label={i18n._(TEXT_SIZE_NAMES[option])}
+            >
+              {i18n._(TEXT_SIZE_LABELS[option])}
+            </SegmentedControlItem>
+          ))}
+        </SegmentedControl>
+      </SettingRow>
+
+      <Separator />
+      <SettingRow
+        label={t`Roundness`}
+        description={t`How rounded buttons, cards and inputs are.`}
+      >
+        <SegmentedControl
+          aria-label={t`Roundness`}
+          selectedKeys={new Set([preference.roundness])}
+          onSelectionChange={(keys: Set<React.Key> | "all") => {
+            const key = keys === "all" ? undefined : String([...keys][0]);
+            if (isRoundnessKey(key)) setPreference({ roundness: key });
+          }}
+          style={settingRowStyles.segmentedControl}
+        >
+          {APPEARANCE_ROUNDNESS.map((option) => (
+            <SegmentedControlItem key={option} id={option}>
+              {i18n._(ROUNDNESS_LABELS[option])}
+            </SegmentedControlItem>
+          ))}
+        </SegmentedControl>
+      </SettingRow>
+
+      <Separator />
+      <SettingRow
+        label={t`Density`}
+        description={t`The spacing between things — tighter for more on screen, looser for more room to read.`}
+      >
+        <SegmentedControl
+          aria-label={t`Density`}
+          selectedKeys={new Set([preference.density])}
+          onSelectionChange={(keys: Set<React.Key> | "all") => {
+            const key = keys === "all" ? undefined : String([...keys][0]);
+            if (isDensityKey(key)) setPreference({ density: key });
+          }}
+          style={settingRowStyles.segmentedControl}
+        >
+          {APPEARANCE_DENSITIES.map((option) => (
+            <SegmentedControlItem key={option} id={option}>
+              {i18n._(DENSITY_LABELS[option])}
+            </SegmentedControlItem>
+          ))}
+        </SegmentedControl>
+      </SettingRow>
+
+      <Separator />
+      <SettingRow
+        label={t`Reset appearance`}
+        description={t`Puts the palette, font, size, roundness and density back to their defaults.`}
+      >
+        <Flex justify="end">
+          <Button variant="secondary" isDisabled={isDefault} onPress={reset}>
+            <Trans>Reset</Trans>
+          </Button>
+        </Flex>
+      </SettingRow>
+    </>
+  );
+}
+
+function isAppearanceFontKey(value: string): value is AppearanceFont {
+  return (APPEARANCE_FONTS as ReadonlyArray<string>).includes(value);
+}
+
+function isTextSizeKey(value: string | undefined): value is AppearanceTextSize {
+  return (
+    value !== undefined &&
+    (APPEARANCE_TEXT_SIZES as ReadonlyArray<string>).includes(value)
+  );
+}
+
+function isRoundnessKey(
+  value: string | undefined,
+): value is AppearanceRoundness {
+  return (
+    value !== undefined &&
+    (APPEARANCE_ROUNDNESS as ReadonlyArray<string>).includes(value)
+  );
+}
+
+function isDensityKey(value: string | undefined): value is AppearanceDensity {
+  return (
+    value !== undefined &&
+    (APPEARANCE_DENSITIES as ReadonlyArray<string>).includes(value)
+  );
+}

--- a/src/components/docs/publishing-docs-page.tsx
+++ b/src/components/docs/publishing-docs-page.tsx
@@ -105,7 +105,7 @@ function SubscribeEmbedSample({ origin }: { origin: string }) {
         borderRadius: "1.55rem",
         maxWidth: "100%",
         overflow: "hidden",
-        width: "400px",
+        width: "25rem",
       }}
     >
       {/* oxlint-disable-next-line iframe-has-title --

--- a/src/components/labeler-detail-view.tsx
+++ b/src/components/labeler-detail-view.tsx
@@ -34,6 +34,7 @@ import {
 } from "../design-system/segmented-control";
 import { Tab, TabList, TabPanel, Tabs } from "../design-system/tabs";
 import { uiColor } from "../design-system/theme/color.stylex";
+import { radius } from "../design-system/theme/radius.stylex";
 import {
   size as boxSize,
   gap,
@@ -354,7 +355,7 @@ const styles = stylex.create({
     rowGap: spacing["4"],
     marginInlineStart: "auto",
     marginInlineEnd: "auto",
-    maxWidth: "1320px",
+    maxWidth: "82.5rem",
     paddingBottom: spacing["0"],
     paddingInlineStart: {
       default: spacing["5"],
@@ -378,7 +379,7 @@ const styles = stylex.create({
     flexBasis: "0%",
     flexGrow: 1,
     flexShrink: 1,
-    minWidth: "240px",
+    minWidth: "15rem",
     paddingTop: spacing["0.5"],
   },
   heroName: {
@@ -441,7 +442,7 @@ const styles = stylex.create({
     boxSizing: "border-box",
     marginInlineStart: "auto",
     marginInlineEnd: "auto",
-    maxWidth: "1320px",
+    maxWidth: "82.5rem",
     paddingInlineStart: {
       default: spacing["5"],
       "@media (min-width: 40rem)": spacing["10"],
@@ -471,7 +472,7 @@ const styles = stylex.create({
   settingGroup: {
     padding: spacing["5"],
     borderColor: uiColor.border1,
-    borderRadius: spacing["3"],
+    borderRadius: radius.lg,
     borderStyle: "solid",
     borderWidth: spacing.px,
     gap: gap["2xl"],

--- a/src/components/labelers-settings-view.tsx
+++ b/src/components/labelers-settings-view.tsx
@@ -17,6 +17,7 @@ import { Badge } from "../design-system/badge";
 import { TextField } from "../design-system/text-field";
 import { animationDuration } from "../design-system/theme/animations.stylex";
 import { uiColor } from "../design-system/theme/color.stylex";
+import { radius } from "../design-system/theme/radius.stylex";
 import {
   gap,
   verticalSpace,
@@ -212,7 +213,7 @@ const styles = stylex.create({
   card: {
     padding: spacing["4"],
     borderColor: { default: uiColor.border1, ":hover": uiColor.border2 },
-    borderRadius: spacing["3"],
+    borderRadius: radius.lg,
     borderStyle: "solid",
     borderWidth: spacing.px,
     gap: gap.md,

--- a/src/components/onboarding/step-follow.tsx
+++ b/src/components/onboarding/step-follow.tsx
@@ -6,6 +6,7 @@ import { discoverApi } from "#/integrations/tanstack-query/api-discover.function
 
 import { Flex } from "../../design-system/flex";
 import { primaryColor, uiColor } from "../../design-system/theme/color.stylex";
+import { radius } from "../../design-system/theme/radius.stylex";
 import { verticalSpace } from "../../design-system/theme/semantic-spacing.stylex";
 import {
   fontFamily,
@@ -29,7 +30,7 @@ const styles = stylex.create({
   },
   rows: {
     borderColor: uiColor.border1,
-    borderRadius: 12,
+    borderRadius: radius.lg,
     borderStyle: "solid",
     borderWidth: 1,
     display: "flex",

--- a/src/components/onboarding/step-friends.tsx
+++ b/src/components/onboarding/step-friends.tsx
@@ -7,6 +7,7 @@ import { ONBOARDING_FRIENDS_LIMIT } from "#/lib/onboarding";
 
 import { Flex } from "../../design-system/flex";
 import { uiColor } from "../../design-system/theme/color.stylex";
+import { radius } from "../../design-system/theme/radius.stylex";
 import { spacing } from "../../design-system/theme/spacing.stylex";
 import {
   fontFamily,
@@ -22,7 +23,7 @@ const styles = stylex.create({
   // step of the wizard reads as one list rather than three treatments.
   rows: {
     borderColor: uiColor.border1,
-    borderRadius: 12,
+    borderRadius: radius.lg,
     borderStyle: "solid",
     borderWidth: 1,
     display: "flex",

--- a/src/components/onboarding/step-settings.tsx
+++ b/src/components/onboarding/step-settings.tsx
@@ -13,12 +13,12 @@ import { Flex } from "../../design-system/flex";
 import { Separator } from "../../design-system/separator";
 import { Switch } from "../../design-system/switch";
 import { primaryColor, uiColor } from "../../design-system/theme/color.stylex";
+import { radius } from "../../design-system/theme/radius.stylex";
 import {
   gap,
   horizontalSpace,
   verticalSpace,
 } from "../../design-system/theme/semantic-spacing.stylex";
-import { spacing } from "../../design-system/theme/spacing.stylex";
 import {
   fontFamily,
   fontSize,
@@ -42,7 +42,7 @@ const styles = stylex.create({
   },
   group: {
     borderColor: uiColor.border1,
-    borderRadius: spacing["2"],
+    borderRadius: radius.md,
     borderStyle: "solid",
     borderWidth: 1,
     display: "flex",

--- a/src/components/reader/about-view.tsx
+++ b/src/components/reader/about-view.tsx
@@ -85,7 +85,7 @@ const styles = stylex.create({
     boxSizing: "border-box",
     marginInlineStart: "auto",
     marginInlineEnd: "auto",
-    maxWidth: "1040px",
+    maxWidth: "65rem",
     paddingBottom: spacing["24"],
     paddingInlineStart: {
       default: spacing["10"],
@@ -112,7 +112,7 @@ const styles = stylex.create({
   },
   sHead: {
     marginBottom: verticalSpace["8xl"],
-    maxWidth: "640px",
+    maxWidth: "40rem",
   },
   sHeadKicker: {
     display: "inline-block",
@@ -287,7 +287,7 @@ const styles = stylex.create({
     marginInlineStart: "auto",
     marginInlineEnd: "auto",
     marginTop: spacing["11"],
-    maxWidth: "760px",
+    maxWidth: "47.5rem",
     // eslint-disable-next-line @stylexjs/valid-styles
     maskImage: "linear-gradient(to bottom, #000 82%, transparent)",
     rowGap: spacing["2.5"],
@@ -796,7 +796,7 @@ const styles = stylex.create({
     fontSize: fontSize.sm,
     marginBottom: verticalSpace.none,
     marginTop: verticalSpace.none,
-    minWidth: "220px",
+    minWidth: "13.75rem",
   },
   builderLink: {
     marginTop: verticalSpace.none,

--- a/src/components/reader/app-shell.tsx
+++ b/src/components/reader/app-shell.tsx
@@ -131,7 +131,10 @@ const styles = stylex.create({
     // stays pinned outside the scrollport and content never hides behind it.
     overflow: "hidden",
     top: 0,
-    width: "264px",
+    // rem, not px: the appearance text-size dial scales the root font size, and
+    // a sidebar pinned in px would keep its width while the labels inside it
+    // grew (264px at the default root size).
+    width: "16.5rem",
   },
   sidebarScroll: {
     overscrollBehavior: "contain",

--- a/src/components/reader/appearance-themes.ts
+++ b/src/components/reader/appearance-themes.ts
@@ -1,0 +1,563 @@
+import * as stylex from "@stylexjs/stylex";
+
+import {
+  primaryColor,
+  uiColor,
+  uiInverted,
+} from "../../design-system/theme/color.stylex";
+import { amber } from "../../design-system/theme/colors/amber.stylex";
+import { grass } from "../../design-system/theme/colors/grass.stylex";
+import { indigo } from "../../design-system/theme/colors/indigo.stylex";
+import {
+  mauve,
+  mauveInverted,
+} from "../../design-system/theme/colors/mauve.stylex";
+import { plum } from "../../design-system/theme/colors/plum.stylex";
+import {
+  sage,
+  sageInverted,
+} from "../../design-system/theme/colors/sage.stylex";
+import {
+  sand,
+  sandInverted,
+} from "../../design-system/theme/colors/sand.stylex";
+import {
+  slate,
+  slateInverted,
+} from "../../design-system/theme/colors/slate.stylex";
+import { teal } from "../../design-system/theme/colors/teal.stylex";
+import { tomato } from "../../design-system/theme/colors/tomato.stylex";
+import { mediaQueries } from "../../design-system/theme/media-queries.stylex";
+import { radius } from "../../design-system/theme/radius.stylex";
+import { size } from "../../design-system/theme/semantic-spacing.stylex";
+import { spacing } from "../../design-system/theme/spacing.stylex";
+import { fontFamily } from "../../design-system/theme/typography.stylex";
+import type { AppearanceFont, PaletteId } from "../../lib/appearance";
+import { editorialPrimary, editorialUi } from "./theme";
+
+/**
+ * Themes behind the `custom` theme mode and the appearance dials
+ * (`#/lib/appearance`).
+ *
+ * Two tracks, deliberately:
+ *
+ * - **Curated palettes** are static `createTheme`s over the vendored Radix
+ *   scales. They cost nothing at runtime and are exactly the palette Radix
+ *   ships — no approximation. Each states one scheme; the shell forces
+ *   `color-scheme` to it, which is what picks the right half of every
+ *   `light-dark()` in the scale.
+ * - **The reader's own colors** go through `appearance-vars.ts`, which
+ *   generates a full contrast-checked ramp into `--sr-*` custom properties that
+ *   `customUi` / `customPrimary` below read.
+ *
+ * The numeric dials are multipliers rather than swapped literals: one `calc()`
+ * per token, so the same setting moves the chrome *and* the article body (whose
+ * sizes are authored as raw rem, not tokens) in step. Each falls back to `1`, so
+ * a reader on the defaults renders identically to before this existed.
+ */
+
+const OVERLAY_BACKDROP = "light-dark(rgba(4, 1, 1, 0.5), rgba(0, 0, 0, 0.75))";
+
+const EDITORIAL_TITLE =
+  "'Newsreader', 'Newsreader Fallback: Georgia', 'Newsreader Fallback: Times New Roman', Georgia, 'Times New Roman', serif";
+const EDITORIAL_SANS =
+  "'Atkinson Hyperlegible Next', 'Atkinson Hyperlegible Next Fallback: -apple-system', 'Atkinson Hyperlegible Next Fallback: Arial', system-ui, -apple-system, sans-serif";
+const EDITORIAL_MONO =
+  "'Spline Sans Mono', 'Spline Sans Mono Fallback', ui-monospace, 'SFMono-Regular', monospace";
+
+/* -------------------------------------------------------------------------- */
+/* Neutral (ui) palettes                                                      */
+/* -------------------------------------------------------------------------- */
+
+export const sageUi = stylex.createTheme(uiColor, {
+  overlayBackdrop: OVERLAY_BACKDROP,
+  bg: sage.bg,
+  bgSubtle: sage.bgSubtle,
+  component1: sage.component1,
+  component2: sage.component2,
+  component3: sage.component3,
+  border1: sage.border1,
+  border2: sage.border2,
+  border3: sage.border3,
+  solid1: sage.solid1,
+  solid2: sage.solid2,
+  text1: sage.text1,
+  text2: sage.text2,
+  textContrast: "white",
+});
+
+export const sageUiInverted = stylex.createTheme(uiInverted, {
+  bg: sageInverted.bg,
+  bgSubtle: sageInverted.bgSubtle,
+  component1: sageInverted.component1,
+  component2: sageInverted.component2,
+  component3: sageInverted.component3,
+  border1: sageInverted.border1,
+  border2: sageInverted.border2,
+  border3: sageInverted.border3,
+  solid1: sageInverted.solid1,
+  solid2: sageInverted.solid2,
+  text1: sageInverted.text1,
+  text2: sageInverted.text2,
+  textContrast: "white",
+});
+
+export const sandUi = stylex.createTheme(uiColor, {
+  overlayBackdrop: OVERLAY_BACKDROP,
+  bg: sand.bg,
+  bgSubtle: sand.bgSubtle,
+  component1: sand.component1,
+  component2: sand.component2,
+  component3: sand.component3,
+  border1: sand.border1,
+  border2: sand.border2,
+  border3: sand.border3,
+  solid1: sand.solid1,
+  solid2: sand.solid2,
+  text1: sand.text1,
+  text2: sand.text2,
+  textContrast: "white",
+});
+
+export const sandUiInverted = stylex.createTheme(uiInverted, {
+  bg: sandInverted.bg,
+  bgSubtle: sandInverted.bgSubtle,
+  component1: sandInverted.component1,
+  component2: sandInverted.component2,
+  component3: sandInverted.component3,
+  border1: sandInverted.border1,
+  border2: sandInverted.border2,
+  border3: sandInverted.border3,
+  solid1: sandInverted.solid1,
+  solid2: sandInverted.solid2,
+  text1: sandInverted.text1,
+  text2: sandInverted.text2,
+  textContrast: "white",
+});
+
+export const slateUi = stylex.createTheme(uiColor, {
+  overlayBackdrop: OVERLAY_BACKDROP,
+  bg: slate.bg,
+  bgSubtle: slate.bgSubtle,
+  component1: slate.component1,
+  component2: slate.component2,
+  component3: slate.component3,
+  border1: slate.border1,
+  border2: slate.border2,
+  border3: slate.border3,
+  solid1: slate.solid1,
+  solid2: slate.solid2,
+  text1: slate.text1,
+  text2: slate.text2,
+  textContrast: "white",
+});
+
+export const slateUiInverted = stylex.createTheme(uiInverted, {
+  bg: slateInverted.bg,
+  bgSubtle: slateInverted.bgSubtle,
+  component1: slateInverted.component1,
+  component2: slateInverted.component2,
+  component3: slateInverted.component3,
+  border1: slateInverted.border1,
+  border2: slateInverted.border2,
+  border3: slateInverted.border3,
+  solid1: slateInverted.solid1,
+  solid2: slateInverted.solid2,
+  text1: slateInverted.text1,
+  text2: slateInverted.text2,
+  textContrast: "white",
+});
+
+export const mauveUi = stylex.createTheme(uiColor, {
+  overlayBackdrop: OVERLAY_BACKDROP,
+  bg: mauve.bg,
+  bgSubtle: mauve.bgSubtle,
+  component1: mauve.component1,
+  component2: mauve.component2,
+  component3: mauve.component3,
+  border1: mauve.border1,
+  border2: mauve.border2,
+  border3: mauve.border3,
+  solid1: mauve.solid1,
+  solid2: mauve.solid2,
+  text1: mauve.text1,
+  text2: mauve.text2,
+  textContrast: "white",
+});
+
+export const mauveUiInverted = stylex.createTheme(uiInverted, {
+  bg: mauveInverted.bg,
+  bgSubtle: mauveInverted.bgSubtle,
+  component1: mauveInverted.component1,
+  component2: mauveInverted.component2,
+  component3: mauveInverted.component3,
+  border1: mauveInverted.border1,
+  border2: mauveInverted.border2,
+  border3: mauveInverted.border3,
+  solid1: mauveInverted.solid1,
+  solid2: mauveInverted.solid2,
+  text1: mauveInverted.text1,
+  text2: mauveInverted.text2,
+  textContrast: "white",
+});
+
+/* -------------------------------------------------------------------------- */
+/* Accent palettes                                                            */
+/* -------------------------------------------------------------------------- */
+
+export const grassPrimary = stylex.createTheme(primaryColor, {
+  bg: grass.bg,
+  bgSubtle: grass.bgSubtle,
+  component1: grass.component1,
+  component2: grass.component2,
+  component3: grass.component3,
+  border1: grass.border1,
+  border2: grass.border2,
+  border3: grass.border3,
+  solid1: grass.solid1,
+  solid2: grass.solid2,
+  text1: grass.text1,
+  text2: grass.text2,
+  textContrast: "white",
+});
+
+export const tomatoPrimary = stylex.createTheme(primaryColor, {
+  bg: tomato.bg,
+  bgSubtle: tomato.bgSubtle,
+  component1: tomato.component1,
+  component2: tomato.component2,
+  component3: tomato.component3,
+  border1: tomato.border1,
+  border2: tomato.border2,
+  border3: tomato.border3,
+  solid1: tomato.solid1,
+  solid2: tomato.solid2,
+  text1: tomato.text1,
+  text2: tomato.text2,
+  textContrast: "white",
+});
+
+export const indigoPrimary = stylex.createTheme(primaryColor, {
+  bg: indigo.bg,
+  bgSubtle: indigo.bgSubtle,
+  component1: indigo.component1,
+  component2: indigo.component2,
+  component3: indigo.component3,
+  border1: indigo.border1,
+  border2: indigo.border2,
+  border3: indigo.border3,
+  solid1: indigo.solid1,
+  solid2: indigo.solid2,
+  text1: indigo.text1,
+  text2: indigo.text2,
+  textContrast: "white",
+});
+
+export const plumPrimary = stylex.createTheme(primaryColor, {
+  bg: plum.bg,
+  bgSubtle: plum.bgSubtle,
+  component1: plum.component1,
+  component2: plum.component2,
+  component3: plum.component3,
+  border1: plum.border1,
+  border2: plum.border2,
+  border3: plum.border3,
+  solid1: plum.solid1,
+  solid2: plum.solid2,
+  text1: plum.text1,
+  text2: plum.text2,
+  textContrast: "white",
+});
+
+export const tealPrimary = stylex.createTheme(primaryColor, {
+  bg: teal.bg,
+  bgSubtle: teal.bgSubtle,
+  component1: teal.component1,
+  component2: teal.component2,
+  component3: teal.component3,
+  border1: teal.border1,
+  border2: teal.border2,
+  border3: teal.border3,
+  solid1: teal.solid1,
+  solid2: teal.solid2,
+  text1: teal.text1,
+  text2: teal.text2,
+  textContrast: "white",
+});
+
+/** Amber's solid steps are bright enough that white on them fails AA. */
+export const amberPrimary = stylex.createTheme(primaryColor, {
+  bg: amber.bg,
+  bgSubtle: amber.bgSubtle,
+  component1: amber.component1,
+  component2: amber.component2,
+  component3: amber.component3,
+  border1: amber.border1,
+  border2: amber.border2,
+  border3: amber.border3,
+  solid1: amber.solid1,
+  solid2: amber.solid2,
+  text1: amber.text1,
+  text2: amber.text2,
+  textContrast: "black",
+});
+
+/* -------------------------------------------------------------------------- */
+/* The reader's own colors                                                    */
+/* -------------------------------------------------------------------------- */
+
+export const customUi = stylex.createTheme(uiColor, {
+  overlayBackdrop:
+    "light-dark(var(--sr-overlay-light), var(--sr-overlay-dark))",
+  bg: "light-dark(var(--sr-bg-light), var(--sr-bg-dark))",
+  bgSubtle: "light-dark(var(--sr-bgSubtle-light), var(--sr-bgSubtle-dark))",
+  component1:
+    "light-dark(var(--sr-component1-light), var(--sr-component1-dark))",
+  component2:
+    "light-dark(var(--sr-component2-light), var(--sr-component2-dark))",
+  component3:
+    "light-dark(var(--sr-component3-light), var(--sr-component3-dark))",
+  border1: "light-dark(var(--sr-border1-light), var(--sr-border1-dark))",
+  border2: "light-dark(var(--sr-border2-light), var(--sr-border2-dark))",
+  border3: "light-dark(var(--sr-border3-light), var(--sr-border3-dark))",
+  solid1: "light-dark(var(--sr-solid1-light), var(--sr-solid1-dark))",
+  solid2: "light-dark(var(--sr-solid2-light), var(--sr-solid2-dark))",
+  text1: "light-dark(var(--sr-text1-light), var(--sr-text1-dark))",
+  text2: "light-dark(var(--sr-text2-light), var(--sr-text2-dark))",
+  textContrast:
+    "light-dark(var(--sr-textContrast-light), var(--sr-textContrast-dark))",
+});
+
+export const customPrimary = stylex.createTheme(primaryColor, {
+  bg: "light-dark(var(--sr-accent-bg-light), var(--sr-accent-bg-dark))",
+  bgSubtle:
+    "light-dark(var(--sr-accent-bgSubtle-light), var(--sr-accent-bgSubtle-dark))",
+  component1:
+    "light-dark(var(--sr-accent-component1-light), var(--sr-accent-component1-dark))",
+  component2:
+    "light-dark(var(--sr-accent-component2-light), var(--sr-accent-component2-dark))",
+  component3:
+    "light-dark(var(--sr-accent-component3-light), var(--sr-accent-component3-dark))",
+  border1:
+    "light-dark(var(--sr-accent-border1-light), var(--sr-accent-border1-dark))",
+  border2:
+    "light-dark(var(--sr-accent-border2-light), var(--sr-accent-border2-dark))",
+  border3:
+    "light-dark(var(--sr-accent-border3-light), var(--sr-accent-border3-dark))",
+  solid1:
+    "light-dark(var(--sr-accent-solid1-light), var(--sr-accent-solid1-dark))",
+  solid2:
+    "light-dark(var(--sr-accent-solid2-light), var(--sr-accent-solid2-dark))",
+  text1:
+    "light-dark(var(--sr-accent-text1-light), var(--sr-accent-text1-dark))",
+  text2:
+    "light-dark(var(--sr-accent-text2-light), var(--sr-accent-text2-dark))",
+  textContrast:
+    "light-dark(var(--sr-accent-textContrast-light), var(--sr-accent-textContrast-dark))",
+});
+
+/* -------------------------------------------------------------------------- */
+/* Interface typeface                                                         */
+/* -------------------------------------------------------------------------- */
+
+/** One family throughout: Atkinson carries headings as well as UI. */
+export const sansInterfaceFonts = stylex.createTheme(fontFamily, {
+  title: EDITORIAL_SANS,
+  sans: EDITORIAL_SANS,
+  serif: EDITORIAL_SANS,
+  mono: EDITORIAL_MONO,
+});
+
+/**
+ * A Google family the reader chose, layered over the editorial stack: if the
+ * font hasn't loaded (or Google doesn't serve it), each slot falls back to the
+ * family it would otherwise have used, including the Capsize metric-adjusted
+ * fallbacks — so text never jumps size as it loads.
+ */
+export const customInterfaceFonts = stylex.createTheme(fontFamily, {
+  title: `var(--sr-ui-font, ${EDITORIAL_TITLE}), ${EDITORIAL_TITLE}`,
+  sans: `var(--sr-ui-font, ${EDITORIAL_SANS}), ${EDITORIAL_SANS}`,
+  serif: `var(--sr-ui-font, ${EDITORIAL_TITLE}), ${EDITORIAL_TITLE}`,
+  mono: EDITORIAL_MONO,
+});
+
+/* -------------------------------------------------------------------------- */
+/* Numeric dials                                                              */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Roundness.
+ *
+ * `full` rides the dial too, via a large finite radius rather than `infinity`:
+ * at any scale above zero it still resolves to a pill, and at `sharp` it
+ * squares off like everything else. Leaving it at `calc(infinity * 1px)` meant
+ * every pill in the app — unread counts, tags, avatars — stayed round while the
+ * surfaces around them went sharp, which reads as a bug rather than a choice.
+ */
+export const radiusScale = stylex.createTheme(radius, {
+  xs: {
+    default: "calc(0.3rem * var(--sr-radius-scale, 1))",
+    [mediaQueries.supportsSquircle]: "calc(0.5rem * var(--sr-radius-scale, 1))",
+  },
+  sm: {
+    default: "calc(0.4rem * var(--sr-radius-scale, 1))",
+    [mediaQueries.supportsSquircle]:
+      "calc(0.75rem * var(--sr-radius-scale, 1))",
+  },
+  md: {
+    default: "calc(0.5rem * var(--sr-radius-scale, 1))",
+    [mediaQueries.supportsSquircle]: "calc(1rem * var(--sr-radius-scale, 1))",
+  },
+  lg: {
+    default: "calc(0.75rem * var(--sr-radius-scale, 1))",
+    [mediaQueries.supportsSquircle]: "calc(1.5rem * var(--sr-radius-scale, 1))",
+  },
+  xl: {
+    default: "calc(1.35rem * var(--sr-radius-scale, 1))",
+    [mediaQueries.supportsSquircle]: "calc(2.5rem * var(--sr-radius-scale, 1))",
+  },
+  "2xl": {
+    default: "calc(1.5rem * var(--sr-radius-scale, 1))",
+    [mediaQueries.supportsSquircle]: "calc(3rem * var(--sr-radius-scale, 1))",
+  },
+  "3xl": {
+    default: "calc(1.9rem * var(--sr-radius-scale, 1))",
+    [mediaQueries.supportsSquircle]: "calc(3.5rem * var(--sr-radius-scale, 1))",
+  },
+  "4xl": {
+    default: "calc(2.1rem * var(--sr-radius-scale, 1))",
+    [mediaQueries.supportsSquircle]: "calc(4rem * var(--sr-radius-scale, 1))",
+  },
+  full: "calc(9999px * var(--sr-radius-scale, 1))",
+});
+
+/**
+ * Density. Scaling the base spacing scale reaches every semantic scale derived
+ * from it (padding, margin, gap) *and* the article body's own rhythm, which is
+ * authored against these same tokens. `px` and `0` stay put: a hairline is a
+ * hairline at any density.
+ */
+export const spaceScale = stylex.createTheme(spacing, {
+  px: "1px",
+  "0": "0px",
+  "0.5": "calc(0.125rem * var(--sr-space-scale, 1))",
+  "1": "calc(0.25rem * var(--sr-space-scale, 1))",
+  "1.5": "calc(0.375rem * var(--sr-space-scale, 1))",
+  "2": "calc(0.5rem * var(--sr-space-scale, 1))",
+  "2.5": "calc(0.625rem * var(--sr-space-scale, 1))",
+  "3": "calc(0.75rem * var(--sr-space-scale, 1))",
+  "3.5": "calc(0.875rem * var(--sr-space-scale, 1))",
+  "4": "calc(1rem * var(--sr-space-scale, 1))",
+  "5": "calc(1.25rem * var(--sr-space-scale, 1))",
+  "6": "calc(1.5rem * var(--sr-space-scale, 1))",
+  "7": "calc(1.75rem * var(--sr-space-scale, 1))",
+  "8": "calc(2rem * var(--sr-space-scale, 1))",
+  "9": "calc(2.25rem * var(--sr-space-scale, 1))",
+  "10": "calc(2.5rem * var(--sr-space-scale, 1))",
+  "11": "calc(2.75rem * var(--sr-space-scale, 1))",
+  "12": "calc(3rem * var(--sr-space-scale, 1))",
+  "14": "calc(3.5rem * var(--sr-space-scale, 1))",
+  "16": "calc(4rem * var(--sr-space-scale, 1))",
+  "20": "calc(5rem * var(--sr-space-scale, 1))",
+  "24": "calc(6rem * var(--sr-space-scale, 1))",
+  "28": "calc(7rem * var(--sr-space-scale, 1))",
+  "32": "calc(8rem * var(--sr-space-scale, 1))",
+  "36": "calc(9rem * var(--sr-space-scale, 1))",
+  "40": "calc(10rem * var(--sr-space-scale, 1))",
+  "44": "calc(11rem * var(--sr-space-scale, 1))",
+  "48": "calc(12rem * var(--sr-space-scale, 1))",
+  "52": "calc(13rem * var(--sr-space-scale, 1))",
+  "56": "calc(14rem * var(--sr-space-scale, 1))",
+  "60": "calc(15rem * var(--sr-space-scale, 1))",
+  "64": "calc(16rem * var(--sr-space-scale, 1))",
+  "72": "calc(18rem * var(--sr-space-scale, 1))",
+  "80": "calc(20rem * var(--sr-space-scale, 1))",
+  "96": "calc(24rem * var(--sr-space-scale, 1))",
+});
+
+/**
+ * Control, icon and avatar boxes, held out of the density dial.
+ *
+ * `size` is derived from `spacing`, so without this theme it would inherit the
+ * density multiplier — and a control's geometry is not spacing. Components mix
+ * steps freely (the switch takes its track height from one step and its width
+ * from another), so scaling only part of the scale distorts them; scaling all of
+ * it clips icons, whose own dimensions are fixed pixel props on the SVG.
+ *
+ * Density stays where it belongs: the padding, margins and gaps *between*
+ * things, which is what the reader perceives as density anyway.
+ *
+ * The text dial isn't here either — it scales the root font size, so every rem
+ * below already follows it.
+ */
+export const controlSizes = stylex.createTheme(size, {
+  none: "0px",
+  xxs: "0.625rem",
+  xs: "0.75rem",
+  sm: "0.875rem",
+  md: "1rem",
+  lg: "1.25rem",
+  xl: "1.5rem",
+  "2xl": "1.75rem",
+  "3xl": "2rem",
+  "4xl": "2.75rem",
+  "5xl": "3.5rem",
+  "6xl": "4rem",
+  "7xl": "5rem",
+  "8xl": "8rem",
+  "9xl": "10rem",
+  "10xl": "15rem",
+  "11xl": "16rem",
+  "12xl": "18rem",
+});
+
+/* -------------------------------------------------------------------------- */
+/* Resolution                                                                 */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The color themes a palette wears. Almanac is the app's own editorial theme —
+ * choosing it in `custom` mode is how a reader pins the default palette to light
+ * or dark without following the OS.
+ */
+export function paletteThemes(palette: PaletteId) {
+  switch (palette) {
+    case "meadow": {
+      return [sageUi, sageUiInverted, grassPrimary];
+    }
+    case "press": {
+      return [sandUi, sandUiInverted, tomatoPrimary];
+    }
+    case "ink": {
+      return [slateUi, slateUiInverted, indigoPrimary];
+    }
+    case "archive": {
+      return [mauveUi, mauveUiInverted, plumPrimary];
+    }
+    case "tide": {
+      return [slateUi, slateUiInverted, tealPrimary];
+    }
+    case "ember": {
+      return [sandUi, sandUiInverted, amberPrimary];
+    }
+    case "custom": {
+      return [customUi, customPrimary];
+    }
+    default: {
+      return [editorialUi, editorialPrimary];
+    }
+  }
+}
+
+/** `null` keeps the editorial stack applied by the shell. */
+export function interfaceFontTheme(font: AppearanceFont) {
+  if (font === "sans") return sansInterfaceFonts;
+  if (font === "custom") return customInterfaceFonts;
+  return null;
+}
+
+/**
+ * Applied in every theme mode: the dials are shape and type, not color, and
+ * they no-op at their default scale.
+ */
+export const APPEARANCE_SCALE_THEMES = [radiusScale, spaceScale, controlSizes];

--- a/src/components/reader/appearance-vars.test.ts
+++ b/src/components/reader/appearance-vars.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import { contrastRatio } from "#/lib/collections/color";
+
 import { customPaletteVars } from "./appearance-vars";
 import { publicationThemeScaleVars } from "./publication-theme-scale";
 
@@ -55,4 +57,34 @@ describe("the reader's own palette", () => {
   it("routes a dark paper to the dark scheme", () => {
     expect(vars("#1b1512", "#e0703a")["--sr-bg-dark"]).toBe("#1b1512");
   });
+});
+
+describe("muted text", () => {
+  /**
+   * `text1` is the secondary/muted step and `text2` the primary ink. The light
+   * scale used to derive the muted one by mixing toward *black*, which on a
+   * light page put it further from the paper than the ink itself — the two came
+   * out ~1.1:1 apart and read as one color.
+   */
+  it.each([
+    ["#fcfaf5", "#ad7f58", "light"],
+    ["#fcfcfd", "#3e63dd", "light"],
+    ["#1b1512", "#e0703a", "dark"],
+    ["#0f0f10", "#12a594", "dark"],
+  ] as const)(
+    "stays clearly distinct from the primary ink (%s)",
+    (paper, accent, scheme) => {
+      const v = vars(paper, accent);
+      const bg = v[`--sr-bg-${scheme}`];
+      const muted = v[`--sr-text1-${scheme}`];
+      const ink = v[`--sr-text2-${scheme}`];
+
+      // Reads as a different color from the ink...
+      expect(contrastRatio(muted, ink)).toBeGreaterThan(2);
+      // ...while still clearing AA against the page it sits on.
+      expect(contrastRatio(muted, bg)).toBeGreaterThanOrEqual(4.5);
+      // ...and staying lighter-weight than the ink, never darker.
+      expect(contrastRatio(ink, bg)).toBeGreaterThan(contrastRatio(muted, bg));
+    },
+  );
 });

--- a/src/components/reader/appearance-vars.test.ts
+++ b/src/components/reader/appearance-vars.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { customPaletteVars } from "./appearance-vars";
+import { publicationThemeScaleVars } from "./publication-theme-scale";
+
+const LIGHT_PAPER = "#fcfaf5";
+/** Pale sand — about 1.2:1 against the paper above, well under AA. */
+const PALE_ACCENT = "#f0d0a0";
+
+function vars(paper: string, accent: string): Record<string, string> {
+  return customPaletteVars(paper, accent) as Record<string, string>;
+}
+
+describe("the reader's own palette", () => {
+  it("keeps the accent they picked, however little contrast it has", () => {
+    expect(vars(LIGHT_PAPER, PALE_ACCENT)["--sr-accent-solid1-light"]).toBe(
+      PALE_ACCENT,
+    );
+  });
+
+  /**
+   * The same colors handed to us by a publication still get the substitution —
+   * a stranger's site shouldn't be able to grey out our chrome. This is the
+   * contrast that makes the reader-facing behaviour a deliberate choice rather
+   * than a hole in the color science.
+   */
+  it("still substitutes a low-contrast accent for a publication theme", () => {
+    const publication = publicationThemeScaleVars({
+      themeBackground: LIGHT_PAPER,
+      themeForeground: "#241f1b",
+      themeAccent: PALE_ACCENT,
+      themeAccentForeground: null,
+    }) as Record<string, string>;
+    expect(publication["--pub-accent-solid1-light"]).not.toBe(PALE_ACCENT);
+  });
+
+  it("keeps a strong accent verbatim too", () => {
+    expect(vars(LIGHT_PAPER, "#ad7f58")["--sr-accent-solid1-light"]).toBe(
+      "#ad7f58",
+    );
+  });
+
+  it("derives warm ink for warm paper rather than snapping to black", () => {
+    const ink = vars("#1b1512", "#e0703a")["--sr-text2-dark"];
+    expect(ink).not.toBe("#ffffff");
+    // Warm: red channel ahead of blue.
+    const [r, , b] = [
+      Number.parseInt(ink.slice(1, 3), 16),
+      Number.parseInt(ink.slice(3, 5), 16),
+      Number.parseInt(ink.slice(5, 7), 16),
+    ];
+    expect(r).toBeGreaterThan(b);
+  });
+
+  it("routes a dark paper to the dark scheme", () => {
+    expect(vars("#1b1512", "#e0703a")["--sr-bg-dark"]).toBe("#1b1512");
+  });
+});

--- a/src/components/reader/appearance-vars.ts
+++ b/src/components/reader/appearance-vars.ts
@@ -1,0 +1,101 @@
+import Color from "colorjs.io";
+import type { CSSProperties } from "react";
+
+import type { AppearancePreference } from "#/lib/appearance";
+import {
+  DEFAULT_CUSTOM_ACCENT,
+  DEFAULT_CUSTOM_PAPER,
+  appearanceScaleVars,
+  normalizeAppearance,
+} from "#/lib/appearance";
+
+import { publicationThemeScaleVars } from "./publication-theme-scale";
+
+/**
+ * Namespace for the reader's own palette, deliberately distinct from the
+ * publication theme's `--pub-*`: a publication page nested inside a custom app
+ * theme sets its own vars, and the two must not overwrite each other.
+ */
+export const APPEARANCE_VAR_PREFIX = "sr";
+
+/**
+ * Ink for a reader-chosen paper.
+ *
+ * The reader picks two colors, not four, so the text color has to come from
+ * somewhere. Snapping to black or white (what the scale generator does on its
+ * own when handed no foreground) throws away the paper's character — warm paper
+ * deserves warm ink. Mirror the paper through OKLCH instead: keep its hue, move
+ * lightness to the far end, and keep a trace of its chroma. The generator still
+ * enforces contrast on top of this, so a low-contrast result can't ship.
+ */
+function inkForPaper(paper: string): string {
+  try {
+    const color = new Color(paper).to("oklch");
+    const lightness = color.coords[0] ?? 1;
+    const chroma = color.coords[1] ?? 0;
+    const hue = color.coords[2] ?? 0;
+    const isDarkPaper = lightness < 0.5;
+    const ink = new Color("oklch", [
+      isDarkPaper ? 0.93 : 0.24,
+      Math.min(chroma * (isDarkPaper ? 0.6 : 1.2), 0.03),
+      hue,
+    ]);
+    return ink.to("srgb").toString({ format: "hex" });
+  } catch {
+    return "#000000";
+  }
+}
+
+/**
+ * The `--sr-*` scale for a reader's own accent + paper, using the same color
+ * science that paints publication themes (`publicationThemeScaleVars`): one
+ * stated background is routed to the mode its luminance matches and the other
+ * mode is mirrored through OKLCH.
+ *
+ * `trustStatedAccent` is the difference between theming your own app and being
+ * handed someone else's. For a publication, an accent that can't clear 3:1
+ * against the page is replaced by the page's ink — a stranger's site shouldn't
+ * be able to make our chrome unreadable. Here the reader picked the color, and
+ * substituting it means choosing a primary color and watching it come back grey.
+ * They keep what they chose; the settings panel scores the result and says so.
+ */
+export function customPaletteVars(
+  paper: string,
+  accent: string,
+): CSSProperties {
+  return publicationThemeScaleVars(
+    {
+      themeBackground: paper,
+      themeForeground: inkForPaper(paper),
+      themeAccent: accent,
+      themeAccentForeground: null,
+    },
+    APPEARANCE_VAR_PREFIX,
+    { trustStatedAccent: true },
+  );
+}
+
+/**
+ * Every custom property the appearance preference publishes: the numeric dials
+ * in all modes, plus the custom palette's scale when one is in use.
+ *
+ * Returns `undefined` when there is nothing to set, so a reader on the defaults
+ * gets no inline `style` at all and the markup stays byte-identical.
+ */
+export function appearanceStyleVars(
+  preference: AppearancePreference,
+  options: { includePalette: boolean },
+): CSSProperties | undefined {
+  const normalized = normalizeAppearance(preference);
+  const scaleVars = appearanceScaleVars(normalized);
+  const paletteVars =
+    options.includePalette && normalized.palette === "custom"
+      ? customPaletteVars(
+          normalized.customPaper ?? DEFAULT_CUSTOM_PAPER,
+          normalized.customAccent ?? DEFAULT_CUSTOM_ACCENT,
+        )
+      : undefined;
+
+  if (!paletteVars && Object.keys(scaleVars).length === 0) return undefined;
+  return { ...paletteVars, ...scaleVars };
+}

--- a/src/components/reader/collection-builder.tsx
+++ b/src/components/reader/collection-builder.tsx
@@ -72,7 +72,7 @@ const MAX_ITEMS = 42;
 const innerPadding = {
   marginInlineStart: "auto",
   marginInlineEnd: "auto",
-  maxWidth: "1320px",
+  maxWidth: "82.5rem",
   paddingInlineStart: {
     default: spacing["5"],
     "@media (min-width: 40rem)": spacing["10"],
@@ -109,7 +109,7 @@ const styles = stylex.create({
     flexBasis: "0%",
     flexGrow: 1,
     flexShrink: 1,
-    minWidth: "240px",
+    minWidth: "15rem",
   },
   heroName: {
     color: uiColor.text2,

--- a/src/components/reader/collection-theme-editor.tsx
+++ b/src/components/reader/collection-theme-editor.tsx
@@ -158,7 +158,7 @@ const styles = stylex.create({
     textTransform: "uppercase",
   },
   previewAccentPill: {
-    borderRadius: "999px",
+    borderRadius: radius.full,
     backgroundColor: "var(--accent)",
     color: "var(--accent-contrast)",
     display: "inline-block",

--- a/src/components/reader/content/body-styles.ts
+++ b/src/components/reader/content/body-styles.ts
@@ -38,11 +38,32 @@ const READING_LINE_HEIGHT = 1.68;
 /** Edge length of a task-list checkbox, relative to the reading font size. */
 const TASK_CHECKBOX_SIZE = "0.75em";
 
+/**
+ * Reading sizes, in rem so the appearance text-size dial carries them: that dial
+ * scales the root font size, which is what makes one setting move the chrome and
+ * the prose together. The reading-typography preference then picks between the
+ * small / default / large sets below, on top of that baseline.
+ */
+const READING_SIZE_DEFAULT = "1.1875rem";
+const READING_SIZE_DEFAULT_WIDE = "1.25rem";
+const READING_SIZE_SMALL = "1rem";
+const READING_SIZE_SMALL_WIDE = "1.0625rem";
+const READING_SIZE_LARGE = "1.3125rem";
+const READING_SIZE_LARGE_WIDE = "1.375rem";
+const READING_SIZE_PULLQUOTE = "1.6875rem";
+
+/** Atkinson, stated literally — see `bodyFontSans`. */
+const READING_SANS_STACK =
+  "'Atkinson Hyperlegible Next', 'Atkinson Hyperlegible Next Fallback: -apple-system', 'Atkinson Hyperlegible Next Fallback: Arial', system-ui, -apple-system, sans-serif";
+
 export const articleBodyStyles = stylex.create({
   body: {
     color: uiColor.text2,
     fontFamily: fontFamily.serif,
-    fontSize: { default: "1.1875rem", "@media (min-width: 40rem)": "1.25rem" },
+    fontSize: {
+      default: READING_SIZE_DEFAULT,
+      "@media (min-width: 40rem)": READING_SIZE_DEFAULT_WIDE,
+    },
     lineHeight: READING_LINE_HEIGHT,
     marginTop: spacing["9"],
     minWidth: 0,
@@ -114,7 +135,7 @@ export const articleBodyStyles = stylex.create({
   pullquote: {
     color: uiColor.text2,
     fontFamily: fontFamily.serif,
-    fontSize: "1.6875rem",
+    fontSize: READING_SIZE_PULLQUOTE,
     fontStyle: "italic",
     fontWeight: fontWeight.medium,
     lineHeight: 1.32,
@@ -660,7 +681,10 @@ export const articleBodyStyles = stylex.create({
     display: "flex",
     flexDirection: "column",
     fontFamily: fontFamily.serif,
-    fontSize: { default: "1.1875rem", "@media (min-width: 40rem)": "1.25rem" },
+    fontSize: {
+      default: READING_SIZE_DEFAULT,
+      "@media (min-width: 40rem)": READING_SIZE_DEFAULT_WIDE,
+    },
     lineHeight: READING_LINE_HEIGHT,
     paddingBottom: spacing["4"],
     paddingInlineStart: spacing["4"],
@@ -694,7 +718,7 @@ export const articleBodyStyles = stylex.create({
     display: "block",
     objectFit: "cover",
     height: "auto",
-    maxHeight: "240px",
+    maxHeight: "15rem",
     width: "100%",
   },
   facetUnderline: {
@@ -816,16 +840,25 @@ export const articleBodyStyles = stylex.create({
     minWidth: 0,
   },
   bodyFontSizeSmall: {
-    fontSize: { default: "1rem", "@media (min-width: 40rem)": "1.0625rem" },
+    fontSize: {
+      default: READING_SIZE_SMALL,
+      "@media (min-width: 40rem)": READING_SIZE_SMALL_WIDE,
+    },
   },
   bodyFontSizeLarge: {
     fontSize: {
-      default: "1.3125rem",
-      "@media (min-width: 40rem)": "1.375rem",
+      default: READING_SIZE_LARGE,
+      "@media (min-width: 40rem)": READING_SIZE_LARGE_WIDE,
     },
   },
+  /**
+   * An explicit reading-font override, so it names the family outright rather
+   * than going through `fontFamily.sans`: that token follows the appearance
+   * interface font, which would collapse this option into the default one for
+   * anyone who picked a font of their own.
+   */
   bodyFontSans: {
-    fontFamily: fontFamily.sans,
+    fontFamily: READING_SANS_STACK,
   },
 });
 

--- a/src/components/reader/format-i18n.ts
+++ b/src/components/reader/format-i18n.ts
@@ -40,3 +40,27 @@ export function formatArticleReadStats(
     msg`${plural(readCount, { one: "# read", other: `${value} reads` })}`,
   );
 }
+
+/**
+ * Publication header meta: how long ago the publication last posted.
+ *
+ * Lives here, taking an `i18n`, because the earlier version took the `t` from
+ * `useLingui()` as a *parameter* — which Lingui's macro cannot see, so none of
+ * these strings were ever extracted and every one of them resolved to an empty
+ * string at runtime. The stat rendered its label with no value.
+ */
+export function formatLastActive(i18n: I18n, iso: string | null): string {
+  if (!iso) return "—";
+  const parsed = Date.parse(iso);
+  if (Number.isNaN(parsed)) return "—";
+  const days = Math.floor((Date.now() - parsed) / 86_400_000);
+  if (days <= 0) return i18n._(msg`today`);
+  if (days === 1) return i18n._(msg`yesterday`);
+  if (days < 30) return i18n._(msg`${days}d ago`);
+  if (days < 365) {
+    const months = Math.floor(days / 30);
+    return i18n._(msg`${months}mo ago`);
+  }
+  const years = Math.floor(days / 365);
+  return i18n._(msg`${years}y ago`);
+}

--- a/src/components/reader/legal-page-styles.ts
+++ b/src/components/reader/legal-page-styles.ts
@@ -21,7 +21,7 @@ export const legalPageStyles = stylex.create({
     boxSizing: "border-box",
     marginInlineStart: "auto",
     marginInlineEnd: "auto",
-    maxWidth: "640px",
+    maxWidth: "40rem",
     paddingBottom: {
       [MOBILE]: spacing["20"],
       default: spacing["20"],

--- a/src/components/reader/primitives.tsx
+++ b/src/components/reader/primitives.tsx
@@ -99,7 +99,7 @@ const styles = stylex.create({
     boxSizing: "border-box",
     marginInlineStart: "auto",
     marginInlineEnd: "auto",
-    maxWidth: "1320px",
+    maxWidth: "82.5rem",
     paddingBottom: `var(--pub-page-content-bottom, ${spacing["20"]})`,
     paddingInlineStart: {
       default: spacing["5"],

--- a/src/components/reader/publication-theme-scale.ts
+++ b/src/components/reader/publication-theme-scale.ts
@@ -481,11 +481,29 @@ function applyNeutralAnchors(
 }
 
 /**
+ * Muted body text (`text1`) for a page.
+ *
+ * Mixed toward the *background*, not toward black or white. The light scale used
+ * to derive this as `darken(foreground, …)`, which on a light page moves the
+ * "secondary" color further from the paper than the primary ink is — so the two
+ * read as the same near-black and the muted step did no work. The app's own
+ * editorial palette sits about 0.42 of the way from ink to page in both modes,
+ * which is the figure used here; `ensureReadable` then pulls it back if a
+ * particular pair lands under AA, keeping its hue rather than snapping to grey.
+ */
+const MUTED_TEXT_MIX = 0.42;
+
+function mutedText(ink: Rgb, background: Rgb): Rgb {
+  return ensureReadable(mix(ink, background, MUTED_TEXT_MIX), background, 4.5);
+}
+
+/**
  * Build the neutral (ui) scale from an already-dark background + foreground.
  * Split out from {@link buildUiScale} so a publisher-authored dark palette can
  * be used verbatim instead of one derived by darkening their light background.
  */
 function buildDarkUiScale(darkBg: Rgb, foreground: Rgb): ColorScale {
+  const darkInk = ensureContrast(lighten(foreground, 0.75), darkBg, 4.5);
   return {
     bg: toHex(darkBg),
     bgSubtle: toHex(lighten(darkBg, 0.03)),
@@ -497,8 +515,8 @@ function buildDarkUiScale(darkBg: Rgb, foreground: Rgb): ColorScale {
     border3: toHex(lighten(darkBg, 0.36)),
     solid1: toHex(lighten(darkBg, 0.72)),
     solid2: toHex(lighten(darkBg, 0.6)),
-    text1: toHex(ensureContrast(lighten(foreground, 0.3), darkBg, 3)),
-    text2: toHex(ensureContrast(lighten(foreground, 0.75), darkBg, 4.5)),
+    text1: toHex(mutedText(darkInk, darkBg)),
+    text2: toHex(darkInk),
     textContrast: toHex(darkBg),
   };
 }
@@ -510,6 +528,7 @@ function buildDarkUiScale(darkBg: Rgb, foreground: Rgb): ColorScale {
  * {@link isDarkColor} routing exists to prevent.
  */
 function buildLightUiScale(background: Rgb, foreground: Rgb): ColorScale {
+  const lightInk = ensureContrast(foreground, background, 4.5);
   return {
     bg: toHex(background),
     bgSubtle: toHex(darken(background, 0.02)),
@@ -521,8 +540,8 @@ function buildLightUiScale(background: Rgb, foreground: Rgb): ColorScale {
     border3: toHex(darken(background, 0.32)),
     solid1: toHex(darken(foreground, 0.75)),
     solid2: toHex(darken(foreground, 0.6)),
-    text1: toHex(ensureContrast(darken(foreground, 0.2), background, 3)),
-    text2: toHex(ensureContrast(foreground, background, 4.5)),
+    text1: toHex(mutedText(lightInk, background)),
+    text2: toHex(lightInk),
     textContrast: toHex(background),
   };
 }

--- a/src/components/reader/publication-theme-scale.ts
+++ b/src/components/reader/publication-theme-scale.ts
@@ -532,8 +532,17 @@ function buildLightUiScale(background: Rgb, foreground: Rgb): ColorScale {
  * reason as {@link buildDarkUiScale} — so a publisher's own dark palette drives
  * it rather than one derived from their light colors.
  */
-function buildDarkAccentScale(accent: Rgb, darkPageBg: Rgb): ColorScale {
+function buildDarkAccentScale(
+  accent: Rgb,
+  darkPageBg: Rgb,
+  trustStated = false,
+): ColorScale {
   const darkAccentBg = darken(accent, 0.78);
+  // `ensureContrast` flips to black or white when a color can't reach the
+  // ratio; `ensureReadable` moves its lightness instead, keeping the hue. For a
+  // publication we take the safe flip, but a reader who picked this color for
+  // their own app should still see their color.
+  const readable = trustStated ? ensureReadable : ensureContrast;
   return {
     bg: toHex(darkAccentBg),
     bgSubtle: toHex(lighten(darkAccentBg, 0.04)),
@@ -545,8 +554,8 @@ function buildDarkAccentScale(accent: Rgb, darkPageBg: Rgb): ColorScale {
     border3: toHex(lighten(darkAccentBg, 0.46)),
     solid1: toHex(lighten(accent, 0.12)),
     solid2: toHex(lighten(accent, 0.24)),
-    text1: toHex(ensureContrast(lighten(accent, 0.3), darkAccentBg, 3)),
-    text2: toHex(ensureContrast(lighten(accent, 0.55), darkAccentBg, 4.5)),
+    text1: toHex(readable(lighten(accent, 0.3), darkAccentBg, 3)),
+    text2: toHex(readable(lighten(accent, 0.55), darkAccentBg, 4.5)),
     textContrast: toHex(darkPageBg),
   };
 }
@@ -555,8 +564,9 @@ function buildDarkAccentScale(accent: Rgb, darkPageBg: Rgb): ColorScale {
  * Build the accent (primary) scale from the publication's accent color.
  * Light: accent tints on light bg; Dark: dark accent-tinted surfaces.
  */
-function buildLightAccentScale(accent: Rgb): ColorScale {
+function buildLightAccentScale(accent: Rgb, trustStated = false): ColorScale {
   const lightBg = lighten(accent, 0.86);
+  const readable = trustStated ? ensureReadable : ensureContrast;
   return {
     bg: toHex(lightBg),
     bgSubtle: toHex(lighten(accent, 0.82)),
@@ -568,8 +578,8 @@ function buildLightAccentScale(accent: Rgb): ColorScale {
     border3: toHex(lighten(accent, 0.16)),
     solid1: toHex(accent),
     solid2: toHex(darken(accent, 0.1)),
-    text1: toHex(ensureContrast(darken(accent, 0.1), lightBg, 3)),
-    text2: toHex(ensureContrast(darken(accent, 0.25), lightBg, 4.5)),
+    text1: toHex(readable(darken(accent, 0.1), lightBg, 3)),
+    text2: toHex(readable(darken(accent, 0.25), lightBg, 4.5)),
     textContrast: toHex(ensureContrast(WHITE, accent, 4.5)),
   };
 }
@@ -594,9 +604,12 @@ const UI_KEYS: ReadonlyArray<ScaleKey> = [
 
 const ACCENT_KEYS: ReadonlyArray<ScaleKey> = UI_KEYS;
 
-/** Prefixes that map scale keys → `--pub-*` CSS variable names. */
+/**
+ * Prefix that maps scale keys → `--pub-*` CSS variable names. Callers can pass
+ * their own (the reader's custom app palette generates `--sr-*` from the same
+ * color science — see `#/components/reader/appearance-vars`).
+ */
 const UI_PREFIX = "pub";
-const ACCENT_PREFIX = "pub-accent";
 
 function scaleKeyToVarName(
   prefix: string,
@@ -614,10 +627,24 @@ function scaleKeyToVarName(
  * Apply these on the same container that wears the `publicationUi` /
  * `publicationPrimary` StyleX theme classes — the theme classes reference
  * these vars via `light-dark(var(--pub-...-light), var(--pub-...-dark))`.
+ *
+ * `prefix` swaps `pub` for another namespace so a second consumer (the reader's
+ * own app palette) can reuse this color science without colliding with a
+ * publication theme nested inside it.
+ *
+ * `trustStatedAccent` turns off the accent's safety substitutions. A publication
+ * theme gets them: a low-contrast accent is replaced by the page's own ink so a
+ * stranger's site stays usable. A reader theming their *own* app does not — they
+ * picked that color deliberately, and silently handing back grey is a worse
+ * answer than an accent they can barely see. The settings panel scores the
+ * generated ramp and warns instead.
  */
 export function publicationThemeScaleVars(
   meta: PublicationThemeColors,
+  prefix: string = UI_PREFIX,
+  { trustStatedAccent = false }: { trustStatedAccent?: boolean } = {},
 ): CSSProperties {
+  const accentPrefix = `${prefix}-accent`;
   const colors = resolveQuoteOgColors({
     themeBackground: meta.themeBackground,
     themeForeground: meta.themeForeground,
@@ -631,7 +658,12 @@ export function publicationThemeScaleVars(
 
   const background = parseHex(colors.background) ?? fallbackBg;
   const foreground = parseHex(colors.foreground) ?? fallbackFg;
-  const accent = parseHex(colors.accent) ?? fallbackAccent;
+  // `resolveQuoteOgColors` swaps a low-contrast accent for the foreground; when
+  // the caller trusts the stated colors, take the accent before that happened.
+  const accent =
+    (trustStatedAccent ? parseHex(meta.themeAccent ?? "") : null) ??
+    parseHex(colors.accent) ??
+    fallbackAccent;
 
   // A theme states one background. Route it to the mode its own luminance
   // matches: a dark publication (Leaflet on black, a dark-scheme Offprint theme)
@@ -659,7 +691,7 @@ export function publicationThemeScaleVars(
     statedBgIsDark ? null : meta.neutral,
     lightBg,
   );
-  const accentLight = buildLightAccentScale(accent);
+  const accentLight = buildLightAccentScale(accent, trustStatedAccent);
 
   // Prefer the publisher's own dark palette (PCKT ships light+dark, Offprint
   // may ship a dark-scheme theme); otherwise use their stated background when it
@@ -702,22 +734,26 @@ export function publicationThemeScaleVars(
     authoredDark ? authoredDark.neutral : statedBgIsDark ? meta.neutral : null,
     WHITE,
   );
-  const accentDark = buildDarkAccentScale(darkAccent ?? accent, darkBg);
+  const accentDark = buildDarkAccentScale(
+    darkAccent ?? accent,
+    darkBg,
+    trustStatedAccent,
+  );
 
   const vars: Record<string, string> = {};
 
   for (const key of UI_KEYS) {
-    vars[scaleKeyToVarName(UI_PREFIX, key, false)] = uiLight[key];
-    vars[scaleKeyToVarName(UI_PREFIX, key, true)] = uiDark[key];
+    vars[scaleKeyToVarName(prefix, key, false)] = uiLight[key];
+    vars[scaleKeyToVarName(prefix, key, true)] = uiDark[key];
   }
   for (const key of ACCENT_KEYS) {
-    vars[scaleKeyToVarName(ACCENT_PREFIX, key, false)] = accentLight[key];
-    vars[scaleKeyToVarName(ACCENT_PREFIX, key, true)] = accentDark[key];
+    vars[scaleKeyToVarName(accentPrefix, key, false)] = accentLight[key];
+    vars[scaleKeyToVarName(accentPrefix, key, true)] = accentDark[key];
   }
 
   // Overlay backdrop — derived from foreground hue.
-  vars["--pub-overlay-light"] = toHex(darken(foreground, 0.6));
-  vars["--pub-overlay-dark"] = toHex(darken(BLACK, 0.2));
+  vars[`--${prefix}-overlay-light`] = toHex(darken(foreground, 0.6));
+  vars[`--${prefix}-overlay-dark`] = toHex(darken(BLACK, 0.2));
 
   // Stated link colour, per mode. Left unset when the publisher states none, so
   // `publicationLink` falls back to the accent's text step. Contrast is enforced
@@ -735,8 +771,8 @@ export function publicationThemeScaleVars(
     authoredDark ? authoredDark.link : meta.link,
     darkBg,
   );
-  if (lightLink) vars["--pub-link-light"] = lightLink;
-  if (darkLink) vars["--pub-link-dark"] = darkLink;
+  if (lightLink) vars[`--${prefix}-link-light`] = lightLink;
+  if (darkLink) vars[`--${prefix}-link-dark`] = darkLink;
 
   return vars as CSSProperties;
 }

--- a/src/components/reading-custom-font-picker.tsx
+++ b/src/components/reading-custom-font-picker.tsx
@@ -79,7 +79,9 @@ export function ReadingCustomFontPicker({
     <ComboBox
       label={label}
       aria-label={label == null ? t`Google Font` : undefined}
-      size="lg"
+      // Sized to match the rest of a settings row; `lg` stood a head above the
+      // segmented controls and switches beside it.
+      size="md"
       placeholder={t`Search Google Fonts`}
       items={items}
       inputValue={search}

--- a/src/components/settings-row-styles.ts
+++ b/src/components/settings-row-styles.ts
@@ -1,0 +1,77 @@
+import * as stylex from "@stylexjs/stylex";
+
+import { uiColor } from "../design-system/theme/color.stylex";
+import {
+  gap,
+  horizontalSpace,
+  verticalSpace,
+} from "../design-system/theme/semantic-spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+} from "../design-system/theme/typography.stylex";
+
+const MOBILE = "@media (max-width: 47.5rem)";
+
+/**
+ * One labelled row in a settings group: label (+ optional description) on the
+ * start edge, the control on the end edge, stacking on mobile.
+ *
+ * Shared by the settings page and the appearance panel so both read as the same
+ * list rather than two designs that happen to sit next to each other. Styles
+ * live apart from the component so each file exports one kind of thing (React
+ * fast refresh only works when a module exports components alone).
+ */
+export const settingRowStyles = stylex.create({
+  row: {
+    alignItems: {
+      [MOBILE]: "stretch",
+      default: "center",
+    },
+    columnGap: gap["3xl"],
+    display: "flex",
+    flexDirection: {
+      [MOBILE]: "column",
+      default: "row",
+    },
+    justifyContent: "space-between",
+    rowGap: gap["lg"],
+    paddingBottom: verticalSpace["3xl"],
+    paddingInlineStart: horizontalSpace["3xl"],
+    paddingInlineEnd: horizontalSpace["3xl"],
+    paddingTop: verticalSpace["3xl"],
+  },
+  label: {
+    color: uiColor.text2,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.sm,
+    fontWeight: fontWeight.medium,
+    lineHeight: lineHeight.sm,
+    marginBottom: verticalSpace.xs,
+    marginTop: verticalSpace.none,
+  },
+  description: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.xs,
+    lineHeight: lineHeight.sm,
+    marginBottom: verticalSpace.none,
+    marginTop: verticalSpace.none,
+    maxWidth: "42ch",
+  },
+  control: {
+    flexShrink: 0,
+    width: {
+      [MOBILE]: "100%",
+      default: "auto",
+    },
+  },
+  segmentedControl: {
+    width: {
+      [MOBILE]: "100%",
+      default: "auto",
+    },
+  },
+});

--- a/src/components/settings-row.tsx
+++ b/src/components/settings-row.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+
+import { settingRowStyles } from "./settings-row-styles";
+
+export function SettingRow({
+  label,
+  description,
+  children,
+}: {
+  label: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div {...stylex.props(settingRowStyles.row)}>
+      <div>
+        <p {...stylex.props(settingRowStyles.label)}>{label}</p>
+        {description ? (
+          <p {...stylex.props(settingRowStyles.description)}>{description}</p>
+        ) : null}
+      </div>
+      <div {...stylex.props(settingRowStyles.control)}>{children}</div>
+    </div>
+  );
+}

--- a/src/components/user-settings-view.tsx
+++ b/src/components/user-settings-view.tsx
@@ -6,7 +6,14 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import * as stylex from "@stylexjs/stylex";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { ChevronRight, Monitor, Moon, Sparkles, Sun } from "lucide-react";
+import {
+  ChevronRight,
+  Monitor,
+  Moon,
+  Palette,
+  Sparkles,
+  Sun,
+} from "lucide-react";
 import { useCallback, useState } from "react";
 
 import { invalidateReadQueries } from "#/components/reader/read-optimistic";
@@ -58,6 +65,11 @@ import {
 import { Avatar } from "../design-system/avatar";
 import { Button } from "../design-system/button";
 import { Dialog, DialogBody, DialogHeader } from "../design-system/dialog";
+import {
+  Disclosure,
+  DisclosurePanel,
+  DisclosureTitle,
+} from "../design-system/disclosure";
 import { Flex } from "../design-system/flex";
 import { ProgressCircle } from "../design-system/progress-circle";
 import {
@@ -82,9 +94,15 @@ import {
   lineHeight,
   tracking,
 } from "../design-system/theme/typography.stylex";
+import {
+  AppearanceAdvancedRows,
+  AppearancePalettePanel,
+} from "./appearance-settings";
 import { Masthead, ReaderContent } from "./reader/primitives";
 import { ReadingCustomFontPicker } from "./reading-custom-font-picker";
 import { ReadingSettingsPreview } from "./reading-settings-preview";
+import { SettingRow } from "./settings-row";
+import { settingRowStyles } from "./settings-row-styles";
 import { TypographySegmentedControl } from "./typography-segmented-control";
 
 const MOBILE = "@media (max-width: 47.5rem)";
@@ -97,6 +115,7 @@ const THEME_OPTIONS: Array<{
   { id: "light", label: msg`Light`, icon: Sun },
   { id: "dark", label: msg`Dark`, icon: Moon },
   { id: "system", label: msg`System`, icon: Monitor },
+  { id: "custom", label: msg`Custom`, icon: Palette },
 ];
 
 /** The pseudo-locale is a translation-coverage tool, not a language to ship. */
@@ -147,55 +166,12 @@ const styles = stylex.create({
   },
   settingGroup: {
     borderColor: uiColor.border1,
-    borderRadius: spacing["2"],
+    borderRadius: radius.md,
     borderStyle: "solid",
     borderWidth: 1,
     overflow: "hidden",
     display: "flex",
     flexDirection: "column",
-  },
-  settingRow: {
-    alignItems: {
-      [MOBILE]: "stretch",
-      default: "center",
-    },
-    columnGap: gap["3xl"],
-    display: "flex",
-    flexDirection: {
-      [MOBILE]: "column",
-      default: "row",
-    },
-    justifyContent: "space-between",
-    rowGap: gap["lg"],
-    paddingBottom: verticalSpace["3xl"],
-    paddingInlineStart: horizontalSpace["3xl"],
-    paddingInlineEnd: horizontalSpace["3xl"],
-    paddingTop: verticalSpace["3xl"],
-  },
-  settingLabel: {
-    color: uiColor.text2,
-    fontFamily: fontFamily.sans,
-    fontSize: fontSize.sm,
-    fontWeight: fontWeight.medium,
-    lineHeight: lineHeight.sm,
-    marginBottom: verticalSpace.xs,
-    marginTop: verticalSpace.none,
-  },
-  settingDescription: {
-    color: uiColor.text1,
-    fontFamily: fontFamily.sans,
-    fontSize: fontSize.xs,
-    lineHeight: lineHeight.sm,
-    marginBottom: verticalSpace.none,
-    marginTop: verticalSpace.none,
-    maxWidth: "42ch",
-  },
-  settingControl: {
-    flexShrink: 0,
-    width: {
-      [MOBILE]: "100%",
-      default: "auto",
-    },
   },
   labelerList: {
     gap: gap.xs,
@@ -248,6 +224,27 @@ const styles = stylex.create({
       [MOBILE]: "100%",
       default: "auto",
     },
+  },
+  /** Line the disclosure up with the setting rows above it. */
+  advancedTitle: {
+    // The design-system disclosure rounds its own trigger, which reads as a
+    // floating box dropped inside the settings group. As the group's last row it
+    // should be flush like every row above it — the group is `overflow: hidden`,
+    // so its own corner shape still clips the bottom edge.
+    borderRadius: 0,
+    color: uiColor.text2,
+    fontSize: fontSize.sm,
+    paddingBottom: verticalSpace["3xl"],
+    paddingInlineStart: horizontalSpace["3xl"],
+    paddingInlineEnd: horizontalSpace["3xl"],
+    paddingTop: verticalSpace["3xl"],
+  },
+  /** The rows inside carry their own padding. */
+  advancedPanel: {
+    paddingBottom: verticalSpace.none,
+    paddingInlineStart: horizontalSpace.none,
+    paddingInlineEnd: horizontalSpace.none,
+    paddingTop: verticalSpace.none,
   },
   voiceSelect: {
     minWidth: {
@@ -315,28 +312,6 @@ const styles = stylex.create({
   },
 });
 
-function SettingRow({
-  label,
-  description,
-  children,
-}: {
-  label: string;
-  description?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div {...stylex.props(styles.settingRow)}>
-      <div>
-        <p {...stylex.props(styles.settingLabel)}>{label}</p>
-        {description ? (
-          <p {...stylex.props(styles.settingDescription)}>{description}</p>
-        ) : null}
-      </div>
-      <div {...stylex.props(styles.settingControl)}>{children}</div>
-    </div>
-  );
-}
-
 function DataDeletionRow({
   label,
   description,
@@ -359,8 +334,8 @@ function DataDeletionRow({
   return (
     <div {...stylex.props(styles.deletionRow)}>
       <div>
-        <p {...stylex.props(styles.settingLabel)}>{label}</p>
-        <p {...stylex.props(styles.settingDescription)}>{description}</p>
+        <p {...stylex.props(settingRowStyles.label)}>{label}</p>
+        <p {...stylex.props(settingRowStyles.description)}>{description}</p>
       </div>
       <AlertDialog
         isOpen={open}
@@ -597,45 +572,11 @@ export function UserSettingsView() {
         </h2>
         <div {...stylex.props(styles.settingGroup)}>
           <SettingRow
-            label={t`Theme`}
-            description={t`Choose light, dark, or match your system setting.`}
-          >
-            <SegmentedControl
-              selectedKeys={new Set([mode])}
-              onSelectionChange={(keys: Set<React.Key> | "all") => {
-                const key = keys === "all" ? undefined : String([...keys][0]);
-                if (isThemeMode(key)) setMode(key);
-              }}
-              style={styles.segmentedControl}
-            >
-              {THEME_OPTIONS.map(({ id, label, icon: Icon }) => (
-                <SegmentedControlItem key={id} id={id}>
-                  <Flex align="center" gap="xs">
-                    <Icon size={14} />
-                    {i18n._(label)}
-                  </Flex>
-                </SegmentedControlItem>
-              ))}
-            </SegmentedControl>
-          </SettingRow>
-          <Separator />
-          <SettingRow
-            label={t`Use publication themes`}
-            description={t`When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme.`}
-          >
-            <Switch
-              isSelected={usePublicationTheme}
-              onChange={setUsePublicationTheme}
-              aria-label={t`Use publication themes`}
-            />
-          </SettingRow>
-          <Separator />
-          <SettingRow
             label={t`Language`}
             description={t`The language used for the reader interface. Articles are shown in the language they were written in.`}
           >
             <Select
-              size="lg"
+              size="md"
               aria-label={t`Language`}
               selectedKey={locale}
               onSelectionChange={(key) => {
@@ -655,6 +596,55 @@ export function UserSettingsView() {
               ))}
             </Select>
           </SettingRow>
+          <Separator />
+          <SettingRow
+            label={t`Use publication themes`}
+            description={t`When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme.`}
+          >
+            <Switch
+              isSelected={usePublicationTheme}
+              onChange={setUsePublicationTheme}
+              aria-label={t`Use publication themes`}
+            />
+          </SettingRow>
+          <Separator />
+          <SettingRow
+            label={t`Theme`}
+            description={t`Light, dark, match your system — or Custom, to choose a palette of your own.`}
+          >
+            <SegmentedControl
+              selectedKeys={new Set([mode])}
+              onSelectionChange={(keys: Set<React.Key> | "all") => {
+                const key = keys === "all" ? undefined : String([...keys][0]);
+                if (isThemeMode(key)) setMode(key);
+              }}
+              style={styles.segmentedControl}
+            >
+              {THEME_OPTIONS.map(({ id, label, icon: Icon }) => (
+                <SegmentedControlItem key={id} id={id}>
+                  <Flex align="center" gap="xs">
+                    <Icon size={14} />
+                    {i18n._(label)}
+                  </Flex>
+                </SegmentedControlItem>
+              ))}
+            </SegmentedControl>
+          </SettingRow>
+          {mode === "custom" ? (
+            <>
+              <Separator />
+              <AppearancePalettePanel />
+            </>
+          ) : null}
+          <Separator />
+          <Disclosure>
+            <DisclosureTitle style={styles.advancedTitle}>
+              <Trans>Advanced</Trans>
+            </DisclosureTitle>
+            <DisclosurePanel contentStyle={styles.advancedPanel}>
+              <AppearanceAdvancedRows />
+            </DisclosurePanel>
+          </Disclosure>
         </div>
       </section>
 
@@ -941,7 +931,7 @@ export function UserSettingsView() {
             description={t`The voice used when you listen to an article with read aloud.`}
           >
             <Select
-              size="lg"
+              size="md"
               aria-label={t`Reader voice`}
               selectedKey={voice}
               style={styles.voiceSelect}

--- a/src/db/schema/auth.ts
+++ b/src/db/schema/auth.ts
@@ -31,8 +31,14 @@ export const user = pgTable("user", {
   did: text("did").unique(),
   image: text("image"),
   isAdmin: boolean("is_admin").default(false).notNull(),
-  /** `light` | `dark`; `null` follows system preference. */
+  /** `light` | `dark` | `custom`; `null` follows system preference. `custom`
+   * takes its colors — and its light/dark identity — from `appearance`. */
   themeMode: text("theme_mode"),
+  /** Compact `palette:paper:accent:font:family:textSize:roundness:density`
+   * encoding (`src/lib/appearance.ts`); `null` = defaults. Holds the custom
+   * palette plus the font/size/roundness/density dials, which apply in every
+   * theme mode. */
+  appearance: text("appearance"),
   /** BCP-47 tag from `LOCALES` (`src/lib/locale.ts`); `null` negotiates from
    * the request's `Accept-Language` header. */
   locale: text("locale"),

--- a/src/design-system/segmented-control/index.tsx
+++ b/src/design-system/segmented-control/index.tsx
@@ -26,6 +26,7 @@ import {
 } from "../theme/semantic-spacing.stylex";
 import { shadow } from "../theme/shadow.stylex";
 import type { Size, StyleXComponentProps } from "../theme/types";
+import { fontSize } from "../theme/typography.stylex";
 
 const styles = stylex.create({
   group: {
@@ -60,6 +61,18 @@ const styles = stylex.create({
     // eslint-disable-next-line @stylexjs/valid-styles
     textBoxTrim: "trim-both",
     borderWidth: 0,
+
+    // Stated rather than inherited: a <button> takes neither the family nor the
+    // size of its ancestors, so without this the items rendered at the UA
+    // default (~13px system font) — close enough to `sm` to look intentional,
+    // but outside the type scale, so no theme or text-size preference reached
+    // them. Matched to the design-system Button's own per-size mapping.
+    fontSize: {
+      ":is([data-size=lg] *)": fontSize["base"],
+      ":is([data-size=md] *)": fontSize["sm"],
+      ":is([data-size=sm] *)": fontSize["xs"],
+      default: fontSize["sm"],
+    },
 
     cornerShape: "squircle",
     gap: gap["xs"],

--- a/src/integrations/tanstack-query/api-user.functions.ts
+++ b/src/integrations/tanstack-query/api-user.functions.ts
@@ -9,6 +9,22 @@ import { z } from "zod";
 import { revokeAtprotoSession } from "#/integrations/auth/atproto";
 import { AUTH_SESSION_TOKEN_COOKIE } from "#/integrations/auth/constants";
 import { hasEmailScope } from "#/integrations/auth/scope";
+import type { AppearancePreference } from "#/lib/appearance";
+import {
+  APPEARANCE_COOKIE,
+  APPEARANCE_COOKIE_MAX_AGE_SECONDS,
+  APPEARANCE_DENSITIES,
+  APPEARANCE_FONTS,
+  APPEARANCE_ROUNDNESS,
+  APPEARANCE_TEXT_SIZES,
+  DEFAULT_APPEARANCE,
+  PALETTE_IDS,
+  appearanceToCookieValue,
+  appearanceToDbValue,
+  dbValueToAppearance,
+  normalizeAppearance,
+  parseAppearanceCookie,
+} from "#/lib/appearance";
 import {
   COUNT_OLD_POSTS_AS_UNREAD_COOKIE,
   COUNT_OLD_POSTS_AS_UNREAD_COOKIE_MAX_AGE_SECONDS,
@@ -288,6 +304,9 @@ const getShellBootstrap = createServerFn({ method: "GET" }).handler(
           cookies[READING_TYPOGRAPHY_COOKIE],
         ),
       },
+      appearance: {
+        preference: parseAppearanceCookie(cookies[APPEARANCE_COOKIE]),
+      },
       usePublicationTheme: { enabled: DEFAULT_USE_PUBLICATION_THEME },
       collectionsAuthoring: { enabled: false },
       shell: null,
@@ -328,6 +347,7 @@ const getShellBootstrap = createServerFn({ method: "GET" }).handler(
             openLinksExternally: true,
             openCollectionsInMagazine: true,
             readingTypography: true,
+            appearance: true,
             usePublicationTheme: true,
             collectionsAuthoringEnabled: true,
             atstoreReviewPromptDismissed: true,
@@ -462,6 +482,7 @@ const getShellBootstrap = createServerFn({ method: "GET" }).handler(
       readingTypography: {
         preference: dbValueToReadingTypography(userRow.readingTypography),
       },
+      appearance: { preference: dbValueToAppearance(userRow.appearance) },
       usePublicationTheme: {
         enabled: dbValueToUsePublicationTheme(userRow.usePublicationTheme),
       },
@@ -959,6 +980,78 @@ const setReadingTypographyPreference = createServerFn({ method: "POST" })
     return { preference };
   });
 
+const HEX_INPUT = /^#?[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$/;
+
+const appearanceInput = z.object({
+  preference: z.object({
+    palette: z.enum(PALETTE_IDS),
+    customPaper: z.string().regex(HEX_INPUT).optional(),
+    customAccent: z.string().regex(HEX_INPUT).optional(),
+    font: z.enum(APPEARANCE_FONTS),
+    customFontFamily: z.string().min(1).max(80).optional(),
+    textSize: z.enum(APPEARANCE_TEXT_SIZES),
+    roundness: z.enum(APPEARANCE_ROUNDNESS),
+    density: z.enum(APPEARANCE_DENSITIES),
+  }),
+});
+
+const getAppearancePreference = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware, maybeAuthMiddleware])
+  .handler(
+    async ({
+      context,
+    }): Promise<{
+      preference: AppearancePreference;
+    }> => {
+      const session = context?.session;
+      if (session?.user) {
+        const row = await context.db.query.user.findFirst({
+          where: eq(context.schema.user.id, session.user.id),
+          columns: { appearance: true },
+        });
+        return { preference: dbValueToAppearance(row?.appearance ?? null) };
+      }
+
+      return {
+        preference: parseAppearanceCookie(getCookie(APPEARANCE_COOKIE)),
+      };
+    },
+  );
+
+const getAppearancePreferenceQueryOptions = queryOptions({
+  queryKey: ["appearancePreference"] as const,
+  queryFn: () => getAppearancePreference(),
+  staleTime: Number.POSITIVE_INFINITY,
+});
+
+const setAppearancePreference = createServerFn({ method: "POST" })
+  .middleware([dbMiddleware, maybeAuthMiddleware])
+  .validator(appearanceInput)
+  .handler(async ({ data, context }) => {
+    // `normalizeAppearance` is the authority: it drops fields the chosen
+    // options don't use and falls back to defaults for anything unusable, so a
+    // hand-rolled request can't persist a half-valid palette.
+    const preference = normalizeAppearance({
+      ...DEFAULT_APPEARANCE,
+      ...data.preference,
+    });
+
+    setCookie(APPEARANCE_COOKIE, appearanceToCookieValue(preference), {
+      path: "/",
+      sameSite: "lax",
+      maxAge: APPEARANCE_COOKIE_MAX_AGE_SECONDS,
+    });
+
+    if (context?.session?.user) {
+      await context.db
+        .update(context.schema.user)
+        .set({ appearance: appearanceToDbValue(preference) })
+        .where(eq(context.schema.user.id, context.session.user.id));
+    }
+
+    return { preference };
+  });
+
 const getTrackReadingHistoryPreference = createServerFn({ method: "GET" })
   .middleware([dbMiddleware, maybeAuthMiddleware])
   .handler(async ({ context }): Promise<{ enabled: boolean }> => {
@@ -1393,6 +1486,9 @@ export const user = {
   getReadingTypographyPreference,
   getReadingTypographyPreferenceQueryOptions,
   setReadingTypographyPreference,
+  getAppearancePreference,
+  getAppearancePreferenceQueryOptions,
+  setAppearancePreference,
   getTrackReadingHistoryPreference,
   getTrackReadingHistoryPreferenceQueryOptions,
   setTrackReadingHistoryPreference,

--- a/src/lib/appearance.test.ts
+++ b/src/lib/appearance.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+
+import type { AppearancePreference } from "./appearance";
+import {
+  DEFAULT_APPEARANCE,
+  appearanceIsDefault,
+  appearanceScaleVars,
+  appearanceScheme,
+  appearanceThemeColor,
+  appearanceToCookieValue,
+  appearanceToDbValue,
+  dbValueToAppearance,
+  normalizeAppearance,
+  normalizeHexColor,
+  parseAppearanceCookie,
+} from "./appearance";
+import { parseReadingTypographyCookie } from "./reading-typography";
+
+const CUSTOM: AppearancePreference = {
+  palette: "custom",
+  customPaper: "#1b1512",
+  customAccent: "#e0703a",
+  font: "custom",
+  customFontFamily: "Playfair Display",
+  textSize: "xl",
+  roundness: "sharp",
+  density: "compact",
+};
+
+describe("appearance cookie encoding", () => {
+  it("round-trips every field", () => {
+    expect(parseAppearanceCookie(appearanceToCookieValue(CUSTOM))).toEqual(
+      CUSTOM,
+    );
+  });
+
+  it("round-trips a curated palette", () => {
+    const preference = { ...DEFAULT_APPEARANCE, palette: "tide" } as const;
+    expect(parseAppearanceCookie(appearanceToCookieValue(preference))).toEqual(
+      preference,
+    );
+  });
+
+  /**
+   * `Set-Cookie` percent-encodes the value, so the string handed back on the
+   * next request has `%3A` where we wrote `:`. Parsing that as-is silently
+   * returned the defaults, wiping the reader's palette on every load.
+   */
+  it("parses the percent-encoded form the browser returns", () => {
+    const encoded = encodeURIComponent(appearanceToCookieValue(CUSTOM));
+    expect(encoded).not.toBe(appearanceToCookieValue(CUSTOM));
+    expect(parseAppearanceCookie(encoded)).toEqual(CUSTOM);
+  });
+
+  it("falls back to defaults for junk", () => {
+    expect(parseAppearanceCookie("")).toEqual(DEFAULT_APPEARANCE);
+    expect(parseAppearanceCookie("nonsense")).toEqual(DEFAULT_APPEARANCE);
+    expect(parseAppearanceCookie(null)).toEqual(DEFAULT_APPEARANCE);
+  });
+
+  it("drops retired option values", () => {
+    // `round` was removed once squircles made it indistinguishable from default.
+    expect(
+      parseAppearanceCookie("almanac:-:-:editorial:-:default:round:default")
+        .roundness,
+    ).toBe("default");
+  });
+});
+
+describe("normalization", () => {
+  it("drops colors that a curated palette doesn't use", () => {
+    const normalized = normalizeAppearance({
+      ...CUSTOM,
+      palette: "meadow",
+    });
+    expect(normalized.customPaper).toBeUndefined();
+    expect(normalized.customAccent).toBeUndefined();
+  });
+
+  it("drops the family when the font isn't custom", () => {
+    const normalized = normalizeAppearance({ ...CUSTOM, font: "sans" });
+    expect(normalized.customFontFamily).toBeUndefined();
+  });
+
+  it("falls back to the editorial stack when the family is unusable", () => {
+    const normalized = normalizeAppearance({
+      ...CUSTOM,
+      customFontFamily: "  ",
+    });
+    expect(normalized.font).toBe("editorial");
+  });
+
+  it("fills in default colors for a custom palette", () => {
+    const normalized = normalizeAppearance({
+      ...DEFAULT_APPEARANCE,
+      palette: "custom",
+    });
+    expect(normalized.customPaper).toBeDefined();
+    expect(normalized.customAccent).toBeDefined();
+  });
+});
+
+describe("normalizeHexColor", () => {
+  it("accepts the forms a color input can produce", () => {
+    expect(normalizeHexColor("#AABBCC")).toBe("#aabbcc");
+    expect(normalizeHexColor("aabbcc")).toBe("#aabbcc");
+    expect(normalizeHexColor("#abc")).toBe("#aabbcc");
+    expect(normalizeHexColor(" #AbC ")).toBe("#aabbcc");
+  });
+
+  it("rejects anything else", () => {
+    expect(normalizeHexColor("rgb(1,2,3)")).toBeNull();
+    expect(normalizeHexColor("#12345")).toBeNull();
+    expect(normalizeHexColor(42)).toBeNull();
+  });
+});
+
+describe("scheme", () => {
+  it("takes a curated palette's stated scheme", () => {
+    expect(appearanceScheme({ ...DEFAULT_APPEARANCE, palette: "meadow" })).toBe(
+      "light",
+    );
+    expect(appearanceScheme({ ...DEFAULT_APPEARANCE, palette: "tide" })).toBe(
+      "dark",
+    );
+  });
+
+  it("derives a custom palette's scheme from the paper", () => {
+    expect(appearanceScheme(CUSTOM)).toBe("dark");
+    expect(appearanceScheme({ ...CUSTOM, customPaper: "#fdfcf8" })).toBe(
+      "light",
+    );
+  });
+
+  it("reports the palette's own page color for the title bar", () => {
+    expect(appearanceThemeColor(CUSTOM)).toBe("#1b1512");
+    expect(
+      appearanceThemeColor({ ...DEFAULT_APPEARANCE, palette: "tide" }),
+    ).toBe("#111113");
+  });
+});
+
+describe("scale vars", () => {
+  it("emits nothing at the defaults, so untouched readers render as before", () => {
+    expect(appearanceScaleVars(DEFAULT_APPEARANCE)).toEqual({});
+  });
+
+  it("emits only the dials that moved", () => {
+    const vars = appearanceScaleVars({
+      ...DEFAULT_APPEARANCE,
+      textSize: "large",
+    });
+    expect(vars).toEqual({ "--sr-text-scale": "1.25" });
+  });
+
+  it("quotes a custom family so it can carry spaces", () => {
+    expect(appearanceScaleVars(CUSTOM)["--sr-ui-font"]).toBe(
+      "'Playfair Display'",
+    );
+  });
+});
+
+describe("db value", () => {
+  it("stores null for the defaults", () => {
+    expect(appearanceToDbValue(DEFAULT_APPEARANCE)).toBeNull();
+    expect(dbValueToAppearance(null)).toEqual(DEFAULT_APPEARANCE);
+  });
+
+  it("round-trips a customized preference", () => {
+    const stored = appearanceToDbValue(CUSTOM);
+    expect(stored).not.toBeNull();
+    expect(dbValueToAppearance(stored)).toEqual(CUSTOM);
+  });
+
+  it("knows when a preference is untouched", () => {
+    expect(appearanceIsDefault(DEFAULT_APPEARANCE)).toBe(true);
+    expect(appearanceIsDefault(CUSTOM)).toBe(false);
+  });
+});
+
+describe("reading typography cookie", () => {
+  /** Same percent-encoding bug as the appearance cookie — regression guard. */
+  it("parses the percent-encoded form the browser returns", () => {
+    expect(parseReadingTypographyCookie("large%3Awide%3Asans")).toEqual({
+      fontSize: "large",
+      measure: "wide",
+      bodyFont: "sans",
+      customFontFamily: undefined,
+    });
+  });
+});

--- a/src/lib/appearance.ts
+++ b/src/lib/appearance.ts
@@ -1,0 +1,479 @@
+/**
+ * Appearance preferences shared types/helpers.
+ *
+ * Two independent things live here:
+ *
+ * 1. **Palette** — which colors the app wears when the theme mode is `custom`
+ *    (see `#/lib/theme`). Either one of the curated pairs below or the reader's
+ *    own accent + paper. A palette states its own light/dark identity: the paper
+ *    color *is* the scheme, so a custom theme does not follow the OS.
+ * 2. **Shape and type** — interface font, text size, roundness, density. These
+ *    apply in every theme mode, not just `custom`, because they aren't color.
+ *
+ * Every numeric dial is a multiplier applied to the design-system token scales
+ * (`--sr-*-scale`), so one setting moves the whole app *and* the article in
+ * step. The Reading section's own controls still override the article on top of
+ * this baseline.
+ *
+ * Persisted in the `standard-reader-appearance` cookie (SSR for everyone).
+ * Signed-in readers also store the same compact encoding on `user.appearance`
+ * (`null` = all defaults).
+ */
+
+import {
+  isValidGoogleFontFamily,
+  normalizeGoogleFontFamily,
+} from "./google-fonts";
+import type { ResolvedThemeScheme } from "./theme";
+
+/** Source of truth for the palette ids — also the zod enum on the server fn. */
+export const PALETTE_IDS = [
+  "almanac",
+  "meadow",
+  "press",
+  "ink",
+  "almanacNight",
+  "archive",
+  "tide",
+  "ember",
+  "custom",
+] as const;
+
+export type PaletteId = (typeof PALETTE_IDS)[number];
+
+export type AppearanceFont = "editorial" | "sans" | "custom";
+
+export type AppearanceTextSize = "xs" | "small" | "default" | "large" | "xl";
+
+export type AppearanceRoundness = "sharp" | "soft" | "default";
+
+export type AppearanceDensity = "compact" | "default" | "relaxed";
+
+export interface AppearancePreference {
+  palette: PaletteId;
+  /** Page color when `palette` is `custom`. Decides light vs dark. */
+  customPaper?: string;
+  /** Accent when `palette` is `custom`. */
+  customAccent?: string;
+  font: AppearanceFont;
+  /** Google Font family when `font` is `custom`. */
+  customFontFamily?: string;
+  textSize: AppearanceTextSize;
+  roundness: AppearanceRoundness;
+  density: AppearanceDensity;
+}
+
+export const APPEARANCE_FONTS = ["editorial", "sans", "custom"] as const;
+export const APPEARANCE_TEXT_SIZES = [
+  "xs",
+  "small",
+  "default",
+  "large",
+  "xl",
+] as const;
+/**
+ * No step above `default`: the design system draws its corners as squircles, and
+ * past the default radius a squircle barely reads as rounder — the option looked
+ * like it did nothing.
+ */
+export const APPEARANCE_ROUNDNESS = ["sharp", "soft", "default"] as const;
+export const APPEARANCE_DENSITIES = ["compact", "default", "relaxed"] as const;
+
+export const DEFAULT_APPEARANCE: AppearancePreference = {
+  palette: "almanac",
+  font: "editorial",
+  textSize: "default",
+  roundness: "default",
+  density: "default",
+};
+
+/** Fallback colors for the custom palette — the app's own light paper + camel. */
+export const DEFAULT_CUSTOM_PAPER = "#fcfaf5";
+export const DEFAULT_CUSTOM_ACCENT = "#ad7f58";
+
+export const APPEARANCE_COOKIE = "standard-reader-appearance";
+
+export const APPEARANCE_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+/**
+ * A curated palette: a Radix accent paired with the gray Radix recommends for
+ * it, in one stated scheme. `paper` / `ink` / `accent` are the rendered scale's
+ * own steps — used for the palette tile summary, the OG-safe title-bar color,
+ * and nothing that needs sub-pixel accuracy (the tiles themselves wear the real
+ * StyleX theme, so they can't drift from these).
+ */
+export interface PaletteMeta {
+  id: Exclude<PaletteId, "custom">;
+  /** Proper noun, deliberately not translated. */
+  name: string;
+  scheme: ResolvedThemeScheme;
+  paper: string;
+  ink: string;
+  accent: string;
+}
+
+export const PALETTES: ReadonlyArray<PaletteMeta> = [
+  {
+    id: "almanac",
+    name: "Almanac",
+    scheme: "light",
+    paper: "#fcfaf5",
+    ink: "#251f1b",
+    accent: "#ad7f58",
+  },
+  {
+    id: "meadow",
+    name: "Meadow",
+    scheme: "light",
+    paper: "#fbfdfc",
+    ink: "#1a211e",
+    accent: "#46a758",
+  },
+  {
+    id: "press",
+    name: "Press",
+    scheme: "light",
+    paper: "#fdfdfc",
+    ink: "#21201c",
+    accent: "#e54d2e",
+  },
+  {
+    id: "ink",
+    name: "Ink",
+    scheme: "light",
+    paper: "#fcfcfd",
+    ink: "#1c2024",
+    accent: "#3e63dd",
+  },
+  {
+    id: "almanacNight",
+    name: "Almanac Night",
+    scheme: "dark",
+    paper: "#110c08",
+    ink: "#e8e4dd",
+    accent: "#ad7f58",
+  },
+  {
+    id: "archive",
+    name: "Archive",
+    scheme: "dark",
+    paper: "#121113",
+    ink: "#eeeef0",
+    accent: "#ab4aba",
+  },
+  {
+    id: "tide",
+    name: "Tide",
+    scheme: "dark",
+    paper: "#111113",
+    ink: "#edeef0",
+    accent: "#12a594",
+  },
+  {
+    id: "ember",
+    name: "Ember",
+    scheme: "dark",
+    paper: "#111110",
+    ink: "#eeeeec",
+    accent: "#ffc53d",
+  },
+];
+
+export function paletteMeta(id: PaletteId): PaletteMeta | null {
+  return PALETTES.find((palette) => palette.id === id) ?? null;
+}
+
+/**
+ * Multipliers applied to the design-system token scales.
+ *
+ * The steps span 14px → 24px of base interface text, which carries the article
+ * body from 19px to 28px. The top of the range is deliberately a big jump: a
+ * size control that only nudges reads as "nothing happened", and the readers who
+ * reach for the largest step want it to actually be large.
+ */
+export const TEXT_SIZE_SCALE: Record<AppearanceTextSize, string> = {
+  xs: "0.875",
+  small: "0.9375",
+  default: "1",
+  large: "1.25",
+  xl: "1.5",
+};
+
+export const ROUNDNESS_SCALE: Record<AppearanceRoundness, string> = {
+  sharp: "0",
+  soft: "0.5",
+  default: "1",
+};
+
+/**
+ * Spacing multipliers. Wider than they look: most of what a reader perceives as
+ * "density" is the padding inside rows and the gaps between them, and ±15% of
+ * that reads as no change at all.
+ */
+export const DENSITY_SCALE: Record<AppearanceDensity, string> = {
+  compact: "0.75",
+  default: "1",
+  relaxed: "1.35",
+};
+
+export function isPaletteId(value: unknown): value is PaletteId {
+  return (
+    typeof value === "string" &&
+    (PALETTE_IDS as ReadonlyArray<string>).includes(value)
+  );
+}
+
+export function isAppearanceFont(value: unknown): value is AppearanceFont {
+  return (
+    typeof value === "string" &&
+    (APPEARANCE_FONTS as ReadonlyArray<string>).includes(value)
+  );
+}
+
+export function isAppearanceTextSize(
+  value: unknown,
+): value is AppearanceTextSize {
+  return (
+    typeof value === "string" &&
+    (APPEARANCE_TEXT_SIZES as ReadonlyArray<string>).includes(value)
+  );
+}
+
+export function isAppearanceRoundness(
+  value: unknown,
+): value is AppearanceRoundness {
+  return (
+    typeof value === "string" &&
+    (APPEARANCE_ROUNDNESS as ReadonlyArray<string>).includes(value)
+  );
+}
+
+export function isAppearanceDensity(
+  value: unknown,
+): value is AppearanceDensity {
+  return (
+    typeof value === "string" &&
+    (APPEARANCE_DENSITIES as ReadonlyArray<string>).includes(value)
+  );
+}
+
+const HEX_PATTERN = /^#[0-9a-f]{6}$/;
+
+/** Normalize `#RGB` / `RRGGBB` / mixed case to `#rrggbb`, or `null`. */
+export function normalizeHexColor(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim().toLowerCase();
+  const bare = trimmed.startsWith("#") ? trimmed.slice(1) : trimmed;
+  const expanded =
+    bare.length === 3 ? [...bare].map((char) => char + char).join("") : bare;
+  const hex = `#${expanded}`;
+  return HEX_PATTERN.test(hex) ? hex : null;
+}
+
+function normalizeCustomFontFamily(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = normalizeGoogleFontFamily(value);
+  return isValidGoogleFontFamily(normalized) ? normalized : undefined;
+}
+
+/**
+ * Drop the fields the chosen options don't use, so two preferences that render
+ * identically also encode identically (and a stale custom color can't leak back
+ * when the reader returns to a curated palette).
+ */
+export function normalizeAppearance(
+  preference: AppearancePreference,
+): AppearancePreference {
+  const palette = isPaletteId(preference.palette)
+    ? preference.palette
+    : DEFAULT_APPEARANCE.palette;
+  const font = isAppearanceFont(preference.font)
+    ? preference.font
+    : DEFAULT_APPEARANCE.font;
+  const customFontFamily =
+    font === "custom"
+      ? normalizeCustomFontFamily(preference.customFontFamily)
+      : undefined;
+
+  return {
+    palette,
+    customPaper:
+      palette === "custom"
+        ? (normalizeHexColor(preference.customPaper) ?? DEFAULT_CUSTOM_PAPER)
+        : undefined,
+    customAccent:
+      palette === "custom"
+        ? (normalizeHexColor(preference.customAccent) ?? DEFAULT_CUSTOM_ACCENT)
+        : undefined,
+    // A `custom` font with no resolvable family is just the editorial stack.
+    font: font === "custom" && !customFontFamily ? "editorial" : font,
+    customFontFamily,
+    textSize: isAppearanceTextSize(preference.textSize)
+      ? preference.textSize
+      : DEFAULT_APPEARANCE.textSize,
+    roundness: isAppearanceRoundness(preference.roundness)
+      ? preference.roundness
+      : DEFAULT_APPEARANCE.roundness,
+    density: isAppearanceDensity(preference.density)
+      ? preference.density
+      : DEFAULT_APPEARANCE.density,
+  };
+}
+
+const ENCODING_SEPARATOR = ":";
+const EMPTY_FIELD = "-";
+
+function encodeField(value: string | undefined): string {
+  return value && value !== "" ? encodeURIComponent(value) : EMPTY_FIELD;
+}
+
+function decodeField(value: string | undefined): string | undefined {
+  if (!value || value === EMPTY_FIELD) return undefined;
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * `palette:paper:accent:font:family:textSize:roundness:density`, hex colors
+ * without their `#` so the value stays cookie-safe.
+ */
+export function appearanceToCookieValue(
+  preference: AppearancePreference,
+): string {
+  const normalized = normalizeAppearance(preference);
+  return [
+    normalized.palette,
+    encodeField(normalized.customPaper?.slice(1)),
+    encodeField(normalized.customAccent?.slice(1)),
+    normalized.font,
+    encodeField(normalized.customFontFamily),
+    normalized.textSize,
+    normalized.roundness,
+    normalized.density,
+  ].join(ENCODING_SEPARATOR);
+}
+
+export function parseAppearanceCookie(value: unknown): AppearancePreference {
+  if (typeof value !== "string" || value.trim() === "") {
+    return DEFAULT_APPEARANCE;
+  }
+
+  // `Set-Cookie` percent-encodes the value, so what comes back over the wire is
+  // `meadow%3A-%3A…` rather than the `:`-joined string we wrote. Decode once up
+  // front — without this the separators never match and every guest silently
+  // falls back to the defaults on their next page load.
+  const decoded = value.includes("%") ? (decodeField(value) ?? value) : value;
+
+  const [palette, paper, accent, font, family, textSize, roundness, density] =
+    decoded.split(ENCODING_SEPARATOR);
+
+  return normalizeAppearance({
+    palette: isPaletteId(palette) ? palette : DEFAULT_APPEARANCE.palette,
+    customPaper: normalizeHexColor(decodeField(paper)) ?? undefined,
+    customAccent: normalizeHexColor(decodeField(accent)) ?? undefined,
+    font: isAppearanceFont(font) ? font : DEFAULT_APPEARANCE.font,
+    customFontFamily: decodeField(family),
+    textSize: isAppearanceTextSize(textSize)
+      ? textSize
+      : DEFAULT_APPEARANCE.textSize,
+    roundness: isAppearanceRoundness(roundness)
+      ? roundness
+      : DEFAULT_APPEARANCE.roundness,
+    density: isAppearanceDensity(density)
+      ? density
+      : DEFAULT_APPEARANCE.density,
+  });
+}
+
+export function appearanceIsDefault(preference: AppearancePreference): boolean {
+  const normalized = normalizeAppearance(preference);
+  return (
+    normalized.palette === DEFAULT_APPEARANCE.palette &&
+    normalized.font === DEFAULT_APPEARANCE.font &&
+    normalized.textSize === DEFAULT_APPEARANCE.textSize &&
+    normalized.roundness === DEFAULT_APPEARANCE.roundness &&
+    normalized.density === DEFAULT_APPEARANCE.density
+  );
+}
+
+export function appearanceToDbValue(
+  preference: AppearancePreference,
+): string | null {
+  return appearanceIsDefault(preference)
+    ? null
+    : appearanceToCookieValue(preference);
+}
+
+export function dbValueToAppearance(
+  value: string | null | undefined,
+): AppearancePreference {
+  return parseAppearanceCookie(value ?? "");
+}
+
+/** sRGB relative luminance (WCAG 2.1), for deciding a paper's scheme. */
+function relativeLuminance(hex: string): number {
+  const value = Number.parseInt(hex.slice(1), 16);
+  const channels = [
+    (value >> 16) & 255,
+    (value >> 8) & 255,
+    value & 255,
+  ] as const;
+  const [r, g, b] = channels.map((channel) => {
+    const srgb = channel / 255;
+    return srgb <= 0.039_28 ? srgb / 12.92 : ((srgb + 0.055) / 1.055) ** 2.4;
+  }) as [number, number, number];
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/**
+ * The scheme a palette renders in. Curated palettes state theirs; a custom one
+ * takes it from the paper the reader picked — pick a dark paper and the app
+ * goes dark, which is the whole point of choosing your own page color.
+ */
+export function appearanceScheme(
+  preference: AppearancePreference,
+): ResolvedThemeScheme {
+  const normalized = normalizeAppearance(preference);
+  if (normalized.palette === "custom") {
+    const paper = normalized.customPaper ?? DEFAULT_CUSTOM_PAPER;
+    return relativeLuminance(paper) < 0.2 ? "dark" : "light";
+  }
+  return paletteMeta(normalized.palette)?.scheme ?? "light";
+}
+
+/** The browser/PWA title-bar color for a palette. */
+export function appearanceThemeColor(preference: AppearancePreference): string {
+  const normalized = normalizeAppearance(preference);
+  if (normalized.palette === "custom") {
+    return normalized.customPaper ?? DEFAULT_CUSTOM_PAPER;
+  }
+  return paletteMeta(normalized.palette)?.paper ?? DEFAULT_CUSTOM_PAPER;
+}
+
+/**
+ * The `--sr-*-scale` custom properties for the numeric dials. Only non-default
+ * dials emit a variable: readers on the defaults get no inline style at all,
+ * and the `calc()`s in `appearance-themes.ts` fall back to `1`.
+ */
+export function appearanceScaleVars(
+  preference: AppearancePreference,
+): Record<string, string> {
+  const normalized = normalizeAppearance(preference);
+  const vars: Record<string, string> = {};
+  if (normalized.textSize !== "default") {
+    vars["--sr-text-scale"] = TEXT_SIZE_SCALE[normalized.textSize];
+  }
+  if (normalized.roundness !== "default") {
+    vars["--sr-radius-scale"] = ROUNDNESS_SCALE[normalized.roundness];
+  }
+  if (normalized.density !== "default") {
+    vars["--sr-space-scale"] = DENSITY_SCALE[normalized.density];
+  }
+  if (normalized.font === "custom" && normalized.customFontFamily) {
+    vars["--sr-ui-font"] = `'${normalized.customFontFamily}'`;
+  }
+  return vars;
+}

--- a/src/lib/reading-typography.ts
+++ b/src/lib/reading-typography.ts
@@ -113,7 +113,19 @@ export function parseReadingTypographyCookie(
     return DEFAULT_READING_TYPOGRAPHY;
   }
 
-  const parts = value.split(ENCODING_SEPARATOR);
+  // `Set-Cookie` percent-encodes the value, so the separators come back as
+  // `%3A` on the next request. Decode once before splitting, or a guest's
+  // stored preference reads as "all defaults" on every load.
+  let decoded = value;
+  if (value.includes("%")) {
+    try {
+      decoded = decodeURIComponent(value);
+    } catch {
+      decoded = value;
+    }
+  }
+
+  const parts = decoded.split(ENCODING_SEPARATOR);
   const [fontSize, measure, bodyFont, encodedCustomFont] = parts;
 
   const parsed: ReadingTypographyPreference = {
@@ -213,6 +225,11 @@ export function readingMeasureLabel(measure: ReadingMeasure): string {
   }
 }
 
+/**
+ * `serif` is the reading face the app itself is set to — Newsreader by default,
+ * or whatever interface font the reader chose under Appearance — so it is
+ * labelled for what it does rather than for the family it usually lands on.
+ */
 export function readingBodyFontLabel(bodyFont: ReadingBodyFont): string {
   switch (bodyFont) {
     case "sans": {
@@ -222,7 +239,7 @@ export function readingBodyFontLabel(bodyFont: ReadingBodyFont): string {
       return "Custom";
     }
     default: {
-      return "Serif";
+      return "Match app";
     }
   }
 }

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,16 +1,27 @@
 /**
  * Theme preference shared types/helpers.
  *
- * Persisted as `light | dark | system` in the `standard-reader-theme` cookie
- * (SSR for everyone). Signed-in users also store `light | dark` on
- * `user.theme_mode` (`null` = system).
+ * Persisted as `light | dark | system | custom` in the `standard-reader-theme`
+ * cookie (SSR for everyone). Signed-in users also store `light | dark | custom`
+ * on `user.theme_mode` (`null` = system).
+ *
+ * `custom` hands the scheme over to the reader's palette (`#/lib/appearance`):
+ * the palette states light or dark, so unlike `system` it does not track the OS.
+ * Everything downstream still deals in a `ResolvedThemeScheme`.
  */
 
-export type ThemeMode = "light" | "dark" | "system";
+export type ThemeMode = "light" | "dark" | "system" | "custom";
+
+/**
+ * A theme mode with `custom` already resolved to the scheme its palette renders
+ * in — what the server passes around when it only needs to know which scheme to
+ * render for (see `themeModeForRequest`).
+ */
+export type ThemeSchemeMode = "light" | "dark" | "system";
 
 export type ResolvedThemeScheme = "light" | "dark";
 
-export const THEME_MODES = ["light", "dark", "system"] as const;
+export const THEME_MODES = ["light", "dark", "system", "custom"] as const;
 
 export const DEFAULT_THEME_MODE: ThemeMode = "system";
 
@@ -19,30 +30,45 @@ export const THEME_COOKIE = "standard-reader-theme";
 export const THEME_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
 
 export function isThemeMode(value: unknown): value is ThemeMode {
-  return value === "light" || value === "dark" || value === "system";
+  return (
+    value === "light" ||
+    value === "dark" ||
+    value === "system" ||
+    value === "custom"
+  );
 }
 
 export function parseThemeMode(value: unknown): ThemeMode {
   return isThemeMode(value) ? value : DEFAULT_THEME_MODE;
 }
 
-export function themeModeToDbValue(mode: ThemeMode): "light" | "dark" | null {
+export function themeModeToDbValue(
+  mode: ThemeMode,
+): "light" | "dark" | "custom" | null {
   return mode === "system" ? null : mode;
 }
 
 export function dbValueToThemeMode(
   value: string | null | undefined,
 ): ThemeMode {
-  return value === "light" || value === "dark" ? value : "system";
+  return value === "light" || value === "dark" || value === "custom"
+    ? value
+    : "system";
 }
 
-/** Resolve `system` using the optional client hint header when present. */
+/**
+ * Resolve `system` using the optional client hint header when present, and
+ * `custom` using the palette's own scheme (the caller resolves the palette —
+ * this module deliberately knows nothing about `#/lib/appearance`).
+ */
 export function resolveThemeScheme(
   mode: ThemeMode,
   prefersColorSchemeHeader?: string | null,
+  paletteScheme?: ResolvedThemeScheme | null,
 ): ResolvedThemeScheme {
   if (mode === "dark") return "dark";
   if (mode === "light") return "light";
+  if (mode === "custom") return paletteScheme ?? "light";
   return prefersColorSchemeHeader === "dark" ? "dark" : "light";
 }
 
@@ -70,18 +96,22 @@ export const THEME_COLOR_BY_SCHEME: Record<ResolvedThemeScheme, string> = {
 
 export const RESOLVED_SCHEME_SCRIPT = `
 (function () {
-  var mode = document.documentElement.getAttribute("data-theme");
+  var root = document.documentElement;
+  var mode = root.getAttribute("data-theme");
   var resolved =
     mode === "dark" ? "dark" :
     mode === "light" ? "light" :
+    mode === "custom" ? (root.getAttribute("data-palette-scheme") === "dark" ? "dark" : "light") :
     (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
-  document.documentElement.setAttribute("data-resolved-scheme", resolved);
+  root.setAttribute("data-resolved-scheme", resolved);
   // Point the title-bar color at the *resolved* scheme so an explicit in-app
   // light/dark override wins over the OS preference (a plain media-query meta
-  // can't see \`data-theme\`).
+  // can't see \`data-theme\`). A custom palette carries its own page color,
+  // rendered onto \`data-theme-color\` server-side.
   var meta = document.querySelector('meta[name="theme-color"]');
   if (meta) {
-    meta.setAttribute("content", resolved === "dark" ? "${THEME_COLOR_BY_SCHEME.dark}" : "${THEME_COLOR_BY_SCHEME.light}");
+    var palette = mode === "custom" ? root.getAttribute("data-theme-color") : null;
+    meta.setAttribute("content", palette || (resolved === "dark" ? "${THEME_COLOR_BY_SCHEME.dark}" : "${THEME_COLOR_BY_SCHEME.light}"));
   }
 })();
 `.trim();
@@ -124,7 +154,11 @@ export function subscribeToResolvedScheme(
   const observer = new MutationObserver(onStoreChange);
   observer.observe(root, {
     attributes: true,
-    attributeFilter: ["data-resolved-scheme", "data-theme"],
+    attributeFilter: [
+      "data-resolved-scheme",
+      "data-theme",
+      "data-palette-scheme",
+    ],
   });
 
   const onMediaChange = (event: MediaQueryListEvent) => {
@@ -141,15 +175,21 @@ export function subscribeToResolvedScheme(
   };
 }
 
-export function resolveSchemeForMode(mode: ThemeMode): ResolvedThemeScheme {
+export function resolveSchemeForMode(
+  mode: ThemeMode,
+  paletteScheme?: ResolvedThemeScheme | null,
+): ResolvedThemeScheme {
   if (mode === "dark" || mode === "light") return mode;
+  if (mode === "custom") return paletteScheme ?? "light";
   return readDomResolvedScheme() ?? getSystemColorScheme();
 }
 
 /** SSR default when `mode` is `system` (no DOM / client hints in this path). */
 export function resolvedSchemeServerSnapshot(
   mode: ThemeMode,
+  paletteScheme?: ResolvedThemeScheme | null,
 ): ResolvedThemeScheme {
   if (mode === "dark" || mode === "light") return mode;
+  if (mode === "custom") return paletteScheme ?? "light";
   return "light";
 }

--- a/src/lib/use-appearance.ts
+++ b/src/lib/use-appearance.ts
@@ -1,0 +1,104 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+
+import { user } from "#/integrations/tanstack-query/api-user.functions";
+
+import type { AppearancePreference } from "./appearance";
+import { DEFAULT_APPEARANCE, normalizeAppearance } from "./appearance";
+
+export interface AppearanceContextValue {
+  preference: AppearancePreference;
+  setPreference: (patch: Partial<AppearancePreference>) => void;
+  reset: () => void;
+  isPending: boolean;
+}
+
+/**
+ * Palette + shape/type preferences — see `#/lib/appearance`.
+ *
+ * Optimistic like the other preference hooks: the cache is updated before the
+ * round trip, so the whole app repaints on the same frame as the click. The app
+ * *is* the preview, which is only honest if it keeps up.
+ */
+export function useAppearance(): AppearanceContextValue {
+  const queryClient = useQueryClient();
+
+  const { data } = useQuery({
+    ...user.getAppearancePreferenceQueryOptions,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+  });
+  const preference = data?.preference ?? DEFAULT_APPEARANCE;
+
+  const setMutation = useMutation({
+    mutationFn: async (next: AppearancePreference) => {
+      return await user.setAppearancePreference({ data: { preference: next } });
+    },
+    onMutate: async (next) => {
+      await queryClient.cancelQueries({
+        queryKey: user.getAppearancePreferenceQueryOptions.queryKey,
+      });
+      const previous = queryClient.getQueryData(
+        user.getAppearancePreferenceQueryOptions.queryKey,
+      );
+      queryClient.setQueryData(
+        user.getAppearancePreferenceQueryOptions.queryKey,
+        { preference: next },
+      );
+      return { previous };
+    },
+    onError: (_error, _next, ctx) => {
+      if (ctx?.previous) {
+        queryClient.setQueryData(
+          user.getAppearancePreferenceQueryOptions.queryKey,
+          ctx.previous,
+        );
+      }
+    },
+    onSuccess: (result) => {
+      queryClient.setQueryData(
+        user.getAppearancePreferenceQueryOptions.queryKey,
+        result,
+      );
+    },
+  });
+
+  const commit = useCallback(
+    (next: AppearancePreference) => {
+      const normalized = normalizeAppearance(next);
+      const current = normalizeAppearance(preference);
+      if (
+        normalized.palette === current.palette &&
+        normalized.customPaper === current.customPaper &&
+        normalized.customAccent === current.customAccent &&
+        normalized.font === current.font &&
+        normalized.customFontFamily === current.customFontFamily &&
+        normalized.textSize === current.textSize &&
+        normalized.roundness === current.roundness &&
+        normalized.density === current.density
+      ) {
+        return;
+      }
+      setMutation.mutate(normalized);
+    },
+    [preference, setMutation],
+  );
+
+  const setPreference = useCallback(
+    (patch: Partial<AppearancePreference>) => {
+      commit({ ...preference, ...patch });
+    },
+    [commit, preference],
+  );
+
+  const reset = useCallback(() => {
+    commit(DEFAULT_APPEARANCE);
+  }, [commit]);
+
+  return {
+    preference,
+    setPreference,
+    reset,
+    isPending: setMutation.isPending,
+  };
+}

--- a/src/lib/use-theme.ts
+++ b/src/lib/use-theme.ts
@@ -3,6 +3,7 @@ import { useCallback, useSyncExternalStore } from "react";
 
 import { user } from "#/integrations/tanstack-query/api-user.functions";
 
+import { DEFAULT_APPEARANCE, appearanceScheme } from "./appearance";
 import type { ResolvedThemeScheme, ThemeMode } from "./theme";
 import {
   DEFAULT_THEME_MODE,
@@ -28,10 +29,23 @@ export function useTheme(): ThemeContextValue {
   });
   const mode = data?.mode ?? DEFAULT_THEME_MODE;
 
+  // A custom palette states its own light/dark, so the resolved scheme comes
+  // from the palette rather than the OS. Seeded by the shell bootstrap, so this
+  // is already correct during SSR — no hydration mismatch for the components
+  // that key off `resolvedScheme` (code highlighting, embeds).
+  const { data: appearanceData } = useQuery({
+    ...user.getAppearancePreferenceQueryOptions,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+  });
+  const paletteScheme = appearanceScheme(
+    appearanceData?.preference ?? DEFAULT_APPEARANCE,
+  );
+
   const resolvedScheme = useSyncExternalStore(
     subscribeToResolvedScheme,
-    () => resolveSchemeForMode(mode),
-    () => resolvedSchemeServerSnapshot(mode),
+    () => resolveSchemeForMode(mode, paletteScheme),
+    () => resolvedSchemeServerSnapshot(mode, paletteScheme),
   );
 
   const setMutation = useMutation({

--- a/src/locales/ar/messages.po
+++ b/src/locales/ar/messages.po
@@ -239,6 +239,10 @@ msgstr ""
 msgid "Opening the collection…"
 msgstr "جارٍ فتح المجموعة…"
 
+#: src/components/appearance-settings.tsx
+msgid "Density"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Open on publication"
 msgstr "فتح في المنشورة"
@@ -280,6 +284,7 @@ msgstr "إرسال الملاحظات"
 msgid "<0>Session cookie.</0> After you sign in through the web app, the extension background worker reads your HttpOnly session cookie on {siteHost} to authenticate API requests. Content scripts do not read this cookie directly."
 msgstr "<0>ملف تعريف ارتباط الجلسة.</0> بعد تسجيل دخولك عبر تطبيق الويب، يقرأ عامل الخلفية في الامتداد ملف تعريف ارتباط الجلسة من نوع HttpOnly على {siteHost} لمصادقة طلبات API. أما نصوص المحتوى البرمجية فلا تقرأ هذا الملف مباشرة."
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/user-settings-view.tsx
 msgid "Light"
@@ -318,9 +323,17 @@ msgstr ""
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 msgstr ""
 
+#: src/components/reader/format-i18n.ts
+msgid "{years}y ago"
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "List"
 msgstr "قائمة"
+
+#: src/components/appearance-settings.tsx
+msgid "The spacing between things — tighter for more on screen, looser for more room to read."
+msgstr ""
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Sign in to run this example (curl uses Bearer $ACCESS_TOKEN)."
@@ -349,6 +362,10 @@ msgstr "سمِّ سلسلتك واختر سمة"
 #: src/components/docs/docs-labelers-nav.tsx
 #: src/components/docs/labelers-docs-page.tsx
 msgid "Reference implementation"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Extra large"
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
@@ -453,6 +470,10 @@ msgstr "احذف نهائيًا البيانات المخزَّنة في حسا�
 msgid "Loading people"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "Links and labels on paper"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Read the piece →"
 msgstr "اقرأ المقال ←"
@@ -493,6 +514,10 @@ msgstr "سجّل الدخول لمتابعة المنشورات"
 #: src/routes/_layout.discover.tsx
 msgid "Search publications"
 msgstr "ابحث في المنشورات"
+
+#: src/components/appearance-settings.tsx
+msgid "Small"
+msgstr ""
 
 #: src/routes/_layout.search.tsx
 msgid "Publications, handles, #tags, headlines…"
@@ -767,6 +792,7 @@ msgstr "النقاشات"
 msgid "Content label"
 msgstr "تصنيف المحتوى"
 
+#: src/components/appearance-settings.tsx
 #: src/components/ReadingTypographyMenu.tsx
 #: src/components/user-settings-view.tsx
 msgid "Text size"
@@ -833,6 +859,11 @@ msgstr "لا توجد منشورات مفهرسة بعد."
 msgid "{0} added to {listName}."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+#: src/components/user-settings-view.tsx
+msgid "Custom"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Read the API docs"
 msgstr "اقرأ وثائق API"
@@ -868,6 +899,10 @@ msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "For more about how {SITE_NAME} works, see the <0>About</0> page. For questions about these terms for this deployment, contact the operator of the site at the URL above."
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Compact"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -931,6 +966,10 @@ msgstr "{documentCount, plural, zero {مستند} one {مستند} two {مستن
 msgid "Publishing"
 msgstr "النشر"
 
+#: src/components/appearance-settings.tsx
+msgid "Roundness"
+msgstr ""
+
 #: src/components/docs/introduction-docs-page.tsx
 msgid "public XRPC queries and procedures for the Standard Reader read-model, with live examples."
 msgstr ""
@@ -971,6 +1010,10 @@ msgstr "أدرِج تلميح <0>site.standard.publication</0> فقط إذا ك�
 #: src/components/reader/about-view.tsx
 msgid "Your week"
 msgstr "أسبوعك"
+
+#: src/components/appearance-settings.tsx
+msgid "Relaxed"
+msgstr ""
 
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.recommended.tsx
@@ -1013,6 +1056,10 @@ msgstr "معطّل"
 msgid "Run example"
 msgstr "تشغيل المثال"
 
+#: src/components/appearance-settings.tsx
+msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "When on, collection posts open in the magazine edition instead of the reader view."
 msgstr "عند التفعيل، تُفتح منشورات المجموعة في نسخة المجلة بدلًا من عرض القارئ."
@@ -1047,6 +1094,10 @@ msgstr "سؤال"
 #: src/components/reader/list-edit-modal.tsx
 msgid "Choose an item to add to the list"
 msgstr "اختر عنصرًا لإضافته إلى القائمة"
+
+#: src/components/appearance-settings.tsx
+msgid "Soft"
+msgstr ""
 
 #: src/magazine/magazine-end-subscribe.tsx
 msgid "Subscribed to list"
@@ -1110,9 +1161,18 @@ msgstr "موضوع هذه القائمة (يظهر في صفحتها العام�
 msgid "Delete collection"
 msgstr "حذف المجموعة"
 
+#: src/components/appearance-settings.tsx
+msgid "Interface font"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No publications in this list."
 msgstr "لا توجد منشورات في هذه القائمة."
+
+#. placeholder {0}: palette.name
+#: src/components/appearance-settings.tsx
+msgid "{0}, dark"
+msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Loading collections…"
@@ -1130,6 +1190,10 @@ msgstr "تصفّح المصنِّفات"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We do not run a separate analytics pipeline inside the extension."
 msgstr "لا نشغّل خط تحليلات منفصلًا داخل الإضافة."
+
+#: src/components/appearance-settings.tsx
+#~ msgid "Text, borders and every other step are derived from these two colors and checked for contrast."
+#~ msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Remove list"
@@ -1436,6 +1500,7 @@ msgstr "{durationMs} م.ث · جُلبت في {fetchedAt}"
 msgid "Loading feedback"
 msgstr "جارٍ تحميل الملاحظات"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Accent"
 msgstr "لون التمييز"
@@ -1483,6 +1548,10 @@ msgstr "إضافة إلى Chrome"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Leaflet, Pckt, Offprint.</0> <1>pub.leaflet.content</1>, <2>blog.pckt.content</2>, and <3>app.offprint.content</3> — the block-based formats those tools write natively."
 msgstr "<0>Leaflet وPckt وOffprint.</0> <1>pub.leaflet.content</1> و<2>blog.pckt.content</2> و<3>app.offprint.content</3> — الصيغ القائمة على الكتل التي تكتبها هذه الأدوات أصلًا."
+
+#: src/components/appearance-settings.tsx
+msgid "XL"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Set your own type"
@@ -1638,6 +1707,10 @@ msgstr "التبديل إلى وضع القارئ"
 msgid "<0>3. Declare your label values.</0> Describe each value (severity, default warn/hide, blur behavior) in an <1>app.standard-reader.labeler.service</1> descriptor, served from <2>app.standard-reader.labeler.getServices</2> (a <3>did:web</3> labeler has no repo to hold the record)."
 msgstr "<0>٣. صرّح بقيم تسمياتك.</0> صف كل قيمة (الشدّة، والوضع الافتراضي للتحذير/الإخفاء، وسلوك التمويه) في واصف <1>app.standard-reader.labeler.service</1>، يُقدَّم عبر <2>app.standard-reader.labeler.getServices</2> (فالمصنِّف من نوع <3>did:web</3> لا يملك مستودعًا يحتوي السجل)."
 
+#: src/components/reader/format-i18n.ts
+msgid "{months}mo ago"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "To email your digest, Standard Reader needs your account email address. We'll ask your PDS to share it — you'll be sent to your login to approve the request, then brought right back here. Your email is used only to send the weekly digest, and you can turn it off any time."
 msgstr "لإرسال ملخصك بالبريد، يحتاج Standard Reader إلى عنوان بريد حسابك. سنطلب من PDS مشاركته — ستُنقل إلى صفحة تسجيل الدخول للموافقة على الطلب، ثم تعود إلى هنا مباشرة. يُستخدم بريدك فقط لإرسال الملخص الأسبوعي، ويمكنك إيقافه في أي وقت."
@@ -1713,6 +1786,10 @@ msgstr ""
 msgid "Every unread article from this publication will be marked read. This can’t be undone."
 msgstr "ستُحدَّد كل مقالة غير مقروءة من هذه المنشورة كمقروءة. لا يمكن التراجع عن هذا."
 
+#: src/components/appearance-settings.tsx
+msgid "Your own colors"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
 msgstr "جارٍ تعيين العدد…"
@@ -1765,6 +1842,11 @@ msgstr "{pubTotal, plural, zero {لا منشورات} one {منشورة واحد
 msgid "Nothing new today"
 msgstr ""
 
+#. placeholder {0}: palette.name
+#: src/components/appearance-settings.tsx
+msgid "{0}, light"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Background"
 msgstr "الخلفية"
@@ -1784,6 +1866,10 @@ msgstr "من اشتراكاتك"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>When you browse without signing in,</0> we serve public writing from our read-model index. We may store a theme preference cookie and, if you have signed in before on this device, a short list of recently used account handles (and optional avatar URLs) to speed up sign-in. We do not require an account to read."
 msgstr "<0>عند التصفح دون تسجيل الدخول،</0> نعرض الكتابات العامة من فهرس نموذج القراءة لدينا. وقد نحفظ ملف تعريف ارتباط لتفضيل السمة، وإذا سبق أن سجّلت الدخول على هذا الجهاز، قائمة قصيرة بمعرّفات الحسابات المستخدمة مؤخرًا (وروابط الصور الرمزية اختياريًا) لتسريع تسجيل الدخول. لا نشترط وجود حساب للقراءة."
+
+#: src/components/appearance-settings.tsx
+msgid "Paper"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
@@ -2235,8 +2321,8 @@ msgid "by @{ownerHandle}"
 msgstr "بقلم @{ownerHandle}"
 
 #: src/components/user-settings-view.tsx
-msgid "Choose light, dark, or match your system setting."
-msgstr "اختر الفاتح أو الداكن أو المطابقة لإعداد نظامك."
+#~ msgid "Choose light, dark, or match your system setting."
+#~ msgstr "اختر الفاتح أو الداكن أو المطابقة لإعداد نظامك."
 
 #. placeholder {0}: rows.length
 #: src/components/reader/subscriptions-table.tsx
@@ -2254,6 +2340,10 @@ msgstr "إنهاء"
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
 msgstr "أحدث الكتابات الطويلة من أنحاء الشبكة."
+
+#: src/components/appearance-settings.tsx
+msgid "Sets the app's colors — and, because the page color decides it, whether the app reads light or dark."
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "{subscribedCount} unread across the publications you subscribe to."
@@ -2291,6 +2381,10 @@ msgstr "أنت مشترك بالفعل في {publicationName}. ستظهر الم
 msgid "The directory"
 msgstr "الدليل"
 
+#: src/components/appearance-settings.tsx
+#~ msgid "Your accent sits close to the paper in tone, so a darkened version of it is used for text and links."
+#~ msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Trending this week"
 msgstr "الرائج هذا الأسبوع"
@@ -2319,6 +2413,10 @@ msgstr "لا توجد قوائم بعد"
 #: src/routes/_layout.discover.tsx
 msgid "Browse everything"
 msgstr "تصفّح كل شيء"
+
+#: src/components/appearance-settings.tsx
+msgid "Large"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
@@ -2476,6 +2574,10 @@ msgstr ""
 msgid "The most-read writing across the network right now."
 msgstr "الأكثر قراءة عبر الشبكة الآن."
 
+#: src/components/appearance-settings.tsx
+msgid "The typeface used across the app. Article text follows this too, unless you set a reading font below."
+msgstr ""
+
 #: src/magazine/magazine-end-like.tsx
 msgid "Recommend this issue"
 msgstr "أوصِ بهذا العدد"
@@ -2491,6 +2593,10 @@ msgstr "{count, plural, zero {لا تأييدات} one {تأييد واحد} two
 #: src/routes/_layout.search.tsx
 msgid "{shown} of {total} matches"
 msgstr "{shown} من {total} نتيجة مطابقة"
+
+#: src/components/appearance-settings.tsx
+msgid "How rounded buttons, cards and inputs are."
+msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
 msgid "What is this series about?"
@@ -2523,6 +2629,10 @@ msgstr ""
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler didn’t publish any label definitions."
 msgstr "لم ينشر هذا المصنِّف أي تعريفات للتصنيفات."
+
+#: src/components/reader/format-i18n.ts
+msgid "{days}d ago"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Continue to approve"
@@ -2570,6 +2680,10 @@ msgstr "لذلك بنينا القارئ الذي أردناه: عمود تتح�
 #: src/routes/_layout.recommended.tsx
 msgid "Recommended articles"
 msgstr "مقالات موصى بها"
+
+#: src/components/user-settings-view.tsx
+msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labeler views"
@@ -2654,6 +2768,10 @@ msgstr "بيان الإصدار"
 msgid "Reader voice"
 msgstr "صوت القارئ"
 
+#: src/components/appearance-settings.tsx
+msgid "Sharp"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "What you get is a reading view made for long-form: a centered column, drop caps and pull quotes, full-bleed images you can open into a gallery. The page gets out of the way so the writing can do its work."
 msgstr "ما تحصل عليه هو عرض قراءة مصمم للكتابات الطويلة: عمود متمركز، وأحرف استهلالية واقتباسات بارزة، وصور بعرض الشاشة يمكنك فتحها في معرض. تنسحب الصفحة جانبًا لتترك للكتابة أن تؤدي عملها."
@@ -2703,6 +2821,10 @@ msgstr "انتهت صلاحية ذلك الرابط."
 #: src/components/reader/privacy-view.tsx
 msgid "You can sign out at any time, which clears your app session cookie. You can clear site cookies in your browser to remove theme and saved-handle preferences. You can change reading-history tracking and delete personal data from Settings. To remove other AT Protocol records you created through the app, use a compatible client or your repository tools."
 msgstr "يمكنك تسجيل الخروج في أي وقت، ما يمسح ملف تعريف ارتباط جلسة التطبيق. ويمكنك مسح ملفات تعريف الارتباط للموقع من متصفحك لإزالة تفضيلات السمة والمعرّف المحفوظ. كما يمكنك تغيير تتبع سجل القراءة وحذف بياناتك الشخصية من الإعدادات. ولإزالة سجلات AT Protocol الأخرى التي أنشأتها عبر التطبيق، استخدم عميلًا متوافقًا أو أدوات المستودع لديك."
+
+#: src/components/appearance-settings.tsx
+msgid "XS"
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
@@ -2884,6 +3006,10 @@ msgstr ""
 msgid "Share on Bluesky"
 msgstr "شارك على Bluesky"
 
+#: src/components/appearance-settings.tsx
+msgid "Reset"
+msgstr ""
+
 #: src/components/docs/docs-lexicons-nav.tsx
 #~ msgid "Lexicon reference"
 #~ msgstr "مرجع Lexicon"
@@ -2939,6 +3065,10 @@ msgstr "الحوار، مجموعًا في مكان واحد"
 msgid "Mark all as read"
 msgstr "تحديد الكل كمقروء"
 
+#: src/components/appearance-settings.tsx
+msgid "Scales every size in the app, article text included — from 14px up to 24px of interface text."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "Your display name, handle, avatar URL, and DID as returned by your account provider."
 msgstr "اسمك المعروض ومعرّفك وعنوان صورتك الرمزية وDID كما يعيدها مزوّد حسابك."
@@ -2970,6 +3100,10 @@ msgstr "شارك إلى عميل آخر"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "What the extension does not do"
 msgstr "ما لا تفعله الإضافة"
+
+#: src/components/appearance-settings.tsx
+msgid "Default"
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Loading recommendations"
@@ -3100,6 +3234,10 @@ msgstr "(يتطلب {min}:1)"
 msgid "Every read record in your repository will be removed. Articles will appear unread again across the app. This cannot be undone."
 msgstr "ستُحذف كل سجلات القراءة من مستودعك، وستظهر المقالات كغير مقروءة مجددًا في التطبيق. لا يمكن التراجع عن هذا."
 
+#: src/components/appearance-settings.tsx
+msgid "Text, borders and every other step are derived from these two colors."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "إذا ثبّت إضافة المتصفح من {SITE_NAME}، فإنها تستخدم الحساب وملف تعريف الارتباط نفسه المستخدم في هذا الموقع. ترسل الإضافة عناوين URL للصفحات إلى نقاط النهاية <0>/api/extension/*</0> لمطابقة الفهرس، وتحفظ إعدادات الطبقة العلوية في مساحة تخزين الإضافات بمتصفحك. راجع <1>سياسة خصوصية الإضافة</1> للتفاصيل الخاصة بالإضافة وحدها."
@@ -3149,6 +3287,7 @@ msgstr ""
 msgid "Unfollowing {peopleCount, plural, one {this person} other {these # people}} also drops the subscriptions that follow created, so their publications leave your feed. Nothing you have saved, read, or recommended is affected."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/user-settings-view.tsx
 msgid "Dark"
@@ -3369,6 +3508,10 @@ msgstr "جهات التصنيف هي خدمات إشراف تشترك فيها �
 msgid "Standard Reader meets you where you read"
 msgstr "‏Standard Reader يلتقيك حيث تقرأ"
 
+#: src/components/appearance-settings.tsx
+msgid "Reset appearance"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/reader/markdown-field.tsx
 #: src/components/reading-settings-preview.tsx
@@ -3442,6 +3585,10 @@ msgstr "ابحث في جهات التصنيف"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · تغذيتك"
 
+#: src/components/reader/format-i18n.ts
+msgid "yesterday"
+msgstr ""
+
 #: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Use publication themes"
@@ -3459,6 +3606,7 @@ msgstr "‏DID الخدمة هو <0>{appviewDid}</0>. تنشر الخدمة <1>�
 msgid "The Slow Web, Revisited"
 msgstr "الويب البطيء، إعادة نظر"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reading-custom-font-picker.tsx
 #: src/components/user-settings-view.tsx
 msgid "Google Font"
@@ -3554,6 +3702,10 @@ msgstr "ابحث في الملاحظات"
 msgid "Unsubscribe"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "L"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "Load more ({remainingPublications} remaining)"
 msgstr "تحميل المزيد (بقي {remainingPublications})"
@@ -3606,6 +3758,10 @@ msgstr "نسخ كود التضمين"
 #: src/components/user-settings-view.tsx
 msgid "Delete all lists?"
 msgstr "حذف كل القوائم؟"
+
+#: src/components/user-settings-view.tsx
+msgid "Advanced"
+msgstr ""
 
 #: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
@@ -3669,6 +3825,10 @@ msgstr "تشغيل"
 #: src/routes/_layout.search.tsx
 msgid "Loading article matches"
 msgstr "جارٍ تحميل المقالات المطابقة"
+
+#: src/components/appearance-settings.tsx
+msgid "Extra small"
+msgstr ""
 
 #: src/components/reader/content/renderers/leaflet-standard-site-publication.tsx
 msgid "Publication not found."
@@ -3738,6 +3898,10 @@ msgstr "السلوك"
 msgid "Reading history"
 msgstr "سجل القراءة"
 
+#: src/components/appearance-settings.tsx
+msgid "M"
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>2. Serve labels.</0> Sign and emit <1>com.atproto.label.defs#label</1> objects, and expose the standard <2>com.atproto.label.queryLabels</2> (HTTP) and <3>com.atproto.label.subscribeLabels</3> (WebSocket) endpoints."
 msgstr "<0>٢. تقديم التصنيفات.</0> وقّع وأصدر كائنات <1>com.atproto.label.defs#label</1>، وأتِح نقطتَي النهاية القياسيتين <2>com.atproto.label.queryLabels</2> (HTTP) و<3>com.atproto.label.subscribeLabels</3> (WebSocket)."
@@ -3800,6 +3964,10 @@ msgstr "لا توجد منشورات في هذه القائمة — أضف بع�
 #: src/components/reader/subscribe-card.tsx
 msgid "Adding {publicationName} to your feed."
 msgstr "جارٍ إضافة {publicationName} إلى تغذيتك."
+
+#: src/components/appearance-settings.tsx
+#~ msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors and checked for contrast."
+#~ msgstr ""
 
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/app-shell.tsx
@@ -3956,6 +4124,10 @@ msgstr "يمرّ تسجيل الدخول والوصول إلى السجلات ع
 msgid "An included article"
 msgstr "مقالة مضمّنة"
 
+#: src/components/appearance-settings.tsx
+msgid "Puts the palette, font, size, roundness and density back to their defaults."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Subscribe to labelers to flag, blur, or hide content as you read."
 msgstr "اشترك في المصنِّفات للإشارة إلى المحتوى أو تمويهه أو إخفائه أثناء القراءة."
@@ -4013,6 +4185,7 @@ msgstr "{weekday} · عبر الشبكة"
 msgid "Publish & share the run"
 msgstr "نشر التشغيل ومشاركته"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-builder.tsx
 msgid "Editorial"
 msgstr "تحريري"
@@ -4175,6 +4348,10 @@ msgstr ""
 msgid "Open on {publicationName}"
 msgstr "الفتح على {publicationName}"
 
+#: src/components/appearance-settings.tsx
+msgid "Sans"
+msgstr ""
+
 #: src/components/reader/add-publication-modal.tsx
 msgid "Search publications or paste a handle"
 msgstr "ابحث في المنشورات أو الصق معرّفًا"
@@ -4299,6 +4476,10 @@ msgstr "قراءة بصوت مسموع"
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "المقالات التي حفظتها لوقت لاحق — في مستودعك، ومُزامَنة عبر أجهزتك."
 
+#: src/components/reader/format-i18n.ts
+msgid "today"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 #: src/components/reader/content/renderers/shared/image-figure.tsx
 #: src/components/reader/content/renderers/shared/markdown-article.tsx
@@ -4406,6 +4587,7 @@ msgstr "تصفية حسب الموضوع"
 msgid "No unread articles from your follows right now."
 msgstr "لا مقالات غير مقروءة من متابَعاتك حاليًا."
 
+#: src/components/appearance-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Search and pick any family from the Google Fonts catalog."
 msgstr "ابحث واختر أي خط من كتالوج Google Fonts."
@@ -4534,6 +4716,10 @@ msgstr "<0>عند تسجيل الدخول</0> بحساب Atmosphere الخاص �
 msgid "Powered by <0>Standard Reader</0>"
 msgstr "مدعوم بـ <0>Standard Reader</0>"
 
+#: src/components/appearance-settings.tsx
+msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Save from anywhere you browse"
 msgstr "احفظ من أي مكان تتصفحه"
@@ -4651,6 +4837,10 @@ msgstr "ابدأ الآن"
 msgid "You don't have any content tabs to show yet."
 msgstr "لا توجد لديك علامات تبويب محتوى لعرضها بعد."
 
+#: src/components/appearance-settings.tsx
+msgid "Body text on paper"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "OK"
 msgstr "حسنًا"
@@ -4719,6 +4909,10 @@ msgstr "@{0} · لديه مستندات لكن بلا منشورات"
 msgid "{connectionLabel} via Semble"
 msgstr "{connectionLabel} عبر Semble"
 
+#: src/components/appearance-settings.tsx
+msgid "S"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "In this issue"
 msgstr "في هذا العدد"
@@ -4729,4 +4923,8 @@ msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Acceptable use"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Palette"
 msgstr ""

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -239,6 +239,10 @@ msgstr ""
 msgid "Opening the collection…"
 msgstr "Sammlung wird geöffnet …"
 
+#: src/components/appearance-settings.tsx
+msgid "Density"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Open on publication"
 msgstr "In der Publikation öffnen"
@@ -280,6 +284,7 @@ msgstr "Feedback senden"
 msgid "<0>Session cookie.</0> After you sign in through the web app, the extension background worker reads your HttpOnly session cookie on {siteHost} to authenticate API requests. Content scripts do not read this cookie directly."
 msgstr "<0>Sitzungs-Cookie.</0> Nachdem Sie sich über die Web-App angemeldet haben, liest der Hintergrundprozess der Erweiterung Ihr HttpOnly-Sitzungs-Cookie auf {siteHost}, um API-Anfragen zu authentifizieren. Content-Skripte lesen dieses Cookie nicht direkt."
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/user-settings-view.tsx
 msgid "Light"
@@ -318,9 +323,17 @@ msgstr ""
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 msgstr ""
 
+#: src/components/reader/format-i18n.ts
+msgid "{years}y ago"
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "List"
 msgstr "Liste"
+
+#: src/components/appearance-settings.tsx
+msgid "The spacing between things — tighter for more on screen, looser for more room to read."
+msgstr ""
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Sign in to run this example (curl uses Bearer $ACCESS_TOKEN)."
@@ -349,6 +362,10 @@ msgstr "Reihe benennen & Thema wählen"
 #: src/components/docs/docs-labelers-nav.tsx
 #: src/components/docs/labelers-docs-page.tsx
 msgid "Reference implementation"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Extra large"
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
@@ -453,6 +470,10 @@ msgstr "Daten dauerhaft aus Ihrem Konto entfernen. Diese Aktionen löschen Recor
 msgid "Loading people"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "Links and labels on paper"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Read the piece →"
 msgstr "Zum Text →"
@@ -493,6 +514,10 @@ msgstr "Anmelden, um Publikationen zu folgen"
 #: src/routes/_layout.discover.tsx
 msgid "Search publications"
 msgstr "Publikationen suchen"
+
+#: src/components/appearance-settings.tsx
+msgid "Small"
+msgstr ""
 
 #: src/routes/_layout.search.tsx
 msgid "Publications, handles, #tags, headlines…"
@@ -767,6 +792,7 @@ msgstr "Diskussionen"
 msgid "Content label"
 msgstr "Inhalts-Label"
 
+#: src/components/appearance-settings.tsx
 #: src/components/ReadingTypographyMenu.tsx
 #: src/components/user-settings-view.tsx
 msgid "Text size"
@@ -833,6 +859,11 @@ msgstr "Noch keine Beiträge indexiert."
 msgid "{0} added to {listName}."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+#: src/components/user-settings-view.tsx
+msgid "Custom"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Read the API docs"
 msgstr "API-Doku lesen"
@@ -868,6 +899,10 @@ msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "For more about how {SITE_NAME} works, see the <0>About</0> page. For questions about these terms for this deployment, contact the operator of the site at the URL above."
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Compact"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -931,6 +966,10 @@ msgstr "{documentCount, plural, one {Dokument} other {Dokumente}}"
 msgid "Publishing"
 msgstr "Veröffentlichen"
 
+#: src/components/appearance-settings.tsx
+msgid "Roundness"
+msgstr ""
+
 #: src/components/docs/introduction-docs-page.tsx
 msgid "public XRPC queries and procedures for the Standard Reader read-model, with live examples."
 msgstr ""
@@ -971,6 +1010,10 @@ msgstr "Fügen Sie den Hinweis <0>site.standard.publication</0> nur hinzu, wenn 
 #: src/components/reader/about-view.tsx
 msgid "Your week"
 msgstr "Ihre Woche"
+
+#: src/components/appearance-settings.tsx
+msgid "Relaxed"
+msgstr ""
 
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.recommended.tsx
@@ -1013,6 +1056,10 @@ msgstr "Aus"
 msgid "Run example"
 msgstr "Beispiel ausführen"
 
+#: src/components/appearance-settings.tsx
+msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "When on, collection posts open in the magazine edition instead of the reader view."
 msgstr "Wenn aktiviert, öffnen sich Beiträge aus Sammlungen in der Magazinausgabe statt in der Leseansicht."
@@ -1047,6 +1094,10 @@ msgstr "Frage"
 #: src/components/reader/list-edit-modal.tsx
 msgid "Choose an item to add to the list"
 msgstr "Wählen Sie einen Eintrag für die Liste"
+
+#: src/components/appearance-settings.tsx
+msgid "Soft"
+msgstr ""
 
 #: src/magazine/magazine-end-subscribe.tsx
 msgid "Subscribed to list"
@@ -1110,9 +1161,18 @@ msgstr "Worum es in dieser Liste geht (wird auf ihrer öffentlichen Seite angeze
 msgid "Delete collection"
 msgstr "Sammlung löschen"
 
+#: src/components/appearance-settings.tsx
+msgid "Interface font"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No publications in this list."
 msgstr "Keine Publikationen in dieser Liste."
+
+#. placeholder {0}: palette.name
+#: src/components/appearance-settings.tsx
+msgid "{0}, dark"
+msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Loading collections…"
@@ -1130,6 +1190,10 @@ msgstr "Labeler durchstöbern"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We do not run a separate analytics pipeline inside the extension."
 msgstr "Wir betreiben innerhalb der Erweiterung keine separate Analyse-Pipeline."
+
+#: src/components/appearance-settings.tsx
+#~ msgid "Text, borders and every other step are derived from these two colors and checked for contrast."
+#~ msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Remove list"
@@ -1436,6 +1500,7 @@ msgstr "{durationMs} ms · abgerufen {fetchedAt}"
 msgid "Loading feedback"
 msgstr "Feedback wird geladen"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Accent"
 msgstr "Akzent"
@@ -1483,6 +1548,10 @@ msgstr "Zu Chrome hinzufügen"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Leaflet, Pckt, Offprint.</0> <1>pub.leaflet.content</1>, <2>blog.pckt.content</2>, and <3>app.offprint.content</3> — the block-based formats those tools write natively."
 msgstr "<0>Leaflet, Pckt, Offprint.</0> <1>pub.leaflet.content</1>, <2>blog.pckt.content</2> und <3>app.offprint.content</3> – die blockbasierten Formate, die diese Tools nativ schreiben."
+
+#: src/components/appearance-settings.tsx
+msgid "XL"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Set your own type"
@@ -1638,6 +1707,10 @@ msgstr "Zur Leseansicht wechseln"
 msgid "<0>3. Declare your label values.</0> Describe each value (severity, default warn/hide, blur behavior) in an <1>app.standard-reader.labeler.service</1> descriptor, served from <2>app.standard-reader.labeler.getServices</2> (a <3>did:web</3> labeler has no repo to hold the record)."
 msgstr "<0>3. Deklarieren Sie Ihre Label-Werte.</0> Beschreiben Sie jeden Wert (Schweregrad, Standardverhalten Warnen/Ausblenden, Weichzeichnen) in einem <1>app.standard-reader.labeler.service</1>-Deskriptor, ausgeliefert über <2>app.standard-reader.labeler.getServices</2> (ein <3>did:web</3>-Labeler hat kein Repo für den Record)."
 
+#: src/components/reader/format-i18n.ts
+msgid "{months}mo ago"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "To email your digest, Standard Reader needs your account email address. We'll ask your PDS to share it — you'll be sent to your login to approve the request, then brought right back here. Your email is used only to send the weekly digest, and you can turn it off any time."
 msgstr "Um Ihren Digest per E-Mail zu senden, benötigt Standard Reader die E-Mail-Adresse Ihres Kontos. Wir fragen Ihren PDS danach – Sie werden zur Anmeldung geleitet, um die Anfrage zu bestätigen, und kommen direkt hierher zurück. Ihre E-Mail-Adresse wird nur für den wöchentlichen Digest verwendet und Sie können ihn jederzeit abschalten."
@@ -1713,6 +1786,10 @@ msgstr ""
 msgid "Every unread article from this publication will be marked read. This can’t be undone."
 msgstr "Jeder ungelesene Artikel dieser Publikation wird als gelesen markiert. Das lässt sich nicht rückgängig machen."
 
+#: src/components/appearance-settings.tsx
+msgid "Your own colors"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
 msgstr "Ausgabe wird gesetzt…"
@@ -1765,6 +1842,11 @@ msgstr "{pubTotal, plural, one {# Publikation} other {# Publikationen}}"
 msgid "Nothing new today"
 msgstr ""
 
+#. placeholder {0}: palette.name
+#: src/components/appearance-settings.tsx
+msgid "{0}, light"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Background"
 msgstr "Hintergrund"
@@ -1784,6 +1866,10 @@ msgstr "Aus Ihren Abos"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>When you browse without signing in,</0> we serve public writing from our read-model index. We may store a theme preference cookie and, if you have signed in before on this device, a short list of recently used account handles (and optional avatar URLs) to speed up sign-in. We do not require an account to read."
 msgstr "<0>Wenn Sie ohne Anmeldung stöbern,</0> liefern wir öffentliche Texte aus unserem Lesemodell-Index aus. Wir speichern eventuell ein Cookie mit Ihrer Theme-Einstellung und, falls Sie sich auf diesem Gerät schon einmal angemeldet haben, eine kurze Liste zuletzt genutzter Konto-Handles (und optionaler Avatar-URLs), um die Anmeldung zu beschleunigen. Zum Lesen ist kein Konto nötig."
+
+#: src/components/appearance-settings.tsx
+msgid "Paper"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
@@ -2235,8 +2321,8 @@ msgid "by @{ownerHandle}"
 msgstr "von @{ownerHandle}"
 
 #: src/components/user-settings-view.tsx
-msgid "Choose light, dark, or match your system setting."
-msgstr "Wählen Sie hell, dunkel oder die Systemeinstellung."
+#~ msgid "Choose light, dark, or match your system setting."
+#~ msgstr "Wählen Sie hell, dunkel oder die Systemeinstellung."
 
 #. placeholder {0}: rows.length
 #: src/components/reader/subscriptions-table.tsx
@@ -2254,6 +2340,10 @@ msgstr "Fertig"
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
 msgstr "Die neuesten Langtexte aus dem gesamten Netzwerk."
+
+#: src/components/appearance-settings.tsx
+msgid "Sets the app's colors — and, because the page color decides it, whether the app reads light or dark."
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "{subscribedCount} unread across the publications you subscribe to."
@@ -2291,6 +2381,10 @@ msgstr "Sie haben {publicationName} bereits abonniert. Neue Beiträge erscheinen
 msgid "The directory"
 msgstr "Das Verzeichnis"
 
+#: src/components/appearance-settings.tsx
+#~ msgid "Your accent sits close to the paper in tone, so a darkened version of it is used for text and links."
+#~ msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Trending this week"
 msgstr "Trends dieser Woche"
@@ -2319,6 +2413,10 @@ msgstr "Noch keine Listen"
 #: src/routes/_layout.discover.tsx
 msgid "Browse everything"
 msgstr "Alles durchstöbern"
+
+#: src/components/appearance-settings.tsx
+msgid "Large"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
@@ -2476,6 +2574,10 @@ msgstr ""
 msgid "The most-read writing across the network right now."
 msgstr "Die meistgelesenen Texte im Netzwerk gerade jetzt."
 
+#: src/components/appearance-settings.tsx
+msgid "The typeface used across the app. Article text follows this too, unless you set a reading font below."
+msgstr ""
+
 #: src/magazine/magazine-end-like.tsx
 msgid "Recommend this issue"
 msgstr "Diese Ausgabe empfehlen"
@@ -2491,6 +2593,10 @@ msgstr "{count, plural, one {# Upvote} other {# Upvotes}} — zum Rückgängigma
 #: src/routes/_layout.search.tsx
 msgid "{shown} of {total} matches"
 msgstr "{shown} von {total} Treffern"
+
+#: src/components/appearance-settings.tsx
+msgid "How rounded buttons, cards and inputs are."
+msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
 msgid "What is this series about?"
@@ -2523,6 +2629,10 @@ msgstr ""
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler didn’t publish any label definitions."
 msgstr "Dieser Labeler hat keine Label-Definitionen veröffentlicht."
+
+#: src/components/reader/format-i18n.ts
+msgid "{days}d ago"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Continue to approve"
@@ -2570,6 +2680,10 @@ msgstr "Also haben wir den Leser gebaut, den wir wollten: eine Spalte, deren Bre
 #: src/routes/_layout.recommended.tsx
 msgid "Recommended articles"
 msgstr "Empfohlene Artikel"
+
+#: src/components/user-settings-view.tsx
+msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labeler views"
@@ -2654,6 +2768,10 @@ msgstr "Impressum"
 msgid "Reader voice"
 msgstr "Vorlesestimme"
 
+#: src/components/appearance-settings.tsx
+msgid "Sharp"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "What you get is a reading view made for long-form: a centered column, drop caps and pull quotes, full-bleed images you can open into a gallery. The page gets out of the way so the writing can do its work."
 msgstr "Sie bekommen eine Leseansicht für Langtexte: eine zentrierte Spalte, Initialen und Zitatblöcke, randlose Bilder, die sich zur Galerie öffnen. Die Seite tritt zurück, damit der Text wirken kann."
@@ -2703,6 +2821,10 @@ msgstr "Dieser Link ist abgelaufen."
 #: src/components/reader/privacy-view.tsx
 msgid "You can sign out at any time, which clears your app session cookie. You can clear site cookies in your browser to remove theme and saved-handle preferences. You can change reading-history tracking and delete personal data from Settings. To remove other AT Protocol records you created through the app, use a compatible client or your repository tools."
 msgstr "Sie können sich jederzeit abmelden, wodurch Ihr App-Sitzungscookie gelöscht wird. Site-Cookies können Sie im Browser löschen, um Theme- und gespeicherte Handle-Einstellungen zu entfernen. Die Erfassung des Leseverlaufs ändern und persönliche Daten löschen können Sie in den Einstellungen. Um andere AT-Protocol-Datensätze zu entfernen, die Sie über die App erstellt haben, nutzen Sie einen kompatiblen Client oder Ihre Repository-Tools."
+
+#: src/components/appearance-settings.tsx
+msgid "XS"
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
@@ -2884,6 +3006,10 @@ msgstr ""
 msgid "Share on Bluesky"
 msgstr "Auf Bluesky teilen"
 
+#: src/components/appearance-settings.tsx
+msgid "Reset"
+msgstr ""
+
 #: src/components/docs/docs-lexicons-nav.tsx
 #~ msgid "Lexicon reference"
 #~ msgstr "Lexikon-Referenz"
@@ -2939,6 +3065,10 @@ msgstr "Das Gespräch, gebündelt"
 msgid "Mark all as read"
 msgstr "Alle als gelesen markieren"
 
+#: src/components/appearance-settings.tsx
+msgid "Scales every size in the app, article text included — from 14px up to 24px of interface text."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "Your display name, handle, avatar URL, and DID as returned by your account provider."
 msgstr "Ihr Anzeigename, Handle, Avatar-URL und DID, wie von Ihrem Konto-Anbieter übermittelt."
@@ -2970,6 +3100,10 @@ msgstr "An anderen Client senden"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "What the extension does not do"
 msgstr "Was die Erweiterung nicht tut"
+
+#: src/components/appearance-settings.tsx
+msgid "Default"
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Loading recommendations"
@@ -3100,6 +3234,10 @@ msgstr "(benötigt {min}:1)"
 msgid "Every read record in your repository will be removed. Articles will appear unread again across the app. This cannot be undone."
 msgstr "Jeder Lese-Eintrag in Ihrem Repository wird entfernt. Artikel erscheinen in der gesamten App wieder als ungelesen. Das lässt sich nicht rückgängig machen."
 
+#: src/components/appearance-settings.tsx
+msgid "Text, borders and every other step are derived from these two colors."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "Wenn Sie die Browser-Erweiterung von {SITE_NAME} installieren, nutzt sie dasselbe Konto und Sitzungs-Cookie wie diese Seite. Die Erweiterung sendet Seiten-URLs zum Index-Abgleich an unsere <0>/api/extension/*</0>-Endpunkte und speichert Overlay-Einstellungen im Erweiterungsspeicher Ihres Browsers. Details, die nur für die Erweiterung gelten, finden Sie in der <1>Datenschutzerklärung der Erweiterung</1>."
@@ -3149,6 +3287,7 @@ msgstr ""
 msgid "Unfollowing {peopleCount, plural, one {this person} other {these # people}} also drops the subscriptions that follow created, so their publications leave your feed. Nothing you have saved, read, or recommended is affected."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/user-settings-view.tsx
 msgid "Dark"
@@ -3369,6 +3508,10 @@ msgstr "Labeler sind Moderationsdienste, die Sie per DID abonnieren. Abonnieren 
 msgid "Standard Reader meets you where you read"
 msgstr "Standard Reader ist da, wo Sie lesen"
 
+#: src/components/appearance-settings.tsx
+msgid "Reset appearance"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/reader/markdown-field.tsx
 #: src/components/reading-settings-preview.tsx
@@ -3442,6 +3585,10 @@ msgstr "Labeler suchen"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · Ihr Feed"
 
+#: src/components/reader/format-i18n.ts
+msgid "yesterday"
+msgstr ""
+
 #: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Use publication themes"
@@ -3459,6 +3606,7 @@ msgstr "Die Dienst-DID lautet <0>{appviewDid}</0>. Der Dienst stellt ein <1>DID-
 msgid "The Slow Web, Revisited"
 msgstr "Das langsame Web, neu betrachtet"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reading-custom-font-picker.tsx
 #: src/components/user-settings-view.tsx
 msgid "Google Font"
@@ -3554,6 +3702,10 @@ msgstr "Feedback durchsuchen"
 msgid "Unsubscribe"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "L"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "Load more ({remainingPublications} remaining)"
 msgstr "Mehr laden (noch {remainingPublications})"
@@ -3606,6 +3758,10 @@ msgstr "Einbettungscode kopieren"
 #: src/components/user-settings-view.tsx
 msgid "Delete all lists?"
 msgstr "Alle Listen löschen?"
+
+#: src/components/user-settings-view.tsx
+msgid "Advanced"
+msgstr ""
 
 #: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
@@ -3669,6 +3825,10 @@ msgstr "Abspielen"
 #: src/routes/_layout.search.tsx
 msgid "Loading article matches"
 msgstr "Artikeltreffer werden geladen"
+
+#: src/components/appearance-settings.tsx
+msgid "Extra small"
+msgstr ""
 
 #: src/components/reader/content/renderers/leaflet-standard-site-publication.tsx
 msgid "Publication not found."
@@ -3738,6 +3898,10 @@ msgstr "Verhalten"
 msgid "Reading history"
 msgstr "Leseverlauf"
 
+#: src/components/appearance-settings.tsx
+msgid "M"
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>2. Serve labels.</0> Sign and emit <1>com.atproto.label.defs#label</1> objects, and expose the standard <2>com.atproto.label.queryLabels</2> (HTTP) and <3>com.atproto.label.subscribeLabels</3> (WebSocket) endpoints."
 msgstr "<0>2. Label ausliefern.</0> Signieren und senden Sie <1>com.atproto.label.defs#label</1>-Objekte und stellen Sie die Standard-Endpunkte <2>com.atproto.label.queryLabels</2> (HTTP) und <3>com.atproto.label.subscribeLabels</3> (WebSocket) bereit."
@@ -3800,6 +3964,10 @@ msgstr "Keine Publikationen in dieser Liste – fügen Sie im Bearbeiten-Dialog 
 #: src/components/reader/subscribe-card.tsx
 msgid "Adding {publicationName} to your feed."
 msgstr "{publicationName} wird Ihrem Feed hinzugefügt."
+
+#: src/components/appearance-settings.tsx
+#~ msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors and checked for contrast."
+#~ msgstr ""
 
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/app-shell.tsx
@@ -3956,6 +4124,10 @@ msgstr "Anmeldung und Zugriff auf Records laufen über Ihren Personal Data Serve
 msgid "An included article"
 msgstr "Ein enthaltener Artikel"
 
+#: src/components/appearance-settings.tsx
+msgid "Puts the palette, font, size, roundness and density back to their defaults."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Subscribe to labelers to flag, blur, or hide content as you read."
 msgstr "Abonnieren Sie Labeler, um Inhalte beim Lesen zu markieren, zu verwischen oder auszublenden."
@@ -4013,6 +4185,7 @@ msgstr "{weekday} · Im ganzen Netzwerk"
 msgid "Publish & share the run"
 msgstr "Lauf veröffentlichen & teilen"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-builder.tsx
 msgid "Editorial"
 msgstr "Redaktionell"
@@ -4175,6 +4348,10 @@ msgstr ""
 msgid "Open on {publicationName}"
 msgstr "Auf {publicationName} öffnen"
 
+#: src/components/appearance-settings.tsx
+msgid "Sans"
+msgstr ""
+
 #: src/components/reader/add-publication-modal.tsx
 msgid "Search publications or paste a handle"
 msgstr "Publikationen suchen oder Handle einfügen"
@@ -4299,6 +4476,10 @@ msgstr "Vorlesen"
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "Artikel, die Sie für später gespeichert haben — in Ihrem Repo, geräteübergreifend synchronisiert."
 
+#: src/components/reader/format-i18n.ts
+msgid "today"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 #: src/components/reader/content/renderers/shared/image-figure.tsx
 #: src/components/reader/content/renderers/shared/markdown-article.tsx
@@ -4406,6 +4587,7 @@ msgstr "Nach Thema filtern"
 msgid "No unread articles from your follows right now."
 msgstr "Derzeit keine ungelesenen Artikel aus Ihren Abos."
 
+#: src/components/appearance-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Search and pick any family from the Google Fonts catalog."
 msgstr "Beliebige Schriftfamilie aus dem Google-Fonts-Katalog suchen und wählen."
@@ -4534,6 +4716,10 @@ msgstr "<0>Wenn Sie sich anmelden</0> mit Ihrem Atmosphere-Konto (etwa per Blues
 msgid "Powered by <0>Standard Reader</0>"
 msgstr "Ermöglicht durch <0>Standard Reader</0>"
 
+#: src/components/appearance-settings.tsx
+msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Save from anywhere you browse"
 msgstr "Speichern, wo immer Sie surfen"
@@ -4651,6 +4837,10 @@ msgstr "Loslegen"
 msgid "You don't have any content tabs to show yet."
 msgstr "Sie haben noch keine Inhalts-Tabs zum Anzeigen."
 
+#: src/components/appearance-settings.tsx
+msgid "Body text on paper"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "OK"
 msgstr "OK"
@@ -4719,6 +4909,10 @@ msgstr "@{0} · Hat Dokumente, aber keine Publikationen"
 msgid "{connectionLabel} via Semble"
 msgstr "{connectionLabel} über Semble"
 
+#: src/components/appearance-settings.tsx
+msgid "S"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "In this issue"
 msgstr "In dieser Ausgabe"
@@ -4729,4 +4923,8 @@ msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Acceptable use"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Palette"
 msgstr ""

--- a/src/locales/en-XA/messages.po
+++ b/src/locales/en-XA/messages.po
@@ -239,6 +239,10 @@ msgstr ""
 msgid "Opening the collection…"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "Density"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Open on publication"
 msgstr ""
@@ -280,6 +284,7 @@ msgstr ""
 msgid "<0>Session cookie.</0> After you sign in through the web app, the extension background worker reads your HttpOnly session cookie on {siteHost} to authenticate API requests. Content scripts do not read this cookie directly."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/user-settings-view.tsx
 msgid "Light"
@@ -318,8 +323,16 @@ msgstr ""
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 msgstr ""
 
+#: src/components/reader/format-i18n.ts
+msgid "{years}y ago"
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "List"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "The spacing between things — tighter for more on screen, looser for more room to read."
 msgstr ""
 
 #: src/components/docs/api-docs-request-panel.tsx
@@ -349,6 +362,10 @@ msgstr ""
 #: src/components/docs/docs-labelers-nav.tsx
 #: src/components/docs/labelers-docs-page.tsx
 msgid "Reference implementation"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Extra large"
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
@@ -453,6 +470,10 @@ msgstr ""
 msgid "Loading people"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "Links and labels on paper"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Read the piece →"
 msgstr ""
@@ -492,6 +513,10 @@ msgstr ""
 
 #: src/routes/_layout.discover.tsx
 msgid "Search publications"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Small"
 msgstr ""
 
 #: src/routes/_layout.search.tsx
@@ -767,6 +792,7 @@ msgstr ""
 msgid "Content label"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
 #: src/components/ReadingTypographyMenu.tsx
 #: src/components/user-settings-view.tsx
 msgid "Text size"
@@ -833,6 +859,11 @@ msgstr ""
 msgid "{0} added to {listName}."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+#: src/components/user-settings-view.tsx
+msgid "Custom"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Read the API docs"
 msgstr ""
@@ -868,6 +899,10 @@ msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "For more about how {SITE_NAME} works, see the <0>About</0> page. For questions about these terms for this deployment, contact the operator of the site at the URL above."
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Compact"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -931,6 +966,10 @@ msgstr ""
 msgid "Publishing"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "Roundness"
+msgstr ""
+
 #: src/components/docs/introduction-docs-page.tsx
 msgid "public XRPC queries and procedures for the Standard Reader read-model, with live examples."
 msgstr ""
@@ -970,6 +1009,10 @@ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Your week"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Relaxed"
 msgstr ""
 
 #: src/routes/_layout.history.tsx
@@ -1013,6 +1056,10 @@ msgstr ""
 msgid "Run example"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "When on, collection posts open in the magazine edition instead of the reader view."
 msgstr ""
@@ -1046,6 +1093,10 @@ msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "Choose an item to add to the list"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Soft"
 msgstr ""
 
 #: src/magazine/magazine-end-subscribe.tsx
@@ -1110,8 +1161,17 @@ msgstr ""
 msgid "Delete collection"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "Interface font"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No publications in this list."
+msgstr ""
+
+#. placeholder {0}: palette.name
+#: src/components/appearance-settings.tsx
+msgid "{0}, dark"
 msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
@@ -1130,6 +1190,10 @@ msgstr ""
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We do not run a separate analytics pipeline inside the extension."
 msgstr ""
+
+#: src/components/appearance-settings.tsx
+#~ msgid "Text, borders and every other step are derived from these two colors and checked for contrast."
+#~ msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Remove list"
@@ -1436,6 +1500,7 @@ msgstr ""
 msgid "Loading feedback"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Accent"
 msgstr ""
@@ -1482,6 +1547,10 @@ msgstr ""
 
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Leaflet, Pckt, Offprint.</0> <1>pub.leaflet.content</1>, <2>blog.pckt.content</2>, and <3>app.offprint.content</3> — the block-based formats those tools write natively."
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "XL"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -1638,6 +1707,10 @@ msgstr ""
 msgid "<0>3. Declare your label values.</0> Describe each value (severity, default warn/hide, blur behavior) in an <1>app.standard-reader.labeler.service</1> descriptor, served from <2>app.standard-reader.labeler.getServices</2> (a <3>did:web</3> labeler has no repo to hold the record)."
 msgstr ""
 
+#: src/components/reader/format-i18n.ts
+msgid "{months}mo ago"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "To email your digest, Standard Reader needs your account email address. We'll ask your PDS to share it — you'll be sent to your login to approve the request, then brought right back here. Your email is used only to send the weekly digest, and you can turn it off any time."
 msgstr ""
@@ -1713,6 +1786,10 @@ msgstr ""
 msgid "Every unread article from this publication will be marked read. This can’t be undone."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "Your own colors"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
 msgstr ""
@@ -1765,6 +1842,11 @@ msgstr ""
 msgid "Nothing new today"
 msgstr ""
 
+#. placeholder {0}: palette.name
+#: src/components/appearance-settings.tsx
+msgid "{0}, light"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Background"
 msgstr ""
@@ -1783,6 +1865,10 @@ msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "<0>When you browse without signing in,</0> we serve public writing from our read-model index. We may store a theme preference cookie and, if you have signed in before on this device, a short list of recently used account handles (and optional avatar URLs) to speed up sign-in. We do not require an account to read."
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Paper"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -2235,8 +2321,8 @@ msgid "by @{ownerHandle}"
 msgstr ""
 
 #: src/components/user-settings-view.tsx
-msgid "Choose light, dark, or match your system setting."
-msgstr ""
+#~ msgid "Choose light, dark, or match your system setting."
+#~ msgstr ""
 
 #. placeholder {0}: rows.length
 #: src/components/reader/subscriptions-table.tsx
@@ -2253,6 +2339,10 @@ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Sets the app's colors — and, because the page color decides it, whether the app reads light or dark."
 msgstr ""
 
 #: src/routes/_layout.index.tsx
@@ -2291,6 +2381,10 @@ msgstr ""
 msgid "The directory"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+#~ msgid "Your accent sits close to the paper in tone, so a darkened version of it is used for text and links."
+#~ msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Trending this week"
 msgstr ""
@@ -2318,6 +2412,10 @@ msgstr ""
 
 #: src/routes/_layout.discover.tsx
 msgid "Browse everything"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Large"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -2476,6 +2574,10 @@ msgstr ""
 msgid "The most-read writing across the network right now."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "The typeface used across the app. Article text follows this too, unless you set a reading font below."
+msgstr ""
+
 #: src/magazine/magazine-end-like.tsx
 msgid "Recommend this issue"
 msgstr ""
@@ -2490,6 +2592,10 @@ msgstr ""
 
 #: src/routes/_layout.search.tsx
 msgid "{shown} of {total} matches"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "How rounded buttons, cards and inputs are."
 msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
@@ -2522,6 +2628,10 @@ msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler didn’t publish any label definitions."
+msgstr ""
+
+#: src/components/reader/format-i18n.ts
+msgid "{days}d ago"
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -2569,6 +2679,10 @@ msgstr ""
 #: src/components/NavbarAuth.tsx
 #: src/routes/_layout.recommended.tsx
 msgid "Recommended articles"
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
 msgstr ""
 
 #: src/components/labeler-detail-view.tsx
@@ -2654,6 +2768,10 @@ msgstr ""
 msgid "Reader voice"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "Sharp"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "What you get is a reading view made for long-form: a centered column, drop caps and pull quotes, full-bleed images you can open into a gallery. The page gets out of the way so the writing can do its work."
 msgstr ""
@@ -2702,6 +2820,10 @@ msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "You can sign out at any time, which clears your app session cookie. You can clear site cookies in your browser to remove theme and saved-handle preferences. You can change reading-history tracking and delete personal data from Settings. To remove other AT Protocol records you created through the app, use a compatible client or your repository tools."
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "XS"
 msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
@@ -2884,6 +3006,10 @@ msgstr ""
 msgid "Share on Bluesky"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "Reset"
+msgstr ""
+
 #: src/components/docs/docs-lexicons-nav.tsx
 #~ msgid "Lexicon reference"
 #~ msgstr ""
@@ -2939,6 +3065,10 @@ msgstr ""
 msgid "Mark all as read"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "Scales every size in the app, article text included — from 14px up to 24px of interface text."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "Your display name, handle, avatar URL, and DID as returned by your account provider."
 msgstr ""
@@ -2969,6 +3099,10 @@ msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "What the extension does not do"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Default"
 msgstr ""
 
 #: src/routes/_layout.index.tsx
@@ -3100,6 +3234,10 @@ msgstr ""
 msgid "Every read record in your repository will be removed. Articles will appear unread again across the app. This cannot be undone."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "Text, borders and every other step are derived from these two colors."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr ""
@@ -3149,6 +3287,7 @@ msgstr ""
 msgid "Unfollowing {peopleCount, plural, one {this person} other {these # people}} also drops the subscriptions that follow created, so their publications leave your feed. Nothing you have saved, read, or recommended is affected."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/user-settings-view.tsx
 msgid "Dark"
@@ -3369,6 +3508,10 @@ msgstr ""
 msgid "Standard Reader meets you where you read"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "Reset appearance"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/reader/markdown-field.tsx
 #: src/components/reading-settings-preview.tsx
@@ -3442,6 +3585,10 @@ msgstr ""
 msgid "{weekday} · Your feed"
 msgstr ""
 
+#: src/components/reader/format-i18n.ts
+msgid "yesterday"
+msgstr ""
+
 #: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Use publication themes"
@@ -3459,6 +3606,7 @@ msgstr ""
 msgid "The Slow Web, Revisited"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
 #: src/components/reading-custom-font-picker.tsx
 #: src/components/user-settings-view.tsx
 msgid "Google Font"
@@ -3554,6 +3702,10 @@ msgstr ""
 msgid "Unsubscribe"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "L"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "Load more ({remainingPublications} remaining)"
 msgstr ""
@@ -3605,6 +3757,10 @@ msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Delete all lists?"
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Advanced"
 msgstr ""
 
 #: src/components/onboarding/step-settings.tsx
@@ -3668,6 +3824,10 @@ msgstr ""
 
 #: src/routes/_layout.search.tsx
 msgid "Loading article matches"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Extra small"
 msgstr ""
 
 #: src/components/reader/content/renderers/leaflet-standard-site-publication.tsx
@@ -3738,6 +3898,10 @@ msgstr ""
 msgid "Reading history"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "M"
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>2. Serve labels.</0> Sign and emit <1>com.atproto.label.defs#label</1> objects, and expose the standard <2>com.atproto.label.queryLabels</2> (HTTP) and <3>com.atproto.label.subscribeLabels</3> (WebSocket) endpoints."
 msgstr ""
@@ -3800,6 +3964,10 @@ msgstr ""
 #: src/components/reader/subscribe-card.tsx
 msgid "Adding {publicationName} to your feed."
 msgstr ""
+
+#: src/components/appearance-settings.tsx
+#~ msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors and checked for contrast."
+#~ msgstr ""
 
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/app-shell.tsx
@@ -3956,6 +4124,10 @@ msgstr ""
 msgid "An included article"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "Puts the palette, font, size, roundness and density back to their defaults."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Subscribe to labelers to flag, blur, or hide content as you read."
 msgstr ""
@@ -4013,6 +4185,7 @@ msgstr ""
 msgid "Publish & share the run"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-builder.tsx
 msgid "Editorial"
 msgstr ""
@@ -4175,6 +4348,10 @@ msgstr ""
 msgid "Open on {publicationName}"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "Sans"
+msgstr ""
+
 #: src/components/reader/add-publication-modal.tsx
 msgid "Search publications or paste a handle"
 msgstr ""
@@ -4299,6 +4476,10 @@ msgstr ""
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr ""
 
+#: src/components/reader/format-i18n.ts
+msgid "today"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 #: src/components/reader/content/renderers/shared/image-figure.tsx
 #: src/components/reader/content/renderers/shared/markdown-article.tsx
@@ -4406,6 +4587,7 @@ msgstr ""
 msgid "No unread articles from your follows right now."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Search and pick any family from the Google Fonts catalog."
 msgstr ""
@@ -4534,6 +4716,10 @@ msgstr ""
 msgid "Powered by <0>Standard Reader</0>"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Save from anywhere you browse"
 msgstr ""
@@ -4651,6 +4837,10 @@ msgstr ""
 msgid "You don't have any content tabs to show yet."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "Body text on paper"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "OK"
 msgstr ""
@@ -4719,6 +4909,10 @@ msgstr ""
 msgid "{connectionLabel} via Semble"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "S"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "In this issue"
 msgstr ""
@@ -4729,4 +4923,8 @@ msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Acceptable use"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Palette"
 msgstr ""

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -239,6 +239,10 @@ msgstr "Show {itemLabel} in the sidebar"
 msgid "Opening the collection…"
 msgstr "Opening the collection…"
 
+#: src/components/appearance-settings.tsx
+msgid "Density"
+msgstr "Density"
+
 #: src/components/reader/article-view.tsx
 msgid "Open on publication"
 msgstr "Open on publication"
@@ -280,6 +284,7 @@ msgstr "Submit feedback"
 msgid "<0>Session cookie.</0> After you sign in through the web app, the extension background worker reads your HttpOnly session cookie on {siteHost} to authenticate API requests. Content scripts do not read this cookie directly."
 msgstr "<0>Session cookie.</0> After you sign in through the web app, the extension background worker reads your HttpOnly session cookie on {siteHost} to authenticate API requests. Content scripts do not read this cookie directly."
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/user-settings-view.tsx
 msgid "Light"
@@ -318,9 +323,17 @@ msgstr "People"
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 msgstr "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 
+#: src/components/reader/format-i18n.ts
+msgid "{years}y ago"
+msgstr "{years}y ago"
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "List"
 msgstr "List"
+
+#: src/components/appearance-settings.tsx
+msgid "The spacing between things — tighter for more on screen, looser for more room to read."
+msgstr "The spacing between things — tighter for more on screen, looser for more room to read."
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Sign in to run this example (curl uses Bearer $ACCESS_TOKEN)."
@@ -350,6 +363,10 @@ msgstr "Name your series & pick a theme"
 #: src/components/docs/labelers-docs-page.tsx
 msgid "Reference implementation"
 msgstr "Reference implementation"
+
+#: src/components/appearance-settings.tsx
+msgid "Extra large"
+msgstr "Extra large"
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Bugs"
@@ -453,6 +470,10 @@ msgstr "Permanently remove data stored in your account. These actions delete rec
 msgid "Loading people"
 msgstr "Loading people"
 
+#: src/components/appearance-settings.tsx
+msgid "Links and labels on paper"
+msgstr "Links and labels on paper"
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Read the piece →"
 msgstr "Read the piece →"
@@ -493,6 +514,10 @@ msgstr "Log in to follow publications"
 #: src/routes/_layout.discover.tsx
 msgid "Search publications"
 msgstr "Search publications"
+
+#: src/components/appearance-settings.tsx
+msgid "Small"
+msgstr "Small"
 
 #: src/routes/_layout.search.tsx
 msgid "Publications, handles, #tags, headlines…"
@@ -767,6 +792,7 @@ msgstr "Discussions"
 msgid "Content label"
 msgstr "Content label"
 
+#: src/components/appearance-settings.tsx
 #: src/components/ReadingTypographyMenu.tsx
 #: src/components/user-settings-view.tsx
 msgid "Text size"
@@ -833,6 +859,11 @@ msgstr "No posts indexed yet."
 msgid "{0} added to {listName}."
 msgstr "{0} added to {listName}."
 
+#: src/components/appearance-settings.tsx
+#: src/components/user-settings-view.tsx
+msgid "Custom"
+msgstr "Custom"
+
 #: src/components/reader/about-view.tsx
 msgid "Read the API docs"
 msgstr "Read the API docs"
@@ -869,6 +900,10 @@ msgstr "how to make a site discoverable on Standard and have its content read in
 #: src/components/reader/terms-view.tsx
 msgid "For more about how {SITE_NAME} works, see the <0>About</0> page. For questions about these terms for this deployment, contact the operator of the site at the URL above."
 msgstr "For more about how {SITE_NAME} works, see the <0>About</0> page. For questions about these terms for this deployment, contact the operator of the site at the URL above."
+
+#: src/components/appearance-settings.tsx
+msgid "Compact"
+msgstr "Compact"
 
 #: src/components/reader/share-menu.tsx
 msgid "Portrait stacks the card vertically. Height adjusts automatically once the embed loads. Change the iframe width as needed."
@@ -931,6 +966,10 @@ msgstr "{documentCount, plural, one {document} other {documents}}"
 msgid "Publishing"
 msgstr "Publishing"
 
+#: src/components/appearance-settings.tsx
+msgid "Roundness"
+msgstr "Roundness"
+
 #: src/components/docs/introduction-docs-page.tsx
 msgid "public XRPC queries and procedures for the Standard Reader read-model, with live examples."
 msgstr "public XRPC queries and procedures for the Standard Reader read-model, with live examples."
@@ -971,6 +1010,10 @@ msgstr "Include the <0>site.standard.publication</0> hint only if the document b
 #: src/components/reader/about-view.tsx
 msgid "Your week"
 msgstr "Your week"
+
+#: src/components/appearance-settings.tsx
+msgid "Relaxed"
+msgstr "Relaxed"
 
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.recommended.tsx
@@ -1013,6 +1056,10 @@ msgstr "Off"
 msgid "Run example"
 msgstr "Run example"
 
+#: src/components/appearance-settings.tsx
+msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors."
+msgstr "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors."
+
 #: src/components/user-settings-view.tsx
 msgid "When on, collection posts open in the magazine edition instead of the reader view."
 msgstr "When on, collection posts open in the magazine edition instead of the reader view."
@@ -1047,6 +1094,10 @@ msgstr "Question"
 #: src/components/reader/list-edit-modal.tsx
 msgid "Choose an item to add to the list"
 msgstr "Choose an item to add to the list"
+
+#: src/components/appearance-settings.tsx
+msgid "Soft"
+msgstr "Soft"
 
 #: src/magazine/magazine-end-subscribe.tsx
 msgid "Subscribed to list"
@@ -1110,9 +1161,18 @@ msgstr "What this list is about (shown on its public page)"
 msgid "Delete collection"
 msgstr "Delete collection"
 
+#: src/components/appearance-settings.tsx
+msgid "Interface font"
+msgstr "Interface font"
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No publications in this list."
 msgstr "No publications in this list."
+
+#. placeholder {0}: palette.name
+#: src/components/appearance-settings.tsx
+msgid "{0}, dark"
+msgstr "{0}, dark"
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Loading collections…"
@@ -1130,6 +1190,10 @@ msgstr "Browse labelers"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We do not run a separate analytics pipeline inside the extension."
 msgstr "We do not run a separate analytics pipeline inside the extension."
+
+#: src/components/appearance-settings.tsx
+#~ msgid "Text, borders and every other step are derived from these two colors and checked for contrast."
+#~ msgstr "Text, borders and every other step are derived from these two colors and checked for contrast."
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Remove list"
@@ -1436,6 +1500,7 @@ msgstr "{durationMs}ms · fetched {fetchedAt}"
 msgid "Loading feedback"
 msgstr "Loading feedback"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Accent"
 msgstr "Accent"
@@ -1483,6 +1548,10 @@ msgstr "Add to Chrome"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Leaflet, Pckt, Offprint.</0> <1>pub.leaflet.content</1>, <2>blog.pckt.content</2>, and <3>app.offprint.content</3> — the block-based formats those tools write natively."
 msgstr "<0>Leaflet, Pckt, Offprint.</0> <1>pub.leaflet.content</1>, <2>blog.pckt.content</2>, and <3>app.offprint.content</3> — the block-based formats those tools write natively."
+
+#: src/components/appearance-settings.tsx
+msgid "XL"
+msgstr "XL"
 
 #: src/components/reader/about-view.tsx
 msgid "Set your own type"
@@ -1638,6 +1707,10 @@ msgstr "Switch to reader view"
 msgid "<0>3. Declare your label values.</0> Describe each value (severity, default warn/hide, blur behavior) in an <1>app.standard-reader.labeler.service</1> descriptor, served from <2>app.standard-reader.labeler.getServices</2> (a <3>did:web</3> labeler has no repo to hold the record)."
 msgstr "<0>3. Declare your label values.</0> Describe each value (severity, default warn/hide, blur behavior) in an <1>app.standard-reader.labeler.service</1> descriptor, served from <2>app.standard-reader.labeler.getServices</2> (a <3>did:web</3> labeler has no repo to hold the record)."
 
+#: src/components/reader/format-i18n.ts
+msgid "{months}mo ago"
+msgstr "{months}mo ago"
+
 #: src/components/user-settings-view.tsx
 msgid "To email your digest, Standard Reader needs your account email address. We'll ask your PDS to share it — you'll be sent to your login to approve the request, then brought right back here. Your email is used only to send the weekly digest, and you can turn it off any time."
 msgstr "To email your digest, Standard Reader needs your account email address. We'll ask your PDS to share it — you'll be sent to your login to approve the request, then brought right back here. Your email is used only to send the weekly digest, and you can turn it off any time."
@@ -1713,6 +1786,10 @@ msgstr "Your account"
 msgid "Every unread article from this publication will be marked read. This can’t be undone."
 msgstr "Every unread article from this publication will be marked read. This can’t be undone."
 
+#: src/components/appearance-settings.tsx
+msgid "Your own colors"
+msgstr "Your own colors"
+
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
 msgstr "Setting the issue…"
@@ -1765,6 +1842,11 @@ msgstr "{pubTotal, plural, one {# publication} other {# publications}}"
 msgid "Nothing new today"
 msgstr "Nothing new today"
 
+#. placeholder {0}: palette.name
+#: src/components/appearance-settings.tsx
+msgid "{0}, light"
+msgstr "{0}, light"
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Background"
 msgstr "Background"
@@ -1784,6 +1866,10 @@ msgstr "From your subscriptions"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>When you browse without signing in,</0> we serve public writing from our read-model index. We may store a theme preference cookie and, if you have signed in before on this device, a short list of recently used account handles (and optional avatar URLs) to speed up sign-in. We do not require an account to read."
 msgstr "<0>When you browse without signing in,</0> we serve public writing from our read-model index. We may store a theme preference cookie and, if you have signed in before on this device, a short list of recently used account handles (and optional avatar URLs) to speed up sign-in. We do not require an account to read."
+
+#: src/components/appearance-settings.tsx
+msgid "Paper"
+msgstr "Paper"
 
 #: src/components/reader/about-view.tsx
 msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
@@ -2235,8 +2321,8 @@ msgid "by @{ownerHandle}"
 msgstr "by @{ownerHandle}"
 
 #: src/components/user-settings-view.tsx
-msgid "Choose light, dark, or match your system setting."
-msgstr "Choose light, dark, or match your system setting."
+#~ msgid "Choose light, dark, or match your system setting."
+#~ msgstr "Choose light, dark, or match your system setting."
 
 #. placeholder {0}: rows.length
 #: src/components/reader/subscriptions-table.tsx
@@ -2254,6 +2340,10 @@ msgstr "Finish"
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
 msgstr "The latest long-form writing from across the network."
+
+#: src/components/appearance-settings.tsx
+msgid "Sets the app's colors — and, because the page color decides it, whether the app reads light or dark."
+msgstr "Sets the app's colors — and, because the page color decides it, whether the app reads light or dark."
 
 #: src/routes/_layout.index.tsx
 msgid "{subscribedCount} unread across the publications you subscribe to."
@@ -2291,6 +2381,10 @@ msgstr "You're already subscribed to {publicationName}. New posts will show up i
 msgid "The directory"
 msgstr "The directory"
 
+#: src/components/appearance-settings.tsx
+#~ msgid "Your accent sits close to the paper in tone, so a darkened version of it is used for text and links."
+#~ msgstr "Your accent sits close to the paper in tone, so a darkened version of it is used for text and links."
+
 #: src/components/reader/about-view.tsx
 msgid "Trending this week"
 msgstr "Trending this week"
@@ -2319,6 +2413,10 @@ msgstr "No lists yet"
 #: src/routes/_layout.discover.tsx
 msgid "Browse everything"
 msgstr "Browse everything"
+
+#: src/components/appearance-settings.tsx
+msgid "Large"
+msgstr "Large"
 
 #: src/components/reader/about-view.tsx
 msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
@@ -2476,6 +2574,10 @@ msgstr "Browse the publication directory to find new writers."
 msgid "The most-read writing across the network right now."
 msgstr "The most-read writing across the network right now."
 
+#: src/components/appearance-settings.tsx
+msgid "The typeface used across the app. Article text follows this too, unless you set a reading font below."
+msgstr "The typeface used across the app. Article text follows this too, unless you set a reading font below."
+
 #: src/magazine/magazine-end-like.tsx
 msgid "Recommend this issue"
 msgstr "Recommend this issue"
@@ -2491,6 +2593,10 @@ msgstr "{count, plural, one {# upvote} other {# upvotes}} — click to undo"
 #: src/routes/_layout.search.tsx
 msgid "{shown} of {total} matches"
 msgstr "{shown} of {total} matches"
+
+#: src/components/appearance-settings.tsx
+msgid "How rounded buttons, cards and inputs are."
+msgstr "How rounded buttons, cards and inputs are."
 
 #: src/components/reader/collection-publication-editor.tsx
 msgid "What is this series about?"
@@ -2523,6 +2629,10 @@ msgstr "Share a bug, idea, or question to see it here."
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler didn’t publish any label definitions."
 msgstr "This labeler didn’t publish any label definitions."
+
+#: src/components/reader/format-i18n.ts
+msgid "{days}d ago"
+msgstr "{days}d ago"
 
 #: src/components/user-settings-view.tsx
 msgid "Continue to approve"
@@ -2570,6 +2680,10 @@ msgstr "So we built the reader we wanted: a column you can size, a font you can 
 #: src/routes/_layout.recommended.tsx
 msgid "Recommended articles"
 msgstr "Recommended articles"
+
+#: src/components/user-settings-view.tsx
+msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
+msgstr "Light, dark, match your system — or Custom, to choose a palette of your own."
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labeler views"
@@ -2654,6 +2768,10 @@ msgstr "Colophon"
 msgid "Reader voice"
 msgstr "Reader voice"
 
+#: src/components/appearance-settings.tsx
+msgid "Sharp"
+msgstr "Sharp"
+
 #: src/components/reader/about-view.tsx
 msgid "What you get is a reading view made for long-form: a centered column, drop caps and pull quotes, full-bleed images you can open into a gallery. The page gets out of the way so the writing can do its work."
 msgstr "What you get is a reading view made for long-form: a centered column, drop caps and pull quotes, full-bleed images you can open into a gallery. The page gets out of the way so the writing can do its work."
@@ -2703,6 +2821,10 @@ msgstr "That link expired."
 #: src/components/reader/privacy-view.tsx
 msgid "You can sign out at any time, which clears your app session cookie. You can clear site cookies in your browser to remove theme and saved-handle preferences. You can change reading-history tracking and delete personal data from Settings. To remove other AT Protocol records you created through the app, use a compatible client or your repository tools."
 msgstr "You can sign out at any time, which clears your app session cookie. You can clear site cookies in your browser to remove theme and saved-handle preferences. You can change reading-history tracking and delete personal data from Settings. To remove other AT Protocol records you created through the app, use a compatible client or your repository tools."
+
+#: src/components/appearance-settings.tsx
+msgid "XS"
+msgstr "XS"
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
@@ -2884,6 +3006,10 @@ msgstr "A couple of publications worth discovering."
 msgid "Share on Bluesky"
 msgstr "Share on Bluesky"
 
+#: src/components/appearance-settings.tsx
+msgid "Reset"
+msgstr "Reset"
+
 #: src/components/docs/docs-lexicons-nav.tsx
 #~ msgid "Lexicon reference"
 #~ msgstr "Lexicon reference"
@@ -2939,6 +3065,10 @@ msgstr "The conversation, gathered"
 msgid "Mark all as read"
 msgstr "Mark all as read"
 
+#: src/components/appearance-settings.tsx
+msgid "Scales every size in the app, article text included — from 14px up to 24px of interface text."
+msgstr "Scales every size in the app, article text included — from 14px up to 24px of interface text."
+
 #: src/components/reader/privacy-view.tsx
 msgid "Your display name, handle, avatar URL, and DID as returned by your account provider."
 msgstr "Your display name, handle, avatar URL, and DID as returned by your account provider."
@@ -2970,6 +3100,10 @@ msgstr "Share to Alternate Client"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "What the extension does not do"
 msgstr "What the extension does not do"
+
+#: src/components/appearance-settings.tsx
+msgid "Default"
+msgstr "Default"
 
 #: src/routes/_layout.index.tsx
 msgid "Loading recommendations"
@@ -3100,6 +3234,10 @@ msgstr "(needs {min}:1)"
 msgid "Every read record in your repository will be removed. Articles will appear unread again across the app. This cannot be undone."
 msgstr "Every read record in your repository will be removed. Articles will appear unread again across the app. This cannot be undone."
 
+#: src/components/appearance-settings.tsx
+msgid "Text, borders and every other step are derived from these two colors."
+msgstr "Text, borders and every other step are derived from these two colors."
+
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
@@ -3149,6 +3287,7 @@ msgstr "Scrape, harvest, or misuse the read-model index or API in ways that harm
 msgid "Unfollowing {peopleCount, plural, one {this person} other {these # people}} also drops the subscriptions that follow created, so their publications leave your feed. Nothing you have saved, read, or recommended is affected."
 msgstr "Unfollowing {peopleCount, plural, one {this person} other {these # people}} also drops the subscriptions that follow created, so their publications leave your feed. Nothing you have saved, read, or recommended is affected."
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/user-settings-view.tsx
 msgid "Dark"
@@ -3369,6 +3508,10 @@ msgstr "Labelers are moderation services you subscribe to by DID. Subscribe to s
 msgid "Standard Reader meets you where you read"
 msgstr "Standard Reader meets you where you read"
 
+#: src/components/appearance-settings.tsx
+msgid "Reset appearance"
+msgstr "Reset appearance"
+
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/reader/markdown-field.tsx
 #: src/components/reading-settings-preview.tsx
@@ -3442,6 +3585,10 @@ msgstr "Search labelers"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · Your feed"
 
+#: src/components/reader/format-i18n.ts
+msgid "yesterday"
+msgstr "yesterday"
+
 #: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Use publication themes"
@@ -3459,6 +3606,7 @@ msgstr "Service DID is <0>{appviewDid}</0>. The service advertises a <1>DID docu
 msgid "The Slow Web, Revisited"
 msgstr "The Slow Web, Revisited"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reading-custom-font-picker.tsx
 #: src/components/user-settings-view.tsx
 msgid "Google Font"
@@ -3554,6 +3702,10 @@ msgstr "Search feedback"
 msgid "Unsubscribe"
 msgstr "Unsubscribe"
 
+#: src/components/appearance-settings.tsx
+msgid "L"
+msgstr "L"
+
 #: src/routes/_layout.search.tsx
 msgid "Load more ({remainingPublications} remaining)"
 msgstr "Load more ({remainingPublications} remaining)"
@@ -3606,6 +3758,10 @@ msgstr "Copy embed code"
 #: src/components/user-settings-view.tsx
 msgid "Delete all lists?"
 msgstr "Delete all lists?"
+
+#: src/components/user-settings-view.tsx
+msgid "Advanced"
+msgstr "Advanced"
 
 #: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
@@ -3669,6 +3825,10 @@ msgstr "Play"
 #: src/routes/_layout.search.tsx
 msgid "Loading article matches"
 msgstr "Loading article matches"
+
+#: src/components/appearance-settings.tsx
+msgid "Extra small"
+msgstr "Extra small"
 
 #: src/components/reader/content/renderers/leaflet-standard-site-publication.tsx
 msgid "Publication not found."
@@ -3738,6 +3898,10 @@ msgstr "Behavior"
 msgid "Reading history"
 msgstr "Reading history"
 
+#: src/components/appearance-settings.tsx
+msgid "M"
+msgstr "M"
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>2. Serve labels.</0> Sign and emit <1>com.atproto.label.defs#label</1> objects, and expose the standard <2>com.atproto.label.queryLabels</2> (HTTP) and <3>com.atproto.label.subscribeLabels</3> (WebSocket) endpoints."
 msgstr "<0>2. Serve labels.</0> Sign and emit <1>com.atproto.label.defs#label</1> objects, and expose the standard <2>com.atproto.label.queryLabels</2> (HTTP) and <3>com.atproto.label.subscribeLabels</3> (WebSocket) endpoints."
@@ -3800,6 +3964,10 @@ msgstr "No publications in this list — add some from the edit dialog."
 #: src/components/reader/subscribe-card.tsx
 msgid "Adding {publicationName} to your feed."
 msgstr "Adding {publicationName} to your feed."
+
+#: src/components/appearance-settings.tsx
+#~ msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors and checked for contrast."
+#~ msgstr "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors and checked for contrast."
 
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/app-shell.tsx
@@ -3956,6 +4124,10 @@ msgstr "Sign-in and record access go through your Personal Data Server and the w
 msgid "An included article"
 msgstr "An included article"
 
+#: src/components/appearance-settings.tsx
+msgid "Puts the palette, font, size, roundness and density back to their defaults."
+msgstr "Puts the palette, font, size, roundness and density back to their defaults."
+
 #: src/components/user-settings-view.tsx
 msgid "Subscribe to labelers to flag, blur, or hide content as you read."
 msgstr "Subscribe to labelers to flag, blur, or hide content as you read."
@@ -4013,6 +4185,7 @@ msgstr "{weekday} · Across the network"
 msgid "Publish & share the run"
 msgstr "Publish & share the run"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-builder.tsx
 msgid "Editorial"
 msgstr "Editorial"
@@ -4175,6 +4348,10 @@ msgstr "Every publication and person you follow. Easily manage them all."
 msgid "Open on {publicationName}"
 msgstr "Open on {publicationName}"
 
+#: src/components/appearance-settings.tsx
+msgid "Sans"
+msgstr "Sans"
+
 #: src/components/reader/add-publication-modal.tsx
 msgid "Search publications or paste a handle"
 msgstr "Search publications or paste a handle"
@@ -4299,6 +4476,10 @@ msgstr "Read aloud"
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "Articles you've saved for later — in your repo, synced across devices."
 
+#: src/components/reader/format-i18n.ts
+msgid "today"
+msgstr "today"
+
 #: src/components/reader/article-view.tsx
 #: src/components/reader/content/renderers/shared/image-figure.tsx
 #: src/components/reader/content/renderers/shared/markdown-article.tsx
@@ -4406,6 +4587,7 @@ msgstr "Filter by topic"
 msgid "No unread articles from your follows right now."
 msgstr "No unread articles from your follows right now."
 
+#: src/components/appearance-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Search and pick any family from the Google Fonts catalog."
 msgstr "Search and pick any family from the Google Fonts catalog."
@@ -4534,6 +4716,10 @@ msgstr "<0>When you sign in</0> with your Atmosphere account (for example via Bl
 msgid "Powered by <0>Standard Reader</0>"
 msgstr "Powered by <0>Standard Reader</0>"
 
+#: src/components/appearance-settings.tsx
+msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."
+msgstr "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."
+
 #: src/components/reader/about-view.tsx
 msgid "Save from anywhere you browse"
 msgstr "Save from anywhere you browse"
@@ -4651,6 +4837,10 @@ msgstr "Get started"
 msgid "You don't have any content tabs to show yet."
 msgstr "You don't have any content tabs to show yet."
 
+#: src/components/appearance-settings.tsx
+msgid "Body text on paper"
+msgstr "Body text on paper"
+
 #: src/components/reader/article-view.tsx
 msgid "OK"
 msgstr "OK"
@@ -4719,6 +4909,10 @@ msgstr "@{0} · Has documents but no publications"
 msgid "{connectionLabel} via Semble"
 msgstr "{connectionLabel} via Semble"
 
+#: src/components/appearance-settings.tsx
+msgid "S"
+msgstr "S"
+
 #: src/magazine/flow.tsx
 msgid "In this issue"
 msgstr "In this issue"
@@ -4730,3 +4924,7 @@ msgstr "Read this on {name}"
 #: src/components/reader/terms-view.tsx
 msgid "Acceptable use"
 msgstr "Acceptable use"
+
+#: src/components/appearance-settings.tsx
+msgid "Palette"
+msgstr "Palette"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -239,6 +239,10 @@ msgstr ""
 msgid "Opening the collection…"
 msgstr "Abriendo la colección…"
 
+#: src/components/appearance-settings.tsx
+msgid "Density"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Open on publication"
 msgstr "Abrir en la publicación"
@@ -280,6 +284,7 @@ msgstr "Enviar comentarios"
 msgid "<0>Session cookie.</0> After you sign in through the web app, the extension background worker reads your HttpOnly session cookie on {siteHost} to authenticate API requests. Content scripts do not read this cookie directly."
 msgstr "<0>Cookie de sesión.</0> Después de iniciar sesión en la app web, el worker en segundo plano de la extensión lee su cookie de sesión HttpOnly en {siteHost} para autenticar las peticiones a la API. Los content scripts no leen esta cookie directamente."
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/user-settings-view.tsx
 msgid "Light"
@@ -318,9 +323,17 @@ msgstr ""
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 msgstr ""
 
+#: src/components/reader/format-i18n.ts
+msgid "{years}y ago"
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "List"
 msgstr "Lista"
+
+#: src/components/appearance-settings.tsx
+msgid "The spacing between things — tighter for more on screen, looser for more room to read."
+msgstr ""
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Sign in to run this example (curl uses Bearer $ACCESS_TOKEN)."
@@ -349,6 +362,10 @@ msgstr "Ponga nombre a su serie y elija un tema"
 #: src/components/docs/docs-labelers-nav.tsx
 #: src/components/docs/labelers-docs-page.tsx
 msgid "Reference implementation"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Extra large"
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
@@ -453,6 +470,10 @@ msgstr "Elimine de forma permanente los datos guardados en su cuenta. Estas acci
 msgid "Loading people"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "Links and labels on paper"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Read the piece →"
 msgstr "Leer la pieza →"
@@ -493,6 +514,10 @@ msgstr "Inicie sesión para seguir publicaciones"
 #: src/routes/_layout.discover.tsx
 msgid "Search publications"
 msgstr "Buscar publicaciones"
+
+#: src/components/appearance-settings.tsx
+msgid "Small"
+msgstr ""
 
 #: src/routes/_layout.search.tsx
 msgid "Publications, handles, #tags, headlines…"
@@ -767,6 +792,7 @@ msgstr "Debates"
 msgid "Content label"
 msgstr "Etiqueta de contenido"
 
+#: src/components/appearance-settings.tsx
 #: src/components/ReadingTypographyMenu.tsx
 #: src/components/user-settings-view.tsx
 msgid "Text size"
@@ -833,6 +859,11 @@ msgstr "Todavía no hay posts indexados."
 msgid "{0} added to {listName}."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+#: src/components/user-settings-view.tsx
+msgid "Custom"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Read the API docs"
 msgstr "Leer la documentación de la API"
@@ -868,6 +899,10 @@ msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "For more about how {SITE_NAME} works, see the <0>About</0> page. For questions about these terms for this deployment, contact the operator of the site at the URL above."
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Compact"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -931,6 +966,10 @@ msgstr "{documentCount, plural, one {documento} other {documentos}}"
 msgid "Publishing"
 msgstr "Publicación"
 
+#: src/components/appearance-settings.tsx
+msgid "Roundness"
+msgstr ""
+
 #: src/components/docs/introduction-docs-page.tsx
 msgid "public XRPC queries and procedures for the Standard Reader read-model, with live examples."
 msgstr ""
@@ -971,6 +1010,10 @@ msgstr "Incluya la pista <0>site.standard.publication</0> solo si el documento p
 #: src/components/reader/about-view.tsx
 msgid "Your week"
 msgstr "Su semana"
+
+#: src/components/appearance-settings.tsx
+msgid "Relaxed"
+msgstr ""
 
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.recommended.tsx
@@ -1013,6 +1056,10 @@ msgstr "Desactivado"
 msgid "Run example"
 msgstr "Ejecutar ejemplo"
 
+#: src/components/appearance-settings.tsx
+msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "When on, collection posts open in the magazine edition instead of the reader view."
 msgstr "Si está activado, las publicaciones de la colección se abren en la edición de revista en lugar de la vista de lectura."
@@ -1047,6 +1094,10 @@ msgstr "Pregunta"
 #: src/components/reader/list-edit-modal.tsx
 msgid "Choose an item to add to the list"
 msgstr "Elija un elemento para agregar a la lista"
+
+#: src/components/appearance-settings.tsx
+msgid "Soft"
+msgstr ""
 
 #: src/magazine/magazine-end-subscribe.tsx
 msgid "Subscribed to list"
@@ -1110,9 +1161,18 @@ msgstr "De qué trata esta lista (se muestra en su página pública)"
 msgid "Delete collection"
 msgstr "Eliminar colección"
 
+#: src/components/appearance-settings.tsx
+msgid "Interface font"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No publications in this list."
 msgstr "No hay publicaciones en esta lista."
+
+#. placeholder {0}: palette.name
+#: src/components/appearance-settings.tsx
+msgid "{0}, dark"
+msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Loading collections…"
@@ -1130,6 +1190,10 @@ msgstr "Explorar etiquetadores"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We do not run a separate analytics pipeline inside the extension."
 msgstr "No ejecutamos una canalización de analítica aparte dentro de la extensión."
+
+#: src/components/appearance-settings.tsx
+#~ msgid "Text, borders and every other step are derived from these two colors and checked for contrast."
+#~ msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Remove list"
@@ -1436,6 +1500,7 @@ msgstr "{durationMs} ms · obtenido {fetchedAt}"
 msgid "Loading feedback"
 msgstr "Cargando comentarios"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Accent"
 msgstr "Acento"
@@ -1483,6 +1548,10 @@ msgstr "Agregar a Chrome"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Leaflet, Pckt, Offprint.</0> <1>pub.leaflet.content</1>, <2>blog.pckt.content</2>, and <3>app.offprint.content</3> — the block-based formats those tools write natively."
 msgstr "<0>Leaflet, Pckt, Offprint.</0> <1>pub.leaflet.content</1>, <2>blog.pckt.content</2> y <3>app.offprint.content</3>: los formatos por bloques que esas herramientas escriben de forma nativa."
+
+#: src/components/appearance-settings.tsx
+msgid "XL"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Set your own type"
@@ -1638,6 +1707,10 @@ msgstr "Cambiar a la vista de lectura"
 msgid "<0>3. Declare your label values.</0> Describe each value (severity, default warn/hide, blur behavior) in an <1>app.standard-reader.labeler.service</1> descriptor, served from <2>app.standard-reader.labeler.getServices</2> (a <3>did:web</3> labeler has no repo to hold the record)."
 msgstr "<0>3. Declare los valores de sus etiquetas.</0> Describa cada valor (gravedad, advertir/ocultar por defecto, comportamiento de desenfoque) en un descriptor <1>app.standard-reader.labeler.service</1>, servido desde <2>app.standard-reader.labeler.getServices</2> (un etiquetador <3>did:web</3> no tiene repositorio donde guardar el registro)."
 
+#: src/components/reader/format-i18n.ts
+msgid "{months}mo ago"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "To email your digest, Standard Reader needs your account email address. We'll ask your PDS to share it — you'll be sent to your login to approve the request, then brought right back here. Your email is used only to send the weekly digest, and you can turn it off any time."
 msgstr "Para enviarle su resumen por correo, Standard Reader necesita la dirección de correo de su cuenta. Se la pediremos a su PDS: irá a su inicio de sesión para aprobar la solicitud y volverá aquí de inmediato. Su correo se usa únicamente para enviar el resumen semanal y puede desactivarlo cuando quiera."
@@ -1713,6 +1786,10 @@ msgstr ""
 msgid "Every unread article from this publication will be marked read. This can’t be undone."
 msgstr "Todos los artículos sin leer de esta publicación se marcarán como leídos. Esto no se puede deshacer."
 
+#: src/components/appearance-settings.tsx
+msgid "Your own colors"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
 msgstr "Estableciendo el número…"
@@ -1765,6 +1842,11 @@ msgstr "{pubTotal, plural, one {# publicación} other {# publicaciones}}"
 msgid "Nothing new today"
 msgstr ""
 
+#. placeholder {0}: palette.name
+#: src/components/appearance-settings.tsx
+msgid "{0}, light"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Background"
 msgstr "Fondo"
@@ -1784,6 +1866,10 @@ msgstr "De sus suscripciones"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>When you browse without signing in,</0> we serve public writing from our read-model index. We may store a theme preference cookie and, if you have signed in before on this device, a short list of recently used account handles (and optional avatar URLs) to speed up sign-in. We do not require an account to read."
 msgstr "<0>Cuando navega sin iniciar sesión,</0> servimos textos públicos desde nuestro índice del modelo de lectura. Es posible que guardemos una cookie con la preferencia de tema y, si ya inició sesión antes en este dispositivo, una lista breve de handles de cuentas usados recientemente (y URL de avatar opcionales) para agilizar el inicio de sesión. No exigimos una cuenta para leer."
+
+#: src/components/appearance-settings.tsx
+msgid "Paper"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
@@ -2235,8 +2321,8 @@ msgid "by @{ownerHandle}"
 msgstr "por @{ownerHandle}"
 
 #: src/components/user-settings-view.tsx
-msgid "Choose light, dark, or match your system setting."
-msgstr "Elija claro, oscuro o seguir la configuración del sistema."
+#~ msgid "Choose light, dark, or match your system setting."
+#~ msgstr "Elija claro, oscuro o seguir la configuración del sistema."
 
 #. placeholder {0}: rows.length
 #: src/components/reader/subscriptions-table.tsx
@@ -2254,6 +2340,10 @@ msgstr "Finalizar"
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
 msgstr "Lo más reciente en textos largos de toda la red."
+
+#: src/components/appearance-settings.tsx
+msgid "Sets the app's colors — and, because the page color decides it, whether the app reads light or dark."
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "{subscribedCount} unread across the publications you subscribe to."
@@ -2291,6 +2381,10 @@ msgstr "Ya está suscrito a {publicationName}. Las nuevas entradas aparecerán e
 msgid "The directory"
 msgstr "El directorio"
 
+#: src/components/appearance-settings.tsx
+#~ msgid "Your accent sits close to the paper in tone, so a darkened version of it is used for text and links."
+#~ msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Trending this week"
 msgstr "Tendencias de esta semana"
@@ -2319,6 +2413,10 @@ msgstr "Aún no hay listas"
 #: src/routes/_layout.discover.tsx
 msgid "Browse everything"
 msgstr "Explorar todo"
+
+#: src/components/appearance-settings.tsx
+msgid "Large"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
@@ -2476,6 +2574,10 @@ msgstr ""
 msgid "The most-read writing across the network right now."
 msgstr "Los textos más leídos de toda la red en este momento."
 
+#: src/components/appearance-settings.tsx
+msgid "The typeface used across the app. Article text follows this too, unless you set a reading font below."
+msgstr ""
+
 #: src/magazine/magazine-end-like.tsx
 msgid "Recommend this issue"
 msgstr "Recomendar este número"
@@ -2491,6 +2593,10 @@ msgstr "{count, plural, one {# voto} other {# votos}} — haga clic para deshace
 #: src/routes/_layout.search.tsx
 msgid "{shown} of {total} matches"
 msgstr "{shown} de {total} coincidencias"
+
+#: src/components/appearance-settings.tsx
+msgid "How rounded buttons, cards and inputs are."
+msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
 msgid "What is this series about?"
@@ -2523,6 +2629,10 @@ msgstr ""
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler didn’t publish any label definitions."
 msgstr "Este etiquetador no publicó ninguna definición de etiqueta."
+
+#: src/components/reader/format-i18n.ts
+msgid "{days}d ago"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Continue to approve"
@@ -2570,6 +2680,10 @@ msgstr "Así que construimos el lector que queríamos: una columna que se puede 
 #: src/routes/_layout.recommended.tsx
 msgid "Recommended articles"
 msgstr "Artículos recomendados"
+
+#: src/components/user-settings-view.tsx
+msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labeler views"
@@ -2654,6 +2768,10 @@ msgstr "Colofón"
 msgid "Reader voice"
 msgstr "Voz del lector"
 
+#: src/components/appearance-settings.tsx
+msgid "Sharp"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "What you get is a reading view made for long-form: a centered column, drop caps and pull quotes, full-bleed images you can open into a gallery. The page gets out of the way so the writing can do its work."
 msgstr "Lo que obtiene es una vista de lectura hecha para textos largos: una columna centrada, capitulares y citas destacadas, imágenes a sangre completa que se pueden abrir en una galería. La página se aparta para que la escritura haga su trabajo."
@@ -2703,6 +2821,10 @@ msgstr "Ese enlace caducó."
 #: src/components/reader/privacy-view.tsx
 msgid "You can sign out at any time, which clears your app session cookie. You can clear site cookies in your browser to remove theme and saved-handle preferences. You can change reading-history tracking and delete personal data from Settings. To remove other AT Protocol records you created through the app, use a compatible client or your repository tools."
 msgstr "Puede cerrar sesión en cualquier momento, lo que borra la cookie de sesión de la app. Puede borrar las cookies del sitio en su navegador para eliminar las preferencias de tema y de identificador guardado. Puede cambiar el registro del historial de lectura y eliminar sus datos personales desde Configuración. Para eliminar otros registros de AT Protocol creados a través de la app, use un cliente compatible o las herramientas de su repositorio."
+
+#: src/components/appearance-settings.tsx
+msgid "XS"
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
@@ -2884,6 +3006,10 @@ msgstr ""
 msgid "Share on Bluesky"
 msgstr "Compartir en Bluesky"
 
+#: src/components/appearance-settings.tsx
+msgid "Reset"
+msgstr ""
+
 #: src/components/docs/docs-lexicons-nav.tsx
 #~ msgid "Lexicon reference"
 #~ msgstr "Referencia del lexicon"
@@ -2939,6 +3065,10 @@ msgstr "La conversación, reunida"
 msgid "Mark all as read"
 msgstr "Marcar todo como leído"
 
+#: src/components/appearance-settings.tsx
+msgid "Scales every size in the app, article text included — from 14px up to 24px of interface text."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "Your display name, handle, avatar URL, and DID as returned by your account provider."
 msgstr "Su nombre visible, handle, URL del avatar y DID, tal como los devuelve su proveedor de cuenta."
@@ -2970,6 +3100,10 @@ msgstr "Compartir en otro cliente"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "What the extension does not do"
 msgstr "Lo que la extensión no hace"
+
+#: src/components/appearance-settings.tsx
+msgid "Default"
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Loading recommendations"
@@ -3100,6 +3234,10 @@ msgstr "(necesita {min}:1)"
 msgid "Every read record in your repository will be removed. Articles will appear unread again across the app. This cannot be undone."
 msgstr "Se eliminarán todos los registros de lectura de su repositorio. Los artículos volverán a aparecer como sin leer en toda la app. Esta acción no se puede deshacer."
 
+#: src/components/appearance-settings.tsx
+msgid "Text, borders and every other step are derived from these two colors."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "Si instala la extensión de navegador de {SITE_NAME}, esta usa la misma cuenta y cookie de sesión que este sitio. La extensión envía las URL de las páginas a nuestros endpoints <0>/api/extension/*</0> para cotejar el índice y guarda los ajustes de la superposición en el almacenamiento de extensiones del navegador. Consulte la <1>política de privacidad de la extensión</1> para conocer los detalles que aplican solo a la extensión."
@@ -3149,6 +3287,7 @@ msgstr ""
 msgid "Unfollowing {peopleCount, plural, one {this person} other {these # people}} also drops the subscriptions that follow created, so their publications leave your feed. Nothing you have saved, read, or recommended is affected."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/user-settings-view.tsx
 msgid "Dark"
@@ -3369,6 +3508,10 @@ msgstr "Los etiquetadores son servicios de moderación a los que se suscribe por
 msgid "Standard Reader meets you where you read"
 msgstr "Standard Reader lo acompaña donde lee"
 
+#: src/components/appearance-settings.tsx
+msgid "Reset appearance"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/reader/markdown-field.tsx
 #: src/components/reading-settings-preview.tsx
@@ -3442,6 +3585,10 @@ msgstr "Buscar etiquetadores"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · Su feed"
 
+#: src/components/reader/format-i18n.ts
+msgid "yesterday"
+msgstr ""
+
 #: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Use publication themes"
@@ -3459,6 +3606,7 @@ msgstr "El DID del servicio es <0>{appviewDid}</0>. El servicio publica un <1>do
 msgid "The Slow Web, Revisited"
 msgstr "La web lenta, revisitada"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reading-custom-font-picker.tsx
 #: src/components/user-settings-view.tsx
 msgid "Google Font"
@@ -3554,6 +3702,10 @@ msgstr "Buscar comentarios"
 msgid "Unsubscribe"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "L"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "Load more ({remainingPublications} remaining)"
 msgstr "Cargar más ({remainingPublications} restantes)"
@@ -3606,6 +3758,10 @@ msgstr "Copiar el código para insertar"
 #: src/components/user-settings-view.tsx
 msgid "Delete all lists?"
 msgstr "¿Eliminar todas las listas?"
+
+#: src/components/user-settings-view.tsx
+msgid "Advanced"
+msgstr ""
 
 #: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
@@ -3669,6 +3825,10 @@ msgstr "Reproducir"
 #: src/routes/_layout.search.tsx
 msgid "Loading article matches"
 msgstr "Cargando artículos coincidentes"
+
+#: src/components/appearance-settings.tsx
+msgid "Extra small"
+msgstr ""
 
 #: src/components/reader/content/renderers/leaflet-standard-site-publication.tsx
 msgid "Publication not found."
@@ -3738,6 +3898,10 @@ msgstr "Comportamiento"
 msgid "Reading history"
 msgstr "Historial de lectura"
 
+#: src/components/appearance-settings.tsx
+msgid "M"
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>2. Serve labels.</0> Sign and emit <1>com.atproto.label.defs#label</1> objects, and expose the standard <2>com.atproto.label.queryLabels</2> (HTTP) and <3>com.atproto.label.subscribeLabels</3> (WebSocket) endpoints."
 msgstr "<0>2. Servir etiquetas.</0> Firme y emita objetos <1>com.atproto.label.defs#label</1>, y exponga los endpoints estándar <2>com.atproto.label.queryLabels</2> (HTTP) y <3>com.atproto.label.subscribeLabels</3> (WebSocket)."
@@ -3800,6 +3964,10 @@ msgstr "No hay publicaciones en esta lista — agregue algunas desde el diálogo
 #: src/components/reader/subscribe-card.tsx
 msgid "Adding {publicationName} to your feed."
 msgstr "Agregando {publicationName} a su feed."
+
+#: src/components/appearance-settings.tsx
+#~ msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors and checked for contrast."
+#~ msgstr ""
 
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/app-shell.tsx
@@ -3956,6 +4124,10 @@ msgstr "El inicio de sesión y el acceso a los registros pasan por su Personal D
 msgid "An included article"
 msgstr "Un artículo incluido"
 
+#: src/components/appearance-settings.tsx
+msgid "Puts the palette, font, size, roundness and density back to their defaults."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Subscribe to labelers to flag, blur, or hide content as you read."
 msgstr "Suscríbase a etiquetadores para marcar, difuminar u ocultar contenido mientras lee."
@@ -4013,6 +4185,7 @@ msgstr "{weekday} · En toda la red"
 msgid "Publish & share the run"
 msgstr "Publicar y compartir la ejecución"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-builder.tsx
 msgid "Editorial"
 msgstr "Editorial"
@@ -4175,6 +4348,10 @@ msgstr ""
 msgid "Open on {publicationName}"
 msgstr "Abrir en {publicationName}"
 
+#: src/components/appearance-settings.tsx
+msgid "Sans"
+msgstr ""
+
 #: src/components/reader/add-publication-modal.tsx
 msgid "Search publications or paste a handle"
 msgstr "Buscar publicaciones o pegar un identificador"
@@ -4299,6 +4476,10 @@ msgstr "Leer en voz alta"
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "Artículos que guardó para después: en su repositorio y sincronizados entre dispositivos."
 
+#: src/components/reader/format-i18n.ts
+msgid "today"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 #: src/components/reader/content/renderers/shared/image-figure.tsx
 #: src/components/reader/content/renderers/shared/markdown-article.tsx
@@ -4406,6 +4587,7 @@ msgstr "Filtrar por tema"
 msgid "No unread articles from your follows right now."
 msgstr "Ahora mismo no hay artículos sin leer de sus seguidos."
 
+#: src/components/appearance-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Search and pick any family from the Google Fonts catalog."
 msgstr "Busque y elija cualquier familia del catálogo de Google Fonts."
@@ -4534,6 +4716,10 @@ msgstr "<0>Cuando inicia sesión</0> con su cuenta de Atmosphere (por ejemplo, m
 msgid "Powered by <0>Standard Reader</0>"
 msgstr "Con la tecnología de <0>Standard Reader</0>"
 
+#: src/components/appearance-settings.tsx
+msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Save from anywhere you browse"
 msgstr "Guarde desde donde navegue"
@@ -4651,6 +4837,10 @@ msgstr "Empezar"
 msgid "You don't have any content tabs to show yet."
 msgstr "Todavía no tiene pestañas de contenido para mostrar."
 
+#: src/components/appearance-settings.tsx
+msgid "Body text on paper"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "OK"
 msgstr "Aceptar"
@@ -4719,6 +4909,10 @@ msgstr "@{0} · Tiene documentos pero no publicaciones"
 msgid "{connectionLabel} via Semble"
 msgstr "{connectionLabel} vía Semble"
 
+#: src/components/appearance-settings.tsx
+msgid "S"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "In this issue"
 msgstr "En este número"
@@ -4729,4 +4923,8 @@ msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Acceptable use"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Palette"
 msgstr ""

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -239,6 +239,10 @@ msgstr ""
 msgid "Opening the collection…"
 msgstr "Ouverture de la collection…"
 
+#: src/components/appearance-settings.tsx
+msgid "Density"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Open on publication"
 msgstr "Ouvrir dans la publication"
@@ -280,6 +284,7 @@ msgstr "Envoyer le retour"
 msgid "<0>Session cookie.</0> After you sign in through the web app, the extension background worker reads your HttpOnly session cookie on {siteHost} to authenticate API requests. Content scripts do not read this cookie directly."
 msgstr "<0>Cookie de session.</0> Après votre connexion via l’application web, le service d’arrière-plan de l’extension lit votre cookie de session HttpOnly sur {siteHost} pour authentifier les requêtes API. Les scripts de contenu ne lisent pas ce cookie directement."
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/user-settings-view.tsx
 msgid "Light"
@@ -318,9 +323,17 @@ msgstr ""
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 msgstr ""
 
+#: src/components/reader/format-i18n.ts
+msgid "{years}y ago"
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "List"
 msgstr "Liste"
+
+#: src/components/appearance-settings.tsx
+msgid "The spacing between things — tighter for more on screen, looser for more room to read."
+msgstr ""
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Sign in to run this example (curl uses Bearer $ACCESS_TOKEN)."
@@ -349,6 +362,10 @@ msgstr "Nommez votre série et choisissez un thème"
 #: src/components/docs/docs-labelers-nav.tsx
 #: src/components/docs/labelers-docs-page.tsx
 msgid "Reference implementation"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Extra large"
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
@@ -453,6 +470,10 @@ msgstr "Supprimez définitivement les données stockées dans votre compte. Ces 
 msgid "Loading people"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "Links and labels on paper"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Read the piece →"
 msgstr "Lire le texte →"
@@ -493,6 +514,10 @@ msgstr "Connectez-vous pour suivre des publications"
 #: src/routes/_layout.discover.tsx
 msgid "Search publications"
 msgstr "Rechercher des publications"
+
+#: src/components/appearance-settings.tsx
+msgid "Small"
+msgstr ""
 
 #: src/routes/_layout.search.tsx
 msgid "Publications, handles, #tags, headlines…"
@@ -767,6 +792,7 @@ msgstr "Discussions"
 msgid "Content label"
 msgstr "Étiquette de contenu"
 
+#: src/components/appearance-settings.tsx
 #: src/components/ReadingTypographyMenu.tsx
 #: src/components/user-settings-view.tsx
 msgid "Text size"
@@ -833,6 +859,11 @@ msgstr "Aucun article indexé pour l’instant."
 msgid "{0} added to {listName}."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+#: src/components/user-settings-view.tsx
+msgid "Custom"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Read the API docs"
 msgstr "Lire la documentation de l’API"
@@ -868,6 +899,10 @@ msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "For more about how {SITE_NAME} works, see the <0>About</0> page. For questions about these terms for this deployment, contact the operator of the site at the URL above."
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Compact"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -931,6 +966,10 @@ msgstr "{documentCount, plural, one {document} other {documents}}"
 msgid "Publishing"
 msgstr "Publication"
 
+#: src/components/appearance-settings.tsx
+msgid "Roundness"
+msgstr ""
+
 #: src/components/docs/introduction-docs-page.tsx
 msgid "public XRPC queries and procedures for the Standard Reader read-model, with live examples."
 msgstr ""
@@ -971,6 +1010,10 @@ msgstr "N'incluez l'indice <0>site.standard.publication</0> que si le document a
 #: src/components/reader/about-view.tsx
 msgid "Your week"
 msgstr "Votre semaine"
+
+#: src/components/appearance-settings.tsx
+msgid "Relaxed"
+msgstr ""
 
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.recommended.tsx
@@ -1013,6 +1056,10 @@ msgstr "Désactivé"
 msgid "Run example"
 msgstr "Lancer l'exemple"
 
+#: src/components/appearance-settings.tsx
+msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "When on, collection posts open in the magazine edition instead of the reader view."
 msgstr "Une fois activé, les publications d'une collection s'ouvrent dans l'édition magazine plutôt qu'en vue lecture."
@@ -1047,6 +1094,10 @@ msgstr "Question"
 #: src/components/reader/list-edit-modal.tsx
 msgid "Choose an item to add to the list"
 msgstr "Choisissez un élément à ajouter à la liste"
+
+#: src/components/appearance-settings.tsx
+msgid "Soft"
+msgstr ""
 
 #: src/magazine/magazine-end-subscribe.tsx
 msgid "Subscribed to list"
@@ -1110,9 +1161,18 @@ msgstr "Le sujet de cette liste (affiché sur sa page publique)"
 msgid "Delete collection"
 msgstr "Supprimer la collection"
 
+#: src/components/appearance-settings.tsx
+msgid "Interface font"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No publications in this list."
 msgstr "Aucune publication dans cette liste."
+
+#. placeholder {0}: palette.name
+#: src/components/appearance-settings.tsx
+msgid "{0}, dark"
+msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Loading collections…"
@@ -1130,6 +1190,10 @@ msgstr "Parcourir les services d'étiquetage"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We do not run a separate analytics pipeline inside the extension."
 msgstr "Nous n'exploitons aucun pipeline d'analyse distinct au sein de l'extension."
+
+#: src/components/appearance-settings.tsx
+#~ msgid "Text, borders and every other step are derived from these two colors and checked for contrast."
+#~ msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Remove list"
@@ -1436,6 +1500,7 @@ msgstr "{durationMs} ms · récupéré {fetchedAt}"
 msgid "Loading feedback"
 msgstr "Chargement des retours"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Accent"
 msgstr "Couleur d'accent"
@@ -1483,6 +1548,10 @@ msgstr "Ajouter à Chrome"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Leaflet, Pckt, Offprint.</0> <1>pub.leaflet.content</1>, <2>blog.pckt.content</2>, and <3>app.offprint.content</3> — the block-based formats those tools write natively."
 msgstr "<0>Leaflet, Pckt, Offprint.</0> <1>pub.leaflet.content</1>, <2>blog.pckt.content</2> et <3>app.offprint.content</3> — les formats par blocs que ces outils écrivent nativement."
+
+#: src/components/appearance-settings.tsx
+msgid "XL"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Set your own type"
@@ -1638,6 +1707,10 @@ msgstr "Passer à la vue lecture"
 msgid "<0>3. Declare your label values.</0> Describe each value (severity, default warn/hide, blur behavior) in an <1>app.standard-reader.labeler.service</1> descriptor, served from <2>app.standard-reader.labeler.getServices</2> (a <3>did:web</3> labeler has no repo to hold the record)."
 msgstr "<0>3. Déclarez vos valeurs d'étiquette.</0> Décrivez chaque valeur (gravité, avertissement/masquage par défaut, comportement de floutage) dans un descripteur <1>app.standard-reader.labeler.service</1>, servi depuis <2>app.standard-reader.labeler.getServices</2> (un service d'étiquetage <3>did:web</3> n'a pas de repo pour héberger l'enregistrement)."
 
+#: src/components/reader/format-i18n.ts
+msgid "{months}mo ago"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "To email your digest, Standard Reader needs your account email address. We'll ask your PDS to share it — you'll be sent to your login to approve the request, then brought right back here. Your email is used only to send the weekly digest, and you can turn it off any time."
 msgstr "Pour vous envoyer votre digest par e-mail, Standard Reader a besoin de l'adresse e-mail de votre compte. Nous demanderons à votre PDS de la partager : vous serez redirigé vers votre page de connexion pour approuver la demande, puis ramené ici. Votre adresse sert uniquement à l'envoi du digest hebdomadaire, et vous pouvez le désactiver à tout moment."
@@ -1713,6 +1786,10 @@ msgstr ""
 msgid "Every unread article from this publication will be marked read. This can’t be undone."
 msgstr "Tous les articles non lus de cette publication seront marqués comme lus. Cette action est irréversible."
 
+#: src/components/appearance-settings.tsx
+msgid "Your own colors"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
 msgstr "Composition du numéro…"
@@ -1765,6 +1842,11 @@ msgstr "{pubTotal, plural, one {# publication} other {# publications}}"
 msgid "Nothing new today"
 msgstr ""
 
+#. placeholder {0}: palette.name
+#: src/components/appearance-settings.tsx
+msgid "{0}, light"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Background"
 msgstr "Arrière-plan"
@@ -1784,6 +1866,10 @@ msgstr "Depuis vos abonnements"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>When you browse without signing in,</0> we serve public writing from our read-model index. We may store a theme preference cookie and, if you have signed in before on this device, a short list of recently used account handles (and optional avatar URLs) to speed up sign-in. We do not require an account to read."
 msgstr "<0>Lorsque vous naviguez sans être connecté,</0> nous servons des textes publics issus de notre index de lecture. Nous pouvons stocker un cookie de préférence de thème et, si vous vous êtes déjà connecté sur cet appareil, une courte liste d'identifiants de comptes récemment utilisés (et éventuellement les URL de leurs avatars) afin d'accélérer la connexion. Aucun compte n'est requis pour lire."
+
+#: src/components/appearance-settings.tsx
+msgid "Paper"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
@@ -2235,8 +2321,8 @@ msgid "by @{ownerHandle}"
 msgstr "par @{ownerHandle}"
 
 #: src/components/user-settings-view.tsx
-msgid "Choose light, dark, or match your system setting."
-msgstr "Choisissez le thème clair, sombre ou celui de votre système."
+#~ msgid "Choose light, dark, or match your system setting."
+#~ msgstr "Choisissez le thème clair, sombre ou celui de votre système."
 
 #. placeholder {0}: rows.length
 #: src/components/reader/subscriptions-table.tsx
@@ -2254,6 +2340,10 @@ msgstr "Terminer"
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
 msgstr "Les derniers textes longs publiés sur le réseau."
+
+#: src/components/appearance-settings.tsx
+msgid "Sets the app's colors — and, because the page color decides it, whether the app reads light or dark."
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "{subscribedCount} unread across the publications you subscribe to."
@@ -2291,6 +2381,10 @@ msgstr "Vous êtes déjà abonné à {publicationName}. Les nouvelles parutions 
 msgid "The directory"
 msgstr "L’annuaire"
 
+#: src/components/appearance-settings.tsx
+#~ msgid "Your accent sits close to the paper in tone, so a darkened version of it is used for text and links."
+#~ msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Trending this week"
 msgstr "Tendances de la semaine"
@@ -2319,6 +2413,10 @@ msgstr "Aucune liste pour l’instant"
 #: src/routes/_layout.discover.tsx
 msgid "Browse everything"
 msgstr "Tout parcourir"
+
+#: src/components/appearance-settings.tsx
+msgid "Large"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
@@ -2476,6 +2574,10 @@ msgstr ""
 msgid "The most-read writing across the network right now."
 msgstr "Les textes les plus lus du réseau en ce moment."
 
+#: src/components/appearance-settings.tsx
+msgid "The typeface used across the app. Article text follows this too, unless you set a reading font below."
+msgstr ""
+
 #: src/magazine/magazine-end-like.tsx
 msgid "Recommend this issue"
 msgstr "Recommander ce numéro"
@@ -2491,6 +2593,10 @@ msgstr "{count, plural, one {# vote} other {# votes}} — cliquez pour annuler"
 #: src/routes/_layout.search.tsx
 msgid "{shown} of {total} matches"
 msgstr "{shown} résultats sur {total}"
+
+#: src/components/appearance-settings.tsx
+msgid "How rounded buttons, cards and inputs are."
+msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
 msgid "What is this series about?"
@@ -2523,6 +2629,10 @@ msgstr ""
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler didn’t publish any label definitions."
 msgstr "Ce service d’étiquetage n’a publié aucune définition d’étiquette."
+
+#: src/components/reader/format-i18n.ts
+msgid "{days}d ago"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Continue to approve"
@@ -2570,6 +2680,10 @@ msgstr "Nous avons donc conçu le lecteur que nous voulions : une colonne dont v
 #: src/routes/_layout.recommended.tsx
 msgid "Recommended articles"
 msgstr "Articles recommandés"
+
+#: src/components/user-settings-view.tsx
+msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labeler views"
@@ -2654,6 +2768,10 @@ msgstr "Colophon"
 msgid "Reader voice"
 msgstr "Voix du lecteur"
 
+#: src/components/appearance-settings.tsx
+msgid "Sharp"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "What you get is a reading view made for long-form: a centered column, drop caps and pull quotes, full-bleed images you can open into a gallery. The page gets out of the way so the writing can do its work."
 msgstr "Vous obtenez une vue de lecture pensée pour les textes longs : une colonne centrée, des lettrines et des exergues, des images pleine largeur que vous pouvez ouvrir en galerie. La page s’efface pour laisser le texte faire son travail."
@@ -2703,6 +2821,10 @@ msgstr "Ce lien a expiré."
 #: src/components/reader/privacy-view.tsx
 msgid "You can sign out at any time, which clears your app session cookie. You can clear site cookies in your browser to remove theme and saved-handle preferences. You can change reading-history tracking and delete personal data from Settings. To remove other AT Protocol records you created through the app, use a compatible client or your repository tools."
 msgstr "Vous pouvez vous déconnecter à tout moment, ce qui efface le cookie de session de l’application. Vous pouvez effacer les cookies du site dans votre navigateur pour supprimer les préférences de thème et l’identifiant enregistré. Vous pouvez modifier le suivi de l’historique de lecture et supprimer vos données personnelles depuis les réglages. Pour supprimer les autres enregistrements AT Protocol créés via l’application, utilisez un client compatible ou les outils de votre dépôt."
+
+#: src/components/appearance-settings.tsx
+msgid "XS"
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
@@ -2884,6 +3006,10 @@ msgstr ""
 msgid "Share on Bluesky"
 msgstr "Partager sur Bluesky"
 
+#: src/components/appearance-settings.tsx
+msgid "Reset"
+msgstr ""
+
 #: src/components/docs/docs-lexicons-nav.tsx
 #~ msgid "Lexicon reference"
 #~ msgstr "Référence du lexique"
@@ -2939,6 +3065,10 @@ msgstr "La conversation, rassemblée"
 msgid "Mark all as read"
 msgstr "Tout marquer comme lu"
 
+#: src/components/appearance-settings.tsx
+msgid "Scales every size in the app, article text included — from 14px up to 24px of interface text."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "Your display name, handle, avatar URL, and DID as returned by your account provider."
 msgstr "Votre nom affiché, votre identifiant, l'URL de votre avatar et votre DID tels que fournis par votre fournisseur de compte."
@@ -2970,6 +3100,10 @@ msgstr "Partager vers un autre client"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "What the extension does not do"
 msgstr "Ce que l'extension ne fait pas"
+
+#: src/components/appearance-settings.tsx
+msgid "Default"
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Loading recommendations"
@@ -3100,6 +3234,10 @@ msgstr "(nécessite {min}:1)"
 msgid "Every read record in your repository will be removed. Articles will appear unread again across the app. This cannot be undone."
 msgstr "Chaque enregistrement de lecture de votre dépôt sera supprimé. Les articles réapparaîtront comme non lus dans toute l'application. Cette action est irréversible."
 
+#: src/components/appearance-settings.tsx
+msgid "Text, borders and every other step are derived from these two colors."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "Si vous installez l'extension de navigateur {SITE_NAME}, elle utilise le même compte et le même cookie de session que ce site. L'extension envoie les URL des pages à nos points de terminaison <0>/api/extension/*</0> pour la correspondance avec l'index et conserve les réglages de la surcouche dans le stockage d'extension de votre navigateur. Consultez la <1>politique de confidentialité de l'extension</1> pour les détails qui la concernent uniquement."
@@ -3149,6 +3287,7 @@ msgstr ""
 msgid "Unfollowing {peopleCount, plural, one {this person} other {these # people}} also drops the subscriptions that follow created, so their publications leave your feed. Nothing you have saved, read, or recommended is affected."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/user-settings-view.tsx
 msgid "Dark"
@@ -3369,6 +3508,10 @@ msgstr "Les services d'étiquetage sont des services de modération auxquels vou
 msgid "Standard Reader meets you where you read"
 msgstr "Standard Reader vous rejoint là où vous lisez"
 
+#: src/components/appearance-settings.tsx
+msgid "Reset appearance"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/reader/markdown-field.tsx
 #: src/components/reading-settings-preview.tsx
@@ -3442,6 +3585,10 @@ msgstr "Rechercher des services d'étiquetage"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · Votre flux"
 
+#: src/components/reader/format-i18n.ts
+msgid "yesterday"
+msgstr ""
+
 #: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Use publication themes"
@@ -3459,6 +3606,7 @@ msgstr "Le DID du service est <0>{appviewDid}</0>. Le service publie un <1>docum
 msgid "The Slow Web, Revisited"
 msgstr "Le Slow Web, revisité"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reading-custom-font-picker.tsx
 #: src/components/user-settings-view.tsx
 msgid "Google Font"
@@ -3554,6 +3702,10 @@ msgstr "Rechercher dans les retours"
 msgid "Unsubscribe"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "L"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "Load more ({remainingPublications} remaining)"
 msgstr "Charger plus ({remainingPublications} restantes)"
@@ -3606,6 +3758,10 @@ msgstr "Copier le code d'intégration"
 #: src/components/user-settings-view.tsx
 msgid "Delete all lists?"
 msgstr "Supprimer toutes les listes ?"
+
+#: src/components/user-settings-view.tsx
+msgid "Advanced"
+msgstr ""
 
 #: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
@@ -3669,6 +3825,10 @@ msgstr "Lire"
 #: src/routes/_layout.search.tsx
 msgid "Loading article matches"
 msgstr "Chargement des articles correspondants"
+
+#: src/components/appearance-settings.tsx
+msgid "Extra small"
+msgstr ""
 
 #: src/components/reader/content/renderers/leaflet-standard-site-publication.tsx
 msgid "Publication not found."
@@ -3738,6 +3898,10 @@ msgstr "Comportement"
 msgid "Reading history"
 msgstr "Historique de lecture"
 
+#: src/components/appearance-settings.tsx
+msgid "M"
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>2. Serve labels.</0> Sign and emit <1>com.atproto.label.defs#label</1> objects, and expose the standard <2>com.atproto.label.queryLabels</2> (HTTP) and <3>com.atproto.label.subscribeLabels</3> (WebSocket) endpoints."
 msgstr "<0>2. Diffuser des étiquettes.</0> Signez et émettez des objets <1>com.atproto.label.defs#label</1>, et exposez les points de terminaison standard <2>com.atproto.label.queryLabels</2> (HTTP) et <3>com.atproto.label.subscribeLabels</3> (WebSocket)."
@@ -3800,6 +3964,10 @@ msgstr "Aucune publication dans cette liste — ajoutez-en depuis la fenêtre de
 #: src/components/reader/subscribe-card.tsx
 msgid "Adding {publicationName} to your feed."
 msgstr "Ajout de {publicationName} à votre flux."
+
+#: src/components/appearance-settings.tsx
+#~ msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors and checked for contrast."
+#~ msgstr ""
 
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/app-shell.tsx
@@ -3956,6 +4124,10 @@ msgstr "La connexion et l'accès aux enregistrements passent par votre Personal 
 msgid "An included article"
 msgstr "Un article inclus"
 
+#: src/components/appearance-settings.tsx
+msgid "Puts the palette, font, size, roundness and density back to their defaults."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Subscribe to labelers to flag, blur, or hide content as you read."
 msgstr "Abonnez-vous à des services d'étiquetage pour signaler, flouter ou masquer du contenu pendant votre lecture."
@@ -4013,6 +4185,7 @@ msgstr "{weekday} · À travers le réseau"
 msgid "Publish & share the run"
 msgstr "Publier et partager l'exécution"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-builder.tsx
 msgid "Editorial"
 msgstr "Éditorial"
@@ -4175,6 +4348,10 @@ msgstr ""
 msgid "Open on {publicationName}"
 msgstr "Ouvrir sur {publicationName}"
 
+#: src/components/appearance-settings.tsx
+msgid "Sans"
+msgstr ""
+
 #: src/components/reader/add-publication-modal.tsx
 msgid "Search publications or paste a handle"
 msgstr "Rechercher des publications ou coller un identifiant"
@@ -4299,6 +4476,10 @@ msgstr "Lire à voix haute"
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "Les articles que vous avez enregistrés pour plus tard — dans votre dépôt, synchronisés entre vos appareils."
 
+#: src/components/reader/format-i18n.ts
+msgid "today"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 #: src/components/reader/content/renderers/shared/image-figure.tsx
 #: src/components/reader/content/renderers/shared/markdown-article.tsx
@@ -4406,6 +4587,7 @@ msgstr "Filtrer par sujet"
 msgid "No unread articles from your follows right now."
 msgstr "Aucun article non lu parmi vos abonnements pour le moment."
 
+#: src/components/appearance-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Search and pick any family from the Google Fonts catalog."
 msgstr "Recherchez et choisissez n'importe quelle famille du catalogue Google Fonts."
@@ -4534,6 +4716,10 @@ msgstr "<0>Lorsque vous vous connectez</0> avec votre compte Atmosphere (par exe
 msgid "Powered by <0>Standard Reader</0>"
 msgstr "Propulsé par <0>Standard Reader</0>"
 
+#: src/components/appearance-settings.tsx
+msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Save from anywhere you browse"
 msgstr "Enregistrez depuis n'importe où sur le web"
@@ -4651,6 +4837,10 @@ msgstr "Commencer"
 msgid "You don't have any content tabs to show yet."
 msgstr "Vous n'avez pas encore d'onglets de contenu à afficher."
 
+#: src/components/appearance-settings.tsx
+msgid "Body text on paper"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "OK"
 msgstr "OK"
@@ -4719,6 +4909,10 @@ msgstr "@{0} · Contient des documents mais aucune publication"
 msgid "{connectionLabel} via Semble"
 msgstr "{connectionLabel} via Semble"
 
+#: src/components/appearance-settings.tsx
+msgid "S"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "In this issue"
 msgstr "Dans ce numéro"
@@ -4729,4 +4923,8 @@ msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Acceptable use"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Palette"
 msgstr ""

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -239,6 +239,10 @@ msgstr ""
 msgid "Opening the collection…"
 msgstr "コレクションを開いています…"
 
+#: src/components/appearance-settings.tsx
+msgid "Density"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Open on publication"
 msgstr "発行物で開く"
@@ -280,6 +284,7 @@ msgstr "フィードバックを送信"
 msgid "<0>Session cookie.</0> After you sign in through the web app, the extension background worker reads your HttpOnly session cookie on {siteHost} to authenticate API requests. Content scripts do not read this cookie directly."
 msgstr "<0>セッション Cookie。</0> ウェブアプリでサインインすると、拡張機能のバックグラウンドワーカーが {siteHost} の HttpOnly セッション Cookie を読み取って API リクエストを認証します。コンテンツスクリプトがこの Cookie を直接読むことはありません。"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/user-settings-view.tsx
 msgid "Light"
@@ -318,9 +323,17 @@ msgstr ""
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 msgstr ""
 
+#: src/components/reader/format-i18n.ts
+msgid "{years}y ago"
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "List"
 msgstr "リスト"
+
+#: src/components/appearance-settings.tsx
+msgid "The spacing between things — tighter for more on screen, looser for more room to read."
+msgstr ""
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Sign in to run this example (curl uses Bearer $ACCESS_TOKEN)."
@@ -349,6 +362,10 @@ msgstr "シリーズに名前を付けてテーマを選ぶ"
 #: src/components/docs/docs-labelers-nav.tsx
 #: src/components/docs/labelers-docs-page.tsx
 msgid "Reference implementation"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Extra large"
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
@@ -453,6 +470,10 @@ msgstr "アカウントに保存されているデータを完全に削除しま
 msgid "Loading people"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "Links and labels on paper"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Read the piece →"
 msgstr "記事を読む →"
@@ -493,6 +514,10 @@ msgstr "発行物をフォローするにはログインしてください"
 #: src/routes/_layout.discover.tsx
 msgid "Search publications"
 msgstr "発行物を検索"
+
+#: src/components/appearance-settings.tsx
+msgid "Small"
+msgstr ""
 
 #: src/routes/_layout.search.tsx
 msgid "Publications, handles, #tags, headlines…"
@@ -767,6 +792,7 @@ msgstr "ディスカッション"
 msgid "Content label"
 msgstr "コンテンツラベル"
 
+#: src/components/appearance-settings.tsx
 #: src/components/ReadingTypographyMenu.tsx
 #: src/components/user-settings-view.tsx
 msgid "Text size"
@@ -833,6 +859,11 @@ msgstr "インデックスされた投稿はまだありません。"
 msgid "{0} added to {listName}."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+#: src/components/user-settings-view.tsx
+msgid "Custom"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Read the API docs"
 msgstr "API ドキュメントを読む"
@@ -868,6 +899,10 @@ msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "For more about how {SITE_NAME} works, see the <0>About</0> page. For questions about these terms for this deployment, contact the operator of the site at the URL above."
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Compact"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -931,6 +966,10 @@ msgstr "{documentCount, plural, one {文書} other {文書}}"
 msgid "Publishing"
 msgstr "公開"
 
+#: src/components/appearance-settings.tsx
+msgid "Roundness"
+msgstr ""
+
 #: src/components/docs/introduction-docs-page.tsx
 msgid "public XRPC queries and procedures for the Standard Reader read-model, with live examples."
 msgstr ""
@@ -971,6 +1010,10 @@ msgstr "<0>site.standard.publication</0> のヒントは、そのドキュメン
 #: src/components/reader/about-view.tsx
 msgid "Your week"
 msgstr "今週"
+
+#: src/components/appearance-settings.tsx
+msgid "Relaxed"
+msgstr ""
 
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.recommended.tsx
@@ -1013,6 +1056,10 @@ msgstr "オフ"
 msgid "Run example"
 msgstr "例を実行"
 
+#: src/components/appearance-settings.tsx
+msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "When on, collection posts open in the magazine edition instead of the reader view."
 msgstr "オンにすると、コレクションの記事はリーダー表示ではなくマガジン版で開きます。"
@@ -1047,6 +1094,10 @@ msgstr "質問"
 #: src/components/reader/list-edit-modal.tsx
 msgid "Choose an item to add to the list"
 msgstr "リストに追加する項目を選択"
+
+#: src/components/appearance-settings.tsx
+msgid "Soft"
+msgstr ""
 
 #: src/magazine/magazine-end-subscribe.tsx
 msgid "Subscribed to list"
@@ -1110,9 +1161,18 @@ msgstr "このリストの説明（公開ページに表示されます）"
 msgid "Delete collection"
 msgstr "コレクションを削除"
 
+#: src/components/appearance-settings.tsx
+msgid "Interface font"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No publications in this list."
 msgstr "このリストには発行物がありません。"
+
+#. placeholder {0}: palette.name
+#: src/components/appearance-settings.tsx
+msgid "{0}, dark"
+msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Loading collections…"
@@ -1130,6 +1190,10 @@ msgstr "ラベラーを見る"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We do not run a separate analytics pipeline inside the extension."
 msgstr "拡張機能の内部で独自の分析パイプラインを運用することはありません。"
+
+#: src/components/appearance-settings.tsx
+#~ msgid "Text, borders and every other step are derived from these two colors and checked for contrast."
+#~ msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Remove list"
@@ -1436,6 +1500,7 @@ msgstr "{durationMs}ms · 取得 {fetchedAt}"
 msgid "Loading feedback"
 msgstr "フィードバックを読み込み中"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Accent"
 msgstr "アクセント"
@@ -1483,6 +1548,10 @@ msgstr "Chrome に追加"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Leaflet, Pckt, Offprint.</0> <1>pub.leaflet.content</1>, <2>blog.pckt.content</2>, and <3>app.offprint.content</3> — the block-based formats those tools write natively."
 msgstr "<0>Leaflet、Pckt、Offprint。</0> <1>pub.leaflet.content</1>、<2>blog.pckt.content</2>、<3>app.offprint.content</3> — これらのツールがネイティブに書き出すブロックベースの形式です。"
+
+#: src/components/appearance-settings.tsx
+msgid "XL"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Set your own type"
@@ -1638,6 +1707,10 @@ msgstr "リーダー表示に切り替え"
 msgid "<0>3. Declare your label values.</0> Describe each value (severity, default warn/hide, blur behavior) in an <1>app.standard-reader.labeler.service</1> descriptor, served from <2>app.standard-reader.labeler.getServices</2> (a <3>did:web</3> labeler has no repo to hold the record)."
 msgstr "<0>3. ラベルの値を宣言する。</0> 各値（深刻度、既定の警告/非表示、ぼかしの挙動）を <1>app.standard-reader.labeler.service</1> ディスクリプタに記述し、<2>app.standard-reader.labeler.getServices</2> から配信します（<3>did:web</3> のラベラーにはレコードを保持するリポジトリがないためです）。"
 
+#: src/components/reader/format-i18n.ts
+msgid "{months}mo ago"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "To email your digest, Standard Reader needs your account email address. We'll ask your PDS to share it — you'll be sent to your login to approve the request, then brought right back here. Your email is used only to send the weekly digest, and you can turn it off any time."
 msgstr "ダイジェストをメールで送るには、Standard Reader にアカウントのメールアドレスが必要です。PDS に共有を依頼するため、ログイン画面で許可していただき、その後ここに戻ります。メールアドレスは週刊ダイジェストの送信にのみ使用され、いつでもオフにできます。"
@@ -1713,6 +1786,10 @@ msgstr ""
 msgid "Every unread article from this publication will be marked read. This can’t be undone."
 msgstr "この発行物の未読記事がすべて既読になります。この操作は取り消せません。"
 
+#: src/components/appearance-settings.tsx
+msgid "Your own colors"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
 msgstr "号を設定中…"
@@ -1765,6 +1842,11 @@ msgstr "{pubTotal, plural, one {# 件の発行物} other {# 件の発行物}}"
 msgid "Nothing new today"
 msgstr ""
 
+#. placeholder {0}: palette.name
+#: src/components/appearance-settings.tsx
+msgid "{0}, light"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Background"
 msgstr "背景"
@@ -1784,6 +1866,10 @@ msgstr "購読中の発行物から"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>When you browse without signing in,</0> we serve public writing from our read-model index. We may store a theme preference cookie and, if you have signed in before on this device, a short list of recently used account handles (and optional avatar URLs) to speed up sign-in. We do not require an account to read."
 msgstr "<0>サインインせずに閲覧する場合、</0>読み取りモデルのインデックスから公開されている記事を配信します。テーマ設定の Cookie と、このデバイスで以前サインインしたことがある場合はサインインを速くするために最近使用したアカウントのハンドル（および任意でアバターの URL）の短いリストを保存することがあります。読むためにアカウントは必要ありません。"
+
+#: src/components/appearance-settings.tsx
+msgid "Paper"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
@@ -2235,8 +2321,8 @@ msgid "by @{ownerHandle}"
 msgstr "@{ownerHandle} による"
 
 #: src/components/user-settings-view.tsx
-msgid "Choose light, dark, or match your system setting."
-msgstr "ライト、ダーク、またはシステム設定に合わせるかを選択します。"
+#~ msgid "Choose light, dark, or match your system setting."
+#~ msgstr "ライト、ダーク、またはシステム設定に合わせるかを選択します。"
 
 #. placeholder {0}: rows.length
 #: src/components/reader/subscriptions-table.tsx
@@ -2254,6 +2340,10 @@ msgstr "完了"
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
 msgstr "ネットワーク全体の最新の長文記事です。"
+
+#: src/components/appearance-settings.tsx
+msgid "Sets the app's colors — and, because the page color decides it, whether the app reads light or dark."
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "{subscribedCount} unread across the publications you subscribe to."
@@ -2291,6 +2381,10 @@ msgstr "{publicationName} はすでに購読済みです。新しい投稿はフ
 msgid "The directory"
 msgstr "ディレクトリ"
 
+#: src/components/appearance-settings.tsx
+#~ msgid "Your accent sits close to the paper in tone, so a darkened version of it is used for text and links."
+#~ msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Trending this week"
 msgstr "今週の急上昇"
@@ -2319,6 +2413,10 @@ msgstr "リストはまだありません"
 #: src/routes/_layout.discover.tsx
 msgid "Browse everything"
 msgstr "すべてを見る"
+
+#: src/components/appearance-settings.tsx
+msgid "Large"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
@@ -2476,6 +2574,10 @@ msgstr ""
 msgid "The most-read writing across the network right now."
 msgstr "いまネットワークで最も読まれている記事です。"
 
+#: src/components/appearance-settings.tsx
+msgid "The typeface used across the app. Article text follows this too, unless you set a reading font below."
+msgstr ""
+
 #: src/magazine/magazine-end-like.tsx
 msgid "Recommend this issue"
 msgstr "この号をおすすめする"
@@ -2491,6 +2593,10 @@ msgstr "{count, plural, one {# 件の高評価} other {# 件の高評価}} — �
 #: src/routes/_layout.search.tsx
 msgid "{shown} of {total} matches"
 msgstr "{total} 件中 {shown} 件が一致"
+
+#: src/components/appearance-settings.tsx
+msgid "How rounded buttons, cards and inputs are."
+msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
 msgid "What is this series about?"
@@ -2523,6 +2629,10 @@ msgstr ""
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler didn’t publish any label definitions."
 msgstr "このラベラーはラベル定義を公開していません。"
+
+#: src/components/reader/format-i18n.ts
+msgid "{days}d ago"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Continue to approve"
@@ -2570,6 +2680,10 @@ msgstr "そこで、私たちが欲しかった読書環境を作りました。
 #: src/routes/_layout.recommended.tsx
 msgid "Recommended articles"
 msgstr "おすすめの記事"
+
+#: src/components/user-settings-view.tsx
+msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labeler views"
@@ -2654,6 +2768,10 @@ msgstr "奥付"
 msgid "Reader voice"
 msgstr "読み上げの声"
 
+#: src/components/appearance-settings.tsx
+msgid "Sharp"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "What you get is a reading view made for long-form: a centered column, drop caps and pull quotes, full-bleed images you can open into a gallery. The page gets out of the way so the writing can do its work."
 msgstr "用意したのは、長文のために作られた読書ビューです。中央寄せのカラム、ドロップキャップとプルクオート、ギャラリーで開ける全幅画像。ページは前に出しゃばらず、文章そのものに仕事をさせます。"
@@ -2703,6 +2821,10 @@ msgstr "このリンクは期限切れです。"
 #: src/components/reader/privacy-view.tsx
 msgid "You can sign out at any time, which clears your app session cookie. You can clear site cookies in your browser to remove theme and saved-handle preferences. You can change reading-history tracking and delete personal data from Settings. To remove other AT Protocol records you created through the app, use a compatible client or your repository tools."
 msgstr "いつでもサインアウトでき、その際アプリのセッション Cookie は消去されます。テーマや保存されたハンドルの設定は、ブラウザでサイトの Cookie を削除すれば消せます。閲覧履歴の記録の変更と個人データの削除は設定から行えます。アプリを通じて作成したその他の AT Protocol レコードを削除するには、対応クライアントまたはリポジトリ用のツールをご利用ください。"
+
+#: src/components/appearance-settings.tsx
+msgid "XS"
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
@@ -2884,6 +3006,10 @@ msgstr ""
 msgid "Share on Bluesky"
 msgstr "Bluesky で共有"
 
+#: src/components/appearance-settings.tsx
+msgid "Reset"
+msgstr ""
+
 #: src/components/docs/docs-lexicons-nav.tsx
 #~ msgid "Lexicon reference"
 #~ msgstr "レキシコンリファレンス"
@@ -2939,6 +3065,10 @@ msgstr "語られていることの、まとめ"
 msgid "Mark all as read"
 msgstr "すべて既読にする"
 
+#: src/components/appearance-settings.tsx
+msgid "Scales every size in the app, article text included — from 14px up to 24px of interface text."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "Your display name, handle, avatar URL, and DID as returned by your account provider."
 msgstr "アカウントプロバイダーから返された表示名、ハンドル、アバターの URL、DID です。"
@@ -2970,6 +3100,10 @@ msgstr "別のクライアントで共有"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "What the extension does not do"
 msgstr "拡張機能が行わないこと"
+
+#: src/components/appearance-settings.tsx
+msgid "Default"
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Loading recommendations"
@@ -3100,6 +3234,10 @@ msgstr "（{min}:1 が必要）"
 msgid "Every read record in your repository will be removed. Articles will appear unread again across the app. This cannot be undone."
 msgstr "リポジトリ内のすべての既読記録が削除されます。アプリ全体で記事が再び未読として表示されます。この操作は取り消せません。"
 
+#: src/components/appearance-settings.tsx
+msgid "Text, borders and every other step are derived from these two colors."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "{SITE_NAME} のブラウザ拡張機能をインストールすると、このサイトと同じアカウントとセッションクッキーが使われます。拡張機能はインデックス照合のためにページの URL を <0>/api/extension/*</0> エンドポイントへ送信し、オーバーレイの設定はブラウザの拡張機能ストレージに保存します。拡張機能のみに適用される詳細は<1>拡張機能のプライバシーポリシー</1>をご覧ください。"
@@ -3149,6 +3287,7 @@ msgstr ""
 msgid "Unfollowing {peopleCount, plural, one {this person} other {these # people}} also drops the subscriptions that follow created, so their publications leave your feed. Nothing you have saved, read, or recommended is affected."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/user-settings-view.tsx
 msgid "Dark"
@@ -3369,6 +3508,10 @@ msgstr "ラベラーは DID を指定して購読するモデレーションサ�
 msgid "Standard Reader meets you where you read"
 msgstr "Standard Reader は、読む場所に寄り添います"
 
+#: src/components/appearance-settings.tsx
+msgid "Reset appearance"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/reader/markdown-field.tsx
 #: src/components/reading-settings-preview.tsx
@@ -3442,6 +3585,10 @@ msgstr "ラベラーを検索"
 msgid "{weekday} · Your feed"
 msgstr "{weekday}・フィード"
 
+#: src/components/reader/format-i18n.ts
+msgid "yesterday"
+msgstr ""
+
 #: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Use publication themes"
@@ -3459,6 +3606,7 @@ msgstr "サービスの DID は <0>{appviewDid}</0> です。スコープを調�
 msgid "The Slow Web, Revisited"
 msgstr "スロー・ウェブ再訪"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reading-custom-font-picker.tsx
 #: src/components/user-settings-view.tsx
 msgid "Google Font"
@@ -3554,6 +3702,10 @@ msgstr "フィードバックを検索"
 msgid "Unsubscribe"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "L"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "Load more ({remainingPublications} remaining)"
 msgstr "さらに読み込む（残り {remainingPublications} 件）"
@@ -3606,6 +3758,10 @@ msgstr "埋め込みコードをコピー"
 #: src/components/user-settings-view.tsx
 msgid "Delete all lists?"
 msgstr "すべてのリストを削除しますか？"
+
+#: src/components/user-settings-view.tsx
+msgid "Advanced"
+msgstr ""
 
 #: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
@@ -3669,6 +3825,10 @@ msgstr "再生"
 #: src/routes/_layout.search.tsx
 msgid "Loading article matches"
 msgstr "一致する記事を読み込み中"
+
+#: src/components/appearance-settings.tsx
+msgid "Extra small"
+msgstr ""
 
 #: src/components/reader/content/renderers/leaflet-standard-site-publication.tsx
 msgid "Publication not found."
@@ -3738,6 +3898,10 @@ msgstr "動作"
 msgid "Reading history"
 msgstr "閲覧履歴"
 
+#: src/components/appearance-settings.tsx
+msgid "M"
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>2. Serve labels.</0> Sign and emit <1>com.atproto.label.defs#label</1> objects, and expose the standard <2>com.atproto.label.queryLabels</2> (HTTP) and <3>com.atproto.label.subscribeLabels</3> (WebSocket) endpoints."
 msgstr "<0>2. ラベルを配信する。</0><1>com.atproto.label.defs#label</1> オブジェクトに署名して発行し、標準の <2>com.atproto.label.queryLabels</2>（HTTP）と <3>com.atproto.label.subscribeLabels</3>（WebSocket）のエンドポイントを公開します。"
@@ -3800,6 +3964,10 @@ msgstr "このリストには発行物がありません。編集ダイアログ
 #: src/components/reader/subscribe-card.tsx
 msgid "Adding {publicationName} to your feed."
 msgstr "{publicationName} をフィードに追加しています。"
+
+#: src/components/appearance-settings.tsx
+#~ msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors and checked for contrast."
+#~ msgstr ""
 
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/app-shell.tsx
@@ -3956,6 +4124,10 @@ msgstr "サインインとレコードへのアクセスは、あなたの Perso
 msgid "An included article"
 msgstr "収録記事"
 
+#: src/components/appearance-settings.tsx
+msgid "Puts the palette, font, size, roundness and density back to their defaults."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Subscribe to labelers to flag, blur, or hide content as you read."
 msgstr "ラベラーを購読すると、読みながらコンテンツにフラグを付けたり、ぼかしたり、非表示にしたりできます。"
@@ -4013,6 +4185,7 @@ msgstr "{weekday}・ネットワーク全体"
 msgid "Publish & share the run"
 msgstr "公開して共有"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-builder.tsx
 msgid "Editorial"
 msgstr "編集部"
@@ -4175,6 +4348,10 @@ msgstr ""
 msgid "Open on {publicationName}"
 msgstr "{publicationName} で開く"
 
+#: src/components/appearance-settings.tsx
+msgid "Sans"
+msgstr ""
+
 #: src/components/reader/add-publication-modal.tsx
 msgid "Search publications or paste a handle"
 msgstr "発行物を検索、またはハンドルを貼り付け"
@@ -4299,6 +4476,10 @@ msgstr "読み上げ"
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "あとで読むために保存した記事です。リポジトリに保存され、デバイス間で同期されます。"
 
+#: src/components/reader/format-i18n.ts
+msgid "today"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 #: src/components/reader/content/renderers/shared/image-figure.tsx
 #: src/components/reader/content/renderers/shared/markdown-article.tsx
@@ -4406,6 +4587,7 @@ msgstr "トピックで絞り込む"
 msgid "No unread articles from your follows right now."
 msgstr "フォロー中の未読記事は今のところありません。"
 
+#: src/components/appearance-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Search and pick any family from the Google Fonts catalog."
 msgstr "Google Fonts のカタログから好きなフォントを検索して選べます。"
@@ -4534,6 +4716,10 @@ msgstr "<0>サインインすると</0>（例えば Bluesky OAuth 経由で）At
 msgid "Powered by <0>Standard Reader</0>"
 msgstr "Powered by <0>Standard Reader</0>"
 
+#: src/components/appearance-settings.tsx
+msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Save from anywhere you browse"
 msgstr "どこで見ていても保存できる"
@@ -4651,6 +4837,10 @@ msgstr "はじめる"
 msgid "You don't have any content tabs to show yet."
 msgstr "表示できるコンテンツタブがまだありません。"
 
+#: src/components/appearance-settings.tsx
+msgid "Body text on paper"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "OK"
 msgstr "OK"
@@ -4719,6 +4909,10 @@ msgstr "@{0}・ドキュメントはありますが発行物がありません"
 msgid "{connectionLabel} via Semble"
 msgstr "Semble 経由の {connectionLabel}"
 
+#: src/components/appearance-settings.tsx
+msgid "S"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "In this issue"
 msgstr "この号の内容"
@@ -4729,4 +4923,8 @@ msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Acceptable use"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Palette"
 msgstr ""

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -239,6 +239,10 @@ msgstr ""
 msgid "Opening the collection…"
 msgstr "컬렉션을 여는 중…"
 
+#: src/components/appearance-settings.tsx
+msgid "Density"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Open on publication"
 msgstr "발행물에서 열기"
@@ -280,6 +284,7 @@ msgstr "피드백 보내기"
 msgid "<0>Session cookie.</0> After you sign in through the web app, the extension background worker reads your HttpOnly session cookie on {siteHost} to authenticate API requests. Content scripts do not read this cookie directly."
 msgstr "<0>세션 쿠키.</0> 웹 앱에서 로그인하면 확장 프로그램의 백그라운드 워커가 {siteHost}의 HttpOnly 세션 쿠키를 읽어 API 요청을 인증합니다. 콘텐츠 스크립트는 이 쿠키를 직접 읽지 않습니다."
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/user-settings-view.tsx
 msgid "Light"
@@ -318,9 +323,17 @@ msgstr ""
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 msgstr ""
 
+#: src/components/reader/format-i18n.ts
+msgid "{years}y ago"
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "List"
 msgstr "목록"
+
+#: src/components/appearance-settings.tsx
+msgid "The spacing between things — tighter for more on screen, looser for more room to read."
+msgstr ""
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Sign in to run this example (curl uses Bearer $ACCESS_TOKEN)."
@@ -349,6 +362,10 @@ msgstr "시리즈 이름과 테마 정하기"
 #: src/components/docs/docs-labelers-nav.tsx
 #: src/components/docs/labelers-docs-page.tsx
 msgid "Reference implementation"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Extra large"
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
@@ -453,6 +470,10 @@ msgstr "계정에 저장된 데이터를 영구적으로 삭제합니다. 이 �
 msgid "Loading people"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "Links and labels on paper"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Read the piece →"
 msgstr "글 읽기 →"
@@ -493,6 +514,10 @@ msgstr "발행물을 팔로우하려면 로그인하세요"
 #: src/routes/_layout.discover.tsx
 msgid "Search publications"
 msgstr "발행물 검색"
+
+#: src/components/appearance-settings.tsx
+msgid "Small"
+msgstr ""
 
 #: src/routes/_layout.search.tsx
 msgid "Publications, handles, #tags, headlines…"
@@ -767,6 +792,7 @@ msgstr "토론"
 msgid "Content label"
 msgstr "콘텐츠 라벨"
 
+#: src/components/appearance-settings.tsx
 #: src/components/ReadingTypographyMenu.tsx
 #: src/components/user-settings-view.tsx
 msgid "Text size"
@@ -833,6 +859,11 @@ msgstr "아직 색인된 글이 없습니다."
 msgid "{0} added to {listName}."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+#: src/components/user-settings-view.tsx
+msgid "Custom"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Read the API docs"
 msgstr "API 문서 보기"
@@ -868,6 +899,10 @@ msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "For more about how {SITE_NAME} works, see the <0>About</0> page. For questions about these terms for this deployment, contact the operator of the site at the URL above."
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Compact"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -931,6 +966,10 @@ msgstr "{documentCount, plural, one {문서} other {문서}}"
 msgid "Publishing"
 msgstr "발행"
 
+#: src/components/appearance-settings.tsx
+msgid "Roundness"
+msgstr ""
+
 #: src/components/docs/introduction-docs-page.tsx
 msgid "public XRPC queries and procedures for the Standard Reader read-model, with live examples."
 msgstr ""
@@ -971,6 +1010,10 @@ msgstr "문서가 발행물 레코드에 속한 경우에만 <0>site.standard.pu
 #: src/components/reader/about-view.tsx
 msgid "Your week"
 msgstr "이번 주"
+
+#: src/components/appearance-settings.tsx
+msgid "Relaxed"
+msgstr ""
 
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.recommended.tsx
@@ -1013,6 +1056,10 @@ msgstr "끄기"
 msgid "Run example"
 msgstr "예제 실행"
 
+#: src/components/appearance-settings.tsx
+msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "When on, collection posts open in the magazine edition instead of the reader view."
 msgstr "켜면 컬렉션 글이 리더 보기 대신 매거진 에디션으로 열립니다."
@@ -1047,6 +1094,10 @@ msgstr "질문"
 #: src/components/reader/list-edit-modal.tsx
 msgid "Choose an item to add to the list"
 msgstr "목록에 추가할 항목을 선택하세요"
+
+#: src/components/appearance-settings.tsx
+msgid "Soft"
+msgstr ""
 
 #: src/magazine/magazine-end-subscribe.tsx
 msgid "Subscribed to list"
@@ -1110,9 +1161,18 @@ msgstr "이 목록에 대한 설명(공개 페이지에 표시됩니다)"
 msgid "Delete collection"
 msgstr "컬렉션 삭제"
 
+#: src/components/appearance-settings.tsx
+msgid "Interface font"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No publications in this list."
 msgstr "이 목록에 발행물이 없습니다."
+
+#. placeholder {0}: palette.name
+#: src/components/appearance-settings.tsx
+msgid "{0}, dark"
+msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Loading collections…"
@@ -1130,6 +1190,10 @@ msgstr "라벨러 둘러보기"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We do not run a separate analytics pipeline inside the extension."
 msgstr "확장 프로그램 내부에서 별도의 분석 파이프라인을 운영하지 않습니다."
+
+#: src/components/appearance-settings.tsx
+#~ msgid "Text, borders and every other step are derived from these two colors and checked for contrast."
+#~ msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Remove list"
@@ -1436,6 +1500,7 @@ msgstr "{durationMs}ms · {fetchedAt}에 가져옴"
 msgid "Loading feedback"
 msgstr "피드백 불러오는 중"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Accent"
 msgstr "강조 색"
@@ -1483,6 +1548,10 @@ msgstr "Chrome에 추가"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Leaflet, Pckt, Offprint.</0> <1>pub.leaflet.content</1>, <2>blog.pckt.content</2>, and <3>app.offprint.content</3> — the block-based formats those tools write natively."
 msgstr "<0>Leaflet, Pckt, Offprint.</0> <1>pub.leaflet.content</1>, <2>blog.pckt.content</2>, <3>app.offprint.content</3> — 이 도구들이 기본으로 사용하는 블록 기반 형식입니다."
+
+#: src/components/appearance-settings.tsx
+msgid "XL"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Set your own type"
@@ -1638,6 +1707,10 @@ msgstr "리더 뷰로 전환"
 msgid "<0>3. Declare your label values.</0> Describe each value (severity, default warn/hide, blur behavior) in an <1>app.standard-reader.labeler.service</1> descriptor, served from <2>app.standard-reader.labeler.getServices</2> (a <3>did:web</3> labeler has no repo to hold the record)."
 msgstr "<0>3. 라벨 값을 선언하세요.</0> 각 값(심각도, 기본 경고/숨김, 블러 동작)을 <1>app.standard-reader.labeler.service</1> 디스크립터에 기술하고 <2>app.standard-reader.labeler.getServices</2>로 제공하세요(<3>did:web</3> 라벨러는 레코드를 담을 저장소가 없습니다)."
 
+#: src/components/reader/format-i18n.ts
+msgid "{months}mo ago"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "To email your digest, Standard Reader needs your account email address. We'll ask your PDS to share it — you'll be sent to your login to approve the request, then brought right back here. Your email is used only to send the weekly digest, and you can turn it off any time."
 msgstr "다이제스트를 보내려면 Standard Reader에 계정 이메일 주소가 필요합니다. PDS에 공유를 요청하며, 로그인 화면에서 승인한 뒤 바로 이곳으로 돌아옵니다. 이메일은 주간 다이제스트 발송에만 사용되고 언제든 끌 수 있습니다."
@@ -1713,6 +1786,10 @@ msgstr ""
 msgid "Every unread article from this publication will be marked read. This can’t be undone."
 msgstr "이 발행물의 읽지 않은 아티클이 모두 읽음으로 표시됩니다. 되돌릴 수 없습니다."
 
+#: src/components/appearance-settings.tsx
+msgid "Your own colors"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
 msgstr "호 설정 중…"
@@ -1765,6 +1842,11 @@ msgstr "{pubTotal, plural, one {발행물 #개} other {발행물 #개}}"
 msgid "Nothing new today"
 msgstr ""
 
+#. placeholder {0}: palette.name
+#: src/components/appearance-settings.tsx
+msgid "{0}, light"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Background"
 msgstr "배경"
@@ -1784,6 +1866,10 @@ msgstr "구독 중인 곳에서"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>When you browse without signing in,</0> we serve public writing from our read-model index. We may store a theme preference cookie and, if you have signed in before on this device, a short list of recently used account handles (and optional avatar URLs) to speed up sign-in. We do not require an account to read."
 msgstr "<0>로그인하지 않고 둘러볼 때는</0> 읽기 모델 색인에 있는 공개 글을 제공합니다. 테마 설정 쿠키를 저장할 수 있으며, 이 기기에서 이전에 로그인한 적이 있다면 로그인을 빠르게 하기 위해 최근 사용한 계정 핸들 목록(및 선택적으로 아바타 URL)을 저장할 수 있습니다. 읽는 데 계정은 필요하지 않습니다."
+
+#: src/components/appearance-settings.tsx
+msgid "Paper"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
@@ -2235,8 +2321,8 @@ msgid "by @{ownerHandle}"
 msgstr "@{ownerHandle} 님"
 
 #: src/components/user-settings-view.tsx
-msgid "Choose light, dark, or match your system setting."
-msgstr "라이트, 다크 또는 시스템 설정 따르기 중에서 선택하세요."
+#~ msgid "Choose light, dark, or match your system setting."
+#~ msgstr "라이트, 다크 또는 시스템 설정 따르기 중에서 선택하세요."
 
 #. placeholder {0}: rows.length
 #: src/components/reader/subscriptions-table.tsx
@@ -2254,6 +2340,10 @@ msgstr "완료"
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
 msgstr "네트워크 전체의 최신 장문 글."
+
+#: src/components/appearance-settings.tsx
+msgid "Sets the app's colors — and, because the page color decides it, whether the app reads light or dark."
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "{subscribedCount} unread across the publications you subscribe to."
@@ -2291,6 +2381,10 @@ msgstr "이미 {publicationName}을(를) 구독 중입니다. 새 글이 피드�
 msgid "The directory"
 msgstr "디렉터리"
 
+#: src/components/appearance-settings.tsx
+#~ msgid "Your accent sits close to the paper in tone, so a darkened version of it is used for text and links."
+#~ msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Trending this week"
 msgstr "이번 주 인기"
@@ -2319,6 +2413,10 @@ msgstr "아직 리스트가 없습니다"
 #: src/routes/_layout.discover.tsx
 msgid "Browse everything"
 msgstr "전체 둘러보기"
+
+#: src/components/appearance-settings.tsx
+msgid "Large"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
@@ -2476,6 +2574,10 @@ msgstr ""
 msgid "The most-read writing across the network right now."
 msgstr "지금 네트워크에서 가장 많이 읽히는 글입니다."
 
+#: src/components/appearance-settings.tsx
+msgid "The typeface used across the app. Article text follows this too, unless you set a reading font below."
+msgstr ""
+
 #: src/magazine/magazine-end-like.tsx
 msgid "Recommend this issue"
 msgstr "이 호 추천하기"
@@ -2491,6 +2593,10 @@ msgstr "{count, plural, one {추천 #개} other {추천 #개}} — 클릭하면 
 #: src/routes/_layout.search.tsx
 msgid "{shown} of {total} matches"
 msgstr "일치 항목 {total}개 중 {shown}개"
+
+#: src/components/appearance-settings.tsx
+msgid "How rounded buttons, cards and inputs are."
+msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
 msgid "What is this series about?"
@@ -2523,6 +2629,10 @@ msgstr ""
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler didn’t publish any label definitions."
 msgstr "이 레이블러는 레이블 정의를 게시하지 않았습니다."
+
+#: src/components/reader/format-i18n.ts
+msgid "{days}d ago"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Continue to approve"
@@ -2570,6 +2680,10 @@ msgstr "그래서 우리가 원하던 리더를 만들었습니다. 너비를 �
 #: src/routes/_layout.recommended.tsx
 msgid "Recommended articles"
 msgstr "추천 아티클"
+
+#: src/components/user-settings-view.tsx
+msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labeler views"
@@ -2654,6 +2768,10 @@ msgstr "콜로폰"
 msgid "Reader voice"
 msgstr "리더 음성"
 
+#: src/components/appearance-settings.tsx
+msgid "Sharp"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "What you get is a reading view made for long-form: a centered column, drop caps and pull quotes, full-bleed images you can open into a gallery. The page gets out of the way so the writing can do its work."
 msgstr "긴 글을 위해 만든 읽기 화면을 만나보세요. 가운데 정렬된 단, 드롭캡과 인용구, 갤러리로 열어볼 수 있는 전체 폭 이미지까지. 글이 제 몫을 하도록 페이지는 뒤로 물러납니다."
@@ -2703,6 +2821,10 @@ msgstr "링크가 만료되었습니다."
 #: src/components/reader/privacy-view.tsx
 msgid "You can sign out at any time, which clears your app session cookie. You can clear site cookies in your browser to remove theme and saved-handle preferences. You can change reading-history tracking and delete personal data from Settings. To remove other AT Protocol records you created through the app, use a compatible client or your repository tools."
 msgstr "언제든지 로그아웃할 수 있으며, 그러면 앱 세션 쿠키가 삭제됩니다. 브라우저에서 사이트 쿠키를 지우면 테마와 저장된 핸들 설정을 제거할 수 있습니다. 읽기 기록 추적은 설정에서 변경할 수 있고 개인 데이터도 삭제할 수 있습니다. 앱을 통해 생성한 다른 AT Protocol 레코드를 삭제하려면 호환되는 클라이언트나 리포지토리 도구를 사용하세요."
+
+#: src/components/appearance-settings.tsx
+msgid "XS"
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
@@ -2884,6 +3006,10 @@ msgstr ""
 msgid "Share on Bluesky"
 msgstr "Bluesky에 공유"
 
+#: src/components/appearance-settings.tsx
+msgid "Reset"
+msgstr ""
+
 #: src/components/docs/docs-lexicons-nav.tsx
 #~ msgid "Lexicon reference"
 #~ msgstr "렉시콘 레퍼런스"
@@ -2939,6 +3065,10 @@ msgstr "한자리에 모인 대화"
 msgid "Mark all as read"
 msgstr "모두 읽음으로 표시"
 
+#: src/components/appearance-settings.tsx
+msgid "Scales every size in the app, article text included — from 14px up to 24px of interface text."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "Your display name, handle, avatar URL, and DID as returned by your account provider."
 msgstr "계정 제공자가 반환한 표시 이름, 핸들, 아바타 URL, DID입니다."
@@ -2970,6 +3100,10 @@ msgstr "다른 클라이언트로 공유"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "What the extension does not do"
 msgstr "확장 프로그램이 하지 않는 일"
+
+#: src/components/appearance-settings.tsx
+msgid "Default"
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Loading recommendations"
@@ -3100,6 +3234,10 @@ msgstr "({min}:1 필요)"
 msgid "Every read record in your repository will be removed. Articles will appear unread again across the app. This cannot be undone."
 msgstr "저장소에 있는 모든 읽음 기록이 삭제됩니다. 앱 전체에서 글이 다시 읽지 않음으로 표시되며, 되돌릴 수 없습니다."
 
+#: src/components/appearance-settings.tsx
+msgid "Text, borders and every other step are derived from these two colors."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "{SITE_NAME} 브라우저 확장 프로그램을 설치하면 이 사이트와 동일한 계정 및 세션 쿠키를 사용합니다. 확장 프로그램은 색인 매칭을 위해 페이지 URL을 <0>/api/extension/*</0> 엔드포인트로 전송하고, 오버레이 설정은 브라우저의 확장 프로그램 저장소에 보관합니다. 확장 프로그램에만 적용되는 자세한 내용은 <1>확장 프로그램 개인정보 처리방침</1>을 참고하세요."
@@ -3149,6 +3287,7 @@ msgstr ""
 msgid "Unfollowing {peopleCount, plural, one {this person} other {these # people}} also drops the subscriptions that follow created, so their publications leave your feed. Nothing you have saved, read, or recommended is affected."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/user-settings-view.tsx
 msgid "Dark"
@@ -3369,6 +3508,10 @@ msgstr "라벨러는 DID로 구독하는 모더레이션 서비스입니다. 구
 msgid "Standard Reader meets you where you read"
 msgstr "Standard Reader는 당신이 읽는 곳으로 찾아갑니다"
 
+#: src/components/appearance-settings.tsx
+msgid "Reset appearance"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/reader/markdown-field.tsx
 #: src/components/reading-settings-preview.tsx
@@ -3442,6 +3585,10 @@ msgstr "라벨러 검색"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · 내 피드"
 
+#: src/components/reader/format-i18n.ts
+msgid "yesterday"
+msgstr ""
+
 #: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Use publication themes"
@@ -3459,6 +3606,7 @@ msgstr "서비스 DID는 <0>{appviewDid}</0>입니다. 이 서비스는 스코�
 msgid "The Slow Web, Revisited"
 msgstr "느린 웹, 다시 보기"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reading-custom-font-picker.tsx
 #: src/components/user-settings-view.tsx
 msgid "Google Font"
@@ -3554,6 +3702,10 @@ msgstr "피드백 검색"
 msgid "Unsubscribe"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "L"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "Load more ({remainingPublications} remaining)"
 msgstr "더 보기 ({remainingPublications}개 남음)"
@@ -3606,6 +3758,10 @@ msgstr "임베드 코드 복사"
 #: src/components/user-settings-view.tsx
 msgid "Delete all lists?"
 msgstr "모든 목록을 삭제할까요?"
+
+#: src/components/user-settings-view.tsx
+msgid "Advanced"
+msgstr ""
 
 #: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
@@ -3669,6 +3825,10 @@ msgstr "재생"
 #: src/routes/_layout.search.tsx
 msgid "Loading article matches"
 msgstr "검색된 글 불러오는 중"
+
+#: src/components/appearance-settings.tsx
+msgid "Extra small"
+msgstr ""
 
 #: src/components/reader/content/renderers/leaflet-standard-site-publication.tsx
 msgid "Publication not found."
@@ -3738,6 +3898,10 @@ msgstr "동작"
 msgid "Reading history"
 msgstr "읽은 기록"
 
+#: src/components/appearance-settings.tsx
+msgid "M"
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>2. Serve labels.</0> Sign and emit <1>com.atproto.label.defs#label</1> objects, and expose the standard <2>com.atproto.label.queryLabels</2> (HTTP) and <3>com.atproto.label.subscribeLabels</3> (WebSocket) endpoints."
 msgstr "<0>2. 라벨 제공.</0> <1>com.atproto.label.defs#label</1> 객체를 서명해 발행하고, 표준 <2>com.atproto.label.queryLabels</2>(HTTP) 및 <3>com.atproto.label.subscribeLabels</3>(WebSocket) 엔드포인트를 공개하세요."
@@ -3800,6 +3964,10 @@ msgstr "이 목록에 발행물이 없습니다. 편집 대화상자에서 추�
 #: src/components/reader/subscribe-card.tsx
 msgid "Adding {publicationName} to your feed."
 msgstr "{publicationName}을(를) 피드에 추가하는 중입니다."
+
+#: src/components/appearance-settings.tsx
+#~ msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors and checked for contrast."
+#~ msgstr ""
 
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/app-shell.tsx
@@ -3956,6 +4124,10 @@ msgstr "로그인과 레코드 접근은 사용자의 Personal Data Server와 �
 msgid "An included article"
 msgstr "포함된 글"
 
+#: src/components/appearance-settings.tsx
+msgid "Puts the palette, font, size, roundness and density back to their defaults."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Subscribe to labelers to flag, blur, or hide content as you read."
 msgstr "라벨러를 구독하면 읽는 동안 콘텐츠를 표시하거나 흐리거나 숨길 수 있습니다."
@@ -4013,6 +4185,7 @@ msgstr "{weekday} · 네트워크 전체"
 msgid "Publish & share the run"
 msgstr "실행 결과 게시 및 공유"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-builder.tsx
 msgid "Editorial"
 msgstr "에디토리얼"
@@ -4175,6 +4348,10 @@ msgstr ""
 msgid "Open on {publicationName}"
 msgstr "{publicationName}에서 열기"
 
+#: src/components/appearance-settings.tsx
+msgid "Sans"
+msgstr ""
+
 #: src/components/reader/add-publication-modal.tsx
 msgid "Search publications or paste a handle"
 msgstr "발행물 검색 또는 핸들 붙여넣기"
@@ -4299,6 +4476,10 @@ msgstr "소리내어 읽기"
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "나중에 읽으려고 저장한 글 — 내 저장소에 보관되어 기기 간에 동기화됩니다."
 
+#: src/components/reader/format-i18n.ts
+msgid "today"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 #: src/components/reader/content/renderers/shared/image-figure.tsx
 #: src/components/reader/content/renderers/shared/markdown-article.tsx
@@ -4406,6 +4587,7 @@ msgstr "주제로 필터"
 msgid "No unread articles from your follows right now."
 msgstr "지금은 팔로우한 곳에 읽지 않은 글이 없습니다."
 
+#: src/components/appearance-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Search and pick any family from the Google Fonts catalog."
 msgstr "Google Fonts 카탈로그에서 원하는 서체를 검색해 선택하세요."
@@ -4534,6 +4716,10 @@ msgstr "<0>Atmosphere 계정으로 로그인하면</0>(예: Bluesky OAuth) AT Pr
 msgid "Powered by <0>Standard Reader</0>"
 msgstr "<0>Standard Reader</0> 제공"
 
+#: src/components/appearance-settings.tsx
+msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Save from anywhere you browse"
 msgstr "어디서 둘러보든 저장하기"
@@ -4651,6 +4837,10 @@ msgstr "시작하기"
 msgid "You don't have any content tabs to show yet."
 msgstr "아직 표시할 콘텐츠 탭이 없습니다."
 
+#: src/components/appearance-settings.tsx
+msgid "Body text on paper"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "OK"
 msgstr "확인"
@@ -4719,6 +4909,10 @@ msgstr "@{0} · 문서는 있지만 발행물이 없음"
 msgid "{connectionLabel} via Semble"
 msgstr "Semble를 통한 {connectionLabel}"
 
+#: src/components/appearance-settings.tsx
+msgid "S"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "In this issue"
 msgstr "이번 호에서"
@@ -4729,4 +4923,8 @@ msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Acceptable use"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Palette"
 msgstr ""

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -239,6 +239,10 @@ msgstr ""
 msgid "Opening the collection…"
 msgstr "Abrindo a coleção…"
 
+#: src/components/appearance-settings.tsx
+msgid "Density"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Open on publication"
 msgstr "Abrir na publicação"
@@ -280,6 +284,7 @@ msgstr "Enviar feedback"
 msgid "<0>Session cookie.</0> After you sign in through the web app, the extension background worker reads your HttpOnly session cookie on {siteHost} to authenticate API requests. Content scripts do not read this cookie directly."
 msgstr "<0>Cookie de sessão.</0> Depois de iniciar sessão na aplicação web, o processo em segundo plano da extensão lê o seu cookie de sessão HttpOnly em {siteHost} para autenticar pedidos à API. Os scripts de conteúdo não leem este cookie diretamente."
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/user-settings-view.tsx
 msgid "Light"
@@ -318,9 +323,17 @@ msgstr "Pessoas"
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 msgstr "Publicações escritas pelas pessoas que você segue no Bluesky, exceto as que você já está inscrito."
 
+#: src/components/reader/format-i18n.ts
+msgid "{years}y ago"
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "List"
 msgstr "Lista"
+
+#: src/components/appearance-settings.tsx
+msgid "The spacing between things — tighter for more on screen, looser for more room to read."
+msgstr ""
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Sign in to run this example (curl uses Bearer $ACCESS_TOKEN)."
@@ -349,6 +362,10 @@ msgstr "Dê um nome a sua série e escolha um tema"
 #: src/components/docs/docs-labelers-nav.tsx
 #: src/components/docs/labelers-docs-page.tsx
 msgid "Reference implementation"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Extra large"
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
@@ -453,6 +470,10 @@ msgstr "Remova permanentemente dados salvos na sua conta. Estas ações apagam r
 msgid "Loading people"
 msgstr "Carregando pessoas"
 
+#: src/components/appearance-settings.tsx
+msgid "Links and labels on paper"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Read the piece →"
 msgstr "Ler o texto →"
@@ -493,6 +514,10 @@ msgstr "Inicie sessão para seguir publicações"
 #: src/routes/_layout.discover.tsx
 msgid "Search publications"
 msgstr "Pesquisar publicações"
+
+#: src/components/appearance-settings.tsx
+msgid "Small"
+msgstr ""
 
 #: src/routes/_layout.search.tsx
 msgid "Publications, handles, #tags, headlines…"
@@ -767,6 +792,7 @@ msgstr "Discussões"
 msgid "Content label"
 msgstr "Etiqueta de conteúdo"
 
+#: src/components/appearance-settings.tsx
 #: src/components/ReadingTypographyMenu.tsx
 #: src/components/user-settings-view.tsx
 msgid "Text size"
@@ -833,6 +859,11 @@ msgstr "Ainda não há publicações indexadas."
 msgid "{0} added to {listName}."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+#: src/components/user-settings-view.tsx
+msgid "Custom"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Read the API docs"
 msgstr "Ler a documentação da API"
@@ -869,6 +900,10 @@ msgstr ""
 #: src/components/reader/terms-view.tsx
 msgid "For more about how {SITE_NAME} works, see the <0>About</0> page. For questions about these terms for this deployment, contact the operator of the site at the URL above."
 msgstr "Para saber mais sobre como o {SITE_NAME} funciona, consulte a página <0>Sobre</0>. Para dúvidas sobre estes termos referentes a esta implementação, entre em contato com o operador do site na URL acima."
+
+#: src/components/appearance-settings.tsx
+msgid "Compact"
+msgstr ""
 
 #: src/components/reader/share-menu.tsx
 msgid "Portrait stacks the card vertically. Height adjusts automatically once the embed loads. Change the iframe width as needed."
@@ -931,6 +966,10 @@ msgstr "{documentCount, plural, one {documento} other {documentos}}"
 msgid "Publishing"
 msgstr "Publicação"
 
+#: src/components/appearance-settings.tsx
+msgid "Roundness"
+msgstr ""
+
 #: src/components/docs/introduction-docs-page.tsx
 msgid "public XRPC queries and procedures for the Standard Reader read-model, with live examples."
 msgstr ""
@@ -971,6 +1010,10 @@ msgstr "Inclua a dica <0>site.standard.publication</0> apenas se o documento per
 #: src/components/reader/about-view.tsx
 msgid "Your week"
 msgstr "A sua semana"
+
+#: src/components/appearance-settings.tsx
+msgid "Relaxed"
+msgstr ""
 
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.recommended.tsx
@@ -1013,6 +1056,10 @@ msgstr "Desligado"
 msgid "Run example"
 msgstr "Executar exemplo"
 
+#: src/components/appearance-settings.tsx
+msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "When on, collection posts open in the magazine edition instead of the reader view."
 msgstr "Quando ativo, as publicações de coleções abrem na edição da revista em vez da vista de leitura."
@@ -1047,6 +1094,10 @@ msgstr "Pergunta"
 #: src/components/reader/list-edit-modal.tsx
 msgid "Choose an item to add to the list"
 msgstr "Escolha um item para adicionar à lista"
+
+#: src/components/appearance-settings.tsx
+msgid "Soft"
+msgstr ""
 
 #: src/magazine/magazine-end-subscribe.tsx
 msgid "Subscribed to list"
@@ -1110,9 +1161,18 @@ msgstr "Sobre o que é esta lista (mostrado na sua página pública)"
 msgid "Delete collection"
 msgstr "Apagar coleção"
 
+#: src/components/appearance-settings.tsx
+msgid "Interface font"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No publications in this list."
 msgstr "Nenhuma publicação nesta lista."
+
+#. placeholder {0}: palette.name
+#: src/components/appearance-settings.tsx
+msgid "{0}, dark"
+msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Loading collections…"
@@ -1130,6 +1190,10 @@ msgstr "Explorar rotuladores"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We do not run a separate analytics pipeline inside the extension."
 msgstr "Não mantemos um pipeline de análise separado dentro da extensão."
+
+#: src/components/appearance-settings.tsx
+#~ msgid "Text, borders and every other step are derived from these two colors and checked for contrast."
+#~ msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Remove list"
@@ -1436,6 +1500,7 @@ msgstr "{durationMs}ms · obtido {fetchedAt}"
 msgid "Loading feedback"
 msgstr "Carregando feedback"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Accent"
 msgstr "Destaque"
@@ -1483,6 +1548,10 @@ msgstr "Adicionar ao Chrome"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Leaflet, Pckt, Offprint.</0> <1>pub.leaflet.content</1>, <2>blog.pckt.content</2>, and <3>app.offprint.content</3> — the block-based formats those tools write natively."
 msgstr "<0>Leaflet, Pckt, Offprint.</0> <1>pub.leaflet.content</1>, <2>blog.pckt.content</2> e <3>app.offprint.content</3> — os formatos por blocos que essas ferramentas escrevem nativamente."
+
+#: src/components/appearance-settings.tsx
+msgid "XL"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Set your own type"
@@ -1638,6 +1707,10 @@ msgstr "Mudar para modo leitor"
 msgid "<0>3. Declare your label values.</0> Describe each value (severity, default warn/hide, blur behavior) in an <1>app.standard-reader.labeler.service</1> descriptor, served from <2>app.standard-reader.labeler.getServices</2> (a <3>did:web</3> labeler has no repo to hold the record)."
 msgstr "<0>3. Declare os valores dos seus rótulos.</0> Descreva cada valor (gravidade, avisar/ocultar por padrão, desfocar) num descritor <1>app.standard-reader.labeler.service</1>, servido a partir de <2>app.standard-reader.labeler.getServices</2> (um rotulador <3>did:web</3> não tem repositório para salvar o registo)."
 
+#: src/components/reader/format-i18n.ts
+msgid "{months}mo ago"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "To email your digest, Standard Reader needs your account email address. We'll ask your PDS to share it — you'll be sent to your login to approve the request, then brought right back here. Your email is used only to send the weekly digest, and you can turn it off any time."
 msgstr "Para lhe enviar o resumo por e-mail, o Standard Reader precisa do endereço de e-mail da sua conta. Vamos pedir ao seu PDS que o compartilhe — será encaminhado para a sua página de início de sessão para aprovar o pedido e voltará para aqui. O seu e-mail é utilizado apenas para enviar o resumo semanal e pode desativá-lo quando quiser."
@@ -1713,6 +1786,10 @@ msgstr "Sua conta"
 msgid "Every unread article from this publication will be marked read. This can’t be undone."
 msgstr "Todos os artigos não lidos desta publicação serão marcados como lidos. Esta ação não pode ser desfeita."
 
+#: src/components/appearance-settings.tsx
+msgid "Your own colors"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
 msgstr "Preparando a edição…"
@@ -1765,6 +1842,11 @@ msgstr "{pubTotal, plural, one {# publicação} other {# publicações}}"
 msgid "Nothing new today"
 msgstr ""
 
+#. placeholder {0}: palette.name
+#: src/components/appearance-settings.tsx
+msgid "{0}, light"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Background"
 msgstr "Fundo"
@@ -1784,6 +1866,10 @@ msgstr "Das suas inscrições"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>When you browse without signing in,</0> we serve public writing from our read-model index. We may store a theme preference cookie and, if you have signed in before on this device, a short list of recently used account handles (and optional avatar URLs) to speed up sign-in. We do not require an account to read."
 msgstr "<0>Quando navega sem iniciar sessão,</0> servimos textos públicos do nosso índice de modelo de leitura. Podemos guardar um cookie com a preferência de tema e, se já tiver iniciado sessão neste dispositivo, uma lista curta de identificadores de conta usados recentemente (e URLs de avatar opcionais) para acelerar o início de sessão. Não exigimos conta para ler."
+
+#: src/components/appearance-settings.tsx
+msgid "Paper"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
@@ -2235,8 +2321,8 @@ msgid "by @{ownerHandle}"
 msgstr "por @{ownerHandle}"
 
 #: src/components/user-settings-view.tsx
-msgid "Choose light, dark, or match your system setting."
-msgstr "Escolha claro, escuro ou igual à definição do sistema."
+#~ msgid "Choose light, dark, or match your system setting."
+#~ msgstr "Escolha claro, escuro ou igual à definição do sistema."
 
 #. placeholder {0}: rows.length
 #: src/components/reader/subscriptions-table.tsx
@@ -2254,6 +2340,10 @@ msgstr "Concluir"
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
 msgstr "Os textos de formato longo mais recentes de toda a rede."
+
+#: src/components/appearance-settings.tsx
+msgid "Sets the app's colors — and, because the page color decides it, whether the app reads light or dark."
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "{subscribedCount} unread across the publications you subscribe to."
@@ -2291,6 +2381,10 @@ msgstr "Já está inscrito em {publicationName}. Novos artigos aparecerão no se
 msgid "The directory"
 msgstr "O diretório"
 
+#: src/components/appearance-settings.tsx
+#~ msgid "Your accent sits close to the paper in tone, so a darkened version of it is used for text and links."
+#~ msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Trending this week"
 msgstr "Em alta esta semana"
@@ -2319,6 +2413,10 @@ msgstr "Ainda não há listas"
 #: src/routes/_layout.discover.tsx
 msgid "Browse everything"
 msgstr "Explorar tudo"
+
+#: src/components/appearance-settings.tsx
+msgid "Large"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
@@ -2476,6 +2574,10 @@ msgstr ""
 msgid "The most-read writing across the network right now."
 msgstr "Os textos mais lidos em toda a rede neste momento."
 
+#: src/components/appearance-settings.tsx
+msgid "The typeface used across the app. Article text follows this too, unless you set a reading font below."
+msgstr ""
+
 #: src/magazine/magazine-end-like.tsx
 msgid "Recommend this issue"
 msgstr "Recomendar esta edição"
@@ -2491,6 +2593,10 @@ msgstr "{count, plural, one {# voto positivo} other {# votos positivos}} — cli
 #: src/routes/_layout.search.tsx
 msgid "{shown} of {total} matches"
 msgstr "{shown} de {total} correspondências"
+
+#: src/components/appearance-settings.tsx
+msgid "How rounded buttons, cards and inputs are."
+msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
 msgid "What is this series about?"
@@ -2523,6 +2629,10 @@ msgstr ""
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler didn’t publish any label definitions."
 msgstr "Este rotulador não publicou nenhuma definição de rótulos."
+
+#: src/components/reader/format-i18n.ts
+msgid "{days}d ago"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Continue to approve"
@@ -2570,6 +2680,10 @@ msgstr "Por isso criámos o leitor que queríamos: uma coluna que você pode dim
 #: src/routes/_layout.recommended.tsx
 msgid "Recommended articles"
 msgstr "Artigos recomendados"
+
+#: src/components/user-settings-view.tsx
+msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labeler views"
@@ -2654,6 +2768,10 @@ msgstr "Colofão"
 msgid "Reader voice"
 msgstr "Voz de leitura"
 
+#: src/components/appearance-settings.tsx
+msgid "Sharp"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "What you get is a reading view made for long-form: a centered column, drop caps and pull quotes, full-bleed images you can open into a gallery. The page gets out of the way so the writing can do its work."
 msgstr "O que obtém é uma vista de leitura feita para formato longo: uma coluna centrada, capitulares e citações em destaque, imagens de largura total que pode abrir numa galeria. A página sai do caminho para que o texto faça o seu trabalho."
@@ -2703,6 +2821,10 @@ msgstr "Esse link expirou."
 #: src/components/reader/privacy-view.tsx
 msgid "You can sign out at any time, which clears your app session cookie. You can clear site cookies in your browser to remove theme and saved-handle preferences. You can change reading-history tracking and delete personal data from Settings. To remove other AT Protocol records you created through the app, use a compatible client or your repository tools."
 msgstr "Pode terminar sessão a qualquer momento, o que limpa o cookie de sessão da aplicação. Pode limpar os cookies do site no seu navegador para remover as preferências de tema e de handle guardados. Pode alterar o registo do histórico de leitura e apagar dados pessoais nas Configurações. Para remover outros registos AT Protocol que criou através da aplicação, use um cliente compatível ou as ferramentas do seu repositório."
+
+#: src/components/appearance-settings.tsx
+msgid "XS"
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
@@ -2884,6 +3006,10 @@ msgstr "Algumas publicações que vale descobrir"
 msgid "Share on Bluesky"
 msgstr "Compartilhar no Bluesky"
 
+#: src/components/appearance-settings.tsx
+msgid "Reset"
+msgstr ""
+
 #: src/components/docs/docs-lexicons-nav.tsx
 #~ msgid "Lexicon reference"
 #~ msgstr "Referência do lexicon"
@@ -2939,6 +3065,10 @@ msgstr "A conversa, reunida"
 msgid "Mark all as read"
 msgstr "Marcar tudo como lido"
 
+#: src/components/appearance-settings.tsx
+msgid "Scales every size in the app, article text included — from 14px up to 24px of interface text."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "Your display name, handle, avatar URL, and DID as returned by your account provider."
 msgstr "O seu nome de apresentação, identificador, URL do avatar e DID, tal como devolvidos pelo fornecedor da sua conta."
@@ -2970,6 +3100,10 @@ msgstr "Compartilhar em outro cliente"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "What the extension does not do"
 msgstr "O que a extensão não faz"
+
+#: src/components/appearance-settings.tsx
+msgid "Default"
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Loading recommendations"
@@ -3100,6 +3234,10 @@ msgstr "(requer {min}:1)"
 msgid "Every read record in your repository will be removed. Articles will appear unread again across the app. This cannot be undone."
 msgstr "Todos os registos de leitura no seu repositório serão removidos. Os artigos voltarão a aparecer como não lidos em toda a aplicação. Esta ação não pode ser desfeita."
 
+#: src/components/appearance-settings.tsx
+msgid "Text, borders and every other step are derived from these two colors."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "Se instalar a extensão de navegador do {SITE_NAME}, esta usa a mesma conta e o mesmo cookie de sessão que este site. A extensão envia URLs de páginas para os nossos endpoints <0>/api/extension/*</0> para correspondência com o índice e guarda as configurações da sobreposição no armazenamento de extensões do seu navegador. Consulte a <1>política de privacidade da extensão</1> para detalhes que se aplicam apenas à extensão."
@@ -3149,6 +3287,7 @@ msgstr "Coletar, extrair ou utilizar indevidamente o modelo de leitura indexador
 msgid "Unfollowing {peopleCount, plural, one {this person} other {these # people}} also drops the subscriptions that follow created, so their publications leave your feed. Nothing you have saved, read, or recommended is affected."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/user-settings-view.tsx
 msgid "Dark"
@@ -3369,6 +3508,10 @@ msgstr "Os rotuladores são serviços de moderação em que se inscreve por DID.
 msgid "Standard Reader meets you where you read"
 msgstr "O Standard Reader vai ter consigo onde quer que leia"
 
+#: src/components/appearance-settings.tsx
+msgid "Reset appearance"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/reader/markdown-field.tsx
 #: src/components/reading-settings-preview.tsx
@@ -3442,6 +3585,10 @@ msgstr "Pesquisar rotuladores"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · O seu feed"
 
+#: src/components/reader/format-i18n.ts
+msgid "yesterday"
+msgstr ""
+
 #: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Use publication themes"
@@ -3459,6 +3606,7 @@ msgstr "O DID do serviço é <0>{appviewDid}</0>. O serviço divulga um <1>docum
 msgid "The Slow Web, Revisited"
 msgstr "A Slow Web, Revisitada"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reading-custom-font-picker.tsx
 #: src/components/user-settings-view.tsx
 msgid "Google Font"
@@ -3554,6 +3702,10 @@ msgstr "Pesquisar feedback"
 msgid "Unsubscribe"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "L"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "Load more ({remainingPublications} remaining)"
 msgstr "Carregar mais ({remainingPublications} restantes)"
@@ -3606,6 +3758,10 @@ msgstr "Copiar código de incorporação"
 #: src/components/user-settings-view.tsx
 msgid "Delete all lists?"
 msgstr "Apagar todas as listas?"
+
+#: src/components/user-settings-view.tsx
+msgid "Advanced"
+msgstr ""
 
 #: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
@@ -3669,6 +3825,10 @@ msgstr "Reproduzir"
 #: src/routes/_layout.search.tsx
 msgid "Loading article matches"
 msgstr "Carregando artigos correspondentes"
+
+#: src/components/appearance-settings.tsx
+msgid "Extra small"
+msgstr ""
 
 #: src/components/reader/content/renderers/leaflet-standard-site-publication.tsx
 msgid "Publication not found."
@@ -3738,6 +3898,10 @@ msgstr "Comportamento"
 msgid "Reading history"
 msgstr "Histórico de leitura"
 
+#: src/components/appearance-settings.tsx
+msgid "M"
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>2. Serve labels.</0> Sign and emit <1>com.atproto.label.defs#label</1> objects, and expose the standard <2>com.atproto.label.queryLabels</2> (HTTP) and <3>com.atproto.label.subscribeLabels</3> (WebSocket) endpoints."
 msgstr "<0>2. Servir rótulos.</0> Assine e emita objetos <1>com.atproto.label.defs#label</1> e exponha os endpoints padrão <2>com.atproto.label.queryLabels</2> (HTTP) e <3>com.atproto.label.subscribeLabels</3> (WebSocket)."
@@ -3800,6 +3964,10 @@ msgstr "Nenhuma publicação nesta lista — adicione algumas na janela de ediç
 #: src/components/reader/subscribe-card.tsx
 msgid "Adding {publicationName} to your feed."
 msgstr "Adicionando {publicationName} ao seu feed."
+
+#: src/components/appearance-settings.tsx
+#~ msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors and checked for contrast."
+#~ msgstr ""
 
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/app-shell.tsx
@@ -3956,6 +4124,10 @@ msgstr "O início de sessão e o acesso aos registos passam pelo seu Personal Da
 msgid "An included article"
 msgstr "Um artigo incluído"
 
+#: src/components/appearance-settings.tsx
+msgid "Puts the palette, font, size, roundness and density back to their defaults."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Subscribe to labelers to flag, blur, or hide content as you read."
 msgstr "Inscreva-se em rotuladores para rotular, desfocar ou ocultar conteúdo enquanto lê."
@@ -4013,6 +4185,7 @@ msgstr "{weekday} · Em toda a rede"
 msgid "Publish & share the run"
 msgstr "Publicar e compartilhar a edição"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-builder.tsx
 msgid "Editorial"
 msgstr "Editorial"
@@ -4175,6 +4348,10 @@ msgstr ""
 msgid "Open on {publicationName}"
 msgstr "Abrir em {publicationName}"
 
+#: src/components/appearance-settings.tsx
+msgid "Sans"
+msgstr ""
+
 #: src/components/reader/add-publication-modal.tsx
 msgid "Search publications or paste a handle"
 msgstr "Pesquise publicações ou cole um identificador"
@@ -4299,6 +4476,10 @@ msgstr "Ler em voz alta"
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "Artigos que salvou para mais tarde — no seu repositório, sincronizados entre dispositivos."
 
+#: src/components/reader/format-i18n.ts
+msgid "today"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 #: src/components/reader/content/renderers/shared/image-figure.tsx
 #: src/components/reader/content/renderers/shared/markdown-article.tsx
@@ -4406,6 +4587,7 @@ msgstr "Filtrar por tópico"
 msgid "No unread articles from your follows right now."
 msgstr "De momento não há artigos por ler das publicações que segue."
 
+#: src/components/appearance-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Search and pick any family from the Google Fonts catalog."
 msgstr "Pesquise e escolha qualquer família do catálogo das Fontes do Google."
@@ -4534,6 +4716,10 @@ msgstr "<0>Quando inicia sessão</0> com a sua conta da Atmosfera (por exemplo v
 msgid "Powered by <0>Standard Reader</0>"
 msgstr "Com tecnologia <0>Standard Reader</0>"
 
+#: src/components/appearance-settings.tsx
+msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Save from anywhere you browse"
 msgstr "Salve a partir de qualquer lugar que navegue"
@@ -4651,6 +4837,10 @@ msgstr "Começar"
 msgid "You don't have any content tabs to show yet."
 msgstr "Ainda não tem separadores de conteúdo para mostrar."
 
+#: src/components/appearance-settings.tsx
+msgid "Body text on paper"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "OK"
 msgstr "OK"
@@ -4719,6 +4909,10 @@ msgstr "@{0} · Tem documentos mas nenhuma publicação"
 msgid "{connectionLabel} via Semble"
 msgstr "{connectionLabel} via Semble"
 
+#: src/components/appearance-settings.tsx
+msgid "S"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "In this issue"
 msgstr "Nesta edição"
@@ -4730,3 +4924,7 @@ msgstr ""
 #: src/components/reader/terms-view.tsx
 msgid "Acceptable use"
 msgstr "Uso aceitável"
+
+#: src/components/appearance-settings.tsx
+msgid "Palette"
+msgstr ""

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -239,6 +239,10 @@ msgstr ""
 msgid "Opening the collection…"
 msgstr "正在打开合集…"
 
+#: src/components/appearance-settings.tsx
+msgid "Density"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Open on publication"
 msgstr "在刊物中打开"
@@ -280,6 +284,7 @@ msgstr "提交反馈"
 msgid "<0>Session cookie.</0> After you sign in through the web app, the extension background worker reads your HttpOnly session cookie on {siteHost} to authenticate API requests. Content scripts do not read this cookie directly."
 msgstr "<0>会话 Cookie。</0>你通过网页应用登录后，扩展的后台工作线程会读取 {siteHost} 上的 HttpOnly 会话 Cookie 来验证 API 请求。内容脚本不会直接读取该 Cookie。"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/user-settings-view.tsx
 msgid "Light"
@@ -318,9 +323,17 @@ msgstr ""
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 msgstr ""
 
+#: src/components/reader/format-i18n.ts
+msgid "{years}y ago"
+msgstr ""
+
 #: src/components/reader/reorder-lists-modal.tsx
 msgid "List"
 msgstr "列表"
+
+#: src/components/appearance-settings.tsx
+msgid "The spacing between things — tighter for more on screen, looser for more room to read."
+msgstr ""
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Sign in to run this example (curl uses Bearer $ACCESS_TOKEN)."
@@ -349,6 +362,10 @@ msgstr "为系列命名并选择主题"
 #: src/components/docs/docs-labelers-nav.tsx
 #: src/components/docs/labelers-docs-page.tsx
 msgid "Reference implementation"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Extra large"
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
@@ -453,6 +470,10 @@ msgstr "永久删除存储在你账户中的数据。这些操作会从你的账
 msgid "Loading people"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "Links and labels on paper"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Read the piece →"
 msgstr "阅读全文 →"
@@ -493,6 +514,10 @@ msgstr "登录后可关注刊物"
 #: src/routes/_layout.discover.tsx
 msgid "Search publications"
 msgstr "搜索刊物"
+
+#: src/components/appearance-settings.tsx
+msgid "Small"
+msgstr ""
 
 #: src/routes/_layout.search.tsx
 msgid "Publications, handles, #tags, headlines…"
@@ -767,6 +792,7 @@ msgstr "讨论"
 msgid "Content label"
 msgstr "内容标签"
 
+#: src/components/appearance-settings.tsx
 #: src/components/ReadingTypographyMenu.tsx
 #: src/components/user-settings-view.tsx
 msgid "Text size"
@@ -833,6 +859,11 @@ msgstr "尚无已索引的文章。"
 msgid "{0} added to {listName}."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+#: src/components/user-settings-view.tsx
+msgid "Custom"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Read the API docs"
 msgstr "阅读 API 文档"
@@ -868,6 +899,10 @@ msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "For more about how {SITE_NAME} works, see the <0>About</0> page. For questions about these terms for this deployment, contact the operator of the site at the URL above."
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Compact"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -931,6 +966,10 @@ msgstr "{documentCount, plural, one {文档} other {文档}}"
 msgid "Publishing"
 msgstr "发布"
 
+#: src/components/appearance-settings.tsx
+msgid "Roundness"
+msgstr ""
+
 #: src/components/docs/introduction-docs-page.tsx
 msgid "public XRPC queries and procedures for the Standard Reader read-model, with live examples."
 msgstr ""
@@ -971,6 +1010,10 @@ msgstr "仅当该文档属于某个刊物记录时，才加入 <0>site.standard.
 #: src/components/reader/about-view.tsx
 msgid "Your week"
 msgstr "你的一周"
+
+#: src/components/appearance-settings.tsx
+msgid "Relaxed"
+msgstr ""
 
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.recommended.tsx
@@ -1013,6 +1056,10 @@ msgstr "关闭"
 msgid "Run example"
 msgstr "运行示例"
 
+#: src/components/appearance-settings.tsx
+msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "When on, collection posts open in the magazine edition instead of the reader view."
 msgstr "开启后，合集帖子将以杂志版式打开，而非阅读视图。"
@@ -1047,6 +1094,10 @@ msgstr "问题"
 #: src/components/reader/list-edit-modal.tsx
 msgid "Choose an item to add to the list"
 msgstr "选择要加入列表的条目"
+
+#: src/components/appearance-settings.tsx
+msgid "Soft"
+msgstr ""
 
 #: src/magazine/magazine-end-subscribe.tsx
 msgid "Subscribed to list"
@@ -1110,9 +1161,18 @@ msgstr "这个列表关于什么（显示在其公开页面上）"
 msgid "Delete collection"
 msgstr "删除合集"
 
+#: src/components/appearance-settings.tsx
+msgid "Interface font"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No publications in this list."
 msgstr "此列表中没有刊物。"
+
+#. placeholder {0}: palette.name
+#: src/components/appearance-settings.tsx
+msgid "{0}, dark"
+msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Loading collections…"
@@ -1130,6 +1190,10 @@ msgstr "浏览标注服务"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We do not run a separate analytics pipeline inside the extension."
 msgstr "我们不在扩展内运行独立的分析管道。"
+
+#: src/components/appearance-settings.tsx
+#~ msgid "Text, borders and every other step are derived from these two colors and checked for contrast."
+#~ msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Remove list"
@@ -1436,6 +1500,7 @@ msgstr "{durationMs}ms · 获取于 {fetchedAt}"
 msgid "Loading feedback"
 msgstr "正在加载反馈"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Accent"
 msgstr "强调色"
@@ -1483,6 +1548,10 @@ msgstr "添加到 Chrome"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Leaflet, Pckt, Offprint.</0> <1>pub.leaflet.content</1>, <2>blog.pckt.content</2>, and <3>app.offprint.content</3> — the block-based formats those tools write natively."
 msgstr "<0>Leaflet、Pckt、Offprint。</0> <1>pub.leaflet.content</1>、<2>blog.pckt.content</2> 和 <3>app.offprint.content</3> —— 这些工具原生写入的块结构格式。"
+
+#: src/components/appearance-settings.tsx
+msgid "XL"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Set your own type"
@@ -1638,6 +1707,10 @@ msgstr "切换到阅读视图"
 msgid "<0>3. Declare your label values.</0> Describe each value (severity, default warn/hide, blur behavior) in an <1>app.standard-reader.labeler.service</1> descriptor, served from <2>app.standard-reader.labeler.getServices</2> (a <3>did:web</3> labeler has no repo to hold the record)."
 msgstr "<0>3. 声明你的标签取值。</0> 在 <1>app.standard-reader.labeler.service</1> 描述文件中说明每个取值（严重程度、默认警告/隐藏、模糊行为），并通过 <2>app.standard-reader.labeler.getServices</2> 提供（<3>did:web</3> 标注服务没有仓库来存放该记录）。"
 
+#: src/components/reader/format-i18n.ts
+msgid "{months}mo ago"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "To email your digest, Standard Reader needs your account email address. We'll ask your PDS to share it — you'll be sent to your login to approve the request, then brought right back here. Your email is used only to send the weekly digest, and you can turn it off any time."
 msgstr "要给你发送每周摘要，Standard Reader 需要你的账号邮箱地址。我们会向你的 PDS 请求共享——你将前往登录页批准该请求，随后自动返回此处。你的邮箱仅用于发送每周摘要，你可以随时关闭。"
@@ -1713,6 +1786,10 @@ msgstr ""
 msgid "Every unread article from this publication will be marked read. This can’t be undone."
 msgstr "该刊物的所有未读文章都将标记为已读。此操作无法撤销。"
 
+#: src/components/appearance-settings.tsx
+msgid "Your own colors"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
 msgstr "正在设置该期…"
@@ -1765,6 +1842,11 @@ msgstr "{pubTotal, plural, one {# 个刊物} other {# 个刊物}}"
 msgid "Nothing new today"
 msgstr ""
 
+#. placeholder {0}: palette.name
+#: src/components/appearance-settings.tsx
+msgid "{0}, light"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Background"
 msgstr "背景"
@@ -1784,6 +1866,10 @@ msgstr "来自你的订阅"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>When you browse without signing in,</0> we serve public writing from our read-model index. We may store a theme preference cookie and, if you have signed in before on this device, a short list of recently used account handles (and optional avatar URLs) to speed up sign-in. We do not require an account to read."
 msgstr "<0>当你未登录浏览时，</0>我们从读模型索引提供公开文章。我们可能会存储主题偏好 cookie；如果你此前在本设备登录过，还会存储一份最近使用的账号 handle 简表（以及可选的头像 URL），以加快登录。阅读无需账号。"
+
+#: src/components/appearance-settings.tsx
+msgid "Paper"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
@@ -2235,8 +2321,8 @@ msgid "by @{ownerHandle}"
 msgstr "作者 @{ownerHandle}"
 
 #: src/components/user-settings-view.tsx
-msgid "Choose light, dark, or match your system setting."
-msgstr "选择浅色、深色，或跟随系统设置。"
+#~ msgid "Choose light, dark, or match your system setting."
+#~ msgstr "选择浅色、深色，或跟随系统设置。"
 
 #. placeholder {0}: rows.length
 #: src/components/reader/subscriptions-table.tsx
@@ -2254,6 +2340,10 @@ msgstr "完成"
 #: src/routes/_layout.index.tsx
 msgid "The latest long-form writing from across the network."
 msgstr "来自整个网络的最新长文。"
+
+#: src/components/appearance-settings.tsx
+msgid "Sets the app's colors — and, because the page color decides it, whether the app reads light or dark."
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "{subscribedCount} unread across the publications you subscribe to."
@@ -2291,6 +2381,10 @@ msgstr "你已订阅 {publicationName}。新内容会出现在你的信息流中
 msgid "The directory"
 msgstr "目录"
 
+#: src/components/appearance-settings.tsx
+#~ msgid "Your accent sits close to the paper in tone, so a darkened version of it is used for text and links."
+#~ msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Trending this week"
 msgstr "本周热门"
@@ -2319,6 +2413,10 @@ msgstr "还没有列表"
 #: src/routes/_layout.discover.tsx
 msgid "Browse everything"
 msgstr "浏览全部"
+
+#: src/components/appearance-settings.tsx
+msgid "Large"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
@@ -2476,6 +2574,10 @@ msgstr ""
 msgid "The most-read writing across the network right now."
 msgstr "当下整个网络阅读量最高的文章。"
 
+#: src/components/appearance-settings.tsx
+msgid "The typeface used across the app. Article text follows this too, unless you set a reading font below."
+msgstr ""
+
 #: src/magazine/magazine-end-like.tsx
 msgid "Recommend this issue"
 msgstr "推荐本期"
@@ -2491,6 +2593,10 @@ msgstr "{count, plural, one {# 次赞同} other {# 次赞同}}——点击撤销
 #: src/routes/_layout.search.tsx
 msgid "{shown} of {total} matches"
 msgstr "{total} 个匹配项中的 {shown} 个"
+
+#: src/components/appearance-settings.tsx
+msgid "How rounded buttons, cards and inputs are."
+msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
 msgid "What is this series about?"
@@ -2523,6 +2629,10 @@ msgstr ""
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler didn’t publish any label definitions."
 msgstr "该标注服务未发布任何标签定义。"
+
+#: src/components/reader/format-i18n.ts
+msgid "{days}d ago"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Continue to approve"
@@ -2570,6 +2680,10 @@ msgstr "于是我们做了自己想要的阅读器：可调宽度的正文栏、
 #: src/routes/_layout.recommended.tsx
 msgid "Recommended articles"
 msgstr "推荐文章"
+
+#: src/components/user-settings-view.tsx
+msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labeler views"
@@ -2654,6 +2768,10 @@ msgstr "版本记录"
 msgid "Reader voice"
 msgstr "朗读音色"
 
+#: src/components/appearance-settings.tsx
+msgid "Sharp"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "What you get is a reading view made for long-form: a centered column, drop caps and pull quotes, full-bleed images you can open into a gallery. The page gets out of the way so the writing can do its work."
 msgstr "你得到的是一个为长文而生的阅读视图：居中的正文栏、首字下沉与引文块、可展开为画廊的通栏大图。页面退到一旁，让文字自己发声。"
@@ -2703,6 +2821,10 @@ msgstr "该链接已过期。"
 #: src/components/reader/privacy-view.tsx
 msgid "You can sign out at any time, which clears your app session cookie. You can clear site cookies in your browser to remove theme and saved-handle preferences. You can change reading-history tracking and delete personal data from Settings. To remove other AT Protocol records you created through the app, use a compatible client or your repository tools."
 msgstr "你可以随时退出登录，这会清除应用的会话 Cookie。在浏览器中清除站点 Cookie 可移除主题和已保存的账号偏好。你可以在设置中更改阅读历史记录并删除个人数据。若要移除你通过本应用创建的其他 AT Protocol 记录，请使用兼容的客户端或你的仓库工具。"
+
+#: src/components/appearance-settings.tsx
+msgid "XS"
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
@@ -2884,6 +3006,10 @@ msgstr ""
 msgid "Share on Bluesky"
 msgstr "分享到 Bluesky"
 
+#: src/components/appearance-settings.tsx
+msgid "Reset"
+msgstr ""
+
 #: src/components/docs/docs-lexicons-nav.tsx
 #~ msgid "Lexicon reference"
 #~ msgstr "Lexicon 参考"
@@ -2939,6 +3065,10 @@ msgstr "汇集在一起的讨论"
 msgid "Mark all as read"
 msgstr "全部标记为已读"
 
+#: src/components/appearance-settings.tsx
+msgid "Scales every size in the app, article text included — from 14px up to 24px of interface text."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "Your display name, handle, avatar URL, and DID as returned by your account provider."
 msgstr "由你的账号服务商返回的显示名称、handle、头像 URL 和 DID。"
@@ -2970,6 +3100,10 @@ msgstr "分享到其他客户端"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "What the extension does not do"
 msgstr "扩展不会做什么"
+
+#: src/components/appearance-settings.tsx
+msgid "Default"
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Loading recommendations"
@@ -3100,6 +3234,10 @@ msgstr "（需要 {min}:1）"
 msgid "Every read record in your repository will be removed. Articles will appear unread again across the app. This cannot be undone."
 msgstr "你仓库中的所有已读记录都将被移除。文章会在整个应用中重新显示为未读。此操作无法撤销。"
 
+#: src/components/appearance-settings.tsx
+msgid "Text, borders and every other step are derived from these two colors."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "如果你安装了 {SITE_NAME} 浏览器扩展，它会使用与本站相同的账号和会话 cookie。扩展会将页面 URL 发送到我们的 <0>/api/extension/*</0> 端点用于索引匹配，并将浮层设置保存在浏览器的扩展存储中。详情请参阅仅适用于扩展的<1>扩展隐私政策</1>。"
@@ -3149,6 +3287,7 @@ msgstr ""
 msgid "Unfollowing {peopleCount, plural, one {this person} other {these # people}} also drops the subscriptions that follow created, so their publications leave your feed. Nothing you have saved, read, or recommended is affected."
 msgstr ""
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/user-settings-view.tsx
 msgid "Dark"
@@ -3369,6 +3508,10 @@ msgstr "标注服务是你通过 DID 订阅的审核服务。订阅后，你在�
 msgid "Standard Reader meets you where you read"
 msgstr "Standard Reader 随你所读之处而至"
 
+#: src/components/appearance-settings.tsx
+msgid "Reset appearance"
+msgstr ""
+
 #: src/components/reader/collection-theme-editor.tsx
 #: src/components/reader/markdown-field.tsx
 #: src/components/reading-settings-preview.tsx
@@ -3442,6 +3585,10 @@ msgstr "搜索标注服务"
 msgid "{weekday} · Your feed"
 msgstr "{weekday} · 你的信息流"
 
+#: src/components/reader/format-i18n.ts
+msgid "yesterday"
+msgstr ""
+
 #: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Use publication themes"
@@ -3459,6 +3606,7 @@ msgstr "服务 DID 是 <0>{appviewDid}</0>。该服务为需要协商 scope 的�
 msgid "The Slow Web, Revisited"
 msgstr "重访慢速网络"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reading-custom-font-picker.tsx
 #: src/components/user-settings-view.tsx
 msgid "Google Font"
@@ -3554,6 +3702,10 @@ msgstr "搜索反馈"
 msgid "Unsubscribe"
 msgstr ""
 
+#: src/components/appearance-settings.tsx
+msgid "L"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "Load more ({remainingPublications} remaining)"
 msgstr "加载更多（还剩 {remainingPublications} 个）"
@@ -3606,6 +3758,10 @@ msgstr "复制嵌入代码"
 #: src/components/user-settings-view.tsx
 msgid "Delete all lists?"
 msgstr "删除所有列表？"
+
+#: src/components/user-settings-view.tsx
+msgid "Advanced"
+msgstr ""
 
 #: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
@@ -3669,6 +3825,10 @@ msgstr "播放"
 #: src/routes/_layout.search.tsx
 msgid "Loading article matches"
 msgstr "正在加载匹配的文章"
+
+#: src/components/appearance-settings.tsx
+msgid "Extra small"
+msgstr ""
 
 #: src/components/reader/content/renderers/leaflet-standard-site-publication.tsx
 msgid "Publication not found."
@@ -3738,6 +3898,10 @@ msgstr "行为"
 msgid "Reading history"
 msgstr "阅读历史"
 
+#: src/components/appearance-settings.tsx
+msgid "M"
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>2. Serve labels.</0> Sign and emit <1>com.atproto.label.defs#label</1> objects, and expose the standard <2>com.atproto.label.queryLabels</2> (HTTP) and <3>com.atproto.label.subscribeLabels</3> (WebSocket) endpoints."
 msgstr "<0>2. 提供标签。</0>签发并输出 <1>com.atproto.label.defs#label</1> 对象，并暴露标准的 <2>com.atproto.label.queryLabels</2>（HTTP）和 <3>com.atproto.label.subscribeLabels</3>（WebSocket）端点。"
@@ -3800,6 +3964,10 @@ msgstr "此列表中没有刊物——在编辑对话框中添加一些。"
 #: src/components/reader/subscribe-card.tsx
 msgid "Adding {publicationName} to your feed."
 msgstr "正在将 {publicationName} 添加到你的信息流。"
+
+#: src/components/appearance-settings.tsx
+#~ msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors and checked for contrast."
+#~ msgstr ""
 
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/app-shell.tsx
@@ -3956,6 +4124,10 @@ msgstr "登录和记录访问都经由你的 Personal Data Server 以及更广�
 msgid "An included article"
 msgstr "收录的一篇文章"
 
+#: src/components/appearance-settings.tsx
+msgid "Puts the palette, font, size, roundness and density back to their defaults."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Subscribe to labelers to flag, blur, or hide content as you read."
 msgstr "订阅标注服务，在阅读时标记、模糊或隐藏内容。"
@@ -4013,6 +4185,7 @@ msgstr "{weekday} · 全网"
 msgid "Publish & share the run"
 msgstr "发布并分享此次运行"
 
+#: src/components/appearance-settings.tsx
 #: src/components/reader/collection-builder.tsx
 msgid "Editorial"
 msgstr "编辑部"
@@ -4175,6 +4348,10 @@ msgstr ""
 msgid "Open on {publicationName}"
 msgstr "在 {publicationName} 中打开"
 
+#: src/components/appearance-settings.tsx
+msgid "Sans"
+msgstr ""
+
 #: src/components/reader/add-publication-modal.tsx
 msgid "Search publications or paste a handle"
 msgstr "搜索刊物或粘贴 handle"
@@ -4299,6 +4476,10 @@ msgstr "朗读"
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "你稍后再读的文章——存放在你的仓库中，跨设备同步。"
 
+#: src/components/reader/format-i18n.ts
+msgid "today"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 #: src/components/reader/content/renderers/shared/image-figure.tsx
 #: src/components/reader/content/renderers/shared/markdown-article.tsx
@@ -4406,6 +4587,7 @@ msgstr "按话题筛选"
 msgid "No unread articles from your follows right now."
 msgstr "你关注的刊物暂无未读文章。"
 
+#: src/components/appearance-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Search and pick any family from the Google Fonts catalog."
 msgstr "在 Google Fonts 目录中搜索并选择任意字体。"
@@ -4534,6 +4716,10 @@ msgstr "<0>当你使用 Atmosphere 账户登录时</0>（例如通过 Bluesky OA
 msgid "Powered by <0>Standard Reader</0>"
 msgstr "由 <0>Standard Reader</0> 提供支持"
 
+#: src/components/appearance-settings.tsx
+msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Save from anywhere you browse"
 msgstr "在任何浏览的地方随手保存"
@@ -4651,6 +4837,10 @@ msgstr "开始使用"
 msgid "You don't have any content tabs to show yet."
 msgstr "你还没有可显示的内容标签页。"
 
+#: src/components/appearance-settings.tsx
+msgid "Body text on paper"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "OK"
 msgstr "好"
@@ -4719,6 +4909,10 @@ msgstr "@{0} · 有文档但没有刊物"
 msgid "{connectionLabel} via Semble"
 msgstr "{connectionLabel}（通过 Semble）"
 
+#: src/components/appearance-settings.tsx
+msgid "S"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "In this issue"
 msgstr "本期内容"
@@ -4729,4 +4923,8 @@ msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Acceptable use"
+msgstr ""
+
+#: src/components/appearance-settings.tsx
+msgid "Palette"
 msgstr ""

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -16,11 +16,12 @@ import { I18nProvider as AriaI18nProvider } from "react-aria-components";
 
 import { NavTelemetry } from "../components/nav-telemetry";
 import {
-  editorialFonts,
-  editorialPrimary,
-  editorialShadow,
-  editorialUi,
-} from "../components/reader/theme";
+  APPEARANCE_SCALE_THEMES,
+  interfaceFontTheme,
+  paletteThemes,
+} from "../components/reader/appearance-themes";
+import { appearanceStyleVars } from "../components/reader/appearance-vars";
+import { editorialFonts, editorialShadow } from "../components/reader/theme";
 import { uiColor } from "../design-system/theme/color.stylex";
 import { ui } from "../design-system/theme/semantic-color.stylex";
 import { PlausibleAnalytics } from "../integrations/plausible/analytics";
@@ -30,6 +31,12 @@ import {
   savedListsQueryOptions,
   sidebarQueryOptions,
 } from "../integrations/tanstack-query/shell-queries";
+import {
+  DEFAULT_APPEARANCE,
+  appearanceScheme,
+  appearanceThemeColor,
+} from "../lib/appearance";
+import { googleFontsStylesheetUrl } from "../lib/google-fonts";
 import { i18nForLocale } from "../lib/i18n";
 import { intlLocale } from "../lib/locale";
 import { getPublicUrlClient } from "../lib/public-url";
@@ -53,10 +60,28 @@ interface RouterContext {
   queryClient: QueryClient;
 }
 
+/**
+ * The text-size dial as a root font-size multiplier.
+ *
+ * Scaling `html` reaches every rem in the app — type, spacing, radii, control
+ * boxes and the fixed widths of the shell — rather than only the tokens we
+ * remembered to route through a multiplier. Media queries are unaffected: they
+ * resolve against the initial font size, so breakpoints stay where they are and
+ * the layout switches at the same viewport width at every text size.
+ */
+const TEXT_SCALE_CSS = `
+html { font-size: calc(100% * var(--sr-text-scale, 1)); }
+`.trim();
+
+// A custom palette states its own scheme (its paper decides), so it pins
+// `color-scheme` rather than tracking the OS — that pin is also what resolves
+// every `light-dark()` in the Radix scales a curated palette is built from.
 const COLOR_SCHEME_CSS = `
 html[data-theme="light"] { color-scheme: light; }
 html[data-theme="dark"] { color-scheme: dark; }
 html[data-theme="system"] { color-scheme: light; }
+html[data-theme="custom"] { color-scheme: light; }
+html[data-theme="custom"][data-palette-scheme="dark"] { color-scheme: dark; }
 @media (prefers-color-scheme: dark) {
   html[data-theme="system"] { color-scheme: dark; }
 }
@@ -174,6 +199,13 @@ export const Route = createRootRouteWithContext<RouterContext>()({
       user.getReadingTypographyPreferenceQueryOptions.queryKey,
       bootstrap.readingTypography,
     );
+    // Seeded here so the palette, its scheme and the dial multipliers are known
+    // during SSR — without this the shell paints the default theme first and
+    // swaps once the client query lands.
+    context.queryClient.setQueryData(
+      user.getAppearancePreferenceQueryOptions.queryKey,
+      bootstrap.appearance,
+    );
     context.queryClient.setQueryData(
       user.getUsePublicationThemePreferenceQueryOptions.queryKey,
       bootstrap.usePublicationTheme,
@@ -263,14 +295,41 @@ function RootDocument({ children }: { children: React.ReactNode }) {
     refetchOnWindowFocus: false,
   });
   const themeMode = themePreference?.mode ?? DEFAULT_THEME_MODE;
+  // Seeded by the same shell bootstrap as the theme mode, so the palette, its
+  // scheme, and the dial multipliers are all known during SSR — the custom
+  // theme paints on the first frame with no flash of the editorial one.
+  const { data: appearanceData } = useQuery({
+    ...user.getAppearancePreferenceQueryOptions,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+  });
+  const appearance = appearanceData?.preference ?? DEFAULT_APPEARANCE;
+  const isCustomTheme = themeMode === "custom";
+  const paletteScheme = appearanceScheme(appearance);
+  const appearanceVars = appearanceStyleVars(appearance, {
+    includePalette: isCustomTheme,
+  });
+  const customUiFontUrl =
+    appearance.font === "custom" && appearance.customFontFamily
+      ? googleFontsStylesheetUrl(appearance.customFontFamily)
+      : null;
+  const fontTheme = interfaceFontTheme(appearance.font);
   // Resolved server-side (DB -> cookie -> Accept-Language) and hydrated with
   // the shell bootstrap, so `lang`/`dir` are correct on the first paint and
   // there is no flash of mis-directed layout.
   const { locale, direction } = useLocale();
   // SSR can't see the OS preference, so "system" defaults to light for the
   // initial paint; RESOLVED_SCHEME_SCRIPT corrects it synchronously before the
-  // first paint, and the effect below keeps it in sync afterwards.
-  const ssrScheme = themeMode === "dark" ? "dark" : "light";
+  // first paint, and the effect below keeps it in sync afterwards. A custom
+  // palette needs no correcting — it carries its own scheme.
+  const ssrScheme = isCustomTheme
+    ? paletteScheme
+    : themeMode === "dark"
+      ? "dark"
+      : "light";
+  const themeColor = isCustomTheme
+    ? appearanceThemeColor(appearance)
+    : THEME_COLOR_BY_SCHEME[ssrScheme];
 
   // Keep the title-bar color on the *resolved* scheme as the user toggles theme
   // (or, in "system" mode, as the OS preference flips) without a reload.
@@ -278,6 +337,11 @@ function RootDocument({ children }: { children: React.ReactNode }) {
     if (globalThis.window === undefined) return;
     const query = globalThis.matchMedia("(prefers-color-scheme: dark)");
     const apply = () => {
+      const meta = document.querySelector('meta[name="theme-color"]');
+      if (themeMode === "custom") {
+        meta?.setAttribute("content", themeColor);
+        return;
+      }
       const resolved =
         themeMode === "dark"
           ? "dark"
@@ -286,29 +350,49 @@ function RootDocument({ children }: { children: React.ReactNode }) {
             : query.matches
               ? "dark"
               : "light";
-      const meta = document.querySelector('meta[name="theme-color"]');
       meta?.setAttribute("content", THEME_COLOR_BY_SCHEME[resolved]);
     };
     apply();
     if (themeMode !== "system") return;
     query.addEventListener("change", apply);
     return () => query.removeEventListener("change", apply);
-  }, [themeMode]);
+  }, [themeMode, themeColor]);
 
   return (
     <html
       lang={locale}
       dir={direction}
       data-theme={themeMode}
+      data-palette-scheme={isCustomTheme ? paletteScheme : undefined}
+      data-theme-color={isCustomTheme ? themeColor : undefined}
       data-embed={isSubscribeEmbed ? "subscribe" : undefined}
+      // The spacing / radius / control-size themes belong HERE, not on <body>.
+      // The semantic scales are declared as `--gap-md: var(--spacing-2)` at
+      // `:root`, and a custom property's value is resolved on the element that
+      // declares it — so overriding `--spacing-*` further down the tree changes
+      // padding that reads a spacing token directly, while every `gap`,
+      // `horizontalSpace` and `verticalSpace` keeps the value it already
+      // computed at the root. Applied on the same element, the override lands
+      // before those scales resolve and the whole spacing system moves with it.
+      {...stylex.props(isSubscribeEmbed ? undefined : APPEARANCE_SCALE_THEMES)}
+      style={isSubscribeEmbed ? undefined : appearanceVars}
       suppressHydrationWarning
     >
       <head>
         {/* Browser/PWA title-bar color. A single meta (no media query) whose
             content tracks the *resolved* scheme — set pre-paint by
             RESOLVED_SCHEME_SCRIPT and kept in sync by useThemeColorMeta — so an
-            explicit in-app light/dark override wins over the OS preference. */}
-        <meta name="theme-color" content={THEME_COLOR_BY_SCHEME[ssrScheme]} />
+            explicit in-app light/dark override wins over the OS preference. A
+            custom palette supplies its own page color instead. */}
+        <meta name="theme-color" content={themeColor} />
+        {customUiFontUrl ? (
+          <link
+            rel="stylesheet"
+            href={customUiFontUrl}
+            referrerPolicy="no-referrer"
+          />
+        ) : null}
+        <style dangerouslySetInnerHTML={{ __html: TEXT_SCALE_CSS }} />
         <style dangerouslySetInnerHTML={{ __html: COLOR_SCHEME_CSS }} />
         <script
           dangerouslySetInnerHTML={{ __html: EMBED_SUBSCRIBE_PATH_SCRIPT }}
@@ -321,9 +405,14 @@ function RootDocument({ children }: { children: React.ReactNode }) {
           isSubscribeEmbed
             ? rootStyles.embedShellBody
             : [
-                editorialUi,
-                editorialPrimary,
-                editorialFonts,
+                // One theme per token group: the palette replaces the editorial
+                // colors outright rather than layering over them, and the
+                // interface font (when the reader picked one) replaces the
+                // editorial stack the same way.
+                ...paletteThemes(
+                  isCustomTheme ? appearance.palette : "almanac",
+                ),
+                fontTheme ?? editorialFonts,
                 editorialShadow,
                 ui.bg,
                 ui.text,

--- a/src/routes/_layout.l.$did.$rkey.tsx
+++ b/src/routes/_layout.l.$did.$rkey.tsx
@@ -157,7 +157,7 @@ const styles = stylex.create({
     rowGap: spacing["4"],
     marginInlineStart: "auto",
     marginInlineEnd: "auto",
-    maxWidth: "1320px",
+    maxWidth: "82.5rem",
     paddingBottom: spacing["0"],
     paddingInlineStart: {
       default: spacing["5"],
@@ -174,7 +174,7 @@ const styles = stylex.create({
     flexBasis: "0%",
     flexGrow: 1,
     flexShrink: 1,
-    minWidth: "240px",
+    minWidth: "15rem",
     paddingTop: spacing["0.5"],
   },
   heroName: {
@@ -250,7 +250,7 @@ const styles = stylex.create({
     boxSizing: "border-box",
     marginInlineStart: "auto",
     marginInlineEnd: "auto",
-    maxWidth: "1320px",
+    maxWidth: "82.5rem",
     paddingInlineStart: {
       default: spacing["5"],
       "@media (min-width: 40rem)": spacing["10"],

--- a/src/routes/_layout.p.$did.$rkey.tsx
+++ b/src/routes/_layout.p.$did.$rkey.tsx
@@ -38,6 +38,7 @@ import {
   formatReaders,
   publicationUriFromParams,
 } from "../components/reader/format";
+import { formatLastActive } from "../components/reader/format-i18n";
 import {
   Handle,
   PublicationAvatar,
@@ -221,7 +222,7 @@ const styles = stylex.create({
     rowGap: spacing["4"],
     marginInlineStart: "auto",
     marginInlineEnd: "auto",
-    maxWidth: "1320px",
+    maxWidth: "82.5rem",
     paddingBottom: spacing["6"],
     paddingInlineStart: {
       default: spacing["5"],
@@ -252,7 +253,7 @@ const styles = stylex.create({
     flexBasis: "0%",
     flexGrow: 1,
     flexShrink: 1,
-    minWidth: "200px",
+    minWidth: "12.5rem",
     paddingTop: spacing["0.5"],
   },
   heroName: {
@@ -437,22 +438,6 @@ const styles = stylex.create({
   },
 });
 
-type TFunction = ReturnType<typeof useLingui>["t"];
-
-function lastActive(iso: string | null, t: TFunction): string {
-  if (!iso) return "—";
-  const parsed = Date.parse(iso);
-  if (Number.isNaN(parsed)) return "—";
-  const days = Math.floor((Date.now() - parsed) / 86_400_000);
-  if (days <= 0) return t`today`;
-  if (days === 1) return t`yesterday`;
-  if (days < 30) return t`${days}d ago`;
-  const months = Math.floor(days / 30);
-  if (days < 365) return t`${months}mo ago`;
-  const years = Math.floor(days / 365);
-  return t`${years}y ago`;
-}
-
 function Stat({
   value,
   label,
@@ -632,7 +617,7 @@ function PublicationProfileContent({
   embedMeta: PublicationEmbedMeta | null | undefined;
   socialProof: PublicationSocialProof | undefined;
 }) {
-  const { t } = useLingui();
+  const { t, i18n } = useLingui();
   const { publication: pub, owner } = header;
   const queryClient = useQueryClient();
   const { data: session } = useSuspenseQuery(user.getSessionQueryOptions);
@@ -815,7 +800,7 @@ function PublicationProfileContent({
             />
             <Stat value={String(pub.documentCount)} label={t`Posts`} />
             <Stat
-              value={lastActive(pub.lastDocumentAt ?? null, t)}
+              value={formatLastActive(i18n, pub.lastDocumentAt ?? null)}
               label={t`Last active`}
               isLast
             />

--- a/src/routes/_layout.tag.$tag.tsx
+++ b/src/routes/_layout.tag.$tag.tsx
@@ -178,7 +178,7 @@ const styles = stylex.create({
     rowGap: spacing["4"],
     marginInlineStart: "auto",
     marginInlineEnd: "auto",
-    maxWidth: "1320px",
+    maxWidth: "82.5rem",
     paddingBottom: spacing["0"],
     paddingInlineStart: {
       default: spacing["5"],
@@ -195,7 +195,7 @@ const styles = stylex.create({
     flexBasis: "0%",
     flexGrow: 1,
     flexShrink: 1,
-    minWidth: "240px",
+    minWidth: "15rem",
     paddingTop: spacing["0.5"],
   },
   heroActs: {
@@ -258,7 +258,7 @@ const styles = stylex.create({
     boxSizing: "border-box",
     marginInlineStart: "auto",
     marginInlineEnd: "auto",
-    maxWidth: "1320px",
+    maxWidth: "82.5rem",
     paddingInlineStart: {
       default: spacing["5"],
       "@media (min-width: 40rem)": spacing["10"],

--- a/src/routes/_layout.u.$did.tsx
+++ b/src/routes/_layout.u.$did.tsx
@@ -173,7 +173,7 @@ const styles = stylex.create({
     rowGap: spacing["4"],
     marginInlineStart: "auto",
     marginInlineEnd: "auto",
-    maxWidth: "1320px",
+    maxWidth: "82.5rem",
     paddingBottom: spacing["4"],
     paddingInlineStart: {
       default: spacing["5"],
@@ -205,7 +205,7 @@ const styles = stylex.create({
     flexBasis: "0%",
     flexGrow: 1,
     flexShrink: 1,
-    minWidth: "200px",
+    minWidth: "12.5rem",
     paddingTop: spacing["0.5"],
   },
   heroName: {
@@ -260,7 +260,7 @@ const styles = stylex.create({
     boxSizing: "border-box",
     marginInlineStart: "auto",
     marginInlineEnd: "auto",
-    maxWidth: "1320px",
+    maxWidth: "82.5rem",
     paddingInlineStart: {
       default: spacing["5"],
       [HERO_DESKTOP]: spacing["10"],
@@ -291,7 +291,7 @@ const styles = stylex.create({
     paddingTop: spacing["6"],
   },
   listRow: {
-    borderRadius: spacing["2"],
+    borderRadius: radius.md,
     borderTopColor: uiColor.border1,
     borderTopStyle: "solid",
     borderTopWidth: 1,

--- a/src/server/reader/article-detail-build.ts
+++ b/src/server/reader/article-detail-build.ts
@@ -27,7 +27,7 @@ import { OFFPRINT_CONTENT } from "#/lib/offprint/types";
 import { pcktBlocks, pcktCodeLanguage } from "#/lib/pckt/blocks";
 import { PCKT_CONTENT } from "#/lib/pckt/types";
 import { getPublicUrl } from "#/lib/public-url";
-import type { CodeHighlightsByScheme, ThemeMode } from "#/lib/theme";
+import type { CodeHighlightsByScheme, ThemeSchemeMode } from "#/lib/theme";
 import { EMPTY_CODE_HIGHLIGHTS } from "#/lib/theme";
 import { cdnImageUrl } from "#/server/atproto/blob";
 import { publicationFontsFromThemeJson } from "#/server/fonts/publication-fonts.server";
@@ -95,7 +95,7 @@ export interface BuildArticleDetailOptions {
 
 async function codeHighlightsForThemeMode(
   blocks: Array<Pick<LeafletCodeBlock, "language" | "plaintext">>,
-  themeMode: ThemeMode,
+  themeMode: ThemeSchemeMode,
   codeTheme: {
     accent: string | null;
     surfaces: ReturnType<typeof publicationRenderedSurfaces>;
@@ -205,7 +205,7 @@ export async function buildArticleDetail(
   schema: Schema,
   row: ArticleDetailSourceRow,
   contributors: Array<ArticleContributor>,
-  themeMode: ThemeMode,
+  themeMode: ThemeSchemeMode,
   options: BuildArticleDetailOptions = {},
 ): Promise<ArticleDetail> {
   const publication = publicationFromRow(row);

--- a/src/server/reader/collection-magazine.ts
+++ b/src/server/reader/collection-magazine.ts
@@ -7,7 +7,7 @@ import type {
   CollectionEditorial,
 } from "#/lib/collections/manifest";
 import type { CollectionTheme } from "#/lib/collections/theme";
-import type { ThemeMode } from "#/lib/theme";
+import type { ThemeSchemeMode } from "#/lib/theme";
 import { MAX_MAGAZINE_FEATURES } from "#/magazine/constants";
 import { getReaderContextForRequest } from "#/middleware/auth-session.server";
 import type { ArticleDetailSourceRow } from "#/server/reader/article-detail-build";
@@ -324,7 +324,7 @@ export async function loadCollectionMagazine(
   const manifest = manifestFromCollectionRow(collectionEntry.row);
   if (!manifest) return null;
 
-  const themeMode: ThemeMode = await themeModeForRequest(
+  const themeMode: ThemeSchemeMode = await themeModeForRequest(
     db,
     schema,
     reader?.userId,

--- a/src/server/theme-preference.ts
+++ b/src/server/theme-preference.ts
@@ -3,10 +3,20 @@ import { eq } from "drizzle-orm";
 
 import type { Db, Schema } from "#/integrations/tanstack-query/api-shapes";
 import {
+  APPEARANCE_COOKIE,
+  appearanceScheme,
+  dbValueToAppearance,
+  parseAppearanceCookie,
+} from "#/lib/appearance";
+import {
   DEFAULT_USE_PUBLICATION_THEME,
   dbValueToUsePublicationTheme,
 } from "#/lib/publication-theme-preference";
-import type { ResolvedThemeScheme, ThemeMode } from "#/lib/theme";
+import type {
+  ResolvedThemeScheme,
+  ThemeMode,
+  ThemeSchemeMode,
+} from "#/lib/theme";
 import {
   THEME_COOKIE,
   dbValueToThemeMode,
@@ -14,20 +24,32 @@ import {
   resolveThemeScheme,
 } from "#/lib/theme";
 
+/**
+ * The reader's theme mode, with `custom` already collapsed to the scheme their
+ * palette renders in. Callers use this to pick a *scheme* (Shiki themes for
+ * code blocks), and a custom palette is never ambiguous about which one it is —
+ * so resolving it here keeps every downstream branch a plain light/dark/system.
+ */
 export async function themeModeForRequest(
   db: Db,
   schema: Schema,
   sessionUserId?: string | null,
-): Promise<ThemeMode> {
+): Promise<ThemeSchemeMode> {
   if (sessionUserId) {
     const row = await db.query.user.findFirst({
       where: eq(schema.user.id, sessionUserId),
-      columns: { themeMode: true },
+      columns: { themeMode: true, appearance: true },
     });
-    return dbValueToThemeMode(row?.themeMode ?? null);
+    const mode = dbValueToThemeMode(row?.themeMode ?? null);
+    return mode === "custom"
+      ? appearanceScheme(dbValueToAppearance(row?.appearance ?? null))
+      : mode;
   }
 
-  return parseThemeMode(getCookie(THEME_COOKIE));
+  const mode = parseThemeMode(getCookie(THEME_COOKIE));
+  return mode === "custom"
+    ? appearanceScheme(parseAppearanceCookie(getCookie(APPEARANCE_COOKIE)))
+    : mode;
 }
 
 /**

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,6 +5,26 @@
 }
 
 /*
+ * Form controls don't inherit `font-family` from their ancestors — the UA
+ * stylesheet gives every button, input and select its own system font. Most
+ * design-system controls (segmented control, select, menu, listbox, text field)
+ * never state a family of their own and so silently rendered in that UA font
+ * rather than the app's typeface; the interface-font preference
+ * (`src/lib/appearance.ts`) made that visible, since those controls were the one
+ * part of the UI it couldn't reach.
+ *
+ * Only the family is inherited: size, weight and line-height stay with each
+ * control, which sets them from the design-system tokens.
+ */
+button,
+input,
+select,
+textarea,
+optgroup {
+  font-family: inherit;
+}
+
+/*
  * Writing-direction multiplier for directional transforms.
  *
  * `transform: translateX()` is always physical — positive X moves right even in


### PR DESCRIPTION
Theme becomes light / dark / system / custom. Custom opens a palette picker: eight curated pairs — a Radix accent with the gray Radix pairs it with — grouped by the scheme they render in, plus the reader's own accent and paper. A palette states its own scheme (the paper color decides), so the shell pins `color-scheme` rather than tracking the OS; that pin is also what resolves `light-dark()` inside the Radix scales.

Curated palettes are static `createTheme`s over the vendored scales. The reader's own two colors run through the generator that paints publication themes, under an `--sr-*` prefix, so ink and borders are derived rather than asked for. One deliberate asymmetry: a reader's stated accent is never substituted. A publication whose accent can't clear 3:1 gets it replaced by the page's ink so a stranger's site can't grey out our chrome; a reader theming their own app keeps what they picked, and the panel scores the result and warns instead.

Alongside it, four dials that apply in every theme mode because none of them is color: interface font (editorial / sans / any Google family), text size (XS-XL, 14->24px), roundness, and density. Text size scales the root font size so every rem follows it — chrome, sidebar, content shells, article body — while roundness and density are multipliers on the radius and spacing scales, applied on the root element (the semantic scales are declared as `--gap-md: var(--spacing-2)` at `:root`, and a custom property resolves on the element that declares it, so an override further down never reaches them). Density stops at the space between things: scaling control geometry stretched a switch's track but not its height.

Persisted as `user.appearance` plus the `standard-reader-appearance` cookie, seeded through `getShellBootstrap` so the first paint is themed.

Fixes found along the way, all pre-existing:

- Cookie values are percent-encoded by `Set-Cookie`, so the `:`-joined appearance and reading-typography preferences came back as `%3A` and silently parsed as "all defaults" on every guest page load.
- Form controls never inherited `font-family`, so the segmented control, select, menu, listbox and inputs sat outside the type system entirely; segmented items also had no font size and rendered at the UA default.
- "Last active" on publication pages rendered no value: `lastActive()` took `t` as a parameter, which Lingui's macro can't extract, so those strings were never in the catalog and resolved to empty.
- Radii stated as spacing tokens or literals (settings groups, labeler cards, onboarding surfaces) couldn't follow the roundness dial, and layout dimensions in px couldn't follow the text scale.