### PR TITLE
Render Leaflet's pub.leaflet.blocks.html block

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -138,6 +138,10 @@ Sections, top to bottom:
   delivered by the tap and indexed onto the document row as its content (sidecar-style, like
   `app.standard-reader.collection`, with a repo fetch as the catch-up path), then rendered from its
   TipTap tree by `renderer-core`.
+  Leaflet's `pub.leaflet.blocks.html` — the author's own HTML — renders in a
+  sandboxed `srcdoc` iframe at the height the block asks for, matching what the lexicon
+  specifies. The sandbox grants scripts only: `allow-same-origin` on a `srcdoc` frame would
+  run the author's markup in the reader's own origin.
   Leaflet image galleries use CSS
   `grid-lanes` where supported with plain CSS Grid fallback elsewhere. Every rendered image in
   a document body — Leaflet galleries and single-image blocks, PCKT image and gallery blocks,

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -824,6 +824,14 @@ Backend/API exists; UI or copy is missing.
       from thumbnail → lightbox in
       [`leaflet-image-gallery.tsx`](src/components/reader/content/renderers/leaflet-image-gallery.tsx)
       and [`src/design-system/lightbox/index.tsx`](src/design-system/lightbox/index.tsx).
+- [x] **`pub.leaflet.blocks.html`** — Leaflet shipped an HTML block (author markup, optional
+      `height` / `aspectRatio`) that read as an unsupported-block placeholder. It now parses in
+      both `renderer-core` and the app's leaflet lib, maps onto a new `htmlEmbed` node distinct
+      from markdown's raw-`html` node, and renders through
+      [`html-embed.tsx`](src/components/reader/content/renderers/shared/html-embed.tsx) — a
+      `srcdoc` iframe sandboxed to `allow-scripts` only, sharing the sizing frame with
+      `iframe-embed.tsx`. The converter carries it natively to Leaflet and as a sandboxed
+      `<iframe srcdoc>` to Markpub; Offprint and pckt have no block for it and report it dropped.
 - [x] **`at.markpub.markdown`** — full [Markpub.at](https://markpub.at/) support: dedicated
       renderer (`src/lib/markpub/*`, [`markpub-content.tsx`](src/components/reader/content/renderers/markpub-content.tsx)),
       flavor/extensions, facet/lens preprocessing, ingest-time `text.textBlob` fetch

--- a/apps/standard-reader/src/components/reader/content/renderers/leaflet-block.tsx
+++ b/apps/standard-reader/src/components/reader/content/renderers/leaflet-block.tsx
@@ -32,6 +32,7 @@ import { CodeBlockView } from "./shared/code-block";
 import { TextBlockView } from "./shared/faceted-text";
 import { HeadingBlockView } from "./shared/heading-block";
 import { HorizontalRuleView } from "./shared/horizontal-rule";
+import { HtmlEmbedView } from "./shared/html-embed";
 import { IframeEmbedView } from "./shared/iframe-embed";
 import { ImageFigureView } from "./shared/image-figure";
 import { UnknownBlockView } from "./shared/unknown-block";
@@ -124,6 +125,15 @@ export function LeafletBlockView({
           plaintext={block.block.plaintext}
           language={block.block.language}
           codeHighlights={codeHighlights}
+        />
+      );
+    }
+    case "html": {
+      return (
+        <HtmlEmbedView
+          html={block.block.html}
+          height={block.block.height}
+          aspectRatio={block.block.aspectRatio}
         />
       );
     }

--- a/apps/standard-reader/src/components/reader/content/renderers/shared/embed-frame.tsx
+++ b/apps/standard-reader/src/components/reader/content/renderers/shared/embed-frame.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+
+import {
+  articleBodyStyles,
+  IFRAME_FRAME_BORDER_WIDTH,
+} from "../../body-styles";
+import { parsePixelDimension } from "./iframe-dimensions";
+
+const DEFAULT_ASPECT_RATIO = "16 / 9";
+
+/**
+ * The bordered, correctly-sized box every `<iframe>` embed sits in.
+ *
+ * Shared by the URL embeds (`IframeEmbedView`) and the srcdoc embeds
+ * (`HtmlEmbedView`) so the two cannot drift on sizing: the iframe itself is
+ * absolutely positioned to fill the frame, and the frame decides how tall it is.
+ */
+export function EmbedFrame({
+  height,
+  aspectRatio,
+  children,
+}: {
+  height?: number;
+  aspectRatio?: { width?: number; height?: number };
+  children: React.ReactNode;
+}) {
+  const ratioWidth = parsePixelDimension(aspectRatio?.width);
+  const ratioHeight = parsePixelDimension(aspectRatio?.height);
+  const hasRatio = ratioWidth != null && ratioHeight != null;
+  const fixedHeight = parsePixelDimension(height);
+
+  // A declared aspect ratio means the embed should scale with the fluid
+  // column width (e.g. a 16:9 video); a bare height with no ratio means the
+  // embed has its own fixed pixel height regardless of width (e.g. an audio
+  // player widget), so only fall back to a fixed height when no ratio is
+  // available.
+  const aspectRatioCss = hasRatio
+    ? `${ratioWidth} / ${ratioHeight}`
+    : fixedHeight == null
+      ? DEFAULT_ASPECT_RATIO
+      : undefined;
+
+  return (
+    <figure {...stylex.props(articleBodyStyles.iframeFigure)}>
+      <div
+        {...stylex.props(articleBodyStyles.iframeFrame)}
+        style={{
+          aspectRatio: aspectRatioCss,
+          // The frame is `border-box`, so grow it by the border so the iframe
+          // itself gets exactly the height the embed asked for.
+          height:
+            aspectRatioCss == null && fixedHeight != null
+              ? `${fixedHeight + IFRAME_FRAME_BORDER_WIDTH * 2}px`
+              : undefined,
+        }}
+      >
+        {children}
+      </div>
+    </figure>
+  );
+}

--- a/apps/standard-reader/src/components/reader/content/renderers/shared/html-embed.tsx
+++ b/apps/standard-reader/src/components/reader/content/renderers/shared/html-embed.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useLingui } from "@lingui/react/macro";
+import * as stylex from "@stylexjs/stylex";
+
+import { articleBodyStyles } from "../../body-styles";
+import { EmbedFrame } from "./embed-frame";
+
+/**
+ * An author-supplied HTML document (Leaflet's `pub.leaflet.blocks.html`).
+ *
+ * The markup is handed to the iframe's `srcdoc` rather than injected into the
+ * reading page, which is what the lexicon specifies and the only way arbitrary
+ * author markup can be shown at all. The sandbox deliberately grants **only**
+ * `allow-scripts`: adding `allow-same-origin` to a `srcdoc` frame would run the
+ * document in the reader's own origin, handing it our DOM, storage and session.
+ */
+export function HtmlEmbedView({
+  html,
+  height,
+  aspectRatio,
+}: {
+  html: string;
+  height?: number;
+  aspectRatio?: { width?: number; height?: number };
+}) {
+  const { t } = useLingui();
+
+  if (!html.trim()) return null;
+
+  return (
+    <EmbedFrame height={height} aspectRatio={aspectRatio}>
+      {/* oxlint-disable-next-line iframe-has-title */}
+      <iframe
+        srcDoc={html}
+        title={t`Embedded content`}
+        loading="lazy"
+        referrerPolicy="no-referrer"
+        sandbox="allow-scripts"
+        {...stylex.props(articleBodyStyles.iframeEmbed)}
+      />
+    </EmbedFrame>
+  );
+}

--- a/apps/standard-reader/src/components/reader/content/renderers/shared/iframe-embed.tsx
+++ b/apps/standard-reader/src/components/reader/content/renderers/shared/iframe-embed.tsx
@@ -3,13 +3,9 @@
 import { useLingui } from "@lingui/react/macro";
 import * as stylex from "@stylexjs/stylex";
 
-import {
-  articleBodyStyles,
-  IFRAME_FRAME_BORDER_WIDTH,
-} from "../../body-styles";
+import { articleBodyStyles } from "../../body-styles";
+import { EmbedFrame } from "./embed-frame";
 import { parsePixelDimension } from "./iframe-dimensions";
-
-const DEFAULT_ASPECT_RATIO = "16 / 9";
 
 /** YouTube (and some other players) reject embeds without a cross-origin Referer. */
 function iframeReferrerPolicy(url: string): React.HTMLAttributeReferrerPolicy {
@@ -40,49 +36,20 @@ export function IframeEmbedView({
 
   if (!url.trim()) return null;
 
-  const ratioWidth = parsePixelDimension(aspectRatio?.width);
-  const ratioHeight = parsePixelDimension(aspectRatio?.height);
-  const hasRatio = ratioWidth != null && ratioHeight != null;
-  const fixedHeight = parsePixelDimension(height);
-
-  // A declared aspect ratio means the embed should scale with the fluid
-  // column width (e.g. a 16:9 video); a bare height with no ratio means the
-  // embed has its own fixed pixel height regardless of width (e.g. an audio
-  // player widget), so only fall back to a fixed height when no ratio is
-  // available.
-  const aspectRatioCss = hasRatio
-    ? `${ratioWidth} / ${ratioHeight}`
-    : fixedHeight == null
-      ? DEFAULT_ASPECT_RATIO
-      : undefined;
-
   return (
-    <figure {...stylex.props(articleBodyStyles.iframeFigure)}>
-      <div
-        {...stylex.props(articleBodyStyles.iframeFrame)}
-        style={{
-          aspectRatio: aspectRatioCss,
-          // The frame is `border-box`, so grow it by the border so the iframe
-          // itself gets exactly the height the embed asked for.
-          height:
-            aspectRatioCss == null && fixedHeight != null
-              ? `${fixedHeight + IFRAME_FRAME_BORDER_WIDTH * 2}px`
-              : undefined,
-        }}
-      >
-        {/* oxlint-disable-next-line iframe-has-title */}
-        <iframe
-          src={url}
-          title={t`Embedded content`}
-          loading="lazy"
-          referrerPolicy={iframeReferrerPolicy(url)}
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-          allowFullScreen
-          sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"
-          {...stylex.props(articleBodyStyles.iframeEmbed)}
-        />
-      </div>
-    </figure>
+    <EmbedFrame height={height} aspectRatio={aspectRatio}>
+      {/* oxlint-disable-next-line iframe-has-title */}
+      <iframe
+        src={url}
+        title={t`Embedded content`}
+        loading="lazy"
+        referrerPolicy={iframeReferrerPolicy(url)}
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        allowFullScreen
+        sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"
+        {...stylex.props(articleBodyStyles.iframeEmbed)}
+      />
+    </EmbedFrame>
   );
 }
 

--- a/apps/standard-reader/src/lib/leaflet/blocks.test.ts
+++ b/apps/standard-reader/src/lib/leaflet/blocks.test.ts
@@ -185,3 +185,43 @@ describe("leafletBlocks website", () => {
     ).toBe("https://current.example.com");
   });
 });
+
+describe("leafletBlocks html", () => {
+  function htmlDoc(block: Record<string, unknown>) {
+    return {
+      $type: LEAFLET_CONTENT,
+      pages: [
+        {
+          $type: LEAFLET_PAGE.linearDocument,
+          id: "root",
+          blocks: [{ $type: LEAFLET_PAGE.linearDocumentBlock, block }],
+        },
+      ],
+    };
+  }
+
+  it("parses an html block with its requested height", () => {
+    const blocks = leafletBlocks(
+      htmlDoc({
+        $type: LEAFLET_BLOCK.html,
+        height: 243,
+        html: "<p>widget</p>",
+      }),
+    );
+
+    expect(blocks).toEqual([
+      {
+        kind: "html",
+        block: expect.objectContaining({ height: 243, html: "<p>widget</p>" }),
+      },
+    ]);
+  });
+
+  it("drops an html block with no markup instead of calling it unsupported", () => {
+    const blocks = leafletBlocks(
+      htmlDoc({ $type: LEAFLET_BLOCK.html, html: "   " }),
+    );
+
+    expect(blocks).toEqual([]);
+  });
+});

--- a/apps/standard-reader/src/lib/leaflet/blocks.ts
+++ b/apps/standard-reader/src/lib/leaflet/blocks.ts
@@ -7,6 +7,7 @@ import type {
   LeafletCodeBlock,
   LeafletContent,
   LeafletHeaderBlock,
+  LeafletHtmlBlock,
   LeafletIframeBlock,
   LeafletImageBlock,
   LeafletImageGalleryBlock,
@@ -147,6 +148,17 @@ function asRenderableBlock(value: unknown): LeafletRenderableBlock | null {
 
   const code = asCodeBlock(value);
   if (code) return { kind: "code", block: code };
+
+  if (value.$type === LEAFLET_BLOCK.html) {
+    // An empty document has nothing to frame; drop it rather than let it fall
+    // through to the unsupported-block placeholder.
+    const html = typeof value.html === "string" ? value.html : null;
+    if (!html?.trim()) return null;
+    return {
+      kind: "html",
+      block: value as unknown as LeafletHtmlBlock,
+    };
+  }
 
   const iframe = asIframeBlock(value);
   if (iframe) return { kind: "iframe", block: iframe };
@@ -479,6 +491,7 @@ export function plaintextLinesFromBlock(
     case "horizontalRule":
     case "separator":
     case "poll":
+    case "html":
     case "iframe":
     case "unknown": {
       return [];

--- a/apps/standard-reader/src/lib/leaflet/types.ts
+++ b/apps/standard-reader/src/lib/leaflet/types.ts
@@ -24,6 +24,7 @@ export const LEAFLET_BLOCK = {
   bskyPost: "pub.leaflet.blocks.bskyPost",
   image: "pub.leaflet.blocks.image",
   code: "pub.leaflet.blocks.code",
+  html: "pub.leaflet.blocks.html",
   iframe: "pub.leaflet.blocks.iframe",
   website: "pub.leaflet.blocks.website",
   math: "pub.leaflet.blocks.math",
@@ -110,6 +111,18 @@ export interface LeafletCodeBlock {
   $type?: string;
   language?: string;
   plaintext: string;
+}
+
+/**
+ * Author-supplied markup. Leaflet's lexicon specifies it is rendered through a
+ * sandboxed iframe's `srcdoc`, never injected into the host document.
+ */
+export interface LeafletHtmlBlock {
+  $type?: string;
+  html: string;
+  /** Fixed pixel height (16–1600 per the lexicon). */
+  height?: number;
+  aspectRatio?: LeafletImageAspectRatio;
 }
 
 export interface LeafletIframeBlock {
@@ -216,6 +229,7 @@ export type LeafletRenderableBlock =
   | { kind: "bskyPost"; block: LeafletBskyPostBlock }
   | { kind: "image"; block: LeafletImageBlock }
   | { kind: "code"; block: LeafletCodeBlock }
+  | { kind: "html"; block: LeafletHtmlBlock }
   | { kind: "iframe"; block: LeafletIframeBlock }
   | { kind: "website"; block: LeafletWebsiteBlock }
   | { kind: "math"; block: LeafletMathBlock }

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -1048,6 +1048,7 @@ msgstr ""
 msgid "public XRPC queries and procedures for the Standard Reader read-model, with live examples."
 msgstr ""
 
+#: src/components/reader/content/renderers/shared/html-embed.tsx
 #: src/components/reader/content/renderers/shared/iframe-embed.tsx
 msgid "Embedded content"
 msgstr "محتوى مضمَّن"

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -1048,6 +1048,7 @@ msgstr ""
 msgid "public XRPC queries and procedures for the Standard Reader read-model, with live examples."
 msgstr ""
 
+#: src/components/reader/content/renderers/shared/html-embed.tsx
 #: src/components/reader/content/renderers/shared/iframe-embed.tsx
 msgid "Embedded content"
 msgstr "Eingebettete Inhalte"

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -1048,6 +1048,7 @@ msgstr ""
 msgid "public XRPC queries and procedures for the Standard Reader read-model, with live examples."
 msgstr ""
 
+#: src/components/reader/content/renderers/shared/html-embed.tsx
 #: src/components/reader/content/renderers/shared/iframe-embed.tsx
 msgid "Embedded content"
 msgstr ""

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -1048,6 +1048,7 @@ msgstr "Roundness"
 msgid "public XRPC queries and procedures for the Standard Reader read-model, with live examples."
 msgstr "public XRPC queries and procedures for the Standard Reader read-model, with live examples."
 
+#: src/components/reader/content/renderers/shared/html-embed.tsx
 #: src/components/reader/content/renderers/shared/iframe-embed.tsx
 msgid "Embedded content"
 msgstr "Embedded content"

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -1048,6 +1048,7 @@ msgstr ""
 msgid "public XRPC queries and procedures for the Standard Reader read-model, with live examples."
 msgstr ""
 
+#: src/components/reader/content/renderers/shared/html-embed.tsx
 #: src/components/reader/content/renderers/shared/iframe-embed.tsx
 msgid "Embedded content"
 msgstr "Contenido incrustado"

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -1048,6 +1048,7 @@ msgstr ""
 msgid "public XRPC queries and procedures for the Standard Reader read-model, with live examples."
 msgstr ""
 
+#: src/components/reader/content/renderers/shared/html-embed.tsx
 #: src/components/reader/content/renderers/shared/iframe-embed.tsx
 msgid "Embedded content"
 msgstr "Contenu intégré"

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -1048,6 +1048,7 @@ msgstr ""
 msgid "public XRPC queries and procedures for the Standard Reader read-model, with live examples."
 msgstr ""
 
+#: src/components/reader/content/renderers/shared/html-embed.tsx
 #: src/components/reader/content/renderers/shared/iframe-embed.tsx
 msgid "Embedded content"
 msgstr "埋め込みコンテンツ"

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -1048,6 +1048,7 @@ msgstr ""
 msgid "public XRPC queries and procedures for the Standard Reader read-model, with live examples."
 msgstr ""
 
+#: src/components/reader/content/renderers/shared/html-embed.tsx
 #: src/components/reader/content/renderers/shared/iframe-embed.tsx
 msgid "Embedded content"
 msgstr "임베드된 콘텐츠"

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -1048,6 +1048,7 @@ msgstr ""
 msgid "public XRPC queries and procedures for the Standard Reader read-model, with live examples."
 msgstr "consultas e procedimentos XRPC públicos para o modelo de leitura Standard Reader, com exemplos em tempo real."
 
+#: src/components/reader/content/renderers/shared/html-embed.tsx
 #: src/components/reader/content/renderers/shared/iframe-embed.tsx
 msgid "Embedded content"
 msgstr "Conteúdo incorporado"

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -1048,6 +1048,7 @@ msgstr ""
 msgid "public XRPC queries and procedures for the Standard Reader read-model, with live examples."
 msgstr ""
 
+#: src/components/reader/content/renderers/shared/html-embed.tsx
 #: src/components/reader/content/renderers/shared/iframe-embed.tsx
 msgid "Embedded content"
 msgstr "嵌入内容"

--- a/packages/converter/README.md
+++ b/packages/converter/README.md
@@ -106,6 +106,7 @@ Two consequences worth knowing:
 | math           |    ✓    |    ✓     |  ~   |    ~    |
 | button         |    ✓    |    ✓     |  ~   |    ~    |
 | iframe / embed |    ✓    |    ✓     |  ✓   |    ~    |
+| HTML embed     |    ✓    |    ✗     |  ✗   |    ~    |
 | bookmark card  |    ✓    |    ✓     |  ✓   |    ~    |
 | Bluesky post   |    ✓    |    ✓     |  ✓   |    ~    |
 | image grid     |    ✓    |    ✓     |  ~   |    ~    |

--- a/packages/converter/src/__tests__/convert.test.ts
+++ b/packages/converter/src/__tests__/convert.test.ts
@@ -156,6 +156,17 @@ describe("leaflet → pckt", () => {
     expect(issue?.fallback).toContain("code block");
   });
 
+  it("drops a Leaflet HTML embed, which pckt has no block for", () => {
+    const result = convert(
+      leafletContent([lf.text("intro"), lf.html("<p>widget</p>", 243)]),
+      "pckt",
+    );
+    expect(items(result)).toHaveLength(1);
+    const [issue] = unsupported(result);
+    expect(issue?.blockType).toBe("htmlEmbed");
+    expect(issue?.blockIndex).toBe(1);
+  });
+
   it("drops a Leaflet poll and flags it as unsupported", () => {
     const result = convert(
       leafletContent([
@@ -425,6 +436,19 @@ describe("leaflet → offprint", () => {
     });
     expect(result.issues).toEqual([]);
   });
+
+  it("round-trips an HTML embed with its height", () => {
+    const result = convert(
+      leafletContent([lf.html("<p>widget</p>", 243)]),
+      "leaflet",
+    );
+    expect(leafletBlocks(result)[0]).toEqual({
+      $type: "pub.leaflet.blocks.html",
+      height: 243,
+      html: "<p>widget</p>",
+    });
+    expect(result.issues).toEqual([]);
+  });
 });
 
 describe("→ markpub", () => {
@@ -454,6 +478,33 @@ describe("→ markpub", () => {
     expect(markdown(result)).toBe(
       "**bold** [link](https://example.com) `code`",
     );
+  });
+
+  it("keeps an HTML embed sandboxed instead of inlining its markup", () => {
+    const result = convert(
+      leafletContent([lf.html('<script>alert("x")</script>', 243)]),
+      "markpub",
+    );
+    expect(markdown(result)).toBe(
+      '<iframe srcdoc="&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;"' +
+        ' height="243" sandbox="allow-scripts" loading="lazy"' +
+        ' title="Embedded content"></iframe>',
+    );
+    expect(result.issues[0]?.severity).toBe("lossy");
+    expect(result.issues[0]?.fallback).toContain("srcdoc");
+  });
+
+  it("keeps a multi-line HTML embed on one line so the html block survives", () => {
+    const result = convert(
+      leafletContent([
+        lf.html("<style>\n\np { color: red }\n\n</style><p>hi</p>"),
+      ]),
+      "markpub",
+    );
+    // A literal blank line inside the attribute would end the markdown HTML
+    // block and render the rest of the tag as prose.
+    expect(markdown(result)).not.toContain("\n");
+    expect(markdown(result)).toContain("&#10;&#10;p { color: red }");
   });
 
   it("keeps text whose formatting markdown lacks, and warns once", () => {

--- a/packages/converter/src/__tests__/fixtures.ts
+++ b/packages/converter/src/__tests__/fixtures.ts
@@ -43,6 +43,11 @@ export const lf = {
     level,
     plaintext,
   }),
+  html: (html: string, height?: number) => ({
+    $type: "pub.leaflet.blocks.html",
+    html,
+    ...(height == null ? {} : { height }),
+  }),
   image: (alt = "", aspectRatio?: { width: number; height: number }) => ({
     $type: "pub.leaflet.blocks.image",
     alt,

--- a/packages/converter/src/__tests__/support.test.ts
+++ b/packages/converter/src/__tests__/support.test.ts
@@ -51,6 +51,11 @@ const SAMPLES: Record<BlockType, BlockNode> = {
   heading: { level: 2, text: text("Title"), type: "heading" },
   horizontalRule: { type: "horizontalRule" },
   html: { html: "<div>raw</div>", type: "html" },
+  htmlEmbed: {
+    height: 240,
+    html: "<style>body{margin:0}</style><p>widget</p>",
+    type: "htmlEmbed",
+  },
   iframe: { height: 400, type: "iframe", url: "https://example.com/embed" },
   image: { ...image("A cat"), type: "image" },
   imageCarousel: {

--- a/packages/converter/src/capabilities.ts
+++ b/packages/converter/src/capabilities.ts
@@ -34,6 +34,19 @@ const HTML_UNSUPPORTED: BlockSupport = {
     "target can carry it.",
 };
 
+/**
+ * A Leaflet HTML block is a whole document that renders inside a sandboxed
+ * iframe. The other block formats have no field for one, and flattening the
+ * markup into the body would run the author's scripts in the reading page
+ * itself — a downgrade no conversion should make silently.
+ */
+const HTML_EMBED_UNSUPPORTED: BlockSupport = {
+  level: "none",
+  note:
+    "An HTML embed is a self-contained document that renders in a sandboxed " +
+    "iframe; this format has no block that can carry one.",
+};
+
 const UNKNOWN_BLOCK: BlockSupport = {
   level: "none",
   note:
@@ -105,6 +118,7 @@ const LEAFLET: Record<BlockType, BlockSupport> = {
   heading: NATIVE,
   horizontalRule: NATIVE,
   html: HTML_UNSUPPORTED,
+  htmlEmbed: NATIVE,
   iframe: NATIVE,
   image: NATIVE,
   imageCarousel: NATIVE,
@@ -149,6 +163,7 @@ const OFFPRINT: Record<BlockType, BlockSupport> = {
   heading: NATIVE,
   horizontalRule: NATIVE,
   html: HTML_UNSUPPORTED,
+  htmlEmbed: HTML_EMBED_UNSUPPORTED,
   iframe: NATIVE,
   image: NATIVE,
   imageCarousel: NATIVE,
@@ -201,6 +216,7 @@ const PCKT: Record<BlockType, BlockSupport> = {
   heading: NATIVE,
   horizontalRule: NATIVE,
   html: HTML_UNSUPPORTED,
+  htmlEmbed: HTML_EMBED_UNSUPPORTED,
   iframe: NATIVE,
   image: NATIVE,
   imageCarousel: IMAGES_IN_SEQUENCE,
@@ -260,6 +276,13 @@ const MARKPUB: Record<BlockType, BlockSupport> = {
   heading: NATIVE,
   horizontalRule: NATIVE,
   html: NATIVE,
+  htmlEmbed: {
+    level: "degraded",
+    note:
+      "Markdown has no embed block, but it does carry raw HTML, so the embed " +
+      "keeps its sandbox rather than being flattened into the body.",
+    fallback: "a sandboxed <iframe srcdoc> (the aspect ratio is dropped)",
+  },
   iframe: MARKDOWN_LINK,
   image: NATIVE,
   imageCarousel: {

--- a/packages/converter/src/targets/leaflet.ts
+++ b/packages/converter/src/targets/leaflet.ts
@@ -36,6 +36,7 @@ const BLOCK = {
   code: "pub.leaflet.blocks.code",
   header: "pub.leaflet.blocks.header",
   horizontalRule: "pub.leaflet.blocks.horizontalRule",
+  html: "pub.leaflet.blocks.html",
   iframe: "pub.leaflet.blocks.iframe",
   image: "pub.leaflet.blocks.image",
   imageGallery: "pub.leaflet.blocks.imageGallery",
@@ -287,6 +288,16 @@ function emitBlock(ctx: Ctx, node: BlockNode): Array<Block> {
           aspectRatio: aspectRatio(node),
           fullBleed: node.fullBleed,
           image: blob,
+        }),
+      ];
+    }
+    case "htmlEmbed": {
+      return [
+        compact({
+          $type: BLOCK.html,
+          aspectRatio: node.aspectRatio,
+          height: node.height,
+          html: node.html,
         }),
       ];
     }

--- a/packages/converter/src/targets/markpub.ts
+++ b/packages/converter/src/targets/markpub.ts
@@ -47,6 +47,22 @@ function escapeInline(value: string): string {
   return value.replaceAll(/([\\`*_[\]~<>|])/g, String.raw`\$1`);
 }
 
+/**
+ * Escape a value so it survives inside a double-quoted HTML attribute, on one
+ * line. The line breaks become character references rather than staying
+ * literal: a blank line anywhere inside the attribute would close the markdown
+ * HTML block early and leave the rest of the tag rendered as prose.
+ */
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("\r", "&#13;")
+    .replaceAll("\n", "&#10;");
+}
+
 /** Wrap inline code in a fence long enough to contain any backticks inside. */
 function inlineCode(value: string): string {
   let longest = 0;
@@ -332,6 +348,15 @@ function blockToMarkdown(ctx: Ctx, node: BlockNode): string | null {
     case "html": {
       // Markdown embeds raw HTML verbatim, so this is a straight pass-through.
       return node.html;
+    }
+    case "htmlEmbed": {
+      // Carry the embed as the sandboxed iframe the source format renders it
+      // in — inlining the markup instead would run the author's scripts in the
+      // reading page itself.
+      const height = node.height ? ` height="${node.height}"` : "";
+      return `<iframe srcdoc="${escapeHtmlAttribute(
+        node.html,
+      )}"${height} sandbox="allow-scripts" loading="lazy" title="Embedded content"></iframe>`;
     }
     case "table": {
       return tableToMarkdown(ctx, node);

--- a/packages/renderer-angular/README.md
+++ b/packages/renderer-angular/README.md
@@ -145,7 +145,8 @@ Override these once and they apply to Leaflet, pckt, Offprint and every
 third-party format. Only the media and data-backed blocks are template-
 overridable:
 
-**Blocks:** `image`, `code`, `iframe`, `website`, `table`, `math`, `button`,
+**Blocks:** `image`, `code`, `html`, `htmlEmbed`, `iframe`, `website`, `table`,
+`math`, `button`,
 `blueskyEmbed`, `imageGrid`, `imageCarousel`, `imageDiff`, `unknown`.
 
 Structural blocks (paragraphs, headings, blockquotes, lists, callouts,

--- a/packages/renderer-angular/src/block.component.ts
+++ b/packages/renderer-angular/src/block.component.ts
@@ -108,6 +108,24 @@ import { RenderContextService } from "./render-context.service";
           *ngTemplateOutlet="tpl; context: { $implicit: { html: node.html } }"
         />
       }
+    } @else if (node.type === "htmlEmbed") {
+      @if (ctx.components.shared?.htmlEmbed; as tpl) {
+        <ng-container *ngTemplateOutlet="tpl; context: { $implicit: node }" />
+      } @else {
+        <!--
+          Angular sanitizes srcdoc as an HTML security context, so this fallback
+          shows the embed with its scripts and styles stripped. Supply an
+          htmlEmbed template with a trusted value for full fidelity — and keep
+          allow-same-origin out of the sandbox when you do.
+        -->
+        <iframe
+          [attr.srcdoc]="node.html"
+          [attr.height]="node.height ?? null"
+          loading="lazy"
+          sandbox="allow-scripts"
+          title="Embedded content"
+        ></iframe>
+      }
     } @else if (node.type === "image") {
       @if (ctx.components.shared?.image; as tpl) {
         <ng-container *ngTemplateOutlet="tpl; context: { $implicit: node }" />

--- a/packages/renderer-angular/src/types.ts
+++ b/packages/renderer-angular/src/types.ts
@@ -35,6 +35,18 @@ export interface AngularSharedComponents {
    * sanitizer. Supply this template to render it.
    */
   html?: Tpl<{ html: string }>;
+  /**
+   * A self-contained HTML embed (Leaflet's `pub.leaflet.blocks.html`). Unlike
+   * `html`, this one renders by default, inside a sandboxed `srcdoc` iframe as
+   * the format specifies. If you override it, keep the sandbox and keep
+   * `allow-same-origin` out of it — with `srcdoc` that grants the embed your
+   * own origin.
+   */
+  htmlEmbed?: Tpl<{
+    html: string;
+    height?: number;
+    aspectRatio?: { width?: number; height?: number };
+  }>;
   iframe?: Tpl<{
     url: string;
     height?: number;

--- a/packages/renderer-core/README.md
+++ b/packages/renderer-core/README.md
@@ -122,6 +122,12 @@ The raw per-format parsers and vocabulary types are available too:
 
 ### Format notes
 
+- **Leaflet** (`pub.leaflet.content`) has two kinds of markup block, and they
+  are deliberately not the same node. `pub.leaflet.blocks.html` is a whole
+  document the format renders through a sandboxed iframe's `srcdoc`, so it maps
+  to `htmlEmbed` and the default components render it. A markdown source's raw
+  markup maps to `html` instead, which renders nothing until the host supplies
+  a component with its own sanitizer.
 - **Markpub** (`at.markpub.markdown`) carries facets over the _markdown source_.
   Facet-only constructs (headers, strong, horizontal rules, front matter) are
   rewritten back into markdown syntax before parsing, so they arrive as real

--- a/packages/renderer-core/src/__tests__/build.test.ts
+++ b/packages/renderer-core/src/__tests__/build.test.ts
@@ -41,6 +41,11 @@ const lf = {
     $type: "pub.leaflet.blocks.poll",
     pollRef: { uri },
   }),
+  html: (html: string, height?: number) => ({
+    $type: "pub.leaflet.blocks.html",
+    html,
+    ...(height == null ? {} : { height }),
+  }),
   unorderedList: (items: Array<string>) => ({
     $type: "pub.leaflet.blocks.unorderedList",
     children: items.map((plaintext) => ({
@@ -108,6 +113,24 @@ describe("buildRenderTree — leaflet", () => {
     expect(tree.footnotes).toHaveLength(1);
     expect(tree.footnotes[0]).toMatchObject({ id: "fn1", number: 1 });
     expect(tree.footnoteNumbers.get("fn1")).toBe(1);
+  });
+
+  it("carries an html block through as a sized embed", () => {
+    const tree = build(
+      leafletDoc([lf.html("<p>widget</p>", 243), lf.text("After")]),
+    );
+    expect(tree.children.map((n) => n.type)).toEqual([
+      "htmlEmbed",
+      "paragraph",
+    ]);
+    const embed = tree.children[0] as Extract<BlockNode, { type: "htmlEmbed" }>;
+    expect(embed.html).toBe("<p>widget</p>");
+    expect(embed.height).toBe(243);
+  });
+
+  it("drops an html block with no markup rather than rendering an empty frame", () => {
+    const tree = build(leafletDoc([lf.html("   "), lf.text("After")]));
+    expect(tree.children.map((n) => n.type)).toEqual(["paragraph"]);
   });
 
   it("builds nested list items", () => {

--- a/packages/renderer-core/src/build.ts
+++ b/packages/renderer-core/src/build.ts
@@ -345,6 +345,14 @@ function leafletToNode(
         language: block.block.language,
       };
     }
+    case "html": {
+      return {
+        type: "htmlEmbed",
+        html: block.block.html,
+        height: block.block.height,
+        aspectRatio: block.block.aspectRatio,
+      };
+    }
     case "iframe": {
       return {
         type: "iframe",

--- a/packages/renderer-core/src/leaflet/blocks.ts
+++ b/packages/renderer-core/src/leaflet/blocks.ts
@@ -7,6 +7,7 @@ import type {
   LeafletCodeBlock,
   LeafletContent,
   LeafletHeaderBlock,
+  LeafletHtmlBlock,
   LeafletIframeBlock,
   LeafletImageBlock,
   LeafletImageGalleryBlock,
@@ -143,6 +144,17 @@ function asRenderableBlock(value: unknown): LeafletRenderableBlock | null {
 
   const code = asCodeBlock(value);
   if (code) return { kind: "code", block: code };
+
+  if (value.$type === LEAFLET_BLOCK.html) {
+    // An empty document has nothing to frame; drop it rather than let it fall
+    // through to the unsupported-block placeholder.
+    const html = typeof value.html === "string" ? value.html : null;
+    if (!html?.trim()) return null;
+    return {
+      kind: "html",
+      block: value as unknown as LeafletHtmlBlock,
+    };
+  }
 
   const iframe = asIframeBlock(value);
   if (iframe) return { kind: "iframe", block: iframe };
@@ -475,6 +487,7 @@ export function plaintextLinesFromBlock(
     case "horizontalRule":
     case "separator":
     case "poll":
+    case "html":
     case "iframe":
     case "unknown": {
       return [];

--- a/packages/renderer-core/src/leaflet/types.ts
+++ b/packages/renderer-core/src/leaflet/types.ts
@@ -24,6 +24,7 @@ export const LEAFLET_BLOCK = {
   bskyPost: "pub.leaflet.blocks.bskyPost",
   image: "pub.leaflet.blocks.image",
   code: "pub.leaflet.blocks.code",
+  html: "pub.leaflet.blocks.html",
   iframe: "pub.leaflet.blocks.iframe",
   website: "pub.leaflet.blocks.website",
   math: "pub.leaflet.blocks.math",
@@ -110,6 +111,18 @@ export interface LeafletCodeBlock {
   $type?: string;
   language?: string;
   plaintext: string;
+}
+
+/**
+ * Author-supplied markup. Leaflet's lexicon specifies it is rendered through a
+ * sandboxed iframe's `srcdoc`, never injected into the host document.
+ */
+export interface LeafletHtmlBlock {
+  $type?: string;
+  html: string;
+  /** Fixed pixel height (16–1600 per the lexicon). */
+  height?: number;
+  aspectRatio?: LeafletImageAspectRatio;
 }
 
 export interface LeafletIframeBlock {
@@ -216,6 +229,7 @@ export type LeafletRenderableBlock =
   | { kind: "bskyPost"; block: LeafletBskyPostBlock }
   | { kind: "image"; block: LeafletImageBlock }
   | { kind: "code"; block: LeafletCodeBlock }
+  | { kind: "html"; block: LeafletHtmlBlock }
   | { kind: "iframe"; block: LeafletIframeBlock }
   | { kind: "website"; block: LeafletWebsiteBlock }
   | { kind: "math"; block: LeafletMathBlock }

--- a/packages/renderer-core/src/nodes.ts
+++ b/packages/renderer-core/src/nodes.ts
@@ -126,6 +126,24 @@ export type BlockNode =
    * an `Html` component to render it.
    */
   | { type: "html"; html: string }
+  /**
+   * A self-contained HTML document the author supplied as an *embed*, not as
+   * markup to splice into the page — Leaflet's `pub.leaflet.blocks.html`.
+   *
+   * Unlike `html`, this one is rendered by the default components, because the
+   * format defines it as running inside a sandboxed iframe's `srcdoc`: the
+   * markup never touches the host document, so no host sanitizer is implied.
+   * Keep the sandbox when overriding `HtmlEmbed`, and in particular keep
+   * `allow-same-origin` out of it — with `srcdoc` that would hand the embed the
+   * embedder's origin.
+   */
+  | {
+      type: "htmlEmbed";
+      html: string;
+      /** Fixed pixel height requested by the block. */
+      height?: number;
+      aspectRatio?: { width?: number; height?: number };
+    }
   | {
       type: "image";
       src: string;

--- a/packages/renderer-lit/README.md
+++ b/packages/renderer-lit/README.md
@@ -164,7 +164,8 @@ third-party format.
 
 **Blocks:** `root`, `paragraph`, `heading`, `blockquote`, `callout`,
 `horizontalRule`, `bulletList`, `orderedList`, `listItem`, `taskList`,
-`taskListItem`, `code`, `image`, `iframe`, `website`, `table`, `math`,
+`taskListItem`, `code`, `html`, `htmlEmbed`, `image`, `iframe`, `website`,
+`table`, `math`,
 `button`, `blueskyEmbed`, `imageGrid`, `imageCarousel`, `imageDiff`,
 `footnotes`, `footnoteItem`, `unknown`.
 

--- a/packages/renderer-lit/src/defaults.ts
+++ b/packages/renderer-lit/src/defaults.ts
@@ -98,6 +98,14 @@ export const defaultComponents: LitComponents = {
         ${children}
       </li>`,
     html: () => nothing,
+    htmlEmbed: ({ html: markup, height }) =>
+      html`<iframe
+        srcdoc=${markup}
+        height=${height ?? nothing}
+        loading="lazy"
+        sandbox="allow-scripts"
+        title="Embedded content"
+      ></iframe>`,
     code: ({ code, language }) =>
       html`<pre><code class=${
         language ? `language-${language}` : nothing

--- a/packages/renderer-lit/src/render.ts
+++ b/packages/renderer-lit/src/render.ts
@@ -137,6 +137,13 @@ function renderBlock(node: BlockNode, ctx: RenderContext): Renderable {
     case "html": {
       return shared.html({ html: node.html });
     }
+    case "htmlEmbed": {
+      return shared.htmlEmbed({
+        html: node.html,
+        height: node.height,
+        aspectRatio: node.aspectRatio,
+      });
+    }
     case "image": {
       return shared.image({
         src: node.src,

--- a/packages/renderer-lit/src/types.ts
+++ b/packages/renderer-lit/src/types.ts
@@ -87,6 +87,18 @@ export interface LitSharedComponents extends LitInlineComponents {
    * sanitizer. Supply this component to render it.
    */
   html: (props: { html: string }) => Renderable;
+  /**
+   * A self-contained HTML embed (Leaflet's `pub.leaflet.blocks.html`). Unlike
+   * `html`, this one renders by default, inside a sandboxed `srcdoc` iframe as
+   * the format specifies. If you override it, keep the sandbox and keep
+   * `allow-same-origin` out of it — with `srcdoc` that grants the embed your
+   * own origin.
+   */
+  htmlEmbed: (props: {
+    html: string;
+    height?: number;
+    aspectRatio?: { width?: number; height?: number };
+  }) => Renderable;
   image: (props: {
     src: string;
     alt: string;

--- a/packages/renderer-react/README.md
+++ b/packages/renderer-react/README.md
@@ -127,7 +127,8 @@ third-party format.
 
 **Blocks:** `Root`, `Paragraph`, `Heading`, `Blockquote`, `Callout`,
 `HorizontalRule`, `BulletList`, `OrderedList`, `ListItem`, `TaskList`,
-`TaskListItem`, `Code`, `Image`, `Iframe`, `Website`, `Table`, `Math`,
+`TaskListItem`, `Code`, `Html`, `HtmlEmbed`, `Image`, `Iframe`, `Website`,
+`Table`, `Math`,
 `Button`, `BlueskyEmbed`, `ImageGrid`, `ImageCarousel`, `ImageDiff`,
 `Footnotes`, `FootnoteItem`, `Unknown`.
 

--- a/packages/renderer-react/src/__tests__/fixtures.ts
+++ b/packages/renderer-react/src/__tests__/fixtures.ts
@@ -46,6 +46,11 @@ export const leaflet = {
     plaintext,
     ...(language ? { language } : {}),
   }),
+  html: (html: string, height?: number) => ({
+    $type: "pub.leaflet.blocks.html",
+    html,
+    ...(height == null ? {} : { height }),
+  }),
   horizontalRule: () => ({ $type: "pub.leaflet.blocks.horizontalRule" }),
   separator: () => ({ $type: "pub.leaflet.blocks.separator" }),
   signup: () => ({ $type: "pub.leaflet.blocks.signup" }),

--- a/packages/renderer-react/src/__tests__/leaflet.test.tsx
+++ b/packages/renderer-react/src/__tests__/leaflet.test.tsx
@@ -175,6 +175,17 @@ describe("leaflet rendering", () => {
     expect(container.querySelector("hr")).not.toBeNull();
   });
 
+  it("renders an html block in a sandboxed srcdoc iframe", () => {
+    const { container } = renderDoc(
+      leafletDoc([leaflet.html("<p>widget</p>", 243)]),
+    );
+    const frame = container.querySelector("iframe");
+    expect(frame?.getAttribute("srcdoc")).toBe("<p>widget</p>");
+    expect(frame?.getAttribute("height")).toBe("243");
+    // `allow-same-origin` on a srcdoc frame would run the embed in our origin.
+    expect(frame?.getAttribute("sandbox")).toBe("allow-scripts");
+  });
+
   it("returns null for an empty document", () => {
     const { container } = renderDoc(leafletDoc([]));
     expect(container.firstChild).toBeNull();

--- a/packages/renderer-react/src/components/defaults.tsx
+++ b/packages/renderer-react/src/components/defaults.tsx
@@ -66,6 +66,17 @@ export const defaultComponents: RendererComponents = {
       </li>
     ),
     Html: () => null,
+    HtmlEmbed: ({ html, height }) => (
+      <iframe
+        srcDoc={html}
+        height={height}
+        loading="lazy"
+        // No `allow-same-origin`: a srcdoc iframe granted it runs in the
+        // embedder's origin, which would defeat the sandbox entirely.
+        sandbox="allow-scripts"
+        title="Embedded content"
+      />
+    ),
     Code: ({ code, language }) => (
       <pre>
         <code className={language ? `language-${language}` : undefined}>

--- a/packages/renderer-react/src/components/types.ts
+++ b/packages/renderer-react/src/components/types.ts
@@ -110,6 +110,12 @@ export interface HtmlProps {
   html: string;
 }
 
+export interface HtmlEmbedProps {
+  html: string;
+  height?: number;
+  aspectRatio?: { width?: number; height?: number };
+}
+
 export interface ListProps {
   children: ReactNode;
 }
@@ -223,6 +229,14 @@ export interface SharedBlockComponents {
    * sanitizer. Supply this component to render it.
    */
   Html: ComponentType<HtmlProps>;
+  /**
+   * A self-contained HTML embed (Leaflet's `pub.leaflet.blocks.html`). Unlike
+   * `Html`, this one renders by default, inside a sandboxed `srcdoc` iframe as
+   * the format specifies. If you override it, keep the sandbox and keep
+   * `allow-same-origin` out of it — with `srcdoc` that grants the embed your
+   * own origin.
+   */
+  HtmlEmbed: ComponentType<HtmlEmbedProps>;
   HorizontalRule: ComponentType<Record<string, never>>;
   BulletList: ComponentType<ListProps>;
   OrderedList: ComponentType<OrderedListProps>;

--- a/packages/renderer-react/src/index.ts
+++ b/packages/renderer-react/src/index.ts
@@ -32,6 +32,7 @@ export type {
   ParagraphProps,
   HeadingProps,
   HtmlProps,
+  HtmlEmbedProps,
   BlockquoteProps,
   CalloutProps,
   ListProps,

--- a/packages/renderer-react/src/render/blocks.tsx
+++ b/packages/renderer-react/src/render/blocks.tsx
@@ -144,6 +144,15 @@ function RenderBlock({ node }: { node: BlockNode }) {
     case "html": {
       return <shared.Html html={node.html} />;
     }
+    case "htmlEmbed": {
+      return (
+        <shared.HtmlEmbed
+          html={node.html}
+          height={node.height}
+          aspectRatio={node.aspectRatio}
+        />
+      );
+    }
     case "image": {
       return (
         <shared.Image

--- a/packages/renderer-solid/README.md
+++ b/packages/renderer-solid/README.md
@@ -129,7 +129,8 @@ third-party format.
 
 **Blocks:** `root`, `paragraph`, `heading`, `blockquote`, `callout`,
 `horizontalRule`, `bulletList`, `orderedList`, `listItem`, `taskList`,
-`taskListItem`, `code`, `image`, `iframe`, `website`, `table`, `math`,
+`taskListItem`, `code`, `html`, `htmlEmbed`, `image`, `iframe`, `website`,
+`table`, `math`,
 `button`, `blueskyEmbed`, `imageGrid`, `imageCarousel`, `imageDiff`,
 `footnotes`, `footnoteItem`, `unknown`.
 

--- a/packages/renderer-solid/src/defaults.ts
+++ b/packages/renderer-solid/src/defaults.ts
@@ -87,6 +87,14 @@ export const defaultComponents: SolidComponents = {
         children,
       ),
     html: () => null,
+    htmlEmbed: ({ html, height }) =>
+      el("iframe", {
+        srcdoc: html,
+        height,
+        loading: "lazy",
+        sandbox: "allow-scripts",
+        title: "Embedded content",
+      }),
     code: ({ code, language }) =>
       el(
         "pre",

--- a/packages/renderer-solid/src/render.ts
+++ b/packages/renderer-solid/src/render.ts
@@ -136,6 +136,13 @@ function renderBlock(node: BlockNode, ctx: RenderContext): Renderable {
     case "html": {
       return shared.html({ html: node.html });
     }
+    case "htmlEmbed": {
+      return shared.htmlEmbed({
+        html: node.html,
+        height: node.height,
+        aspectRatio: node.aspectRatio,
+      });
+    }
     case "image": {
       return shared.image({
         src: node.src,

--- a/packages/renderer-solid/src/types.ts
+++ b/packages/renderer-solid/src/types.ts
@@ -81,6 +81,18 @@ export interface SolidSharedComponents extends SolidInlineComponents {
    * sanitizer. Supply this component to render it.
    */
   html: (props: { html: string }) => Renderable;
+  /**
+   * A self-contained HTML embed (Leaflet's `pub.leaflet.blocks.html`). Unlike
+   * `html`, this one renders by default, inside a sandboxed `srcdoc` iframe as
+   * the format specifies. If you override it, keep the sandbox and keep
+   * `allow-same-origin` out of it — with `srcdoc` that grants the embed your
+   * own origin.
+   */
+  htmlEmbed: (props: {
+    html: string;
+    height?: number;
+    aspectRatio?: { width?: number; height?: number };
+  }) => Renderable;
   image: (props: {
     src: string;
     alt: string;

--- a/packages/renderer-svelte/README.md
+++ b/packages/renderer-svelte/README.md
@@ -145,7 +145,8 @@ third-party format.
 
 **Blocks:** `root`, `paragraph`, `heading`, `blockquote`, `callout`,
 `horizontalRule`, `bulletList`, `orderedList`, `listItem`, `taskList`,
-`taskListItem`, `code`, `image`, `iframe`, `website`, `table`, `math`,
+`taskListItem`, `code`, `html`, `htmlEmbed`, `image`, `iframe`, `website`,
+`table`, `math`,
 `button`, `blueskyEmbed`, `imageGrid`, `imageCarousel`, `imageDiff`,
 `footnotes`, `footnoteItem`, `unknown`.
 

--- a/packages/renderer-svelte/src/Block.svelte
+++ b/packages/renderer-svelte/src/Block.svelte
@@ -83,6 +83,18 @@
       ></pre>{/if}
 {:else if node.type === "html"}
   {#if s.html}{@render s.html({ html: node.html })}{/if}
+{:else if node.type === "htmlEmbed"}
+  {#if s.htmlEmbed}{@render s.htmlEmbed({
+      html: node.html,
+      height: node.height,
+      aspectRatio: node.aspectRatio,
+    })}{:else}<iframe
+      srcdoc={node.html}
+      height={node.height}
+      loading="lazy"
+      sandbox="allow-scripts"
+      title="Embedded content"
+    ></iframe>{/if}
 {:else if node.type === "image"}
   {#if s.image}{@render s.image({
       src: node.src,

--- a/packages/renderer-svelte/src/types.ts
+++ b/packages/renderer-svelte/src/types.ts
@@ -67,6 +67,22 @@ export interface SvelteSharedComponents extends SvelteInlineComponents {
    * sanitizer. Supply this snippet to render it.
    */
   html?: Snippet<[{ html: string }]>;
+  /**
+   * A self-contained HTML embed (Leaflet's `pub.leaflet.blocks.html`). Unlike
+   * `html`, this one renders by default, inside a sandboxed `srcdoc` iframe as
+   * the format specifies. If you override it, keep the sandbox and keep
+   * `allow-same-origin` out of it — with `srcdoc` that grants the embed your
+   * own origin.
+   */
+  htmlEmbed?: Snippet<
+    [
+      {
+        html: string;
+        height?: number;
+        aspectRatio?: { width?: number; height?: number };
+      },
+    ]
+  >;
   image?: Snippet<
     [
       {

--- a/packages/renderer-vue/README.md
+++ b/packages/renderer-vue/README.md
@@ -159,7 +159,8 @@ third-party format.
 
 **Blocks:** `root`, `paragraph`, `heading`, `blockquote`, `callout`,
 `horizontalRule`, `bulletList`, `orderedList`, `listItem`, `taskList`,
-`taskListItem`, `code`, `image`, `iframe`, `website`, `table`, `math`,
+`taskListItem`, `code`, `html`, `htmlEmbed`, `image`, `iframe`, `website`,
+`table`, `math`,
 `button`, `blueskyEmbed`, `imageGrid`, `imageCarousel`, `imageDiff`,
 `footnotes`, `footnoteItem`, `unknown`.
 

--- a/packages/renderer-vue/src/defaults.ts
+++ b/packages/renderer-vue/src/defaults.ts
@@ -73,6 +73,14 @@ export const defaultComponents: VueComponents = {
         children,
       ]),
     html: () => null,
+    htmlEmbed: ({ html, height }) =>
+      h("iframe", {
+        srcdoc: html,
+        height,
+        loading: "lazy",
+        sandbox: "allow-scripts",
+        title: "Embedded content",
+      }),
     code: ({ code, language }) =>
       h("pre", [
         h("code", { class: language ? `language-${language}` : undefined }, [

--- a/packages/renderer-vue/src/render.ts
+++ b/packages/renderer-vue/src/render.ts
@@ -137,6 +137,13 @@ function renderBlock(node: BlockNode, ctx: RenderContext): Renderable {
     case "html": {
       return shared.html({ html: node.html });
     }
+    case "htmlEmbed": {
+      return shared.htmlEmbed({
+        html: node.html,
+        height: node.height,
+        aspectRatio: node.aspectRatio,
+      });
+    }
     case "image": {
       return shared.image({
         src: node.src,

--- a/packages/renderer-vue/src/types.ts
+++ b/packages/renderer-vue/src/types.ts
@@ -88,6 +88,18 @@ export interface VueSharedComponents extends VueInlineComponents {
    * sanitizer. Supply this component to render it.
    */
   html: (props: { html: string }) => Renderable;
+  /**
+   * A self-contained HTML embed (Leaflet's `pub.leaflet.blocks.html`). Unlike
+   * `html`, this one renders by default, inside a sandboxed `srcdoc` iframe as
+   * the format specifies. If you override it, keep the sandbox and keep
+   * `allow-same-origin` out of it — with `srcdoc` that grants the embed your
+   * own origin.
+   */
+  htmlEmbed: (props: {
+    html: string;
+    height?: number;
+    aspectRatio?: { width?: number; height?: number };
+  }) => Renderable;
   image: (props: {
     src: string;
     alt: string;


### PR DESCRIPTION
Leaflet shipped an HTML block — author-supplied markup with an optional
`height` / `aspectRatio` — that the reader showed as an unsupported-block
placeholder. The lexicon specifies it renders through a sandboxed iframe's
`srcdoc`, so that is what we do.

renderer-core parses it onto a new `htmlEmbed` node, deliberately separate
from the existing `html` node: `html` is raw markup from a markdown source
that only the host can decide is safe to inject, while `htmlEmbed` never
touches the host document and so renders by default. Every framework
renderer gets the matching component/slot, sandboxed to `allow-scripts`
only — `allow-same-origin` on a `srcdoc` frame would run the embed in the
embedder's own origin.

In the reader, the sizing frame shared with the URL embeds moves into
`embed-frame.tsx` so the two cannot drift.

The converter carries the block natively to Leaflet, and to Markpub as a
sandboxed `<iframe srcdoc>` with its line breaks encoded, since a blank
line inside the attribute would end the markdown HTML block early.
Offprint and pckt have no block for it and report it dropped.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014C9KWAHvwzfMsWkqyN9Wug