### PR TITLE
Move viewer's own recommend indicator to like-count heart

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -408,13 +408,15 @@ Build each on hip-ui components + StyleX tokens (no raw HTML/inline styles).
 - [x] **Search result snippets** — `ts_headline` excerpts in `searchArticles` /
       `searchPublications`; highlighted `<mark>` terms in `ArticleRow` and
       `PubDirectoryRow` on `/search`.
-- [x] **"Recommended by you" indicator** — document cards across every surface (home, latest,
-      discover, tag, publication, author, search, saved, and history feeds) show a red heart +
-      "Recommended by you" eyebrow when the signed-in reader has recommended that document. Attached
-      server-side in one batched, index-served query (`attachViewerRecommendedToArticles` →
-      `viewerHasRecommended` on `ArticleCard`), toggled optimistically alongside the recommend
-      action (`recommend-optimistic.ts`), and rendered by `RecommendedByLine` (the viewer's own
-      signal takes precedence over the followed-user "@handle and N others" attribution).
+- [x] **Viewer's own recommend indicator** — document items across every surface (home, latest,
+      discover, tag, publication, author, search, saved, history, article byline, and mention hover
+      cards) **fill and tint the heart on the document's like count** when the signed-in reader has
+      recommended that document — no separate "Recommended by you" eyebrow. Attached server-side in
+      one batched, index-served query (`attachViewerRecommendedToArticles` → `viewerHasRecommended`
+      on `ArticleCard`), toggled optimistically alongside the recommend action
+      (`recommend-optimistic.ts`), and rendered by `LikeCount` / `ArticleEngagement`
+      (`primitives.tsx`) via the `filled` / `viewerHasRecommended` props. `RecommendedByLine`
+      (`cards.tsx`) now carries only the followed-user "@handle and N others" attribution.
 - [x] **Article** (reading view) — ~680px measure, drop-cap, pull quotes, hero, sticky bar (back/byline/follow/save/share), reading-progress bar, footer pub card + "More from {publication}". Route `/a/$did/$rkey` (`_layout.a.$did.$rkey.tsx`); feed/profile cards link here; `publicationApi.getArticle` returns core content + stale-while-revalidate `commentCount`; below-the-fold rails (`moreFrom`, `readersAlsoFollow`) and discussion load client-side via `getArticleExtras` + `commentsApi.getDocumentComments`. Save toggle writes `site.standard.graph.recommend`; like counts on cards + article byline.
 - [x] **Article discussion** — Bluesky comment section on documents: Constellation backlink discovery for external + app quote-share URLs, direct replies to the author's `bskyPostRef` (excluded from the list itself), hydrated via public AppView, facet-rendered commentary, reply counts linking to bsky threads (`commentsApi.getDocumentComments`).
 - [x] **Article discussion — margin.at** — merge `at.margin.note` / `at.margin.annotation` / `at.margin.highlight` and `network.cosmik.card` NOTE cards on the document's canonical URL into the same Discussion feed via Constellation (`at.margin.*` at `.target.source`, cosmik at `.url` / `.content.url`); hydrate from author PDS + Bluesky/margin profile; quote-style cards for `TextQuoteSelector` passages; reply counts via `at.margin.reply`; margin notes link to margin.at; cosmik NOTE cards link to Semble (`semble.so/url?id=…`); cosmik URL bookmarks excluded from counts.

--- a/src/components/reader/article-result-row.tsx
+++ b/src/components/reader/article-result-row.tsx
@@ -193,6 +193,7 @@ function MetaLine({
         recommendCount={article.recommendCount}
         commentCount={article.commentCount}
         size="xs"
+        viewerHasRecommended={article.viewerHasRecommended}
       />
     </Flex>
   );

--- a/src/components/reader/article-view.tsx
+++ b/src/components/reader/article-view.tsx
@@ -960,7 +960,9 @@ function ArticleViewBody({
   } = useArticleBookmark(article.uri, signedIn);
 
   const readStats = formatArticleReadStats(i18n, article.readCount);
-  const hasEngagement = article.recommendCount > 0 || article.commentCount > 0;
+  // Use the optimistic recommend count so the byline heart fills (and the line
+  // appears on a first recommend) the instant the reader taps Recommend.
+  const hasEngagement = recommendCount > 0 || article.commentCount > 0;
   const hero = useMemo(() => resolveArticleHeroImage(article), [article]);
   const [heroLightboxOpen, setHeroLightboxOpen] = useState(false);
   const [heroTransitionActive, setHeroTransitionActive] = useState(false);
@@ -1366,9 +1368,10 @@ function ArticleViewBody({
                   <>
                     <span aria-hidden>·</span>
                     <ArticleEngagement
-                      recommendCount={article.recommendCount}
+                      recommendCount={recommendCount}
                       commentCount={article.commentCount}
                       size="sm"
+                      viewerHasRecommended={recommended}
                     />
                   </>
                 ) : null}

--- a/src/components/reader/cards.tsx
+++ b/src/components/reader/cards.tsx
@@ -1029,29 +1029,17 @@ function OwnerHandleLink({
 
 /** Whether {@link RecommendedByLine} would render anything for this card. */
 function hasRecommendedByLine(article: ArticleCard): boolean {
-  return (
-    article.viewerHasRecommended || (article.recommendedBy?.length ?? 0) > 0
-  );
+  return (article.recommendedBy?.length ?? 0) > 0;
 }
 
 /**
- * Recommend attribution shown above the byline on document items. When the
- * viewer recommended the article themselves it reads "Recommended by you" (the
- * personal signal takes precedence); otherwise it collapses the followed users
- * who recommended it into one line ("@handle and N others"). Either way a red
- * heart marks it as a recommendation at a glance.
+ * Recommend attribution shown above the byline on document items: the followed
+ * users who recommended it, collapsed into one line ("@handle and N others"),
+ * with a red heart marking it as a recommendation at a glance. The viewer's own
+ * recommend is *not* shown here — it fills the heart on the card's like count
+ * instead (see `LikeCount`).
  */
 function RecommendedByLine({ article }: { article: ArticleCard }) {
-  if (article.viewerHasRecommended) {
-    return (
-      <Flex align="center" gap="sm" style={styles.recommendedByLine}>
-        <span {...stylex.props(styles.recommendedByHeart)}>
-          <Heart size={13} aria-hidden fill="currentColor" />
-        </span>
-        <span>Recommended by you</span>
-      </Flex>
-    );
-  }
   const recommenders = article.recommendedBy;
   if (!recommenders || recommenders.length === 0) {
     return null;
@@ -1316,6 +1304,7 @@ function ArticleMetaLine({
         <ArticleEngagement
           recommendCount={article.recommendCount}
           commentCount={article.commentCount}
+          viewerHasRecommended={article.viewerHasRecommended}
         />
       ) : null}
       {hasEngagement && hasTrailing ? (
@@ -1665,10 +1654,10 @@ export function FeatureArticle({
     );
   }
 
-  // Byline-less (publication page): the recommend attribution still applies —
-  // "Recommended by you" or the followed-user line. Lift it out of the card link
-  // (it holds its own profile links) and let the shell own the row's border so
-  // the grid inside stays border-free.
+  // Byline-less (publication page): the followed-user recommend attribution
+  // still applies. Lift it out of the card link (it holds its own profile
+  // links) and let the shell own the row's border so the grid inside stays
+  // border-free.
   if (hasRecommendedByLine(article)) {
     return (
       <div {...stylex.props(styles.featureShell)}>
@@ -1962,6 +1951,7 @@ export function CompactRow({
               <ArticleEngagement
                 recommendCount={article.recommendCount}
                 commentCount={article.commentCount}
+                viewerHasRecommended={article.viewerHasRecommended}
               />
             </>
           ) : null}

--- a/src/components/reader/cards.tsx
+++ b/src/components/reader/cards.tsx
@@ -45,11 +45,7 @@ import { Flex } from "../../design-system/flex";
 import { IconButton } from "../../design-system/icon-button";
 import { Skeleton } from "../../design-system/skeleton";
 import { animationDuration } from "../../design-system/theme/animations.stylex";
-import {
-  criticalColor,
-  primaryColor,
-  uiColor,
-} from "../../design-system/theme/color.stylex";
+import { primaryColor, uiColor } from "../../design-system/theme/color.stylex";
 import { radius } from "../../design-system/theme/radius.stylex";
 import { shadow } from "../../design-system/theme/shadow.stylex";
 import {
@@ -170,12 +166,11 @@ const styles = stylex.create({
     fontSize: fontSize.xs,
     fontWeight: fontWeight.medium,
   },
-  // A quiet tint on the heart so the "Recommended by" eyebrow reads as a
-  // recommendation at a glance — noticeable, but the text stays muted so it
-  // never competes with the title.
+  // The heart inherits the eyebrow's muted text color — the red tint is
+  // reserved for the like count's filled heart (the viewer's own recommend),
+  // so a followed user's recommendation never reads as your own.
   recommendedByHeart: {
     alignItems: "center",
-    color: criticalColor.solid1,
     display: "inline-flex",
     flexShrink: 0,
   },
@@ -1035,8 +1030,8 @@ function hasRecommendedByLine(article: ArticleCard): boolean {
 /**
  * Recommend attribution shown above the byline on document items: the followed
  * users who recommended it, collapsed into one line ("@handle and N others"),
- * with a red heart marking it as a recommendation at a glance. The viewer's own
- * recommend is *not* shown here — it fills the heart on the card's like count
+ * with a heart in the eyebrow's own muted color. The viewer's own recommend is
+ * *not* shown here — it fills (and tints) the heart on the card's like count
  * instead (see `LikeCount`).
  */
 function RecommendedByLine({ article }: { article: ArticleCard }) {

--- a/src/components/reader/mention-hover-card.tsx
+++ b/src/components/reader/mention-hover-card.tsx
@@ -495,7 +495,12 @@ export function DocumentHoverCardBody({
                   <DotJoined parts={metaParts} />
                 </span>
               ) : null}
-              {art ? <LikeCount count={art.recommendCount} /> : null}
+              {art ? (
+                <LikeCount
+                  count={art.recommendCount}
+                  filled={art.viewerHasRecommended}
+                />
+              ) : null}
             </div>
           ) : null}
         </>

--- a/src/components/reader/primitives.tsx
+++ b/src/components/reader/primitives.tsx
@@ -5,7 +5,11 @@ import { Text } from "#/design-system/typography/text.tsx";
 
 import { Avatar } from "../../design-system/avatar";
 import { Flex } from "../../design-system/flex";
-import { primaryColor, uiColor } from "../../design-system/theme/color.stylex";
+import {
+  criticalColor,
+  primaryColor,
+  uiColor,
+} from "../../design-system/theme/color.stylex";
 import { radius } from "../../design-system/theme/radius.stylex";
 import { ui } from "../../design-system/theme/semantic-color.stylex";
 import { gap } from "../../design-system/theme/semantic-spacing.stylex";
@@ -60,6 +64,17 @@ const styles = stylex.create({
   },
   likeCountSm: {
     fontSize: fontSize.sm,
+  },
+  likeCountHeart: {
+    alignItems: "center",
+    display: "inline-flex",
+    flexShrink: 0,
+  },
+  // The viewer's own recommend: a filled, tinted heart on the count instead of
+  // a separate "Recommended by you" line. The number stays muted so only the
+  // heart carries the signal.
+  likeCountHeartFilled: {
+    color: criticalColor.solid1,
   },
   commentCount: {
     color: uiColor.text1,
@@ -295,13 +310,21 @@ export function MetaLine({ children }: { children: React.ReactNode }) {
 
 const ENGAGEMENT_ICON_SIZE = { sm: 14, xs: 12 } as const;
 
-/** Network recommendation count with a heart icon; renders nothing when `count` is zero. */
+/**
+ * Network recommendation count with a heart icon; renders nothing when `count`
+ * is zero. When `filled` is set the viewer recommended this article themselves —
+ * the heart fills and takes the critical tint, which is the whole "you
+ * recommended this" signal (there is no separate attribution line for it).
+ */
 export function LikeCount({
   count,
   size = "xs",
+  filled = false,
 }: {
   count: number;
   size?: keyof typeof ENGAGEMENT_ICON_SIZE;
+  /** The viewer has recommended this article — fill and tint the heart. */
+  filled?: boolean;
 }) {
   if (count <= 0) return null;
   return (
@@ -310,7 +333,21 @@ export function LikeCount({
       gap="xs"
       style={[styles.likeCount, size === "sm" && styles.likeCountSm]}
     >
-      <Heart size={ENGAGEMENT_ICON_SIZE[size]} aria-hidden strokeWidth={2} />
+      <span
+        {...stylex.props(
+          styles.likeCountHeart,
+          filled && styles.likeCountHeartFilled,
+        )}
+        {...(filled
+          ? { role: "img", "aria-label": "Recommended by you" }
+          : { "aria-hidden": true })}
+      >
+        <Heart
+          size={ENGAGEMENT_ICON_SIZE[size]}
+          strokeWidth={2}
+          fill={filled ? "currentColor" : "none"}
+        />
+      </span>
       <span>{formatReaders(count)}</span>
     </Flex>
   );
@@ -346,10 +383,13 @@ export function ArticleEngagement({
   recommendCount,
   commentCount,
   size = "xs",
+  viewerHasRecommended = false,
 }: {
   recommendCount: number;
   commentCount: number;
   size?: keyof typeof ENGAGEMENT_ICON_SIZE;
+  /** The viewer recommended this article — fills the heart on the like count. */
+  viewerHasRecommended?: boolean;
 }) {
   const hasLikes = recommendCount > 0;
   const hasComments = commentCount > 0;
@@ -357,7 +397,13 @@ export function ArticleEngagement({
 
   return (
     <Flex align="center" gap="md" wrap style={styles.meta}>
-      {hasLikes ? <LikeCount count={recommendCount} size={size} /> : null}
+      {hasLikes ? (
+        <LikeCount
+          count={recommendCount}
+          size={size}
+          filled={viewerHasRecommended}
+        />
+      ) : null}
       {hasLikes && hasComments ? (
         <span aria-hidden {...stylex.props(styles.metaDot)}>
           ·

--- a/src/components/reader/recommend-optimistic.ts
+++ b/src/components/reader/recommend-optimistic.ts
@@ -43,8 +43,8 @@ function bumpCard(
   recommended: boolean,
 ): ArticleCard {
   if (card.uri !== documentUri) return card;
-  // Also flip the viewer's own recommend flag so the "Recommended by you"
-  // indicator toggles instantly, even when the count is unchanged (delta 0).
+  // Also flip the viewer's own recommend flag so the filled heart on the like
+  // count toggles instantly, even when the count is unchanged (delta 0).
   return {
     ...card,
     recommendCount: bumpCount(card.recommendCount, delta),

--- a/src/integrations/tanstack-query/api-author.functions.ts
+++ b/src/integrations/tanstack-query/api-author.functions.ts
@@ -335,7 +335,7 @@ const getAuthorProfile = createServerFn({ method: "GET" })
               did,
             ),
           ]);
-        // Flag the viewer's own recommends so cards show "Recommended by you".
+        // Flag the viewer's own recommends so cards fill the like-count heart.
         const [documentsWithRecs, recommendationsWithRecs] = await Promise.all([
           attachViewerRecommendedToArticles(
             db,

--- a/src/integrations/tanstack-query/api-feed.functions.ts
+++ b/src/integrations/tanstack-query/api-feed.functions.ts
@@ -412,7 +412,7 @@ async function buildHomeFeedCritical(
       ? attachRecommendedByToArticles(db, schema, ctx.followedUserDids, cards)
       : Promise.resolve(cards),
   ]);
-  // Flag the viewer's own recommends so cards show "Recommended by you".
+  // Flag the viewer's own recommends so cards fill the like-count heart.
   const withViewerRecs = await attachViewerRecommendedToArticles(
     db,
     schema,

--- a/src/integrations/tanstack-query/api-reader.functions.ts
+++ b/src/integrations/tanstack-query/api-reader.functions.ts
@@ -173,7 +173,7 @@ function buildReaderListPage<T>(
 
 /**
  * Flag the queue items (saved / history) whose article the viewer recommended,
- * so the rows show the "Recommended by you" indicator. One batched query over
+ * so the rows show a filled heart on the like count. One batched query over
  * the page's cards; a no-op when nothing on the page is recommended.
  */
 async function flagViewerRecommendedItems<

--- a/src/integrations/tanstack-query/api-shapes.ts
+++ b/src/integrations/tanstack-query/api-shapes.ts
@@ -147,8 +147,8 @@ export interface ArticleCard {
   recommendedBy?: Array<ArticleCardRecommender>;
   /**
    * Whether the requesting reader has recommended this article themselves.
-   * Drives the "Recommended by you" indicator (red heart) shown on document
-   * items across the app. Attached server-side (see
+   * Fills (and tints) the heart on the document's like count across the app —
+   * there is no separate "Recommended by you" line. Attached server-side (see
    * `attachViewerRecommendedToArticles`); only meaningful when the query ran for
    * a signed-in reader, otherwise defaults to `false`.
    */

--- a/src/server/reader/recommended-by.ts
+++ b/src/server/reader/recommended-by.ts
@@ -79,7 +79,7 @@ export async function attachRecommendedByToArticles<
 
 /**
  * Flag the cards the requesting reader has recommended themselves, so document
- * items across the app can show the "Recommended by you" indicator. One batched,
+ * items across the app can fill the heart on the like count. One batched,
  * index-served query (rides the `(recommender_did, document_uri)` composite
  * index) sets `viewerHasRecommended: true` on matching cards; the rest keep the
  * `false` default from {@link toArticleCard}.


### PR DESCRIPTION
## Summary

Refactors the "Recommended by you" indicator from a separate attribution line to a filled, tinted heart on the document's like count. This consolidates the viewer's own recommendation signal into the engagement metrics, simplifying the UI while maintaining the visual affordance.

## Changes

- **`LikeCount` component** (`primitives.tsx`): Added `filled` prop to fill and tint the heart icon with `criticalColor` when the viewer has recommended the article. Wraps the heart in a span with appropriate ARIA labels (`role="img"` + `aria-label: "Recommended by you"` when filled, `aria-hidden` otherwise).

- **`ArticleEngagement` component** (`primitives.tsx`): Added `viewerHasRecommended` prop and passes it to `LikeCount` as the `filled` prop.

- **`RecommendedByLine` component** (`cards.tsx`): Removed the "Recommended by you" branch entirely. Now only renders the followed-user attribution ("@handle and N others"), or nothing if no other users recommended the article.

- **`hasRecommendedByLine` helper** (`cards.tsx`): Updated to only check for `recommendedBy` length, no longer considers `viewerHasRecommended`.

- **`ArticleMetaLine` and `CompactRow`** (`cards.tsx`): Pass `viewerHasRecommended` to `ArticleEngagement`.

- **`ArticleViewBody`** (`article-view.tsx`): Uses optimistic `recommendCount` for engagement visibility and passes `recommended` flag to `ArticleEngagement` so the byline heart fills instantly on recommend.

- **`DocumentHoverCardBody`** (`mention-hover-card.tsx`): Passes `viewerHasRecommended` to `LikeCount`.

- **`recommend-optimistic.ts`**: Updated comment to reflect that the flag now controls the filled heart, not a separate line.

- **Documentation & comments**: Updated `TODO.md`, API shape comments, and server function comments throughout to reflect the new behavior (filled heart instead of separate "Recommended by you" line).

## Implementation Details

- The filled heart uses `fill="currentColor"` to inherit the `criticalColor.solid1` tint from the parent span's `color` style.
- The heart remains inline with the count (no separate line), reducing visual clutter while maintaining the recommendation signal.
- ARIA labeling ensures the filled heart is properly announced to screen readers as "Recommended by you" when filled.
- The optimistic recommend action now fills the heart instantly, even when the count doesn't change (delta 0).

https://claude.ai/code/session_01TYJ4QeUQHwNbNqf3WyJFCG