### PR TITLE
Extract mention chip styling into reusable component

### DIFF
--- a/src/components/reader/content/body-styles.ts
+++ b/src/components/reader/content/body-styles.ts
@@ -171,10 +171,25 @@ export const articleBodyStyles = stylex.create({
     textUnderlineOffset: spacing["1.5"],
     fontWeight: fontWeight.semibold,
   },
+  /**
+   * Inline mention chip — an entity's avatar + name rendered as a pill inside
+   * prose. The label is arbitrary author content (publication names, document
+   * titles), so the chip wraps like the text around it; pinning it to one line
+   * pushed long Leaflet titles past the reading column and off the screen on
+   * mobile.
+   */
   facetMentionLink: {
     cornerShape: "squircle",
     borderRadius: radius.xs,
     textDecoration: "none",
+    whiteSpace: "normal",
+    // Labels that are one unbroken run (long handles, URL-ish names) have no
+    // wrap opportunity of their own; break inside them rather than overflow.
+    overflowWrap: "break-word",
+    // Give each line fragment of a wrapped chip its own padding and rounded
+    // corners, so it still reads as a pill and not a sliced rectangle.
+    // eslint-disable-next-line @stylexjs/valid-styles
+    boxDecorationBreak: "clone",
     backgroundColor: {
       default: primaryColor.component1,
       ":is([data-hovered=true])": primaryColor.component2,
@@ -185,6 +200,14 @@ export const articleBodyStyles = stylex.create({
     textUnderlineOffset: spacing["1.5"],
     paddingBlock: spacing["1.5"],
     paddingInline: spacing["2"],
+  },
+  /** Shrinks the design-system Avatar to sit inline with body text. */
+  facetMentionAvatar: {
+    display: "inline-flex",
+    width: "1.05em",
+    height: "1.05em",
+    marginInlineEnd: "0.25em",
+    verticalAlign: "-0.2em",
   },
   facetCode: {
     borderRadius: radius.sm,

--- a/src/components/reader/content/mention-chip.tsx
+++ b/src/components/reader/content/mention-chip.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+/**
+ * U+2060 WORD JOINER — an invisible, zero-width character that forbids a line
+ * break on either side of it (UAX #14 LB11). Now that chips wrap, this is what
+ * keeps the avatar glued to the first word of the label instead of being left
+ * behind alone at the end of a line.
+ */
+const WORD_JOINER = "\u2060";
+
+/**
+ * Contents of a mention chip: the entity's avatar (when it has one) followed by
+ * the label, joined so a wrap can never separate the two.
+ */
+export function MentionChipBody({
+  avatar,
+  children,
+}: {
+  avatar: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      {avatar}
+      {avatar ? WORD_JOINER : null}
+      {children}
+    </>
+  );
+}

--- a/src/components/reader/content/renderers/shared/faceted-text.tsx
+++ b/src/components/reader/content/renderers/shared/faceted-text.tsx
@@ -5,6 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { Fragment } from "react";
 
+import { MentionChipBody } from "#/components/reader/content/mention-chip";
 import { SmartArticleLink } from "#/components/reader/content/smart-article-link";
 import { initials } from "#/components/reader/format";
 import {
@@ -48,20 +49,6 @@ import { findFacetFeature, hasFacetKind } from "./facets";
 import { useFootnoteNumber } from "./footnote-context";
 import { useInlineMentions } from "./publication-mention-context";
 
-const styles = stylex.create({
-  mentionChip: {
-    whiteSpace: "nowrap",
-  },
-  // Shrink the design-system Avatar to sit inline with body text.
-  mentionAvatar: {
-    display: "inline-flex",
-    width: "1.05em",
-    height: "1.05em",
-    marginInlineEnd: "0.25em",
-    verticalAlign: "-0.2em",
-  },
-});
-
 /**
  * Inline publication reference — the pub's icon (when it has one) + name,
  * linking to its Standard Reader page. Mirrors how Leaflet renders publication
@@ -100,19 +87,21 @@ function PublicationMentionChip({
           params={{ did: mention.did, rkey: mention.rkey }}
           {...triggerProps}
           data-hovered={isHovered || undefined}
-          {...stylex.props(
-            articleBodyStyles.facetMentionLink,
-            styles.mentionChip,
-          )}
+          {...stylex.props(articleBodyStyles.facetMentionLink)}
         >
-          {mention.iconUrl ? (
-            <PublicationAvatar
-              pub={{ name: mention.name, iconUrl: mention.iconUrl }}
-              size="sm"
-              style={styles.mentionAvatar}
-            />
-          ) : null}
-          {children}
+          <MentionChipBody
+            avatar={
+              mention.iconUrl ? (
+                <PublicationAvatar
+                  pub={{ name: mention.name, iconUrl: mention.iconUrl }}
+                  size="sm"
+                  style={articleBodyStyles.facetMentionAvatar}
+                />
+              ) : null
+            }
+          >
+            {children}
+          </MentionChipBody>
         </Link>
       )}
     </EntityHoverCard>
@@ -156,21 +145,23 @@ function DocumentMentionChip({
           params={{ did: mention.did, rkey: mention.rkey }}
           {...triggerProps}
           data-hovered={isHovered || undefined}
-          {...stylex.props(
-            articleBodyStyles.facetMentionLink,
-            styles.mentionChip,
-          )}
+          {...stylex.props(articleBodyStyles.facetMentionLink)}
         >
-          {mention.iconUrl ? (
-            <Avatar
-              size="sm"
-              src={mention.iconUrl}
-              alt=""
-              fallback={initials(mention.title)}
-              style={styles.mentionAvatar}
-            />
-          ) : null}
-          {children}
+          <MentionChipBody
+            avatar={
+              mention.iconUrl ? (
+                <Avatar
+                  size="sm"
+                  src={mention.iconUrl}
+                  alt=""
+                  fallback={initials(mention.title)}
+                  style={articleBodyStyles.facetMentionAvatar}
+                />
+              ) : null
+            }
+          >
+            {children}
+          </MentionChipBody>
         </Link>
       )}
     </EntityHoverCard>
@@ -216,21 +207,23 @@ function ActorMentionChip({
           params={{ did }}
           {...triggerProps}
           data-hovered={isHovered || undefined}
-          {...stylex.props(
-            articleBodyStyles.facetMentionLink,
-            styles.mentionChip,
-          )}
+          {...stylex.props(articleBodyStyles.facetMentionLink)}
         >
-          {actor ? (
-            <Avatar
-              size="sm"
-              src={actor.avatarUrl ?? undefined}
-              fallback={initials(actor.handle ?? label)}
-              alt={actor.handle ?? ""}
-              style={styles.mentionAvatar}
-            />
-          ) : null}
-          {label}
+          <MentionChipBody
+            avatar={
+              actor ? (
+                <Avatar
+                  size="sm"
+                  src={actor.avatarUrl ?? undefined}
+                  fallback={initials(actor.handle ?? label)}
+                  alt={actor.handle ?? ""}
+                  style={articleBodyStyles.facetMentionAvatar}
+                />
+              ) : null
+            }
+          >
+            {label}
+          </MentionChipBody>
         </Link>
       )}
     </EntityHoverCard>
@@ -278,21 +271,23 @@ function LinkedActorChip({
           params={{ did: ident }}
           {...triggerProps}
           data-hovered={isHovered || undefined}
-          {...stylex.props(
-            articleBodyStyles.facetMentionLink,
-            styles.mentionChip,
-          )}
+          {...stylex.props(articleBodyStyles.facetMentionLink)}
         >
-          {actor ? (
-            <Avatar
-              size="sm"
-              src={actor.avatarUrl ?? undefined}
-              fallback={initials(actor.handle ?? label)}
-              alt={actor.handle ?? ""}
-              style={styles.mentionAvatar}
-            />
-          ) : null}
-          {label}
+          <MentionChipBody
+            avatar={
+              actor ? (
+                <Avatar
+                  size="sm"
+                  src={actor.avatarUrl ?? undefined}
+                  fallback={initials(actor.handle ?? label)}
+                  alt={actor.handle ?? ""}
+                  style={articleBodyStyles.facetMentionAvatar}
+                />
+              ) : null
+            }
+          >
+            {label}
+          </MentionChipBody>
         </Link>
       )}
     </EntityHoverCard>

--- a/src/components/reader/content/smart-article-link.tsx
+++ b/src/components/reader/content/smart-article-link.tsx
@@ -14,6 +14,7 @@ import {
 
 import { AppLink } from "#/components/reader/app-link";
 import { articleBodyStyles } from "#/components/reader/content/body-styles";
+import { MentionChipBody } from "#/components/reader/content/mention-chip";
 import { initials } from "#/components/reader/format";
 import {
   DocumentHoverCardBody,
@@ -164,18 +165,23 @@ function UserLinkChip({
           params={{ did: ident }}
           {...triggerProps}
           data-hovered={isHovered || undefined}
-          {...stylex.props(articleBodyStyles.facetMentionLink, styles.chip)}
+          {...stylex.props(articleBodyStyles.facetMentionLink)}
         >
-          {avatarUrl ? (
-            <Avatar
-              size="sm"
-              src={avatarUrl}
-              fallback={initials(label)}
-              alt={handle ?? ""}
-              style={styles.avatar}
-            />
-          ) : null}
-          {children}
+          <MentionChipBody
+            avatar={
+              avatarUrl ? (
+                <Avatar
+                  size="sm"
+                  src={avatarUrl}
+                  fallback={initials(label)}
+                  alt={handle ?? ""}
+                  style={articleBodyStyles.facetMentionAvatar}
+                />
+              ) : null
+            }
+          >
+            {children}
+          </MentionChipBody>
         </Link>
       )}
     </EntityHoverCard>
@@ -213,18 +219,23 @@ function ArticleLinkChip({
           params={{ did: target.did, rkey: target.rkey }}
           {...triggerProps}
           data-hovered={isHovered || undefined}
-          {...stylex.props(articleBodyStyles.facetMentionLink, styles.chip)}
+          {...stylex.props(articleBodyStyles.facetMentionLink)}
         >
-          {target.publicationIconUrl ? (
-            <Avatar
-              size="sm"
-              src={target.publicationIconUrl}
-              alt=""
-              fallback={initials(target.title)}
-              style={styles.avatar}
-            />
-          ) : null}
-          {children}
+          <MentionChipBody
+            avatar={
+              target.publicationIconUrl ? (
+                <Avatar
+                  size="sm"
+                  src={target.publicationIconUrl}
+                  alt=""
+                  fallback={initials(target.title)}
+                  style={articleBodyStyles.facetMentionAvatar}
+                />
+              ) : null
+            }
+          >
+            {children}
+          </MentionChipBody>
         </Link>
       )}
     </EntityHoverCard>
@@ -265,16 +276,21 @@ function PublicationLinkChip({
           params={{ did: target.did, rkey: target.rkey }}
           {...triggerProps}
           data-hovered={isHovered || undefined}
-          {...stylex.props(articleBodyStyles.facetMentionLink, styles.chip)}
+          {...stylex.props(articleBodyStyles.facetMentionLink)}
         >
-          {target.iconUrl ? (
-            <PublicationAvatar
-              pub={{ name: target.name, iconUrl: target.iconUrl }}
-              size="sm"
-              style={styles.avatar}
-            />
-          ) : null}
-          {children}
+          <MentionChipBody
+            avatar={
+              target.iconUrl ? (
+                <PublicationAvatar
+                  pub={{ name: target.name, iconUrl: target.iconUrl }}
+                  size="sm"
+                  style={articleBodyStyles.facetMentionAvatar}
+                />
+              ) : null
+            }
+          >
+            {children}
+          </MentionChipBody>
         </Link>
       )}
     </EntityHoverCard>
@@ -292,16 +308,3 @@ function nodeText(node: React.ReactNode): string | undefined {
   }
   return;
 }
-
-const styles = stylex.create({
-  chip: {
-    whiteSpace: "nowrap",
-  },
-  avatar: {
-    display: "inline-flex",
-    width: "1.05em",
-    height: "1.05em",
-    marginInlineEnd: "0.25em",
-    verticalAlign: "-0.2em",
-  },
-});

--- a/src/locales/ar/messages.po
+++ b/src/locales/ar/messages.po
@@ -1387,6 +1387,7 @@ msgstr "{count, plural, zero {لا أصوات} one {صوت واحد} two {صوت
 msgid "Apps you have connected to Standard Reader through its <0>MCP server</0>. Disconnecting one revokes its access immediately; it can ask to reconnect at any time."
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.history.tsx
 msgid "Read"
 msgstr "قراءة"
@@ -1446,6 +1447,10 @@ msgstr "إخفاء المقالات المقروءة"
 #: src/components/reader/collection-builder.tsx
 msgid "Collection cover"
 msgstr "غلاف المجموعة"
+
+#: src/components/reader/publication-actions.tsx
+msgid "Visit publication site"
+msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Attempt to disrupt, overload, or gain unauthorized access to the service, its infrastructure, or other users' accounts."
@@ -1792,6 +1797,7 @@ msgstr "مدعوم بـ Standard Reader"
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "RSS feed"
@@ -1929,7 +1935,7 @@ msgstr "جارٍ الاشتراك"
 msgid "Your account"
 msgstr ""
 
-#: src/routes/_layout.p.$did.$rkey.tsx
+#: src/components/reader/publication-actions.tsx
 msgid "Every unread article from this publication will be marked read. This can’t be undone."
 msgstr "ستُحدَّد كل مقالة غير مقروءة من هذه المنشورة كمقروءة. لا يمكن التراجع عن هذا."
 
@@ -2141,6 +2147,7 @@ msgstr "رمز رابط الاشتراك"
 
 #: src/components/reader/add-to-list-button.tsx
 #: src/components/reader/add-to-list-modal.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 msgid "Add to list"
 msgstr "إضافة إلى قائمة"
@@ -2488,6 +2495,7 @@ msgid "Author sections"
 msgstr "أقسام المؤلف"
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "More actions"
 msgstr "إجراءات أخرى"
@@ -2710,6 +2718,7 @@ msgstr "جارٍ إنشاء الصوت… {percent}٪"
 msgid "Renderers"
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.latest.tsx
 msgid "Unread"
@@ -2833,8 +2842,8 @@ msgstr "تابع للموافقة"
 msgid "<0>T</0>here is a particular pleasure in reading something that was made to be read, and not to be measured. It asks nothing of you but your attention."
 msgstr "<0>ه</0>ناك متعة خاصة في قراءة شيء صُنع ليُقرأ، لا ليُقاس. إنه لا يطلب منك سوى انتباهك."
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
-#: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Mark all as read?"
 msgstr "تحديد الكل كمقروء؟"
 
@@ -2970,7 +2979,6 @@ msgstr "الحواشي"
 msgid "Every publication the network knows about — {publicationCount} and counting. Subscribe to the ones worth your mornings."
 msgstr "كل منشورة تعرفها الشبكة — {publicationCount} والعدد في ازدياد. اشترك في ما يستحق صباحاتك."
 
-#: src/components/reader/cards.tsx
 #: src/components/reader/follow-user-button.tsx
 msgid "Follow"
 msgstr "متابعة"
@@ -3047,6 +3055,7 @@ msgid "Keep reading"
 msgstr "تابع القراءة"
 
 #: src/components/reader/discover-topic-filters.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.feedback.index.tsx
 #: src/routes/_layout.latest.tsx
@@ -3222,6 +3231,7 @@ msgstr "إغلاق المجلة"
 msgid "Introduce the collection… (markdown supported)"
 msgstr "قدّم للمجموعة… (يدعم markdown)"
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.feedback.index.tsx
 msgid "Filter"
 msgstr ""
@@ -3302,8 +3312,8 @@ msgstr "لا منشورات تطابق هذا الوسم بعد."
 msgid "The conversation, gathered"
 msgstr "الحوار، مجموعًا في مكان واحد"
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
-#: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Mark all as read"
 msgstr "تحديد الكل كمقروء"
 
@@ -3424,6 +3434,10 @@ msgstr "الاشتراكات"
 msgid "{0, plural, one {# post} other {{1} posts}}"
 msgstr "{0, plural, zero {لا منشورات} one {منشور واحد} two {منشوران} few {# منشورات} many {{1} منشورًا} other {{1} منشور}}"
 
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You haven’t read anything here yet."
+msgstr ""
+
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
 msgid "Authentication"
@@ -3487,6 +3501,10 @@ msgstr "(يتطلب {min}:1)"
 #: src/components/user-settings-view.tsx
 msgid "Every read record in your repository will be removed. Articles will appear unread again across the app. This cannot be undone."
 msgstr "ستُحذف كل سجلات القراءة من مستودعك، وستظهر المقالات كغير مقروءة مجددًا في التطبيق. لا يمكن التراجع عن هذا."
+
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You’ve read everything from this publication."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Text, borders and every other step are derived from these two colors."
@@ -3815,6 +3833,11 @@ msgstr "قيد التنفيذ"
 #: src/components/site-legal-links.tsx
 msgid "Privacy"
 msgstr "الخصوصية"
+
+#. placeholder {0}: labels[filter]
+#: src/components/reader/publication-actions.tsx
+msgid "Filter: {0}"
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "Last updated June 11, 2026"
@@ -4256,6 +4279,10 @@ msgstr "جارٍ إضافة {publicationName} إلى تغذيتك."
 #~ msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors and checked for contrast."
 #~ msgstr ""
 
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You haven’t recommended anything here yet."
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/user-settings-view.tsx
@@ -4548,8 +4575,8 @@ msgid "Hide"
 msgstr "إخفاء"
 
 #: src/routes/_layout.p.$did.$rkey.tsx
-msgid "Open publication"
-msgstr "فتح المنشورة"
+#~ msgid "Open publication"
+#~ msgstr "فتح المنشورة"
 
 #: src/components/reader/link-share-menu.tsx
 msgid "Send to Disperse"
@@ -4673,6 +4700,7 @@ msgid "Text selection actions"
 msgstr "إجراءات تحديد النص"
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/magazine/magazine-end-like.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.recommended.tsx

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -1387,6 +1387,7 @@ msgstr "{count, plural, one {# Upvote} other {# Upvotes}} – klicken zum Upvote
 msgid "Apps you have connected to Standard Reader through its <0>MCP server</0>. Disconnecting one revokes its access immediately; it can ask to reconnect at any time."
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.history.tsx
 msgid "Read"
 msgstr "Lesen"
@@ -1446,6 +1447,10 @@ msgstr "Gelesene Artikel ausblenden"
 #: src/components/reader/collection-builder.tsx
 msgid "Collection cover"
 msgstr "Cover der Sammlung"
+
+#: src/components/reader/publication-actions.tsx
+msgid "Visit publication site"
+msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Attempt to disrupt, overload, or gain unauthorized access to the service, its infrastructure, or other users' accounts."
@@ -1792,6 +1797,7 @@ msgstr "Bereitgestellt von Standard Reader"
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "RSS feed"
@@ -1929,7 +1935,7 @@ msgstr "Wird abonniert"
 msgid "Your account"
 msgstr ""
 
-#: src/routes/_layout.p.$did.$rkey.tsx
+#: src/components/reader/publication-actions.tsx
 msgid "Every unread article from this publication will be marked read. This can’t be undone."
 msgstr "Jeder ungelesene Artikel dieser Publikation wird als gelesen markiert. Das lässt sich nicht rückgängig machen."
 
@@ -2141,6 +2147,7 @@ msgstr "Code für Abo-Link"
 
 #: src/components/reader/add-to-list-button.tsx
 #: src/components/reader/add-to-list-modal.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 msgid "Add to list"
 msgstr "Zur Liste hinzufügen"
@@ -2488,6 +2495,7 @@ msgid "Author sections"
 msgstr "Autorenbereiche"
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "More actions"
 msgstr "Weitere Aktionen"
@@ -2710,6 +2718,7 @@ msgstr "Audio wird erzeugt… {percent} %"
 msgid "Renderers"
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.latest.tsx
 msgid "Unread"
@@ -2833,8 +2842,8 @@ msgstr "Weiter zur Freigabe"
 msgid "<0>T</0>here is a particular pleasure in reading something that was made to be read, and not to be measured. It asks nothing of you but your attention."
 msgstr "<0>E</0>s liegt ein besonderes Vergnügen darin, etwas zu lesen, das zum Lesen gemacht wurde und nicht zum Messen. Es verlangt nichts von Ihnen außer Ihrer Aufmerksamkeit."
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
-#: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Mark all as read?"
 msgstr "Alle als gelesen markieren?"
 
@@ -2970,7 +2979,6 @@ msgstr "Fußnoten"
 msgid "Every publication the network knows about — {publicationCount} and counting. Subscribe to the ones worth your mornings."
 msgstr "Jede Publikation, die das Netzwerk kennt — {publicationCount} und es werden mehr. Abonnieren Sie die, die Ihre Morgen wert sind."
 
-#: src/components/reader/cards.tsx
 #: src/components/reader/follow-user-button.tsx
 msgid "Follow"
 msgstr "Folgen"
@@ -3047,6 +3055,7 @@ msgid "Keep reading"
 msgstr "Weiterlesen"
 
 #: src/components/reader/discover-topic-filters.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.feedback.index.tsx
 #: src/routes/_layout.latest.tsx
@@ -3222,6 +3231,7 @@ msgstr "Magazin schließen"
 msgid "Introduce the collection… (markdown supported)"
 msgstr "Sammlung vorstellen … (Markdown möglich)"
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.feedback.index.tsx
 msgid "Filter"
 msgstr ""
@@ -3302,8 +3312,8 @@ msgstr "Noch keine Publikationen zu diesem Tag."
 msgid "The conversation, gathered"
 msgstr "Das Gespräch, gebündelt"
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
-#: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Mark all as read"
 msgstr "Alle als gelesen markieren"
 
@@ -3424,6 +3434,10 @@ msgstr "Abos"
 msgid "{0, plural, one {# post} other {{1} posts}}"
 msgstr "{0, plural, one {# Beitrag} other {{1} Beiträge}}"
 
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You haven’t read anything here yet."
+msgstr ""
+
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
 msgid "Authentication"
@@ -3487,6 +3501,10 @@ msgstr "(benötigt {min}:1)"
 #: src/components/user-settings-view.tsx
 msgid "Every read record in your repository will be removed. Articles will appear unread again across the app. This cannot be undone."
 msgstr "Jeder Lese-Eintrag in Ihrem Repository wird entfernt. Artikel erscheinen in der gesamten App wieder als ungelesen. Das lässt sich nicht rückgängig machen."
+
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You’ve read everything from this publication."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Text, borders and every other step are derived from these two colors."
@@ -3815,6 +3833,11 @@ msgstr "Läuft"
 #: src/components/site-legal-links.tsx
 msgid "Privacy"
 msgstr "Datenschutz"
+
+#. placeholder {0}: labels[filter]
+#: src/components/reader/publication-actions.tsx
+msgid "Filter: {0}"
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "Last updated June 11, 2026"
@@ -4256,6 +4279,10 @@ msgstr "{publicationName} wird Ihrem Feed hinzugefügt."
 #~ msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors and checked for contrast."
 #~ msgstr ""
 
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You haven’t recommended anything here yet."
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/user-settings-view.tsx
@@ -4548,8 +4575,8 @@ msgid "Hide"
 msgstr "Ausblenden"
 
 #: src/routes/_layout.p.$did.$rkey.tsx
-msgid "Open publication"
-msgstr "Publikation öffnen"
+#~ msgid "Open publication"
+#~ msgstr "Publikation öffnen"
 
 #: src/components/reader/link-share-menu.tsx
 msgid "Send to Disperse"
@@ -4673,6 +4700,7 @@ msgid "Text selection actions"
 msgstr "Aktionen für markierten Text"
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/magazine/magazine-end-like.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.recommended.tsx

--- a/src/locales/en-XA/messages.po
+++ b/src/locales/en-XA/messages.po
@@ -1387,6 +1387,7 @@ msgstr ""
 msgid "Apps you have connected to Standard Reader through its <0>MCP server</0>. Disconnecting one revokes its access immediately; it can ask to reconnect at any time."
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.history.tsx
 msgid "Read"
 msgstr ""
@@ -1445,6 +1446,10 @@ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "Collection cover"
+msgstr ""
+
+#: src/components/reader/publication-actions.tsx
+msgid "Visit publication site"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -1792,6 +1797,7 @@ msgstr ""
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "RSS feed"
@@ -1929,7 +1935,7 @@ msgstr ""
 msgid "Your account"
 msgstr ""
 
-#: src/routes/_layout.p.$did.$rkey.tsx
+#: src/components/reader/publication-actions.tsx
 msgid "Every unread article from this publication will be marked read. This can’t be undone."
 msgstr ""
 
@@ -2141,6 +2147,7 @@ msgstr ""
 
 #: src/components/reader/add-to-list-button.tsx
 #: src/components/reader/add-to-list-modal.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 msgid "Add to list"
 msgstr ""
@@ -2488,6 +2495,7 @@ msgid "Author sections"
 msgstr ""
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "More actions"
 msgstr ""
@@ -2710,6 +2718,7 @@ msgstr ""
 msgid "Renderers"
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.latest.tsx
 msgid "Unread"
@@ -2833,8 +2842,8 @@ msgstr ""
 msgid "<0>T</0>here is a particular pleasure in reading something that was made to be read, and not to be measured. It asks nothing of you but your attention."
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
-#: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Mark all as read?"
 msgstr ""
 
@@ -2970,7 +2979,6 @@ msgstr ""
 msgid "Every publication the network knows about — {publicationCount} and counting. Subscribe to the ones worth your mornings."
 msgstr ""
 
-#: src/components/reader/cards.tsx
 #: src/components/reader/follow-user-button.tsx
 msgid "Follow"
 msgstr ""
@@ -3047,6 +3055,7 @@ msgid "Keep reading"
 msgstr ""
 
 #: src/components/reader/discover-topic-filters.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.feedback.index.tsx
 #: src/routes/_layout.latest.tsx
@@ -3222,6 +3231,7 @@ msgstr ""
 msgid "Introduce the collection… (markdown supported)"
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.feedback.index.tsx
 msgid "Filter"
 msgstr ""
@@ -3302,8 +3312,8 @@ msgstr ""
 msgid "The conversation, gathered"
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
-#: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Mark all as read"
 msgstr ""
 
@@ -3424,6 +3434,10 @@ msgstr ""
 msgid "{0, plural, one {# post} other {{1} posts}}"
 msgstr ""
 
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You haven’t read anything here yet."
+msgstr ""
+
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
 msgid "Authentication"
@@ -3486,6 +3500,10 @@ msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Every read record in your repository will be removed. Articles will appear unread again across the app. This cannot be undone."
+msgstr ""
+
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You’ve read everything from this publication."
 msgstr ""
 
 #: src/components/appearance-settings.tsx
@@ -3814,6 +3832,11 @@ msgstr ""
 #: src/components/reader/terms-view.tsx
 #: src/components/site-legal-links.tsx
 msgid "Privacy"
+msgstr ""
+
+#. placeholder {0}: labels[filter]
+#: src/components/reader/publication-actions.tsx
+msgid "Filter: {0}"
 msgstr ""
 
 #: src/components/reader/privacy-view.tsx
@@ -4256,6 +4279,10 @@ msgstr ""
 #~ msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors and checked for contrast."
 #~ msgstr ""
 
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You haven’t recommended anything here yet."
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/user-settings-view.tsx
@@ -4548,8 +4575,8 @@ msgid "Hide"
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
-msgid "Open publication"
-msgstr ""
+#~ msgid "Open publication"
+#~ msgstr ""
 
 #: src/components/reader/link-share-menu.tsx
 msgid "Send to Disperse"
@@ -4673,6 +4700,7 @@ msgid "Text selection actions"
 msgstr ""
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/magazine/magazine-end-like.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.recommended.tsx

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -1387,6 +1387,7 @@ msgstr "{count, plural, one {# upvote} other {# upvotes}} — click to upvote"
 msgid "Apps you have connected to Standard Reader through its <0>MCP server</0>. Disconnecting one revokes its access immediately; it can ask to reconnect at any time."
 msgstr "Apps you have connected to Standard Reader through its <0>MCP server</0>. Disconnecting one revokes its access immediately; it can ask to reconnect at any time."
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.history.tsx
 msgid "Read"
 msgstr "Read"
@@ -1446,6 +1447,10 @@ msgstr "Hide read articles"
 #: src/components/reader/collection-builder.tsx
 msgid "Collection cover"
 msgstr "Collection cover"
+
+#: src/components/reader/publication-actions.tsx
+msgid "Visit publication site"
+msgstr "Visit publication site"
 
 #: src/components/reader/terms-view.tsx
 msgid "Attempt to disrupt, overload, or gain unauthorized access to the service, its infrastructure, or other users' accounts."
@@ -1792,6 +1797,7 @@ msgstr "Powered by Standard Reader"
 msgid "Clear selection"
 msgstr "Clear selection"
 
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "RSS feed"
@@ -1929,7 +1935,7 @@ msgstr "Subscribing"
 msgid "Your account"
 msgstr "Your account"
 
-#: src/routes/_layout.p.$did.$rkey.tsx
+#: src/components/reader/publication-actions.tsx
 msgid "Every unread article from this publication will be marked read. This can’t be undone."
 msgstr "Every unread article from this publication will be marked read. This can’t be undone."
 
@@ -2141,6 +2147,7 @@ msgstr "Subscribe link code"
 
 #: src/components/reader/add-to-list-button.tsx
 #: src/components/reader/add-to-list-modal.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 msgid "Add to list"
 msgstr "Add to list"
@@ -2488,6 +2495,7 @@ msgid "Author sections"
 msgstr "Author sections"
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "More actions"
 msgstr "More actions"
@@ -2710,6 +2718,7 @@ msgstr "Generating audio… {percent}%"
 msgid "Renderers"
 msgstr "Renderers"
 
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.latest.tsx
 msgid "Unread"
@@ -2833,8 +2842,8 @@ msgstr "Continue to approve"
 msgid "<0>T</0>here is a particular pleasure in reading something that was made to be read, and not to be measured. It asks nothing of you but your attention."
 msgstr "<0>T</0>here is a particular pleasure in reading something that was made to be read, and not to be measured. It asks nothing of you but your attention."
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
-#: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Mark all as read?"
 msgstr "Mark all as read?"
 
@@ -2970,7 +2979,6 @@ msgstr "Footnotes"
 msgid "Every publication the network knows about — {publicationCount} and counting. Subscribe to the ones worth your mornings."
 msgstr "Every publication the network knows about — {publicationCount} and counting. Subscribe to the ones worth your mornings."
 
-#: src/components/reader/cards.tsx
 #: src/components/reader/follow-user-button.tsx
 msgid "Follow"
 msgstr "Follow"
@@ -3047,6 +3055,7 @@ msgid "Keep reading"
 msgstr "Keep reading"
 
 #: src/components/reader/discover-topic-filters.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.feedback.index.tsx
 #: src/routes/_layout.latest.tsx
@@ -3222,6 +3231,7 @@ msgstr "Close magazine"
 msgid "Introduce the collection… (markdown supported)"
 msgstr "Introduce the collection… (markdown supported)"
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.feedback.index.tsx
 msgid "Filter"
 msgstr "Filter"
@@ -3302,8 +3312,8 @@ msgstr "No publications match this tag yet."
 msgid "The conversation, gathered"
 msgstr "The conversation, gathered"
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
-#: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Mark all as read"
 msgstr "Mark all as read"
 
@@ -3424,6 +3434,10 @@ msgstr "Subscriptions"
 msgid "{0, plural, one {# post} other {{1} posts}}"
 msgstr "{0, plural, one {# post} other {{1} posts}}"
 
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You haven’t read anything here yet."
+msgstr "You haven’t read anything here yet."
+
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
 msgid "Authentication"
@@ -3487,6 +3501,10 @@ msgstr "(needs {min}:1)"
 #: src/components/user-settings-view.tsx
 msgid "Every read record in your repository will be removed. Articles will appear unread again across the app. This cannot be undone."
 msgstr "Every read record in your repository will be removed. Articles will appear unread again across the app. This cannot be undone."
+
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You’ve read everything from this publication."
+msgstr "You’ve read everything from this publication."
 
 #: src/components/appearance-settings.tsx
 msgid "Text, borders and every other step are derived from these two colors."
@@ -3815,6 +3833,11 @@ msgstr "Running"
 #: src/components/site-legal-links.tsx
 msgid "Privacy"
 msgstr "Privacy"
+
+#. placeholder {0}: labels[filter]
+#: src/components/reader/publication-actions.tsx
+msgid "Filter: {0}"
+msgstr "Filter: {0}"
 
 #: src/components/reader/privacy-view.tsx
 msgid "Last updated June 11, 2026"
@@ -4256,6 +4279,10 @@ msgstr "Adding {publicationName} to your feed."
 #~ msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors and checked for contrast."
 #~ msgstr "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors and checked for contrast."
 
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You haven’t recommended anything here yet."
+msgstr "You haven’t recommended anything here yet."
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/user-settings-view.tsx
@@ -4548,8 +4575,8 @@ msgid "Hide"
 msgstr "Hide"
 
 #: src/routes/_layout.p.$did.$rkey.tsx
-msgid "Open publication"
-msgstr "Open publication"
+#~ msgid "Open publication"
+#~ msgstr "Open publication"
 
 #: src/components/reader/link-share-menu.tsx
 msgid "Send to Disperse"
@@ -4673,6 +4700,7 @@ msgid "Text selection actions"
 msgstr "Text selection actions"
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/magazine/magazine-end-like.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.recommended.tsx

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1387,6 +1387,7 @@ msgstr "{count, plural, one {# voto} other {# votos}} — haga clic para votar"
 msgid "Apps you have connected to Standard Reader through its <0>MCP server</0>. Disconnecting one revokes its access immediately; it can ask to reconnect at any time."
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.history.tsx
 msgid "Read"
 msgstr "Leer"
@@ -1446,6 +1447,10 @@ msgstr "Ocultar artículos leídos"
 #: src/components/reader/collection-builder.tsx
 msgid "Collection cover"
 msgstr "Portada de la colección"
+
+#: src/components/reader/publication-actions.tsx
+msgid "Visit publication site"
+msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Attempt to disrupt, overload, or gain unauthorized access to the service, its infrastructure, or other users' accounts."
@@ -1792,6 +1797,7 @@ msgstr "Con la tecnología de Standard Reader"
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "RSS feed"
@@ -1929,7 +1935,7 @@ msgstr "Suscribiendo"
 msgid "Your account"
 msgstr ""
 
-#: src/routes/_layout.p.$did.$rkey.tsx
+#: src/components/reader/publication-actions.tsx
 msgid "Every unread article from this publication will be marked read. This can’t be undone."
 msgstr "Todos los artículos sin leer de esta publicación se marcarán como leídos. Esto no se puede deshacer."
 
@@ -2141,6 +2147,7 @@ msgstr "Código del enlace de suscripción"
 
 #: src/components/reader/add-to-list-button.tsx
 #: src/components/reader/add-to-list-modal.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 msgid "Add to list"
 msgstr "Añadir a la lista"
@@ -2488,6 +2495,7 @@ msgid "Author sections"
 msgstr "Secciones del autor"
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "More actions"
 msgstr "Más acciones"
@@ -2710,6 +2718,7 @@ msgstr "Generando audio… {percent} %"
 msgid "Renderers"
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.latest.tsx
 msgid "Unread"
@@ -2833,8 +2842,8 @@ msgstr "Continuar para aprobar"
 msgid "<0>T</0>here is a particular pleasure in reading something that was made to be read, and not to be measured. It asks nothing of you but your attention."
 msgstr "<0>H</0>ay un placer particular en leer algo hecho para ser leído, y no para ser medido. No pide nada más que atención."
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
-#: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Mark all as read?"
 msgstr "¿Marcar todo como leído?"
 
@@ -2970,7 +2979,6 @@ msgstr "Notas al pie"
 msgid "Every publication the network knows about — {publicationCount} and counting. Subscribe to the ones worth your mornings."
 msgstr "Todas las publicaciones que la red conoce: {publicationCount} y subiendo. Suscríbase a las que merezcan sus mañanas."
 
-#: src/components/reader/cards.tsx
 #: src/components/reader/follow-user-button.tsx
 msgid "Follow"
 msgstr "Seguir"
@@ -3047,6 +3055,7 @@ msgid "Keep reading"
 msgstr "Seguir leyendo"
 
 #: src/components/reader/discover-topic-filters.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.feedback.index.tsx
 #: src/routes/_layout.latest.tsx
@@ -3222,6 +3231,7 @@ msgstr "Cerrar revista"
 msgid "Introduce the collection… (markdown supported)"
 msgstr "Presente la colección… (admite markdown)"
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.feedback.index.tsx
 msgid "Filter"
 msgstr ""
@@ -3302,8 +3312,8 @@ msgstr "Todavía no hay publicaciones con esta etiqueta."
 msgid "The conversation, gathered"
 msgstr "La conversación, reunida"
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
-#: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Mark all as read"
 msgstr "Marcar todo como leído"
 
@@ -3424,6 +3434,10 @@ msgstr "Suscripciones"
 msgid "{0, plural, one {# post} other {{1} posts}}"
 msgstr "{0, plural, one {# publicación} other {{1} publicaciones}}"
 
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You haven’t read anything here yet."
+msgstr ""
+
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
 msgid "Authentication"
@@ -3487,6 +3501,10 @@ msgstr "(necesita {min}:1)"
 #: src/components/user-settings-view.tsx
 msgid "Every read record in your repository will be removed. Articles will appear unread again across the app. This cannot be undone."
 msgstr "Se eliminarán todos los registros de lectura de su repositorio. Los artículos volverán a aparecer como sin leer en toda la app. Esta acción no se puede deshacer."
+
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You’ve read everything from this publication."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Text, borders and every other step are derived from these two colors."
@@ -3815,6 +3833,11 @@ msgstr "En ejecución"
 #: src/components/site-legal-links.tsx
 msgid "Privacy"
 msgstr "Privacidad"
+
+#. placeholder {0}: labels[filter]
+#: src/components/reader/publication-actions.tsx
+msgid "Filter: {0}"
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "Last updated June 11, 2026"
@@ -4256,6 +4279,10 @@ msgstr "Agregando {publicationName} a su feed."
 #~ msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors and checked for contrast."
 #~ msgstr ""
 
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You haven’t recommended anything here yet."
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/user-settings-view.tsx
@@ -4548,8 +4575,8 @@ msgid "Hide"
 msgstr "Ocultar"
 
 #: src/routes/_layout.p.$did.$rkey.tsx
-msgid "Open publication"
-msgstr "Abrir publicación"
+#~ msgid "Open publication"
+#~ msgstr "Abrir publicación"
 
 #: src/components/reader/link-share-menu.tsx
 msgid "Send to Disperse"
@@ -4673,6 +4700,7 @@ msgid "Text selection actions"
 msgstr "Acciones de selección de texto"
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/magazine/magazine-end-like.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.recommended.tsx

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1387,6 +1387,7 @@ msgstr "{count, plural, one {# vote} other {# votes}} — cliquez pour voter"
 msgid "Apps you have connected to Standard Reader through its <0>MCP server</0>. Disconnecting one revokes its access immediately; it can ask to reconnect at any time."
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.history.tsx
 msgid "Read"
 msgstr "Lire"
@@ -1446,6 +1447,10 @@ msgstr "Masquer les articles lus"
 #: src/components/reader/collection-builder.tsx
 msgid "Collection cover"
 msgstr "Couverture de la collection"
+
+#: src/components/reader/publication-actions.tsx
+msgid "Visit publication site"
+msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Attempt to disrupt, overload, or gain unauthorized access to the service, its infrastructure, or other users' accounts."
@@ -1792,6 +1797,7 @@ msgstr "Propulsé par Standard Reader"
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "RSS feed"
@@ -1929,7 +1935,7 @@ msgstr "Abonnement en cours"
 msgid "Your account"
 msgstr ""
 
-#: src/routes/_layout.p.$did.$rkey.tsx
+#: src/components/reader/publication-actions.tsx
 msgid "Every unread article from this publication will be marked read. This can’t be undone."
 msgstr "Tous les articles non lus de cette publication seront marqués comme lus. Cette action est irréversible."
 
@@ -2141,6 +2147,7 @@ msgstr "Code du lien d’abonnement"
 
 #: src/components/reader/add-to-list-button.tsx
 #: src/components/reader/add-to-list-modal.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 msgid "Add to list"
 msgstr "Ajouter à la liste"
@@ -2488,6 +2495,7 @@ msgid "Author sections"
 msgstr "Sections de l’auteur"
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "More actions"
 msgstr "Plus d’actions"
@@ -2710,6 +2718,7 @@ msgstr "Génération de l’audio… {percent} %"
 msgid "Renderers"
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.latest.tsx
 msgid "Unread"
@@ -2833,8 +2842,8 @@ msgstr "Continuer pour approuver"
 msgid "<0>T</0>here is a particular pleasure in reading something that was made to be read, and not to be measured. It asks nothing of you but your attention."
 msgstr "<0>I</0>l y a un plaisir particulier à lire quelque chose qui a été fait pour être lu, et non pour être mesuré. Cela ne vous demande rien d’autre que votre attention."
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
-#: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Mark all as read?"
 msgstr "Tout marquer comme lu ?"
 
@@ -2970,7 +2979,6 @@ msgstr "Notes de bas de page"
 msgid "Every publication the network knows about — {publicationCount} and counting. Subscribe to the ones worth your mornings."
 msgstr "Toutes les publications connues du réseau — {publicationCount} et ce n’est qu’un début. Abonnez-vous à celles qui méritent vos matinées."
 
-#: src/components/reader/cards.tsx
 #: src/components/reader/follow-user-button.tsx
 msgid "Follow"
 msgstr "Suivre"
@@ -3047,6 +3055,7 @@ msgid "Keep reading"
 msgstr "Continuer la lecture"
 
 #: src/components/reader/discover-topic-filters.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.feedback.index.tsx
 #: src/routes/_layout.latest.tsx
@@ -3222,6 +3231,7 @@ msgstr "Fermer le magazine"
 msgid "Introduce the collection… (markdown supported)"
 msgstr "Présentez la collection… (markdown pris en charge)"
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.feedback.index.tsx
 msgid "Filter"
 msgstr ""
@@ -3302,8 +3312,8 @@ msgstr "Aucune publication ne correspond encore à ce tag."
 msgid "The conversation, gathered"
 msgstr "La conversation, rassemblée"
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
-#: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Mark all as read"
 msgstr "Tout marquer comme lu"
 
@@ -3424,6 +3434,10 @@ msgstr "Abonnements"
 msgid "{0, plural, one {# post} other {{1} posts}}"
 msgstr "{0, plural, one {# publication} other {{1} publications}}"
 
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You haven’t read anything here yet."
+msgstr ""
+
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
 msgid "Authentication"
@@ -3487,6 +3501,10 @@ msgstr "(nécessite {min}:1)"
 #: src/components/user-settings-view.tsx
 msgid "Every read record in your repository will be removed. Articles will appear unread again across the app. This cannot be undone."
 msgstr "Chaque enregistrement de lecture de votre dépôt sera supprimé. Les articles réapparaîtront comme non lus dans toute l'application. Cette action est irréversible."
+
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You’ve read everything from this publication."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Text, borders and every other step are derived from these two colors."
@@ -3815,6 +3833,11 @@ msgstr "En cours"
 #: src/components/site-legal-links.tsx
 msgid "Privacy"
 msgstr "Confidentialité"
+
+#. placeholder {0}: labels[filter]
+#: src/components/reader/publication-actions.tsx
+msgid "Filter: {0}"
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "Last updated June 11, 2026"
@@ -4256,6 +4279,10 @@ msgstr "Ajout de {publicationName} à votre flux."
 #~ msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors and checked for contrast."
 #~ msgstr ""
 
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You haven’t recommended anything here yet."
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/user-settings-view.tsx
@@ -4548,8 +4575,8 @@ msgid "Hide"
 msgstr "Masquer"
 
 #: src/routes/_layout.p.$did.$rkey.tsx
-msgid "Open publication"
-msgstr "Ouvrir la publication"
+#~ msgid "Open publication"
+#~ msgstr "Ouvrir la publication"
 
 #: src/components/reader/link-share-menu.tsx
 msgid "Send to Disperse"
@@ -4673,6 +4700,7 @@ msgid "Text selection actions"
 msgstr "Actions sur la sélection de texte"
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/magazine/magazine-end-like.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.recommended.tsx

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -1387,6 +1387,7 @@ msgstr "{count, plural, one {# 件の高評価} other {# 件の高評価}} — �
 msgid "Apps you have connected to Standard Reader through its <0>MCP server</0>. Disconnecting one revokes its access immediately; it can ask to reconnect at any time."
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.history.tsx
 msgid "Read"
 msgstr "既読"
@@ -1446,6 +1447,10 @@ msgstr "既読の記事を隠す"
 #: src/components/reader/collection-builder.tsx
 msgid "Collection cover"
 msgstr "コレクションの表紙"
+
+#: src/components/reader/publication-actions.tsx
+msgid "Visit publication site"
+msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Attempt to disrupt, overload, or gain unauthorized access to the service, its infrastructure, or other users' accounts."
@@ -1792,6 +1797,7 @@ msgstr "Powered by Standard Reader"
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "RSS feed"
@@ -1929,7 +1935,7 @@ msgstr "購読中"
 msgid "Your account"
 msgstr ""
 
-#: src/routes/_layout.p.$did.$rkey.tsx
+#: src/components/reader/publication-actions.tsx
 msgid "Every unread article from this publication will be marked read. This can’t be undone."
 msgstr "この発行物の未読記事がすべて既読になります。この操作は取り消せません。"
 
@@ -2141,6 +2147,7 @@ msgstr "購読リンクのコード"
 
 #: src/components/reader/add-to-list-button.tsx
 #: src/components/reader/add-to-list-modal.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 msgid "Add to list"
 msgstr "リストに追加"
@@ -2488,6 +2495,7 @@ msgid "Author sections"
 msgstr "著者セクション"
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "More actions"
 msgstr "その他の操作"
@@ -2710,6 +2718,7 @@ msgstr "音声を生成中… {percent}%"
 msgid "Renderers"
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.latest.tsx
 msgid "Unread"
@@ -2833,8 +2842,8 @@ msgstr "続けて承認する"
 msgid "<0>T</0>here is a particular pleasure in reading something that was made to be read, and not to be measured. It asks nothing of you but your attention."
 msgstr "<0>読</0>まれるために作られ、測られるために作られたのではない文章を読むことには、格別の喜びがあります。求められるのは、注意を向けることだけです。"
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
-#: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Mark all as read?"
 msgstr "すべて既読にしますか？"
 
@@ -2970,7 +2979,6 @@ msgstr "脚注"
 msgid "Every publication the network knows about — {publicationCount} and counting. Subscribe to the ones worth your mornings."
 msgstr "ネットワークが把握しているすべての発行物 — {publicationCount} 件、さらに増え続けています。朝の時間を使う価値のある発行物を購読しましょう。"
 
-#: src/components/reader/cards.tsx
 #: src/components/reader/follow-user-button.tsx
 msgid "Follow"
 msgstr "フォロー"
@@ -3047,6 +3055,7 @@ msgid "Keep reading"
 msgstr "読み続ける"
 
 #: src/components/reader/discover-topic-filters.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.feedback.index.tsx
 #: src/routes/_layout.latest.tsx
@@ -3222,6 +3231,7 @@ msgstr "雑誌を閉じる"
 msgid "Introduce the collection… (markdown supported)"
 msgstr "コレクションの紹介文…（markdown 対応）"
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.feedback.index.tsx
 msgid "Filter"
 msgstr ""
@@ -3302,8 +3312,8 @@ msgstr "このタグに一致する発行物はまだありません。"
 msgid "The conversation, gathered"
 msgstr "語られていることの、まとめ"
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
-#: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Mark all as read"
 msgstr "すべて既読にする"
 
@@ -3424,6 +3434,10 @@ msgstr "購読"
 msgid "{0, plural, one {# post} other {{1} posts}}"
 msgstr "{0, plural, one {投稿 # 件} other {投稿 {1} 件}}"
 
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You haven’t read anything here yet."
+msgstr ""
+
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
 msgid "Authentication"
@@ -3487,6 +3501,10 @@ msgstr "（{min}:1 が必要）"
 #: src/components/user-settings-view.tsx
 msgid "Every read record in your repository will be removed. Articles will appear unread again across the app. This cannot be undone."
 msgstr "リポジトリ内のすべての既読記録が削除されます。アプリ全体で記事が再び未読として表示されます。この操作は取り消せません。"
+
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You’ve read everything from this publication."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Text, borders and every other step are derived from these two colors."
@@ -3815,6 +3833,11 @@ msgstr "実行中"
 #: src/components/site-legal-links.tsx
 msgid "Privacy"
 msgstr "プライバシー"
+
+#. placeholder {0}: labels[filter]
+#: src/components/reader/publication-actions.tsx
+msgid "Filter: {0}"
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "Last updated June 11, 2026"
@@ -4256,6 +4279,10 @@ msgstr "{publicationName} をフィードに追加しています。"
 #~ msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors and checked for contrast."
 #~ msgstr ""
 
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You haven’t recommended anything here yet."
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/user-settings-view.tsx
@@ -4548,8 +4575,8 @@ msgid "Hide"
 msgstr "非表示"
 
 #: src/routes/_layout.p.$did.$rkey.tsx
-msgid "Open publication"
-msgstr "発行物を開く"
+#~ msgid "Open publication"
+#~ msgstr "発行物を開く"
 
 #: src/components/reader/link-share-menu.tsx
 msgid "Send to Disperse"
@@ -4673,6 +4700,7 @@ msgid "Text selection actions"
 msgstr "テキスト選択時の操作"
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/magazine/magazine-end-like.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.recommended.tsx

--- a/src/locales/ko/messages.po
+++ b/src/locales/ko/messages.po
@@ -1387,6 +1387,7 @@ msgstr "{count, plural, one {추천 #개} other {추천 #개}} — 클릭해서 
 msgid "Apps you have connected to Standard Reader through its <0>MCP server</0>. Disconnecting one revokes its access immediately; it can ask to reconnect at any time."
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.history.tsx
 msgid "Read"
 msgstr "읽기"
@@ -1446,6 +1447,10 @@ msgstr "읽은 아티클 숨기기"
 #: src/components/reader/collection-builder.tsx
 msgid "Collection cover"
 msgstr "컬렉션 커버"
+
+#: src/components/reader/publication-actions.tsx
+msgid "Visit publication site"
+msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Attempt to disrupt, overload, or gain unauthorized access to the service, its infrastructure, or other users' accounts."
@@ -1792,6 +1797,7 @@ msgstr "Standard Reader 제공"
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "RSS feed"
@@ -1929,7 +1935,7 @@ msgstr "구독 중"
 msgid "Your account"
 msgstr ""
 
-#: src/routes/_layout.p.$did.$rkey.tsx
+#: src/components/reader/publication-actions.tsx
 msgid "Every unread article from this publication will be marked read. This can’t be undone."
 msgstr "이 발행물의 읽지 않은 아티클이 모두 읽음으로 표시됩니다. 되돌릴 수 없습니다."
 
@@ -2141,6 +2147,7 @@ msgstr "구독 링크 코드"
 
 #: src/components/reader/add-to-list-button.tsx
 #: src/components/reader/add-to-list-modal.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 msgid "Add to list"
 msgstr "리스트에 추가"
@@ -2488,6 +2495,7 @@ msgid "Author sections"
 msgstr "글쓴이 섹션"
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "More actions"
 msgstr "더 보기"
@@ -2710,6 +2718,7 @@ msgstr "오디오 생성 중… {percent}%"
 msgid "Renderers"
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.latest.tsx
 msgid "Unread"
@@ -2833,8 +2842,8 @@ msgstr "계속해서 승인"
 msgid "<0>T</0>here is a particular pleasure in reading something that was made to be read, and not to be measured. It asks nothing of you but your attention."
 msgstr "<0>읽</0>히기 위해 만들어진 글, 측정되기 위해 만들어지지 않은 글을 읽는 데에는 특별한 즐거움이 있습니다. 그 글은 당신의 주의 말고는 아무것도 요구하지 않습니다."
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
-#: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Mark all as read?"
 msgstr "모두 읽음으로 표시할까요?"
 
@@ -2970,7 +2979,6 @@ msgstr "각주"
 msgid "Every publication the network knows about — {publicationCount} and counting. Subscribe to the ones worth your mornings."
 msgstr "네트워크가 알고 있는 모든 발행물 — {publicationCount}개, 그리고 계속 늘어나는 중. 당신의 아침을 함께할 만한 곳을 구독하세요."
 
-#: src/components/reader/cards.tsx
 #: src/components/reader/follow-user-button.tsx
 msgid "Follow"
 msgstr "팔로우"
@@ -3047,6 +3055,7 @@ msgid "Keep reading"
 msgstr "계속 읽기"
 
 #: src/components/reader/discover-topic-filters.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.feedback.index.tsx
 #: src/routes/_layout.latest.tsx
@@ -3222,6 +3231,7 @@ msgstr "매거진 닫기"
 msgid "Introduce the collection… (markdown supported)"
 msgstr "컬렉션을 소개해 주세요… (마크다운 지원)"
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.feedback.index.tsx
 msgid "Filter"
 msgstr ""
@@ -3302,8 +3312,8 @@ msgstr "아직 이 태그와 일치하는 발행물이 없습니다."
 msgid "The conversation, gathered"
 msgstr "한자리에 모인 대화"
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
-#: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Mark all as read"
 msgstr "모두 읽음으로 표시"
 
@@ -3424,6 +3434,10 @@ msgstr "구독"
 msgid "{0, plural, one {# post} other {{1} posts}}"
 msgstr "{0, plural, one {게시물 #개} other {게시물 {1}개}}"
 
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You haven’t read anything here yet."
+msgstr ""
+
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
 msgid "Authentication"
@@ -3487,6 +3501,10 @@ msgstr "({min}:1 필요)"
 #: src/components/user-settings-view.tsx
 msgid "Every read record in your repository will be removed. Articles will appear unread again across the app. This cannot be undone."
 msgstr "저장소에 있는 모든 읽음 기록이 삭제됩니다. 앱 전체에서 글이 다시 읽지 않음으로 표시되며, 되돌릴 수 없습니다."
+
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You’ve read everything from this publication."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Text, borders and every other step are derived from these two colors."
@@ -3815,6 +3833,11 @@ msgstr "진행 중"
 #: src/components/site-legal-links.tsx
 msgid "Privacy"
 msgstr "개인정보"
+
+#. placeholder {0}: labels[filter]
+#: src/components/reader/publication-actions.tsx
+msgid "Filter: {0}"
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "Last updated June 11, 2026"
@@ -4256,6 +4279,10 @@ msgstr "{publicationName}을(를) 피드에 추가하는 중입니다."
 #~ msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors and checked for contrast."
 #~ msgstr ""
 
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You haven’t recommended anything here yet."
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/user-settings-view.tsx
@@ -4548,8 +4575,8 @@ msgid "Hide"
 msgstr "숨기기"
 
 #: src/routes/_layout.p.$did.$rkey.tsx
-msgid "Open publication"
-msgstr "발행물 열기"
+#~ msgid "Open publication"
+#~ msgstr "발행물 열기"
 
 #: src/components/reader/link-share-menu.tsx
 msgid "Send to Disperse"
@@ -4673,6 +4700,7 @@ msgid "Text selection actions"
 msgstr "텍스트 선택 동작"
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/magazine/magazine-end-like.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.recommended.tsx

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -1387,6 +1387,7 @@ msgstr "{count, plural, one {# voto} other {# votos}} — clique para votar"
 msgid "Apps you have connected to Standard Reader through its <0>MCP server</0>. Disconnecting one revokes its access immediately; it can ask to reconnect at any time."
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.history.tsx
 msgid "Read"
 msgstr "Lido"
@@ -1446,6 +1447,10 @@ msgstr "Ocultar artigos lidos"
 #: src/components/reader/collection-builder.tsx
 msgid "Collection cover"
 msgstr "Capa da coleção"
+
+#: src/components/reader/publication-actions.tsx
+msgid "Visit publication site"
+msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Attempt to disrupt, overload, or gain unauthorized access to the service, its infrastructure, or other users' accounts."
@@ -1792,6 +1797,7 @@ msgstr "Com tecnologia Standard Reader"
 msgid "Clear selection"
 msgstr "Limpar a seleção"
 
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "RSS feed"
@@ -1929,7 +1935,7 @@ msgstr "Inscrevendo-se"
 msgid "Your account"
 msgstr "Sua conta"
 
-#: src/routes/_layout.p.$did.$rkey.tsx
+#: src/components/reader/publication-actions.tsx
 msgid "Every unread article from this publication will be marked read. This can’t be undone."
 msgstr "Todos os artigos não lidos desta publicação serão marcados como lidos. Esta ação não pode ser desfeita."
 
@@ -2141,6 +2147,7 @@ msgstr "Código do link de inscrição"
 
 #: src/components/reader/add-to-list-button.tsx
 #: src/components/reader/add-to-list-modal.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 msgid "Add to list"
 msgstr "Adicionar à lista"
@@ -2488,6 +2495,7 @@ msgid "Author sections"
 msgstr "Seções do autor"
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "More actions"
 msgstr "Mais ações"
@@ -2710,6 +2718,7 @@ msgstr "A gerar áudio… {percent}%"
 msgid "Renderers"
 msgstr "Renderizadores"
 
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.latest.tsx
 msgid "Unread"
@@ -2833,8 +2842,8 @@ msgstr "Continuar para aprovar"
 msgid "<0>T</0>here is a particular pleasure in reading something that was made to be read, and not to be measured. It asks nothing of you but your attention."
 msgstr "<0>H</0>á um prazer particular em ler algo que foi feito para ser lido, e não para ser medido. Nada pede de si além da sua atenção."
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
-#: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Mark all as read?"
 msgstr "Marcar tudo como lido?"
 
@@ -2970,7 +2979,6 @@ msgstr "Notas de rodapé"
 msgid "Every publication the network knows about — {publicationCount} and counting. Subscribe to the ones worth your mornings."
 msgstr "Todas as publicações que a rede conhece — {publicationCount} e contando. Inscreva-se nas que merecem as suas manhãs."
 
-#: src/components/reader/cards.tsx
 #: src/components/reader/follow-user-button.tsx
 msgid "Follow"
 msgstr "Seguir"
@@ -3047,6 +3055,7 @@ msgid "Keep reading"
 msgstr "Continuar a ler"
 
 #: src/components/reader/discover-topic-filters.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.feedback.index.tsx
 #: src/routes/_layout.latest.tsx
@@ -3222,6 +3231,7 @@ msgstr "Fechar revista"
 msgid "Introduce the collection… (markdown supported)"
 msgstr "Apresente a coleção… (com suporte para markdown)"
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.feedback.index.tsx
 msgid "Filter"
 msgstr ""
@@ -3302,8 +3312,8 @@ msgstr "Ainda não há publicações com esta etiqueta."
 msgid "The conversation, gathered"
 msgstr "A conversa, reunida"
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
-#: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Mark all as read"
 msgstr "Marcar tudo como lido"
 
@@ -3424,6 +3434,10 @@ msgstr "Inscrições"
 msgid "{0, plural, one {# post} other {{1} posts}}"
 msgstr "{0, plural, one {# publicação} other {{1} publicações}}"
 
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You haven’t read anything here yet."
+msgstr ""
+
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
 msgid "Authentication"
@@ -3487,6 +3501,10 @@ msgstr "(requer {min}:1)"
 #: src/components/user-settings-view.tsx
 msgid "Every read record in your repository will be removed. Articles will appear unread again across the app. This cannot be undone."
 msgstr "Todos os registos de leitura no seu repositório serão removidos. Os artigos voltarão a aparecer como não lidos em toda a aplicação. Esta ação não pode ser desfeita."
+
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You’ve read everything from this publication."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Text, borders and every other step are derived from these two colors."
@@ -3815,6 +3833,11 @@ msgstr "Em execução"
 #: src/components/site-legal-links.tsx
 msgid "Privacy"
 msgstr "Privacidade"
+
+#. placeholder {0}: labels[filter]
+#: src/components/reader/publication-actions.tsx
+msgid "Filter: {0}"
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "Last updated June 11, 2026"
@@ -4256,6 +4279,10 @@ msgstr "Adicionando {publicationName} ao seu feed."
 #~ msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors and checked for contrast."
 #~ msgstr ""
 
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You haven’t recommended anything here yet."
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/user-settings-view.tsx
@@ -4548,8 +4575,8 @@ msgid "Hide"
 msgstr "Ocultar"
 
 #: src/routes/_layout.p.$did.$rkey.tsx
-msgid "Open publication"
-msgstr "Abrir publicação"
+#~ msgid "Open publication"
+#~ msgstr "Abrir publicação"
 
 #: src/components/reader/link-share-menu.tsx
 msgid "Send to Disperse"
@@ -4673,6 +4700,7 @@ msgid "Text selection actions"
 msgstr "Ações de seleção de texto"
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/magazine/magazine-end-like.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.recommended.tsx

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1387,6 +1387,7 @@ msgstr "{count, plural, one {# 次赞同} other {# 次赞同}} — 点击赞同"
 msgid "Apps you have connected to Standard Reader through its <0>MCP server</0>. Disconnecting one revokes its access immediately; it can ask to reconnect at any time."
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.history.tsx
 msgid "Read"
 msgstr "阅读"
@@ -1446,6 +1447,10 @@ msgstr "隐藏已读文章"
 #: src/components/reader/collection-builder.tsx
 msgid "Collection cover"
 msgstr "合集封面"
+
+#: src/components/reader/publication-actions.tsx
+msgid "Visit publication site"
+msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Attempt to disrupt, overload, or gain unauthorized access to the service, its infrastructure, or other users' accounts."
@@ -1792,6 +1797,7 @@ msgstr "由 Standard Reader 提供支持"
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "RSS feed"
@@ -1929,7 +1935,7 @@ msgstr "正在订阅"
 msgid "Your account"
 msgstr ""
 
-#: src/routes/_layout.p.$did.$rkey.tsx
+#: src/components/reader/publication-actions.tsx
 msgid "Every unread article from this publication will be marked read. This can’t be undone."
 msgstr "该刊物的所有未读文章都将标记为已读。此操作无法撤销。"
 
@@ -2141,6 +2147,7 @@ msgstr "订阅链接代码"
 
 #: src/components/reader/add-to-list-button.tsx
 #: src/components/reader/add-to-list-modal.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 msgid "Add to list"
 msgstr "添加到列表"
@@ -2488,6 +2495,7 @@ msgid "Author sections"
 msgstr "作者栏目"
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "More actions"
 msgstr "更多操作"
@@ -2710,6 +2718,7 @@ msgstr "正在生成音频… {percent}%"
 msgid "Renderers"
 msgstr ""
 
+#: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.latest.tsx
 msgid "Unread"
@@ -2833,8 +2842,8 @@ msgstr "继续以批准"
 msgid "<0>T</0>here is a particular pleasure in reading something that was made to be read, and not to be measured. It asks nothing of you but your attention."
 msgstr "<0>阅</0>读那些为阅读而写、而非为衡量而写的文字，自有一种独特的乐趣。它别无所求，只要你的注意力。"
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
-#: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Mark all as read?"
 msgstr "将全部标为已读？"
 
@@ -2970,7 +2979,6 @@ msgstr "脚注"
 msgid "Every publication the network knows about — {publicationCount} and counting. Subscribe to the ones worth your mornings."
 msgstr "网络已知的全部刊物——{publicationCount} 个，还在增加。订阅那些值得你清晨时光的刊物。"
 
-#: src/components/reader/cards.tsx
 #: src/components/reader/follow-user-button.tsx
 msgid "Follow"
 msgstr "关注"
@@ -3047,6 +3055,7 @@ msgid "Keep reading"
 msgstr "继续阅读"
 
 #: src/components/reader/discover-topic-filters.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.feedback.index.tsx
 #: src/routes/_layout.latest.tsx
@@ -3222,6 +3231,7 @@ msgstr "关闭杂志"
 msgid "Introduce the collection… (markdown supported)"
 msgstr "介绍一下这个合集……（支持 markdown）"
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.feedback.index.tsx
 msgid "Filter"
 msgstr ""
@@ -3302,8 +3312,8 @@ msgstr "暂时没有符合此标签的刊物。"
 msgid "The conversation, gathered"
 msgstr "汇集在一起的讨论"
 
+#: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
-#: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Mark all as read"
 msgstr "全部标记为已读"
 
@@ -3424,6 +3434,10 @@ msgstr "订阅"
 msgid "{0, plural, one {# post} other {{1} posts}}"
 msgstr "{0, plural, one {# 篇内容} other {{1} 篇内容}}"
 
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You haven’t read anything here yet."
+msgstr ""
+
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
 msgid "Authentication"
@@ -3487,6 +3501,10 @@ msgstr "（需要 {min}:1）"
 #: src/components/user-settings-view.tsx
 msgid "Every read record in your repository will be removed. Articles will appear unread again across the app. This cannot be undone."
 msgstr "你仓库中的所有已读记录都将被移除。文章会在整个应用中重新显示为未读。此操作无法撤销。"
+
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You’ve read everything from this publication."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Text, borders and every other step are derived from these two colors."
@@ -3815,6 +3833,11 @@ msgstr "运行中"
 #: src/components/site-legal-links.tsx
 msgid "Privacy"
 msgstr "隐私"
+
+#. placeholder {0}: labels[filter]
+#: src/components/reader/publication-actions.tsx
+msgid "Filter: {0}"
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "Last updated June 11, 2026"
@@ -4256,6 +4279,10 @@ msgstr "正在将 {publicationName} 添加到你的信息流。"
 #~ msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors and checked for contrast."
 #~ msgstr ""
 
+#: src/routes/_layout.p.$did.$rkey.tsx
+msgid "You haven’t recommended anything here yet."
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/user-settings-view.tsx
@@ -4548,8 +4575,8 @@ msgid "Hide"
 msgstr "隐藏"
 
 #: src/routes/_layout.p.$did.$rkey.tsx
-msgid "Open publication"
-msgstr "打开刊物"
+#~ msgid "Open publication"
+#~ msgstr "打开刊物"
 
 #: src/components/reader/link-share-menu.tsx
 msgid "Send to Disperse"
@@ -4673,6 +4700,7 @@ msgid "Text selection actions"
 msgstr "选中文本操作"
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/publication-actions.tsx
 #: src/magazine/magazine-end-like.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.recommended.tsx


### PR DESCRIPTION
## Summary

Refactors mention chip rendering across the codebase by extracting the avatar + label composition into a new `MentionChipBody` component, and consolidates duplicated styling into the centralized `articleBodyStyles` theme.

## Changes

- **New component:** `src/components/reader/content/mention-chip.tsx`
  - Exports `MentionChipBody` to wrap avatar + label with a word joiner character (U+2060) that prevents line breaks from separating the avatar from the label text
  - Enables mention chips to wrap naturally in prose while keeping avatar and label visually grouped

- **Styling consolidation:** `src/components/reader/content/body-styles.ts`
  - Moved `mentionChip` and `mentionAvatar` styles from local `styles` objects into `articleBodyStyles`
  - Enhanced `facetMentionLink` with wrapping support:
    - `whiteSpace: "normal"` (was hardcoded `"nowrap"`)
    - `overflowWrap: "break-word"` for long unbroken runs
    - `boxDecorationBreak: "clone"` so wrapped fragments retain padding and rounded corners
  - Added `facetMentionAvatar` style definition for consistent avatar sizing

- **Refactored components:**
  - `src/components/reader/content/renderers/shared/faceted-text.tsx`: Updated `PublicationMentionChip`, `DocumentMentionChip`, `ActorMentionChip`, and `LinkedActorChip` to use `MentionChipBody`
  - `src/components/reader/content/smart-article-link.tsx`: Updated `UserLinkChip`, `ArticleLinkChip`, and `PublicationLinkChip` to use `MentionChipBody`
  - Removed local `styles` objects from both files

## Implementation Details

- The word joiner character ensures that when a mention chip wraps across lines, the avatar stays attached to the first word of the label rather than being orphaned at the end of a line
- Centralized styling in `articleBodyStyles` eliminates duplication and makes future updates to mention chip appearance consistent across all mention types
- The `boxDecorationBreak: "clone"` property ensures each line fragment of a wrapped chip maintains its visual pill appearance with proper padding and border radius

https://claude.ai/code/session_01QE37nxYVbbtN56STup8yFD