### PR TITLE
Remove em dashes from /about page copy

### DIFF
--- a/apps/standard-reader/src/components/reader/about-view.tsx
+++ b/apps/standard-reader/src/components/reader/about-view.tsx
@@ -1095,8 +1095,8 @@ export function AboutView() {
   const firstPub = pubs[0];
   const secondPub = pubs[1];
   const discoverDek = countLabel
-    ? t`Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all ${countLabel} publications on the network — not just the handful you've heard of.`
-    : t`Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of.`;
+    ? t`Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all ${countLabel} publications on the network, not just the handful you've heard of.`
+    : t`Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network, not just the handful you've heard of.`;
 
   return (
     <article {...stylex.props(styles.root)} data-screen-label="About">
@@ -1118,9 +1118,8 @@ export function AboutView() {
               standard.site
             </a>{" "}
             you care about. New writing simply arrives, in the order it was
-            written — no feed to fight, nothing shouting for your attention.
-            Just good long-form, and a genuinely nice way to keep finding more
-            of it.
+            written: no feed to fight, nothing shouting for your attention. Just
+            good long-form, and a genuinely nice way to keep finding more of it.
           </Trans>
         </p>
         <div {...stylex.props(styles.ctaRow, styles.heroCtaRow)}>
@@ -1135,7 +1134,7 @@ export function AboutView() {
           <div {...stylex.props(styles.count)}>
             <Trans>
               <span {...stylex.props(styles.countNum)}>{countLabel}</span>{" "}
-              publications indexed — and counting
+              publications indexed, and counting
             </Trans>
           </div>
         ) : null}
@@ -1172,8 +1171,8 @@ export function AboutView() {
             <p {...stylex.props(styles.splitPara, styles.splitParaLast)}>
               <Trans>
                 And it never feels sealed off. We connect each article to the
-                conversation happening across the Atmosphere — the open network
-                beyond this app — gathering the Bluesky posts and replies about
+                conversation happening across the Atmosphere (the open network
+                beyond this app), gathering the Bluesky posts and replies about
                 a piece, the notes left in its margins, and the other writing
                 that cites it, quietly beneath what you&rsquo;re reading.
               </Trans>
@@ -1227,15 +1226,15 @@ export function AboutView() {
         <div {...stylex.props(styles.miniGrid)}>
           <MiniFeature icon={SlidersHorizontal} title={t`Set your own type`}>
             <Trans>
-              Choose body text size, column width, and font — serif, sans, or
-              any Google Font. Read the way that’s easy on your eyes.
+              Choose body text size, column width, and font: serif, sans, or any
+              Google Font. Read the way that’s easy on your eyes.
             </Trans>
           </MiniFeature>
           <MiniFeature icon={Headphones} title={t`Listen to anything`}>
             <Trans>
               A Listen button reads any article aloud, right on your device, and
               highlights each word as it goes. The player follows you around the
-              app — it’ll even read an embedded Bluesky post. Signed in, you can
+              app; it’ll even read an embedded Bluesky post. Signed in, you can
               pick a voice.
             </Trans>
           </MiniFeature>
@@ -1289,7 +1288,7 @@ export function AboutView() {
         <SectionHead
           kicker={t`Integrations`}
           title={t`Standard Reader meets you where you read`}
-          dek={t`It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network.`}
+          dek={t`It doesn't ask you to leave the rest of the web behind. It reaches out to it, and stays a good citizen of the wider network.`}
         />
 
         <div {...stylex.props(styles.intGrid)}>
@@ -1307,7 +1306,7 @@ export function AboutView() {
               <p {...stylex.props(styles.intDesc)}>
                 <Trans>
                   A lightweight browser extension lets you save and subscribe to
-                  publications while you’re out on the web — with subtle badges
+                  publications while you’re out on the web, with subtle badges
                   on bsky.app and a one-click overlay on any page you land on.
                   Your reading list fills itself.
                 </Trans>
@@ -1325,7 +1324,7 @@ export function AboutView() {
 
           <IntegrationCard
             icon={Heart}
-            title={t`Save, like, subscribe — everywhere`}
+            title={t`Save, like, subscribe: everywhere`}
           >
             <Trans>
               One tap from the reading view, on any device, instantly in sync.
@@ -1336,8 +1335,8 @@ export function AboutView() {
           <IntegrationCard icon={Users} title={t`The conversation, gathered`}>
             <Trans>
               Under each article you see the discussion from across the open
-              network — Bluesky posts and replies, margin notes, links from
-              other pieces that cite it, and related reading. All read-only, all
+              network: Bluesky posts and replies, margin notes, links from other
+              pieces that cite it, and related reading. All read-only, all
               linking back to the source.
             </Trans>
           </IntegrationCard>
@@ -1345,7 +1344,7 @@ export function AboutView() {
           <IntegrationCard icon={Share2} title={t`Shareable everywhere`}>
             <Trans>
               Publications, lists, and collections each get a clean link with a
-              rich preview card — plus a subscribe button a publication can drop
+              rich preview card, plus a subscribe button a publication can drop
               on its own site.
             </Trans>
           </IntegrationCard>
@@ -1356,7 +1355,7 @@ export function AboutView() {
             link={{ to: "/collections", label: t`See collections` }}
           >
             <Trans>
-              Build named, shareable lists of publications — a playlist for
+              Build named, shareable lists of publications: a playlist for
               reading. Anyone can add your list to their own reader in a single
               tap.
             </Trans>
@@ -1446,7 +1445,7 @@ export function AboutView() {
                 <Trans>
                   Don’t want another app to check? Opt into a weekly email with
                   the best of the publications you subscribe to, plus a couple
-                  worth discovering. One email, one click to leave — and you can
+                  worth discovering. One email, one click to leave, and you can
                   preview exactly what it looks like before you ever turn it on.
                 </Trans>
               </p>
@@ -1474,7 +1473,7 @@ export function AboutView() {
               <p {...stylex.props(styles.panelPara)}>
                 <Trans>
                   Standard Reader doesn’t trap your reading inside one app. Any
-                  slice of the network comes with its own RSS feed — pipe it
+                  slice of the network comes with its own RSS feed: pipe it
                   straight into whatever reader you already use.
                 </Trans>
               </p>
@@ -1510,8 +1509,8 @@ export function AboutView() {
         <p {...stylex.props(styles.closeDek)}>
           <Trans>
             Read without an account. Sign in with Bluesky when you want to
-            subscribe, like, and save — and take all of it with you, wherever
-            you choose to read next.
+            subscribe, like, and save, and take all of it with you, wherever you
+            choose to read next.
           </Trans>
         </p>
         <div {...stylex.props(styles.ctaRow, styles.heroCtaRow)}>

--- a/apps/standard-reader/src/lib/site-metadata.ts
+++ b/apps/standard-reader/src/lib/site-metadata.ts
@@ -75,7 +75,7 @@ export const PAGE_OG_CARDS = {
     path: "/about",
     title: "A home for the writing you love",
     tagline:
-      "New writing from the standard.site publications you subscribe to — calm, chronological, and yours to take anywhere.",
+      "New writing from the standard.site publications you subscribe to: calm, chronological, and yours to take anywhere.",
   },
   docsIntroduction: {
     path: "/docs/introduction",

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -134,6 +134,10 @@ msgstr "إزالة الأيقونة"
 msgid "The {SITE_NAME} browser extension helps you save articles and follow publications on the standard.site network from any tab. It connects to the same account as the web app at <0>{siteHost}</0>. This policy covers the extension only; the <1>site privacy policy</1> describes data handling on the website itself."
 msgstr "يساعدك امتداد المتصفح من {SITE_NAME} على حفظ المقالات ومتابعة المنشورات على شبكة standard.site من أي تبويب. وهو يتصل بالحساب نفسه المستخدم في تطبيق الويب على <0>{siteHost}</0>. تغطي هذه السياسة الامتداد وحده؛ أما <1>سياسة خصوصية الموقع</1> فتوضّح كيفية التعامل مع البيانات على الموقع نفسه."
 
+#: src/components/reader/about-view.tsx
+msgid "Save, like, subscribe: everywhere"
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Change language"
@@ -256,6 +260,10 @@ msgstr "جارٍ فتح المجموعة…"
 msgid "Density"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Choose body text size, column width, and font: serif, sans, or any Google Font. Read the way that’s easy on your eyes."
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Open on publication"
 msgstr "فتح في المنشورة"
@@ -265,8 +273,8 @@ msgid "(this is what Standard Reader itself uses)"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
-msgstr "ولا يبدو الأمر منغلقًا أبدًا. نربط كل مقال بالنقاش الدائر عبر Atmosphere — الشبكة المفتوحة خارج هذا التطبيق — فنجمع منشورات Bluesky وردودها حول المقال، والملاحظات المتروكة في هوامشه، وسائر ما يستشهد به، بهدوء أسفل ما تقرأه."
+#~ msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+#~ msgstr "ولا يبدو الأمر منغلقًا أبدًا. نربط كل مقال بالنقاش الدائر عبر Atmosphere — الشبكة المفتوحة خارج هذا التطبيق — فنجمع منشورات Bluesky وردودها حول المقال، والملاحظات المتروكة في هوامشه، وسائر ما يستشهد به، بهدوء أسفل ما تقرأه."
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "running…"
@@ -365,8 +373,8 @@ msgid "Set these now, or change them any time in Settings."
 msgstr "اضبطها الآن، أو غيّرها في أي وقت من الإعدادات."
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
-msgstr "يتوقف معظم القرّاء عند ما اشتركوا فيه بالفعل. أما Standard Reader فيعتبر العثور على مفضّلتك التالية جزءًا من مهمته. تصفّح كل المنشورات على الشبكة — لا تلك القليلة التي سمعت بها فقط."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
+#~ msgstr "يتوقف معظم القرّاء عند ما اشتركوا فيه بالفعل. أما Standard Reader فيعتبر العثور على مفضّلتك التالية جزءًا من مهمته. تصفّح كل المنشورات على الشبكة — لا تلك القليلة التي سمعت بها فقط."
 
 #: src/routes/_layout.collections.index.tsx
 msgid "Name your series & pick a theme"
@@ -770,6 +778,10 @@ msgstr "أين تُخزَّن البيانات"
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "We couldn’t find that list."
 msgstr "تعذّر العثور على تلك القائمة."
+
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network, not just the handful you've heard of."
+msgstr ""
 
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/mention-hover-card.tsx
@@ -1363,8 +1375,8 @@ msgid "You're subscribed to every publication on this page — scroll for more, 
 msgstr "أنت مشترك في كل منشورة على هذه الصفحة — مرّر للمزيد، أو أوقف عامل التصفية."
 
 #: src/components/reader/about-view.tsx
-msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
-msgstr "تحت كل مقال ترى النقاش من عموم الشبكة المفتوحة — منشورات Bluesky وردودها، وملاحظات الهوامش، وروابط من مقالات أخرى تستشهد به، وقراءات ذات صلة. كلها للقراءة فقط، وكلها تعود بالرابط إلى المصدر."
+#~ msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+#~ msgstr "تحت كل مقال ترى النقاش من عموم الشبكة المفتوحة — منشورات Bluesky وردودها، وملاحظات الهوامش، وروابط من مقالات أخرى تستشهد به، وقراءات ذات صلة. كلها للقراءة فقط، وكلها تعود بالرابط إلى المصدر."
 
 #: src/routes/_layout.latest.tsx
 msgid "Show all subscriptions"
@@ -1405,8 +1417,8 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, zero {لا مطابقات} one {مطابقة واحدة} two {مطابقتان} few {# مطابقات} many {# مطابقة} other {# مطابقة}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
-msgstr "تحصل المنشورات والقوائم والمجموعات على رابط أنيق مع بطاقة معاينة غنية — إضافةً إلى زر اشتراك يمكن للمنشورة وضعه على موقعها."
+#~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
+#~ msgstr "تحصل المنشورات والقوائم والمجموعات على رابط أنيق مع بطاقة معاينة غنية — إضافةً إلى زر اشتراك يمكن للمنشورة وضعه على موقعها."
 
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Search topics"
@@ -1548,8 +1560,8 @@ msgid "Something went wrong while submitting your feedback."
 msgstr "حدث خطأ أثناء إرسال ملاحظاتك."
 
 #: src/components/reader/about-view.tsx
-msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
-msgstr "لا تريد تطبيقًا آخر لتتفقّده؟ اشترك في بريد أسبوعي يضم أفضل ما في المنشورات التي تتابعها، مع منشورتين تستحقان الاكتشاف. رسالة واحدة، ونقرة واحدة لإلغاء الاشتراك — ويمكنك معاينة شكلها بالضبط قبل تفعيلها."
+#~ msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
+#~ msgstr "لا تريد تطبيقًا آخر لتتفقّده؟ اشترك في بريد أسبوعي يضم أفضل ما في المنشورات التي تتابعها، مع منشورتين تستحقان الاكتشاف. رسالة واحدة، ونقرة واحدة لإلغاء الاشتراك — ويمكنك معاينة شكلها بالضبط قبل تفعيلها."
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/collection-builder.tsx
@@ -1645,6 +1657,10 @@ msgstr "الموقع"
 #: src/routes/_layout.index.tsx
 msgid "Today"
 msgstr "اليوم"
+
+#: src/components/reader/about-view.tsx
+msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere (the open network beyond this app), gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/reader/cards.tsx
@@ -1805,6 +1821,10 @@ msgstr "مدعوم بـ Standard Reader"
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network, not just the handful you've heard of."
+msgstr ""
+
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -1881,6 +1901,10 @@ msgstr "لإرسال ملخصك بالبريد، يحتاج Standard Reader إل
 #: src/components/reader/about-view.tsx
 msgid "Discovery"
 msgstr "الاكتشاف"
+
+#: src/components/reader/about-view.tsx
+msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app; it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
+msgstr ""
 
 #. placeholder {0}: selected.count
 #: src/components/reader/subscriptions-table.tsx
@@ -2069,8 +2093,8 @@ msgid "Subscribe to a few publications or follow some people, and their latest w
 msgstr "اشترك في بضع منشورات أو تابع بعض الأشخاص، وستتجمع هنا أحدث كتاباتهم وتوصياتهم."
 
 #: src/components/reader/about-view.tsx
-msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save — and take all of it with you, wherever you choose to read next."
-msgstr "اقرأ دون حساب. سجّل الدخول عبر Bluesky عندما ترغب في الاشتراك والإعجاب والحفظ — وخذ ذلك كله معك أينما اخترت أن تقرأ."
+#~ msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save — and take all of it with you, wherever you choose to read next."
+#~ msgstr "اقرأ دون حساب. سجّل الدخول عبر Bluesky عندما ترغب في الاشتراك والإعجاب والحفظ — وخذ ذلك كله معك أينما اخترت أن تقرأ."
 
 #: src/components/reader/collection-builder.tsx
 msgid "Remove {itemTitle}"
@@ -2087,8 +2111,8 @@ msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, zero {متابع} one {متابع} two {متابعان} few {متابعين} many {متابعًا} other {متابع}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
-msgstr "يكتفي معظم القرّاء بما اشتركوا فيه بالفعل. أما Standard Reader فيعتبر العثور على مفضّلتك التالية جزءًا من مهمته. تصفّح كل المنشورات على الشبكة وعددها {countLabel} — لا الحفنة التي سمعت بها فقط."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgstr "يكتفي معظم القرّاء بما اشتركوا فيه بالفعل. أما Standard Reader فيعتبر العثور على مفضّلتك التالية جزءًا من مهمته. تصفّح كل المنشورات على الشبكة وعددها {countLabel} — لا الحفنة التي سمعت بها فقط."
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labels"
@@ -2627,8 +2651,8 @@ msgid "Large"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
-msgstr "زر الاستماع يقرأ أي مقال بصوت مسموع على جهازك مباشرةً، ويبرز كل كلمة أثناء القراءة. يرافقك المشغّل في أنحاء التطبيق — بل يقرأ حتى منشور Bluesky المضمّن. وبتسجيل الدخول يمكنك اختيار الصوت."
+#~ msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
+#~ msgstr "زر الاستماع يقرأ أي مقال بصوت مسموع على جهازك مباشرةً، ويبرز كل كلمة أثناء القراءة. يرافقك المشغّل في أنحاء التطبيق — بل يقرأ حتى منشور Bluesky المضمّن. وبتسجيل الدخول يمكنك اختيار الصوت."
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Something went wrong while preparing your review."
@@ -3029,8 +3053,8 @@ msgid "Select a tag"
 msgstr "اختر وسمًا"
 
 #: src/components/reader/about-view.tsx
-msgid "<0>{countLabel}</0> publications indexed — and counting"
-msgstr "<0>{countLabel}</0> منشورة مفهرسة — والعدد في ازدياد"
+#~ msgid "<0>{countLabel}</0> publications indexed — and counting"
+#~ msgstr "<0>{countLabel}</0> منشورة مفهرسة — والعدد في ازدياد"
 
 #: src/routes/_layout.index.tsx
 msgid "{newCount} new"
@@ -3220,8 +3244,8 @@ msgid "Browse publications"
 msgstr "تصفّح المنشورات"
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
-msgstr "لا يحبس Standard Reader قراءتك داخل تطبيق واحد. كل جزء من الشبكة يأتي بتغذية RSS خاصة به — وجّهها مباشرة إلى أي قارئ تستخدمه بالفعل."
+#~ msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
+#~ msgstr "لا يحبس Standard Reader قراءتك داخل تطبيق واحد. كل جزء من الشبكة يأتي بتغذية RSS خاصة به — وجّهها مباشرة إلى أي قارئ تستخدمه بالفعل."
 
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Choose images"
@@ -3362,8 +3386,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Save, like, subscribe — everywhere"
-msgstr "احفظ وأعجب واشترك — في كل مكان"
+#~ msgid "Save, like, subscribe — everywhere"
+#~ msgstr "احفظ وأعجب واشترك — في كل مكان"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe?"
@@ -3492,6 +3516,10 @@ msgstr "البيانات الشخصية"
 msgid "on Leaflet"
 msgstr "على Leaflet"
 
+#: src/components/reader/about-view.tsx
+msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save, and take all of it with you, wherever you choose to read next."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 #: src/components/user-settings-view.tsx
 msgid "Not now"
@@ -3609,8 +3637,8 @@ msgid "Loading…"
 msgstr "جارٍ التحميل…"
 
 #: src/components/reader/about-view.tsx
-msgid "Choose body text size, column width, and font — serif, sans, or any Google Font. Read the way that’s easy on your eyes."
-msgstr "اختر حجم النص وعرض العمود والخط — بحروف مذيّلة أو غير مذيّلة أو أي خط من Google Font. اقرأ بالطريقة الأريح لعينيك."
+#~ msgid "Choose body text size, column width, and font — serif, sans, or any Google Font. Read the way that’s easy on your eyes."
+#~ msgstr "اختر حجم النص وعرض العمود والخط — بحروف مذيّلة أو غير مذيّلة أو أي خط من Google Font. اقرأ بالطريقة الأريح لعينيك."
 
 #: src/routes/_layout.u.$did.tsx
 msgid "{name} hasn't started reading or publishing here. You can find them on Bluesky."
@@ -3892,6 +3920,10 @@ msgid "Unfollow?"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
+msgid "Build named, shareable lists of publications: a playlist for reading. Anyone can add your list to their own reader in a single tap."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
 msgid "Listen to anything"
 msgstr "استمع إلى أي شيء"
 
@@ -3949,6 +3981,10 @@ msgstr "المقالات التي رشّحتها عبر الشبكة."
 #: src/routes/_layout.feedback.return.tsx
 msgid "View feedback"
 msgstr "عرض الملاحظات"
+
+#: src/components/reader/about-view.tsx
+msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave, and you can preview exactly what it looks like before you ever turn it on."
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "All caught up"
@@ -4189,8 +4225,8 @@ msgid "The core / new frameworks"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written — no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
-msgstr "اشترك في المنشورات التي تهمّك على <0>standard.site</0>. تصلك الكتابات الجديدة تباعًا، بترتيب نشرها — بلا تغذية تصارعها، ولا شيء يصرخ لجذب انتباهك. مجرد كتابات طويلة جيدة، وطريقة لطيفة حقًا لاكتشاف المزيد منها."
+#~ msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written — no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
+#~ msgstr "اشترك في المنشورات التي تهمّك على <0>standard.site</0>. تصلك الكتابات الجديدة تباعًا، بترتيب نشرها — بلا تغذية تصارعها، ولا شيء يصرخ لجذب انتباهك. مجرد كتابات طويلة جيدة، وطريقة لطيفة حقًا لاكتشاف المزيد منها."
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Save"
@@ -4273,6 +4309,10 @@ msgstr "تغذية الرئيسية فارغة حاليًا — انتقل إل�
 msgid "Articles"
 msgstr "المقالات"
 
+#: src/components/reader/about-view.tsx
+msgid "Under each article you see the discussion from across the open network: Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Leave a review"
 msgstr "اكتب مراجعة"
@@ -4322,8 +4362,8 @@ msgid "Settings"
 msgstr "الإعدادات"
 
 #: src/components/reader/about-view.tsx
-msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
-msgstr "امتداد متصفح خفيف يتيح لك حفظ المنشورات والاشتراك فيها أثناء تصفّحك للويب — بشارات خفيفة على bsky.app وطبقة بنقرة واحدة على أي صفحة تزورها. قائمة قراءتك تملأ نفسها."
+#~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+#~ msgstr "امتداد متصفح خفيف يتيح لك حفظ المنشورات والاشتراك فيها أثناء تصفّحك للويب — بشارات خفيفة على bsky.app وطبقة بنقرة واحدة على أي صفحة تزورها. قائمة قراءتك تملأ نفسها."
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -4389,6 +4429,10 @@ msgstr "قراءة المقالة"
 msgid "Terms of service"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "<0>{countLabel}</0> publications indexed, and counting"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Delete all reading history?"
 msgstr "حذف كل سجل القراءة؟"
@@ -4445,6 +4489,10 @@ msgstr "متوقف مؤقتًا"
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "التفاصيل"
+
+#: src/components/reader/about-view.tsx
+msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web, with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "When you save or follow from the extension, {SITE_NAME} writes AT Protocol records to <0>your</0> repository through the same server paths as the web app. Those records follow the network's visibility rules and your account settings."
@@ -4517,8 +4565,8 @@ msgid "Open any article while signed in and it'll show up here. Your history liv
 msgstr "افتح أي مقالة وأنت مسجّل الدخول وستظهر هنا. سجلّك محفوظ في مستودعك على شكل سجلات <0>app.standard-reader.read</0>."
 
 #: src/components/reader/about-view.tsx
-msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
-msgstr "أنشئ قوائم منشورات مسمّاة وقابلة للمشاركة — قائمة تشغيل للقراءة. يمكن لأي شخص إضافة قائمتك إلى قارئه بنقرة واحدة."
+#~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
+#~ msgstr "أنشئ قوائم منشورات مسمّاة وقابلة للمشاركة — قائمة تشغيل للقراءة. يمكن لأي شخص إضافة قائمتك إلى قارئه بنقرة واحدة."
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
@@ -4593,6 +4641,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Labelers"
 msgstr "المصنِّفات"
+
+#: src/components/reader/about-view.tsx
+msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written: no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
+msgstr ""
 
 #: src/components/reader/language-dialog.tsx
 msgid "Choose your language"
@@ -4996,6 +5048,10 @@ msgstr "الحفظ في Margin…"
 msgid "{minutes} min"
 msgstr "{minutes} دقيقة"
 
+#: src/components/reader/about-view.tsx
+msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it, and stays a good citizen of the wider network."
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Landscape"
 msgstr "أفقي"
@@ -5044,8 +5100,8 @@ msgid "Opening the issue…"
 msgstr "جارٍ فتح العدد…"
 
 #: src/components/reader/about-view.tsx
-msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
-msgstr "لا يطلب منك أن تترك بقية الويب خلفك. بل يمد يده إليها — ويبقى مواطنًا صالحًا في الشبكة الأوسع."
+#~ msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+#~ msgstr "لا يطلب منك أن تترك بقية الويب خلفك. بل يمد يده إليها — ويبقى مواطنًا صالحًا في الشبكة الأوسع."
 
 #: src/routes/_layout.collections.edit.$rkey.tsx
 msgid "We couldn’t load that collection to edit."
@@ -5177,6 +5233,10 @@ msgstr "رابط"
 #: src/components/reader/collection-publication-editor.tsx
 msgid "Save series"
 msgstr "حفظ السلسلة"
+
+#: src/components/reader/about-view.tsx
+msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed: pipe it straight into whatever reader you already use."
+msgstr ""
 
 #: src/components/labelers-settings-view.tsx
 msgid "No labelers match “{searchTrim}”."
@@ -5326,6 +5386,10 @@ msgstr "{connectionLabel} عبر Semble"
 
 #: src/components/appearance-settings.tsx
 msgid "S"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Publications, lists, and collections each get a clean link with a rich preview card, plus a subscribe button a publication can drop on its own site."
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -134,6 +134,10 @@ msgstr "Symbol entfernen"
 msgid "The {SITE_NAME} browser extension helps you save articles and follow publications on the standard.site network from any tab. It connects to the same account as the web app at <0>{siteHost}</0>. This policy covers the extension only; the <1>site privacy policy</1> describes data handling on the website itself."
 msgstr "Die {SITE_NAME}-Browsererweiterung hilft Ihnen, Artikel zu speichern und Publikationen im standard.site-Netzwerk aus jedem Tab heraus zu folgen. Sie nutzt dasselbe Konto wie die Web-App unter <0>{siteHost}</0>. Diese Richtlinie gilt nur für die Erweiterung; die <1>Datenschutzerklärung der Website</1> beschreibt den Umgang mit Daten auf der Website selbst."
 
+#: src/components/reader/about-view.tsx
+msgid "Save, like, subscribe: everywhere"
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Change language"
@@ -256,6 +260,10 @@ msgstr "Sammlung wird geöffnet …"
 msgid "Density"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Choose body text size, column width, and font: serif, sans, or any Google Font. Read the way that’s easy on your eyes."
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Open on publication"
 msgstr "In der Publikation öffnen"
@@ -265,8 +273,8 @@ msgid "(this is what Standard Reader itself uses)"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
-msgstr "Und es wirkt nie abgeschottet. Wir verbinden jeden Artikel mit dem Gespräch in der Atmosphere – dem offenen Netzwerk jenseits dieser App – und sammeln die Bluesky-Beiträge und Antworten zu einem Text, die Notizen an seinen Rändern und die anderen Texte, die ihn zitieren, unauffällig unter dem, was Sie gerade lesen."
+#~ msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+#~ msgstr "Und es wirkt nie abgeschottet. Wir verbinden jeden Artikel mit dem Gespräch in der Atmosphere – dem offenen Netzwerk jenseits dieser App – und sammeln die Bluesky-Beiträge und Antworten zu einem Text, die Notizen an seinen Rändern und die anderen Texte, die ihn zitieren, unauffällig unter dem, was Sie gerade lesen."
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "running…"
@@ -365,8 +373,8 @@ msgid "Set these now, or change them any time in Settings."
 msgstr "Legen Sie das jetzt fest oder ändern Sie es jederzeit in den Einstellungen."
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
-msgstr "Die meisten Leser bleiben bei dem, was sie schon abonniert haben. Für Standard Reader gehört es zur Aufgabe, Ihren nächsten Favoriten zu finden. Stöbern Sie in allen Publikationen im Netzwerk – nicht nur in den wenigen, von denen Sie schon gehört haben."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
+#~ msgstr "Die meisten Leser bleiben bei dem, was sie schon abonniert haben. Für Standard Reader gehört es zur Aufgabe, Ihren nächsten Favoriten zu finden. Stöbern Sie in allen Publikationen im Netzwerk – nicht nur in den wenigen, von denen Sie schon gehört haben."
 
 #: src/routes/_layout.collections.index.tsx
 msgid "Name your series & pick a theme"
@@ -770,6 +778,10 @@ msgstr "Wo die Daten liegen"
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "We couldn’t find that list."
 msgstr "Diese Liste wurde nicht gefunden."
+
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network, not just the handful you've heard of."
+msgstr ""
 
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/mention-hover-card.tsx
@@ -1363,8 +1375,8 @@ msgid "You're subscribed to every publication on this page — scroll for more, 
 msgstr "Sie haben jede Publikation auf dieser Seite abonniert – scrollen Sie weiter oder schalten Sie den Filter aus."
 
 #: src/components/reader/about-view.tsx
-msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
-msgstr "Unter jedem Artikel sehen Sie die Diskussion aus dem gesamten offenen Netzwerk – Bluesky-Posts und -Antworten, Randnotizen, Links aus anderen Texten, die ihn zitieren, und verwandte Lektüre. Alles nur lesend, alles mit Link zur Quelle."
+#~ msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+#~ msgstr "Unter jedem Artikel sehen Sie die Diskussion aus dem gesamten offenen Netzwerk – Bluesky-Posts und -Antworten, Randnotizen, Links aus anderen Texten, die ihn zitieren, und verwandte Lektüre. Alles nur lesend, alles mit Link zur Quelle."
 
 #: src/routes/_layout.latest.tsx
 msgid "Show all subscriptions"
@@ -1405,8 +1417,8 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {# Treffer} other {# Treffer}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
-msgstr "Publikationen, Listen und Sammlungen bekommen jeweils einen sauberen Link mit einer schönen Vorschaukarte – plus einen Abo-Button, den eine Publikation auf ihrer eigenen Website einbauen kann."
+#~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
+#~ msgstr "Publikationen, Listen und Sammlungen bekommen jeweils einen sauberen Link mit einer schönen Vorschaukarte – plus einen Abo-Button, den eine Publikation auf ihrer eigenen Website einbauen kann."
 
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Search topics"
@@ -1548,8 +1560,8 @@ msgid "Something went wrong while submitting your feedback."
 msgstr "Beim Senden Ihres Feedbacks ist etwas schiefgelaufen."
 
 #: src/components/reader/about-view.tsx
-msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
-msgstr "Keine Lust, noch eine App zu prüfen? Abonnieren Sie eine wöchentliche E-Mail mit dem Besten aus Ihren abonnierten Publikationen und ein paar Entdeckungen dazu. Eine E-Mail, ein Klick zum Abbestellen – und Sie können vorher genau sehen, wie sie aussieht."
+#~ msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
+#~ msgstr "Keine Lust, noch eine App zu prüfen? Abonnieren Sie eine wöchentliche E-Mail mit dem Besten aus Ihren abonnierten Publikationen und ein paar Entdeckungen dazu. Eine E-Mail, ein Klick zum Abbestellen – und Sie können vorher genau sehen, wie sie aussieht."
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/collection-builder.tsx
@@ -1645,6 +1657,10 @@ msgstr "Website"
 #: src/routes/_layout.index.tsx
 msgid "Today"
 msgstr "Heute"
+
+#: src/components/reader/about-view.tsx
+msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere (the open network beyond this app), gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/reader/cards.tsx
@@ -1805,6 +1821,10 @@ msgstr "Bereitgestellt von Standard Reader"
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network, not just the handful you've heard of."
+msgstr ""
+
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -1881,6 +1901,10 @@ msgstr "Um Ihren Digest per E-Mail zu senden, benötigt Standard Reader die E-Ma
 #: src/components/reader/about-view.tsx
 msgid "Discovery"
 msgstr "Entdecken"
+
+#: src/components/reader/about-view.tsx
+msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app; it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
+msgstr ""
 
 #. placeholder {0}: selected.count
 #: src/components/reader/subscriptions-table.tsx
@@ -2069,8 +2093,8 @@ msgid "Subscribe to a few publications or follow some people, and their latest w
 msgstr "Abonnieren Sie ein paar Publikationen oder folgen Sie ein paar Leuten – deren neueste Texte und Empfehlungen sammeln sich dann hier."
 
 #: src/components/reader/about-view.tsx
-msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save — and take all of it with you, wherever you choose to read next."
-msgstr "Lesen Sie ohne Konto. Melden Sie sich mit Bluesky an, wenn Sie abonnieren, liken und speichern möchten – und nehmen Sie alles mit, wo immer Sie als Nächstes lesen."
+#~ msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save — and take all of it with you, wherever you choose to read next."
+#~ msgstr "Lesen Sie ohne Konto. Melden Sie sich mit Bluesky an, wenn Sie abonnieren, liken und speichern möchten – und nehmen Sie alles mit, wo immer Sie als Nächstes lesen."
 
 #: src/components/reader/collection-builder.tsx
 msgid "Remove {itemTitle}"
@@ -2087,8 +2111,8 @@ msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {Follower} other {Follower}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
-msgstr "Die meisten Leser bleiben bei dem, was sie schon abonniert haben. Standard Reader sieht es als Teil seiner Aufgabe, Ihren nächsten Favoriten zu finden. Stöbern Sie durch alle {countLabel} Publikationen im Netzwerk – nicht nur die paar, die Sie kennen."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgstr "Die meisten Leser bleiben bei dem, was sie schon abonniert haben. Standard Reader sieht es als Teil seiner Aufgabe, Ihren nächsten Favoriten zu finden. Stöbern Sie durch alle {countLabel} Publikationen im Netzwerk – nicht nur die paar, die Sie kennen."
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labels"
@@ -2627,8 +2651,8 @@ msgid "Large"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
-msgstr "Ein Vorlesen-Button liest jeden Artikel direkt auf Ihrem Gerät vor und hebt dabei jedes Wort hervor. Der Player folgt Ihnen durch die App — er liest sogar einen eingebetteten Bluesky-Beitrag vor. Angemeldet können Sie eine Stimme wählen."
+#~ msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
+#~ msgstr "Ein Vorlesen-Button liest jeden Artikel direkt auf Ihrem Gerät vor und hebt dabei jedes Wort hervor. Der Player folgt Ihnen durch die App — er liest sogar einen eingebetteten Bluesky-Beitrag vor. Angemeldet können Sie eine Stimme wählen."
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Something went wrong while preparing your review."
@@ -3029,8 +3053,8 @@ msgid "Select a tag"
 msgstr "Tag auswählen"
 
 #: src/components/reader/about-view.tsx
-msgid "<0>{countLabel}</0> publications indexed — and counting"
-msgstr "<0>{countLabel}</0> Publikationen indexiert — und es werden mehr"
+#~ msgid "<0>{countLabel}</0> publications indexed — and counting"
+#~ msgstr "<0>{countLabel}</0> Publikationen indexiert — und es werden mehr"
 
 #: src/routes/_layout.index.tsx
 msgid "{newCount} new"
@@ -3220,8 +3244,8 @@ msgid "Browse publications"
 msgstr "Publikationen durchstöbern"
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
-msgstr "Standard Reader sperrt Ihre Lektüre nicht in eine App. Jeder Ausschnitt des Netzwerks hat einen eigenen RSS-Feed — leiten Sie ihn direkt in den Reader, den Sie ohnehin nutzen."
+#~ msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
+#~ msgstr "Standard Reader sperrt Ihre Lektüre nicht in eine App. Jeder Ausschnitt des Netzwerks hat einen eigenen RSS-Feed — leiten Sie ihn direkt in den Reader, den Sie ohnehin nutzen."
 
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Choose images"
@@ -3362,8 +3386,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Save, like, subscribe — everywhere"
-msgstr "Speichern, liken, abonnieren – überall"
+#~ msgid "Save, like, subscribe — everywhere"
+#~ msgstr "Speichern, liken, abonnieren – überall"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe?"
@@ -3492,6 +3516,10 @@ msgstr "Persönliche Daten"
 msgid "on Leaflet"
 msgstr "auf Leaflet"
 
+#: src/components/reader/about-view.tsx
+msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save, and take all of it with you, wherever you choose to read next."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 #: src/components/user-settings-view.tsx
 msgid "Not now"
@@ -3609,8 +3637,8 @@ msgid "Loading…"
 msgstr "Wird geladen …"
 
 #: src/components/reader/about-view.tsx
-msgid "Choose body text size, column width, and font — serif, sans, or any Google Font. Read the way that’s easy on your eyes."
-msgstr "Wählen Sie Textgröße, Spaltenbreite und Schrift – Serif, Sans oder jede Google Font. Lesen Sie so, wie es Ihren Augen guttut."
+#~ msgid "Choose body text size, column width, and font — serif, sans, or any Google Font. Read the way that’s easy on your eyes."
+#~ msgstr "Wählen Sie Textgröße, Spaltenbreite und Schrift – Serif, Sans oder jede Google Font. Lesen Sie so, wie es Ihren Augen guttut."
 
 #: src/routes/_layout.u.$did.tsx
 msgid "{name} hasn't started reading or publishing here. You can find them on Bluesky."
@@ -3892,6 +3920,10 @@ msgid "Unfollow?"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
+msgid "Build named, shareable lists of publications: a playlist for reading. Anyone can add your list to their own reader in a single tap."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
 msgid "Listen to anything"
 msgstr "Alles anhören"
 
@@ -3949,6 +3981,10 @@ msgstr "Artikel, die Sie im Netzwerk empfohlen haben."
 #: src/routes/_layout.feedback.return.tsx
 msgid "View feedback"
 msgstr "Feedback ansehen"
+
+#: src/components/reader/about-view.tsx
+msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave, and you can preview exactly what it looks like before you ever turn it on."
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "All caught up"
@@ -4189,8 +4225,8 @@ msgid "The core / new frameworks"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written — no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
-msgstr "Abonnieren Sie die Publikationen auf <0>standard.site</0>, die Ihnen wichtig sind. Neue Texte kommen einfach an, in der Reihenfolge, in der sie geschrieben wurden – kein Feed, gegen den man ankämpfen muss, nichts, was nach Ihrer Aufmerksamkeit schreit. Nur gute lange Texte und ein wirklich schöner Weg, immer mehr davon zu finden."
+#~ msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written — no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
+#~ msgstr "Abonnieren Sie die Publikationen auf <0>standard.site</0>, die Ihnen wichtig sind. Neue Texte kommen einfach an, in der Reihenfolge, in der sie geschrieben wurden – kein Feed, gegen den man ankämpfen muss, nichts, was nach Ihrer Aufmerksamkeit schreit. Nur gute lange Texte und ein wirklich schöner Weg, immer mehr davon zu finden."
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Save"
@@ -4273,6 +4309,10 @@ msgstr "Ihr Home-Feed ist noch leer – schauen Sie bei „Entdecken“ vorbei, 
 msgid "Articles"
 msgstr "Artikel"
 
+#: src/components/reader/about-view.tsx
+msgid "Under each article you see the discussion from across the open network: Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Leave a review"
 msgstr "Bewertung schreiben"
@@ -4322,8 +4362,8 @@ msgid "Settings"
 msgstr "Einstellungen"
 
 #: src/components/reader/about-view.tsx
-msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
-msgstr "Eine schlanke Browser-Erweiterung lässt Sie Publikationen speichern und abonnieren, während Sie im Web unterwegs sind – mit dezenten Badges auf bsky.app und einem Overlay mit einem Klick auf jeder Seite. Ihre Leseliste füllt sich von selbst."
+#~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+#~ msgstr "Eine schlanke Browser-Erweiterung lässt Sie Publikationen speichern und abonnieren, während Sie im Web unterwegs sind – mit dezenten Badges auf bsky.app und einem Overlay mit einem Klick auf jeder Seite. Ihre Leseliste füllt sich von selbst."
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -4389,6 +4429,10 @@ msgstr "Artikel lesen"
 msgid "Terms of service"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "<0>{countLabel}</0> publications indexed, and counting"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Delete all reading history?"
 msgstr "Gesamten Leseverlauf löschen?"
@@ -4445,6 +4489,10 @@ msgstr "Pausiert"
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "Details"
+
+#: src/components/reader/about-view.tsx
+msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web, with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "When you save or follow from the extension, {SITE_NAME} writes AT Protocol records to <0>your</0> repository through the same server paths as the web app. Those records follow the network's visibility rules and your account settings."
@@ -4517,8 +4565,8 @@ msgid "Open any article while signed in and it'll show up here. Your history liv
 msgstr "Öffnen Sie angemeldet einen beliebigen Artikel und er erscheint hier. Ihr Verlauf liegt als <0>app.standard-reader.read</0>-Records in Ihrem Repo."
 
 #: src/components/reader/about-view.tsx
-msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
-msgstr "Erstellen Sie benannte, teilbare Listen von Publikationen — eine Playlist zum Lesen. Jeder kann Ihre Liste mit einem Tipp in den eigenen Reader übernehmen."
+#~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
+#~ msgstr "Erstellen Sie benannte, teilbare Listen von Publikationen — eine Playlist zum Lesen. Jeder kann Ihre Liste mit einem Tipp in den eigenen Reader übernehmen."
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
@@ -4593,6 +4641,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Labelers"
 msgstr "Labeler"
+
+#: src/components/reader/about-view.tsx
+msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written: no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
+msgstr ""
 
 #: src/components/reader/language-dialog.tsx
 msgid "Choose your language"
@@ -4996,6 +5048,10 @@ msgstr "In Margin speichern…"
 msgid "{minutes} min"
 msgstr "{minutes} Min."
 
+#: src/components/reader/about-view.tsx
+msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it, and stays a good citizen of the wider network."
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Landscape"
 msgstr "Querformat"
@@ -5044,8 +5100,8 @@ msgid "Opening the issue…"
 msgstr "Ausgabe wird geöffnet…"
 
 #: src/components/reader/about-view.tsx
-msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
-msgstr "Sie müssen den Rest des Webs nicht hinter sich lassen. Der Reader greift danach — und bleibt ein guter Bürger im weiteren Netzwerk."
+#~ msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+#~ msgstr "Sie müssen den Rest des Webs nicht hinter sich lassen. Der Reader greift danach — und bleibt ein guter Bürger im weiteren Netzwerk."
 
 #: src/routes/_layout.collections.edit.$rkey.tsx
 msgid "We couldn’t load that collection to edit."
@@ -5177,6 +5233,10 @@ msgstr "Link"
 #: src/components/reader/collection-publication-editor.tsx
 msgid "Save series"
 msgstr "Reihe speichern"
+
+#: src/components/reader/about-view.tsx
+msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed: pipe it straight into whatever reader you already use."
+msgstr ""
 
 #: src/components/labelers-settings-view.tsx
 msgid "No labelers match “{searchTrim}”."
@@ -5326,6 +5386,10 @@ msgstr "{connectionLabel} über Semble"
 
 #: src/components/appearance-settings.tsx
 msgid "S"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Publications, lists, and collections each get a clean link with a rich preview card, plus a subscribe button a publication can drop on its own site."
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -134,6 +134,10 @@ msgstr ""
 msgid "The {SITE_NAME} browser extension helps you save articles and follow publications on the standard.site network from any tab. It connects to the same account as the web app at <0>{siteHost}</0>. This policy covers the extension only; the <1>site privacy policy</1> describes data handling on the website itself."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Save, like, subscribe: everywhere"
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Change language"
@@ -256,6 +260,10 @@ msgstr ""
 msgid "Density"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Choose body text size, column width, and font: serif, sans, or any Google Font. Read the way that’s easy on your eyes."
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Open on publication"
 msgstr ""
@@ -265,8 +273,8 @@ msgid "(this is what Standard Reader itself uses)"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
-msgstr ""
+#~ msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+#~ msgstr ""
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "running…"
@@ -365,8 +373,8 @@ msgid "Set these now, or change them any time in Settings."
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
-msgstr ""
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
+#~ msgstr ""
 
 #: src/routes/_layout.collections.index.tsx
 msgid "Name your series & pick a theme"
@@ -769,6 +777,10 @@ msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "We couldn’t find that list."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network, not just the handful you've heard of."
 msgstr ""
 
 #: src/components/NavbarAuth.tsx
@@ -1363,8 +1375,8 @@ msgid "You're subscribed to every publication on this page — scroll for more, 
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
-msgstr ""
+#~ msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+#~ msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "Show all subscriptions"
@@ -1405,8 +1417,8 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
-msgstr ""
+#~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
+#~ msgstr ""
 
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Search topics"
@@ -1548,8 +1560,8 @@ msgid "Something went wrong while submitting your feedback."
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
-msgstr ""
+#~ msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
+#~ msgstr ""
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/collection-builder.tsx
@@ -1644,6 +1656,10 @@ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Today"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere (the open network beyond this app), gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
 msgstr ""
 
 #: src/components/labeler-detail-view.tsx
@@ -1805,6 +1821,10 @@ msgstr ""
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network, not just the handful you've heard of."
+msgstr ""
+
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -1880,6 +1900,10 @@ msgstr ""
 #: src/components/docs/publishing-docs-page.tsx
 #: src/components/reader/about-view.tsx
 msgid "Discovery"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app; it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
 msgstr ""
 
 #. placeholder {0}: selected.count
@@ -2069,8 +2093,8 @@ msgid "Subscribe to a few publications or follow some people, and their latest w
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save — and take all of it with you, wherever you choose to read next."
-msgstr ""
+#~ msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save — and take all of it with you, wherever you choose to read next."
+#~ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "Remove {itemTitle}"
@@ -2087,8 +2111,8 @@ msgid "{0, plural, one {follower} other {followers}}"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
-msgstr ""
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labels"
@@ -2627,8 +2651,8 @@ msgid "Large"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
-msgstr ""
+#~ msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
+#~ msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Something went wrong while preparing your review."
@@ -3029,8 +3053,8 @@ msgid "Select a tag"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "<0>{countLabel}</0> publications indexed — and counting"
-msgstr ""
+#~ msgid "<0>{countLabel}</0> publications indexed — and counting"
+#~ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "{newCount} new"
@@ -3220,8 +3244,8 @@ msgid "Browse publications"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
-msgstr ""
+#~ msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
+#~ msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Choose images"
@@ -3362,8 +3386,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Save, like, subscribe — everywhere"
-msgstr ""
+#~ msgid "Save, like, subscribe — everywhere"
+#~ msgstr ""
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe?"
@@ -3492,6 +3516,10 @@ msgstr ""
 msgid "on Leaflet"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save, and take all of it with you, wherever you choose to read next."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 #: src/components/user-settings-view.tsx
 msgid "Not now"
@@ -3609,8 +3637,8 @@ msgid "Loading…"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Choose body text size, column width, and font — serif, sans, or any Google Font. Read the way that’s easy on your eyes."
-msgstr ""
+#~ msgid "Choose body text size, column width, and font — serif, sans, or any Google Font. Read the way that’s easy on your eyes."
+#~ msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
 msgid "{name} hasn't started reading or publishing here. You can find them on Bluesky."
@@ -3892,6 +3920,10 @@ msgid "Unfollow?"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
+msgid "Build named, shareable lists of publications: a playlist for reading. Anyone can add your list to their own reader in a single tap."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
 msgid "Listen to anything"
 msgstr ""
 
@@ -3948,6 +3980,10 @@ msgstr ""
 
 #: src/routes/_layout.feedback.return.tsx
 msgid "View feedback"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave, and you can preview exactly what it looks like before you ever turn it on."
 msgstr ""
 
 #: src/routes/_layout.latest.tsx
@@ -4189,8 +4225,8 @@ msgid "The core / new frameworks"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written — no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
-msgstr ""
+#~ msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written — no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
+#~ msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Save"
@@ -4273,6 +4309,10 @@ msgstr ""
 msgid "Articles"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Under each article you see the discussion from across the open network: Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Leave a review"
 msgstr ""
@@ -4322,8 +4362,8 @@ msgid "Settings"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
-msgstr ""
+#~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+#~ msgstr ""
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -4389,6 +4429,10 @@ msgstr ""
 msgid "Terms of service"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "<0>{countLabel}</0> publications indexed, and counting"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Delete all reading history?"
 msgstr ""
@@ -4444,6 +4488,10 @@ msgstr ""
 
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web, with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
 msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
@@ -4517,8 +4565,8 @@ msgid "Open any article while signed in and it'll show up here. Your history liv
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
-msgstr ""
+#~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
+#~ msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
@@ -4592,6 +4640,10 @@ msgstr ""
 #: src/components/reader/app-shell.tsx
 #: src/components/user-settings-view.tsx
 msgid "Labelers"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written: no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
 msgstr ""
 
 #: src/components/reader/language-dialog.tsx
@@ -4996,6 +5048,10 @@ msgstr ""
 msgid "{minutes} min"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it, and stays a good citizen of the wider network."
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Landscape"
 msgstr ""
@@ -5044,8 +5100,8 @@ msgid "Opening the issue…"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
-msgstr ""
+#~ msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+#~ msgstr ""
 
 #: src/routes/_layout.collections.edit.$rkey.tsx
 msgid "We couldn’t load that collection to edit."
@@ -5176,6 +5232,10 @@ msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
 msgid "Save series"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed: pipe it straight into whatever reader you already use."
 msgstr ""
 
 #: src/components/labelers-settings-view.tsx
@@ -5326,6 +5386,10 @@ msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "S"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Publications, lists, and collections each get a clean link with a rich preview card, plus a subscribe button a publication can drop on its own site."
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -134,6 +134,10 @@ msgstr "Remove icon"
 msgid "The {SITE_NAME} browser extension helps you save articles and follow publications on the standard.site network from any tab. It connects to the same account as the web app at <0>{siteHost}</0>. This policy covers the extension only; the <1>site privacy policy</1> describes data handling on the website itself."
 msgstr "The {SITE_NAME} browser extension helps you save articles and follow publications on the standard.site network from any tab. It connects to the same account as the web app at <0>{siteHost}</0>. This policy covers the extension only; the <1>site privacy policy</1> describes data handling on the website itself."
 
+#: src/components/reader/about-view.tsx
+msgid "Save, like, subscribe: everywhere"
+msgstr "Save, like, subscribe: everywhere"
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Change language"
@@ -256,6 +260,10 @@ msgstr "Opening the collection…"
 msgid "Density"
 msgstr "Density"
 
+#: src/components/reader/about-view.tsx
+msgid "Choose body text size, column width, and font: serif, sans, or any Google Font. Read the way that’s easy on your eyes."
+msgstr "Choose body text size, column width, and font: serif, sans, or any Google Font. Read the way that’s easy on your eyes."
+
 #: src/components/reader/article-view.tsx
 msgid "Open on publication"
 msgstr "Open on publication"
@@ -265,8 +273,8 @@ msgid "(this is what Standard Reader itself uses)"
 msgstr "(this is what Standard Reader itself uses)"
 
 #: src/components/reader/about-view.tsx
-msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
-msgstr "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+#~ msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+#~ msgstr "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "running…"
@@ -365,8 +373,8 @@ msgid "Set these now, or change them any time in Settings."
 msgstr "Set these now, or change them any time in Settings."
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
-msgstr "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
+#~ msgstr "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
 
 #: src/routes/_layout.collections.index.tsx
 msgid "Name your series & pick a theme"
@@ -770,6 +778,10 @@ msgstr "Where data lives"
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "We couldn’t find that list."
 msgstr "We couldn’t find that list."
+
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network, not just the handful you've heard of."
+msgstr "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network, not just the handful you've heard of."
 
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/mention-hover-card.tsx
@@ -1363,8 +1375,8 @@ msgid "You're subscribed to every publication on this page — scroll for more, 
 msgstr "You're subscribed to every publication on this page — scroll for more, or turn off the filter."
 
 #: src/components/reader/about-view.tsx
-msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
-msgstr "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+#~ msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+#~ msgstr "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
 
 #: src/routes/_layout.latest.tsx
 msgid "Show all subscriptions"
@@ -1405,8 +1417,8 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {# match} other {# matches}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
-msgstr "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
+#~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
+#~ msgstr "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
 
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Search topics"
@@ -1548,8 +1560,8 @@ msgid "Something went wrong while submitting your feedback."
 msgstr "Something went wrong while submitting your feedback."
 
 #: src/components/reader/about-view.tsx
-msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
-msgstr "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
+#~ msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
+#~ msgstr "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/collection-builder.tsx
@@ -1645,6 +1657,10 @@ msgstr "Site"
 #: src/routes/_layout.index.tsx
 msgid "Today"
 msgstr "Today"
+
+#: src/components/reader/about-view.tsx
+msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere (the open network beyond this app), gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+msgstr "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere (the open network beyond this app), gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/reader/cards.tsx
@@ -1805,6 +1821,10 @@ msgstr "Powered by Standard Reader"
 msgid "Clear selection"
 msgstr "Clear selection"
 
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network, not just the handful you've heard of."
+msgstr "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network, not just the handful you've heard of."
+
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -1881,6 +1901,10 @@ msgstr "To email your digest, Standard Reader needs your account email address. 
 #: src/components/reader/about-view.tsx
 msgid "Discovery"
 msgstr "Discovery"
+
+#: src/components/reader/about-view.tsx
+msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app; it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
+msgstr "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app; it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
 
 #. placeholder {0}: selected.count
 #: src/components/reader/subscriptions-table.tsx
@@ -2069,8 +2093,8 @@ msgid "Subscribe to a few publications or follow some people, and their latest w
 msgstr "Subscribe to a few publications or follow some people, and their latest writing and recommendations will collect here."
 
 #: src/components/reader/about-view.tsx
-msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save — and take all of it with you, wherever you choose to read next."
-msgstr "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save — and take all of it with you, wherever you choose to read next."
+#~ msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save — and take all of it with you, wherever you choose to read next."
+#~ msgstr "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save — and take all of it with you, wherever you choose to read next."
 
 #: src/components/reader/collection-builder.tsx
 msgid "Remove {itemTitle}"
@@ -2087,8 +2111,8 @@ msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {follower} other {followers}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
-msgstr "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgstr "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labels"
@@ -2627,8 +2651,8 @@ msgid "Large"
 msgstr "Large"
 
 #: src/components/reader/about-view.tsx
-msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
-msgstr "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
+#~ msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
+#~ msgstr "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Something went wrong while preparing your review."
@@ -3029,8 +3053,8 @@ msgid "Select a tag"
 msgstr "Select a tag"
 
 #: src/components/reader/about-view.tsx
-msgid "<0>{countLabel}</0> publications indexed — and counting"
-msgstr "<0>{countLabel}</0> publications indexed — and counting"
+#~ msgid "<0>{countLabel}</0> publications indexed — and counting"
+#~ msgstr "<0>{countLabel}</0> publications indexed — and counting"
 
 #: src/routes/_layout.index.tsx
 msgid "{newCount} new"
@@ -3220,8 +3244,8 @@ msgid "Browse publications"
 msgstr "Browse publications"
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
-msgstr "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
+#~ msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
+#~ msgstr "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
 
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Choose images"
@@ -3362,8 +3386,8 @@ msgstr "Publish AT Protocol labels that Standard Reader shows — and can warn o
 #~ msgstr "The exact override mechanism is idiomatic per framework — a components object of functions in React, Vue and Solid, <0>lit-html</0> templates in Lit, snippets in Svelte, or <1><ng-template></1> refs in Angular — but the split and the vocabulary are the same everywhere. See each package's README for the framework-specific shape."
 
 #: src/components/reader/about-view.tsx
-msgid "Save, like, subscribe — everywhere"
-msgstr "Save, like, subscribe — everywhere"
+#~ msgid "Save, like, subscribe — everywhere"
+#~ msgstr "Save, like, subscribe — everywhere"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe?"
@@ -3492,6 +3516,10 @@ msgstr "Personal data"
 msgid "on Leaflet"
 msgstr "on Leaflet"
 
+#: src/components/reader/about-view.tsx
+msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save, and take all of it with you, wherever you choose to read next."
+msgstr "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save, and take all of it with you, wherever you choose to read next."
+
 #: src/components/reader/collections-upgrade-gate.tsx
 #: src/components/user-settings-view.tsx
 msgid "Not now"
@@ -3609,8 +3637,8 @@ msgid "Loading…"
 msgstr "Loading…"
 
 #: src/components/reader/about-view.tsx
-msgid "Choose body text size, column width, and font — serif, sans, or any Google Font. Read the way that’s easy on your eyes."
-msgstr "Choose body text size, column width, and font — serif, sans, or any Google Font. Read the way that’s easy on your eyes."
+#~ msgid "Choose body text size, column width, and font — serif, sans, or any Google Font. Read the way that’s easy on your eyes."
+#~ msgstr "Choose body text size, column width, and font — serif, sans, or any Google Font. Read the way that’s easy on your eyes."
 
 #: src/routes/_layout.u.$did.tsx
 msgid "{name} hasn't started reading or publishing here. You can find them on Bluesky."
@@ -3892,6 +3920,10 @@ msgid "Unfollow?"
 msgstr "Unfollow?"
 
 #: src/components/reader/about-view.tsx
+msgid "Build named, shareable lists of publications: a playlist for reading. Anyone can add your list to their own reader in a single tap."
+msgstr "Build named, shareable lists of publications: a playlist for reading. Anyone can add your list to their own reader in a single tap."
+
+#: src/components/reader/about-view.tsx
 msgid "Listen to anything"
 msgstr "Listen to anything"
 
@@ -3949,6 +3981,10 @@ msgstr "Articles you've recommended across the network."
 #: src/routes/_layout.feedback.return.tsx
 msgid "View feedback"
 msgstr "View feedback"
+
+#: src/components/reader/about-view.tsx
+msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave, and you can preview exactly what it looks like before you ever turn it on."
+msgstr "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave, and you can preview exactly what it looks like before you ever turn it on."
 
 #: src/routes/_layout.latest.tsx
 msgid "All caught up"
@@ -4189,8 +4225,8 @@ msgid "The core / new frameworks"
 msgstr "The core / new frameworks"
 
 #: src/components/reader/about-view.tsx
-msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written — no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
-msgstr "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written — no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
+#~ msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written — no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
+#~ msgstr "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written — no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Save"
@@ -4273,6 +4309,10 @@ msgstr "Your Home feed is empty for now — head to Discover whenever you're rea
 msgid "Articles"
 msgstr "Articles"
 
+#: src/components/reader/about-view.tsx
+msgid "Under each article you see the discussion from across the open network: Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+msgstr "Under each article you see the discussion from across the open network: Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Leave a review"
 msgstr "Leave a review"
@@ -4322,8 +4362,8 @@ msgid "Settings"
 msgstr "Settings"
 
 #: src/components/reader/about-view.tsx
-msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
-msgstr "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+#~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+#~ msgstr "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -4389,6 +4429,10 @@ msgstr "Read article"
 msgid "Terms of service"
 msgstr "Terms of service"
 
+#: src/components/reader/about-view.tsx
+msgid "<0>{countLabel}</0> publications indexed, and counting"
+msgstr "<0>{countLabel}</0> publications indexed, and counting"
+
 #: src/components/user-settings-view.tsx
 msgid "Delete all reading history?"
 msgstr "Delete all reading history?"
@@ -4445,6 +4489,10 @@ msgstr "Paused"
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "Details"
+
+#: src/components/reader/about-view.tsx
+msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web, with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+msgstr "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web, with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "When you save or follow from the extension, {SITE_NAME} writes AT Protocol records to <0>your</0> repository through the same server paths as the web app. Those records follow the network's visibility rules and your account settings."
@@ -4517,8 +4565,8 @@ msgid "Open any article while signed in and it'll show up here. Your history liv
 msgstr "Open any article while signed in and it'll show up here. Your history lives in your repo as <0>app.standard-reader.read</0> records."
 
 #: src/components/reader/about-view.tsx
-msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
-msgstr "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
+#~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
+#~ msgstr "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
@@ -4593,6 +4641,10 @@ msgstr "Uploading images…"
 #: src/components/user-settings-view.tsx
 msgid "Labelers"
 msgstr "Labelers"
+
+#: src/components/reader/about-view.tsx
+msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written: no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
+msgstr "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written: no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
 
 #: src/components/reader/language-dialog.tsx
 msgid "Choose your language"
@@ -4996,6 +5048,10 @@ msgstr "Save to Margin…"
 msgid "{minutes} min"
 msgstr "{minutes} min"
 
+#: src/components/reader/about-view.tsx
+msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it, and stays a good citizen of the wider network."
+msgstr "It doesn't ask you to leave the rest of the web behind. It reaches out to it, and stays a good citizen of the wider network."
+
 #: src/components/reader/share-menu.tsx
 msgid "Landscape"
 msgstr "Landscape"
@@ -5044,8 +5100,8 @@ msgid "Opening the issue…"
 msgstr "Opening the issue…"
 
 #: src/components/reader/about-view.tsx
-msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
-msgstr "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+#~ msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+#~ msgstr "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
 
 #: src/routes/_layout.collections.edit.$rkey.tsx
 msgid "We couldn’t load that collection to edit."
@@ -5177,6 +5233,10 @@ msgstr "Link"
 #: src/components/reader/collection-publication-editor.tsx
 msgid "Save series"
 msgstr "Save series"
+
+#: src/components/reader/about-view.tsx
+msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed: pipe it straight into whatever reader you already use."
+msgstr "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed: pipe it straight into whatever reader you already use."
 
 #: src/components/labelers-settings-view.tsx
 msgid "No labelers match “{searchTrim}”."
@@ -5327,6 +5387,10 @@ msgstr "{connectionLabel} via Semble"
 #: src/components/appearance-settings.tsx
 msgid "S"
 msgstr "S"
+
+#: src/components/reader/about-view.tsx
+msgid "Publications, lists, and collections each get a clean link with a rich preview card, plus a subscribe button a publication can drop on its own site."
+msgstr "Publications, lists, and collections each get a clean link with a rich preview card, plus a subscribe button a publication can drop on its own site."
 
 #: src/routes/mcp/authorize.tsx
 msgid "Signed in as"

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -134,6 +134,10 @@ msgstr "Quitar icono"
 msgid "The {SITE_NAME} browser extension helps you save articles and follow publications on the standard.site network from any tab. It connects to the same account as the web app at <0>{siteHost}</0>. This policy covers the extension only; the <1>site privacy policy</1> describes data handling on the website itself."
 msgstr "La extensión de navegador de {SITE_NAME} le ayuda a guardar artículos y seguir publicaciones de la red standard.site desde cualquier pestaña. Se conecta a la misma cuenta que la app web en <0>{siteHost}</0>. Esta política cubre solo la extensión; la <1>política de privacidad del sitio</1> describe el tratamiento de datos en el sitio web."
 
+#: src/components/reader/about-view.tsx
+msgid "Save, like, subscribe: everywhere"
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Change language"
@@ -256,6 +260,10 @@ msgstr "Abriendo la colección…"
 msgid "Density"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Choose body text size, column width, and font: serif, sans, or any Google Font. Read the way that’s easy on your eyes."
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Open on publication"
 msgstr "Abrir en la publicación"
@@ -265,8 +273,8 @@ msgid "(this is what Standard Reader itself uses)"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
-msgstr "Y nunca se siente aislado. Conectamos cada artículo con la conversación que ocurre en la Atmosphere —la red abierta más allá de esta app—, reuniendo los posts y respuestas de Bluesky sobre una pieza, las notas dejadas en sus márgenes y los demás textos que la citan, discretamente bajo lo que está leyendo."
+#~ msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+#~ msgstr "Y nunca se siente aislado. Conectamos cada artículo con la conversación que ocurre en la Atmosphere —la red abierta más allá de esta app—, reuniendo los posts y respuestas de Bluesky sobre una pieza, las notas dejadas en sus márgenes y los demás textos que la citan, discretamente bajo lo que está leyendo."
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "running…"
@@ -365,8 +373,8 @@ msgid "Set these now, or change them any time in Settings."
 msgstr "Configúrelos ahora o cámbielos cuando quiera en Configuración."
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
-msgstr "La mayoría de los lectores se quedan en lo que ya siguen. Standard Reader considera que encontrar su próximo favorito es parte del trabajo. Explore todas las publicaciones de la red, no solo el puñado del que ya ha oído hablar."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
+#~ msgstr "La mayoría de los lectores se quedan en lo que ya siguen. Standard Reader considera que encontrar su próximo favorito es parte del trabajo. Explore todas las publicaciones de la red, no solo el puñado del que ya ha oído hablar."
 
 #: src/routes/_layout.collections.index.tsx
 msgid "Name your series & pick a theme"
@@ -770,6 +778,10 @@ msgstr "Dónde viven los datos"
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "We couldn’t find that list."
 msgstr "No encontramos esa lista."
+
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network, not just the handful you've heard of."
+msgstr ""
 
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/mention-hover-card.tsx
@@ -1363,8 +1375,8 @@ msgid "You're subscribed to every publication on this page — scroll for more, 
 msgstr "Está suscrito a todas las publicaciones de esta página: siga desplazándose para ver más o desactive el filtro."
 
 #: src/components/reader/about-view.tsx
-msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
-msgstr "Debajo de cada artículo verá la conversación de toda la red abierta: publicaciones y respuestas de Bluesky, notas al margen, enlaces desde otros textos que lo citan y lecturas relacionadas. Todo de solo lectura y todo enlazado a la fuente."
+#~ msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+#~ msgstr "Debajo de cada artículo verá la conversación de toda la red abierta: publicaciones y respuestas de Bluesky, notas al margen, enlaces desde otros textos que lo citan y lecturas relacionadas. Todo de solo lectura y todo enlazado a la fuente."
 
 #: src/routes/_layout.latest.tsx
 msgid "Show all subscriptions"
@@ -1405,8 +1417,8 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {# coincidencia} other {# coincidencias}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
-msgstr "Las publicaciones, las listas y las colecciones tienen cada una un enlace limpio con una tarjeta de vista previa enriquecida, además de un botón de suscripción que una publicación puede colocar en su propio sitio."
+#~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
+#~ msgstr "Las publicaciones, las listas y las colecciones tienen cada una un enlace limpio con una tarjeta de vista previa enriquecida, además de un botón de suscripción que una publicación puede colocar en su propio sitio."
 
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Search topics"
@@ -1548,8 +1560,8 @@ msgid "Something went wrong while submitting your feedback."
 msgstr "Algo salió mal al enviar su comentario."
 
 #: src/components/reader/about-view.tsx
-msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
-msgstr "¿No quiere otra aplicación más que revisar? Suscríbase a un correo semanal con lo mejor de las publicaciones que sigue, más un par que vale la pena descubrir. Un correo, un clic para darse de baja, y puede ver exactamente cómo se ve antes de activarlo."
+#~ msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
+#~ msgstr "¿No quiere otra aplicación más que revisar? Suscríbase a un correo semanal con lo mejor de las publicaciones que sigue, más un par que vale la pena descubrir. Un correo, un clic para darse de baja, y puede ver exactamente cómo se ve antes de activarlo."
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/collection-builder.tsx
@@ -1645,6 +1657,10 @@ msgstr "Sitio"
 #: src/routes/_layout.index.tsx
 msgid "Today"
 msgstr "Hoy"
+
+#: src/components/reader/about-view.tsx
+msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere (the open network beyond this app), gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/reader/cards.tsx
@@ -1805,6 +1821,10 @@ msgstr "Con la tecnología de Standard Reader"
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network, not just the handful you've heard of."
+msgstr ""
+
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -1881,6 +1901,10 @@ msgstr "Para enviarle su resumen por correo, Standard Reader necesita la direcci
 #: src/components/reader/about-view.tsx
 msgid "Discovery"
 msgstr "Descubrimiento"
+
+#: src/components/reader/about-view.tsx
+msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app; it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
+msgstr ""
 
 #. placeholder {0}: selected.count
 #: src/components/reader/subscriptions-table.tsx
@@ -2069,8 +2093,8 @@ msgid "Subscribe to a few publications or follow some people, and their latest w
 msgstr "Suscríbase a algunas publicaciones o siga a algunas personas, y sus textos y recomendaciones más recientes se reunirán aquí."
 
 #: src/components/reader/about-view.tsx
-msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save — and take all of it with you, wherever you choose to read next."
-msgstr "Lea sin cuenta. Inicie sesión con Bluesky cuando quiera suscribirse, dar me gusta y guardar, y llévese todo consigo, dondequiera que elija leer después."
+#~ msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save — and take all of it with you, wherever you choose to read next."
+#~ msgstr "Lea sin cuenta. Inicie sesión con Bluesky cuando quiera suscribirse, dar me gusta y guardar, y llévese todo consigo, dondequiera que elija leer después."
 
 #: src/components/reader/collection-builder.tsx
 msgid "Remove {itemTitle}"
@@ -2087,8 +2111,8 @@ msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {seguidor} other {seguidores}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
-msgstr "La mayoría de los lectores se quedan en lo que ya siguen. Standard Reader considera que encontrar su próximo favorito es parte del trabajo. Explore las {countLabel} publicaciones de la red, no solo el puñado del que ha oído hablar."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgstr "La mayoría de los lectores se quedan en lo que ya siguen. Standard Reader considera que encontrar su próximo favorito es parte del trabajo. Explore las {countLabel} publicaciones de la red, no solo el puñado del que ha oído hablar."
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labels"
@@ -2627,8 +2651,8 @@ msgid "Large"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
-msgstr "Un botón de Escuchar lee cualquier artículo en voz alta, directamente en su dispositivo, y resalta cada palabra a su paso. El reproductor le acompaña por toda la app e incluso lee una entrada incrustada de Bluesky. Con la sesión iniciada, puede elegir una voz."
+#~ msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
+#~ msgstr "Un botón de Escuchar lee cualquier artículo en voz alta, directamente en su dispositivo, y resalta cada palabra a su paso. El reproductor le acompaña por toda la app e incluso lee una entrada incrustada de Bluesky. Con la sesión iniciada, puede elegir una voz."
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Something went wrong while preparing your review."
@@ -3029,8 +3053,8 @@ msgid "Select a tag"
 msgstr "Seleccionar una etiqueta"
 
 #: src/components/reader/about-view.tsx
-msgid "<0>{countLabel}</0> publications indexed — and counting"
-msgstr "<0>{countLabel}</0> publicaciones indexadas, y subiendo"
+#~ msgid "<0>{countLabel}</0> publications indexed — and counting"
+#~ msgstr "<0>{countLabel}</0> publicaciones indexadas, y subiendo"
 
 #: src/routes/_layout.index.tsx
 msgid "{newCount} new"
@@ -3220,8 +3244,8 @@ msgid "Browse publications"
 msgstr "Explorar publicaciones"
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
-msgstr "Standard Reader no encierra su lectura en una sola app. Cualquier parte de la red viene con su propio feed RSS: conéctelo directamente al lector que ya usa."
+#~ msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
+#~ msgstr "Standard Reader no encierra su lectura en una sola app. Cualquier parte de la red viene con su propio feed RSS: conéctelo directamente al lector que ya usa."
 
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Choose images"
@@ -3362,8 +3386,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Save, like, subscribe — everywhere"
-msgstr "Guardar, dar me gusta, suscribirse: en todas partes"
+#~ msgid "Save, like, subscribe — everywhere"
+#~ msgstr "Guardar, dar me gusta, suscribirse: en todas partes"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe?"
@@ -3492,6 +3516,10 @@ msgstr "Datos personales"
 msgid "on Leaflet"
 msgstr "en Leaflet"
 
+#: src/components/reader/about-view.tsx
+msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save, and take all of it with you, wherever you choose to read next."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 #: src/components/user-settings-view.tsx
 msgid "Not now"
@@ -3609,8 +3637,8 @@ msgid "Loading…"
 msgstr "Cargando…"
 
 #: src/components/reader/about-view.tsx
-msgid "Choose body text size, column width, and font — serif, sans, or any Google Font. Read the way that’s easy on your eyes."
-msgstr "Elija el tamaño del texto, el ancho de columna y la fuente: serif, sans o cualquier Google Font. Lea de la forma más cómoda para sus ojos."
+#~ msgid "Choose body text size, column width, and font — serif, sans, or any Google Font. Read the way that’s easy on your eyes."
+#~ msgstr "Elija el tamaño del texto, el ancho de columna y la fuente: serif, sans o cualquier Google Font. Lea de la forma más cómoda para sus ojos."
 
 #: src/routes/_layout.u.$did.tsx
 msgid "{name} hasn't started reading or publishing here. You can find them on Bluesky."
@@ -3892,6 +3920,10 @@ msgid "Unfollow?"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
+msgid "Build named, shareable lists of publications: a playlist for reading. Anyone can add your list to their own reader in a single tap."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
 msgid "Listen to anything"
 msgstr "Escuche lo que sea"
 
@@ -3949,6 +3981,10 @@ msgstr "Artículos que ha recomendado en la red."
 #: src/routes/_layout.feedback.return.tsx
 msgid "View feedback"
 msgstr "Ver comentarios"
+
+#: src/components/reader/about-view.tsx
+msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave, and you can preview exactly what it looks like before you ever turn it on."
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "All caught up"
@@ -4189,8 +4225,8 @@ msgid "The core / new frameworks"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written — no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
-msgstr "Suscríbase a las publicaciones de <0>standard.site</0> que le interesen. Los textos nuevos simplemente llegan, en el orden en que se escribieron: sin un feed contra el que pelear, sin nada que grite por su atención. Solo buen contenido largo y una manera realmente agradable de seguir encontrando más."
+#~ msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written — no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
+#~ msgstr "Suscríbase a las publicaciones de <0>standard.site</0> que le interesen. Los textos nuevos simplemente llegan, en el orden en que se escribieron: sin un feed contra el que pelear, sin nada que grite por su atención. Solo buen contenido largo y una manera realmente agradable de seguir encontrando más."
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Save"
@@ -4273,6 +4309,10 @@ msgstr "Su feed de Inicio está vacío por ahora — pase por Descubrir cuando q
 msgid "Articles"
 msgstr "Artículos"
 
+#: src/components/reader/about-view.tsx
+msgid "Under each article you see the discussion from across the open network: Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Leave a review"
 msgstr "Dejar una reseña"
@@ -4322,8 +4362,8 @@ msgid "Settings"
 msgstr "Ajustes"
 
 #: src/components/reader/about-view.tsx
-msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
-msgstr "Una extensión de navegador ligera le permite guardar publicaciones y suscribirse a ellas mientras navega por la web, con distintivos sutiles en bsky.app y una superposición de un clic en cualquier página que visite. Su lista de lectura se llena sola."
+#~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+#~ msgstr "Una extensión de navegador ligera le permite guardar publicaciones y suscribirse a ellas mientras navega por la web, con distintivos sutiles en bsky.app y una superposición de un clic en cualquier página que visite. Su lista de lectura se llena sola."
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -4389,6 +4429,10 @@ msgstr "Leer artículo"
 msgid "Terms of service"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "<0>{countLabel}</0> publications indexed, and counting"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Delete all reading history?"
 msgstr "¿Eliminar todo el historial de lectura?"
@@ -4445,6 +4489,10 @@ msgstr "En pausa"
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "Detalles"
+
+#: src/components/reader/about-view.tsx
+msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web, with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "When you save or follow from the extension, {SITE_NAME} writes AT Protocol records to <0>your</0> repository through the same server paths as the web app. Those records follow the network's visibility rules and your account settings."
@@ -4517,8 +4565,8 @@ msgid "Open any article while signed in and it'll show up here. Your history liv
 msgstr "Abra cualquier artículo con la sesión iniciada y aparecerá aquí. Su historial vive en su repositorio como registros <0>app.standard-reader.read</0>."
 
 #: src/components/reader/about-view.tsx
-msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
-msgstr "Cree listas de publicaciones con nombre y fáciles de compartir: una playlist para leer. Cualquiera puede añadir su lista a su propio lector con un solo toque."
+#~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
+#~ msgstr "Cree listas de publicaciones con nombre y fáciles de compartir: una playlist para leer. Cualquiera puede añadir su lista a su propio lector con un solo toque."
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
@@ -4593,6 +4641,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Labelers"
 msgstr "Etiquetadores"
+
+#: src/components/reader/about-view.tsx
+msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written: no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
+msgstr ""
 
 #: src/components/reader/language-dialog.tsx
 msgid "Choose your language"
@@ -4996,6 +5048,10 @@ msgstr "Guardar en Margin…"
 msgid "{minutes} min"
 msgstr "{minutes} min"
 
+#: src/components/reader/about-view.tsx
+msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it, and stays a good citizen of the wider network."
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Landscape"
 msgstr "Horizontal"
@@ -5044,8 +5100,8 @@ msgid "Opening the issue…"
 msgstr "Abriendo el número…"
 
 #: src/components/reader/about-view.tsx
-msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
-msgstr "No le pide dejar atrás el resto de la web. Se acerca a ella y sigue siendo un buen ciudadano de la red en general."
+#~ msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+#~ msgstr "No le pide dejar atrás el resto de la web. Se acerca a ella y sigue siendo un buen ciudadano de la red en general."
 
 #: src/routes/_layout.collections.edit.$rkey.tsx
 msgid "We couldn’t load that collection to edit."
@@ -5177,6 +5233,10 @@ msgstr "Enlace"
 #: src/components/reader/collection-publication-editor.tsx
 msgid "Save series"
 msgstr "Guardar serie"
+
+#: src/components/reader/about-view.tsx
+msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed: pipe it straight into whatever reader you already use."
+msgstr ""
 
 #: src/components/labelers-settings-view.tsx
 msgid "No labelers match “{searchTrim}”."
@@ -5326,6 +5386,10 @@ msgstr "{connectionLabel} vía Semble"
 
 #: src/components/appearance-settings.tsx
 msgid "S"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Publications, lists, and collections each get a clean link with a rich preview card, plus a subscribe button a publication can drop on its own site."
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -134,6 +134,10 @@ msgstr "Retirer l’icône"
 msgid "The {SITE_NAME} browser extension helps you save articles and follow publications on the standard.site network from any tab. It connects to the same account as the web app at <0>{siteHost}</0>. This policy covers the extension only; the <1>site privacy policy</1> describes data handling on the website itself."
 msgstr "L’extension de navigateur {SITE_NAME} vous aide à enregistrer des articles et à suivre des publications sur le réseau standard.site depuis n’importe quel onglet. Elle utilise le même compte que l’application web sur <0>{siteHost}</0>. Cette politique ne couvre que l’extension ; la <1>politique de confidentialité du site</1> décrit le traitement des données sur le site lui-même."
 
+#: src/components/reader/about-view.tsx
+msgid "Save, like, subscribe: everywhere"
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Change language"
@@ -256,6 +260,10 @@ msgstr "Ouverture de la collection…"
 msgid "Density"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Choose body text size, column width, and font: serif, sans, or any Google Font. Read the way that’s easy on your eyes."
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Open on publication"
 msgstr "Ouvrir dans la publication"
@@ -265,8 +273,8 @@ msgid "(this is what Standard Reader itself uses)"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
-msgstr "Et rien n’y semble cloisonné. Nous relions chaque article à la conversation qui se tient dans l’Atmosphere — le réseau ouvert au-delà de cette application — en rassemblant les posts et réponses Bluesky à son sujet, les notes laissées dans ses marges et les autres textes qui le citent, discrètement sous ce que vous lisez."
+#~ msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+#~ msgstr "Et rien n’y semble cloisonné. Nous relions chaque article à la conversation qui se tient dans l’Atmosphere — le réseau ouvert au-delà de cette application — en rassemblant les posts et réponses Bluesky à son sujet, les notes laissées dans ses marges et les autres textes qui le citent, discrètement sous ce que vous lisez."
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "running…"
@@ -365,8 +373,8 @@ msgid "Set these now, or change them any time in Settings."
 msgstr "Réglez cela maintenant, ou modifiez-le à tout moment dans les Paramètres."
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
-msgstr "La plupart des lecteurs s’arrêtent à ce qu’ils suivent déjà. Standard Reader considère la découverte de votre prochain coup de cœur comme faisant partie du travail. Parcourez toutes les publications du réseau — pas seulement celles dont vous avez entendu parler."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
+#~ msgstr "La plupart des lecteurs s’arrêtent à ce qu’ils suivent déjà. Standard Reader considère la découverte de votre prochain coup de cœur comme faisant partie du travail. Parcourez toutes les publications du réseau — pas seulement celles dont vous avez entendu parler."
 
 #: src/routes/_layout.collections.index.tsx
 msgid "Name your series & pick a theme"
@@ -770,6 +778,10 @@ msgstr "Où vivent les données"
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "We couldn’t find that list."
 msgstr "Liste introuvable."
+
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network, not just the handful you've heard of."
+msgstr ""
 
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/mention-hover-card.tsx
@@ -1363,8 +1375,8 @@ msgid "You're subscribed to every publication on this page — scroll for more, 
 msgstr "Vous êtes abonné à toutes les publications de cette page — faites défiler pour en voir plus, ou désactivez le filtre."
 
 #: src/components/reader/about-view.tsx
-msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
-msgstr "Sous chaque article, vous retrouvez les discussions de tout le réseau ouvert : publications et réponses Bluesky, notes en marge, liens d'autres articles qui le citent et lectures associées. Le tout en lecture seule, avec un lien vers la source."
+#~ msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+#~ msgstr "Sous chaque article, vous retrouvez les discussions de tout le réseau ouvert : publications et réponses Bluesky, notes en marge, liens d'autres articles qui le citent et lectures associées. Le tout en lecture seule, avec un lien vers la source."
 
 #: src/routes/_layout.latest.tsx
 msgid "Show all subscriptions"
@@ -1405,8 +1417,8 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {# résultat} other {# résultats}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
-msgstr "Publications, listes et collections disposent chacune d'un lien épuré avec un aperçu enrichi — ainsi que d'un bouton d'abonnement qu'une publication peut installer sur son propre site."
+#~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
+#~ msgstr "Publications, listes et collections disposent chacune d'un lien épuré avec un aperçu enrichi — ainsi que d'un bouton d'abonnement qu'une publication peut installer sur son propre site."
 
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Search topics"
@@ -1548,8 +1560,8 @@ msgid "Something went wrong while submitting your feedback."
 msgstr "Une erreur est survenue lors de l'envoi de votre retour."
 
 #: src/components/reader/about-view.tsx
-msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
-msgstr "Pas envie d'une application de plus à consulter ? Inscrivez-vous à un e-mail hebdomadaire réunissant le meilleur des publications auxquelles vous êtes abonné, plus quelques pépites à découvrir. Un seul e-mail, un seul clic pour se désinscrire — et vous pouvez prévisualiser exactement son rendu avant même de l'activer."
+#~ msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
+#~ msgstr "Pas envie d'une application de plus à consulter ? Inscrivez-vous à un e-mail hebdomadaire réunissant le meilleur des publications auxquelles vous êtes abonné, plus quelques pépites à découvrir. Un seul e-mail, un seul clic pour se désinscrire — et vous pouvez prévisualiser exactement son rendu avant même de l'activer."
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/collection-builder.tsx
@@ -1645,6 +1657,10 @@ msgstr "Site"
 #: src/routes/_layout.index.tsx
 msgid "Today"
 msgstr "Aujourd'hui"
+
+#: src/components/reader/about-view.tsx
+msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere (the open network beyond this app), gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/reader/cards.tsx
@@ -1805,6 +1821,10 @@ msgstr "Propulsé par Standard Reader"
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network, not just the handful you've heard of."
+msgstr ""
+
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -1881,6 +1901,10 @@ msgstr "Pour vous envoyer votre digest par e-mail, Standard Reader a besoin de l
 #: src/components/reader/about-view.tsx
 msgid "Discovery"
 msgstr "Découverte"
+
+#: src/components/reader/about-view.tsx
+msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app; it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
+msgstr ""
 
 #. placeholder {0}: selected.count
 #: src/components/reader/subscriptions-table.tsx
@@ -2069,8 +2093,8 @@ msgid "Subscribe to a few publications or follow some people, and their latest w
 msgstr "Abonnez-vous à quelques publications ou suivez quelques personnes : leurs derniers textes et leurs recommandations viendront s'afficher ici."
 
 #: src/components/reader/about-view.tsx
-msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save — and take all of it with you, wherever you choose to read next."
-msgstr "Lisez sans compte. Connectez-vous avec Bluesky quand vous voulez vous abonner, aimer et enregistrer — et emportez tout avec vous, où que vous choisissiez de lire ensuite."
+#~ msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save — and take all of it with you, wherever you choose to read next."
+#~ msgstr "Lisez sans compte. Connectez-vous avec Bluesky quand vous voulez vous abonner, aimer et enregistrer — et emportez tout avec vous, où que vous choisissiez de lire ensuite."
 
 #: src/components/reader/collection-builder.tsx
 msgid "Remove {itemTitle}"
@@ -2087,8 +2111,8 @@ msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {abonné} other {abonnés}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
-msgstr "La plupart des lecteurs s'arrêtent à ce à quoi ils sont déjà abonnés. Standard Reader considère que vous aider à trouver votre prochain coup de cœur fait partie du travail. Parcourez les {countLabel} publications du réseau — pas seulement la poignée dont vous avez entendu parler."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgstr "La plupart des lecteurs s'arrêtent à ce à quoi ils sont déjà abonnés. Standard Reader considère que vous aider à trouver votre prochain coup de cœur fait partie du travail. Parcourez les {countLabel} publications du réseau — pas seulement la poignée dont vous avez entendu parler."
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labels"
@@ -2627,8 +2651,8 @@ msgid "Large"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
-msgstr "Un bouton Écouter lit n’importe quel article à voix haute, directement sur votre appareil, en surlignant chaque mot au passage. Le lecteur vous suit dans toute l’application — il lira même un post Bluesky intégré. Une fois connecté, vous pouvez choisir une voix."
+#~ msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
+#~ msgstr "Un bouton Écouter lit n’importe quel article à voix haute, directement sur votre appareil, en surlignant chaque mot au passage. Le lecteur vous suit dans toute l’application — il lira même un post Bluesky intégré. Une fois connecté, vous pouvez choisir une voix."
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Something went wrong while preparing your review."
@@ -3029,8 +3053,8 @@ msgid "Select a tag"
 msgstr "Sélectionner un mot-clé"
 
 #: src/components/reader/about-view.tsx
-msgid "<0>{countLabel}</0> publications indexed — and counting"
-msgstr "<0>{countLabel}</0> publications indexées — et ce n’est qu’un début"
+#~ msgid "<0>{countLabel}</0> publications indexed — and counting"
+#~ msgstr "<0>{countLabel}</0> publications indexées — et ce n’est qu’un début"
 
 #: src/routes/_layout.index.tsx
 msgid "{newCount} new"
@@ -3220,8 +3244,8 @@ msgid "Browse publications"
 msgstr "Parcourir les publications"
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
-msgstr "Standard Reader n’enferme pas votre lecture dans une seule application. Chaque partie du réseau dispose de son propre flux RSS — branchez-le directement sur le lecteur que vous utilisez déjà."
+#~ msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
+#~ msgstr "Standard Reader n’enferme pas votre lecture dans une seule application. Chaque partie du réseau dispose de son propre flux RSS — branchez-le directement sur le lecteur que vous utilisez déjà."
 
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Choose images"
@@ -3362,8 +3386,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Save, like, subscribe — everywhere"
-msgstr "Enregistrer, aimer, s'abonner — partout"
+#~ msgid "Save, like, subscribe — everywhere"
+#~ msgstr "Enregistrer, aimer, s'abonner — partout"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe?"
@@ -3492,6 +3516,10 @@ msgstr "Données personnelles"
 msgid "on Leaflet"
 msgstr "sur Leaflet"
 
+#: src/components/reader/about-view.tsx
+msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save, and take all of it with you, wherever you choose to read next."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 #: src/components/user-settings-view.tsx
 msgid "Not now"
@@ -3609,8 +3637,8 @@ msgid "Loading…"
 msgstr "Chargement…"
 
 #: src/components/reader/about-view.tsx
-msgid "Choose body text size, column width, and font — serif, sans, or any Google Font. Read the way that’s easy on your eyes."
-msgstr "Choisissez la taille du texte, la largeur de colonne et la police — serif, sans, ou n'importe quelle Google Font. Lisez d'une manière agréable pour vos yeux."
+#~ msgid "Choose body text size, column width, and font — serif, sans, or any Google Font. Read the way that’s easy on your eyes."
+#~ msgstr "Choisissez la taille du texte, la largeur de colonne et la police — serif, sans, ou n'importe quelle Google Font. Lisez d'une manière agréable pour vos yeux."
 
 #: src/routes/_layout.u.$did.tsx
 msgid "{name} hasn't started reading or publishing here. You can find them on Bluesky."
@@ -3892,6 +3920,10 @@ msgid "Unfollow?"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
+msgid "Build named, shareable lists of publications: a playlist for reading. Anyone can add your list to their own reader in a single tap."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
 msgid "Listen to anything"
 msgstr "Écouter n'importe quoi"
 
@@ -3949,6 +3981,10 @@ msgstr "Les articles que vous avez recommandés sur le réseau."
 #: src/routes/_layout.feedback.return.tsx
 msgid "View feedback"
 msgstr "Voir les retours"
+
+#: src/components/reader/about-view.tsx
+msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave, and you can preview exactly what it looks like before you ever turn it on."
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "All caught up"
@@ -4189,8 +4225,8 @@ msgid "The core / new frameworks"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written — no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
-msgstr "Abonnez-vous aux publications de <0>standard.site</0> qui vous intéressent. Les nouveaux textes arrivent simplement, dans l'ordre où ils ont été écrits — aucun flux à combattre, rien qui crie pour attirer votre attention. Juste du bon texte long, et une manière vraiment agréable d'en découvrir toujours plus."
+#~ msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written — no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
+#~ msgstr "Abonnez-vous aux publications de <0>standard.site</0> qui vous intéressent. Les nouveaux textes arrivent simplement, dans l'ordre où ils ont été écrits — aucun flux à combattre, rien qui crie pour attirer votre attention. Juste du bon texte long, et une manière vraiment agréable d'en découvrir toujours plus."
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Save"
@@ -4273,6 +4309,10 @@ msgstr "Votre flux Accueil est vide pour le moment — passez par Découvrir qua
 msgid "Articles"
 msgstr "Articles"
 
+#: src/components/reader/about-view.tsx
+msgid "Under each article you see the discussion from across the open network: Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Leave a review"
 msgstr "Laisser un avis"
@@ -4322,8 +4362,8 @@ msgid "Settings"
 msgstr "Paramètres"
 
 #: src/components/reader/about-view.tsx
-msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
-msgstr "Une extension de navigateur légère vous permet d'enregistrer des publications et de vous y abonner pendant votre navigation — avec de discrets badges sur bsky.app et une surcouche accessible en un clic sur n'importe quelle page. Votre liste de lecture se remplit toute seule."
+#~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+#~ msgstr "Une extension de navigateur légère vous permet d'enregistrer des publications et de vous y abonner pendant votre navigation — avec de discrets badges sur bsky.app et une surcouche accessible en un clic sur n'importe quelle page. Votre liste de lecture se remplit toute seule."
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -4389,6 +4429,10 @@ msgstr "Lire l'article"
 msgid "Terms of service"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "<0>{countLabel}</0> publications indexed, and counting"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Delete all reading history?"
 msgstr "Supprimer tout l'historique de lecture ?"
@@ -4445,6 +4489,10 @@ msgstr "En pause"
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "Détails"
+
+#: src/components/reader/about-view.tsx
+msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web, with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "When you save or follow from the extension, {SITE_NAME} writes AT Protocol records to <0>your</0> repository through the same server paths as the web app. Those records follow the network's visibility rules and your account settings."
@@ -4517,8 +4565,8 @@ msgid "Open any article while signed in and it'll show up here. Your history liv
 msgstr "Ouvrez un article en étant connecté et il apparaîtra ici. Votre historique vit dans votre dépôt sous forme d'enregistrements <0>app.standard-reader.read</0>."
 
 #: src/components/reader/about-view.tsx
-msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
-msgstr "Composez des listes de publications nommées et partageables — une playlist de lecture. N'importe qui peut ajouter votre liste à son propre lecteur en un seul geste."
+#~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
+#~ msgstr "Composez des listes de publications nommées et partageables — une playlist de lecture. N'importe qui peut ajouter votre liste à son propre lecteur en un seul geste."
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
@@ -4593,6 +4641,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Labelers"
 msgstr "Services d'étiquetage"
+
+#: src/components/reader/about-view.tsx
+msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written: no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
+msgstr ""
 
 #: src/components/reader/language-dialog.tsx
 msgid "Choose your language"
@@ -4996,6 +5048,10 @@ msgstr "Enregistrer dans Margin…"
 msgid "{minutes} min"
 msgstr "{minutes} min"
 
+#: src/components/reader/about-view.tsx
+msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it, and stays a good citizen of the wider network."
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Landscape"
 msgstr "Paysage"
@@ -5044,8 +5100,8 @@ msgid "Opening the issue…"
 msgstr "Ouverture du numéro…"
 
 #: src/components/reader/about-view.tsx
-msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
-msgstr "Il ne vous demande pas de laisser le reste du web derrière vous. Il va à sa rencontre — et reste un bon citoyen du réseau au sens large."
+#~ msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+#~ msgstr "Il ne vous demande pas de laisser le reste du web derrière vous. Il va à sa rencontre — et reste un bon citoyen du réseau au sens large."
 
 #: src/routes/_layout.collections.edit.$rkey.tsx
 msgid "We couldn’t load that collection to edit."
@@ -5177,6 +5233,10 @@ msgstr "Lien"
 #: src/components/reader/collection-publication-editor.tsx
 msgid "Save series"
 msgstr "Enregistrer la série"
+
+#: src/components/reader/about-view.tsx
+msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed: pipe it straight into whatever reader you already use."
+msgstr ""
 
 #: src/components/labelers-settings-view.tsx
 msgid "No labelers match “{searchTrim}”."
@@ -5326,6 +5386,10 @@ msgstr "{connectionLabel} via Semble"
 
 #: src/components/appearance-settings.tsx
 msgid "S"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Publications, lists, and collections each get a clean link with a rich preview card, plus a subscribe button a publication can drop on its own site."
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -134,6 +134,10 @@ msgstr "アイコンを削除"
 msgid "The {SITE_NAME} browser extension helps you save articles and follow publications on the standard.site network from any tab. It connects to the same account as the web app at <0>{siteHost}</0>. This policy covers the extension only; the <1>site privacy policy</1> describes data handling on the website itself."
 msgstr "{SITE_NAME} のブラウザ拡張機能を使うと、どのタブからでも standard.site ネットワークの記事を保存したり発行物をフォローしたりできます。拡張機能は <0>{siteHost}</0> のウェブアプリと同じアカウントに接続します。このポリシーは拡張機能のみを対象としています。ウェブサイト自体のデータの取り扱いについては<1>サイトのプライバシーポリシー</1>をご覧ください。"
 
+#: src/components/reader/about-view.tsx
+msgid "Save, like, subscribe: everywhere"
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Change language"
@@ -256,6 +260,10 @@ msgstr "コレクションを開いています…"
 msgid "Density"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Choose body text size, column width, and font: serif, sans, or any Google Font. Read the way that’s easy on your eyes."
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Open on publication"
 msgstr "発行物で開く"
@@ -265,8 +273,8 @@ msgid "(this is what Standard Reader itself uses)"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
-msgstr "そして閉じた場所にはなりません。それぞれの記事を Atmosphere（このアプリの外に広がるオープンなネットワーク）で交わされる会話につなぎ、その記事についての Bluesky の投稿や返信、余白に残されたメモ、引用している他の文章を、読んでいるものの下にそっと集めます。"
+#~ msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+#~ msgstr "そして閉じた場所にはなりません。それぞれの記事を Atmosphere（このアプリの外に広がるオープンなネットワーク）で交わされる会話につなぎ、その記事についての Bluesky の投稿や返信、余白に残されたメモ、引用している他の文章を、読んでいるものの下にそっと集めます。"
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "running…"
@@ -365,8 +373,8 @@ msgid "Set these now, or change them any time in Settings."
 msgstr "今すぐ設定するか、あとで設定からいつでも変更できます。"
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
-msgstr "多くのリーダーは、すでに購読しているものを見せて終わりです。Standard Reader は次のお気に入りを見つけることも役目だと考えています。名前を知っている一握りだけでなく、ネットワーク上のすべての発行物を見てまわりましょう。"
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
+#~ msgstr "多くのリーダーは、すでに購読しているものを見せて終わりです。Standard Reader は次のお気に入りを見つけることも役目だと考えています。名前を知っている一握りだけでなく、ネットワーク上のすべての発行物を見てまわりましょう。"
 
 #: src/routes/_layout.collections.index.tsx
 msgid "Name your series & pick a theme"
@@ -770,6 +778,10 @@ msgstr "データの保存先"
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "We couldn’t find that list."
 msgstr "そのリストは見つかりませんでした。"
+
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network, not just the handful you've heard of."
+msgstr ""
 
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/mention-hover-card.tsx
@@ -1363,8 +1375,8 @@ msgid "You're subscribed to every publication on this page — scroll for more, 
 msgstr "このページの発行物はすべて購読済みです。さらにスクロールするか、フィルターをオフにしてください。"
 
 #: src/components/reader/about-view.tsx
-msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
-msgstr "各記事の下では、オープンなネットワーク全体の反応をまとめて確認できます。Bluesky の投稿や返信、マージンノート、その記事を引用した他の記事からのリンク、関連する読み物などです。すべて読み取り専用で、元の投稿へリンクしています。"
+#~ msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+#~ msgstr "各記事の下では、オープンなネットワーク全体の反応をまとめて確認できます。Bluesky の投稿や返信、マージンノート、その記事を引用した他の記事からのリンク、関連する読み物などです。すべて読み取り専用で、元の投稿へリンクしています。"
 
 #: src/routes/_layout.latest.tsx
 msgid "Show all subscriptions"
@@ -1405,8 +1417,8 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {# 件の一致} other {# 件の一致}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
-msgstr "発行物・リスト・コレクションのそれぞれに、リッチなプレビューカード付きのすっきりしたリンクが用意されます。発行物が自分のサイトに設置できる購読ボタンも使えます。"
+#~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
+#~ msgstr "発行物・リスト・コレクションのそれぞれに、リッチなプレビューカード付きのすっきりしたリンクが用意されます。発行物が自分のサイトに設置できる購読ボタンも使えます。"
 
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Search topics"
@@ -1548,8 +1560,8 @@ msgid "Something went wrong while submitting your feedback."
 msgstr "フィードバックの送信中に問題が発生しました。"
 
 #: src/components/reader/about-view.tsx
-msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
-msgstr "もう一つアプリを開くのは面倒ですか？購読中の発行物のベスト記事に、見つける価値のある数本を添えた週刊メールを受け取れます。メールは週1通、解除はワンクリック。オンにする前に、どんな内容か実際にプレビューできます。"
+#~ msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
+#~ msgstr "もう一つアプリを開くのは面倒ですか？購読中の発行物のベスト記事に、見つける価値のある数本を添えた週刊メールを受け取れます。メールは週1通、解除はワンクリック。オンにする前に、どんな内容か実際にプレビューできます。"
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/collection-builder.tsx
@@ -1645,6 +1657,10 @@ msgstr "サイト"
 #: src/routes/_layout.index.tsx
 msgid "Today"
 msgstr "今日"
+
+#: src/components/reader/about-view.tsx
+msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere (the open network beyond this app), gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/reader/cards.tsx
@@ -1805,6 +1821,10 @@ msgstr "Powered by Standard Reader"
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network, not just the handful you've heard of."
+msgstr ""
+
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -1881,6 +1901,10 @@ msgstr "ダイジェストをメールで送るには、Standard Reader にア�
 #: src/components/reader/about-view.tsx
 msgid "Discovery"
 msgstr "ディスカバリー"
+
+#: src/components/reader/about-view.tsx
+msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app; it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
+msgstr ""
 
 #. placeholder {0}: selected.count
 #: src/components/reader/subscriptions-table.tsx
@@ -2069,8 +2093,8 @@ msgid "Subscribe to a few publications or follow some people, and their latest w
 msgstr "発行物をいくつか購読するか、何人かをフォローすると、その最新記事やおすすめがここに集まります。"
 
 #: src/components/reader/about-view.tsx
-msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save — and take all of it with you, wherever you choose to read next."
-msgstr "アカウントなしで読めます。購読・いいね・保存をしたくなったら Bluesky でサインイン。そのすべてを、次にどこで読むとしても持っていけます。"
+#~ msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save — and take all of it with you, wherever you choose to read next."
+#~ msgstr "アカウントなしで読めます。購読・いいね・保存をしたくなったら Bluesky でサインイン。そのすべてを、次にどこで読むとしても持っていけます。"
 
 #: src/components/reader/collection-builder.tsx
 msgid "Remove {itemTitle}"
@@ -2087,8 +2111,8 @@ msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {フォロワー} other {フォロワー}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
-msgstr "多くのリーダーは、すでに購読しているものまでしか見せてくれません。Standard Reader は、次のお気に入りを見つけることも役目のうちだと考えています。名前を知っている一握りだけでなく、ネットワーク上の {countLabel} 件すべての発行物を見てまわれます。"
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgstr "多くのリーダーは、すでに購読しているものまでしか見せてくれません。Standard Reader は、次のお気に入りを見つけることも役目のうちだと考えています。名前を知っている一握りだけでなく、ネットワーク上の {countLabel} 件すべての発行物を見てまわれます。"
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labels"
@@ -2627,8 +2651,8 @@ msgid "Large"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
-msgstr "「読み上げ」ボタンで、どの記事もデバイス上で音声にして読み上げ、単語を1つずつハイライトします。プレーヤーはアプリ内のどこへでも付いてきて、埋め込まれた Bluesky の投稿も読み上げます。サインインすれば声も選べます。"
+#~ msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
+#~ msgstr "「読み上げ」ボタンで、どの記事もデバイス上で音声にして読み上げ、単語を1つずつハイライトします。プレーヤーはアプリ内のどこへでも付いてきて、埋め込まれた Bluesky の投稿も読み上げます。サインインすれば声も選べます。"
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Something went wrong while preparing your review."
@@ -3029,8 +3053,8 @@ msgid "Select a tag"
 msgstr "タグを選択"
 
 #: src/components/reader/about-view.tsx
-msgid "<0>{countLabel}</0> publications indexed — and counting"
-msgstr "<0>{countLabel}</0> 件の発行物をインデックス済み — さらに増加中"
+#~ msgid "<0>{countLabel}</0> publications indexed — and counting"
+#~ msgstr "<0>{countLabel}</0> 件の発行物をインデックス済み — さらに増加中"
 
 #: src/routes/_layout.index.tsx
 msgid "{newCount} new"
@@ -3220,8 +3244,8 @@ msgid "Browse publications"
 msgstr "発行物を見る"
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
-msgstr "Standard Reader は読書を1つのアプリに閉じ込めません。ネットワークのどの断面にも独自の RSS フィードが付いてくるので、すでに使っているリーダーにそのまま流し込めます。"
+#~ msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
+#~ msgstr "Standard Reader は読書を1つのアプリに閉じ込めません。ネットワークのどの断面にも独自の RSS フィードが付いてくるので、すでに使っているリーダーにそのまま流し込めます。"
 
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Choose images"
@@ -3362,8 +3386,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Save, like, subscribe — everywhere"
-msgstr "保存も、いいねも、購読も、どこでも"
+#~ msgid "Save, like, subscribe — everywhere"
+#~ msgstr "保存も、いいねも、購読も、どこでも"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe?"
@@ -3492,6 +3516,10 @@ msgstr "個人データ"
 msgid "on Leaflet"
 msgstr "Leaflet で"
 
+#: src/components/reader/about-view.tsx
+msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save, and take all of it with you, wherever you choose to read next."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 #: src/components/user-settings-view.tsx
 msgid "Not now"
@@ -3609,8 +3637,8 @@ msgid "Loading…"
 msgstr "読み込み中…"
 
 #: src/components/reader/about-view.tsx
-msgid "Choose body text size, column width, and font — serif, sans, or any Google Font. Read the way that’s easy on your eyes."
-msgstr "本文のサイズ、段の幅、フォント（セリフ、サンセリフ、任意の Google Font）を選べます。目にやさしい読み方で。"
+#~ msgid "Choose body text size, column width, and font — serif, sans, or any Google Font. Read the way that’s easy on your eyes."
+#~ msgstr "本文のサイズ、段の幅、フォント（セリフ、サンセリフ、任意の Google Font）を選べます。目にやさしい読み方で。"
 
 #: src/routes/_layout.u.$did.tsx
 msgid "{name} hasn't started reading or publishing here. You can find them on Bluesky."
@@ -3892,6 +3920,10 @@ msgid "Unfollow?"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
+msgid "Build named, shareable lists of publications: a playlist for reading. Anyone can add your list to their own reader in a single tap."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
 msgid "Listen to anything"
 msgstr "何でも聴く"
 
@@ -3949,6 +3981,10 @@ msgstr "ネットワーク上でおすすめした記事です。"
 #: src/routes/_layout.feedback.return.tsx
 msgid "View feedback"
 msgstr "フィードバックを見る"
+
+#: src/components/reader/about-view.tsx
+msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave, and you can preview exactly what it looks like before you ever turn it on."
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "All caught up"
@@ -4189,8 +4225,8 @@ msgid "The core / new frameworks"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written — no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
-msgstr "<0>standard.site</0> で気になる発行物を購読しましょう。新しい記事は書かれた順にただ届きます。戦うべきフィードも、注意を奪おうとするものもありません。良質な長文と、それをもっと見つけるための心地よい方法があるだけです。"
+#~ msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written — no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
+#~ msgstr "<0>standard.site</0> で気になる発行物を購読しましょう。新しい記事は書かれた順にただ届きます。戦うべきフィードも、注意を奪おうとするものもありません。良質な長文と、それをもっと見つけるための心地よい方法があるだけです。"
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Save"
@@ -4273,6 +4309,10 @@ msgstr "ホームフィードは今のところ空です。準備ができたら
 msgid "Articles"
 msgstr "記事"
 
+#: src/components/reader/about-view.tsx
+msgid "Under each article you see the discussion from across the open network: Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Leave a review"
 msgstr "レビューを書く"
@@ -4322,8 +4362,8 @@ msgid "Settings"
 msgstr "設定"
 
 #: src/components/reader/about-view.tsx
-msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
-msgstr "軽量なブラウザ拡張機能を使えば、ウェブを見ている最中でも発行物を保存・購読できます。bsky.app 上のさりげないバッジと、どのページでもワンクリックで開くオーバーレイ付き。読むものリストが自然に埋まっていきます。"
+#~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+#~ msgstr "軽量なブラウザ拡張機能を使えば、ウェブを見ている最中でも発行物を保存・購読できます。bsky.app 上のさりげないバッジと、どのページでもワンクリックで開くオーバーレイ付き。読むものリストが自然に埋まっていきます。"
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -4389,6 +4429,10 @@ msgstr "記事を読む"
 msgid "Terms of service"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "<0>{countLabel}</0> publications indexed, and counting"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Delete all reading history?"
 msgstr "閲覧履歴をすべて削除しますか？"
@@ -4445,6 +4489,10 @@ msgstr "一時停止中"
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "詳細"
+
+#: src/components/reader/about-view.tsx
+msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web, with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "When you save or follow from the extension, {SITE_NAME} writes AT Protocol records to <0>your</0> repository through the same server paths as the web app. Those records follow the network's visibility rules and your account settings."
@@ -4517,8 +4565,8 @@ msgid "Open any article while signed in and it'll show up here. Your history liv
 msgstr "サインイン状態で記事を開くと、ここに表示されます。履歴はリポジトリ内に <0>app.standard-reader.read</0> レコードとして保存されます。"
 
 #: src/components/reader/about-view.tsx
-msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
-msgstr "名前を付けて共有できる発行物のリストを作りましょう。読書のプレイリストです。だれでもワンタップで自分のリーダーに追加できます。"
+#~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
+#~ msgstr "名前を付けて共有できる発行物のリストを作りましょう。読書のプレイリストです。だれでもワンタップで自分のリーダーに追加できます。"
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
@@ -4593,6 +4641,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Labelers"
 msgstr "ラベラー"
+
+#: src/components/reader/about-view.tsx
+msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written: no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
+msgstr ""
 
 #: src/components/reader/language-dialog.tsx
 msgid "Choose your language"
@@ -4996,6 +5048,10 @@ msgstr "Margin に保存…"
 msgid "{minutes} min"
 msgstr "{minutes} 分"
 
+#: src/components/reader/about-view.tsx
+msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it, and stays a good citizen of the wider network."
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Landscape"
 msgstr "横長"
@@ -5044,8 +5100,8 @@ msgid "Opening the issue…"
 msgstr "号を開いています…"
 
 #: src/components/reader/about-view.tsx
-msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
-msgstr "Web のほかの部分を手放すことを求めたりはしません。むしろそこに手を伸ばし、広いネットワークのよき一員であり続けます。"
+#~ msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+#~ msgstr "Web のほかの部分を手放すことを求めたりはしません。むしろそこに手を伸ばし、広いネットワークのよき一員であり続けます。"
 
 #: src/routes/_layout.collections.edit.$rkey.tsx
 msgid "We couldn’t load that collection to edit."
@@ -5177,6 +5233,10 @@ msgstr "リンク"
 #: src/components/reader/collection-publication-editor.tsx
 msgid "Save series"
 msgstr "シリーズを保存"
+
+#: src/components/reader/about-view.tsx
+msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed: pipe it straight into whatever reader you already use."
+msgstr ""
 
 #: src/components/labelers-settings-view.tsx
 msgid "No labelers match “{searchTrim}”."
@@ -5326,6 +5386,10 @@ msgstr "Semble 経由の {connectionLabel}"
 
 #: src/components/appearance-settings.tsx
 msgid "S"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Publications, lists, and collections each get a clean link with a rich preview card, plus a subscribe button a publication can drop on its own site."
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -134,6 +134,10 @@ msgstr "아이콘 제거"
 msgid "The {SITE_NAME} browser extension helps you save articles and follow publications on the standard.site network from any tab. It connects to the same account as the web app at <0>{siteHost}</0>. This policy covers the extension only; the <1>site privacy policy</1> describes data handling on the website itself."
 msgstr "{SITE_NAME} 브라우저 확장 프로그램을 사용하면 어느 탭에서든 standard.site 네트워크의 글을 저장하고 발행물을 팔로우할 수 있습니다. <0>{siteHost}</0>의 웹 앱과 동일한 계정으로 연결됩니다. 이 정책은 확장 프로그램에만 적용되며, 웹사이트 자체의 데이터 처리는 <1>사이트 개인정보처리방침</1>을 참고하세요."
 
+#: src/components/reader/about-view.tsx
+msgid "Save, like, subscribe: everywhere"
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Change language"
@@ -256,6 +260,10 @@ msgstr "컬렉션을 여는 중…"
 msgid "Density"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Choose body text size, column width, and font: serif, sans, or any Google Font. Read the way that’s easy on your eyes."
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Open on publication"
 msgstr "발행물에서 열기"
@@ -265,8 +273,8 @@ msgid "(this is what Standard Reader itself uses)"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
-msgstr "그리고 결코 닫혀 있다고 느껴지지 않습니다. 저희는 각 글을 Atmosphere — 이 앱 너머의 열린 네트워크 — 에서 벌어지는 대화와 연결해, 그 글에 대한 Bluesky 게시물과 답글, 여백에 남겨진 메모, 그리고 그 글을 인용한 다른 글들을 읽고 있는 화면 아래에 조용히 모아 둡니다."
+#~ msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+#~ msgstr "그리고 결코 닫혀 있다고 느껴지지 않습니다. 저희는 각 글을 Atmosphere — 이 앱 너머의 열린 네트워크 — 에서 벌어지는 대화와 연결해, 그 글에 대한 Bluesky 게시물과 답글, 여백에 남겨진 메모, 그리고 그 글을 인용한 다른 글들을 읽고 있는 화면 아래에 조용히 모아 둡니다."
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "running…"
@@ -365,8 +373,8 @@ msgid "Set these now, or change them any time in Settings."
 msgstr "지금 설정하거나 설정에서 언제든지 변경하세요."
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
-msgstr "대부분의 리더는 이미 구독한 것에서 멈춥니다. Standard Reader는 다음에 좋아할 것을 찾아주는 일까지 자기 몫으로 여깁니다. 이름을 들어본 몇 곳뿐 아니라 네트워크의 모든 발행물을 둘러보세요."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
+#~ msgstr "대부분의 리더는 이미 구독한 것에서 멈춥니다. Standard Reader는 다음에 좋아할 것을 찾아주는 일까지 자기 몫으로 여깁니다. 이름을 들어본 몇 곳뿐 아니라 네트워크의 모든 발행물을 둘러보세요."
 
 #: src/routes/_layout.collections.index.tsx
 msgid "Name your series & pick a theme"
@@ -770,6 +778,10 @@ msgstr "데이터가 저장되는 곳"
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "We couldn’t find that list."
 msgstr "해당 목록을 찾을 수 없습니다."
+
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network, not just the handful you've heard of."
+msgstr ""
 
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/mention-hover-card.tsx
@@ -1363,8 +1375,8 @@ msgid "You're subscribed to every publication on this page — scroll for more, 
 msgstr "이 페이지의 모든 발행물을 구독 중입니다. 더 보려면 스크롤하거나 필터를 끄세요."
 
 #: src/components/reader/about-view.tsx
-msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
-msgstr "각 아티클 아래에서 열린 네트워크 전체의 논의를 볼 수 있습니다. Bluesky 게시물과 답글, 마진 노트, 이 글을 인용한 다른 글의 링크, 관련 읽을거리까지. 모두 읽기 전용이며 원본으로 연결됩니다."
+#~ msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+#~ msgstr "각 아티클 아래에서 열린 네트워크 전체의 논의를 볼 수 있습니다. Bluesky 게시물과 답글, 마진 노트, 이 글을 인용한 다른 글의 링크, 관련 읽을거리까지. 모두 읽기 전용이며 원본으로 연결됩니다."
 
 #: src/routes/_layout.latest.tsx
 msgid "Show all subscriptions"
@@ -1405,8 +1417,8 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {검색 결과 #개} other {검색 결과 #개}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
-msgstr "발행물, 리스트, 컬렉션마다 리치 미리보기 카드가 달린 깔끔한 링크가 생깁니다. 발행물이 자체 사이트에 넣을 수 있는 구독 버튼도 함께 제공됩니다."
+#~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
+#~ msgstr "발행물, 리스트, 컬렉션마다 리치 미리보기 카드가 달린 깔끔한 링크가 생깁니다. 발행물이 자체 사이트에 넣을 수 있는 구독 버튼도 함께 제공됩니다."
 
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Search topics"
@@ -1548,8 +1560,8 @@ msgid "Something went wrong while submitting your feedback."
 msgstr "피드백을 보내는 중 문제가 발생했습니다."
 
 #: src/components/reader/about-view.tsx
-msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
-msgstr "앱을 또 확인하기 번거롭나요? 구독한 발행물의 가장 좋은 글과 발견할 만한 글 몇 편을 담은 주간 이메일을 신청하세요. 이메일 한 통, 해지는 클릭 한 번. 신청 전에 어떤 모습인지 미리 볼 수도 있습니다."
+#~ msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
+#~ msgstr "앱을 또 확인하기 번거롭나요? 구독한 발행물의 가장 좋은 글과 발견할 만한 글 몇 편을 담은 주간 이메일을 신청하세요. 이메일 한 통, 해지는 클릭 한 번. 신청 전에 어떤 모습인지 미리 볼 수도 있습니다."
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/collection-builder.tsx
@@ -1645,6 +1657,10 @@ msgstr "사이트"
 #: src/routes/_layout.index.tsx
 msgid "Today"
 msgstr "오늘"
+
+#: src/components/reader/about-view.tsx
+msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere (the open network beyond this app), gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/reader/cards.tsx
@@ -1805,6 +1821,10 @@ msgstr "Standard Reader 제공"
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network, not just the handful you've heard of."
+msgstr ""
+
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -1881,6 +1901,10 @@ msgstr "다이제스트를 보내려면 Standard Reader에 계정 이메일 주�
 #: src/components/reader/about-view.tsx
 msgid "Discovery"
 msgstr "발견"
+
+#: src/components/reader/about-view.tsx
+msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app; it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
+msgstr ""
 
 #. placeholder {0}: selected.count
 #: src/components/reader/subscriptions-table.tsx
@@ -2069,8 +2093,8 @@ msgid "Subscribe to a few publications or follow some people, and their latest w
 msgstr "발행물 몇 곳을 구독하거나 사람들을 팔로우하면, 그들의 최신 글과 추천이 여기에 모입니다."
 
 #: src/components/reader/about-view.tsx
-msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save — and take all of it with you, wherever you choose to read next."
-msgstr "계정 없이 읽어 보세요. 구독하고, 좋아요를 누르고, 저장하고 싶어지면 Bluesky로 로그인하세요. 다음에 어디서 읽든 그대로 가져갈 수 있습니다."
+#~ msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save — and take all of it with you, wherever you choose to read next."
+#~ msgstr "계정 없이 읽어 보세요. 구독하고, 좋아요를 누르고, 저장하고 싶어지면 Bluesky로 로그인하세요. 다음에 어디서 읽든 그대로 가져갈 수 있습니다."
 
 #: src/components/reader/collection-builder.tsx
 msgid "Remove {itemTitle}"
@@ -2087,8 +2111,8 @@ msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {팔로워} other {팔로워}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
-msgstr "대부분의 리더는 이미 구독한 것에서 멈춥니다. Standard Reader는 다음에 좋아할 글을 찾아 주는 것까지 자기 일로 여깁니다. 네트워크의 발행물 {countLabel}곳을 모두 둘러보세요 — 이름을 들어본 몇 곳만이 아니라요."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgstr "대부분의 리더는 이미 구독한 것에서 멈춥니다. Standard Reader는 다음에 좋아할 글을 찾아 주는 것까지 자기 일로 여깁니다. 네트워크의 발행물 {countLabel}곳을 모두 둘러보세요 — 이름을 들어본 몇 곳만이 아니라요."
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labels"
@@ -2627,8 +2651,8 @@ msgid "Large"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
-msgstr "듣기 버튼을 누르면 어떤 글이든 기기에서 바로 읽어 주고, 읽는 단어를 하나씩 강조해 줍니다. 플레이어는 앱 어디를 가든 따라오며, 임베드된 Bluesky 게시물도 읽어 줍니다. 로그인하면 목소리를 고를 수 있습니다."
+#~ msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
+#~ msgstr "듣기 버튼을 누르면 어떤 글이든 기기에서 바로 읽어 주고, 읽는 단어를 하나씩 강조해 줍니다. 플레이어는 앱 어디를 가든 따라오며, 임베드된 Bluesky 게시물도 읽어 줍니다. 로그인하면 목소리를 고를 수 있습니다."
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Something went wrong while preparing your review."
@@ -3029,8 +3053,8 @@ msgid "Select a tag"
 msgstr "태그 선택"
 
 #: src/components/reader/about-view.tsx
-msgid "<0>{countLabel}</0> publications indexed — and counting"
-msgstr "<0>{countLabel}</0>개의 발행물이 색인됨 — 그리고 계속 늘어나는 중"
+#~ msgid "<0>{countLabel}</0> publications indexed — and counting"
+#~ msgstr "<0>{countLabel}</0>개의 발행물이 색인됨 — 그리고 계속 늘어나는 중"
 
 #: src/routes/_layout.index.tsx
 msgid "{newCount} new"
@@ -3220,8 +3244,8 @@ msgid "Browse publications"
 msgstr "발행물 둘러보기"
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
-msgstr "Standard Reader는 당신의 읽기를 하나의 앱에 가두지 않습니다. 네트워크의 어느 부분이든 자체 RSS 피드를 제공하니, 이미 쓰고 있는 리더로 바로 연결하세요."
+#~ msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
+#~ msgstr "Standard Reader는 당신의 읽기를 하나의 앱에 가두지 않습니다. 네트워크의 어느 부분이든 자체 RSS 피드를 제공하니, 이미 쓰고 있는 리더로 바로 연결하세요."
 
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Choose images"
@@ -3362,8 +3386,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Save, like, subscribe — everywhere"
-msgstr "저장, 좋아요, 구독 — 어디서나"
+#~ msgid "Save, like, subscribe — everywhere"
+#~ msgstr "저장, 좋아요, 구독 — 어디서나"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe?"
@@ -3492,6 +3516,10 @@ msgstr "개인 정보"
 msgid "on Leaflet"
 msgstr "Leaflet에서"
 
+#: src/components/reader/about-view.tsx
+msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save, and take all of it with you, wherever you choose to read next."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 #: src/components/user-settings-view.tsx
 msgid "Not now"
@@ -3609,8 +3637,8 @@ msgid "Loading…"
 msgstr "불러오는 중…"
 
 #: src/components/reader/about-view.tsx
-msgid "Choose body text size, column width, and font — serif, sans, or any Google Font. Read the way that’s easy on your eyes."
-msgstr "본문 크기, 단 너비, 글꼴을 고르세요. 세리프, 산세리프, 원하는 Google Font까지. 눈이 편한 방식으로 읽으세요."
+#~ msgid "Choose body text size, column width, and font — serif, sans, or any Google Font. Read the way that’s easy on your eyes."
+#~ msgstr "본문 크기, 단 너비, 글꼴을 고르세요. 세리프, 산세리프, 원하는 Google Font까지. 눈이 편한 방식으로 읽으세요."
 
 #: src/routes/_layout.u.$did.tsx
 msgid "{name} hasn't started reading or publishing here. You can find them on Bluesky."
@@ -3892,6 +3920,10 @@ msgid "Unfollow?"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
+msgid "Build named, shareable lists of publications: a playlist for reading. Anyone can add your list to their own reader in a single tap."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
 msgid "Listen to anything"
 msgstr "무엇이든 들어보세요"
 
@@ -3949,6 +3981,10 @@ msgstr "네트워크에서 추천한 글입니다."
 #: src/routes/_layout.feedback.return.tsx
 msgid "View feedback"
 msgstr "피드백 보기"
+
+#: src/components/reader/about-view.tsx
+msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave, and you can preview exactly what it looks like before you ever turn it on."
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "All caught up"
@@ -4189,8 +4225,8 @@ msgid "The core / new frameworks"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written — no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
-msgstr "관심 있는 <0>standard.site</0>의 발행물을 구독하세요. 새 글이 쓰인 순서 그대로 조용히 도착합니다. 씨름할 피드도, 관심을 끌려 소리치는 것도 없습니다. 좋은 장문의 글과, 그런 글을 계속 발견하는 기분 좋은 방법이 있을 뿐입니다."
+#~ msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written — no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
+#~ msgstr "관심 있는 <0>standard.site</0>의 발행물을 구독하세요. 새 글이 쓰인 순서 그대로 조용히 도착합니다. 씨름할 피드도, 관심을 끌려 소리치는 것도 없습니다. 좋은 장문의 글과, 그런 글을 계속 발견하는 기분 좋은 방법이 있을 뿐입니다."
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Save"
@@ -4273,6 +4309,10 @@ msgstr "홈 피드가 아직 비어 있습니다. 준비되면 언제든 탐색�
 msgid "Articles"
 msgstr "글"
 
+#: src/components/reader/about-view.tsx
+msgid "Under each article you see the discussion from across the open network: Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Leave a review"
 msgstr "리뷰 남기기"
@@ -4322,8 +4362,8 @@ msgid "Settings"
 msgstr "설정"
 
 #: src/components/reader/about-view.tsx
-msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
-msgstr "가벼운 브라우저 확장 프로그램으로 웹을 둘러보다가 바로 발행물을 저장하고 구독할 수 있습니다. bsky.app에는 은은한 배지가, 방문하는 어떤 페이지에서든 원클릭 오버레이가 나타납니다. 읽을 목록이 저절로 채워집니다."
+#~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+#~ msgstr "가벼운 브라우저 확장 프로그램으로 웹을 둘러보다가 바로 발행물을 저장하고 구독할 수 있습니다. bsky.app에는 은은한 배지가, 방문하는 어떤 페이지에서든 원클릭 오버레이가 나타납니다. 읽을 목록이 저절로 채워집니다."
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -4389,6 +4429,10 @@ msgstr "글 읽기"
 msgid "Terms of service"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "<0>{countLabel}</0> publications indexed, and counting"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Delete all reading history?"
 msgstr "읽은 기록을 모두 삭제할까요?"
@@ -4445,6 +4489,10 @@ msgstr "일시정지됨"
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "세부 정보"
+
+#: src/components/reader/about-view.tsx
+msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web, with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "When you save or follow from the extension, {SITE_NAME} writes AT Protocol records to <0>your</0> repository through the same server paths as the web app. Those records follow the network's visibility rules and your account settings."
@@ -4517,8 +4565,8 @@ msgid "Open any article while signed in and it'll show up here. Your history liv
 msgstr "로그인한 상태로 글을 열면 여기에 표시됩니다. 기록은 내 저장소에 <0>app.standard-reader.read</0> 레코드로 보관됩니다."
 
 #: src/components/reader/about-view.tsx
-msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
-msgstr "이름을 붙여 공유할 수 있는 발행물 목록을 만드세요. 읽기용 플레이리스트입니다. 누구나 한 번의 탭으로 자기 리더에 추가할 수 있습니다."
+#~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
+#~ msgstr "이름을 붙여 공유할 수 있는 발행물 목록을 만드세요. 읽기용 플레이리스트입니다. 누구나 한 번의 탭으로 자기 리더에 추가할 수 있습니다."
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
@@ -4593,6 +4641,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Labelers"
 msgstr "라벨러"
+
+#: src/components/reader/about-view.tsx
+msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written: no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
+msgstr ""
 
 #: src/components/reader/language-dialog.tsx
 msgid "Choose your language"
@@ -4996,6 +5048,10 @@ msgstr "Margin에 저장…"
 msgid "{minutes} min"
 msgstr "{minutes}분"
 
+#: src/components/reader/about-view.tsx
+msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it, and stays a good citizen of the wider network."
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Landscape"
 msgstr "가로"
@@ -5044,8 +5100,8 @@ msgid "Opening the issue…"
 msgstr "호를 여는 중…"
 
 #: src/components/reader/about-view.tsx
-msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
-msgstr "웹의 나머지를 등지라고 요구하지 않습니다. 오히려 손을 내밀며, 더 넓은 네트워크의 좋은 구성원으로 남습니다."
+#~ msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+#~ msgstr "웹의 나머지를 등지라고 요구하지 않습니다. 오히려 손을 내밀며, 더 넓은 네트워크의 좋은 구성원으로 남습니다."
 
 #: src/routes/_layout.collections.edit.$rkey.tsx
 msgid "We couldn’t load that collection to edit."
@@ -5177,6 +5233,10 @@ msgstr "링크"
 #: src/components/reader/collection-publication-editor.tsx
 msgid "Save series"
 msgstr "시리즈 저장"
+
+#: src/components/reader/about-view.tsx
+msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed: pipe it straight into whatever reader you already use."
+msgstr ""
 
 #: src/components/labelers-settings-view.tsx
 msgid "No labelers match “{searchTrim}”."
@@ -5326,6 +5386,10 @@ msgstr "Semble를 통한 {connectionLabel}"
 
 #: src/components/appearance-settings.tsx
 msgid "S"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Publications, lists, and collections each get a clean link with a rich preview card, plus a subscribe button a publication can drop on its own site."
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -134,6 +134,10 @@ msgstr "Remover ícone"
 msgid "The {SITE_NAME} browser extension helps you save articles and follow publications on the standard.site network from any tab. It connects to the same account as the web app at <0>{siteHost}</0>. This policy covers the extension only; the <1>site privacy policy</1> describes data handling on the website itself."
 msgstr "A extensão de navegador do {SITE_NAME} ajuda-o a salvar artigos e a seguir publicações na rede standard.site a partir de qualquer aba. Se conecta à mesma conta que a aplicação web em <0>{siteHost}</0>. Esta política abrange apenas a extensão; a <1>política de privacidade do site</1> descreve o tratamento de dados no próprio site."
 
+#: src/components/reader/about-view.tsx
+msgid "Save, like, subscribe: everywhere"
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Change language"
@@ -256,6 +260,10 @@ msgstr "Abrindo a coleção…"
 msgid "Density"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Choose body text size, column width, and font: serif, sans, or any Google Font. Read the way that’s easy on your eyes."
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Open on publication"
 msgstr "Abrir na publicação"
@@ -265,8 +273,8 @@ msgid "(this is what Standard Reader itself uses)"
 msgstr "(é o que o próprio Standard Reader utiliza)"
 
 #: src/components/reader/about-view.tsx
-msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
-msgstr "E nunca parece um mundo fechado. Ligamos cada artigo à conversa que decorre em toda a Atmosfera — a rede aberta para além desta aplicação — reunindo as publicações e respostas do Bluesky sobre um texto, as notas deixadas nas suas margens e os outras escritas que o citam, discretamente abaixo do que está lendo."
+#~ msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+#~ msgstr "E nunca parece um mundo fechado. Ligamos cada artigo à conversa que decorre em toda a Atmosfera — a rede aberta para além desta aplicação — reunindo as publicações e respostas do Bluesky sobre um texto, as notas deixadas nas suas margens e os outras escritas que o citam, discretamente abaixo do que está lendo."
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "running…"
@@ -365,8 +373,8 @@ msgid "Set these now, or change them any time in Settings."
 msgstr "Defina isto agora ou altere quando quiser nas Configurações."
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
-msgstr "A maioria dos leitores para no que já está inscrito. O Standard Reader trata a descoberta do seu próximo favorito como parte do trabalho. Explore todas as publicações da rede — não apenas as de que já ouviu falar."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
+#~ msgstr "A maioria dos leitores para no que já está inscrito. O Standard Reader trata a descoberta do seu próximo favorito como parte do trabalho. Explore todas as publicações da rede — não apenas as de que já ouviu falar."
 
 #: src/routes/_layout.collections.index.tsx
 msgid "Name your series & pick a theme"
@@ -770,6 +778,10 @@ msgstr "Onde residem os dados"
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "We couldn’t find that list."
 msgstr "Não foi possível encontrar essa lista."
+
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network, not just the handful you've heard of."
+msgstr ""
 
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/mention-hover-card.tsx
@@ -1363,8 +1375,8 @@ msgid "You're subscribed to every publication on this page — scroll for more, 
 msgstr "Você se inscreveu em todas as publicações desta página — continue a rolar para mais, ou desligue o filtro."
 
 #: src/components/reader/about-view.tsx
-msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
-msgstr "Abaixo de cada artigo veja a discussão através da rede aberta — publicações e respostas no Bluesky, anotações no Margin, outros textos que o citam e leituras relacionadas. Tudo em modo apenas de leitura, tudo com conexão direto à origem."
+#~ msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+#~ msgstr "Abaixo de cada artigo veja a discussão através da rede aberta — publicações e respostas no Bluesky, anotações no Margin, outros textos que o citam e leituras relacionadas. Tudo em modo apenas de leitura, tudo com conexão direto à origem."
 
 #: src/routes/_layout.latest.tsx
 msgid "Show all subscriptions"
@@ -1405,8 +1417,8 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {# resultado} other {# resultados}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
-msgstr "Publicações, listas e coleções, cada uma têm um link com um cartão de pré-visualização — mais um botão de inscrição que uma publicação pode colocar no seu próprio site."
+#~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
+#~ msgstr "Publicações, listas e coleções, cada uma têm um link com um cartão de pré-visualização — mais um botão de inscrição que uma publicação pode colocar no seu próprio site."
 
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Search topics"
@@ -1548,8 +1560,8 @@ msgid "Something went wrong while submitting your feedback."
 msgstr "Algo deu errado ao enviar o seu feedback."
 
 #: src/components/reader/about-view.tsx
-msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
-msgstr "Não quer mais um aplicativo para conferir? Opte por um e-mail semanal com o melhor das publicações em que está inscrito, e mais algumas que vale a pena descobrir. Um e-mail, um clique para sair — e pode pré-visualizar exatamente como é antes de sequer ativá-lo."
+#~ msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
+#~ msgstr "Não quer mais um aplicativo para conferir? Opte por um e-mail semanal com o melhor das publicações em que está inscrito, e mais algumas que vale a pena descobrir. Um e-mail, um clique para sair — e pode pré-visualizar exatamente como é antes de sequer ativá-lo."
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/collection-builder.tsx
@@ -1645,6 +1657,10 @@ msgstr "Site"
 #: src/routes/_layout.index.tsx
 msgid "Today"
 msgstr "Hoje"
+
+#: src/components/reader/about-view.tsx
+msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere (the open network beyond this app), gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/reader/cards.tsx
@@ -1805,6 +1821,10 @@ msgstr "Com tecnologia Standard Reader"
 msgid "Clear selection"
 msgstr "Limpar a seleção"
 
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network, not just the handful you've heard of."
+msgstr ""
+
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -1881,6 +1901,10 @@ msgstr "Para lhe enviar o resumo por e-mail, o Standard Reader precisa do endere
 #: src/components/reader/about-view.tsx
 msgid "Discovery"
 msgstr "Descoberta"
+
+#: src/components/reader/about-view.tsx
+msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app; it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
+msgstr ""
 
 #. placeholder {0}: selected.count
 #: src/components/reader/subscriptions-table.tsx
@@ -2069,8 +2093,8 @@ msgid "Subscribe to a few publications or follow some people, and their latest w
 msgstr "Inscreva-se em algumas publicações ou siga algumas pessoas, e seus textos e recomendações mais recentes aparecerão aqui."
 
 #: src/components/reader/about-view.tsx
-msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save — and take all of it with you, wherever you choose to read next."
-msgstr "Leia sem uma conta. Inicie sessão com o Bluesky quando quiser se inscrever, recomendar e salvar — e leve tudo consigo, onde quer que escolha ler a seguir."
+#~ msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save — and take all of it with you, wherever you choose to read next."
+#~ msgstr "Leia sem uma conta. Inicie sessão com o Bluesky quando quiser se inscrever, recomendar e salvar — e leve tudo consigo, onde quer que escolha ler a seguir."
 
 #: src/components/reader/collection-builder.tsx
 msgid "Remove {itemTitle}"
@@ -2087,8 +2111,8 @@ msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {seguidor} other {seguidores}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
-msgstr "A maioria dos leitores ficam apenas nas suas inscrições. O Standard Reader trata a descoberta do seu próximo favorito como parte do trabalho. Explore todas as {countLabel} publicações da rede — não apenas as poucas de que já ouviu falar."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgstr "A maioria dos leitores ficam apenas nas suas inscrições. O Standard Reader trata a descoberta do seu próximo favorito como parte do trabalho. Explore todas as {countLabel} publicações da rede — não apenas as poucas de que já ouviu falar."
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labels"
@@ -2627,8 +2651,8 @@ msgid "Large"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
-msgstr "Um botão Ouvir lê qualquer artigo em voz alta, no seu próprio dispositivo, destacando cada palavra à medida que avança. O leitor acompanha-o por toda a aplicação — até lê um artigo do Bluesky incorporado. Com sessão iniciada, pode escolher uma voz."
+#~ msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
+#~ msgstr "Um botão Ouvir lê qualquer artigo em voz alta, no seu próprio dispositivo, destacando cada palavra à medida que avança. O leitor acompanha-o por toda a aplicação — até lê um artigo do Bluesky incorporado. Com sessão iniciada, pode escolher uma voz."
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Something went wrong while preparing your review."
@@ -3029,8 +3053,8 @@ msgid "Select a tag"
 msgstr "Selecione uma etiqueta"
 
 #: src/components/reader/about-view.tsx
-msgid "<0>{countLabel}</0> publications indexed — and counting"
-msgstr "<0>{countLabel}</0> publicações indexadas — e a contar"
+#~ msgid "<0>{countLabel}</0> publications indexed — and counting"
+#~ msgstr "<0>{countLabel}</0> publicações indexadas — e a contar"
 
 #: src/routes/_layout.index.tsx
 msgid "{newCount} new"
@@ -3220,8 +3244,8 @@ msgid "Browse publications"
 msgstr "Explorar publicações"
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
-msgstr "O Standard Reader não prende a sua leitura dentro de uma só aplicação. Qualquer parte da rede vem com o seu próprio feed RSS — encaminhe-o diretamente para o leitor que já usa."
+#~ msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
+#~ msgstr "O Standard Reader não prende a sua leitura dentro de uma só aplicação. Qualquer parte da rede vem com o seu próprio feed RSS — encaminhe-o diretamente para o leitor que já usa."
 
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Choose images"
@@ -3362,8 +3386,8 @@ msgstr "publicar rótulos do AT Protocol que o Standard Reader exibe — e com b
 #~ msgstr "O mecanismo exato de substituição é idiomático para cada framework — um objeto de funções de componentes no React, Vue e Solid; templates <0>lit-html</0> no Lit; snippets no Svelte; ou refs <1><ng-template></1> no Angular —, mas a divisão e a terminologia são as mesmas em todos eles. Consulte o arquivo README de cada pacote para verificar a estrutura específica do framework."
 
 #: src/components/reader/about-view.tsx
-msgid "Save, like, subscribe — everywhere"
-msgstr "Salvar, recomendar, se inscrever — em todo lugar"
+#~ msgid "Save, like, subscribe — everywhere"
+#~ msgstr "Salvar, recomendar, se inscrever — em todo lugar"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe?"
@@ -3492,6 +3516,10 @@ msgstr "Dados pessoais"
 msgid "on Leaflet"
 msgstr "no Leaflet"
 
+#: src/components/reader/about-view.tsx
+msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save, and take all of it with you, wherever you choose to read next."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 #: src/components/user-settings-view.tsx
 msgid "Not now"
@@ -3609,8 +3637,8 @@ msgid "Loading…"
 msgstr "Carregando…"
 
 #: src/components/reader/about-view.tsx
-msgid "Choose body text size, column width, and font — serif, sans, or any Google Font. Read the way that’s easy on your eyes."
-msgstr "Escolha o tamanho do texto, a largura da coluna e o tipo de letra — serifado, sem serifa ou qualquer Fonte do Google. Leia da forma que for mais confortável para os seus olhos."
+#~ msgid "Choose body text size, column width, and font — serif, sans, or any Google Font. Read the way that’s easy on your eyes."
+#~ msgstr "Escolha o tamanho do texto, a largura da coluna e o tipo de letra — serifado, sem serifa ou qualquer Fonte do Google. Leia da forma que for mais confortável para os seus olhos."
 
 #: src/routes/_layout.u.$did.tsx
 msgid "{name} hasn't started reading or publishing here. You can find them on Bluesky."
@@ -3892,6 +3920,10 @@ msgid "Unfollow?"
 msgstr "Deixar de seguir?"
 
 #: src/components/reader/about-view.tsx
+msgid "Build named, shareable lists of publications: a playlist for reading. Anyone can add your list to their own reader in a single tap."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
 msgid "Listen to anything"
 msgstr "Ouvir seja o que for"
 
@@ -3949,6 +3981,10 @@ msgstr "Artigos que recomendou pela rede fora."
 #: src/routes/_layout.feedback.return.tsx
 msgid "View feedback"
 msgstr "Ver feedback"
+
+#: src/components/reader/about-view.tsx
+msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave, and you can preview exactly what it looks like before you ever turn it on."
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "All caught up"
@@ -4189,8 +4225,8 @@ msgid "The core / new frameworks"
 msgstr "O núcleo / novos frameworks"
 
 #: src/components/reader/about-view.tsx
-msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written — no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
-msgstr "Inscreva-se nas publicações em <0>standard.site</0> que lhe interessam. Os novos textos simplesmente chegam, pela ordem em que foram escritos — nada de brigar contra o feed, nada gritando pela sua atenção. Apenas bons textos longos, e uma forma genuinamente agradável de continuar a encontrar mais."
+#~ msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written — no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
+#~ msgstr "Inscreva-se nas publicações em <0>standard.site</0> que lhe interessam. Os novos textos simplesmente chegam, pela ordem em que foram escritos — nada de brigar contra o feed, nada gritando pela sua atenção. Apenas bons textos longos, e uma forma genuinamente agradável de continuar a encontrar mais."
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Save"
@@ -4273,6 +4309,10 @@ msgstr "O seu feed Início está vazio por agora — passe pelo Descobrir quando
 msgid "Articles"
 msgstr "Artigos"
 
+#: src/components/reader/about-view.tsx
+msgid "Under each article you see the discussion from across the open network: Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Leave a review"
 msgstr "Deixar uma avaliação"
@@ -4322,8 +4362,8 @@ msgid "Settings"
 msgstr "Configurações"
 
 #: src/components/reader/about-view.tsx
-msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
-msgstr "Uma extensão de navegador leve que lhe permite salvar e se inscrever em publicações enquanto navega pela web — com discretos botões no bsky.app e uma sobreposição de um clique em qualquer página onde estiver. A sua lista de leitura enche-se sozinha."
+#~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+#~ msgstr "Uma extensão de navegador leve que lhe permite salvar e se inscrever em publicações enquanto navega pela web — com discretos botões no bsky.app e uma sobreposição de um clique em qualquer página onde estiver. A sua lista de leitura enche-se sozinha."
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -4389,6 +4429,10 @@ msgstr "Ler artigo"
 msgid "Terms of service"
 msgstr "Termos de serviço"
 
+#: src/components/reader/about-view.tsx
+msgid "<0>{countLabel}</0> publications indexed, and counting"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Delete all reading history?"
 msgstr "Apagar todo o histórico de leitura?"
@@ -4445,6 +4489,10 @@ msgstr "Em pausa"
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "Detalhes"
+
+#: src/components/reader/about-view.tsx
+msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web, with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "When you save or follow from the extension, {SITE_NAME} writes AT Protocol records to <0>your</0> repository through the same server paths as the web app. Those records follow the network's visibility rules and your account settings."
@@ -4517,8 +4565,8 @@ msgid "Open any article while signed in and it'll show up here. Your history liv
 msgstr "Abra qualquer artigo com sessão iniciada e ele aparecerá aqui. O seu histórico vive no seu repositório como registos <0>app.standard-reader.read</0>."
 
 #: src/components/reader/about-view.tsx
-msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
-msgstr "Crie listas de publicações com nome e partilháveis — uma playlist para ler. Qualquer pessoa pode adicionar a sua lista ao próprio leitor com um só toque."
+#~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
+#~ msgstr "Crie listas de publicações com nome e partilháveis — uma playlist para ler. Qualquer pessoa pode adicionar a sua lista ao próprio leitor com um só toque."
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
@@ -4593,6 +4641,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Labelers"
 msgstr "Rotuladores"
+
+#: src/components/reader/about-view.tsx
+msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written: no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
+msgstr ""
 
 #: src/components/reader/language-dialog.tsx
 msgid "Choose your language"
@@ -4996,6 +5048,10 @@ msgstr "Salvar no Margin…"
 msgid "{minutes} min"
 msgstr "{minutes} min"
 
+#: src/components/reader/about-view.tsx
+msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it, and stays a good citizen of the wider network."
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Landscape"
 msgstr "Horizontal"
@@ -5044,8 +5100,8 @@ msgid "Opening the issue…"
 msgstr "A abrir a edição…"
 
 #: src/components/reader/about-view.tsx
-msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
-msgstr "Não lhe pede que deixe o resto da web para trás. Estende-lhe a mão — e continua a ser um bom cidadão da rede mais ampla."
+#~ msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+#~ msgstr "Não lhe pede que deixe o resto da web para trás. Estende-lhe a mão — e continua a ser um bom cidadão da rede mais ampla."
 
 #: src/routes/_layout.collections.edit.$rkey.tsx
 msgid "We couldn’t load that collection to edit."
@@ -5177,6 +5233,10 @@ msgstr "Link"
 #: src/components/reader/collection-publication-editor.tsx
 msgid "Save series"
 msgstr "Salvar série"
+
+#: src/components/reader/about-view.tsx
+msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed: pipe it straight into whatever reader you already use."
+msgstr ""
 
 #: src/components/labelers-settings-view.tsx
 msgid "No labelers match “{searchTrim}”."
@@ -5326,6 +5386,10 @@ msgstr "{connectionLabel} via Semble"
 
 #: src/components/appearance-settings.tsx
 msgid "S"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Publications, lists, and collections each get a clean link with a rich preview card, plus a subscribe button a publication can drop on its own site."
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -134,6 +134,10 @@ msgstr "移除图标"
 msgid "The {SITE_NAME} browser extension helps you save articles and follow publications on the standard.site network from any tab. It connects to the same account as the web app at <0>{siteHost}</0>. This policy covers the extension only; the <1>site privacy policy</1> describes data handling on the website itself."
 msgstr "{SITE_NAME} 浏览器扩展帮助你在任意标签页中保存文章、关注 standard.site 网络上的刊物。它与网页应用 <0>{siteHost}</0> 使用同一个账户。本政策仅适用于该扩展；<1>站点隐私政策</1>说明网站本身的数据处理方式。"
 
+#: src/components/reader/about-view.tsx
+msgid "Save, like, subscribe: everywhere"
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Change language"
@@ -256,6 +260,10 @@ msgstr "正在打开合集…"
 msgid "Density"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Choose body text size, column width, and font: serif, sans, or any Google Font. Read the way that’s easy on your eyes."
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Open on publication"
 msgstr "在刊物中打开"
@@ -265,8 +273,8 @@ msgid "(this is what Standard Reader itself uses)"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
-msgstr "而且它从不封闭。我们把每篇文章与 Atmosphere（这个应用之外的开放网络）中正在发生的讨论连接起来——汇集关于它的 Bluesky 帖子与回复、留在页边的批注，以及引用过它的其他写作，安静地呈现在你阅读的内容下方。"
+#~ msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+#~ msgstr "而且它从不封闭。我们把每篇文章与 Atmosphere（这个应用之外的开放网络）中正在发生的讨论连接起来——汇集关于它的 Bluesky 帖子与回复、留在页边的批注，以及引用过它的其他写作，安静地呈现在你阅读的内容下方。"
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "running…"
@@ -365,8 +373,8 @@ msgid "Set these now, or change them any time in Settings."
 msgstr "现在设置，或随时在「设置」中更改。"
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
-msgstr "大多数阅读器止步于你已订阅的内容。Standard Reader 把帮你找到下一个心头好当作分内事。浏览网络上的每一个刊物——不只是你听说过的那几个。"
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
+#~ msgstr "大多数阅读器止步于你已订阅的内容。Standard Reader 把帮你找到下一个心头好当作分内事。浏览网络上的每一个刊物——不只是你听说过的那几个。"
 
 #: src/routes/_layout.collections.index.tsx
 msgid "Name your series & pick a theme"
@@ -770,6 +778,10 @@ msgstr "数据存放在哪里"
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "We couldn’t find that list."
 msgstr "我们找不到该列表。"
+
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network, not just the handful you've heard of."
+msgstr ""
 
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/mention-hover-card.tsx
@@ -1363,8 +1375,8 @@ msgid "You're subscribed to every publication on this page — scroll for more, 
 msgstr "本页所有刊物你都已订阅——继续滚动查看更多，或关闭筛选。"
 
 #: src/components/reader/about-view.tsx
-msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
-msgstr "每篇文章下方都能看到来自开放网络的讨论——Bluesky 的帖子与回复、页边笔记、引用它的其他文章链接，以及相关阅读。全部只读，且都链接回原始出处。"
+#~ msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+#~ msgstr "每篇文章下方都能看到来自开放网络的讨论——Bluesky 的帖子与回复、页边笔记、引用它的其他文章链接，以及相关阅读。全部只读，且都链接回原始出处。"
 
 #: src/routes/_layout.latest.tsx
 msgid "Show all subscriptions"
@@ -1405,8 +1417,8 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {# 条匹配} other {# 条匹配}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
-msgstr "刊物、列表和合集都有简洁的链接与丰富的预览卡片——刊物还能把订阅按钮放到自己的网站上。"
+#~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
+#~ msgstr "刊物、列表和合集都有简洁的链接与丰富的预览卡片——刊物还能把订阅按钮放到自己的网站上。"
 
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Search topics"
@@ -1548,8 +1560,8 @@ msgid "Something went wrong while submitting your feedback."
 msgstr "提交反馈时出错了。"
 
 #: src/components/reader/about-view.tsx
-msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
-msgstr "不想再多装一个应用来查看？可以订阅每周邮件，收录你所订阅刊物中的精华，外加几个值得发现的新去处。一封邮件，一键退订——开启之前还能先预览它的样子。"
+#~ msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
+#~ msgstr "不想再多装一个应用来查看？可以订阅每周邮件，收录你所订阅刊物中的精华，外加几个值得发现的新去处。一封邮件，一键退订——开启之前还能先预览它的样子。"
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/collection-builder.tsx
@@ -1645,6 +1657,10 @@ msgstr "站点"
 #: src/routes/_layout.index.tsx
 msgid "Today"
 msgstr "今天"
+
+#: src/components/reader/about-view.tsx
+msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere (the open network beyond this app), gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/reader/cards.tsx
@@ -1805,6 +1821,10 @@ msgstr "由 Standard Reader 提供支持"
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network, not just the handful you've heard of."
+msgstr ""
+
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -1881,6 +1901,10 @@ msgstr "要给你发送每周摘要，Standard Reader 需要你的账号邮箱�
 #: src/components/reader/about-view.tsx
 msgid "Discovery"
 msgstr "发现"
+
+#: src/components/reader/about-view.tsx
+msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app; it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
+msgstr ""
 
 #. placeholder {0}: selected.count
 #: src/components/reader/subscriptions-table.tsx
@@ -2069,8 +2093,8 @@ msgid "Subscribe to a few publications or follow some people, and their latest w
 msgstr "订阅几个刊物或关注一些人，他们的最新文章和推荐就会汇聚到这里。"
 
 #: src/components/reader/about-view.tsx
-msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save — and take all of it with you, wherever you choose to read next."
-msgstr "无需账号即可阅读。想订阅、点赞和保存时，用 Bluesky 登录——这些内容都归你所有，可以带到你下一个想读的地方。"
+#~ msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save — and take all of it with you, wherever you choose to read next."
+#~ msgstr "无需账号即可阅读。想订阅、点赞和保存时，用 Bluesky 登录——这些内容都归你所有，可以带到你下一个想读的地方。"
 
 #: src/components/reader/collection-builder.tsx
 msgid "Remove {itemTitle}"
@@ -2087,8 +2111,8 @@ msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {位关注者} other {位关注者}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
-msgstr "大多数阅读器止步于你已经订阅的内容。Standard Reader 把帮你找到下一个心头好也当作本职。浏览网络上全部 {countLabel} 个刊物——不只是你听说过的那几个。"
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgstr "大多数阅读器止步于你已经订阅的内容。Standard Reader 把帮你找到下一个心头好也当作本职。浏览网络上全部 {countLabel} 个刊物——不只是你听说过的那几个。"
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labels"
@@ -2627,8 +2651,8 @@ msgid "Large"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
-msgstr "「朗读」按钮可在你的设备上直接朗读任意文章，并逐词高亮。播放器会跟随你在应用中移动——甚至能读出嵌入的 Bluesky 帖子。登录后还可以挑选音色。"
+#~ msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
+#~ msgstr "「朗读」按钮可在你的设备上直接朗读任意文章，并逐词高亮。播放器会跟随你在应用中移动——甚至能读出嵌入的 Bluesky 帖子。登录后还可以挑选音色。"
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Something went wrong while preparing your review."
@@ -3029,8 +3053,8 @@ msgid "Select a tag"
 msgstr "选择标签"
 
 #: src/components/reader/about-view.tsx
-msgid "<0>{countLabel}</0> publications indexed — and counting"
-msgstr "已收录 <0>{countLabel}</0> 个刊物，还在持续增加"
+#~ msgid "<0>{countLabel}</0> publications indexed — and counting"
+#~ msgstr "已收录 <0>{countLabel}</0> 个刊物，还在持续增加"
 
 #: src/routes/_layout.index.tsx
 msgid "{newCount} new"
@@ -3220,8 +3244,8 @@ msgid "Browse publications"
 msgstr "浏览刊物"
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
-msgstr "Standard Reader 不会把你的阅读困在一个应用里。网络的任何一部分都自带 RSS 源——直接接入你已经在用的阅读器即可。"
+#~ msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
+#~ msgstr "Standard Reader 不会把你的阅读困在一个应用里。网络的任何一部分都自带 RSS 源——直接接入你已经在用的阅读器即可。"
 
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Choose images"
@@ -3362,8 +3386,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Save, like, subscribe — everywhere"
-msgstr "保存、点赞、订阅——随处可用"
+#~ msgid "Save, like, subscribe — everywhere"
+#~ msgstr "保存、点赞、订阅——随处可用"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe?"
@@ -3492,6 +3516,10 @@ msgstr "个人数据"
 msgid "on Leaflet"
 msgstr "在 Leaflet 上"
 
+#: src/components/reader/about-view.tsx
+msgid "Read without an account. Sign in with Bluesky when you want to subscribe, like, and save, and take all of it with you, wherever you choose to read next."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 #: src/components/user-settings-view.tsx
 msgid "Not now"
@@ -3609,8 +3637,8 @@ msgid "Loading…"
 msgstr "加载中……"
 
 #: src/components/reader/about-view.tsx
-msgid "Choose body text size, column width, and font — serif, sans, or any Google Font. Read the way that’s easy on your eyes."
-msgstr "选择正文字号、栏宽和字体——衬线、无衬线，或任意 Google Font。用最舒适的方式阅读。"
+#~ msgid "Choose body text size, column width, and font — serif, sans, or any Google Font. Read the way that’s easy on your eyes."
+#~ msgstr "选择正文字号、栏宽和字体——衬线、无衬线，或任意 Google Font。用最舒适的方式阅读。"
 
 #: src/routes/_layout.u.$did.tsx
 msgid "{name} hasn't started reading or publishing here. You can find them on Bluesky."
@@ -3892,6 +3920,10 @@ msgid "Unfollow?"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
+msgid "Build named, shareable lists of publications: a playlist for reading. Anyone can add your list to their own reader in a single tap."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
 msgid "Listen to anything"
 msgstr "任意内容都能听"
 
@@ -3949,6 +3981,10 @@ msgstr "你在全网推荐过的文章。"
 #: src/routes/_layout.feedback.return.tsx
 msgid "View feedback"
 msgstr "查看反馈"
+
+#: src/components/reader/about-view.tsx
+msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave, and you can preview exactly what it looks like before you ever turn it on."
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "All caught up"
@@ -4189,8 +4225,8 @@ msgid "The core / new frameworks"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written — no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
-msgstr "订阅 <0>standard.site</0> 上你在意的刊物。新的作品会按写作顺序自然抵达——无需与信息流搏斗，也没有什么争抢你的注意力。只有优质的长文，以及一种真正舒服的方式，让你不断发现更多。"
+#~ msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written — no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
+#~ msgstr "订阅 <0>standard.site</0> 上你在意的刊物。新的作品会按写作顺序自然抵达——无需与信息流搏斗，也没有什么争抢你的注意力。只有优质的长文，以及一种真正舒服的方式，让你不断发现更多。"
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Save"
@@ -4273,6 +4309,10 @@ msgstr "你的首页信息流暂时是空的——随时可以去「发现」看
 msgid "Articles"
 msgstr "文章"
 
+#: src/components/reader/about-view.tsx
+msgid "Under each article you see the discussion from across the open network: Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Leave a review"
 msgstr "写个评价"
@@ -4322,8 +4362,8 @@ msgid "Settings"
 msgstr "设置"
 
 #: src/components/reader/about-view.tsx
-msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
-msgstr "轻量的浏览器扩展让你在网上浏览时随手保存和订阅刊物——在 bsky.app 上显示低调的徽标，在你访问的任何页面上提供一键浮层。你的阅读清单会自己充实起来。"
+#~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+#~ msgstr "轻量的浏览器扩展让你在网上浏览时随手保存和订阅刊物——在 bsky.app 上显示低调的徽标，在你访问的任何页面上提供一键浮层。你的阅读清单会自己充实起来。"
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -4389,6 +4429,10 @@ msgstr "阅读文章"
 msgid "Terms of service"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "<0>{countLabel}</0> publications indexed, and counting"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Delete all reading history?"
 msgstr "删除全部阅读记录？"
@@ -4445,6 +4489,10 @@ msgstr "已暂停"
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "详情"
+
+#: src/components/reader/about-view.tsx
+msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web, with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "When you save or follow from the extension, {SITE_NAME} writes AT Protocol records to <0>your</0> repository through the same server paths as the web app. Those records follow the network's visibility rules and your account settings."
@@ -4517,8 +4565,8 @@ msgid "Open any article while signed in and it'll show up here. Your history liv
 msgstr "登录后打开任意文章，它就会出现在这里。你的阅读记录以 <0>app.standard-reader.read</0> 记录形式存放在你的仓库中。"
 
 #: src/components/reader/about-view.tsx
-msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
-msgstr "建立有名字、可分享的刊物列表——像阅读歌单一样。任何人都能一键把你的列表加进自己的阅读器。"
+#~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
+#~ msgstr "建立有名字、可分享的刊物列表——像阅读歌单一样。任何人都能一键把你的列表加进自己的阅读器。"
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
@@ -4593,6 +4641,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Labelers"
 msgstr "标注服务"
+
+#: src/components/reader/about-view.tsx
+msgid "Subscribe to the publications on <0>standard.site</0> you care about. New writing simply arrives, in the order it was written: no feed to fight, nothing shouting for your attention. Just good long-form, and a genuinely nice way to keep finding more of it."
+msgstr ""
 
 #: src/components/reader/language-dialog.tsx
 msgid "Choose your language"
@@ -4996,6 +5048,10 @@ msgstr "保存到 Margin…"
 msgid "{minutes} min"
 msgstr "{minutes} 分钟"
 
+#: src/components/reader/about-view.tsx
+msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it, and stays a good citizen of the wider network."
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Landscape"
 msgstr "横版"
@@ -5044,8 +5100,8 @@ msgid "Opening the issue…"
 msgstr "正在打开本期…"
 
 #: src/components/reader/about-view.tsx
-msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
-msgstr "它不要求你抛下网络的其余部分，而是主动伸手连接——始终做更广网络中的好公民。"
+#~ msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+#~ msgstr "它不要求你抛下网络的其余部分，而是主动伸手连接——始终做更广网络中的好公民。"
 
 #: src/routes/_layout.collections.edit.$rkey.tsx
 msgid "We couldn’t load that collection to edit."
@@ -5177,6 +5233,10 @@ msgstr "链接"
 #: src/components/reader/collection-publication-editor.tsx
 msgid "Save series"
 msgstr "保存系列"
+
+#: src/components/reader/about-view.tsx
+msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed: pipe it straight into whatever reader you already use."
+msgstr ""
 
 #: src/components/labelers-settings-view.tsx
 msgid "No labelers match “{searchTrim}”."
@@ -5326,6 +5386,10 @@ msgstr "{connectionLabel}（通过 Semble）"
 
 #: src/components/appearance-settings.tsx
 msgid "S"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Publications, lists, and collections each get a clean link with a rich preview card, plus a subscribe button a publication can drop on its own site."
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx


### PR DESCRIPTION
## Discussion

at://did:plc:f4os2wz5fjl56xpwcvtnqu7m/app.userinput.discussion/3mrottj6ctj2k

## Original request

> Title: remove emdashes from /about page
> (no body)

## What I found

The `/about` page (`src/routes/_layout.about.tsx` → `AboutView` in
`src/components/reader/about-view.tsx`) is a long marketing/explainer page and
its prose used em dashes (`—`) in ~15 places — asides, list-style
introductions, and connecting clauses. The page's social-preview tagline in
`src/lib/site-metadata.ts` (used for the `<meta description>`/OG tags on
`/about`) had one more.

There was no incorrect assumption to correct here — the report was accurate
and literal. I replaced each em dash with punctuation matched to its
grammatical role instead of a blanket find-and-replace, so the copy still
reads naturally:

- Parenthetical asides → parentheses or a comma (e.g. "the conversation
  happening across the Atmosphere (the open network beyond this app),
  gathering...")
- List-style introductions → a colon (e.g. "Choose body text size, column
  width, and font: serif, sans, or any Google Font.")
- One contrastive clause → a semicolon ("The player follows you around the
  app; it'll even read an embedded Bluesky post.")
- Otherwise → a comma joining the two clauses

Two source comments in `about-view.tsx` (an internal JSDoc note and an inline
dev comment) still contain em dashes; I left those alone since they're never
rendered to a reader and are out of scope for a page-copy report.

Because these strings are `t`/`<Trans>` lingui macros, I re-ran
`pnpm i18n:extract` + `pnpm i18n:compile` after the copy changes so the
`.po` catalogs stay in sync with the new English source text (this is also a
gated CI check). The ~16 changed strings now show as untranslated in the
non-English catalogs, same as any other copy change, pending normal
translation.

### Shape brief (compact, per the routine's autonomous-run rules)

- Remove all em dashes from `/about` page copy — pure copy substitution, no
  layout/component/visual changes.
- Preserve the calm, editorial "good magazine" voice from `PRODUCT.md`; no
  meaning changes.
- Confirmed and implemented directly (no visual ambiguity to gate on).

### Screenshots

I could not capture a live screenshot: this sandbox has no `DATABASE_URL` /
Neon credentials, and `/about`'s route loader queries the Neon read-model
(publication counts, directory, trending) before it can render, so
`pnpm dev` 500s on this route without a database. Rather than fabricate a
screenshot, here's the full before/after text diff of the changed copy for
review — since this is a pure typographic/punctuation change with zero layout
impact, the diff is the meaningful review artifact:

```diff
- Browse all ${countLabel} publications on the network — not just the handful you've heard of.
+ Browse all ${countLabel} publications on the network, not just the handful you've heard of.

- written — no feed to fight, nothing shouting for your attention.
+ written: no feed to fight, nothing shouting for your attention.

- publications indexed — and counting
+ publications indexed, and counting

- across the Atmosphere — the open network beyond this app — gathering the Bluesky posts
+ across the Atmosphere (the open network beyond this app), gathering the Bluesky posts

- Choose body text size, column width, and font — serif, sans, or any Google Font.
+ Choose body text size, column width, and font: serif, sans, or any Google Font.

- The player follows you around the app — it'll even read an embedded Bluesky post.
+ The player follows you around the app; it'll even read an embedded Bluesky post.

- It reaches out to it — and stays a good citizen of the wider network.
+ It reaches out to it, and stays a good citizen of the wider network.

- while you're out on the web — with subtle badges on bsky.app
+ while you're out on the web, with subtle badges on bsky.app

- Save, like, subscribe — everywhere
+ Save, like, subscribe: everywhere

- network — Bluesky posts and replies, margin notes
+ network: Bluesky posts and replies, margin notes

- rich preview card — plus a subscribe button
+ rich preview card, plus a subscribe button

- Build named, shareable lists of publications — a playlist for reading.
+ Build named, shareable lists of publications: a playlist for reading.

- One email, one click to leave — and you can preview
+ One email, one click to leave, and you can preview

- Any slice of the network comes with its own RSS feed — pipe it straight
+ Any slice of the network comes with its own RSS feed: pipe it straight

- subscribe, like, and save — and take all of it with you
+ subscribe, like, and save, and take all of it with you

- (site-metadata.ts) subscribe to — calm, chronological, and yours to take anywhere.
+ (site-metadata.ts) subscribe to: calm, chronological, and yours to take anywhere.
```

## Testing

- `pnpm build` ✅
- `pnpm format:check` ✅
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅ (525 passed, 4 skipped)
- `pnpm i18n:extract` produces no further diff (catalogs are up to date)

---
_Generated by [Claude Code](https://claude.ai/code/session_0151jyQH5cXKWCQVPCbva69t)_