### PR TITLE
Add `at:` meta tags for AT Protocol record discovery

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -982,9 +982,10 @@ one, and small in-app strings such as a collection colophon.
 ### Record meta tags (`at:`)
 
 Every page we serve says, in its `<head>`, which AT Protocol records it is built from — the
-convention the Atmosphere converged on in 2026, and the successor to the unregistered
-`<link rel="site.standard.*">` discovery hints (which we keep emitting alongside, so nothing
-already reading them breaks).
+convention the Atmosphere converged on in 2026. These sit **alongside**, not instead of, the
+`<link rel="site.standard.*">` discovery hints: the rels are part of the site.standard spec and
+plenty of clients read only those, while the meta tags carry intent the rels can't express.
+Article, publication and collection pages emit both.
 
 | Tag            | Means                               | Example on `/a/$did/$rkey`        |
 | -------------- | ----------------------------------- | --------------------------------- |

--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -979,6 +979,36 @@ react-markdown remains for two things that are not document markdown: HTML-in-re
 (WordPress, Ghost, Known, Gutenberg-as-HTML), which need an HTML pipeline rather than a markdown
 one, and small in-app strings such as a collection colophon.
 
+### Record meta tags (`at:`)
+
+Every page we serve says, in its `<head>`, which AT Protocol records it is built from — the
+convention the Atmosphere converged on in 2026, and the successor to the unregistered
+`<link rel="site.standard.*">` discovery hints (which we keep emitting alongside, so nothing
+already reading them breaks).
+
+| Tag            | Means                               | Example on `/a/$did/$rkey`        |
+| -------------- | ----------------------------------- | --------------------------------- |
+| `at:canonical` | the records the page is made of     | the `site.standard.document`      |
+| `at:alternate` | records the page merely shows       | its publication, its Bluesky post |
+| `at:author`    | the identity that wrote the content | the document's repo DID           |
+
+Where they come from and why they're not route `head.meta`:
+
+- A route declares its records by returning an **`atMeta`** key from its loader
+  (`WithAtMeta` in `src/lib/at-meta-tags.ts`). `AtRecordMeta` reads the deepest match that has
+  one and renders the tags as raw elements in `RootDocument`'s `<head>`.
+- They **can't** be route `head.meta` entries: TanStack dedupes head meta by `name`, and these
+  names repeat — an article carries two `at:alternate` tags. Same reason `theme-color` is a raw
+  tag. `src/components/at-record-meta.ssr.test.ts` renders a router through the shell to keep
+  that property from regressing silently.
+- Covered routes: `/a/…` (document + publication + Bluesky post), `/p/…`, `/l/…`,
+  `/collection/…`, and `/u/…` — the profile page declares **no canonical**, since it is a
+  directory of someone's publications with their Bluesky profile draped over it and stands up
+  fine without that record.
+- We do **not** emit `at:me`. That tag asserts the page belongs to the identity, and every
+  record we render belongs to someone else; it's the right tag for a platform serving an
+  author's own site, not for a reader.
+
 ### Browser extension architecture
 
 ```
@@ -995,6 +1025,9 @@ Web page / bsky.app                Extension (WXT MV3)
 ```
 
 - **Resolve:** canonical URL → document/publication (`src/server/extension/resolve-page-url.server.ts`).
+  When the URL isn't indexed, fall back to the page's own record hints: the `at:canonical` /
+  `at:alternate` meta tags first, then the older `<link rel="site.standard.*">` tags
+  (`src/lib/discovery-hints.ts`). Our own pages emit both — see "Record meta tags" below.
 - **Writes:** bookmark + follow reuse existing repo-record + ingest handlers.
 - **Login completion:** `/extension/connected` landing tab after OAuth redirect.
 

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -758,7 +758,16 @@ Build each on hip-ui components + StyleX tokens (no raw HTML/inline styles).
       `<link rel="site.standard.publication" href="at://…">` and `/a/...` emits
       `rel="site.standard.document"` (+ the publication hint when the document belongs to one),
       per https://standard.site/docs/verification/#discovery-hint (hints only; verification
-      stays with the publisher's `.well-known`).
+      stays with the publisher's `.well-known`). Kept alongside the `at:` meta tags below so
+      anything still reading the rels keeps working.
+- [x] **`at:` record meta tags** — the community convention that supersedes those rels
+      (`at:canonical` / `at:alternate` / `at:author`), adopted across the network in 2026.
+      `/a/...`, `/p/...`, `/l/...`, `/u/...` and `/collection/...` declare their records via an
+      `atMeta` key on loader data; `AtRecordMeta` renders them as raw tags in `RootDocument`'s
+      `<head>` (route `head.meta` dedupes by `name` and the convention repeats). We deliberately
+      do not emit `at:me` — every record we render belongs to someone else. Discovery-hint
+      parsing reads the meta tags first and falls back to the rels, so peers that drop the old
+      tags still resolve. See `src/lib/at-meta-tags.ts`.
 
 ## 7. Discovery engine (network-powered)
 

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -758,10 +758,11 @@ Build each on hip-ui components + StyleX tokens (no raw HTML/inline styles).
       `<link rel="site.standard.publication" href="at://…">` and `/a/...` emits
       `rel="site.standard.document"` (+ the publication hint when the document belongs to one),
       per https://standard.site/docs/verification/#discovery-hint (hints only; verification
-      stays with the publisher's `.well-known`). Kept alongside the `at:` meta tags below so
-      anything still reading the rels keeps working.
-- [x] **`at:` record meta tags** — the community convention that supersedes those rels
-      (`at:canonical` / `at:alternate` / `at:author`), adopted across the network in 2026.
+      stays with the publisher's `.well-known`). `/collection/...` emits the same pair for the
+      collection manifest document. Part of the site.standard spec and still the only thing many
+      clients read — kept permanently, not a migration step.
+- [x] **`at:` record meta tags** — the community convention adopted across the network in 2026
+      (`at:canonical` / `at:alternate` / `at:author`), emitted _alongside_ the rels above.
       `/a/...`, `/p/...`, `/l/...`, `/u/...` and `/collection/...` declare their records via an
       `atMeta` key on loader data; `AtRecordMeta` renders them as raw tags in `RootDocument`'s
       `<head>` (route `head.meta` dedupes by `name` and the convention repeats). We deliberately

--- a/apps/standard-reader/src/components/at-record-meta.ssr.test.ts
+++ b/apps/standard-reader/src/components/at-record-meta.ssr.test.ts
@@ -1,0 +1,70 @@
+/**
+ * The `at:` tags are rendered from the router's match store inside the root
+ * shell, not from route `head.meta` — see `AtRecordMeta`. That wiring is easy to
+ * break silently (a route's loader data stops reaching the shell and the tags
+ * just vanish), so render a real router through it and assert on the HTML.
+ */
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from "@tanstack/react-router";
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { AtRecordMeta } from "./at-record-meta.tsx";
+
+const DID = "did:plc:sov5kv5byjmdksdjacjiysg3";
+const DOCUMENT = `at://${DID}/site.standard.document/3mrnculcx5c2v`;
+const PUBLICATION = `at://${DID}/site.standard.publication/3mnuandrwh22s`;
+const BSKY_POST = `at://${DID}/app.bsky.feed.post/3mrnculiuls2c`;
+
+async function renderRoute(loader: () => unknown) {
+  const rootRoute = createRootRoute({
+    shellComponent: ({ children }: { children: React.ReactNode }) =>
+      createElement("div", null, createElement(AtRecordMeta), children),
+  });
+  const articleRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/article",
+    loader,
+    component: () => createElement("main"),
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([articleRoute]),
+    history: createMemoryHistory({ initialEntries: ["/article"] }),
+  });
+  await router.load();
+  return renderToString(createElement(RouterProvider, { router }));
+}
+
+describe("AtRecordMeta", () => {
+  it("renders every tag a route declares, repeats included", async () => {
+    const html = await renderRoute(() => ({
+      atMeta: {
+        canonical: [DOCUMENT],
+        alternate: [PUBLICATION, BSKY_POST],
+        author: [DID],
+      },
+    }));
+
+    // Both alternates survive — the reason these aren't route `head.meta`
+    // entries, which TanStack dedupes by `name`.
+    expect(html).toContain(`<meta name="at:canonical" content="${DOCUMENT}"/>`);
+    expect(html).toContain(
+      `<meta name="at:alternate" content="${PUBLICATION}"/>`,
+    );
+    expect(html).toContain(
+      `<meta name="at:alternate" content="${BSKY_POST}"/>`,
+    );
+    expect(html).toContain(`<meta name="at:author" content="at://${DID}"/>`);
+  });
+
+  it("renders nothing for a route that declares no records", async () => {
+    const html = await renderRoute(() => ({ title: "Latest" }));
+    expect(html).not.toContain("at:");
+  });
+});

--- a/apps/standard-reader/src/components/at-record-meta.tsx
+++ b/apps/standard-reader/src/components/at-record-meta.tsx
@@ -1,0 +1,33 @@
+import { useRouterState } from "@tanstack/react-router";
+
+import { atMetaFromMatches, atMetaTags } from "#/lib/at-meta-tags";
+
+/**
+ * Renders the `at:canonical` / `at:alternate` / `at:author` tags for the deepest
+ * matched route that declares any (see `WithAtMeta` in `#/lib/at-meta-tags`).
+ *
+ * These are raw tags in `RootDocument`'s `<head>` rather than route `head.meta`
+ * entries for the same reason `theme-color` is: TanStack dedupes head meta by
+ * `name`, and the `at:` convention is explicitly repeatable — an article page
+ * carries one `at:alternate` for its publication and another for its companion
+ * Bluesky post, and route `head.meta` would collapse them into one.
+ */
+export function AtRecordMeta() {
+  const records = useRouterState({
+    select: (state) => atMetaFromMatches(state.matches),
+  });
+
+  if (!records) return null;
+
+  return (
+    <>
+      {atMetaTags(records).map((tag) => (
+        <meta
+          key={`${tag.name} ${tag.content}`}
+          name={tag.name}
+          content={tag.content}
+        />
+      ))}
+    </>
+  );
+}

--- a/apps/standard-reader/src/components/docs/publishing-docs-page.tsx
+++ b/apps/standard-reader/src/components/docs/publishing-docs-page.tsx
@@ -235,26 +235,37 @@ export function PublishingDocsPage() {
         <CodePanel tag="head" code={DISCOVERY_SNIPPET} />
         <p {...stylex.props(docsStyles.prose)}>
           <Trans>
-            Standard Reader emits these on its own article, publication, list
-            and profile pages, and reads them from yours.
+            Standard Reader emits these on its own article, publication,
+            collection, list and profile pages, and reads them from yours.
           </Trans>
         </p>
         <h3 {...stylex.props(docsStyles.h3)}>
-          <Trans>The older link rels</Trans>
+          <Trans>The site.standard link rels</Trans>
         </h3>
         <p {...stylex.props(docsStyles.prose)}>
           <Trans>
-            Before the meta tags, discovery hints rode on{" "}
-            <code {...stylex.props(docsStyles.codeInline)}>link</code> tags
-            whose <code {...stylex.props(docsStyles.codeInline)}>rel</code> was
-            the record&apos;s collection. We still read these, so pages that
-            haven&apos;t migrated keep working — but an unregistered{" "}
-            <code {...stylex.props(docsStyles.codeInline)}>rel</code> value
-            isn&apos;t valid HTML, and it can&apos;t say why a record is on the
-            page. New sites should reach for the meta tags. If you already emit
-            the rels, the friendly move is what SkyPress did: keep them and put
-            the meta tags alongside, so nothing already reading the old ones
-            breaks.
+            Emit these too. Discovery hints are part of the site.standard spec
+            itself — a{" "}
+            <code {...stylex.props(docsStyles.codeInline)}>link</code> tag whose{" "}
+            <code {...stylex.props(docsStyles.codeInline)}>rel</code> is the
+            record&apos;s collection and whose{" "}
+            <code {...stylex.props(docsStyles.codeInline)}>href</code> is its{" "}
+            <code {...stylex.props(docsStyles.codeInline)}>at://</code> URI —
+            and plenty of clients across the network still read only these.
+            Include the{" "}
+            <code {...stylex.props(docsStyles.codeInline)}>
+              site.standard.publication
+            </code>{" "}
+            hint when the document belongs to a publication record.
+          </Trans>
+        </p>
+        <p {...stylex.props(docsStyles.prose)}>
+          <Trans>
+            The two say overlapping things, and that&apos;s fine: the meta tags
+            carry intent the rels can&apos;t, while the rels are what the
+            site.standard spec asks for. Carry both, which is what Standard
+            Reader itself does on every article, publication and collection
+            page.
           </Trans>
         </p>
         <CodePanel tag="head" code={DISCOVERY_LEGACY_SNIPPET} />

--- a/apps/standard-reader/src/components/docs/publishing-docs-page.tsx
+++ b/apps/standard-reader/src/components/docs/publishing-docs-page.tsx
@@ -18,7 +18,17 @@ import { DocsPublishingNav } from "./docs-publishing-nav";
 import { DocsRefShell } from "./docs-ref-shell";
 import { DocsSideNav } from "./docs-side-nav";
 
-const DISCOVERY_SNIPPET = `<link
+const DISCOVERY_SNIPPET = `<meta
+  name="at:canonical"
+  content="at://did:plc:you/site.standard.document/<rkey>"
+/>
+<meta
+  name="at:alternate"
+  content="at://did:plc:you/site.standard.publication/<rkey>"
+/>
+<meta name="at:author" content="at://did:plc:you" />`;
+
+const DISCOVERY_LEGACY_SNIPPET = `<link
   rel="site.standard.document"
   href="at://did:plc:you/site.standard.document/<rkey>"
 />
@@ -199,31 +209,55 @@ export function PublishingDocsPage() {
         </h2>
         <p {...stylex.props(docsStyles.prose)}>
           <Trans>
-            Discovery hints are part of the site.standard spec itself, and our
-            browser extension uses it too! When you land on a URL it hasn&apos;t
-            indexed yet, it looks in that page&apos;s{" "}
-            <code {...stylex.props(docsStyles.codeInline)}>head</code> for a{" "}
-            <code {...stylex.props(docsStyles.codeInline)}>link</code> tag whose{" "}
-            <code {...stylex.props(docsStyles.codeInline)}>rel</code> matches
-            the record&apos;s collection and whose{" "}
-            <code {...stylex.props(docsStyles.codeInline)}>href</code> is the
-            record&apos;s{" "}
-            <code {...stylex.props(docsStyles.codeInline)}>at://</code> URI.
+            Say in your page&apos;s{" "}
+            <code {...stylex.props(docsStyles.codeInline)}>head</code> which
+            records it is built from, and any client on the network can resolve
+            the page back to them. Our browser extension uses this: when you
+            land on a URL it hasn&apos;t indexed yet, it reads those tags rather
+            than guessing from the URL.
+          </Trans>
+        </p>
+        <p {...stylex.props(docsStyles.prose)}>
+          <Trans>
+            Use the <code {...stylex.props(docsStyles.codeInline)}>at:</code>{" "}
+            meta tags — the convention the Atmosphere settled on in 2026.{" "}
+            <code {...stylex.props(docsStyles.codeInline)}>at:canonical</code>{" "}
+            names the records the page is made of, the ones it would have no
+            reason to exist without.{" "}
+            <code {...stylex.props(docsStyles.codeInline)}>at:alternate</code>{" "}
+            names records the page merely shows — the publication a document
+            belongs to, a companion Bluesky post.{" "}
+            <code {...stylex.props(docsStyles.codeInline)}>at:author</code>{" "}
+            names the identity that wrote it. Every name repeats, so a page with
+            two alternates emits two tags.
           </Trans>
         </p>
         <CodePanel tag="head" code={DISCOVERY_SNIPPET} />
         <p {...stylex.props(docsStyles.prose)}>
           <Trans>
-            Include the{" "}
-            <code {...stylex.props(docsStyles.codeInline)}>
-              site.standard.publication
-            </code>{" "}
-            hint only if the document belongs to a publication record. Add both
-            regardless of which reader you care about — they&apos;re how any
-            client on the network resolves your page to its record, not just our
-            extension.
+            Standard Reader emits these on its own article, publication, list
+            and profile pages, and reads them from yours.
           </Trans>
         </p>
+        <h3 {...stylex.props(docsStyles.h3)}>
+          <Trans>The older link rels</Trans>
+        </h3>
+        <p {...stylex.props(docsStyles.prose)}>
+          <Trans>
+            Before the meta tags, discovery hints rode on{" "}
+            <code {...stylex.props(docsStyles.codeInline)}>link</code> tags
+            whose <code {...stylex.props(docsStyles.codeInline)}>rel</code> was
+            the record&apos;s collection. We still read these, so pages that
+            haven&apos;t migrated keep working — but an unregistered{" "}
+            <code {...stylex.props(docsStyles.codeInline)}>rel</code> value
+            isn&apos;t valid HTML, and it can&apos;t say why a record is on the
+            page. New sites should reach for the meta tags. If you already emit
+            the rels, the friendly move is what SkyPress did: keep them and put
+            the meta tags alongside, so nothing already reading the old ones
+            breaks.
+          </Trans>
+        </p>
+        <CodePanel tag="head" code={DISCOVERY_LEGACY_SNIPPET} />
 
         <h2
           {...stylex.props(docsStyles.h2)}

--- a/apps/standard-reader/src/components/reader/format.ts
+++ b/apps/standard-reader/src/components/reader/format.ts
@@ -1,7 +1,7 @@
 /** Formatting helpers shared by the reader UI (kept apart from components). */
 
 import type { ArticleDetail } from "#/integrations/tanstack-query/api-publication.functions";
-import { STANDARD_NSID } from "#/lib/atproto/nsids";
+import { APP_NSID, STANDARD_NSID } from "#/lib/atproto/nsids";
 
 /** Byline author (lead contributor, else publication owner, else publication
  * name). Lives here (not in a component file) so both `article-view.tsx` and
@@ -73,6 +73,11 @@ export function listLinkParams(
   uri: string,
 ): { did: string; rkey: string } | null {
   return publicationLinkParams(uri);
+}
+
+/** Rebuild a list AT-URI from its `/l/$did/$rkey` route params. */
+export function listUriFromParams(did: string, rkey: string): string {
+  return `at://${did}/${APP_NSID.list}/${rkey}`;
 }
 
 /**

--- a/apps/standard-reader/src/lib/at-meta-tags.test.ts
+++ b/apps/standard-reader/src/lib/at-meta-tags.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { atMetaFromMatches, atMetaTags } from "./at-meta-tags.ts";
+
+const DID = "did:plc:sov5kv5byjmdksdjacjiysg3";
+const DOCUMENT = `at://${DID}/site.standard.document/3mrnculcx5c2v`;
+const PUBLICATION = `at://${DID}/site.standard.publication/3mnuandrwh22s`;
+const BSKY_POST = `at://${DID}/app.bsky.feed.post/3mrnculiuls2c`;
+
+describe("atMetaTags", () => {
+  it("emits the article shape from the SkyPress example", () => {
+    expect(
+      atMetaTags({
+        canonical: [DOCUMENT],
+        alternate: [PUBLICATION, BSKY_POST],
+        author: [DID],
+      }),
+    ).toEqual([
+      { name: "at:canonical", content: DOCUMENT },
+      { name: "at:alternate", content: PUBLICATION },
+      { name: "at:alternate", content: BSKY_POST },
+      { name: "at:author", content: `at://${DID}` },
+    ]);
+  });
+
+  it("drops nullish entries so callers can pass optional loader data", () => {
+    expect(
+      atMetaTags({ canonical: [DOCUMENT], alternate: [null, undefined, ""] }),
+    ).toEqual([{ name: "at:canonical", content: DOCUMENT }]);
+  });
+
+  it("leaves an at:// identity URI alone but promotes a bare DID", () => {
+    expect(atMetaTags({ author: [`at://${DID}`, DID] })).toEqual([
+      { name: "at:author", content: `at://${DID}` },
+    ]);
+  });
+
+  it("ignores values that are neither an at:// URI nor a DID", () => {
+    expect(
+      atMetaTags({ canonical: ["https://example.com/post", "at://"] }),
+    ).toEqual([]);
+  });
+
+  it("does not repeat a canonical record as an alternate", () => {
+    expect(
+      atMetaTags({ canonical: [DOCUMENT], alternate: [DOCUMENT, PUBLICATION] }),
+    ).toEqual([
+      { name: "at:canonical", content: DOCUMENT },
+      { name: "at:alternate", content: PUBLICATION },
+    ]);
+  });
+
+  it("collapses duplicates within a single name", () => {
+    expect(atMetaTags({ alternate: [PUBLICATION, PUBLICATION] })).toEqual([
+      { name: "at:alternate", content: PUBLICATION },
+    ]);
+  });
+
+  it("returns nothing for a page with no records", () => {
+    expect(atMetaTags({})).toEqual([]);
+  });
+});
+
+describe("atMetaFromMatches", () => {
+  it("takes the deepest match that declares records", () => {
+    expect(
+      atMetaFromMatches([
+        { loaderData: { atMeta: { canonical: [PUBLICATION] } } },
+        { loaderData: { atMeta: { canonical: [DOCUMENT] } } },
+      ]),
+    ).toEqual({ canonical: [DOCUMENT] });
+  });
+
+  it("skips matches that declare none", () => {
+    expect(
+      atMetaFromMatches([
+        { loaderData: { atMeta: { canonical: [DOCUMENT] } } },
+        { loaderData: { publicationTheme: null } },
+        {},
+      ]),
+    ).toEqual({ canonical: [DOCUMENT] });
+  });
+
+  it("returns null when no match declares any", () => {
+    expect(atMetaFromMatches([{ loaderData: undefined }, {}])).toBeNull();
+    expect(atMetaFromMatches([])).toBeNull();
+  });
+});

--- a/apps/standard-reader/src/lib/at-meta-tags.ts
+++ b/apps/standard-reader/src/lib/at-meta-tags.ts
@@ -4,10 +4,11 @@
  *
  * Proposed on the Atmosphere forum ("Mapping web pages to canonical AT
  * records") and shipped across the network through mid-2026 — Leaflet,
- * Frontpage, Semble, aturi.to, µ, SkyPress. It supersedes the ad-hoc
- * `<link rel="site.standard.document">` discovery hints: a `rel` value nobody
- * registered isn't valid HTML, and `rel` can't express *why* a record is on the
- * page. Four names:
+ * Frontpage, Semble, aturi.to, µ, SkyPress. It covers ground the older
+ * `<link rel="site.standard.document">` discovery hints can't: `rel` says
+ * *which* record, never *why* it's on the page. It does not replace them —
+ * the rels are part of the site.standard spec and plenty of clients read only
+ * those, so our record pages emit both. Four names:
  *
  * - `at:canonical` — the records the page is made of. If they went away, the
  *   page would have no reason to exist.

--- a/apps/standard-reader/src/lib/at-meta-tags.ts
+++ b/apps/standard-reader/src/lib/at-meta-tags.ts
@@ -1,0 +1,125 @@
+/**
+ * `at:` meta tags — the community convention for declaring which AT Protocol
+ * records a web page is built out of.
+ *
+ * Proposed on the Atmosphere forum ("Mapping web pages to canonical AT
+ * records") and shipped across the network through mid-2026 — Leaflet,
+ * Frontpage, Semble, aturi.to, µ, SkyPress. It supersedes the ad-hoc
+ * `<link rel="site.standard.document">` discovery hints: a `rel` value nobody
+ * registered isn't valid HTML, and `rel` can't express *why* a record is on the
+ * page. Four names:
+ *
+ * - `at:canonical` — the records the page is made of. If they went away, the
+ *   page would have no reason to exist.
+ * - `at:alternate` — records the page merely shows.
+ * - `at:author` — the identity that wrote the content.
+ * - `at:me` — the identity the page *belongs to*.
+ *
+ * Standard Reader emits the first three. It deliberately does **not** emit
+ * `at:me`: that tag is `rel="me"` for the Atmosphere — an assertion that the
+ * page is that identity's own — and every record we render belongs to someone
+ * else. A publishing platform serving an author's own site (SkyPress, Leaflet)
+ * is the right place for `at:me`; a reader rendering a third party's document
+ * is not.
+ *
+ * All names repeat: a page with two alternates emits two `at:alternate` tags.
+ * That matters for how these are rendered — see `AtRecordMeta`.
+ *
+ * @see https://skypress.blog/@skypress.blog/its-always-sunny-on-skypress/3mrnculcx5c2v
+ * @see https://discourse.atmosphere.community/t/mapping-web-pages-to-canonical-at-records/904
+ */
+
+export const AT_META_NAME = {
+  canonical: "at:canonical",
+  alternate: "at:alternate",
+  author: "at:author",
+} as const;
+
+export type AtMetaName = (typeof AT_META_NAME)[keyof typeof AT_META_NAME];
+
+/**
+ * The records behind one page. Every field takes nullable entries so callers can
+ * hand over optional loader data (`article.bskyPostUri`) without filtering
+ * first. Values may be `at://` URIs or bare DIDs — bare DIDs are normalized to
+ * `at://<did>`, the form the convention uses for identities.
+ */
+export type AtMetaRecords = {
+  canonical?: Array<string | null | undefined>;
+  alternate?: Array<string | null | undefined>;
+  author?: Array<string | null | undefined>;
+};
+
+export type AtMetaTag = { name: AtMetaName; content: string };
+
+function normalizeAtUri(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith("at://")) {
+    return trimmed.length > "at://".length ? trimmed : null;
+  }
+  // Identities are commonly carried as a bare DID; the tag wants an AT-URI.
+  if (trimmed.startsWith("did:")) return `at://${trimmed}`;
+  return null;
+}
+
+/**
+ * Build the `at:` meta tags for a page.
+ *
+ * Emitted in convention order (canonical, alternate, author). A URI already
+ * claimed as canonical is not repeated as an alternate, and exact duplicates are
+ * dropped, so callers can pass overlapping lists without curating them.
+ */
+export function atMetaTags(records: AtMetaRecords): Array<AtMetaTag> {
+  const tags: Array<AtMetaTag> = [];
+  const seen = new Set<string>();
+  const claimed = new Set<string>();
+
+  const push = (
+    name: AtMetaName,
+    values: AtMetaRecords[keyof AtMetaRecords],
+  ) => {
+    for (const value of values ?? []) {
+      const content = normalizeAtUri(value);
+      if (!content) continue;
+      // An alternate is "a record the page merely shows" — a canonical record
+      // is more than that, so it never doubles as one.
+      if (name === AT_META_NAME.alternate && claimed.has(content)) continue;
+      const key = `${name} ${content}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      if (name === AT_META_NAME.canonical) claimed.add(content);
+      tags.push({ name, content });
+    }
+  };
+
+  push(AT_META_NAME.canonical, records.canonical);
+  push(AT_META_NAME.alternate, records.alternate);
+  push(AT_META_NAME.author, records.author);
+
+  return tags;
+}
+
+/**
+ * Loader data shape a route uses to declare the records its page is built from.
+ * Return `atMeta` from a route loader and `AtRecordMeta` renders the tags.
+ */
+export type WithAtMeta = { atMeta: AtMetaRecords };
+
+/**
+ * The records for a page, taken from the deepest matched route that declares
+ * any — an article's own records win over the layout's.
+ */
+export function atMetaFromMatches(
+  matches: ReadonlyArray<{ loaderData?: unknown }>,
+): AtMetaRecords | null {
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const loaderData = matches[i]?.loaderData;
+    if (typeof loaderData !== "object" || loaderData === null) continue;
+    if (!("atMeta" in loaderData)) continue;
+    const atMeta = (loaderData as { atMeta: unknown }).atMeta;
+    if (typeof atMeta === "object" && atMeta !== null) {
+      return atMeta as AtMetaRecords;
+    }
+  }
+  return null;
+}

--- a/apps/standard-reader/src/lib/discovery-hints.test.ts
+++ b/apps/standard-reader/src/lib/discovery-hints.test.ts
@@ -9,6 +9,17 @@ const LEAFLET_HEAD_SNIPPET = `
 <link rel="site.standard.publication" href="at://did:plc:hochc4ppzwv5idi6ypeio7ow/site.standard.publication/3mcz3le7qjc22"/>
 `;
 
+/** A live SkyPress article — the new meta tags sitting next to the old rels. */
+const SKYPRESS_HEAD_SNIPPET = `
+<link rel="site.standard.document" href="at://did:plc:sov5kv5byjmdksdjacjiysg3/site.standard.document/3mrnculcx5c2v">
+<link rel="site.standard.publication" href="at://did:plc:sov5kv5byjmdksdjacjiysg3/site.standard.publication/3mnuandrwh22s">
+<meta name="at:canonical" content="at://did:plc:sov5kv5byjmdksdjacjiysg3/site.standard.document/3mrnculcx5c2v">
+<meta name="at:alternate" content="at://did:plc:sov5kv5byjmdksdjacjiysg3/site.standard.publication/3mnuandrwh22s">
+<meta name="at:alternate" content="at://did:plc:sov5kv5byjmdksdjacjiysg3/app.bsky.feed.post/3mrnculiuls2c">
+<meta name="at:author" content="at://did:plc:sov5kv5byjmdksdjacjiysg3">
+<meta name="at:me" content="at://did:plc:sov5kv5byjmdksdjacjiysg3">
+`;
+
 describe("parseDiscoveryHintsFromHtml", () => {
   it("reads site.standard.document and publication hints from Leaflet HTML", () => {
     const hints = parseDiscoveryHintsFromHtml(LEAFLET_HEAD_SNIPPET);
@@ -23,6 +34,69 @@ describe("parseDiscoveryHintsFromHtml", () => {
   it("ignores non-at-uri link targets", () => {
     const hints = parseDiscoveryHintsFromHtml(
       `<link rel="site.standard.document" href="https://example.com/article"/>`,
+    );
+    expect(hints.documentUri).toBeNull();
+  });
+
+  it("reads at: meta tags from a SkyPress article", () => {
+    const hints = parseDiscoveryHintsFromHtml(SKYPRESS_HEAD_SNIPPET);
+    expect(hints.documentUri).toBe(
+      "at://did:plc:sov5kv5byjmdksdjacjiysg3/site.standard.document/3mrnculcx5c2v",
+    );
+    expect(hints.publicationUri).toBe(
+      "at://did:plc:sov5kv5byjmdksdjacjiysg3/site.standard.publication/3mnuandrwh22s",
+    );
+  });
+
+  it("still resolves a page that dropped the legacy rels", () => {
+    const hints = parseDiscoveryHintsFromHtml(`
+      <meta name="at:canonical" content="at://did:plc:abc/site.standard.document/3aaa"/>
+      <meta name="at:alternate" content="at://did:plc:abc/site.standard.publication/3bbb"/>
+    `);
+    expect(hints).toEqual({
+      documentUri: "at://did:plc:abc/site.standard.document/3aaa",
+      publicationUri: "at://did:plc:abc/site.standard.publication/3bbb",
+    });
+  });
+
+  it("prefers the canonical record over one the page merely shows", () => {
+    const hints = parseDiscoveryHintsFromHtml(`
+      <meta name="at:alternate" content="at://did:plc:abc/site.standard.document/3quoted"/>
+      <meta name="at:canonical" content="at://did:plc:abc/site.standard.document/3main"/>
+    `);
+    expect(hints.documentUri).toBe(
+      "at://did:plc:abc/site.standard.document/3main",
+    );
+  });
+
+  it("prefers an at: meta hint over a legacy rel that disagrees", () => {
+    const hints = parseDiscoveryHintsFromHtml(`
+      <link rel="site.standard.document" href="at://did:plc:abc/site.standard.document/3stale"/>
+      <meta name="at:canonical" content="at://did:plc:abc/site.standard.document/3fresh"/>
+    `);
+    expect(hints.documentUri).toBe(
+      "at://did:plc:abc/site.standard.document/3fresh",
+    );
+  });
+
+  it("ignores at: tags pointing at collections it cannot render", () => {
+    const hints = parseDiscoveryHintsFromHtml(
+      `<meta name="at:canonical" content="at://did:plc:abc/app.bsky.feed.post/3ccc"/>`,
+    );
+    expect(hints).toEqual({ documentUri: null, publicationUri: null });
+  });
+
+  it("ignores at:author and at:me, which name an identity and not a record", () => {
+    const hints = parseDiscoveryHintsFromHtml(`
+      <meta name="at:author" content="at://did:plc:abc"/>
+      <meta name="at:me" content="at://did:plc:abc"/>
+    `);
+    expect(hints).toEqual({ documentUri: null, publicationUri: null });
+  });
+
+  it("ignores unrelated meta tags", () => {
+    const hints = parseDiscoveryHintsFromHtml(
+      `<meta name="description" content="at://did:plc:abc/site.standard.document/3ddd"/>`,
     );
     expect(hints.documentUri).toBeNull();
   });

--- a/apps/standard-reader/src/lib/discovery-hints.ts
+++ b/apps/standard-reader/src/lib/discovery-hints.ts
@@ -1,3 +1,4 @@
+import { AT_META_NAME } from "#/lib/at-meta-tags";
 import { STANDARD_NSID } from "#/lib/atproto/nsids";
 
 /** standard.site discovery hint rel values — see standard.site/docs/verification */
@@ -17,9 +18,35 @@ const EMPTY_HINTS: DiscoveryHints = {
 };
 
 const LINK_TAG_RE = /<link\b[^>]*>/gi;
+const META_TAG_RE = /<meta\b[^>]*>/gi;
 const ATTR_RE = /([^\s=/>]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]+))/g;
 
-function parseLinkTagAttributes(tag: string): Record<string, string> {
+/**
+ * Where a hint came from, best first. The `at:` meta tags say *why* a record is
+ * on the page, so a canonical record outranks one the page merely shows, and
+ * both outrank the unregistered `rel` values they replace. See
+ * `#/lib/at-meta-tags` for the convention.
+ */
+const HINT_RANK = { canonical: 0, alternate: 1, legacyRel: 2 } as const;
+type HintRank = (typeof HINT_RANK)[keyof typeof HINT_RANK];
+
+type HintAccumulator = {
+  documentUri: string | null;
+  documentRank: HintRank | null;
+  publicationUri: string | null;
+  publicationRank: HintRank | null;
+};
+
+function emptyAccumulator(): HintAccumulator {
+  return {
+    documentUri: null,
+    documentRank: null,
+    publicationUri: null,
+    publicationRank: null,
+  };
+}
+
+function parseTagAttributes(tag: string): Record<string, string> {
   const attrs: Record<string, string> = {};
   for (const match of tag.matchAll(ATTR_RE)) {
     const name = match[1]?.toLowerCase();
@@ -50,67 +77,111 @@ function isPublicationUri(uri: string): boolean {
   return uri.includes(`/${STANDARD_NSID.publication}/`);
 }
 
-/** Parse standard.site discovery hints from an HTML document string. */
+/** Keep a hint only when nothing better-ranked already claimed that slot. */
+function offerHint(acc: HintAccumulator, uri: string, rank: HintRank): void {
+  if (isDocumentUri(uri)) {
+    if (acc.documentRank === null || rank < acc.documentRank) {
+      acc.documentUri = uri;
+      acc.documentRank = rank;
+    }
+    return;
+  }
+  if (
+    isPublicationUri(uri) &&
+    (acc.publicationRank === null || rank < acc.publicationRank)
+  ) {
+    acc.publicationUri = uri;
+    acc.publicationRank = rank;
+  }
+}
+
+/** `at:canonical` / `at:alternate` — the convention that replaces the rels. */
+function collectAtMetaHint(
+  acc: HintAccumulator,
+  name: string | undefined,
+  content: string | undefined,
+): void {
+  const uri = content?.trim();
+  if (!name || !uri || !isAtUri(uri)) return;
+  const key = name.trim().toLowerCase();
+  if (key === AT_META_NAME.canonical) offerHint(acc, uri, HINT_RANK.canonical);
+  else if (key === AT_META_NAME.alternate) {
+    offerHint(acc, uri, HINT_RANK.alternate);
+  }
+}
+
+/** Legacy `<link rel="site.standard.*">` hints, kept for sites still on them. */
+function collectLegacyRelHint(
+  acc: HintAccumulator,
+  rel: string | undefined,
+  href: string | undefined,
+): void {
+  const uri = href?.trim();
+  if (!rel || !uri || !isAtUri(uri)) return;
+  for (const token of normalizeHintRel(rel)) {
+    if (token === DISCOVERY_HINT_REL.document && isDocumentUri(uri)) {
+      offerHint(acc, uri, HINT_RANK.legacyRel);
+    }
+    if (token === DISCOVERY_HINT_REL.publication && isPublicationUri(uri)) {
+      offerHint(acc, uri, HINT_RANK.legacyRel);
+    }
+  }
+}
+
+function toHints(acc: HintAccumulator): DiscoveryHints {
+  return {
+    documentUri: acc.documentUri,
+    publicationUri: acc.publicationUri,
+  };
+}
+
+/**
+ * Parse discovery hints from an HTML document string.
+ *
+ * Reads both the `at:` meta tags and the older `site.standard.*` link rels —
+ * sites are mid-migration and many (SkyPress among them) emit both.
+ */
 export function parseDiscoveryHintsFromHtml(html: string): DiscoveryHints {
-  const hints: DiscoveryHints = { ...EMPTY_HINTS };
+  const acc = emptyAccumulator();
+
+  for (const match of html.matchAll(META_TAG_RE)) {
+    const tag = match[0];
+    if (!tag) continue;
+    const attrs = parseTagAttributes(tag);
+    collectAtMetaHint(acc, attrs.name ?? attrs.property, attrs.content);
+  }
 
   for (const match of html.matchAll(LINK_TAG_RE)) {
     const tag = match[0];
     if (!tag) continue;
-    const attrs = parseLinkTagAttributes(tag);
-    const rel = attrs.rel;
-    const href = attrs.href?.trim();
-    if (!rel || !href || !isAtUri(href)) continue;
-
-    for (const token of normalizeHintRel(rel)) {
-      if (
-        !hints.documentUri &&
-        token === DISCOVERY_HINT_REL.document &&
-        isDocumentUri(href)
-      ) {
-        hints.documentUri = href;
-      }
-      if (
-        !hints.publicationUri &&
-        token === DISCOVERY_HINT_REL.publication &&
-        isPublicationUri(href)
-      ) {
-        hints.publicationUri = href;
-      }
-    }
+    const attrs = parseTagAttributes(tag);
+    collectLegacyRelHint(acc, attrs.rel, attrs.href);
   }
 
-  return hints;
+  return toHints(acc);
 }
 
 /** Read discovery hints from a live document (extension content scripts). */
 export function readDiscoveryHintsFromDocument(doc: Document): DiscoveryHints {
-  const hints: DiscoveryHints = { ...EMPTY_HINTS };
+  const acc = emptyAccumulator();
 
-  for (const link of doc.querySelectorAll("link[rel][href]")) {
-    const rel = link.getAttribute("rel");
-    const href = link.getAttribute("href")?.trim();
-    if (!rel || !href || !isAtUri(href)) continue;
-
-    for (const token of normalizeHintRel(rel)) {
-      if (
-        !hints.documentUri &&
-        token === DISCOVERY_HINT_REL.document &&
-        isDocumentUri(href)
-      ) {
-        hints.documentUri = href;
-      }
-      if (
-        !hints.publicationUri &&
-        token === DISCOVERY_HINT_REL.publication &&
-        isPublicationUri(href)
-      ) {
-        hints.publicationUri = href;
-      }
-    }
+  for (const meta of doc.querySelectorAll("meta[content]")) {
+    collectAtMetaHint(
+      acc,
+      meta.getAttribute("name") ?? meta.getAttribute("property") ?? undefined,
+      meta.getAttribute("content") ?? undefined,
+    );
   }
 
-  return hints;
+  for (const link of doc.querySelectorAll("link[rel][href]")) {
+    collectLegacyRelHint(
+      acc,
+      link.getAttribute("rel") ?? undefined,
+      link.getAttribute("href") ?? undefined,
+    );
+  }
+
+  return toHints(acc);
 }
 
 export function mergeDiscoveryHints(

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -1539,6 +1539,10 @@ msgstr ""
 msgid "Recommended for you"
 msgstr "موصى به لك"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The site.standard link rels"
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Something went wrong while submitting your feedback."
 msgstr "حدث خطأ أثناء إرسال ملاحظاتك."
@@ -2278,6 +2282,10 @@ msgstr "اشترك في هذه القائمة لقراءة المقالات ال
 msgid "{itemCount} of {MAX_ITEMS}"
 msgstr "{itemCount} من {MAX_ITEMS}"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Emit these too. Discovery hints are part of the site.standard spec itself — a <0>link</0> tag whose <1>rel</1> is the record's collection and whose <2>href</2> is its <3>at://</3> URI — and plenty of clients across the network still read only these. Include the <4>site.standard.publication</4> hint when the document belongs to a publication record."
+msgstr ""
+
 #: src/routes/_layout.latest.tsx
 msgid "{metaCount, plural, one {{formattedMetaCount} article} other {{formattedMetaCount} articles}}"
 msgstr "{metaCount, plural, zero {لا توجد مقالات} one {مقال واحد} two {مقالان} few {{formattedMetaCount} مقالات} many {{formattedMetaCount} مقالًا} other {{formattedMetaCount} مقال}}"
@@ -2522,8 +2530,8 @@ msgid "Finish"
 msgstr "إنهاء"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
-msgstr ""
+#~ msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
+#~ msgstr ""
 
 #: src/routes/_layout.friends.tsx
 #~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
@@ -2601,6 +2609,10 @@ msgstr "البحث في المنشورات والمقالات"
 #: src/components/reader/subscriptions-table.tsx
 msgid "Publication"
 msgstr "منشورة"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Standard Reader emits these on its own article, publication, collection, list and profile pages, and reads them from yours."
+msgstr ""
 
 #: src/components/reader/add-to-list-button.tsx
 msgid "No lists yet"
@@ -3802,8 +3814,8 @@ msgid "Labelers are moderation services you subscribe to by DID. Subscribe to se
 msgstr "جهات التصنيف هي خدمات إشراف تشترك فيها عبر DID. اشترك لترى تصنيفاتها — ولتشويش المنشورات المصنّفة أو إخفائها — أثناء القراءة."
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "The older link rels"
-msgstr ""
+#~ msgid "The older link rels"
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Standard Reader meets you where you read"
@@ -3853,6 +3865,10 @@ msgstr "الخصوصية"
 #. placeholder {0}: labels[filter]
 #: src/components/reader/publication-actions.tsx
 msgid "Filter: {0}"
+msgstr ""
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The two say overlapping things, and that's fine: the meta tags carry intent the rels can't, while the rels are what the site.standard spec asks for. Carry both, which is what Standard Reader itself does on every article, publication and collection page."
 msgstr ""
 
 #: src/components/reader/privacy-view.tsx
@@ -4881,8 +4897,8 @@ msgid "<0>Structured blocks.</0> Rich block-editor documents, each in that edito
 msgstr "<0>كتل مُهيكلة.</0> مستندات محرّر كتل غنية، كلٌّ منها بمخطط المحرّر الخاص به — مثل <1>org.blocknote.document#content</1> (BlockNote) أو <2>pub.oxa.document.document</2> (Oxa). لا تفيد إلا إن كنت تنتجها بالفعل؛ ولا تستحق التبنّي من الصفر."
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
-msgstr ""
+#~ msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
+#~ msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -898,6 +898,10 @@ msgstr "نوع الملاحظات"
 msgid "Enable the weekly digest"
 msgstr "تفعيل الملخّص الأسبوعي"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Say in your page's <0>head</0> which records it is built from, and any client on the network can resolve the page back to them. Our browser extension uses this: when you land on a URL it hasn't indexed yet, it reads those tags rather than guessing from the URL."
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Follow at least {MIN_FOLLOWS} to fill your feed"
 msgstr "تابِع {MIN_FOLLOWS} على الأقل لملء تغذيتك"
@@ -1074,8 +1078,8 @@ msgid "your collection"
 msgstr "مجموعتك"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
-msgstr "أدرِج تلميح <0>site.standard.publication</0> فقط إذا كان المستند ينتمي إلى سجل منشورة. أضِف كليهما بغضّ النظر عن القارئ الذي يهمّك — فهما وسيلة أي عميل على الشبكة لربط صفحتك بسجلّها، لا إضافتنا وحدها."
+#~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
+#~ msgstr "أدرِج تلميح <0>site.standard.publication</0> فقط إذا كان المستند ينتمي إلى سجل منشورة. أضِف كليهما بغضّ النظر عن القارئ الذي يهمّك — فهما وسيلة أي عميل على الشبكة لربط صفحتك بسجلّها، لا إضافتنا وحدها."
 
 #: src/components/reader/about-view.tsx
 msgid "Your week"
@@ -2041,8 +2045,8 @@ msgid "No matching subscriptions."
 msgstr "لا توجد اشتراكات مطابقة."
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Discovery hints are part of the site.standard spec itself, and our browser extension uses it too! When you land on a URL it hasn't indexed yet, it looks in that page's <0>head</0> for a <1>link</1> tag whose <2>rel</2> matches the record's collection and whose <3>href</3> is the record's <4>at://</4> URI."
-msgstr "تلميحات الاكتشاف جزء من مواصفة site.standard نفسها، وامتداد المتصفح لدينا يستخدمها أيضًا! عندما تصل إلى رابط لم يفهرسه بعد، يبحث في <0>head</0> تلك الصفحة عن وسم <1>link</1> تتطابق فيه قيمة <2>rel</2> مع مجموعة السجل ويكون <3>href</3> فيه هو معرّف <4>at://</4> الخاص بالسجل."
+#~ msgid "Discovery hints are part of the site.standard spec itself, and our browser extension uses it too! When you land on a URL it hasn't indexed yet, it looks in that page's <0>head</0> for a <1>link</1> tag whose <2>rel</2> matches the record's collection and whose <3>href</3> is the record's <4>at://</4> URI."
+#~ msgstr "تلميحات الاكتشاف جزء من مواصفة site.standard نفسها، وامتداد المتصفح لدينا يستخدمها أيضًا! عندما تصل إلى رابط لم يفهرسه بعد، يبحث في <0>head</0> تلك الصفحة عن وسم <1>link</1> تتطابق فيه قيمة <2>rel</2> مع مجموعة السجل ويكون <3>href</3> فيه هو معرّف <4>at://</4> الخاص بالسجل."
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Re-run"
@@ -2516,6 +2520,10 @@ msgstr ""
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Finish"
 msgstr "إنهاء"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
+msgstr ""
 
 #: src/routes/_layout.friends.tsx
 #~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
@@ -3265,6 +3273,10 @@ msgstr ""
 #~ msgid "Lexicon reference"
 #~ msgstr "مرجع Lexicon"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Use the <0>at:</0> meta tags — the convention the Atmosphere settled on in 2026. <1>at:canonical</1> names the records the page is made of, the ones it would have no reason to exist without. <2>at:alternate</2> names records the page merely shows — the publication a document belongs to, a companion Bluesky post. <3>at:author</3> names the identity that wrote it. Every name repeats, so a page with two alternates emits two tags."
+msgstr ""
+
 #: src/components/reader/profile-tabs-settings-modal.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
@@ -3788,6 +3800,10 @@ msgstr "لا شيء للقراءة هنا بعد."
 #: src/components/labelers-settings-view.tsx
 msgid "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
 msgstr "جهات التصنيف هي خدمات إشراف تشترك فيها عبر DID. اشترك لترى تصنيفاتها — ولتشويش المنشورات المصنّفة أو إخفائها — أثناء القراءة."
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The older link rels"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Standard Reader meets you where you read"
@@ -4863,6 +4879,10 @@ msgstr "الاشتراك في {publicationName}"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Structured blocks.</0> Rich block-editor documents, each in that editor's own schema — e.g. <1>org.blocknote.document#content</1> (BlockNote) or <2>pub.oxa.document.document</2> (Oxa). Only useful if you're already producing one of these; not worth adopting from scratch."
 msgstr "<0>كتل مُهيكلة.</0> مستندات محرّر كتل غنية، كلٌّ منها بمخطط المحرّر الخاص به — مثل <1>org.blocknote.document#content</1> (BlockNote) أو <2>pub.oxa.document.document</2> (Oxa). لا تفيد إلا إن كنت تنتجها بالفعل؛ ولا تستحق التبنّي من الصفر."
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -898,6 +898,10 @@ msgstr "Art des Feedbacks"
 msgid "Enable the weekly digest"
 msgstr "Wochenrückblick aktivieren"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Say in your page's <0>head</0> which records it is built from, and any client on the network can resolve the page back to them. Our browser extension uses this: when you land on a URL it hasn't indexed yet, it reads those tags rather than guessing from the URL."
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Follow at least {MIN_FOLLOWS} to fill your feed"
 msgstr "Folgen Sie mindestens {MIN_FOLLOWS}, um Ihren Feed zu füllen"
@@ -1074,8 +1078,8 @@ msgid "your collection"
 msgstr "Ihre Sammlung"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
-msgstr "Fügen Sie den Hinweis <0>site.standard.publication</0> nur hinzu, wenn das Dokument zu einer Publikation gehört. Fügen Sie beide hinzu, unabhängig davon, welcher Leser Sie interessiert – so löst jeder Client im Netzwerk Ihre Seite zu ihrem Record auf, nicht nur unsere Erweiterung."
+#~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
+#~ msgstr "Fügen Sie den Hinweis <0>site.standard.publication</0> nur hinzu, wenn das Dokument zu einer Publikation gehört. Fügen Sie beide hinzu, unabhängig davon, welcher Leser Sie interessiert – so löst jeder Client im Netzwerk Ihre Seite zu ihrem Record auf, nicht nur unsere Erweiterung."
 
 #: src/components/reader/about-view.tsx
 msgid "Your week"
@@ -2041,8 +2045,8 @@ msgid "No matching subscriptions."
 msgstr "Keine passenden Abos."
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Discovery hints are part of the site.standard spec itself, and our browser extension uses it too! When you land on a URL it hasn't indexed yet, it looks in that page's <0>head</0> for a <1>link</1> tag whose <2>rel</2> matches the record's collection and whose <3>href</3> is the record's <4>at://</4> URI."
-msgstr "Discovery-Hinweise sind Teil der site.standard-Spezifikation selbst, und unsere Browser-Erweiterung nutzt sie ebenfalls! Wenn Sie auf eine noch nicht indexierte URL kommen, sucht sie im <0>head</0> der Seite nach einem <1>link</1>-Tag, dessen <2>rel</2> zur Collection des Records passt und dessen <3>href</3> die <4>at://</4>-URI des Records ist."
+#~ msgid "Discovery hints are part of the site.standard spec itself, and our browser extension uses it too! When you land on a URL it hasn't indexed yet, it looks in that page's <0>head</0> for a <1>link</1> tag whose <2>rel</2> matches the record's collection and whose <3>href</3> is the record's <4>at://</4> URI."
+#~ msgstr "Discovery-Hinweise sind Teil der site.standard-Spezifikation selbst, und unsere Browser-Erweiterung nutzt sie ebenfalls! Wenn Sie auf eine noch nicht indexierte URL kommen, sucht sie im <0>head</0> der Seite nach einem <1>link</1>-Tag, dessen <2>rel</2> zur Collection des Records passt und dessen <3>href</3> die <4>at://</4>-URI des Records ist."
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Re-run"
@@ -2516,6 +2520,10 @@ msgstr ""
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Finish"
 msgstr "Fertig"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
+msgstr ""
 
 #: src/routes/_layout.friends.tsx
 #~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
@@ -3265,6 +3273,10 @@ msgstr ""
 #~ msgid "Lexicon reference"
 #~ msgstr "Lexikon-Referenz"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Use the <0>at:</0> meta tags — the convention the Atmosphere settled on in 2026. <1>at:canonical</1> names the records the page is made of, the ones it would have no reason to exist without. <2>at:alternate</2> names records the page merely shows — the publication a document belongs to, a companion Bluesky post. <3>at:author</3> names the identity that wrote it. Every name repeats, so a page with two alternates emits two tags."
+msgstr ""
+
 #: src/components/reader/profile-tabs-settings-modal.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
@@ -3788,6 +3800,10 @@ msgstr "Hier gibt es noch nichts zu lesen."
 #: src/components/labelers-settings-view.tsx
 msgid "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
 msgstr "Labeler sind Moderationsdienste, die Sie per DID abonnieren. Abonnieren Sie sie, um beim Lesen ihre Label zu sehen – und gelabelte Beiträge unkenntlich zu machen oder auszublenden."
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The older link rels"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Standard Reader meets you where you read"
@@ -4863,6 +4879,10 @@ msgstr "{publicationName} abonnieren"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Structured blocks.</0> Rich block-editor documents, each in that editor's own schema — e.g. <1>org.blocknote.document#content</1> (BlockNote) or <2>pub.oxa.document.document</2> (Oxa). Only useful if you're already producing one of these; not worth adopting from scratch."
 msgstr "<0>Strukturierte Blöcke.</0> Dokumente aus Block-Editoren, jeweils im Schema des Editors — z. B. <1>org.blocknote.document#content</1> (BlockNote) oder <2>pub.oxa.document.document</2> (Oxa). Nur sinnvoll, wenn Sie ohnehin eines davon erzeugen; ein Umstieg lohnt sich nicht."
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -1539,6 +1539,10 @@ msgstr ""
 msgid "Recommended for you"
 msgstr "Für Sie empfohlen"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The site.standard link rels"
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Something went wrong while submitting your feedback."
 msgstr "Beim Senden Ihres Feedbacks ist etwas schiefgelaufen."
@@ -2278,6 +2282,10 @@ msgstr "Abonnieren Sie diese Liste, um neue Artikel ihrer Publikationen zu lesen
 msgid "{itemCount} of {MAX_ITEMS}"
 msgstr "{itemCount} von {MAX_ITEMS}"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Emit these too. Discovery hints are part of the site.standard spec itself — a <0>link</0> tag whose <1>rel</1> is the record's collection and whose <2>href</2> is its <3>at://</3> URI — and plenty of clients across the network still read only these. Include the <4>site.standard.publication</4> hint when the document belongs to a publication record."
+msgstr ""
+
 #: src/routes/_layout.latest.tsx
 msgid "{metaCount, plural, one {{formattedMetaCount} article} other {{formattedMetaCount} articles}}"
 msgstr "{metaCount, plural, one {{formattedMetaCount} Artikel} other {{formattedMetaCount} Artikel}}"
@@ -2522,8 +2530,8 @@ msgid "Finish"
 msgstr "Fertig"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
-msgstr ""
+#~ msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
+#~ msgstr ""
 
 #: src/routes/_layout.friends.tsx
 #~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
@@ -2601,6 +2609,10 @@ msgstr "Publikationen und Artikel suchen"
 #: src/components/reader/subscriptions-table.tsx
 msgid "Publication"
 msgstr "Publikation"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Standard Reader emits these on its own article, publication, collection, list and profile pages, and reads them from yours."
+msgstr ""
 
 #: src/components/reader/add-to-list-button.tsx
 msgid "No lists yet"
@@ -3802,8 +3814,8 @@ msgid "Labelers are moderation services you subscribe to by DID. Subscribe to se
 msgstr "Labeler sind Moderationsdienste, die Sie per DID abonnieren. Abonnieren Sie sie, um beim Lesen ihre Label zu sehen – und gelabelte Beiträge unkenntlich zu machen oder auszublenden."
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "The older link rels"
-msgstr ""
+#~ msgid "The older link rels"
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Standard Reader meets you where you read"
@@ -3853,6 +3865,10 @@ msgstr "Datenschutz"
 #. placeholder {0}: labels[filter]
 #: src/components/reader/publication-actions.tsx
 msgid "Filter: {0}"
+msgstr ""
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The two say overlapping things, and that's fine: the meta tags carry intent the rels can't, while the rels are what the site.standard spec asks for. Carry both, which is what Standard Reader itself does on every article, publication and collection page."
 msgstr ""
 
 #: src/components/reader/privacy-view.tsx
@@ -4881,8 +4897,8 @@ msgid "<0>Structured blocks.</0> Rich block-editor documents, each in that edito
 msgstr "<0>Strukturierte Blöcke.</0> Dokumente aus Block-Editoren, jeweils im Schema des Editors — z. B. <1>org.blocknote.document#content</1> (BlockNote) oder <2>pub.oxa.document.document</2> (Oxa). Nur sinnvoll, wenn Sie ohnehin eines davon erzeugen; ein Umstieg lohnt sich nicht."
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
-msgstr ""
+#~ msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
+#~ msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -1539,6 +1539,10 @@ msgstr ""
 msgid "Recommended for you"
 msgstr ""
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The site.standard link rels"
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Something went wrong while submitting your feedback."
 msgstr ""
@@ -2278,6 +2282,10 @@ msgstr ""
 msgid "{itemCount} of {MAX_ITEMS}"
 msgstr ""
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Emit these too. Discovery hints are part of the site.standard spec itself — a <0>link</0> tag whose <1>rel</1> is the record's collection and whose <2>href</2> is its <3>at://</3> URI — and plenty of clients across the network still read only these. Include the <4>site.standard.publication</4> hint when the document belongs to a publication record."
+msgstr ""
+
 #: src/routes/_layout.latest.tsx
 msgid "{metaCount, plural, one {{formattedMetaCount} article} other {{formattedMetaCount} articles}}"
 msgstr ""
@@ -2522,8 +2530,8 @@ msgid "Finish"
 msgstr ""
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
-msgstr ""
+#~ msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
+#~ msgstr ""
 
 #: src/routes/_layout.friends.tsx
 #~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
@@ -2600,6 +2608,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 #: src/components/reader/subscriptions-table.tsx
 msgid "Publication"
+msgstr ""
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Standard Reader emits these on its own article, publication, collection, list and profile pages, and reads them from yours."
 msgstr ""
 
 #: src/components/reader/add-to-list-button.tsx
@@ -3802,8 +3814,8 @@ msgid "Labelers are moderation services you subscribe to by DID. Subscribe to se
 msgstr ""
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "The older link rels"
-msgstr ""
+#~ msgid "The older link rels"
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Standard Reader meets you where you read"
@@ -3853,6 +3865,10 @@ msgstr ""
 #. placeholder {0}: labels[filter]
 #: src/components/reader/publication-actions.tsx
 msgid "Filter: {0}"
+msgstr ""
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The two say overlapping things, and that's fine: the meta tags carry intent the rels can't, while the rels are what the site.standard spec asks for. Carry both, which is what Standard Reader itself does on every article, publication and collection page."
 msgstr ""
 
 #: src/components/reader/privacy-view.tsx
@@ -4881,8 +4897,8 @@ msgid "<0>Structured blocks.</0> Rich block-editor documents, each in that edito
 msgstr ""
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
-msgstr ""
+#~ msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
+#~ msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -898,6 +898,10 @@ msgstr ""
 msgid "Enable the weekly digest"
 msgstr ""
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Say in your page's <0>head</0> which records it is built from, and any client on the network can resolve the page back to them. Our browser extension uses this: when you land on a URL it hasn't indexed yet, it reads those tags rather than guessing from the URL."
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Follow at least {MIN_FOLLOWS} to fill your feed"
 msgstr ""
@@ -1074,8 +1078,8 @@ msgid "your collection"
 msgstr ""
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
-msgstr ""
+#~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Your week"
@@ -2041,8 +2045,8 @@ msgid "No matching subscriptions."
 msgstr ""
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Discovery hints are part of the site.standard spec itself, and our browser extension uses it too! When you land on a URL it hasn't indexed yet, it looks in that page's <0>head</0> for a <1>link</1> tag whose <2>rel</2> matches the record's collection and whose <3>href</3> is the record's <4>at://</4> URI."
-msgstr ""
+#~ msgid "Discovery hints are part of the site.standard spec itself, and our browser extension uses it too! When you land on a URL it hasn't indexed yet, it looks in that page's <0>head</0> for a <1>link</1> tag whose <2>rel</2> matches the record's collection and whose <3>href</3> is the record's <4>at://</4> URI."
+#~ msgstr ""
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Re-run"
@@ -2515,6 +2519,10 @@ msgstr ""
 
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Finish"
+msgstr ""
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
 msgstr ""
 
 #: src/routes/_layout.friends.tsx
@@ -3265,6 +3273,10 @@ msgstr ""
 #~ msgid "Lexicon reference"
 #~ msgstr ""
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Use the <0>at:</0> meta tags — the convention the Atmosphere settled on in 2026. <1>at:canonical</1> names the records the page is made of, the ones it would have no reason to exist without. <2>at:alternate</2> names records the page merely shows — the publication a document belongs to, a companion Bluesky post. <3>at:author</3> names the identity that wrote it. Every name repeats, so a page with two alternates emits two tags."
+msgstr ""
+
 #: src/components/reader/profile-tabs-settings-modal.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
@@ -3787,6 +3799,10 @@ msgstr ""
 
 #: src/components/labelers-settings-view.tsx
 msgid "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
+msgstr ""
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The older link rels"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -4862,6 +4878,10 @@ msgstr ""
 
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Structured blocks.</0> Rich block-editor documents, each in that editor's own schema — e.g. <1>org.blocknote.document#content</1> (BlockNote) or <2>pub.oxa.document.document</2> (Oxa). Only useful if you're already producing one of these; not worth adopting from scratch."
+msgstr ""
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
 msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -898,6 +898,10 @@ msgstr "Feedback type"
 msgid "Enable the weekly digest"
 msgstr "Enable the weekly digest"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Say in your page's <0>head</0> which records it is built from, and any client on the network can resolve the page back to them. Our browser extension uses this: when you land on a URL it hasn't indexed yet, it reads those tags rather than guessing from the URL."
+msgstr "Say in your page's <0>head</0> which records it is built from, and any client on the network can resolve the page back to them. Our browser extension uses this: when you land on a URL it hasn't indexed yet, it reads those tags rather than guessing from the URL."
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Follow at least {MIN_FOLLOWS} to fill your feed"
 msgstr "Follow at least {MIN_FOLLOWS} to fill your feed"
@@ -1074,8 +1078,8 @@ msgid "your collection"
 msgstr "your collection"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
-msgstr "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
+#~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
+#~ msgstr "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
 
 #: src/components/reader/about-view.tsx
 msgid "Your week"
@@ -2041,8 +2045,8 @@ msgid "No matching subscriptions."
 msgstr "No matching subscriptions."
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Discovery hints are part of the site.standard spec itself, and our browser extension uses it too! When you land on a URL it hasn't indexed yet, it looks in that page's <0>head</0> for a <1>link</1> tag whose <2>rel</2> matches the record's collection and whose <3>href</3> is the record's <4>at://</4> URI."
-msgstr "Discovery hints are part of the site.standard spec itself, and our browser extension uses it too! When you land on a URL it hasn't indexed yet, it looks in that page's <0>head</0> for a <1>link</1> tag whose <2>rel</2> matches the record's collection and whose <3>href</3> is the record's <4>at://</4> URI."
+#~ msgid "Discovery hints are part of the site.standard spec itself, and our browser extension uses it too! When you land on a URL it hasn't indexed yet, it looks in that page's <0>head</0> for a <1>link</1> tag whose <2>rel</2> matches the record's collection and whose <3>href</3> is the record's <4>at://</4> URI."
+#~ msgstr "Discovery hints are part of the site.standard spec itself, and our browser extension uses it too! When you land on a URL it hasn't indexed yet, it looks in that page's <0>head</0> for a <1>link</1> tag whose <2>rel</2> matches the record's collection and whose <3>href</3> is the record's <4>at://</4> URI."
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Re-run"
@@ -2516,6 +2520,10 @@ msgstr "{0} total"
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Finish"
 msgstr "Finish"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
+msgstr "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
 
 #: src/routes/_layout.friends.tsx
 #~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
@@ -3265,6 +3273,10 @@ msgstr "Reset"
 #~ msgid "Lexicon reference"
 #~ msgstr "Lexicon reference"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Use the <0>at:</0> meta tags — the convention the Atmosphere settled on in 2026. <1>at:canonical</1> names the records the page is made of, the ones it would have no reason to exist without. <2>at:alternate</2> names records the page merely shows — the publication a document belongs to, a companion Bluesky post. <3>at:author</3> names the identity that wrote it. Every name repeats, so a page with two alternates emits two tags."
+msgstr "Use the <0>at:</0> meta tags — the convention the Atmosphere settled on in 2026. <1>at:canonical</1> names the records the page is made of, the ones it would have no reason to exist without. <2>at:alternate</2> names records the page merely shows — the publication a document belongs to, a companion Bluesky post. <3>at:author</3> names the identity that wrote it. Every name repeats, so a page with two alternates emits two tags."
+
 #: src/components/reader/profile-tabs-settings-modal.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
@@ -3788,6 +3800,10 @@ msgstr "Nothing to read here yet."
 #: src/components/labelers-settings-view.tsx
 msgid "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
 msgstr "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The older link rels"
+msgstr "The older link rels"
 
 #: src/components/reader/about-view.tsx
 msgid "Standard Reader meets you where you read"
@@ -4863,6 +4879,10 @@ msgstr "Subscribe to {publicationName}"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Structured blocks.</0> Rich block-editor documents, each in that editor's own schema — e.g. <1>org.blocknote.document#content</1> (BlockNote) or <2>pub.oxa.document.document</2> (Oxa). Only useful if you're already producing one of these; not worth adopting from scratch."
 msgstr "<0>Structured blocks.</0> Rich block-editor documents, each in that editor's own schema — e.g. <1>org.blocknote.document#content</1> (BlockNote) or <2>pub.oxa.document.document</2> (Oxa). Only useful if you're already producing one of these; not worth adopting from scratch."
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
+msgstr "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -1539,6 +1539,10 @@ msgstr "It is an OAuth 2.1 protected resource: an unauthenticated request answer
 msgid "Recommended for you"
 msgstr "Recommended for you"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The site.standard link rels"
+msgstr "The site.standard link rels"
+
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Something went wrong while submitting your feedback."
 msgstr "Something went wrong while submitting your feedback."
@@ -2278,6 +2282,10 @@ msgstr "Subscribe to this list to read new articles from its publications."
 msgid "{itemCount} of {MAX_ITEMS}"
 msgstr "{itemCount} of {MAX_ITEMS}"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Emit these too. Discovery hints are part of the site.standard spec itself — a <0>link</0> tag whose <1>rel</1> is the record's collection and whose <2>href</2> is its <3>at://</3> URI — and plenty of clients across the network still read only these. Include the <4>site.standard.publication</4> hint when the document belongs to a publication record."
+msgstr "Emit these too. Discovery hints are part of the site.standard spec itself — a <0>link</0> tag whose <1>rel</1> is the record's collection and whose <2>href</2> is its <3>at://</3> URI — and plenty of clients across the network still read only these. Include the <4>site.standard.publication</4> hint when the document belongs to a publication record."
+
 #: src/routes/_layout.latest.tsx
 msgid "{metaCount, plural, one {{formattedMetaCount} article} other {{formattedMetaCount} articles}}"
 msgstr "{metaCount, plural, one {{formattedMetaCount} article} other {{formattedMetaCount} articles}}"
@@ -2522,8 +2530,8 @@ msgid "Finish"
 msgstr "Finish"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
-msgstr "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
+#~ msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
+#~ msgstr "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
 
 #: src/routes/_layout.friends.tsx
 #~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
@@ -2601,6 +2609,10 @@ msgstr "Search publications and articles"
 #: src/components/reader/subscriptions-table.tsx
 msgid "Publication"
 msgstr "Publication"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Standard Reader emits these on its own article, publication, collection, list and profile pages, and reads them from yours."
+msgstr "Standard Reader emits these on its own article, publication, collection, list and profile pages, and reads them from yours."
 
 #: src/components/reader/add-to-list-button.tsx
 msgid "No lists yet"
@@ -3802,8 +3814,8 @@ msgid "Labelers are moderation services you subscribe to by DID. Subscribe to se
 msgstr "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "The older link rels"
-msgstr "The older link rels"
+#~ msgid "The older link rels"
+#~ msgstr "The older link rels"
 
 #: src/components/reader/about-view.tsx
 msgid "Standard Reader meets you where you read"
@@ -3854,6 +3866,10 @@ msgstr "Privacy"
 #: src/components/reader/publication-actions.tsx
 msgid "Filter: {0}"
 msgstr "Filter: {0}"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The two say overlapping things, and that's fine: the meta tags carry intent the rels can't, while the rels are what the site.standard spec asks for. Carry both, which is what Standard Reader itself does on every article, publication and collection page."
+msgstr "The two say overlapping things, and that's fine: the meta tags carry intent the rels can't, while the rels are what the site.standard spec asks for. Carry both, which is what Standard Reader itself does on every article, publication and collection page."
 
 #: src/components/reader/privacy-view.tsx
 msgid "Last updated June 11, 2026"
@@ -4881,8 +4897,8 @@ msgid "<0>Structured blocks.</0> Rich block-editor documents, each in that edito
 msgstr "<0>Structured blocks.</0> Rich block-editor documents, each in that editor's own schema — e.g. <1>org.blocknote.document#content</1> (BlockNote) or <2>pub.oxa.document.document</2> (Oxa). Only useful if you're already producing one of these; not worth adopting from scratch."
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
-msgstr "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
+#~ msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
+#~ msgstr "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -898,6 +898,10 @@ msgstr "Tipo de comentario"
 msgid "Enable the weekly digest"
 msgstr "Activar el resumen semanal"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Say in your page's <0>head</0> which records it is built from, and any client on the network can resolve the page back to them. Our browser extension uses this: when you land on a URL it hasn't indexed yet, it reads those tags rather than guessing from the URL."
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Follow at least {MIN_FOLLOWS} to fill your feed"
 msgstr "Siga al menos {MIN_FOLLOWS} para llenar su feed"
@@ -1074,8 +1078,8 @@ msgid "your collection"
 msgstr "su colección"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
-msgstr "Incluya la pista <0>site.standard.publication</0> solo si el documento pertenece a un registro de publicación. Agregue ambas sin importar qué lector le interese: así es como cualquier cliente de la red resuelve su página hasta su registro, no solo nuestra extensión."
+#~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
+#~ msgstr "Incluya la pista <0>site.standard.publication</0> solo si el documento pertenece a un registro de publicación. Agregue ambas sin importar qué lector le interese: así es como cualquier cliente de la red resuelve su página hasta su registro, no solo nuestra extensión."
 
 #: src/components/reader/about-view.tsx
 msgid "Your week"
@@ -2041,8 +2045,8 @@ msgid "No matching subscriptions."
 msgstr "No hay suscripciones que coincidan."
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Discovery hints are part of the site.standard spec itself, and our browser extension uses it too! When you land on a URL it hasn't indexed yet, it looks in that page's <0>head</0> for a <1>link</1> tag whose <2>rel</2> matches the record's collection and whose <3>href</3> is the record's <4>at://</4> URI."
-msgstr "Las pistas de descubrimiento forman parte de la propia especificación site.standard, ¡y nuestra extensión del navegador también las usa! Cuando llega a una URL que aún no ha indexado, busca en el <0>head</0> de esa página una etiqueta <1>link</1> cuyo <2>rel</2> coincida con la colección del registro y cuyo <3>href</3> sea el URI <4>at://</4> del registro."
+#~ msgid "Discovery hints are part of the site.standard spec itself, and our browser extension uses it too! When you land on a URL it hasn't indexed yet, it looks in that page's <0>head</0> for a <1>link</1> tag whose <2>rel</2> matches the record's collection and whose <3>href</3> is the record's <4>at://</4> URI."
+#~ msgstr "Las pistas de descubrimiento forman parte de la propia especificación site.standard, ¡y nuestra extensión del navegador también las usa! Cuando llega a una URL que aún no ha indexado, busca en el <0>head</0> de esa página una etiqueta <1>link</1> cuyo <2>rel</2> coincida con la colección del registro y cuyo <3>href</3> sea el URI <4>at://</4> del registro."
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Re-run"
@@ -2516,6 +2520,10 @@ msgstr ""
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Finish"
 msgstr "Finalizar"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
+msgstr ""
 
 #: src/routes/_layout.friends.tsx
 #~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
@@ -3265,6 +3273,10 @@ msgstr ""
 #~ msgid "Lexicon reference"
 #~ msgstr "Referencia del lexicon"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Use the <0>at:</0> meta tags — the convention the Atmosphere settled on in 2026. <1>at:canonical</1> names the records the page is made of, the ones it would have no reason to exist without. <2>at:alternate</2> names records the page merely shows — the publication a document belongs to, a companion Bluesky post. <3>at:author</3> names the identity that wrote it. Every name repeats, so a page with two alternates emits two tags."
+msgstr ""
+
 #: src/components/reader/profile-tabs-settings-modal.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
@@ -3788,6 +3800,10 @@ msgstr "Todavía no hay nada que leer aquí."
 #: src/components/labelers-settings-view.tsx
 msgid "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
 msgstr "Los etiquetadores son servicios de moderación a los que se suscribe por DID. Suscríbase para ver sus etiquetas — y difuminar u ocultar las publicaciones etiquetadas — mientras lee."
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The older link rels"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Standard Reader meets you where you read"
@@ -4863,6 +4879,10 @@ msgstr "Suscribirse a {publicationName}"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Structured blocks.</0> Rich block-editor documents, each in that editor's own schema — e.g. <1>org.blocknote.document#content</1> (BlockNote) or <2>pub.oxa.document.document</2> (Oxa). Only useful if you're already producing one of these; not worth adopting from scratch."
 msgstr "<0>Bloques estructurados.</0> Documentos de editor de bloques enriquecido, cada uno con el esquema propio de ese editor; por ejemplo, <1>org.blocknote.document#content</1> (BlockNote) o <2>pub.oxa.document.document</2> (Oxa). Solo son útiles si ya produce alguno de estos; no vale la pena adoptarlos desde cero."
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -1539,6 +1539,10 @@ msgstr ""
 msgid "Recommended for you"
 msgstr "Recomendado para usted"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The site.standard link rels"
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Something went wrong while submitting your feedback."
 msgstr "Algo salió mal al enviar su comentario."
@@ -2278,6 +2282,10 @@ msgstr "Suscríbase a esta lista para leer los nuevos artículos de sus publicac
 msgid "{itemCount} of {MAX_ITEMS}"
 msgstr "{itemCount} de {MAX_ITEMS}"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Emit these too. Discovery hints are part of the site.standard spec itself — a <0>link</0> tag whose <1>rel</1> is the record's collection and whose <2>href</2> is its <3>at://</3> URI — and plenty of clients across the network still read only these. Include the <4>site.standard.publication</4> hint when the document belongs to a publication record."
+msgstr ""
+
 #: src/routes/_layout.latest.tsx
 msgid "{metaCount, plural, one {{formattedMetaCount} article} other {{formattedMetaCount} articles}}"
 msgstr "{metaCount, plural, one {{formattedMetaCount} artículo} other {{formattedMetaCount} artículos}}"
@@ -2522,8 +2530,8 @@ msgid "Finish"
 msgstr "Finalizar"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
-msgstr ""
+#~ msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
+#~ msgstr ""
 
 #: src/routes/_layout.friends.tsx
 #~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
@@ -2601,6 +2609,10 @@ msgstr "Buscar publicaciones y artículos"
 #: src/components/reader/subscriptions-table.tsx
 msgid "Publication"
 msgstr "Publicación"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Standard Reader emits these on its own article, publication, collection, list and profile pages, and reads them from yours."
+msgstr ""
 
 #: src/components/reader/add-to-list-button.tsx
 msgid "No lists yet"
@@ -3802,8 +3814,8 @@ msgid "Labelers are moderation services you subscribe to by DID. Subscribe to se
 msgstr "Los etiquetadores son servicios de moderación a los que se suscribe por DID. Suscríbase para ver sus etiquetas — y difuminar u ocultar las publicaciones etiquetadas — mientras lee."
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "The older link rels"
-msgstr ""
+#~ msgid "The older link rels"
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Standard Reader meets you where you read"
@@ -3853,6 +3865,10 @@ msgstr "Privacidad"
 #. placeholder {0}: labels[filter]
 #: src/components/reader/publication-actions.tsx
 msgid "Filter: {0}"
+msgstr ""
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The two say overlapping things, and that's fine: the meta tags carry intent the rels can't, while the rels are what the site.standard spec asks for. Carry both, which is what Standard Reader itself does on every article, publication and collection page."
 msgstr ""
 
 #: src/components/reader/privacy-view.tsx
@@ -4881,8 +4897,8 @@ msgid "<0>Structured blocks.</0> Rich block-editor documents, each in that edito
 msgstr "<0>Bloques estructurados.</0> Documentos de editor de bloques enriquecido, cada uno con el esquema propio de ese editor; por ejemplo, <1>org.blocknote.document#content</1> (BlockNote) o <2>pub.oxa.document.document</2> (Oxa). Solo son útiles si ya produce alguno de estos; no vale la pena adoptarlos desde cero."
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
-msgstr ""
+#~ msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
+#~ msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -1539,6 +1539,10 @@ msgstr ""
 msgid "Recommended for you"
 msgstr "Recommandé pour vous"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The site.standard link rels"
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Something went wrong while submitting your feedback."
 msgstr "Une erreur est survenue lors de l'envoi de votre retour."
@@ -2278,6 +2282,10 @@ msgstr "Abonnez-vous à cette liste pour lire les nouveaux articles de ses publi
 msgid "{itemCount} of {MAX_ITEMS}"
 msgstr "{itemCount} sur {MAX_ITEMS}"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Emit these too. Discovery hints are part of the site.standard spec itself — a <0>link</0> tag whose <1>rel</1> is the record's collection and whose <2>href</2> is its <3>at://</3> URI — and plenty of clients across the network still read only these. Include the <4>site.standard.publication</4> hint when the document belongs to a publication record."
+msgstr ""
+
 #: src/routes/_layout.latest.tsx
 msgid "{metaCount, plural, one {{formattedMetaCount} article} other {{formattedMetaCount} articles}}"
 msgstr "{metaCount, plural, one {{formattedMetaCount} article} other {{formattedMetaCount} articles}}"
@@ -2522,8 +2530,8 @@ msgid "Finish"
 msgstr "Terminer"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
-msgstr ""
+#~ msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
+#~ msgstr ""
 
 #: src/routes/_layout.friends.tsx
 #~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
@@ -2601,6 +2609,10 @@ msgstr "Rechercher des publications et des articles"
 #: src/components/reader/subscriptions-table.tsx
 msgid "Publication"
 msgstr "Publication"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Standard Reader emits these on its own article, publication, collection, list and profile pages, and reads them from yours."
+msgstr ""
 
 #: src/components/reader/add-to-list-button.tsx
 msgid "No lists yet"
@@ -3802,8 +3814,8 @@ msgid "Labelers are moderation services you subscribe to by DID. Subscribe to se
 msgstr "Les services d'étiquetage sont des services de modération auxquels vous vous abonnez par DID. Abonnez-vous pour voir leurs étiquettes — et flouter ou masquer les publications étiquetées — pendant votre lecture."
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "The older link rels"
-msgstr ""
+#~ msgid "The older link rels"
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Standard Reader meets you where you read"
@@ -3853,6 +3865,10 @@ msgstr "Confidentialité"
 #. placeholder {0}: labels[filter]
 #: src/components/reader/publication-actions.tsx
 msgid "Filter: {0}"
+msgstr ""
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The two say overlapping things, and that's fine: the meta tags carry intent the rels can't, while the rels are what the site.standard spec asks for. Carry both, which is what Standard Reader itself does on every article, publication and collection page."
 msgstr ""
 
 #: src/components/reader/privacy-view.tsx
@@ -4881,8 +4897,8 @@ msgid "<0>Structured blocks.</0> Rich block-editor documents, each in that edito
 msgstr "<0>Blocs structurés.</0> Documents riches issus d'éditeurs de blocs, chacun dans le schéma propre à son éditeur — par exemple <1>org.blocknote.document#content</1> (BlockNote) ou <2>pub.oxa.document.document</2> (Oxa). Utile uniquement si vous en produisez déjà ; inutile de l'adopter en partant de zéro."
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
-msgstr ""
+#~ msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
+#~ msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -898,6 +898,10 @@ msgstr "Type de retour"
 msgid "Enable the weekly digest"
 msgstr "Activer le résumé hebdomadaire"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Say in your page's <0>head</0> which records it is built from, and any client on the network can resolve the page back to them. Our browser extension uses this: when you land on a URL it hasn't indexed yet, it reads those tags rather than guessing from the URL."
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Follow at least {MIN_FOLLOWS} to fill your feed"
 msgstr "Suivez au moins {MIN_FOLLOWS} publications pour remplir votre flux"
@@ -1074,8 +1078,8 @@ msgid "your collection"
 msgstr "votre collection"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
-msgstr "N'incluez l'indice <0>site.standard.publication</0> que si le document appartient à un enregistrement de publication. Ajoutez les deux quel que soit le lecteur qui vous intéresse : c'est ainsi que n'importe quel client du réseau relie votre page à son enregistrement, et pas seulement notre extension."
+#~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
+#~ msgstr "N'incluez l'indice <0>site.standard.publication</0> que si le document appartient à un enregistrement de publication. Ajoutez les deux quel que soit le lecteur qui vous intéresse : c'est ainsi que n'importe quel client du réseau relie votre page à son enregistrement, et pas seulement notre extension."
 
 #: src/components/reader/about-view.tsx
 msgid "Your week"
@@ -2041,8 +2045,8 @@ msgid "No matching subscriptions."
 msgstr "Aucun abonnement correspondant."
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Discovery hints are part of the site.standard spec itself, and our browser extension uses it too! When you land on a URL it hasn't indexed yet, it looks in that page's <0>head</0> for a <1>link</1> tag whose <2>rel</2> matches the record's collection and whose <3>href</3> is the record's <4>at://</4> URI."
-msgstr "Les indices de découverte font partie intégrante de la spécification site.standard, et notre extension de navigateur s'en sert aussi ! Lorsqu'elle arrive sur une URL qu'elle n'a pas encore indexée, elle cherche dans le <0>head</0> de la page une balise <1>link</1> dont le <2>rel</2> correspond à la collection de l'enregistrement et dont le <3>href</3> est l'URI <4>at://</4> de cet enregistrement."
+#~ msgid "Discovery hints are part of the site.standard spec itself, and our browser extension uses it too! When you land on a URL it hasn't indexed yet, it looks in that page's <0>head</0> for a <1>link</1> tag whose <2>rel</2> matches the record's collection and whose <3>href</3> is the record's <4>at://</4> URI."
+#~ msgstr "Les indices de découverte font partie intégrante de la spécification site.standard, et notre extension de navigateur s'en sert aussi ! Lorsqu'elle arrive sur une URL qu'elle n'a pas encore indexée, elle cherche dans le <0>head</0> de la page une balise <1>link</1> dont le <2>rel</2> correspond à la collection de l'enregistrement et dont le <3>href</3> est l'URI <4>at://</4> de cet enregistrement."
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Re-run"
@@ -2516,6 +2520,10 @@ msgstr ""
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Finish"
 msgstr "Terminer"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
+msgstr ""
 
 #: src/routes/_layout.friends.tsx
 #~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
@@ -3265,6 +3273,10 @@ msgstr ""
 #~ msgid "Lexicon reference"
 #~ msgstr "Référence du lexique"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Use the <0>at:</0> meta tags — the convention the Atmosphere settled on in 2026. <1>at:canonical</1> names the records the page is made of, the ones it would have no reason to exist without. <2>at:alternate</2> names records the page merely shows — the publication a document belongs to, a companion Bluesky post. <3>at:author</3> names the identity that wrote it. Every name repeats, so a page with two alternates emits two tags."
+msgstr ""
+
 #: src/components/reader/profile-tabs-settings-modal.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
@@ -3788,6 +3800,10 @@ msgstr "Rien à lire ici pour l'instant."
 #: src/components/labelers-settings-view.tsx
 msgid "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
 msgstr "Les services d'étiquetage sont des services de modération auxquels vous vous abonnez par DID. Abonnez-vous pour voir leurs étiquettes — et flouter ou masquer les publications étiquetées — pendant votre lecture."
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The older link rels"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Standard Reader meets you where you read"
@@ -4863,6 +4879,10 @@ msgstr "S'abonner à {publicationName}"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Structured blocks.</0> Rich block-editor documents, each in that editor's own schema — e.g. <1>org.blocknote.document#content</1> (BlockNote) or <2>pub.oxa.document.document</2> (Oxa). Only useful if you're already producing one of these; not worth adopting from scratch."
 msgstr "<0>Blocs structurés.</0> Documents riches issus d'éditeurs de blocs, chacun dans le schéma propre à son éditeur — par exemple <1>org.blocknote.document#content</1> (BlockNote) ou <2>pub.oxa.document.document</2> (Oxa). Utile uniquement si vous en produisez déjà ; inutile de l'adopter en partant de zéro."
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -898,6 +898,10 @@ msgstr "フィードバックの種類"
 msgid "Enable the weekly digest"
 msgstr "週刊ダイジェストを有効にする"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Say in your page's <0>head</0> which records it is built from, and any client on the network can resolve the page back to them. Our browser extension uses this: when you land on a URL it hasn't indexed yet, it reads those tags rather than guessing from the URL."
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Follow at least {MIN_FOLLOWS} to fill your feed"
 msgstr "フィードを満たすには {MIN_FOLLOWS} 件以上フォローしてください"
@@ -1074,8 +1078,8 @@ msgid "your collection"
 msgstr "自分のコレクション"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
-msgstr "<0>site.standard.publication</0> のヒントは、そのドキュメントが発行物のレコードに属している場合にのみ含めてください。どのリーダーを想定していても両方を追加してください。これは当社の拡張機能だけでなく、ネットワーク上のあらゆるクライアントがページからレコードを解決するための仕組みです。"
+#~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
+#~ msgstr "<0>site.standard.publication</0> のヒントは、そのドキュメントが発行物のレコードに属している場合にのみ含めてください。どのリーダーを想定していても両方を追加してください。これは当社の拡張機能だけでなく、ネットワーク上のあらゆるクライアントがページからレコードを解決するための仕組みです。"
 
 #: src/components/reader/about-view.tsx
 msgid "Your week"
@@ -2041,8 +2045,8 @@ msgid "No matching subscriptions."
 msgstr "一致する購読はありません。"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Discovery hints are part of the site.standard spec itself, and our browser extension uses it too! When you land on a URL it hasn't indexed yet, it looks in that page's <0>head</0> for a <1>link</1> tag whose <2>rel</2> matches the record's collection and whose <3>href</3> is the record's <4>at://</4> URI."
-msgstr "ディスカバリーのヒントは site.standard 仕様そのものの一部で、当社のブラウザ拡張機能もこれを利用しています。まだインデックスされていない URL を開くと、そのページの <0>head</0> の中から、<2>rel</2> がレコードのコレクションに一致し、<3>href</3> がレコードの <4>at://</4> URI になっている <1>link</1> タグを探します。"
+#~ msgid "Discovery hints are part of the site.standard spec itself, and our browser extension uses it too! When you land on a URL it hasn't indexed yet, it looks in that page's <0>head</0> for a <1>link</1> tag whose <2>rel</2> matches the record's collection and whose <3>href</3> is the record's <4>at://</4> URI."
+#~ msgstr "ディスカバリーのヒントは site.standard 仕様そのものの一部で、当社のブラウザ拡張機能もこれを利用しています。まだインデックスされていない URL を開くと、そのページの <0>head</0> の中から、<2>rel</2> がレコードのコレクションに一致し、<3>href</3> がレコードの <4>at://</4> URI になっている <1>link</1> タグを探します。"
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Re-run"
@@ -2516,6 +2520,10 @@ msgstr ""
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Finish"
 msgstr "完了"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
+msgstr ""
 
 #: src/routes/_layout.friends.tsx
 #~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
@@ -3265,6 +3273,10 @@ msgstr ""
 #~ msgid "Lexicon reference"
 #~ msgstr "レキシコンリファレンス"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Use the <0>at:</0> meta tags — the convention the Atmosphere settled on in 2026. <1>at:canonical</1> names the records the page is made of, the ones it would have no reason to exist without. <2>at:alternate</2> names records the page merely shows — the publication a document belongs to, a companion Bluesky post. <3>at:author</3> names the identity that wrote it. Every name repeats, so a page with two alternates emits two tags."
+msgstr ""
+
 #: src/components/reader/profile-tabs-settings-modal.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
@@ -3788,6 +3800,10 @@ msgstr "ここにはまだ読むものがありません。"
 #: src/components/labelers-settings-view.tsx
 msgid "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
 msgstr "ラベラーは DID を指定して購読するモデレーションサービスです。購読すると、読書中にラベルを確認したり、ラベル付きの投稿をぼかしたり非表示にしたりできます。"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The older link rels"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Standard Reader meets you where you read"
@@ -4863,6 +4879,10 @@ msgstr "{publicationName} を購読"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Structured blocks.</0> Rich block-editor documents, each in that editor's own schema — e.g. <1>org.blocknote.document#content</1> (BlockNote) or <2>pub.oxa.document.document</2> (Oxa). Only useful if you're already producing one of these; not worth adopting from scratch."
 msgstr "<0>構造化ブロック。</0> リッチなブロックエディタの文書で、それぞれエディタ独自のスキーマを使います。例えば <1>org.blocknote.document#content</1>（BlockNote）や <2>pub.oxa.document.document</2>（Oxa）です。すでにこれらを使っている場合にのみ有用で、新たに導入する価値はありません。"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -1539,6 +1539,10 @@ msgstr ""
 msgid "Recommended for you"
 msgstr "おすすめ"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The site.standard link rels"
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Something went wrong while submitting your feedback."
 msgstr "フィードバックの送信中に問題が発生しました。"
@@ -2278,6 +2282,10 @@ msgstr "このリストを購読すると、含まれる発行物の新着記事
 msgid "{itemCount} of {MAX_ITEMS}"
 msgstr "{itemCount} / {MAX_ITEMS}"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Emit these too. Discovery hints are part of the site.standard spec itself — a <0>link</0> tag whose <1>rel</1> is the record's collection and whose <2>href</2> is its <3>at://</3> URI — and plenty of clients across the network still read only these. Include the <4>site.standard.publication</4> hint when the document belongs to a publication record."
+msgstr ""
+
 #: src/routes/_layout.latest.tsx
 msgid "{metaCount, plural, one {{formattedMetaCount} article} other {{formattedMetaCount} articles}}"
 msgstr "{metaCount, plural, one {{formattedMetaCount} 件の記事} other {{formattedMetaCount} 件の記事}}"
@@ -2522,8 +2530,8 @@ msgid "Finish"
 msgstr "完了"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
-msgstr ""
+#~ msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
+#~ msgstr ""
 
 #: src/routes/_layout.friends.tsx
 #~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
@@ -2601,6 +2609,10 @@ msgstr "発行物と記事を検索"
 #: src/components/reader/subscriptions-table.tsx
 msgid "Publication"
 msgstr "発行物"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Standard Reader emits these on its own article, publication, collection, list and profile pages, and reads them from yours."
+msgstr ""
 
 #: src/components/reader/add-to-list-button.tsx
 msgid "No lists yet"
@@ -3802,8 +3814,8 @@ msgid "Labelers are moderation services you subscribe to by DID. Subscribe to se
 msgstr "ラベラーは DID を指定して購読するモデレーションサービスです。購読すると、読書中にラベルを確認したり、ラベル付きの投稿をぼかしたり非表示にしたりできます。"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "The older link rels"
-msgstr ""
+#~ msgid "The older link rels"
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Standard Reader meets you where you read"
@@ -3853,6 +3865,10 @@ msgstr "プライバシー"
 #. placeholder {0}: labels[filter]
 #: src/components/reader/publication-actions.tsx
 msgid "Filter: {0}"
+msgstr ""
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The two say overlapping things, and that's fine: the meta tags carry intent the rels can't, while the rels are what the site.standard spec asks for. Carry both, which is what Standard Reader itself does on every article, publication and collection page."
 msgstr ""
 
 #: src/components/reader/privacy-view.tsx
@@ -4881,8 +4897,8 @@ msgid "<0>Structured blocks.</0> Rich block-editor documents, each in that edito
 msgstr "<0>構造化ブロック。</0> リッチなブロックエディタの文書で、それぞれエディタ独自のスキーマを使います。例えば <1>org.blocknote.document#content</1>（BlockNote）や <2>pub.oxa.document.document</2>（Oxa）です。すでにこれらを使っている場合にのみ有用で、新たに導入する価値はありません。"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
-msgstr ""
+#~ msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
+#~ msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -898,6 +898,10 @@ msgstr "피드백 유형"
 msgid "Enable the weekly digest"
 msgstr "주간 다이제스트 켜기"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Say in your page's <0>head</0> which records it is built from, and any client on the network can resolve the page back to them. Our browser extension uses this: when you land on a URL it hasn't indexed yet, it reads those tags rather than guessing from the URL."
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Follow at least {MIN_FOLLOWS} to fill your feed"
 msgstr "피드를 채우려면 최소 {MIN_FOLLOWS}개를 팔로우하세요"
@@ -1074,8 +1078,8 @@ msgid "your collection"
 msgstr "내 컬렉션"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
-msgstr "문서가 발행물 레코드에 속한 경우에만 <0>site.standard.publication</0> 힌트를 포함하세요. 어떤 리더를 염두에 두든 둘 다 추가하세요. 이는 우리 확장 프로그램뿐 아니라 네트워크의 모든 클라이언트가 페이지를 해당 레코드로 연결하는 방식입니다."
+#~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
+#~ msgstr "문서가 발행물 레코드에 속한 경우에만 <0>site.standard.publication</0> 힌트를 포함하세요. 어떤 리더를 염두에 두든 둘 다 추가하세요. 이는 우리 확장 프로그램뿐 아니라 네트워크의 모든 클라이언트가 페이지를 해당 레코드로 연결하는 방식입니다."
 
 #: src/components/reader/about-view.tsx
 msgid "Your week"
@@ -2041,8 +2045,8 @@ msgid "No matching subscriptions."
 msgstr "일치하는 구독이 없습니다."
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Discovery hints are part of the site.standard spec itself, and our browser extension uses it too! When you land on a URL it hasn't indexed yet, it looks in that page's <0>head</0> for a <1>link</1> tag whose <2>rel</2> matches the record's collection and whose <3>href</3> is the record's <4>at://</4> URI."
-msgstr "탐색 힌트는 site.standard 명세 자체의 일부이며, 저희 브라우저 확장 프로그램도 이를 사용합니다! 아직 색인하지 않은 URL에 접속하면 해당 페이지의 <0>head</0>에서 <2>rel</2>이 레코드의 컬렉션과 일치하고 <3>href</3>가 레코드의 <4>at://</4> URI인 <1>link</1> 태그를 찾습니다."
+#~ msgid "Discovery hints are part of the site.standard spec itself, and our browser extension uses it too! When you land on a URL it hasn't indexed yet, it looks in that page's <0>head</0> for a <1>link</1> tag whose <2>rel</2> matches the record's collection and whose <3>href</3> is the record's <4>at://</4> URI."
+#~ msgstr "탐색 힌트는 site.standard 명세 자체의 일부이며, 저희 브라우저 확장 프로그램도 이를 사용합니다! 아직 색인하지 않은 URL에 접속하면 해당 페이지의 <0>head</0>에서 <2>rel</2>이 레코드의 컬렉션과 일치하고 <3>href</3>가 레코드의 <4>at://</4> URI인 <1>link</1> 태그를 찾습니다."
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Re-run"
@@ -2516,6 +2520,10 @@ msgstr ""
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Finish"
 msgstr "완료"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
+msgstr ""
 
 #: src/routes/_layout.friends.tsx
 #~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
@@ -3265,6 +3273,10 @@ msgstr ""
 #~ msgid "Lexicon reference"
 #~ msgstr "렉시콘 레퍼런스"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Use the <0>at:</0> meta tags — the convention the Atmosphere settled on in 2026. <1>at:canonical</1> names the records the page is made of, the ones it would have no reason to exist without. <2>at:alternate</2> names records the page merely shows — the publication a document belongs to, a companion Bluesky post. <3>at:author</3> names the identity that wrote it. Every name repeats, so a page with two alternates emits two tags."
+msgstr ""
+
 #: src/components/reader/profile-tabs-settings-modal.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
@@ -3788,6 +3800,10 @@ msgstr "아직 읽을 글이 없습니다."
 #: src/components/labelers-settings-view.tsx
 msgid "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
 msgstr "라벨러는 DID로 구독하는 모더레이션 서비스입니다. 구독하면 읽는 동안 해당 라벨을 확인하고, 라벨이 붙은 게시물을 흐리게 하거나 숨길 수 있습니다."
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The older link rels"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Standard Reader meets you where you read"
@@ -4863,6 +4879,10 @@ msgstr "{publicationName} 구독"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Structured blocks.</0> Rich block-editor documents, each in that editor's own schema — e.g. <1>org.blocknote.document#content</1> (BlockNote) or <2>pub.oxa.document.document</2> (Oxa). Only useful if you're already producing one of these; not worth adopting from scratch."
 msgstr "<0>구조화된 블록.</0> 리치 블록 에디터 문서로, 각각 해당 에디터 고유의 스키마를 사용합니다 — 예: <1>org.blocknote.document#content</1>(BlockNote) 또는 <2>pub.oxa.document.document</2>(Oxa). 이미 이런 형식을 쓰고 있을 때만 유용하며, 처음부터 도입할 만하지는 않습니다."
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -1539,6 +1539,10 @@ msgstr ""
 msgid "Recommended for you"
 msgstr "추천 콘텐츠"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The site.standard link rels"
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Something went wrong while submitting your feedback."
 msgstr "피드백을 보내는 중 문제가 발생했습니다."
@@ -2278,6 +2282,10 @@ msgstr "이 리스트를 구독하면 소속 발행물의 새 글을 받아볼 �
 msgid "{itemCount} of {MAX_ITEMS}"
 msgstr "{MAX_ITEMS}개 중 {itemCount}개"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Emit these too. Discovery hints are part of the site.standard spec itself — a <0>link</0> tag whose <1>rel</1> is the record's collection and whose <2>href</2> is its <3>at://</3> URI — and plenty of clients across the network still read only these. Include the <4>site.standard.publication</4> hint when the document belongs to a publication record."
+msgstr ""
+
 #: src/routes/_layout.latest.tsx
 msgid "{metaCount, plural, one {{formattedMetaCount} article} other {{formattedMetaCount} articles}}"
 msgstr "{metaCount, plural, one {글 {formattedMetaCount}편} other {글 {formattedMetaCount}편}}"
@@ -2522,8 +2530,8 @@ msgid "Finish"
 msgstr "완료"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
-msgstr ""
+#~ msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
+#~ msgstr ""
 
 #: src/routes/_layout.friends.tsx
 #~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
@@ -2601,6 +2609,10 @@ msgstr "발행물과 글 검색"
 #: src/components/reader/subscriptions-table.tsx
 msgid "Publication"
 msgstr "발행물"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Standard Reader emits these on its own article, publication, collection, list and profile pages, and reads them from yours."
+msgstr ""
 
 #: src/components/reader/add-to-list-button.tsx
 msgid "No lists yet"
@@ -3802,8 +3814,8 @@ msgid "Labelers are moderation services you subscribe to by DID. Subscribe to se
 msgstr "라벨러는 DID로 구독하는 모더레이션 서비스입니다. 구독하면 읽는 동안 해당 라벨을 확인하고, 라벨이 붙은 게시물을 흐리게 하거나 숨길 수 있습니다."
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "The older link rels"
-msgstr ""
+#~ msgid "The older link rels"
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Standard Reader meets you where you read"
@@ -3853,6 +3865,10 @@ msgstr "개인정보"
 #. placeholder {0}: labels[filter]
 #: src/components/reader/publication-actions.tsx
 msgid "Filter: {0}"
+msgstr ""
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The two say overlapping things, and that's fine: the meta tags carry intent the rels can't, while the rels are what the site.standard spec asks for. Carry both, which is what Standard Reader itself does on every article, publication and collection page."
 msgstr ""
 
 #: src/components/reader/privacy-view.tsx
@@ -4881,8 +4897,8 @@ msgid "<0>Structured blocks.</0> Rich block-editor documents, each in that edito
 msgstr "<0>구조화된 블록.</0> 리치 블록 에디터 문서로, 각각 해당 에디터 고유의 스키마를 사용합니다 — 예: <1>org.blocknote.document#content</1>(BlockNote) 또는 <2>pub.oxa.document.document</2>(Oxa). 이미 이런 형식을 쓰고 있을 때만 유용하며, 처음부터 도입할 만하지는 않습니다."
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
-msgstr ""
+#~ msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
+#~ msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -898,6 +898,10 @@ msgstr "Tipo de comentário"
 msgid "Enable the weekly digest"
 msgstr "Ativar o resumo semanal"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Say in your page's <0>head</0> which records it is built from, and any client on the network can resolve the page back to them. Our browser extension uses this: when you land on a URL it hasn't indexed yet, it reads those tags rather than guessing from the URL."
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Follow at least {MIN_FOLLOWS} to fill your feed"
 msgstr "Siga pelo menos {MIN_FOLLOWS} para preencher o seu feed"
@@ -1074,8 +1078,8 @@ msgid "your collection"
 msgstr "a sua coleção"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
-msgstr "Inclua a dica <0>site.standard.publication</0> apenas se o documento pertencer a um registo de publicação. Adicione ambas, independentemente do leitor que lhe interessa — é assim que qualquer cliente na rede resolve a sua página para o respetivo registo, não só a nossa extensão."
+#~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
+#~ msgstr "Inclua a dica <0>site.standard.publication</0> apenas se o documento pertencer a um registo de publicação. Adicione ambas, independentemente do leitor que lhe interessa — é assim que qualquer cliente na rede resolve a sua página para o respetivo registo, não só a nossa extensão."
 
 #: src/components/reader/about-view.tsx
 msgid "Your week"
@@ -2041,8 +2045,8 @@ msgid "No matching subscriptions."
 msgstr "Nenhuma inscrição corresponde."
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Discovery hints are part of the site.standard spec itself, and our browser extension uses it too! When you land on a URL it hasn't indexed yet, it looks in that page's <0>head</0> for a <1>link</1> tag whose <2>rel</2> matches the record's collection and whose <3>href</3> is the record's <4>at://</4> URI."
-msgstr "As dicas de descoberta fazem parte da própria especificação site.standard, e a nossa extensão de navegador também as usa! Quando chega a um URL que ainda não indexou, procura no <0>head</0> dessa página uma etiqueta <1>link</1> cujo <2>rel</2> corresponda à coleção do registo e cujo <3>href</3> seja o URI <4>at://</4> do registo."
+#~ msgid "Discovery hints are part of the site.standard spec itself, and our browser extension uses it too! When you land on a URL it hasn't indexed yet, it looks in that page's <0>head</0> for a <1>link</1> tag whose <2>rel</2> matches the record's collection and whose <3>href</3> is the record's <4>at://</4> URI."
+#~ msgstr "As dicas de descoberta fazem parte da própria especificação site.standard, e a nossa extensão de navegador também as usa! Quando chega a um URL que ainda não indexou, procura no <0>head</0> dessa página uma etiqueta <1>link</1> cujo <2>rel</2> corresponda à coleção do registo e cujo <3>href</3> seja o URI <4>at://</4> do registo."
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Re-run"
@@ -2516,6 +2520,10 @@ msgstr "{0} total"
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Finish"
 msgstr "Concluir"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
+msgstr ""
 
 #: src/routes/_layout.friends.tsx
 #~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
@@ -3265,6 +3273,10 @@ msgstr ""
 #~ msgid "Lexicon reference"
 #~ msgstr "Referência do lexicon"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Use the <0>at:</0> meta tags — the convention the Atmosphere settled on in 2026. <1>at:canonical</1> names the records the page is made of, the ones it would have no reason to exist without. <2>at:alternate</2> names records the page merely shows — the publication a document belongs to, a companion Bluesky post. <3>at:author</3> names the identity that wrote it. Every name repeats, so a page with two alternates emits two tags."
+msgstr ""
+
 #: src/components/reader/profile-tabs-settings-modal.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
@@ -3788,6 +3800,10 @@ msgstr "Ainda não há nada para ler aqui."
 #: src/components/labelers-settings-view.tsx
 msgid "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
 msgstr "Os rotuladores são serviços de moderação em que se inscreve por DID. Inscreva-se para ver seus rótulos — e desfocar ou ocultar publicações rotuladas — enquanto lê."
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The older link rels"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Standard Reader meets you where you read"
@@ -4863,6 +4879,10 @@ msgstr "Inscreva-se em {publicationName}"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Structured blocks.</0> Rich block-editor documents, each in that editor's own schema — e.g. <1>org.blocknote.document#content</1> (BlockNote) or <2>pub.oxa.document.document</2> (Oxa). Only useful if you're already producing one of these; not worth adopting from scratch."
 msgstr "<0>Blocos estruturados.</0> Documentos de editores de blocos, cada um no esquema do próprio editor — por exemplo <1>org.blocknote.document#content</1> (BlockNote) ou <2>pub.oxa.document.document</2> (Oxa). Só é útil se já estiver a produzir um destes; não vale a pena adotar de raiz."
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -1539,6 +1539,10 @@ msgstr ""
 msgid "Recommended for you"
 msgstr "Recomendado para você"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The site.standard link rels"
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Something went wrong while submitting your feedback."
 msgstr "Algo deu errado ao enviar o seu feedback."
@@ -2278,6 +2282,10 @@ msgstr "Inscreva-se nesta lista para ler os novos artigos das suas publicações
 msgid "{itemCount} of {MAX_ITEMS}"
 msgstr "{itemCount} de {MAX_ITEMS}"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Emit these too. Discovery hints are part of the site.standard spec itself — a <0>link</0> tag whose <1>rel</1> is the record's collection and whose <2>href</2> is its <3>at://</3> URI — and plenty of clients across the network still read only these. Include the <4>site.standard.publication</4> hint when the document belongs to a publication record."
+msgstr ""
+
 #: src/routes/_layout.latest.tsx
 msgid "{metaCount, plural, one {{formattedMetaCount} article} other {{formattedMetaCount} articles}}"
 msgstr "{metaCount, plural, one {{formattedMetaCount} artigo} other {{formattedMetaCount} artigos}}"
@@ -2522,8 +2530,8 @@ msgid "Finish"
 msgstr "Concluir"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
-msgstr ""
+#~ msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
+#~ msgstr ""
 
 #: src/routes/_layout.friends.tsx
 #~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
@@ -2601,6 +2609,10 @@ msgstr "Pesquisar publicações e artigos"
 #: src/components/reader/subscriptions-table.tsx
 msgid "Publication"
 msgstr "Publicação"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Standard Reader emits these on its own article, publication, collection, list and profile pages, and reads them from yours."
+msgstr ""
 
 #: src/components/reader/add-to-list-button.tsx
 msgid "No lists yet"
@@ -3802,8 +3814,8 @@ msgid "Labelers are moderation services you subscribe to by DID. Subscribe to se
 msgstr "Os rotuladores são serviços de moderação em que se inscreve por DID. Inscreva-se para ver seus rótulos — e desfocar ou ocultar publicações rotuladas — enquanto lê."
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "The older link rels"
-msgstr ""
+#~ msgid "The older link rels"
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Standard Reader meets you where you read"
@@ -3853,6 +3865,10 @@ msgstr "Privacidade"
 #. placeholder {0}: labels[filter]
 #: src/components/reader/publication-actions.tsx
 msgid "Filter: {0}"
+msgstr ""
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The two say overlapping things, and that's fine: the meta tags carry intent the rels can't, while the rels are what the site.standard spec asks for. Carry both, which is what Standard Reader itself does on every article, publication and collection page."
 msgstr ""
 
 #: src/components/reader/privacy-view.tsx
@@ -4881,8 +4897,8 @@ msgid "<0>Structured blocks.</0> Rich block-editor documents, each in that edito
 msgstr "<0>Blocos estruturados.</0> Documentos de editores de blocos, cada um no esquema do próprio editor — por exemplo <1>org.blocknote.document#content</1> (BlockNote) ou <2>pub.oxa.document.document</2> (Oxa). Só é útil se já estiver a produzir um destes; não vale a pena adotar de raiz."
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
-msgstr ""
+#~ msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
+#~ msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -898,6 +898,10 @@ msgstr "反馈类型"
 msgid "Enable the weekly digest"
 msgstr "启用每周摘要"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Say in your page's <0>head</0> which records it is built from, and any client on the network can resolve the page back to them. Our browser extension uses this: when you land on a URL it hasn't indexed yet, it reads those tags rather than guessing from the URL."
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Follow at least {MIN_FOLLOWS} to fill your feed"
 msgstr "至少关注 {MIN_FOLLOWS} 个以填充你的信息流"
@@ -1074,8 +1078,8 @@ msgid "your collection"
 msgstr "你的合集"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
-msgstr "仅当该文档属于某个刊物记录时，才加入 <0>site.standard.publication</0> 提示。无论你在意哪个阅读器，两者都请加上——网络上任何客户端都靠它们把你的页面解析到对应记录，不只是我们的扩展。"
+#~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
+#~ msgstr "仅当该文档属于某个刊物记录时，才加入 <0>site.standard.publication</0> 提示。无论你在意哪个阅读器，两者都请加上——网络上任何客户端都靠它们把你的页面解析到对应记录，不只是我们的扩展。"
 
 #: src/components/reader/about-view.tsx
 msgid "Your week"
@@ -2041,8 +2045,8 @@ msgid "No matching subscriptions."
 msgstr "没有匹配的订阅。"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Discovery hints are part of the site.standard spec itself, and our browser extension uses it too! When you land on a URL it hasn't indexed yet, it looks in that page's <0>head</0> for a <1>link</1> tag whose <2>rel</2> matches the record's collection and whose <3>href</3> is the record's <4>at://</4> URI."
-msgstr "发现提示本身就是 site.standard 规范的一部分，我们的浏览器扩展也在用它！当你打开一个尚未索引的 URL 时，它会在该页面的 <0>head</0> 中查找 <1>link</1> 标签——其 <2>rel</2> 与记录所属 collection 匹配，<3>href</3> 为该记录的 <4>at://</4> URI。"
+#~ msgid "Discovery hints are part of the site.standard spec itself, and our browser extension uses it too! When you land on a URL it hasn't indexed yet, it looks in that page's <0>head</0> for a <1>link</1> tag whose <2>rel</2> matches the record's collection and whose <3>href</3> is the record's <4>at://</4> URI."
+#~ msgstr "发现提示本身就是 site.standard 规范的一部分，我们的浏览器扩展也在用它！当你打开一个尚未索引的 URL 时，它会在该页面的 <0>head</0> 中查找 <1>link</1> 标签——其 <2>rel</2> 与记录所属 collection 匹配，<3>href</3> 为该记录的 <4>at://</4> URI。"
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Re-run"
@@ -2516,6 +2520,10 @@ msgstr ""
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Finish"
 msgstr "完成"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
+msgstr ""
 
 #: src/routes/_layout.friends.tsx
 #~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
@@ -3265,6 +3273,10 @@ msgstr ""
 #~ msgid "Lexicon reference"
 #~ msgstr "Lexicon 参考"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Use the <0>at:</0> meta tags — the convention the Atmosphere settled on in 2026. <1>at:canonical</1> names the records the page is made of, the ones it would have no reason to exist without. <2>at:alternate</2> names records the page merely shows — the publication a document belongs to, a companion Bluesky post. <3>at:author</3> names the identity that wrote it. Every name repeats, so a page with two alternates emits two tags."
+msgstr ""
+
 #: src/components/reader/profile-tabs-settings-modal.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
@@ -3788,6 +3800,10 @@ msgstr "这里还没有可读的内容。"
 #: src/components/labelers-settings-view.tsx
 msgid "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
 msgstr "标注服务是你通过 DID 订阅的审核服务。订阅后，你在阅读时就能看到它们的标签，并模糊或隐藏被标注的帖子。"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The older link rels"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Standard Reader meets you where you read"
@@ -4863,6 +4879,10 @@ msgstr "订阅 {publicationName}"
 #: src/components/docs/publishing-docs-page.tsx
 msgid "<0>Structured blocks.</0> Rich block-editor documents, each in that editor's own schema — e.g. <1>org.blocknote.document#content</1> (BlockNote) or <2>pub.oxa.document.document</2> (Oxa). Only useful if you're already producing one of these; not worth adopting from scratch."
 msgstr "<0>结构化区块。</0>富文本区块编辑器文档，各自采用该编辑器的模式——例如 <1>org.blocknote.document#content</1>（BlockNote）或 <2>pub.oxa.document.document</2>（Oxa）。只有在你本来就使用其中之一时才有用；不值得从零开始采用。"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -1539,6 +1539,10 @@ msgstr ""
 msgid "Recommended for you"
 msgstr "为你推荐"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The site.standard link rels"
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Something went wrong while submitting your feedback."
 msgstr "提交反馈时出错了。"
@@ -2278,6 +2282,10 @@ msgstr "订阅此列表，即可阅读其中刊物的新文章。"
 msgid "{itemCount} of {MAX_ITEMS}"
 msgstr "{itemCount} / {MAX_ITEMS}"
 
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Emit these too. Discovery hints are part of the site.standard spec itself — a <0>link</0> tag whose <1>rel</1> is the record's collection and whose <2>href</2> is its <3>at://</3> URI — and plenty of clients across the network still read only these. Include the <4>site.standard.publication</4> hint when the document belongs to a publication record."
+msgstr ""
+
 #: src/routes/_layout.latest.tsx
 msgid "{metaCount, plural, one {{formattedMetaCount} article} other {{formattedMetaCount} articles}}"
 msgstr "{metaCount, plural, one {{formattedMetaCount} 篇文章} other {{formattedMetaCount} 篇文章}}"
@@ -2522,8 +2530,8 @@ msgid "Finish"
 msgstr "完成"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
-msgstr ""
+#~ msgid "Before the meta tags, discovery hints rode on <0>link</0> tags whose <1>rel</1> was the record's collection. We still read these, so pages that haven't migrated keep working — but an unregistered <2>rel</2> value isn't valid HTML, and it can't say why a record is on the page. New sites should reach for the meta tags. If you already emit the rels, the friendly move is what SkyPress did: keep them and put the meta tags alongside, so nothing already reading the old ones breaks."
+#~ msgstr ""
 
 #: src/routes/_layout.friends.tsx
 #~ msgid "We checked the people you follow on Bluesky against every publication on the network and didn't find a match. As more of them start publishing, they'll show up here."
@@ -2601,6 +2609,10 @@ msgstr "搜索刊物和文章"
 #: src/components/reader/subscriptions-table.tsx
 msgid "Publication"
 msgstr "刊物"
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "Standard Reader emits these on its own article, publication, collection, list and profile pages, and reads them from yours."
+msgstr ""
 
 #: src/components/reader/add-to-list-button.tsx
 msgid "No lists yet"
@@ -3802,8 +3814,8 @@ msgid "Labelers are moderation services you subscribe to by DID. Subscribe to se
 msgstr "标注服务是你通过 DID 订阅的审核服务。订阅后，你在阅读时就能看到它们的标签，并模糊或隐藏被标注的帖子。"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "The older link rels"
-msgstr ""
+#~ msgid "The older link rels"
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Standard Reader meets you where you read"
@@ -3853,6 +3865,10 @@ msgstr "隐私"
 #. placeholder {0}: labels[filter]
 #: src/components/reader/publication-actions.tsx
 msgid "Filter: {0}"
+msgstr ""
+
+#: src/components/docs/publishing-docs-page.tsx
+msgid "The two say overlapping things, and that's fine: the meta tags carry intent the rels can't, while the rels are what the site.standard spec asks for. Carry both, which is what Standard Reader itself does on every article, publication and collection page."
 msgstr ""
 
 #: src/components/reader/privacy-view.tsx
@@ -4881,8 +4897,8 @@ msgid "<0>Structured blocks.</0> Rich block-editor documents, each in that edito
 msgstr "<0>结构化区块。</0>富文本区块编辑器文档，各自采用该编辑器的模式——例如 <1>org.blocknote.document#content</1>（BlockNote）或 <2>pub.oxa.document.document</2>（Oxa）。只有在你本来就使用其中之一时才有用；不值得从零开始采用。"
 
 #: src/components/docs/publishing-docs-page.tsx
-msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
-msgstr ""
+#~ msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
+#~ msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"

--- a/apps/standard-reader/src/routes/__root.tsx
+++ b/apps/standard-reader/src/routes/__root.tsx
@@ -16,6 +16,7 @@ import { useEffect, useLayoutEffect } from "react";
 // them apart.
 import { I18nProvider as AriaI18nProvider } from "react-aria-components";
 
+import { AtRecordMeta } from "../components/at-record-meta";
 import { NavTelemetry } from "../components/nav-telemetry";
 import {
   APPEARANCE_SCALE_THEMES,
@@ -408,6 +409,10 @@ function RootDocument({ children }: { children: React.ReactNode }) {
             explicit in-app light/dark override wins over the OS preference. A
             custom palette supplies its own page color instead. */}
         <meta name="theme-color" content={themeColor} />
+        {/* Which AT Protocol records this page is built from. Raw tags for the
+            same reason theme-color is — the `at:` names repeat and route
+            `head.meta` dedupes by name. See `#/lib/at-meta-tags`. */}
+        <AtRecordMeta />
         {customUiFontUrl ? (
           <link
             rel="stylesheet"

--- a/apps/standard-reader/src/routes/_layout.a.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/_layout.a.$did.$rkey.tsx
@@ -130,6 +130,18 @@ export const Route = createFileRoute("/_layout/a/$did/$rkey")({
       article,
       sharedQuote,
       publicationTheme: articleThemeColors(article),
+      // The records this page is built from — rendered by `AtRecordMeta`. The
+      // document is why the page exists; the publication it belongs to and its
+      // companion Bluesky post are things the page merely shows. Nothing is
+      // claimed when the document didn't resolve — a page that failed to find
+      // its record shouldn't assert one.
+      atMeta: article
+        ? {
+            canonical: [uri],
+            alternate: [article.publicationUri, article.bskyPostUri],
+            author: [article.did],
+          }
+        : {},
     };
   },
   head: ({ loaderData, match }) => {

--- a/apps/standard-reader/src/routes/_layout.l.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/_layout.l.$did.$rkey.tsx
@@ -74,7 +74,7 @@ import { useTrackReadingHistory } from "#/lib/use-track-reading-history";
 import { AuthorProfileLink } from "../components/reader/author-profile-link";
 import { ArticleRow, PubDirectoryRow } from "../components/reader/cards";
 import { FeedLoadMore } from "../components/reader/feed-load-more";
-import { initials } from "../components/reader/format";
+import { initials, listUriFromParams } from "../components/reader/format";
 import { ListEditModal } from "../components/reader/list-edit-modal";
 import { Handle, Kicker, ReaderContent } from "../components/reader/primitives";
 import { isArticleUnreadForReader } from "../components/reader/read-optimistic";
@@ -121,6 +121,14 @@ export const Route = createFileRoute("/_layout/l/$did/$rkey")({
       listName: page.list?.name ?? null,
       listDescription: page.list?.description ?? null,
       ownerHandle: page.owner?.handle ?? null,
+      // The records this page is built from — rendered by `AtRecordMeta`.
+      // Nothing is claimed when the list didn't resolve.
+      atMeta: page.list
+        ? {
+            canonical: [listUriFromParams(params.did, params.rkey)],
+            author: [page.owner?.did ?? params.did],
+          }
+        : {},
     };
   },
   head: ({ loaderData, match, params }) => {

--- a/apps/standard-reader/src/routes/_layout.p.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/_layout.p.$did.$rkey.tsx
@@ -123,6 +123,8 @@ export const Route = createFileRoute("/_layout/p/$did/$rkey")({
         publicationName: null,
         publicationDescription: null,
         publicationTheme: null,
+        // Derivable from the params alone, so a preload pass carries it too.
+        atMeta: { canonical: [uri], author: [params.did] },
       };
     }
 
@@ -157,6 +159,9 @@ export const Route = createFileRoute("/_layout/p/$did/$rkey")({
       publicationDescription: header?.publication.description ?? null,
       // Read by `PublicationThemeScope` in the app shell — see its doc comment.
       publicationTheme: header?.theme ?? null,
+      // The records this page is built from — rendered by `AtRecordMeta`.
+      // Nothing is claimed when the publication didn't resolve.
+      atMeta: header ? { canonical: [uri], author: [header.owner.did] } : {},
     };
   },
   head: ({ loaderData, match }) => {

--- a/apps/standard-reader/src/routes/_layout.u.$did.tsx
+++ b/apps/standard-reader/src/routes/_layout.u.$did.tsx
@@ -132,6 +132,16 @@ export const Route = createFileRoute("/_layout/u/$did")({
       displayName,
       description: profile?.description ?? null,
       handle: profile?.handle ?? null,
+      // The records this page is built from — rendered by `AtRecordMeta`.
+      // No canonical, deliberately: this page is a directory of someone's
+      // publications with their Bluesky profile draped over it. Drop the profile
+      // record and the page still stands, which makes it an alternate.
+      atMeta: {
+        alternate: profile
+          ? [`at://${profile.did}/app.bsky.actor.profile/self`]
+          : [],
+        author: [profile?.did ?? params.did],
+      },
     };
   },
   head: ({ loaderData, match }) => {

--- a/apps/standard-reader/src/routes/collection.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/collection.$did.$rkey.tsx
@@ -149,6 +149,29 @@ export const Route = createFileRoute("/collection/$did/$rkey")({
       }),
       links: [
         ...magazineThemeFontHeadLinks(theme),
+        // standard.site discovery hints — a collection edition renders a
+        // `site.standard.document` like any article view does, so it carries the
+        // same hints (alongside the `at:` meta tags from the loader's `atMeta`).
+        // See https://standard.site/docs/verification/#discovery-hint
+        ...(collection
+          ? [
+              {
+                rel: "site.standard.document",
+                href: documentUriFromParams(
+                  match.params.did,
+                  match.params.rkey,
+                ),
+              },
+              ...(collection.collectionDoc.publicationUri
+                ? [
+                    {
+                      rel: "site.standard.publication",
+                      href: collection.collectionDoc.publicationUri,
+                    },
+                  ]
+                : []),
+            ]
+          : []),
         {
           rel: "alternate",
           type: "application/rss+xml",

--- a/apps/standard-reader/src/routes/collection.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/collection.$did.$rkey.tsx
@@ -89,6 +89,12 @@ export const Route = createFileRoute("/collection/$did/$rkey")({
         shell: shellFromCollectionData(collection),
         isListMode: false,
         collection,
+        // The records this page is built from — rendered by `AtRecordMeta`.
+        atMeta: {
+          canonical: [uri],
+          alternate: [collection.collectionDoc.publicationUri],
+          author: [params.did],
+        },
       };
     }
 
@@ -101,6 +107,17 @@ export const Route = createFileRoute("/collection/$did/$rkey")({
       shell: shellFromArticle(article),
       isListMode: !article?.collection,
       collection: null as CollectionMagazineData | null,
+      // The records this page is built from — rendered by `AtRecordMeta`. In
+      // list mode the params name a list rather than a document, and the
+      // magazine is assembled from its members, so there is nothing single and
+      // canonical to point at.
+      atMeta: article
+        ? {
+            canonical: [uri],
+            alternate: [article.publicationUri],
+            author: [article.did],
+          }
+        : {},
     };
   },
   head: ({ loaderData, match }) => {


### PR DESCRIPTION
Implements the `at:` meta tag convention for declaring which AT Protocol records a web page is built from, superseding the ad-hoc `<link rel="site.standard.*">` discovery hints.

## Summary

This change adds support for the community-standard `at:canonical`, `at:alternate`, and `at:author` meta tags that allow any client on the AT Protocol network to resolve a web page back to its source records. The implementation reads both the new meta tags and legacy link rels (for backward compatibility), with a ranking system that prefers canonical records over alternates and both over legacy rels.

## Key Changes

- **New module `src/lib/at-meta-tags.ts`**: Defines the `at:` meta tag convention with:
  - `AT_META_NAME` constants for the three tag types
  - `atMetaTags()` function to generate tags from loader data, with deduplication and ranking
  - `atMetaFromMatches()` to extract records from the deepest matched route
  - `WithAtMeta` type for route loaders to declare their records

- **Updated `src/lib/discovery-hints.ts`**: Refactored to support both conventions:
  - Added `META_TAG_RE` regex and `parseTagAttributes()` (renamed from `parseLinkTagAttributes`)
  - Introduced `HintAccumulator` and `HINT_RANK` system to prefer canonical > alternate > legacy rels
  - Split hint collection into `collectAtMetaHint()` and `collectLegacyRelHint()` functions
  - Both `parseDiscoveryHintsFromHtml()` and `readDiscoveryHintsFromDocument()` now read meta tags first, then link rels

- **New component `src/components/at-record-meta.tsx`**: Renders the `at:` tags in the document head by:
  - Reading the deepest matched route's `atMeta` via `useRouterState()`
  - Generating tags via `atMetaTags()` and rendering them as raw `<meta>` elements
  - Placed in `RootDocument`'s `<head>` rather than route `head.meta` to preserve repeating tag names (TanStack dedupes by name)

- **Route loaders updated** to declare their records:
  - `/_layout/a/$did/$rkey` (article): canonical document, alternates for publication and Bluesky post, author DID
  - `/collection/$did/$rkey`: canonical collection, alternate publication, author DID
  - `/_layout/u/$did` (profile): alternates for publications, author DID
  - `/_layout/p/$did/$rkey` (publication): canonical publication, author DID

- **Documentation updated**:
  - `APP_VISION.md`: Added "Record meta tags (`at:`)" section explaining the convention, sources, and implementation
  - `publishing-docs-page.tsx`: Updated discovery hints docs to promote `at:` tags and explain the difference between canonical and alternate records
  - `TODO.md`: Marked discovery hints task as complete

## Implementation Details

- **Ranking system**: `HINT_RANK` ensures that if a page declares both `at:canonical` and `at:alternate` for the same record, the canonical wins. Legacy rels are lowest priority.
- **Backward compatibility**: Sites mid-migration (like SkyPress) emit both old and new tags; the parser handles both gracefully.
- **Repeating tags**: Unlike route `head.meta` (which dedupes by name), these are raw elements so a page can emit multiple `at:alternate` tags for different records.
- **Identity normalization**: Bare DIDs in `at:author` are promoted to `at://` URIs; invalid URIs are dropped.
- **Tests added**: Comprehensive test coverage for `atMetaTags()`, `atMetaFromMatches()`, and both discovery hint parsers with real-world examples (Leaflet, SkyPress).

## Localization

New translatable strings added to all locale files (ar, de, en, en-XA, es, fr, ja, ko, pt, zh) for the updated publishing docs copy.

https://claude.ai/code/session_01XdGvsynCtpeph8NUxhBoBK