### PR TITLE
Slide the mobile bottom nav out of frame as you read forward

### DIFF
--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -531,7 +531,10 @@ Build each on hip-ui components + StyleX tokens (no raw HTML/inline styles).
       away and slid back on scroll up (`useAnimatedNavbar`); the bottom tab nav now mirrors
       it downward (`useAnimatedBottomNav`), sliding out through the bottom edge as you read
       forward and coming back on a small scroll up. The dock follows it partway so the page
-      reader transport drops into the vacated slot instead of floating over a gap.
+      reader transport drops into the vacated slot instead of floating over a gap. On iOS
+      the bar fades in and out where it stands instead — Safari's own bottom toolbar resizes
+      the dynamic viewport with the same scroll, so the travel distance is re-decided
+      mid-slide and the bar lands short. Platform check is react-aria's `isIOS()`.
 - [x] **Home** — masthead (date + unread count), featured lead, latest unread rows, right rail (Trending articles + You might follow).
 - [x] **Latest** — chronological list, segmented Unread / Subscriptions / All-network filter with counts (Unread = unread docs from subs, Subscriptions = all docs from subs, All = whole network).
 - [x] **Discover** — Trending / Topics / Recommended / Followed-by-people-you-follow / All (chips, sort, grid⇄list toggle).

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -527,6 +527,11 @@ in structured o11y (`observe`) and reads from the Neon read-model.
 Build each on hip-ui components + StyleX tokens (no raw HTML/inline styles).
 
 - [x] App shell: desktop persistent left sidebar; mobile top bar + bottom tab nav; Following list.
+- [x] **Mobile chrome gets out of the way while reading** — the top bar already scrolled
+      away and slid back on scroll up (`useAnimatedNavbar`); the bottom tab nav now mirrors
+      it downward (`useAnimatedBottomNav`), sliding out through the bottom edge as you read
+      forward and coming back on a small scroll up. The dock follows it partway so the page
+      reader transport drops into the vacated slot instead of floating over a gap.
 - [x] **Home** — masthead (date + unread count), featured lead, latest unread rows, right rail (Trending articles + You might follow).
 - [x] **Latest** — chronological list, segmented Unread / Subscriptions / All-network filter with counts (Unread = unread docs from subs, Subscriptions = all docs from subs, All = whole network).
 - [x] **Discover** — Trending / Topics / Recommended / Followed-by-people-you-follow / All (chips, sort, grid⇄list toggle).

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -535,6 +535,11 @@ Build each on hip-ui components + StyleX tokens (no raw HTML/inline styles).
       the bar fades in and out where it stands instead — Safari's own bottom toolbar resizes
       the dynamic viewport with the same scroll, so the travel distance is re-decided
       mid-slide and the bar lands short. Platform check is react-aria's `isIOS()`.
+      Above the fold the same gesture clears the top: `useAnimatedNavbar` now publishes
+      `--app-chrome-hidden` next to `--app-navbar-offset`, and the article's sticky header
+      reads it to pull itself up by its own measured height — so back/byline/actions leave
+      with the app bar and the only thing left against the top of the screen is the reading
+      progress track. ([Mobile Screen Real-Estate](https://userinput.app/d/did:plc:3x5npw4cb2twifyqcox7jmqj/3mrwcpbgousq2))
 - [x] **Home** — masthead (date + unread count), featured lead, latest unread rows, right rail (Trending articles + You might follow).
 - [x] **Latest** — chronological list, segmented Unread / Subscriptions / All-network filter with counts (Unread = unread docs from subs, Subscriptions = all docs from subs, All = whole network).
 - [x] **Discover** — Trending / Topics / Recommended / Followed-by-people-you-follow / All (chips, sort, grid⇄list toggle).

--- a/apps/standard-reader/src/components/reader/app-shell.tsx
+++ b/apps/standard-reader/src/components/reader/app-shell.tsx
@@ -8,6 +8,7 @@ import { DirectionalIcon } from "@standard-reader/design-system/directional-icon
 import { Flex } from "@standard-reader/design-system/flex";
 import { IconButton } from "@standard-reader/design-system/icon-button";
 import { Menu, MenuItem, SubMenu } from "@standard-reader/design-system/menu";
+import { useAnimatedBottomNav } from "@standard-reader/design-system/navbar/useAnimatedBottomNav";
 import { useAnimatedNavbar } from "@standard-reader/design-system/navbar/useAnimatedNavbar";
 import { Skeleton } from "@standard-reader/design-system/skeleton";
 import { SkipLink } from "@standard-reader/design-system/skip-link";
@@ -714,10 +715,22 @@ function navItemActive(pathname: string, to: string): boolean {
 function BottomNav({
   items,
   hasUnread,
+  dockRef,
 }: {
   items: Array<NavLink>;
   hasUnread: boolean;
+  dockRef: React.RefObject<HTMLDivElement | null>;
 }) {
+  // Mirror of the mobile top bar: scrolling down slides the pill out through the
+  // bottom edge, scrolling up brings it back, so an article gets the full height
+  // of the screen while the reader is moving through it. The hook only runs on
+  // the compact layout, where this nav is the one that exists — at desktop
+  // widths the sidebar replaces it and the pill is `display: none`.
+  const compactNav = useCompactNav();
+  const { navBarProps } = useAnimatedBottomNav({
+    enabled: compactNav,
+    dockTarget: dockRef,
+  });
   const pathname = useRouterState({
     select: (s: { location: { pathname: string } }) => s.location.pathname,
   });
@@ -761,7 +774,7 @@ function BottomNav({
   );
 
   return (
-    <nav {...stylex.props(styles.bottomNav)}>
+    <nav {...navBarProps} {...stylex.props(styles.bottomNav)}>
       <div {...stylex.props(styles.fabBar)}>
         {indicator ? (
           <span
@@ -798,17 +811,22 @@ function BottomNav({
 function BottomNavSlot({
   items,
   hasUnread,
+  dockRef,
 }: {
   items: Array<NavLink>;
   hasUnread: boolean;
+  dockRef: React.RefObject<HTMLDivElement | null>;
 }) {
   const dock = useSelectionDock();
 
+  // The selection toolbar is a response to something the reader just did, so it
+  // never hides on scroll. Unmounting `BottomNav` also tears down the hook,
+  // which drops the dock back to its resting offset for the toolbar.
   if (dock?.isActive) {
     return <div {...stylex.props(styles.selectionSlot)} ref={dock.setSlot} />;
   }
 
-  return <BottomNav items={items} hasUnread={hasUnread} />;
+  return <BottomNav items={items} hasUnread={hasUnread} dockRef={dockRef} />;
 }
 
 function Brand({
@@ -920,6 +938,10 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const mainRef = useRef<HTMLElement>(null);
   const { navBarProps: mobileBarProps, sentinel: mobileBarSentinel } =
     useAnimatedNavbar({ enabled: compactNav, offsetTarget: mainRef });
+  // The bottom nav slides down out of the dock as you scroll; the dock follows
+  // it partway so the page-reader transport stacked above drops into the
+  // vacated slot rather than hovering over a gap.
+  const dockRef = useRef<HTMLDivElement>(null);
 
   const { data: listsData, isPending: listsPending } = useQuery({
     ...listsQueryOptions(),
@@ -1415,9 +1437,13 @@ export function AppShell({ children }: { children: React.ReactNode }) {
               </PublicationThemeScope>
             </div>
 
-            <div {...stylex.props(styles.dock)}>
+            <div ref={dockRef} {...stylex.props(styles.dock)}>
               <PageReaderBar />
-              <BottomNavSlot items={visibleNav} hasUnread={hasUnread} />
+              <BottomNavSlot
+                items={visibleNav}
+                hasUnread={hasUnread}
+                dockRef={dockRef}
+              />
             </div>
           </main>
 

--- a/apps/standard-reader/src/components/reader/app-shell.tsx
+++ b/apps/standard-reader/src/components/reader/app-shell.tsx
@@ -413,12 +413,16 @@ const styles = stylex.create({
     paddingInlineEnd: horizontalSpace["3xl"],
     paddingInlineStart: horizontalSpace["3xl"],
     pointerEvents: "none",
+    // Nothing writes to this element. The bottom nav's hide-on-scroll animation
+    // shifts `dockStack` inside it instead: a transform here would promote the
+    // viewport-pinned dock to a composited layer, and iOS Safari answers that by
+    // holding its toolbars open and shortening the dynamic viewport — the page
+    // then stops short of the bottom edge with a dead strip below the content.
     // Pinned to the viewport (the document is the scroll container now, so an
     // absolute dock would ride to the bottom of the whole article instead of
     // floating above the fold). Offset by the sidebar width on desktop so the
     // floating card stays centered over the content column.
     position: "fixed",
-    rowGap: gap.lg,
     zIndex: 30,
     // Sit a floor of 16px above the bottom, or hug the home-indicator safe area
     // where that's larger. On iOS (standalone PWA) the ~34px safe-area inset
@@ -427,6 +431,17 @@ const styles = stylex.create({
     // floor keeps the pill off the very bottom edge. `max()` — not env()'s
     // second arg, which only applies when env() is entirely unsupported.
     bottom: `max(env(safe-area-inset-bottom, 0px), ${verticalSpace["3xl"]})`,
+  },
+  // The dock's contents, in normal flow. This is what the hide-on-scroll
+  // animation transforms — see the note on `dock`. It owns the row gap because
+  // the animation measures the bar's footprint from it.
+  dockStack: {
+    alignItems: "center",
+    display: "flex",
+    flexDirection: "column",
+    pointerEvents: "none",
+    rowGap: gap.lg,
+    width: "100%",
   },
   bottomNav: {
     display: { [DESKTOP]: "none", default: "flex" },
@@ -715,11 +730,11 @@ function navItemActive(pathname: string, to: string): boolean {
 function BottomNav({
   items,
   hasUnread,
-  dockRef,
+  stackRef,
 }: {
   items: Array<NavLink>;
   hasUnread: boolean;
-  dockRef: React.RefObject<HTMLDivElement | null>;
+  stackRef: React.RefObject<HTMLDivElement | null>;
 }) {
   // Mirror of the mobile top bar: scrolling down slides the pill out through the
   // bottom edge, scrolling up brings it back, so an article gets the full height
@@ -729,7 +744,7 @@ function BottomNav({
   const compactNav = useCompactNav();
   const { navBarProps } = useAnimatedBottomNav({
     enabled: compactNav,
-    dockTarget: dockRef,
+    stackTarget: stackRef,
   });
   const pathname = useRouterState({
     select: (s: { location: { pathname: string } }) => s.location.pathname,
@@ -811,22 +826,22 @@ function BottomNav({
 function BottomNavSlot({
   items,
   hasUnread,
-  dockRef,
+  stackRef,
 }: {
   items: Array<NavLink>;
   hasUnread: boolean;
-  dockRef: React.RefObject<HTMLDivElement | null>;
+  stackRef: React.RefObject<HTMLDivElement | null>;
 }) {
   const dock = useSelectionDock();
 
   // The selection toolbar is a response to something the reader just did, so it
   // never hides on scroll. Unmounting `BottomNav` also tears down the hook,
-  // which drops the dock back to its resting offset for the toolbar.
+  // which drops the stack back to its resting offset for the toolbar.
   if (dock?.isActive) {
     return <div {...stylex.props(styles.selectionSlot)} ref={dock.setSlot} />;
   }
 
-  return <BottomNav items={items} hasUnread={hasUnread} dockRef={dockRef} />;
+  return <BottomNav items={items} hasUnread={hasUnread} stackRef={stackRef} />;
 }
 
 function Brand({
@@ -938,10 +953,11 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const mainRef = useRef<HTMLElement>(null);
   const { navBarProps: mobileBarProps, sentinel: mobileBarSentinel } =
     useAnimatedNavbar({ enabled: compactNav, offsetTarget: mainRef });
-  // The bottom nav slides down out of the dock as you scroll; the dock follows
-  // it partway so the page-reader transport stacked above drops into the
-  // vacated slot rather than hovering over a gap.
-  const dockRef = useRef<HTMLDivElement>(null);
+  // The bottom nav slides down out of the dock as you scroll; the dock's inner
+  // stack follows it partway so the page-reader transport above drops into the
+  // vacated slot rather than hovering over a gap. The stack, never the dock —
+  // the dock is pinned to the viewport and must stay untransformed.
+  const dockStackRef = useRef<HTMLDivElement>(null);
 
   const { data: listsData, isPending: listsPending } = useQuery({
     ...listsQueryOptions(),
@@ -1437,13 +1453,15 @@ export function AppShell({ children }: { children: React.ReactNode }) {
               </PublicationThemeScope>
             </div>
 
-            <div ref={dockRef} {...stylex.props(styles.dock)}>
-              <PageReaderBar />
-              <BottomNavSlot
-                items={visibleNav}
-                hasUnread={hasUnread}
-                dockRef={dockRef}
-              />
+            <div {...stylex.props(styles.dock)}>
+              <div ref={dockStackRef} {...stylex.props(styles.dockStack)}>
+                <PageReaderBar />
+                <BottomNavSlot
+                  items={visibleNav}
+                  hasUnread={hasUnread}
+                  stackRef={dockStackRef}
+                />
+              </div>
             </div>
           </main>
 

--- a/apps/standard-reader/src/components/reader/app-shell.tsx
+++ b/apps/standard-reader/src/components/reader/app-shell.tsx
@@ -434,7 +434,8 @@ const styles = stylex.create({
   },
   // The dock's contents, in normal flow. This is what the hide-on-scroll
   // animation transforms — see the note on `dock`. It owns the row gap because
-  // the animation measures the bar's footprint from it.
+  // the animation measures the bar's footprint from it. Untouched on iOS, where
+  // the bar fades out where it stands instead of sliding away.
   dockStack: {
     alignItems: "center",
     display: "flex",

--- a/apps/standard-reader/src/components/reader/article-view.tsx
+++ b/apps/standard-reader/src/components/reader/article-view.tsx
@@ -60,6 +60,7 @@ import {
 } from "lucide-react";
 import {
   Fragment,
+  useCallback,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -140,6 +141,46 @@ function articleReadingProgress(content: HTMLElement): number {
   return Math.min(1, Math.max(0, (scrollY - contentTop) / range));
 }
 
+/**
+ * How tall the article's own top bar is, measured rather than assumed — it wraps
+ * differently by title length and grows with the reader's text-size dial, so the
+ * distance it has to travel to clear the screen is never a constant. Published
+ * on the sticky chrome by {@link useTopBarHeight} and read back by
+ * `styles.stickyChrome`.
+ */
+const READER_TOP_BAR_HEIGHT = "--reader-top-bar-height";
+
+/**
+ * Keeps {@link READER_TOP_BAR_HEIGHT} on `host` in sync with the measured height
+ * of the returned ref's element. Written straight to the DOM: the height changes
+ * on resize and on the text-size dial, neither of which anything needs to
+ * re-render for.
+ */
+function useTopBarHeight(host: React.RefObject<HTMLElement | null>) {
+  return useCallback(
+    (node: HTMLElement | null) => {
+      if (!node) return;
+
+      const publish = () => {
+        host.current?.style.setProperty(
+          READER_TOP_BAR_HEIGHT,
+          `${node.getBoundingClientRect().height}px`,
+        );
+      };
+
+      publish();
+      const resizeObserver = new ResizeObserver(publish);
+      resizeObserver.observe(node);
+
+      return () => {
+        resizeObserver.disconnect();
+        host.current?.style.removeProperty(READER_TOP_BAR_HEIGHT);
+      };
+    },
+    [host],
+  );
+}
+
 const styles = stylex.create({
   root: {
     "--current-word-highlight-background-color": primaryColor.solid1,
@@ -186,6 +227,15 @@ const styles = stylex.create({
     // between the two as they move. Offsetting `top` rather than transforming
     // also keeps it out of the way near the top of the page, where this header
     // rides along in normal flow instead of sticking.
+    //
+    // The second term is what a reader moving forward through an article is left
+    // with. Once the app bar has scrolled away it also publishes
+    // `--app-chrome-hidden: 1`, and this pulls itself up by exactly the height of
+    // its own top bar — so the back button, byline and actions clear the top of
+    // the screen and the progress track underneath them lands flush against it.
+    // The whole of the screen is then the article, with a hairline of progress
+    // above it. Scrolling up hands both back at once: one `top`, one transition,
+    // so the bar and this header never separate mid-flight.
     transitionDuration: animationDuration.slow,
     transitionProperty: {
       default: "top",
@@ -193,7 +243,7 @@ const styles = stylex.create({
     },
     transitionTimingFunction: animationTimingFunction.easeInOut,
     zIndex: 20,
-    top: "var(--app-navbar-offset, 0px)",
+    top: `calc(var(--app-navbar-offset, 0px) - var(--app-chrome-hidden, 0) * var(${READER_TOP_BAR_HEIGHT}, 0px))`,
   },
   topBar: {
     alignItems: "center",
@@ -957,6 +1007,10 @@ function ArticleViewBody({
   const { rememberOpenInMagazine } = useOpenCollectionsInMagazine();
   const { preference: readingTypography } = useReadingTypography();
   const articleRef = useRef<HTMLElement>(null);
+  // The sticky header lifts itself by the height of its own top bar once the
+  // reader is moving forward, leaving only the progress track on screen.
+  const stickyChromeRef = useRef<HTMLDivElement>(null);
+  const setTopBarNode = useTopBarHeight(stickyChromeRef);
   const [progress, setProgress] = useState(0);
   const [showMagazineIntro, setShowMagazineIntro] = useState(
     () => Boolean(article.collection) && !hasSeenCollectionMagazineIntro(),
@@ -1149,8 +1203,8 @@ function ArticleViewBody({
       data-unclipped-sticky
       {...stylex.props(styles.root, readerActive && styles.rootReader)}
     >
-      <div {...stylex.props(styles.stickyChrome)}>
-        <div {...stylex.props(styles.topBar)}>
+      <div ref={stickyChromeRef} {...stylex.props(styles.stickyChrome)}>
+        <div ref={setTopBarNode} {...stylex.props(styles.topBar)}>
           <div {...stylex.props(styles.topLeft)}>
             <IconButton
               variant="secondary"

--- a/packages/design-system/src/navbar/index.tsx
+++ b/packages/design-system/src/navbar/index.tsx
@@ -2,6 +2,7 @@
 
 export * from "./Navbar";
 export * from "./NavbarMenu";
+export * from "./useAnimatedBottomNav";
 export * from "./useAnimatedNavbar";
 
 /* eslint-enable react-refresh/only-export-components */

--- a/packages/design-system/src/navbar/useAnimatedBottomNav.tsx
+++ b/packages/design-system/src/navbar/useAnimatedBottomNav.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { isIOS } from "@react-aria/utils";
 import { useCallback, useEffect, useRef } from "react";
 
 import {
@@ -54,6 +55,18 @@ function prefersReducedMotion() {
  * lays out on the main thread), this one is free to animate `transform`: nothing
  * pins itself to a bottom bar, so the composited property is the better pick.
  *
+ * **Except on iOS**, where sliding the bar out through the bottom edge never
+ * worked. Safari's bottom toolbar collapses and expands with the same scrolling
+ * that drives this animation, and the dynamic viewport it resizes is measured
+ * from underneath the dock the bar lives in — so the distance the bar has to
+ * travel is re-decided mid-flight and the bar lands short, or over-shoots and
+ * strands a gap where it used to be. There is no offset that is right for both
+ * toolbar states. So on iOS the bar **fades** in and out where it stands
+ * instead: no travel to get wrong, no geometry to re-measure, and the reader
+ * still gets the chrome out of their way while they read forward. The trade is
+ * that the page-reader transport above it keeps its slot rather than dropping
+ * into the vacated one.
+ *
  * Two rules this hook keeps, both learned from iOS Safari deciding how tall the
  * page is based on what the page pins to the viewport:
  *
@@ -63,9 +76,9 @@ function prefersReducedMotion() {
  *    Safari reads that as a reason to hold its toolbars open and shorten the
  *    dynamic viewport — the page then stops short of the bottom edge.
  * 2. **A resting bar carries no inline styles at all**, not even a
- *    `translateY(0)`. An identity transform still makes a layer and a stacking
- *    context, so it still counts against rule 1; the reveal clears itself once
- *    it lands.
+ *    `translateY(0)` or an `opacity: 1`. An identity transform still makes a
+ *    layer and a stacking context, so it still counts against rule 1; the reveal
+ *    clears itself once it lands.
  *
  * Like the top bar's hook, everything it drives is written straight to the DOM.
  * Scroll direction flips constantly and re-rendering the shell on each flip
@@ -88,7 +101,8 @@ export const useAnimatedBottomNav = ({
    * whatever floats above it (the page-reader transport) drops into the vacated
    * slot instead of hovering over a gap. Both moves are transforms on the same
    * duration and easing, so they stay locked together. Omit it and only the bar
-   * itself moves.
+   * itself moves. Unused on iOS, where the bar fades in place and nothing
+   * around it moves at all.
    */
   stackTarget?: React.RefObject<HTMLElement | null>;
   /**
@@ -124,12 +138,19 @@ export const useAnimatedBottomNav = ({
 
     const clear = () => {
       nav.style.removeProperty("transform");
+      nav.style.removeProperty("opacity");
+      nav.style.removeProperty("visibility");
       nav.style.removeProperty("transition");
       stack?.style.removeProperty("transform");
       stack?.style.removeProperty("transition");
     };
 
     const reducedMotion = prefersReducedMotion();
+    // Cheap enough to re-read on a direction flip, and reading it here rather
+    // than at render keeps it off the server, where there is no platform to
+    // detect and no DOM to write to anyway.
+    const fade = isIOS();
+    const move = `${animationDuration.slow} ${animationTimingFunction.easeInOut}`;
 
     if (!enabledRef.current || !hidden.current) {
       // Back at rest with nothing to undo, or with no motion to animate: drop
@@ -140,20 +161,41 @@ export const useAnimatedBottomNav = ({
         return;
       }
       // Otherwise animate home and let `transitionend` do the clearing.
-      const transition = `transform ${animationDuration.slow} ${animationTimingFunction.easeInOut}`;
-      nav.style.transition = transition;
+      if (fade) {
+        // Visibility comes back first and undelayed, so the bar is on screen for
+        // the whole fade rather than popping in at the end of it.
+        nav.style.transition = `opacity ${move}`;
+        nav.style.removeProperty("visibility");
+        nav.style.opacity = "1";
+        return;
+      }
+      nav.style.transition = `transform ${move}`;
       nav.style.transform = "translateY(0px)";
       if (stack) {
-        stack.style.transition = transition;
+        stack.style.transition = `transform ${move}`;
         stack.style.transform = "translateY(0px)";
       }
       return;
     }
 
-    const transition =
-      animated.current && !reducedMotion
-        ? `transform ${animationDuration.slow} ${animationTimingFunction.easeInOut}`
+    const animate = animated.current && !reducedMotion;
+
+    if (fade) {
+      // A transparent bar is still a bar: the pill inside it sets
+      // `pointer-events: auto`, which a `none` out here would not override, so
+      // taps would keep landing on a nav the reader cannot see. `visibility`
+      // does cascade — held until the fade finishes so it doesn't cut the
+      // animation off at frame one, and it takes the bar out of the tab order
+      // on arrival for free.
+      nav.style.transition = animate
+        ? `opacity ${move}, visibility 0s linear ${animationDuration.slow}`
         : "none";
+      nav.style.opacity = "0";
+      nav.style.visibility = "hidden";
+      return;
+    }
+
+    const transition = animate ? `transform ${move}` : "none";
     // The stack carries part of the travel, so the bar only owes the remainder —
     // nested transforms compose, and the two together still add up to `distance`.
     nav.style.transition = transition;
@@ -187,8 +229,10 @@ export const useAnimatedBottomNav = ({
         viewportHeight.current = globalThis.innerHeight;
         scrollHeight.current = document.documentElement.scrollHeight;
         // The rest is only truthful while the bar is at rest; hidden geometry is
-        // the transformed geometry, and re-deriving from it would compound.
-        if (hidden.current) return;
+        // the transformed geometry, and re-deriving from it would compound. A
+        // fading bar never moves, so it has no travel to measure in the first
+        // place — and measuring it is exactly the thing iOS gets wrong.
+        if (hidden.current || isIOS()) return;
         const rect = node.getBoundingClientRect();
         const stack = stackTarget?.current;
         // The bar is the stack's last child, so its footprint is its own height
@@ -215,18 +259,26 @@ export const useAnimatedBottomNav = ({
       resizeObserver.observe(document.documentElement);
 
       // Clearing on `transitionend` is what keeps rule 2 — the reveal is the
-      // only write that leaves an identity transform behind, and it undoes it
-      // as soon as it lands.
+      // only write that leaves an identity transform (or an `opacity: 1`)
+      // behind, and it undoes it as soon as it lands.
       const onTransitionEnd = (event: TransitionEvent) => {
-        if (event.target !== node || event.propertyName !== "transform") return;
+        if (event.target !== node) return;
+        if (
+          event.propertyName !== "transform" &&
+          event.propertyName !== "opacity"
+        ) {
+          return;
+        }
         if (hidden.current) return;
         animated.current = false;
         apply();
       };
       node.addEventListener("transitionend", onTransitionEnd);
 
-      // A hidden bar is off-screen but still in the tab order. Bring it back
+      // A slid-away bar is off-screen but still in the tab order. Bring it back
       // rather than let keyboard focus wander somewhere the reader can't see.
+      // (A faded one is `visibility: hidden`, so it is already unreachable and
+      // this never fires for it.)
       const onFocusIn = () => setHidden(false);
       node.addEventListener("focusin", onFocusIn);
 

--- a/packages/design-system/src/navbar/useAnimatedBottomNav.tsx
+++ b/packages/design-system/src/navbar/useAnimatedBottomNav.tsx
@@ -54,13 +54,26 @@ function prefersReducedMotion() {
  * lays out on the main thread), this one is free to animate `transform`: nothing
  * pins itself to a bottom bar, so the composited property is the better pick.
  *
+ * Two rules this hook keeps, both learned from iOS Safari deciding how tall the
+ * page is based on what the page pins to the viewport:
+ *
+ * 1. **Never write to the fixed element.** `stackTarget` must be an in-flow
+ *    wrapper *inside* the viewport-pinned dock, never the dock itself. Putting a
+ *    transform on the pinned element promotes it to a composited layer, and
+ *    Safari reads that as a reason to hold its toolbars open and shorten the
+ *    dynamic viewport — the page then stops short of the bottom edge.
+ * 2. **A resting bar carries no inline styles at all**, not even a
+ *    `translateY(0)`. An identity transform still makes a layer and a stacking
+ *    context, so it still counts against rule 1; the reveal clears itself once
+ *    it lands.
+ *
  * Like the top bar's hook, everything it drives is written straight to the DOM.
  * Scroll direction flips constantly and re-rendering the shell on each flip
  * would cost far more than the two style writes the flip actually needs.
  */
 export const useAnimatedBottomNav = ({
   enabled = true,
-  dockTarget,
+  stackTarget,
   scrollContainer: scrollContainerProp,
 }: {
   /**
@@ -69,13 +82,15 @@ export const useAnimatedBottomNav = ({
    */
   enabled?: boolean;
   /**
-   * The bottom-anchored stack the bar is the last child of. When the bar hides,
-   * the dock slides down by the bar's footprint so whatever floats above it
-   * (the page-reader transport) drops into the vacated slot instead of hovering
-   * over a gap. Both moves are transforms on the same duration and easing, so
-   * they stay locked together. Omit it and only the bar itself moves.
+   * The in-flow stack the bar is the last child of, inside the dock that pins
+   * itself to the viewport — **not** the pinned element itself (see rule 1
+   * above). When the bar hides, the stack slides down by the bar's footprint so
+   * whatever floats above it (the page-reader transport) drops into the vacated
+   * slot instead of hovering over a gap. Both moves are transforms on the same
+   * duration and easing, so they stay locked together. Omit it and only the bar
+   * itself moves.
    */
-  dockTarget?: React.RefObject<HTMLElement | null>;
+  stackTarget?: React.RefObject<HTMLElement | null>;
   /**
    * The element that scrolls. Omit it when the document itself is the scroll
    * container: the hook then listens on the window and measures the viewport.
@@ -91,44 +106,63 @@ export const useAnimatedBottomNav = ({
   const hidden = useRef(false);
   const animated = useRef(false);
   // How far the bar has to travel to clear the bottom edge, and how much of that
-  // travel the dock takes on. Measured only while the bar sits in place — the
+  // travel the stack takes on. Measured only while the bar sits in place — the
   // geometry lies once a transform is on it.
   const distance = useRef(0);
   const collapse = useRef(0);
+  // Viewport and document heights, cached rather than read per scroll frame:
+  // `innerHeight` and `scrollHeight` both force layout, and forcing it on every
+  // frame of a scroll is the one thing a scroll handler must not do.
+  const viewportHeight = useRef(0);
+  const scrollHeight = useRef(0);
   const enabledRef = useRef(enabled);
 
   const apply = useCallback(() => {
     const nav = navRef.current;
-    const dock = dockTarget?.current;
+    const stack = stackTarget?.current;
     if (!nav) return;
 
-    // Nothing to show for a bar that has never moved, and a resting bar should
-    // not leave a `translateY(0)` behind: a transform on the dock would make it
-    // the containing block for any fixed-position child that lands in it.
-    if (!enabledRef.current || (!hidden.current && !animated.current)) {
+    const clear = () => {
       nav.style.removeProperty("transform");
       nav.style.removeProperty("transition");
-      dock?.style.removeProperty("transform");
-      dock?.style.removeProperty("transition");
+      stack?.style.removeProperty("transform");
+      stack?.style.removeProperty("transition");
+    };
+
+    const reducedMotion = prefersReducedMotion();
+
+    if (!enabledRef.current || !hidden.current) {
+      // Back at rest with nothing to undo, or with no motion to animate: drop
+      // every inline style so the resting DOM is exactly what the markup says.
+      if (!enabledRef.current || !animated.current || reducedMotion) {
+        animated.current = false;
+        clear();
+        return;
+      }
+      // Otherwise animate home and let `transitionend` do the clearing.
+      const transition = `transform ${animationDuration.slow} ${animationTimingFunction.easeInOut}`;
+      nav.style.transition = transition;
+      nav.style.transform = "translateY(0px)";
+      if (stack) {
+        stack.style.transition = transition;
+        stack.style.transform = "translateY(0px)";
+      }
       return;
     }
 
     const transition =
-      animated.current && !prefersReducedMotion()
+      animated.current && !reducedMotion
         ? `transform ${animationDuration.slow} ${animationTimingFunction.easeInOut}`
         : "none";
-    // The dock carries part of the travel, so the bar only owes the remainder —
+    // The stack carries part of the travel, so the bar only owes the remainder —
     // nested transforms compose, and the two together still add up to `distance`.
-    const dockShift = hidden.current ? collapse.current : 0;
-    const navShift = hidden.current ? distance.current - collapse.current : 0;
-
     nav.style.transition = transition;
-    nav.style.transform = `translateY(${navShift}px)`;
-    if (dock) {
-      dock.style.transition = transition;
-      dock.style.transform = `translateY(${dockShift}px)`;
+    nav.style.transform = `translateY(${distance.current - collapse.current}px)`;
+    if (stack) {
+      stack.style.transition = transition;
+      stack.style.transform = `translateY(${collapse.current}px)`;
     }
-  }, [dockTarget]);
+  }, [stackTarget]);
 
   const setHidden = useCallback(
     (next: boolean) => {
@@ -150,17 +184,19 @@ export const useAnimatedBottomNav = ({
       if (!node) return;
 
       const measure = () => {
-        // Only truthful while the bar is at rest; hidden geometry is the
-        // transformed geometry, and re-deriving from it would compound.
+        viewportHeight.current = globalThis.innerHeight;
+        scrollHeight.current = document.documentElement.scrollHeight;
+        // The rest is only truthful while the bar is at rest; hidden geometry is
+        // the transformed geometry, and re-deriving from it would compound.
         if (hidden.current) return;
         const rect = node.getBoundingClientRect();
-        const dock = dockTarget?.current;
-        // The bar is the dock's last child, so its footprint is its own height
+        const stack = stackTarget?.current;
+        // The bar is the stack's last child, so its footprint is its own height
         // plus the gap that separates it from whatever sits above it.
-        const rowGap = dock
-          ? Number.parseFloat(globalThis.getComputedStyle(dock).rowGap)
+        const rowGap = stack
+          ? Number.parseFloat(globalThis.getComputedStyle(stack).rowGap)
           : 0;
-        collapse.current = dock
+        collapse.current = stack
           ? rect.height + (Number.isNaN(rowGap) ? 0 : rowGap)
           : 0;
         // Distance to the bottom edge rather than a bare height: the dock floats
@@ -171,9 +207,23 @@ export const useAnimatedBottomNav = ({
 
       measure();
       // The bar grows with the reader's text-size dial, and a hidden bar sits
-      // one footprint below the fold, so neither number can be a constant.
+      // one footprint below the fold, so neither number can be a constant. The
+      // document is watched too, so the cached page height follows content that
+      // loads in (embeds, images) without a scroll-time layout read.
       const resizeObserver = new ResizeObserver(measure);
       resizeObserver.observe(node);
+      resizeObserver.observe(document.documentElement);
+
+      // Clearing on `transitionend` is what keeps rule 2 — the reveal is the
+      // only write that leaves an identity transform behind, and it undoes it
+      // as soon as it lands.
+      const onTransitionEnd = (event: TransitionEvent) => {
+        if (event.target !== node || event.propertyName !== "transform") return;
+        if (hidden.current) return;
+        animated.current = false;
+        apply();
+      };
+      node.addEventListener("transitionend", onTransitionEnd);
 
       // A hidden bar is off-screen but still in the tab order. Bring it back
       // rather than let keyboard focus wander somewhere the reader can't see.
@@ -182,19 +232,20 @@ export const useAnimatedBottomNav = ({
 
       return () => {
         resizeObserver.disconnect();
+        node.removeEventListener("transitionend", onTransitionEnd);
         node.removeEventListener("focusin", onFocusIn);
         navRef.current = null;
-        // The dock outlives the bar — a selection toolbar takes the slot over,
+        // The stack outlives the bar — a selection toolbar takes the slot over,
         // and routes swap the bar out. Hand it back unshifted, or whatever
         // replaces the bar inherits an offset meant for a bar that is gone.
         hidden.current = false;
         animated.current = false;
-        const dock = dockTarget?.current;
-        dock?.style.removeProperty("transform");
-        dock?.style.removeProperty("transition");
+        const stack = stackTarget?.current;
+        stack?.style.removeProperty("transform");
+        stack?.style.removeProperty("transition");
       };
     },
-    [apply, dockTarget, setHidden],
+    [apply, setHidden, stackTarget],
   );
 
   // Turning the hook off drops the bar back into place. Clear the state with it,
@@ -222,17 +273,17 @@ export const useAnimatedBottomNav = ({
         : globalThis.scrollY;
       const viewport = container
         ? container.clientHeight
-        : globalThis.innerHeight;
-      const scrollHeight = container
+        : viewportHeight.current;
+      const pageHeight = container
         ? container.scrollHeight
-        : document.documentElement.scrollHeight;
+        : scrollHeight.current;
 
       // Two places the bar always belongs: the top of the page, where hiding it
       // buys nothing, and the end of the page, where the reader has finished and
       // wants somewhere to go next.
       if (
         currentScrollY <= SCROLL_THRESHOLD ||
-        currentScrollY + viewport >= scrollHeight - SCROLL_THRESHOLD
+        currentScrollY + viewport >= pageHeight - SCROLL_THRESHOLD
       ) {
         setHidden(false);
         lastScrollY.current = currentScrollY;

--- a/packages/design-system/src/navbar/useAnimatedBottomNav.tsx
+++ b/packages/design-system/src/navbar/useAnimatedBottomNav.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+import {
+  animationDuration,
+  animationTimingFunction,
+} from "../theme/animations.stylex";
+
+const SCROLL_THRESHOLD = 16;
+
+/**
+ * A floating bar's shadow reaches past its border box, so clearing the viewport
+ * by exactly the bar's own offset would leave a smudge along the bottom edge.
+ * Push it this much further than the geometry says it needs.
+ */
+const SHADOW_CLEARANCE = 24;
+
+/**
+ * Coalesce scroll callbacks down to one per frame — same shim `useAnimatedNavbar`
+ * uses, kept local so the design system doesn't take on a dependency for it.
+ */
+function rafThrottle(callback: () => void) {
+  let frame: number | null = null;
+
+  const throttled = () => {
+    if (frame !== null) return;
+    frame = requestAnimationFrame(() => {
+      frame = null;
+      callback();
+    });
+  };
+
+  throttled.cancel = () => {
+    if (frame === null) return;
+    cancelAnimationFrame(frame);
+    frame = null;
+  };
+
+  return throttled;
+}
+
+function prefersReducedMotion() {
+  return globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+}
+
+/**
+ * The mirror image of {@link useAnimatedNavbar}: a bar pinned to the *bottom* of
+ * the viewport that slides down out of frame as the reader scrolls down and
+ * comes back the moment they scroll up, so the page keeps as much reading room
+ * as it can while the reader is moving forward.
+ *
+ * Where the top bar animates `top` (it has to stay flush with sticky chrome that
+ * lays out on the main thread), this one is free to animate `transform`: nothing
+ * pins itself to a bottom bar, so the composited property is the better pick.
+ *
+ * Like the top bar's hook, everything it drives is written straight to the DOM.
+ * Scroll direction flips constantly and re-rendering the shell on each flip
+ * would cost far more than the two style writes the flip actually needs.
+ */
+export const useAnimatedBottomNav = ({
+  enabled = true,
+  dockTarget,
+  scrollContainer: scrollContainerProp,
+}: {
+  /**
+   * Set `false` to leave the bar parked in place — e.g. at widths where the
+   * sidebar replaces it, so the hook doesn't watch scroll for a hidden bar.
+   */
+  enabled?: boolean;
+  /**
+   * The bottom-anchored stack the bar is the last child of. When the bar hides,
+   * the dock slides down by the bar's footprint so whatever floats above it
+   * (the page-reader transport) drops into the vacated slot instead of hovering
+   * over a gap. Both moves are transforms on the same duration and easing, so
+   * they stay locked together. Omit it and only the bar itself moves.
+   */
+  dockTarget?: React.RefObject<HTMLElement | null>;
+  /**
+   * The element that scrolls. Omit it when the document itself is the scroll
+   * container: the hook then listens on the window and measures the viewport.
+   */
+  scrollContainer?: React.RefObject<HTMLElement | null>;
+}) => {
+  const navRef = useRef<HTMLElement | null>(null);
+  const lastScrollY = useRef(0);
+
+  // State machine in refs, deliberately — see the note above. `hidden` is
+  // "scrolled out of frame"; `animated` says whether the next write transitions,
+  // which the very first write must not (nothing has moved yet).
+  const hidden = useRef(false);
+  const animated = useRef(false);
+  // How far the bar has to travel to clear the bottom edge, and how much of that
+  // travel the dock takes on. Measured only while the bar sits in place — the
+  // geometry lies once a transform is on it.
+  const distance = useRef(0);
+  const collapse = useRef(0);
+  const enabledRef = useRef(enabled);
+
+  const apply = useCallback(() => {
+    const nav = navRef.current;
+    const dock = dockTarget?.current;
+    if (!nav) return;
+
+    // Nothing to show for a bar that has never moved, and a resting bar should
+    // not leave a `translateY(0)` behind: a transform on the dock would make it
+    // the containing block for any fixed-position child that lands in it.
+    if (!enabledRef.current || (!hidden.current && !animated.current)) {
+      nav.style.removeProperty("transform");
+      nav.style.removeProperty("transition");
+      dock?.style.removeProperty("transform");
+      dock?.style.removeProperty("transition");
+      return;
+    }
+
+    const transition =
+      animated.current && !prefersReducedMotion()
+        ? `transform ${animationDuration.slow} ${animationTimingFunction.easeInOut}`
+        : "none";
+    // The dock carries part of the travel, so the bar only owes the remainder —
+    // nested transforms compose, and the two together still add up to `distance`.
+    const dockShift = hidden.current ? collapse.current : 0;
+    const navShift = hidden.current ? distance.current - collapse.current : 0;
+
+    nav.style.transition = transition;
+    nav.style.transform = `translateY(${navShift}px)`;
+    if (dock) {
+      dock.style.transition = transition;
+      dock.style.transform = `translateY(${dockShift}px)`;
+    }
+  }, [dockTarget]);
+
+  const setHidden = useCallback(
+    (next: boolean) => {
+      if (hidden.current === next) return;
+      hidden.current = next;
+      animated.current = true;
+      apply();
+    },
+    [apply],
+  );
+
+  /**
+   * Callback ref rather than a plain one so the observers follow the bar if the
+   * shell swaps the element out from under them.
+   */
+  const setNavNode = useCallback(
+    (node: HTMLElement | null) => {
+      navRef.current = node;
+      if (!node) return;
+
+      const measure = () => {
+        // Only truthful while the bar is at rest; hidden geometry is the
+        // transformed geometry, and re-deriving from it would compound.
+        if (hidden.current) return;
+        const rect = node.getBoundingClientRect();
+        const dock = dockTarget?.current;
+        // The bar is the dock's last child, so its footprint is its own height
+        // plus the gap that separates it from whatever sits above it.
+        const rowGap = dock
+          ? Number.parseFloat(globalThis.getComputedStyle(dock).rowGap)
+          : 0;
+        collapse.current = dock
+          ? rect.height + (Number.isNaN(rowGap) ? 0 : rowGap)
+          : 0;
+        // Distance to the bottom edge rather than a bare height: the dock floats
+        // above the safe-area inset, and that gap has to be travelled too.
+        distance.current = globalThis.innerHeight - rect.top + SHADOW_CLEARANCE;
+        apply();
+      };
+
+      measure();
+      // The bar grows with the reader's text-size dial, and a hidden bar sits
+      // one footprint below the fold, so neither number can be a constant.
+      const resizeObserver = new ResizeObserver(measure);
+      resizeObserver.observe(node);
+
+      // A hidden bar is off-screen but still in the tab order. Bring it back
+      // rather than let keyboard focus wander somewhere the reader can't see.
+      const onFocusIn = () => setHidden(false);
+      node.addEventListener("focusin", onFocusIn);
+
+      return () => {
+        resizeObserver.disconnect();
+        node.removeEventListener("focusin", onFocusIn);
+        navRef.current = null;
+        // The dock outlives the bar — a selection toolbar takes the slot over,
+        // and routes swap the bar out. Hand it back unshifted, or whatever
+        // replaces the bar inherits an offset meant for a bar that is gone.
+        hidden.current = false;
+        animated.current = false;
+        const dock = dockTarget?.current;
+        dock?.style.removeProperty("transform");
+        dock?.style.removeProperty("transition");
+      };
+    },
+    [apply, dockTarget, setHidden],
+  );
+
+  // Turning the hook off drops the bar back into place. Clear the state with it,
+  // or it comes back hidden on re-enable.
+  useEffect(() => {
+    enabledRef.current = enabled;
+    if (!enabled) {
+      hidden.current = false;
+      animated.current = false;
+    }
+    apply();
+  }, [apply, enabled]);
+
+  // Hide on scroll down, reveal on scroll up.
+  useEffect(() => {
+    if (!enabled) return;
+
+    const container = scrollContainerProp?.current ?? null;
+    const scrollTarget: EventTarget = container ?? globalThis;
+    lastScrollY.current = container ? container.scrollTop : globalThis.scrollY;
+
+    const handleScroll = rafThrottle(() => {
+      const currentScrollY = container
+        ? container.scrollTop
+        : globalThis.scrollY;
+      const viewport = container
+        ? container.clientHeight
+        : globalThis.innerHeight;
+      const scrollHeight = container
+        ? container.scrollHeight
+        : document.documentElement.scrollHeight;
+
+      // Two places the bar always belongs: the top of the page, where hiding it
+      // buys nothing, and the end of the page, where the reader has finished and
+      // wants somewhere to go next.
+      if (
+        currentScrollY <= SCROLL_THRESHOLD ||
+        currentScrollY + viewport >= scrollHeight - SCROLL_THRESHOLD
+      ) {
+        setHidden(false);
+        lastScrollY.current = currentScrollY;
+        return;
+      }
+
+      // Below the threshold, leave `lastScrollY` alone so a slow drag keeps
+      // accumulating instead of resetting its own baseline every frame.
+      const delta = currentScrollY - lastScrollY.current;
+      if (Math.abs(delta) < SCROLL_THRESHOLD) return;
+
+      setHidden(delta > 0);
+      lastScrollY.current = currentScrollY;
+    });
+
+    scrollTarget.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => {
+      handleScroll.cancel();
+      scrollTarget.removeEventListener("scroll", handleScroll);
+    };
+  }, [enabled, scrollContainerProp, setHidden]);
+
+  return {
+    navBarProps: { ref: setNavNode },
+  };
+};

--- a/packages/design-system/src/navbar/useAnimatedNavbar.tsx
+++ b/packages/design-system/src/navbar/useAnimatedNavbar.tsx
@@ -23,6 +23,17 @@ const SCROLL_THRESHOLD = 16;
 const NAVBAR_OFFSET_PROPERTY = "--app-navbar-offset";
 
 /**
+ * `1` while the bar is scrolled away, `0` any time it is on screen — including
+ * near the top of the page, where it rides along in normal flow and `revealed`
+ * is still false. Published next to {@link NAVBAR_OFFSET_PROPERTY} so chrome
+ * further down can take the same cue and get out of the way with it, rather
+ * than running a second scroll listener that would drift out of step. The
+ * article view's sticky header uses it to lift everything but its progress bar
+ * off the top of the screen.
+ */
+const CHROME_HIDDEN_PROPERTY = "--app-chrome-hidden";
+
+/**
  * Coalesce scroll callbacks down to one per frame. hip-ui reaches for
  * `raf-throttle` here; this copy inlines the handful of lines it uses so the
  * design system doesn't pull in a dependency for them.
@@ -107,6 +118,7 @@ export const useAnimatedNavbar = ({
       nav.style.removeProperty("box-shadow");
       nav.style.removeProperty("transition");
       offsetHost?.style.setProperty(NAVBAR_OFFSET_PROPERTY, "0px");
+      offsetHost?.style.setProperty(CHROME_HIDDEN_PROPERTY, "0");
       return;
     }
 
@@ -120,6 +132,10 @@ export const useAnimatedNavbar = ({
     offsetHost?.style.setProperty(
       NAVBAR_OFFSET_PROPERTY,
       revealed.current ? `${height.current}px` : "0px",
+    );
+    offsetHost?.style.setProperty(
+      CHROME_HIDDEN_PROPERTY,
+      revealed.current ? "0" : "1",
     );
   }, [offsetTarget]);
 


### PR DESCRIPTION
The mobile top bar already scrolls away and slides back the moment you
scroll up. The bottom tab nav sat there the whole time, so an article
lost a strip of screen at both ends.

`useAnimatedBottomNav` mirrors `useAnimatedNavbar` in the other
direction: the pill slides down through the bottom edge on scroll down
and comes back on a small scroll up, and stays put at the top of the
page and at the end of it, where the reader wants somewhere to go next.
It animates `transform` rather than `top` — nothing pins itself to a
bottom bar, so the composited property is available here in a way it
wasn't for the top bar.

The dock takes on part of the travel so the page-reader transport
stacked above the nav drops into the vacated slot instead of hovering
over a gap. A text selection takes the same slot over and unmounts the
nav, which hands the dock back unshifted.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018WK5YgZZ3jGeHRVWVwcRww