### PR TITLE
Add article sort controls to tag page Articles tab

### DIFF
--- a/APP_VISION.md
+++ b/APP_VISION.md
@@ -113,8 +113,12 @@ Sections, top to bottom:
 
 - Route `/tag/$tag`; linked from topic chips on article cards, publication cards, and
   article kickers.
-- **Articles** tab: chronological feed of indexed, published articles carrying the tag
-  (case-insensitive) on discover-eligible publications.
+- **Articles** tab: indexed, published articles carrying the tag (case-insensitive) on
+  discover-eligible publications, with a **Recent / Trending / Most popular** sort select
+  sitting in the tab row. Trending ranks by the precomputed `documents.trending_score`;
+  Most popular ranks by all-time likes then Bluesky backlinks. Both rank rather than
+  filter — score ties fall back to newest-first, so the list stays paginable on a
+  low-traffic tag.
 - **Publications** tab: discover-eligible publications with at least one such document,
   with per-publication **tagged-post counts**, Most posts / Readers / Active / A–Z sort,
   and grid ⇄ list toggle.

--- a/TODO.md
+++ b/TODO.md
@@ -366,6 +366,9 @@ in structured o11y (`observe`) and reads from the Neon read-model.
 - [x] Tag directory: `/tag/$tag` lists publications with indexed posts carrying the tag
       and per-publication tagged-post counts; topic chips on cards link there.
       `tagApi` in `api-tag.functions.ts`.
+- [x] Tag Articles tab sort: Recent / Trending / Most popular select in the tab row
+      (`?articleSort=`, its own search param so the Publications-tab `sort` is
+      independent). Backed by `ArticleCardSort` on `selectArticleCards`.
 - [x] Publication profile query (header + owner identity, recent writing,
       readers-also-follow). `publicationApi.getPublicationProfile`.
 - [x] Article query (full content + publication card + byline contributors +

--- a/src/integrations/tanstack-query/api-shapes.ts
+++ b/src/integrations/tanstack-query/api-shapes.ts
@@ -211,6 +211,26 @@ export function publicationCardColumns(schema: Schema) {
 }
 
 /**
+ * Scalar subquery: all-time non-deleted likes on a document. Served as an
+ * index-only scan by `recommends_doc_recommender_created_idx` (partial on
+ * `deleted = false`), so it is cheap enough to also drive an `ORDER BY` over a
+ * filtered document set (see the tag feed's "Most liked" sort).
+ *
+ * Shared with {@link articleCardColumns} so a query that both selects and sorts
+ * on the count uses one expression rather than two that can drift apart.
+ */
+export function documentRecommendCountSql(schema: Schema) {
+  const d = schema.documents;
+  const rec = schema.recommends;
+  return sql<number>`coalesce((
+      select count(*)::int
+      from ${rec}
+      where ${rec.documentUri} = ${d.uri}
+        and ${rec.deleted} = false
+    ), 0)`.mapWith(Number);
+}
+
+/**
  * Select-columns for an {@link ArticleCard}. Pulls the document plus its
  * publication's name/icon and the owner profile's banner; queries should
  * `leftJoin` publications on `publications.uri = documents.publication_uri`
@@ -231,7 +251,6 @@ export function articleCardColumns(schema: Schema) {
   // `documents.did`) at the same time. Joining the same table object twice
   // throws "Alias 'profiles' is already used in this query".
   const pa = alias(schema.profiles, "pa");
-  const rec = schema.recommends;
   return {
     uri: d.uri,
     did: d.did,
@@ -259,12 +278,7 @@ export function articleCardColumns(schema: Schema) {
     textContent: d.textContent,
     hasRenderableBody: d.hasRenderableBody,
     isCollection: documentIsCollectionColumn(d.collectionJson),
-    recommendCount: sql<number>`coalesce((
-      select count(*)::int
-      from ${rec}
-      where ${rec.documentUri} = ${d.uri}
-        and ${rec.deleted} = false
-    ), 0)`.mapWith(Number),
+    recommendCount: documentRecommendCountSql(schema),
   };
 }
 

--- a/src/integrations/tanstack-query/api-tag.functions.ts
+++ b/src/integrations/tanstack-query/api-tag.functions.ts
@@ -38,6 +38,11 @@ export type { TagPublicationCard };
 
 const directorySort = z.enum(["tagged", "readers", "active", "az"]);
 
+/** Ranking for the tag page's **Articles** tab (see {@link ArticleCardSort}). */
+const articleSortEnum = z.enum(["recent", "trending", "popular"]);
+
+export type TagArticleSort = z.infer<typeof articleSortEnum>;
+
 const tagInput = z.object({
   tag: z.string().trim().min(1).max(80),
 });
@@ -59,6 +64,7 @@ export interface TagArticleDirectoryPage {
 }
 
 const articlesPageInput = tagInput.extend({
+  articleSort: articleSortEnum.default("recent"),
   limit: z.number().int().min(1).max(60).default(24),
   offset: z.number().int().min(0).default(0),
 });
@@ -106,6 +112,7 @@ const getArticles = createServerFn({ method: "GET" })
         context;
       const did = await attachReaderSpanContext(span, getRequest());
       span.set("tag", data.tag);
+      span.set("articleSort", data.articleSort);
       span.set("offset", data.offset);
 
       const trackReading = did == null ? false : trackReadingEnabled;
@@ -118,6 +125,7 @@ const getArticles = createServerFn({ method: "GET" })
         selectArticleCards(db, schema, {
           tag: data.tag,
           discoverOnly: true,
+          sort: data.articleSort,
           limit: data.limit,
           offset: data.offset,
           readForDid: trackReading && did ? did : undefined,
@@ -186,6 +194,7 @@ const getPublications = createServerFn({ method: "GET" })
 const tagPageInput = tagInput.extend({
   view: z.enum(["feed", "publications"]),
   sort: directorySort.default("tagged"),
+  articleSort: articleSortEnum.default("recent"),
   limit: z.number().int().min(1).max(60).default(24),
   offset: z.number().int().min(0).default(0),
 });
@@ -222,6 +231,8 @@ const getTagPage = createServerFn({ method: "GET" })
       span.set("offset", data.offset);
       if (data.view === "publications") {
         span.set("sort", data.sort);
+      } else {
+        span.set("articleSort", data.articleSort);
       }
 
       const trackReading = did == null ? false : trackReadingEnabled;
@@ -236,6 +247,7 @@ const getTagPage = createServerFn({ method: "GET" })
             ? selectArticleCards(db, schema, {
                 tag: data.tag,
                 discoverOnly: true,
+                sort: data.articleSort,
                 limit: data.limit,
                 offset: data.offset,
                 readForDid: trackReading && did ? did : undefined,
@@ -429,12 +441,14 @@ function getArticleCountQueryOptions({ tag }: z.input<typeof tagInput>) {
 
 function getArticlesQueryOptions({
   tag,
+  articleSort = "recent",
   limit = 24,
   offset = 0,
 }: z.input<typeof articlesPageInput>) {
   return queryOptions({
-    queryKey: ["tag", "articles", tag, limit, offset] as const,
-    queryFn: async () => getArticles({ data: { tag, limit, offset } }),
+    queryKey: ["tag", "articles", tag, articleSort, limit, offset] as const,
+    queryFn: async () =>
+      getArticles({ data: { tag, articleSort, limit, offset } }),
   });
 }
 
@@ -465,6 +479,7 @@ function seedTagPageCaches(
   {
     tag,
     sort = "tagged",
+    articleSort = "recent",
     limit = 24,
     offset = 0,
   }: z.input<typeof tagPageInput>,
@@ -480,7 +495,7 @@ function seedTagPageCaches(
 
   if (page.articles) {
     queryClient.setQueryData(
-      getArticlesQueryOptions({ tag, limit, offset }).queryKey,
+      getArticlesQueryOptions({ tag, articleSort, limit, offset }).queryKey,
       page.articles,
     );
   }

--- a/src/locales/ar/messages.po
+++ b/src/locales/ar/messages.po
@@ -468,6 +468,7 @@ msgstr "انقر على القلب في أي مقال لتوصي به. تعيش 
 
 #: src/routes/_layout.index.tsx
 #: src/routes/_layout.latest.tsx
+#: src/routes/_layout.tag.$tag.tsx
 msgid "Trending"
 msgstr "الرائج"
 
@@ -699,6 +700,10 @@ msgstr ""
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, zero {الاشتراك في {formattedUnfollowedCount} منشورة؟} one {الاشتراك في منشورة واحدة؟} two {الاشتراك في منشورتين؟} few {الاشتراك في {formattedUnfollowedCount} منشورات؟} many {الاشتراك في {formattedUnfollowedCount} منشورة؟} other {الاشتراك في {formattedUnfollowedCount} منشورة؟}}"
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Sort articles"
+msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
 msgid "No articles match this tag yet."
@@ -1298,6 +1303,10 @@ msgstr ""
 #: src/components/reader/extension-privacy-view.tsx
 msgid "You can disable the page overlay and Bluesky embed save button in the extension options page. You can sign out from the web app to invalidate the session cookie the extension uses. Uninstalling the extension removes locally stored settings from your browser profile."
 msgstr "يمكنك تعطيل تراكب الصفحة وزر الحفظ في تضمينات Bluesky من صفحة خيارات الإضافة. ويمكنك تسجيل الخروج من تطبيق الويب لإبطال ملف تعريف ارتباط الجلسة الذي تستخدمه الإضافة. أما إلغاء تثبيت الإضافة فيحذف الإعدادات المخزَّنة محليًا من ملف تعريف متصفحك."
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Recent"
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "List members"
@@ -4920,6 +4929,10 @@ msgstr "لمعرفة المزيد عن كيفية عمل {SITE_NAME}، اطّل�
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Copy link"
 msgstr "نسخ الرابط"
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Most popular"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "A weekly email with the best of what you subscribe to, plus a couple of publications worth discovering. Turning this on asks your PDS to share your email address."

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -468,6 +468,7 @@ msgstr "Tippen Sie bei einem Artikel auf das Herz, um ihn zu empfehlen. Ihre Emp
 
 #: src/routes/_layout.index.tsx
 #: src/routes/_layout.latest.tsx
+#: src/routes/_layout.tag.$tag.tsx
 msgid "Trending"
 msgstr "Im Trend"
 
@@ -699,6 +700,10 @@ msgstr ""
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {{formattedUnfollowedCount} Publikation abonnieren?} other {{formattedUnfollowedCount} Publikationen abonnieren?}}"
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Sort articles"
+msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
 msgid "No articles match this tag yet."
@@ -1298,6 +1303,10 @@ msgstr ""
 #: src/components/reader/extension-privacy-view.tsx
 msgid "You can disable the page overlay and Bluesky embed save button in the extension options page. You can sign out from the web app to invalidate the session cookie the extension uses. Uninstalling the extension removes locally stored settings from your browser profile."
 msgstr "Sie können das Seiten-Overlay und den Speichern-Button in Bluesky-Embeds in den Optionen der Erweiterung deaktivieren. In der Web-App können Sie sich abmelden, um das von der Erweiterung genutzte Session-Cookie ungültig zu machen. Beim Deinstallieren der Erweiterung werden lokal gespeicherte Einstellungen aus Ihrem Browserprofil entfernt."
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Recent"
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "List members"
@@ -4920,6 +4929,10 @@ msgstr "Mehr dazu, wie {SITE_NAME} funktioniert, finden Sie auf der Seite <0>Üb
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Copy link"
 msgstr "Link kopieren"
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Most popular"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "A weekly email with the best of what you subscribe to, plus a couple of publications worth discovering. Turning this on asks your PDS to share your email address."

--- a/src/locales/en-XA/messages.po
+++ b/src/locales/en-XA/messages.po
@@ -468,6 +468,7 @@ msgstr ""
 
 #: src/routes/_layout.index.tsx
 #: src/routes/_layout.latest.tsx
+#: src/routes/_layout.tag.$tag.tsx
 msgid "Trending"
 msgstr ""
 
@@ -698,6 +699,10 @@ msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
+msgstr ""
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Sort articles"
 msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
@@ -1297,6 +1302,10 @@ msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "You can disable the page overlay and Bluesky embed save button in the extension options page. You can sign out from the web app to invalidate the session cookie the extension uses. Uninstalling the extension removes locally stored settings from your browser profile."
+msgstr ""
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Recent"
 msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
@@ -4919,6 +4928,10 @@ msgstr ""
 #: src/components/reader/share-menu.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Copy link"
+msgstr ""
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Most popular"
 msgstr ""
 
 #: src/components/user-settings-view.tsx

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -468,6 +468,7 @@ msgstr "Tap the heart on any article to recommend it. Your recommendations live 
 
 #: src/routes/_layout.index.tsx
 #: src/routes/_layout.latest.tsx
+#: src/routes/_layout.tag.$tag.tsx
 msgid "Trending"
 msgstr "Trending"
 
@@ -699,6 +700,10 @@ msgstr "Turn on to choose which items appear in the sidebar. Subscriptions and y
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Sort articles"
+msgstr "Sort articles"
 
 #: src/routes/_layout.tag.$tag.tsx
 msgid "No articles match this tag yet."
@@ -1298,6 +1303,10 @@ msgstr "The core, and new frameworks"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "You can disable the page overlay and Bluesky embed save button in the extension options page. You can sign out from the web app to invalidate the session cookie the extension uses. Uninstalling the extension removes locally stored settings from your browser profile."
 msgstr "You can disable the page overlay and Bluesky embed save button in the extension options page. You can sign out from the web app to invalidate the session cookie the extension uses. Uninstalling the extension removes locally stored settings from your browser profile."
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Recent"
+msgstr "Recent"
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "List members"
@@ -4920,6 +4929,10 @@ msgstr "For more about how {SITE_NAME} works, see the <0>About</0> page. For pri
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Copy link"
 msgstr "Copy link"
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Most popular"
+msgstr "Most popular"
 
 #: src/components/user-settings-view.tsx
 msgid "A weekly email with the best of what you subscribe to, plus a couple of publications worth discovering. Turning this on asks your PDS to share your email address."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -468,6 +468,7 @@ msgstr "Toque el corazón en cualquier artículo para recomendarlo. Sus recomend
 
 #: src/routes/_layout.index.tsx
 #: src/routes/_layout.latest.tsx
+#: src/routes/_layout.tag.$tag.tsx
 msgid "Trending"
 msgstr "Tendencias"
 
@@ -699,6 +700,10 @@ msgstr ""
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {¿Suscribirse a {formattedUnfollowedCount} publicación?} other {¿Suscribirse a {formattedUnfollowedCount} publicaciones?}}"
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Sort articles"
+msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
 msgid "No articles match this tag yet."
@@ -1298,6 +1303,10 @@ msgstr ""
 #: src/components/reader/extension-privacy-view.tsx
 msgid "You can disable the page overlay and Bluesky embed save button in the extension options page. You can sign out from the web app to invalidate the session cookie the extension uses. Uninstalling the extension removes locally stored settings from your browser profile."
 msgstr "Puede desactivar la superposición de página y el botón de guardado en los embeds de Bluesky desde la página de opciones de la extensión. Puede cerrar sesión en la aplicación web para invalidar la cookie de sesión que usa la extensión. Al desinstalar la extensión se eliminan los ajustes guardados localmente en su perfil del navegador."
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Recent"
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "List members"
@@ -4920,6 +4929,10 @@ msgstr "Para saber más sobre cómo funciona {SITE_NAME}, consulte la página <0
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Copy link"
 msgstr "Copiar enlace"
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Most popular"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "A weekly email with the best of what you subscribe to, plus a couple of publications worth discovering. Turning this on asks your PDS to share your email address."

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -468,6 +468,7 @@ msgstr "Touchez le cœur sur un article pour le recommander. Vos recommandations
 
 #: src/routes/_layout.index.tsx
 #: src/routes/_layout.latest.tsx
+#: src/routes/_layout.tag.$tag.tsx
 msgid "Trending"
 msgstr "Tendances"
 
@@ -699,6 +700,10 @@ msgstr ""
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {S’abonner à {formattedUnfollowedCount} publication ?} other {S’abonner à {formattedUnfollowedCount} publications ?}}"
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Sort articles"
+msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
 msgid "No articles match this tag yet."
@@ -1298,6 +1303,10 @@ msgstr ""
 #: src/components/reader/extension-privacy-view.tsx
 msgid "You can disable the page overlay and Bluesky embed save button in the extension options page. You can sign out from the web app to invalidate the session cookie the extension uses. Uninstalling the extension removes locally stored settings from your browser profile."
 msgstr "Vous pouvez désactiver la surcouche de page et le bouton d'enregistrement des intégrations Bluesky depuis la page d'options de l'extension. Vous pouvez vous déconnecter de l'application web pour invalider le cookie de session utilisé par l'extension. Désinstaller l'extension supprime les réglages stockés localement dans votre profil de navigateur."
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Recent"
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "List members"
@@ -4920,6 +4929,10 @@ msgstr "Pour en savoir plus sur le fonctionnement de {SITE_NAME}, consultez la p
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Copy link"
 msgstr "Copier le lien"
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Most popular"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "A weekly email with the best of what you subscribe to, plus a couple of publications worth discovering. Turning this on asks your PDS to share your email address."

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -468,6 +468,7 @@ msgstr "記事のハートをタップするとおすすめできます。おす
 
 #: src/routes/_layout.index.tsx
 #: src/routes/_layout.latest.tsx
+#: src/routes/_layout.tag.$tag.tsx
 msgid "Trending"
 msgstr "トレンド"
 
@@ -699,6 +700,10 @@ msgstr ""
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {{formattedUnfollowedCount} 件の発行物を購読しますか？} other {{formattedUnfollowedCount} 件の発行物を購読しますか？}}"
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Sort articles"
+msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
 msgid "No articles match this tag yet."
@@ -1298,6 +1303,10 @@ msgstr ""
 #: src/components/reader/extension-privacy-view.tsx
 msgid "You can disable the page overlay and Bluesky embed save button in the extension options page. You can sign out from the web app to invalidate the session cookie the extension uses. Uninstalling the extension removes locally stored settings from your browser profile."
 msgstr "ページのオーバーレイと Bluesky 埋め込みの保存ボタンは、拡張機能のオプションページで無効にできます。拡張機能が使用するセッション Cookie を無効にするには、Web アプリからサインアウトしてください。拡張機能をアンインストールすると、ブラウザのプロファイルに保存されたローカル設定も削除されます。"
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Recent"
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "List members"
@@ -4920,6 +4929,10 @@ msgstr "{SITE_NAME} の仕組みについて詳しくは <0>概要</0> ページ
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Copy link"
 msgstr "リンクをコピー"
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Most popular"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "A weekly email with the best of what you subscribe to, plus a couple of publications worth discovering. Turning this on asks your PDS to share your email address."

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -468,6 +468,7 @@ msgstr "글의 하트를 탭해 추천하세요. 추천은 회원님의 repo에 
 
 #: src/routes/_layout.index.tsx
 #: src/routes/_layout.latest.tsx
+#: src/routes/_layout.tag.$tag.tsx
 msgid "Trending"
 msgstr "인기"
 
@@ -699,6 +700,10 @@ msgstr ""
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {발행물 {formattedUnfollowedCount}개를 구독할까요?} other {발행물 {formattedUnfollowedCount}개를 구독할까요?}}"
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Sort articles"
+msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
 msgid "No articles match this tag yet."
@@ -1298,6 +1303,10 @@ msgstr ""
 #: src/components/reader/extension-privacy-view.tsx
 msgid "You can disable the page overlay and Bluesky embed save button in the extension options page. You can sign out from the web app to invalidate the session cookie the extension uses. Uninstalling the extension removes locally stored settings from your browser profile."
 msgstr "확장 프로그램 옵션 페이지에서 페이지 오버레이와 Bluesky 임베드 저장 버튼을 끌 수 있습니다. 웹 앱에서 로그아웃하면 확장 프로그램이 사용하는 세션 쿠키가 무효화됩니다. 확장 프로그램을 삭제하면 브라우저 프로필에 로컬로 저장된 설정도 제거됩니다."
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Recent"
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "List members"
@@ -4920,6 +4929,10 @@ msgstr "{SITE_NAME}의 작동 방식에 대한 자세한 내용은 <0>소개</0>
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Copy link"
 msgstr "링크 복사"
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Most popular"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "A weekly email with the best of what you subscribe to, plus a couple of publications worth discovering. Turning this on asks your PDS to share your email address."

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -468,6 +468,7 @@ msgstr "Toque no coração de qualquer artigo para o recomendar. As suas recomen
 
 #: src/routes/_layout.index.tsx
 #: src/routes/_layout.latest.tsx
+#: src/routes/_layout.tag.$tag.tsx
 msgid "Trending"
 msgstr "Em alta"
 
@@ -699,6 +700,10 @@ msgstr ""
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {Se inscrever em {formattedUnfollowedCount} publicação?} other {Se inscrever em {formattedUnfollowedCount} publicações?}}"
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Sort articles"
+msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
 msgid "No articles match this tag yet."
@@ -1298,6 +1303,10 @@ msgstr "O núcleo e novos frameworks"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "You can disable the page overlay and Bluesky embed save button in the extension options page. You can sign out from the web app to invalidate the session cookie the extension uses. Uninstalling the extension removes locally stored settings from your browser profile."
 msgstr "Você pode desativar a sobreposição na página e o botão de salvar nos links incorporados do Bluesky na página de opções da extensão. Pode terminar sessão na aplicação web para invalidar o cookie de sessão que a extensão utiliza. Desinstalar a extensão remove as configurações guardadas localmente no perfil do seu navegador."
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Recent"
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "List members"
@@ -4920,6 +4929,10 @@ msgstr "Para saber mais sobre como o {SITE_NAME} funciona, consulte a página <0
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Copy link"
 msgstr "Copiar link"
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Most popular"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "A weekly email with the best of what you subscribe to, plus a couple of publications worth discovering. Turning this on asks your PDS to share your email address."

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -468,6 +468,7 @@ msgstr "轻点任意文章上的爱心即可推荐它。你的推荐以 <0>site.
 
 #: src/routes/_layout.index.tsx
 #: src/routes/_layout.latest.tsx
+#: src/routes/_layout.tag.$tag.tsx
 msgid "Trending"
 msgstr "热门"
 
@@ -699,6 +700,10 @@ msgstr ""
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {订阅 {formattedUnfollowedCount} 个刊物？} other {订阅 {formattedUnfollowedCount} 个刊物？}}"
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Sort articles"
+msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
 msgid "No articles match this tag yet."
@@ -1298,6 +1303,10 @@ msgstr ""
 #: src/components/reader/extension-privacy-view.tsx
 msgid "You can disable the page overlay and Bluesky embed save button in the extension options page. You can sign out from the web app to invalidate the session cookie the extension uses. Uninstalling the extension removes locally stored settings from your browser profile."
 msgstr "你可以在扩展的选项页面中关闭页面浮层和 Bluesky 嵌入保存按钮。你可以在网页版退出登录，使扩展所用的会话 cookie 失效。卸载扩展会从浏览器配置文件中删除本地存储的设置。"
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Recent"
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "List members"
@@ -4920,6 +4929,10 @@ msgstr "想进一步了解 {SITE_NAME} 的运作方式，请查看<0>关于</0>�
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Copy link"
 msgstr "复制链接"
+
+#: src/routes/_layout.tag.$tag.tsx
+msgid "Most popular"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "A weekly email with the best of what you subscribe to, plus a couple of publications worth discovering. Turning this on asks your PDS to share your email address."

--- a/src/routes/_layout.tag.$tag.tsx
+++ b/src/routes/_layout.tag.$tag.tsx
@@ -15,7 +15,14 @@ import {
   useNavigate,
   useRouterState,
 } from "@tanstack/react-router";
-import { Check, LayoutGrid, List, Plus, Tag } from "lucide-react";
+import {
+  ArrowDownWideNarrow,
+  Check,
+  LayoutGrid,
+  List,
+  Plus,
+  Tag,
+} from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { z } from "zod";
 
@@ -55,6 +62,7 @@ import {
   SegmentedControl,
   SegmentedControlItem,
 } from "#/design-system/segmented-control";
+import { Select, SelectItem } from "#/design-system/select";
 import { Skeleton } from "#/design-system/skeleton";
 import { Tab, TabList, TabPanel, Tabs } from "#/design-system/tabs";
 import { uiColor } from "#/design-system/theme/color.stylex";
@@ -69,6 +77,7 @@ import {
 } from "#/design-system/theme/typography.stylex";
 import type { ArticleCard } from "#/integrations/tanstack-query/api-shapes";
 import type {
+  TagArticleSort,
   TagFollowSummary,
   TagPublicationCard,
   TagPublicationDirectoryPage,
@@ -112,6 +121,9 @@ function normalizeTagSearch(search: unknown) {
 const tagSearchShape = z.object({
   view: z.enum(["feed", "publications"]).default("feed"),
   sort: z.enum(["tagged", "readers", "active", "az"]).default("tagged"),
+  /** Articles-tab ranking. Named apart from `sort` (the publications-tab
+   * directory ranking) so the two tabs keep independent state in the URL. */
+  articleSort: z.enum(["recent", "trending", "popular"]).default("recent"),
   layout: z.enum(["grid", "list"]).default("list"),
 });
 
@@ -123,7 +135,11 @@ type TagView = TagSearch["view"];
 export const Route = createFileRoute("/_layout/tag/$tag")({
   validateSearch: tagSearchSchema,
   staleTime: 60_000,
-  loaderDeps: ({ search }) => ({ view: search.view, sort: search.sort }),
+  loaderDeps: ({ search }) => ({
+    view: search.view,
+    sort: search.sort,
+    articleSort: search.articleSort,
+  }),
   loader: async ({ context, params, deps }) => {
     const tag = decodeURIComponent(params.tag);
     const page = await tagApi.getTagPage({
@@ -131,6 +147,7 @@ export const Route = createFileRoute("/_layout/tag/$tag")({
         tag,
         view: deps.view,
         sort: deps.sort,
+        articleSort: deps.articleSort,
         limit: PAGE_SIZE,
         offset: 0,
       },
@@ -139,6 +156,7 @@ export const Route = createFileRoute("/_layout/tag/$tag")({
       tag,
       view: deps.view,
       sort: deps.sort,
+      articleSort: deps.articleSort,
       limit: PAGE_SIZE,
       offset: 0,
     });
@@ -255,7 +273,14 @@ const styles = stylex.create({
     width: "100%",
   },
   tabBarInner: {
+    // Tabs on the leading edge, the active tab's sort control on the trailing
+    // edge, both sitting on the shared rule below (`alignItems: flex-end`).
+    alignItems: "flex-end",
     boxSizing: "border-box",
+    columnGap: spacing["4"],
+    display: "flex",
+    flexWrap: "wrap",
+    rowGap: spacing["2"],
     marginInlineStart: "auto",
     marginInlineEnd: "auto",
     maxWidth: "82.5rem",
@@ -273,6 +298,19 @@ const styles = stylex.create({
   tabList: {
     borderBottomStyle: "none",
     borderBottomWidth: 0,
+    // The design-system TabList scrolls its own overflow, so it would happily
+    // shrink to nothing beside the sort control. Pinning it keeps the tabs
+    // intact and lets the control wrap to its own line on narrow screens.
+    flexShrink: 0,
+  },
+  tabBarSort: {
+    flexShrink: 0,
+    // Trailing edge whether or not the row wrapped (`space-between` would pull
+    // a wrapped control back to the leading edge).
+    marginInlineStart: "auto",
+    minWidth: spacing["40"],
+    // Lift the trigger off the rule the tab labels rest on.
+    paddingBottom: spacing["2"],
   },
   tabRule: {
     borderBottomColor: uiColor.border1,
@@ -355,6 +393,12 @@ const SORT_OPTIONS = [
   { id: "readers", label: msg`Readers` },
   { id: "active", label: msg`Active` },
   { id: "az", label: msg`A–Z` },
+] as const;
+
+const ARTICLE_SORT_OPTIONS = [
+  { id: "recent", label: msg`Recent` },
+  { id: "trending", label: msg`Trending` },
+  { id: "popular", label: msg`Most popular` },
 ] as const;
 
 function ArticleRowSkeleton({
@@ -440,7 +484,13 @@ function TagDirectorySkeleton({
   );
 }
 
-function TagArticlesPanel({ tag }: { tag: string }) {
+function TagArticlesPanel({
+  tag,
+  articleSort,
+}: {
+  tag: string;
+  articleSort: TagArticleSort;
+}) {
   const { t } = useLingui();
   const queryClient = useQueryClient();
   const { data: session } = useQuery(user.getSessionQueryOptions);
@@ -454,6 +504,7 @@ function TagArticlesPanel({ tag }: { tag: string }) {
   } = useQuery({
     ...tagApi.getArticlesQueryOptions({
       tag,
+      articleSort,
       limit: PAGE_SIZE,
       offset: 0,
     }),
@@ -475,7 +526,7 @@ function TagArticlesPanel({ tag }: { tag: string }) {
   useEffect(() => {
     setLoadedMore([]);
     setLoadedMoreNextOffset(null);
-  }, [tag]);
+  }, [tag, articleSort]);
 
   const items = useMemo(
     () => [...(feed?.items ?? []), ...loadedMore],
@@ -494,7 +545,7 @@ function TagArticlesPanel({ tag }: { tag: string }) {
     setLoadingMore(true);
     try {
       const page = await tagApi.getArticles({
-        data: { tag, limit: PAGE_SIZE, offset: nextOffset },
+        data: { tag, articleSort, limit: PAGE_SIZE, offset: nextOffset },
       });
       setLoadedMore((prev) => [...prev, ...page.items]);
       setLoadedMoreNextOffset(page.nextOffset);
@@ -502,7 +553,7 @@ function TagArticlesPanel({ tag }: { tag: string }) {
       loadingMoreRef.current = false;
       setLoadingMore(false);
     }
-  }, [nextOffset, tag]);
+  }, [articleSort, nextOffset, tag]);
 
   const loadMoreSentinelRef = useInfiniteScrollSentinel(
     loadMore,
@@ -925,11 +976,11 @@ function TagFollowAllButton({
 }
 
 function TagPage() {
-  const { t } = useLingui();
+  const { t, i18n } = useLingui();
   const fmt = useFormatters();
   const { tag: rawTag } = Route.useParams();
   const tag = decodeURIComponent(rawTag);
-  const { view, sort, layout } = Route.useSearch();
+  const { view, sort, articleSort, layout } = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
   const routePending = useRouterState({ select: (state) => state.isLoading });
   const [pendingViews, setPendingViews] = useState<
@@ -964,6 +1015,7 @@ function TagPage() {
       void queryClient.prefetchQuery(
         tagApi.getArticlesQueryOptions({
           tag,
+          articleSort,
           limit: PAGE_SIZE,
           offset: 0,
         }),
@@ -984,7 +1036,7 @@ function TagPage() {
 
     const idleId = scheduleIdle(prefetchOtherTab);
     return () => cancelIdle(idleId);
-  }, [queryClient, routePending, sort, tag, view]);
+  }, [articleSort, queryClient, routePending, sort, tag, view]);
 
   const pendingView = pendingViews[tag] ?? null;
   const activeView = routePending ? (pendingView ?? view) : view;
@@ -997,6 +1049,16 @@ function TagPage() {
       setPendingViews((prev) => ({ ...prev, [tag]: next }));
     }
     void navigate({ search: (prev: TagSearch) => ({ ...prev, view: next }) });
+  };
+
+  const onArticleSortChange = (key: React.Key | null) => {
+    if (key == null) return;
+    const next = String(key) as TagArticleSort;
+    void navigate({
+      replace: true,
+      resetScroll: false,
+      search: (prev: TagSearch) => ({ ...prev, articleSort: next }),
+    });
   };
 
   return (
@@ -1060,13 +1122,39 @@ function TagPage() {
                 <Trans>Publications</Trans>
               </Tab>
             </TabList>
+
+            {/* Articles-only: the Publications tab carries its own sort in the
+                directory toolbar. */}
+            {isFeed ? (
+              <Select
+                aria-label={t`Sort articles`}
+                size="sm"
+                variant="secondary"
+                prefix={<ArrowDownWideNarrow size={14} aria-hidden />}
+                selectedKey={articleSort}
+                style={styles.tabBarSort}
+                onSelectionChange={onArticleSortChange}
+              >
+                {ARTICLE_SORT_OPTIONS.map((option) => (
+                  <SelectItem
+                    key={option.id}
+                    id={option.id}
+                    textValue={i18n._(option.label)}
+                  >
+                    {i18n._(option.label)}
+                  </SelectItem>
+                ))}
+              </Select>
+            ) : null}
           </div>
           <div {...stylex.props(styles.tabRule)} aria-hidden />
         </div>
 
         <ReaderContent>
           <TabPanel id="feed" style={styles.tabPanel}>
-            {isFeed ? <TagArticlesPanel tag={tag} /> : null}
+            {isFeed ? (
+              <TagArticlesPanel tag={tag} articleSort={articleSort} />
+            ) : null}
           </TabPanel>
           <TabPanel id="publications" style={styles.tabPanel}>
             {isFeed ? null : (

--- a/src/routes/_layout.tag.$tag.tsx
+++ b/src/routes/_layout.tag.$tag.tsx
@@ -24,6 +24,7 @@ import {
   Tag,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { Selection } from "react-aria-components";
 import { z } from "zod";
 
 import {
@@ -58,6 +59,8 @@ import {
 import { Button } from "#/design-system/button";
 import { Flex } from "#/design-system/flex";
 import { Grid } from "#/design-system/grid";
+import { IconButton } from "#/design-system/icon-button";
+import { Menu, MenuItem } from "#/design-system/menu";
 import {
   SegmentedControl,
   SegmentedControlItem,
@@ -66,6 +69,7 @@ import { Select, SelectItem } from "#/design-system/select";
 import { Skeleton } from "#/design-system/skeleton";
 import { Tab, TabList, TabPanel, Tabs } from "#/design-system/tabs";
 import { uiColor } from "#/design-system/theme/color.stylex";
+import { breakpoints } from "#/design-system/theme/media-queries.stylex";
 import { gap } from "#/design-system/theme/semantic-spacing.stylex";
 import { spacing } from "#/design-system/theme/spacing.stylex";
 import {
@@ -303,14 +307,29 @@ const styles = stylex.create({
     // intact and lets the control wrap to its own line on narrow screens.
     flexShrink: 0,
   },
+  // Shared slot geometry for the articles sort control. Two controls occupy it
+  // — a compact icon menu and the full select — swapped by media query rather
+  // than by a JS viewport check, so SSR emits both and neither can hydrate to
+  // the wrong one. `display: none` also drops the hidden one from the a11y
+  // tree, so the duplicate label is never announced twice.
   tabBarSort: {
     flexShrink: 0,
     // Trailing edge whether or not the row wrapped (`space-between` would pull
     // a wrapped control back to the leading edge).
     marginInlineStart: "auto",
-    minWidth: spacing["40"],
-    // Lift the trigger off the rule the tab labels rest on.
+    // Lift the control off the rule the tab labels rest on.
     paddingBottom: spacing["2"],
+  },
+  // One breakpoint drives both slots (never `max-width` for one and
+  // `min-width` for the other — they'd both match at exactly 40rem).
+  tabBarSortCompact: {
+    display: { default: "flex", [breakpoints.sm]: "none" },
+  },
+  tabBarSortFull: {
+    display: { default: "none", [breakpoints.sm]: "flex" },
+  },
+  tabBarSortSelect: {
+    minWidth: spacing["40"],
   },
   tabRule: {
     borderBottomColor: uiColor.border1,
@@ -1061,6 +1080,12 @@ function TagPage() {
     });
   };
 
+  /** Menu hands back a `Selection`; the select hands back a single key. */
+  const onArticleSortSelection = (keys: Selection) => {
+    if (keys === "all") return;
+    onArticleSortChange([...keys][0] ?? null);
+  };
+
   return (
     <div>
       <div {...stylex.props(styles.heroInner)}>
@@ -1126,25 +1151,57 @@ function TagPage() {
             {/* Articles-only: the Publications tab carries its own sort in the
                 directory toolbar. */}
             {isFeed ? (
-              <Select
-                aria-label={t`Sort articles`}
-                size="sm"
-                variant="secondary"
-                prefix={<ArrowDownWideNarrow size={14} aria-hidden />}
-                selectedKey={articleSort}
-                style={styles.tabBarSort}
-                onSelectionChange={onArticleSortChange}
-              >
-                {ARTICLE_SORT_OPTIONS.map((option) => (
-                  <SelectItem
-                    key={option.id}
-                    id={option.id}
-                    textValue={i18n._(option.label)}
+              <>
+                <div
+                  {...stylex.props(styles.tabBarSort, styles.tabBarSortCompact)}
+                >
+                  <Menu
+                    placement="bottom end"
+                    selectionMode="single"
+                    selectedKeys={new Set([articleSort])}
+                    onSelectionChange={onArticleSortSelection}
+                    trigger={
+                      <IconButton
+                        aria-label={t`Sort articles`}
+                        size="md"
+                        variant="secondary"
+                      >
+                        <ArrowDownWideNarrow size={16} />
+                      </IconButton>
+                    }
                   >
-                    {i18n._(option.label)}
-                  </SelectItem>
-                ))}
-              </Select>
+                    {ARTICLE_SORT_OPTIONS.map((option) => (
+                      <MenuItem key={option.id} id={option.id}>
+                        {i18n._(option.label)}
+                      </MenuItem>
+                    ))}
+                  </Menu>
+                </div>
+
+                <div
+                  {...stylex.props(styles.tabBarSort, styles.tabBarSortFull)}
+                >
+                  <Select
+                    aria-label={t`Sort articles`}
+                    size="md"
+                    variant="secondary"
+                    prefix={<ArrowDownWideNarrow size={14} aria-hidden />}
+                    selectedKey={articleSort}
+                    style={styles.tabBarSortSelect}
+                    onSelectionChange={onArticleSortChange}
+                  >
+                    {ARTICLE_SORT_OPTIONS.map((option) => (
+                      <SelectItem
+                        key={option.id}
+                        id={option.id}
+                        textValue={i18n._(option.label)}
+                      >
+                        {i18n._(option.label)}
+                      </SelectItem>
+                    ))}
+                  </Select>
+                </div>
+              </>
             ) : null}
           </div>
           <div {...stylex.props(styles.tabRule)} aria-hidden />

--- a/src/server/reader/queries.ts
+++ b/src/server/reader/queries.ts
@@ -41,6 +41,7 @@ import {
   articleCardColumns,
   articleQueueCardColumns,
   documentIsCollectionColumn,
+  documentRecommendCountSql,
   publicationCardColumns,
   publicationSortNameSql,
   toArticleCard,
@@ -86,6 +87,27 @@ const RECOMMENDATION_BLEND = {
  */
 const CUTOFF_POOL_MULT = 5;
 
+/**
+ * Ranking for a plain (non-follow-feed) article list.
+ *
+ * - `recent` — newest first (`published_at desc`). The default everywhere.
+ * - `trending` — precomputed `documents.trending_score` first, then recency.
+ *   The score is only maintained for the 4-day discover slice (see
+ *   `recompute.ts`), so this ranks rather than filters: currently-hot articles
+ *   float to the top and everything else keeps its chronological order, which
+ *   keeps the list paginable instead of near-empty on a niche tag.
+ * - `popular` — all-time likes (`recommends`), then Bluesky backlinks, then
+ *   recency. Computed live because `distinct_recommender_count` shares
+ *   `trending_score`'s 4-day staleness and would rank an all-time list wrong.
+ *
+ * PERF: `popular` sorts on a correlated subquery, so Postgres evaluates it for
+ * every row the `WHERE` admits — not just the page. That is fine for a filtered
+ * list (today: one tag, served by `documents_tags_norm_idx`, with each count an
+ * index-only scan on the partial `recommends_doc_recommender_created_idx`), but
+ * do NOT reach for it on an unfiltered feed; pre-aggregate instead.
+ */
+export type ArticleCardSort = "recent" | "trending" | "popular";
+
 export interface ArticleCardQuery {
   /** Restrict to documents in these publications (e.g. a reader's follows). */
   publicationUris?: Array<string>;
@@ -116,6 +138,12 @@ export interface ArticleCardQuery {
    * to today's behaviour. See {@link UnreadCutoffOpts}.
    */
   countOldPostsAsUnread?: boolean;
+  /**
+   * Ranking for the plain (non-follow-feed) path. Ignored in follow-feed union
+   * mode, which is always ordered by its computed `feedAt`. Defaults to
+   * `recent`.
+   */
+  sort?: ArticleCardSort;
   limit: number;
   offset?: number;
 }
@@ -708,7 +736,7 @@ export async function selectArticleCards(
 
   const rows = await query
     .where(and(...conds))
-    .orderBy(...documentsNewestFirst(d))
+    .orderBy(...articleCardOrderBy(schema, opts.sort))
     .limit(opts.limit)
     .offset(opts.offset ?? 0);
 
@@ -2039,6 +2067,32 @@ function documentCarriesTagWhere(d: Schema["documents"], tag: string): SQL {
  */
 function documentsNewestFirst(d: Schema["documents"]): Array<SQL> {
   return [sql`${d.publishedAt} desc nulls last`, desc(d.uri)];
+}
+
+/**
+ * `ORDER BY` for an {@link ArticleCardSort}. Every ranking falls back to
+ * newest-first, so score ties (the common case — `trending_score` is 0 outside
+ * the 4-day discover slice, and most articles have no likes) stay chronological
+ * and `documents.uri` keeps paging deterministic.
+ */
+function articleCardOrderBy(
+  schema: Schema,
+  sort: ArticleCardSort = "recent",
+): Array<SQL> {
+  const d = schema.documents;
+  const newestFirst = documentsNewestFirst(d);
+
+  if (sort === "trending") {
+    return [sql`${d.trendingScore} desc`, ...newestFirst];
+  }
+  if (sort === "popular") {
+    return [
+      sql`${documentRecommendCountSql(schema)} desc`,
+      sql`coalesce(${d.backlinkCount}, 0) desc`,
+      ...newestFirst,
+    ];
+  }
+  return newestFirst;
 }
 
 /** Count indexed, published articles carrying a tag on discover-eligible pubs. */


### PR DESCRIPTION
## Summary

Adds a sort dropdown to the tag page's Articles tab, allowing users to rank articles by **Recent** (newest first, default), **Trending** (precomputed trending score), or **Most popular** (all-time likes + Bluesky backlinks). The sort preference is persisted in the URL search params independently from the Publications tab's directory sort.

## Key Changes

- **Frontend (tag page route)**
  - Added `articleSort` search param (enum: `recent` | `trending` | `popular`) to the tag search schema, separate from the Publications tab's `sort` param so each tab maintains independent state
  - Integrated `ArrowDownWideNarrow` icon and new `Select` component from design-system
  - Created `ARTICLE_SORT_OPTIONS` constant with localized labels
  - Added `onArticleSortChange` handler to update URL on sort selection
  - Styled the sort dropdown in the tab bar using flexbox layout (`tabBarSort` style) to sit on the trailing edge and wrap gracefully on narrow screens
  - Updated `TagArticlesPanel` to accept and pass `articleSort` to API queries
  - Updated route loader and prefetch logic to include `articleSort` in dependencies

- **Backend (query layer)**
  - Exported new `ArticleCardSort` type (`"recent" | "trending" | "popular"`)
  - Added `sort` field to `ArticleCardQuery` interface with documentation explaining each ranking strategy
  - Implemented `articleCardOrderBy()` function that applies the appropriate `ORDER BY` clause:
    - `recent`: newest-first (existing behavior)
    - `trending`: by `documents.trending_score` desc, then newest-first
    - `popular`: by `documentRecommendCountSql()` (all-time likes), then backlink count, then newest-first
  - Extracted `documentRecommendCountSql()` helper (scalar subquery for like counts) so it can be reused in both SELECT and ORDER BY without drift
  - Updated `selectArticleCards()` to use `articleCardOrderBy()` instead of hardcoded `documentsNewestFirst()`

- **API layer**
  - Added `articleSortEnum` validation and `TagArticleSort` type export
  - Updated `articlesPageInput` and `tagPageInput` schemas to include `articleSort` with default `"recent"`
  - Updated `getArticles` and `getTagPage` server functions to accept and pass `articleSort` to the query layer
  - Updated query option builders to include `articleSort` in the query key and function calls

- **Localization**
  - Added new message keys: `"Sort articles"`, `"Recent"`, `"Most popular"` across all locale files (en, ar, de, en-XA, es, fr, ja, ko, pt, zh)

- **Documentation**
  - Updated `APP_VISION.md` to describe the Articles tab sort feature and ranking strategies
  - Checked off completed task in `TODO.md`

## Implementation Details

- **URL state management:** The `articleSort` param is independent from `sort` (Publications tab), allowing users to switch between tabs without losing their sort preference on each
- **Ranking strategy:** Trending and Popular sorts rank rather than filter — score ties fall back to newest-first, keeping the list paginable on low-traffic tags
- **Performance:** Popular sort uses a correlated subquery (`documentRecommendCountSql`) which is acceptable for filtered lists (tag-scoped queries use indexed lookups) but would be expensive on unfiltered feeds
- **Layout:** The sort dropdown uses flexbox with `flexShrink: 0` and `marginInlineStart: auto` to stay on the trailing edge of the tab bar, wrapping to its own line on narrow screens

https://claude.ai/code/session_01Lh8FR6RwYzm4PLLA8RuHPM