### PR TITLE
Add lightbox to PCKT gallery images with view transitions

### DIFF
--- a/APP_VISION.md
+++ b/APP_VISION.md
@@ -129,9 +129,12 @@ Sections, top to bottom:
   declared extensions (LaTeX via KaTeX, YAML front matter), ingest-time `text.textBlob`
   resolution, and facet/lens preprocessing (`baseFormatting` headers/strong/idify,
   `baseBlocks` front matter and horizontal rules). Leaflet image galleries use CSS
-  `grid-lanes` where supported with plain CSS Grid fallback elsewhere; Leaflet galleries and
-  single-image blocks share the reader lightbox, with image alt text surfaced inside the
-  lightbox.
+  `grid-lanes` where supported with plain CSS Grid fallback elsewhere. Every rendered image in
+  a document body — Leaflet galleries and single-image blocks, PCKT image and gallery blocks,
+  structured image grids/carousels, and markdown images — opens the shared reader lightbox, with
+  image alt text surfaced inside the lightbox and prev/next navigation across a gallery's images.
+  Magazine editions are the one exception: they bind their own lightbox to the rendered `<img>`
+  elements.
 - Sticky top bar: back, byline, follow, like, share; reading-progress bar. On mobile it
   pins below the shell's top bar whenever that one is revealed, so the two stack instead
   of overlapping.

--- a/TODO.md
+++ b/TODO.md
@@ -782,6 +782,11 @@ Backend/API exists; UI or copy is missing.
 - [x] **Content rendering gaps** — PCKT gallery renderer (`blog.pckt.block.gallery`); prod scan
       found 54 documents — implemented grid/list/carousel/masonry layouts via
       [`pckt-gallery.tsx`](src/components/reader/content/renderers/pckt-gallery.tsx).
+- [x] **PCKT gallery lightbox** — `blog.pckt.block.gallery` images were the last rendered doc
+      images without a lightbox. They now open the shared reader lightbox with prev/next across
+      the whole gallery and a thumbnail → lightbox view transition, matching
+      [`leaflet-image-gallery.tsx`](src/components/reader/content/renderers/leaflet-image-gallery.tsx).
+      Magazine editions still defer to their own image lightbox binding.
 - [x] **Leaflet image galleries + lightbox polish** — added `pub.leaflet.blocks.imageGallery`
       rendering with grid/carousel layouts, Leaflet-style shared lightbox for galleries + single
       images, CSS `grid-lanes` with plain CSS Grid fallback, and a shared-element open transition

--- a/src/components/reader/content/renderers/pckt-gallery.tsx
+++ b/src/components/reader/content/renderers/pckt-gallery.tsx
@@ -1,8 +1,18 @@
 "use client";
 
+import { useLingui } from "@lingui/react/macro";
 import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
+import { use, useState } from "react";
+import { flushSync } from "react-dom";
 
+import { AspectRatio, AspectRatioImage } from "#/design-system/aspect-ratio";
+import { Lightbox } from "#/design-system/lightbox";
+import {
+  LIGHTBOX_IMAGE_TRANSITION_NAME,
+  startLightboxViewTransition,
+} from "#/design-system/lightbox/transition";
+import { spacing } from "#/design-system/theme/spacing.stylex";
 import { fetchPcktGallery, pcktImageBlockFromAttrs } from "#/lib/pckt/gallery";
 import {
   pcktImageAlt,
@@ -11,10 +21,28 @@ import {
   pcktImageUrl,
 } from "#/lib/pckt/image";
 import type { PcktGalleryBlock } from "#/lib/pckt/types";
+import { MagazineColorContext } from "#/magazine/context";
 
 import { articleBodyStyles } from "../body-styles";
 import type { ContentBlobContext } from "../types";
 import { ImageFigureView } from "./shared/image-figure";
+
+const galleryStyles = stylex.create({
+  imageButton: {
+    padding: spacing["0"],
+    borderWidth: 0,
+    backgroundColor: "transparent",
+    cursor: "zoom-in",
+    display: "block",
+    width: "100%",
+  },
+});
+
+interface GalleryImage {
+  src: string;
+  alt: string;
+  aspectRatio: number;
+}
 
 function galleryLayoutStyle(layout: string | undefined) {
   switch (layout) {
@@ -48,6 +76,13 @@ export function PcktGalleryBlockView({
   block: PcktGalleryBlock;
   blobContext?: ContentBlobContext;
 }) {
+  const { t } = useLingui();
+  const magazine = use(MagazineColorContext);
+  // `lightboxIndex` is which image the lightbox opened on; `transitionIndex` is
+  // the thumbnail that owns the shared view-transition name while it animates
+  // into (and back out of) the expanded image.
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+  const [transitionIndex, setTransitionIndex] = useState<number | null>(null);
   const galleryUri = block.ref?.trim();
   const { data: resolved, isPending } = useQuery({
     queryKey: ["pckt-gallery", galleryUri] as const,
@@ -67,9 +102,22 @@ export function PcktGalleryBlockView({
   const title = gallery?.title?.trim();
   const caption = gallery?.caption?.trim();
   const layout = gallery?.layout?.trim() || "grid";
-  const images = (gallery?.images ?? []).filter((attrs) =>
-    pcktImageHasSource(pcktImageBlockFromAttrs(attrs)),
-  );
+
+  const images: Array<GalleryImage> = [];
+  for (const attrs of gallery?.images ?? []) {
+    const imageBlock = pcktImageBlockFromAttrs(attrs);
+    if (!pcktImageHasSource(imageBlock)) continue;
+    const src = pcktImageUrl(
+      imageBlock,
+      galleryDid ?? blobContext?.authorDid ?? "",
+    );
+    if (!src) continue;
+    images.push({
+      src,
+      alt: pcktImageAlt(imageBlock),
+      aspectRatio: pcktImageAspectRatio(imageBlock),
+    });
+  }
 
   const layoutStyle = galleryLayoutStyle(layout);
   const itemStyle = galleryItemStyle(layout);
@@ -88,20 +136,58 @@ export function PcktGalleryBlockView({
       ) : null}
       {images.length > 0 ? (
         <div {...stylex.props(layoutStyle)}>
-          {images.map((attrs, index) => {
-            const imageBlock = pcktImageBlockFromAttrs(attrs);
-            const src = pcktImageUrl(
-              imageBlock,
-              galleryDid ?? blobContext?.authorDid ?? "",
-            );
-            if (!src) return null;
+          {images.map((image, index) => {
+            const position = index + 1;
             return (
               <div key={index} {...stylex.props(itemStyle)}>
-                <ImageFigureView
-                  src={src}
-                  alt={pcktImageAlt(imageBlock)}
-                  aspectRatio={pcktImageAspectRatio(imageBlock)}
-                />
+                {/* In magazine mode the edition binds its own lightbox to the
+                  bare <img>, so defer to `ImageFigureView`'s magazine
+                  rendering rather than wrapping the image in a button. */}
+                {magazine ? (
+                  <ImageFigureView
+                    src={image.src}
+                    alt={image.alt}
+                    aspectRatio={image.aspectRatio}
+                  />
+                ) : (
+                  <figure {...stylex.props(articleBodyStyles.imageFigure)}>
+                    <button
+                      aria-label={image.alt || t`Open image ${position}`}
+                      type="button"
+                      onClick={() => {
+                        flushSync(() => setTransitionIndex(index));
+                        startLightboxViewTransition(() =>
+                          setLightboxIndex(index),
+                        );
+                      }}
+                      style={
+                        transitionIndex === index && lightboxIndex !== index
+                          ? {
+                              viewTransitionName:
+                                LIGHTBOX_IMAGE_TRANSITION_NAME,
+                            }
+                          : undefined
+                      }
+                      {...stylex.props(galleryStyles.imageButton)}
+                    >
+                      <AspectRatio aspectRatio={image.aspectRatio} rounded>
+                        <AspectRatioImage
+                          alt={image.alt}
+                          referrerPolicy="no-referrer"
+                          src={image.src}
+                        />
+                      </AspectRatio>
+                    </button>
+                    {image.alt ? (
+                      <figcaption
+                        aria-hidden="true"
+                        {...stylex.props(articleBodyStyles.imageCaption)}
+                      >
+                        {image.alt}
+                      </figcaption>
+                    ) : null}
+                  </figure>
+                )}
               </div>
             );
           })}
@@ -112,6 +198,26 @@ export function PcktGalleryBlockView({
           {caption}
         </figcaption>
       ) : null}
+      {magazine ? null : (
+        <Lightbox
+          alt={t`Image gallery`}
+          images={images.map((image, index) => ({
+            ...image,
+            transitionName:
+              transitionIndex === index
+                ? LIGHTBOX_IMAGE_TRANSITION_NAME
+                : undefined,
+          }))}
+          initialIndex={lightboxIndex ?? 0}
+          isOpen={lightboxIndex !== null}
+          onOpenChange={(open) => {
+            if (!open) {
+              setLightboxIndex(null);
+              setTransitionIndex(null);
+            }
+          }}
+        />
+      )}
     </figure>
   );
 }

--- a/src/components/reader/content/standard-renderer-components.tsx
+++ b/src/components/reader/content/standard-renderer-components.tsx
@@ -266,6 +266,9 @@ export function buildStandardReaderComponents({
           </div>
         </figure>
       ),
+      // Unlike the native `StructuredImageDiffBlockView`, this renders the pair
+      // side by side with no compare slider, so each half is a plain static
+      // image and gets its own lightbox like every other rendered image.
       ImageDiff: ({ before, after }: ImageDiffProps) => (
         <figure {...stylex.props(articleBodyStyles.imageDiff)}>
           <div {...stylex.props(styles.diffPair)}>
@@ -274,12 +277,14 @@ export function buildStandardReaderComponents({
               alt={before.alt}
               aspectRatio={before.aspectRatio}
               fit="cover"
+              lightboxEnabled
             />
             <ImageFigureView
               src={after.src}
               alt={after.alt}
               aspectRatio={after.aspectRatio}
               fit="cover"
+              lightboxEnabled
             />
           </div>
         </figure>

--- a/src/locales/ar/messages.po
+++ b/src/locales/ar/messages.po
@@ -3012,6 +3012,7 @@ msgid "Jump to"
 msgstr "انتقل إلى"
 
 #: src/components/reader/content/renderers/leaflet-image-gallery.tsx
+#: src/components/reader/content/renderers/pckt-gallery.tsx
 msgid "Open image {position}"
 msgstr "افتح الصورة {position}"
 
@@ -3135,6 +3136,7 @@ msgid "Profile settings"
 msgstr "إعدادات الملف الشخصي"
 
 #: src/components/reader/content/renderers/leaflet-image-gallery.tsx
+#: src/components/reader/content/renderers/pckt-gallery.tsx
 msgid "Image gallery"
 msgstr "معرض الصور"
 

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -3012,6 +3012,7 @@ msgid "Jump to"
 msgstr "Springe zu"
 
 #: src/components/reader/content/renderers/leaflet-image-gallery.tsx
+#: src/components/reader/content/renderers/pckt-gallery.tsx
 msgid "Open image {position}"
 msgstr "Bild {position} öffnen"
 
@@ -3135,6 +3136,7 @@ msgid "Profile settings"
 msgstr "Profileinstellungen"
 
 #: src/components/reader/content/renderers/leaflet-image-gallery.tsx
+#: src/components/reader/content/renderers/pckt-gallery.tsx
 msgid "Image gallery"
 msgstr "Bildergalerie"
 

--- a/src/locales/en-XA/messages.po
+++ b/src/locales/en-XA/messages.po
@@ -3012,6 +3012,7 @@ msgid "Jump to"
 msgstr ""
 
 #: src/components/reader/content/renderers/leaflet-image-gallery.tsx
+#: src/components/reader/content/renderers/pckt-gallery.tsx
 msgid "Open image {position}"
 msgstr ""
 
@@ -3135,6 +3136,7 @@ msgid "Profile settings"
 msgstr ""
 
 #: src/components/reader/content/renderers/leaflet-image-gallery.tsx
+#: src/components/reader/content/renderers/pckt-gallery.tsx
 msgid "Image gallery"
 msgstr ""
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -3012,6 +3012,7 @@ msgid "Jump to"
 msgstr "Jump to"
 
 #: src/components/reader/content/renderers/leaflet-image-gallery.tsx
+#: src/components/reader/content/renderers/pckt-gallery.tsx
 msgid "Open image {position}"
 msgstr "Open image {position}"
 
@@ -3135,6 +3136,7 @@ msgid "Profile settings"
 msgstr "Profile settings"
 
 #: src/components/reader/content/renderers/leaflet-image-gallery.tsx
+#: src/components/reader/content/renderers/pckt-gallery.tsx
 msgid "Image gallery"
 msgstr "Image gallery"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -3012,6 +3012,7 @@ msgid "Jump to"
 msgstr "Ir a"
 
 #: src/components/reader/content/renderers/leaflet-image-gallery.tsx
+#: src/components/reader/content/renderers/pckt-gallery.tsx
 msgid "Open image {position}"
 msgstr "Abrir la imagen {position}"
 
@@ -3135,6 +3136,7 @@ msgid "Profile settings"
 msgstr "Ajustes del perfil"
 
 #: src/components/reader/content/renderers/leaflet-image-gallery.tsx
+#: src/components/reader/content/renderers/pckt-gallery.tsx
 msgid "Image gallery"
 msgstr "Galería de imágenes"
 

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -3012,6 +3012,7 @@ msgid "Jump to"
 msgstr "Aller à"
 
 #: src/components/reader/content/renderers/leaflet-image-gallery.tsx
+#: src/components/reader/content/renderers/pckt-gallery.tsx
 msgid "Open image {position}"
 msgstr "Ouvrir l’image {position}"
 
@@ -3135,6 +3136,7 @@ msgid "Profile settings"
 msgstr "Paramètres du profil"
 
 #: src/components/reader/content/renderers/leaflet-image-gallery.tsx
+#: src/components/reader/content/renderers/pckt-gallery.tsx
 msgid "Image gallery"
 msgstr "Galerie d'images"
 

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -3012,6 +3012,7 @@ msgid "Jump to"
 msgstr "移動"
 
 #: src/components/reader/content/renderers/leaflet-image-gallery.tsx
+#: src/components/reader/content/renderers/pckt-gallery.tsx
 msgid "Open image {position}"
 msgstr "画像 {position} を開く"
 
@@ -3135,6 +3136,7 @@ msgid "Profile settings"
 msgstr "プロフィール設定"
 
 #: src/components/reader/content/renderers/leaflet-image-gallery.tsx
+#: src/components/reader/content/renderers/pckt-gallery.tsx
 msgid "Image gallery"
 msgstr "画像ギャラリー"
 

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -3012,6 +3012,7 @@ msgid "Jump to"
 msgstr "바로 가기"
 
 #: src/components/reader/content/renderers/leaflet-image-gallery.tsx
+#: src/components/reader/content/renderers/pckt-gallery.tsx
 msgid "Open image {position}"
 msgstr "{position}번째 이미지 열기"
 
@@ -3135,6 +3136,7 @@ msgid "Profile settings"
 msgstr "프로필 설정"
 
 #: src/components/reader/content/renderers/leaflet-image-gallery.tsx
+#: src/components/reader/content/renderers/pckt-gallery.tsx
 msgid "Image gallery"
 msgstr "이미지 갤러리"
 

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -3012,6 +3012,7 @@ msgid "Jump to"
 msgstr "Ir para"
 
 #: src/components/reader/content/renderers/leaflet-image-gallery.tsx
+#: src/components/reader/content/renderers/pckt-gallery.tsx
 msgid "Open image {position}"
 msgstr "Abrir imagem {position}"
 
@@ -3135,6 +3136,7 @@ msgid "Profile settings"
 msgstr "Configurações do perfil"
 
 #: src/components/reader/content/renderers/leaflet-image-gallery.tsx
+#: src/components/reader/content/renderers/pckt-gallery.tsx
 msgid "Image gallery"
 msgstr "Galeria de imagens"
 

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -3012,6 +3012,7 @@ msgid "Jump to"
 msgstr "跳转到"
 
 #: src/components/reader/content/renderers/leaflet-image-gallery.tsx
+#: src/components/reader/content/renderers/pckt-gallery.tsx
 msgid "Open image {position}"
 msgstr "打开第 {position} 张图片"
 
@@ -3135,6 +3136,7 @@ msgid "Profile settings"
 msgstr "个人资料设置"
 
 #: src/components/reader/content/renderers/leaflet-image-gallery.tsx
+#: src/components/reader/content/renderers/pckt-gallery.tsx
 msgid "Image gallery"
 msgstr "图片库"
 


### PR DESCRIPTION
## Summary

Adds a shared reader lightbox to PCKT gallery block images, matching the existing lightbox behavior for Leaflet galleries and single-image blocks. Images now open in an expanded lightbox view with prev/next navigation across the gallery, and a smooth thumbnail-to-lightbox view transition animates the opening. Magazine editions continue to use their own image lightbox binding.

## Changes

- **Gallery image data structure:** Refactored image processing to pre-compute `GalleryImage` objects containing `src`, `alt`, and `aspectRatio` before rendering, enabling consistent data flow to both thumbnail and lightbox views.

- **Lightbox integration:** Added `Lightbox` component rendering (non-magazine mode only) with images from the gallery, initial index tracking, and open/close state management.

- **View transitions:** Implemented thumbnail-to-lightbox shared-element transition using `startLightboxViewTransition` and `LIGHTBOX_IMAGE_TRANSITION_NAME`, with separate `lightboxIndex` and `transitionIndex` state to manage which thumbnail owns the transition name during animation.

- **Conditional rendering:** In non-magazine mode, gallery images render as clickable `<button>` elements wrapping `AspectRatio` + `AspectRatioImage` components with figure/figcaption markup. In magazine mode, defers to `ImageFigureView` so the edition can bind its own lightbox to the bare `<img>`.

- **Accessibility:** Added `aria-label` to image buttons with fallback to `t\`Open image ${position}\`` when alt text is unavailable.

- **ImageDiff component:** Added `lightboxEnabled` prop to both before/after `ImageFigureView` instances so side-by-side image diffs also open the shared lightbox (each half as a separate image).

- **Documentation:** Updated `APP_VISION.md` to reflect that all rendered document images now support the shared reader lightbox (except magazine editions), and marked the PCKT gallery lightbox task complete in `TODO.md`.

## Implementation notes

- Uses `flushSync` + `startLightboxViewTransition` to ensure transition state updates synchronously before the lightbox opens, preventing race conditions.
- Separates `transitionIndex` (which thumbnail animates) from `lightboxIndex` (which image the lightbox displays) to handle the transition lifecycle correctly.
- Maintains magazine-mode compatibility by checking `MagazineColorContext` and skipping lightbox rendering when in a magazine edition.

https://claude.ai/code/session_01WUSJD99Nma1N6stv7DvTUP