### PR TITLE
Add native embeds for Bluesky web client links

### DIFF
--- a/apps/extension/src/lib/manifest-hosts.ts
+++ b/apps/extension/src/lib/manifest-hosts.ts
@@ -1,9 +1,17 @@
+import { BSKY_WEB_CLIENT_HOSTS } from "../../../standard-reader/src/lib/atproto/bsky-clients.ts";
+
 // bsky.app and web clients forked from its `social-app` codebase share the
 // same post/embed DOM shape, so they all get the in-embed "Save to Standard
-// Reader" button. Add a fork's host here and every permission / content
-// script match / exclusion list below picks it up.
-const BSKY_HOSTS = ["bsky.app", "witchsky.app", "mu.social"] as const;
-const DEV_BSKY_HOSTS = ["staging.bsky.app"] as const;
+// Reader" button. The host list is shared with the reader app (which resolves
+// links to these clients into in-app embeds); add a fork there and every
+// permission / content script match / exclusion list below picks it up.
+const DEV_BSKY_HOSTS: ReadonlyArray<string> = [
+  "staging.bsky.app",
+  "main.bsky.dev",
+];
+const BSKY_HOSTS: ReadonlyArray<string> = BSKY_WEB_CLIENT_HOSTS.filter(
+  (host) => !DEV_BSKY_HOSTS.includes(host),
+);
 
 /** Production host permissions for store builds (build / zip). */
 export const PRODUCTION_HOST_PERMISSIONS = [
@@ -13,12 +21,12 @@ export const PRODUCTION_HOST_PERMISSIONS = [
 ] as const;
 
 /** Extra hosts for local dev and staging (`pnpm extension:dev`). */
-export const DEV_HOST_PERMISSIONS = [
+export const DEV_HOST_PERMISSIONS: ReadonlyArray<string> = [
   "https://staging.standard-reader.app/*",
   "http://127.0.0.1:3000/*",
   "http://127.0.0.1:3001/*",
-  "https://staging.bsky.app/*",
-] as const;
+  ...DEV_BSKY_HOSTS.map((host) => `https://${host}/*`),
+];
 
 export function hostPermissions(includeDev: boolean): Array<string> {
   return includeDev
@@ -55,7 +63,7 @@ export function pageOverlayExcludeMatches(includeDev: boolean): Array<string> {
   if (includeDev) {
     excludes.push(
       "*://staging.standard-reader.app/*",
-      "*://staging.bsky.app/*",
+      ...DEV_BSKY_HOSTS.map((host) => `*://${host}/*`),
       "*://localhost/*",
       "*://127.0.0.1/*",
     );
@@ -76,6 +84,8 @@ export function authCallbackMatches(includeDev: boolean): Array<string> {
 
 export function bskyEmbedMatches(includeDev: boolean): Array<string> {
   const matches = BSKY_HOSTS.map((host) => `https://${host}/*`);
-  if (includeDev) matches.push("https://staging.bsky.app/*");
+  if (includeDev) {
+    matches.push(...DEV_BSKY_HOSTS.map((host) => `https://${host}/*`));
+  }
   return matches;
 }

--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -149,6 +149,17 @@ Sections, top to bottom:
   image alt text surfaced inside the lightbox and prev/next navigation across a gallery's images.
   Magazine editions are the one exception: they bind their own lightbox to the rendered `<img>`
   elements.
+- **Bluesky web-client links resolve to their records.** `bsky.app` and the clients forked from
+  its `social-app` codebase — Witchsky, Mu, deer.social — share one URL grammar and address the
+  same AT Protocol records, so a link to any of them is a link to the _record_, not to a
+  third-party page. The host list lives in
+  [`lib/atproto/bsky-clients.ts`](src/lib/atproto/bsky-clients.ts) and is shared with the
+  extension's manifest generation; adding a fork there lights it up everywhere at once. Inline
+  profile links become mention chips routed to `/u/$did`; a link-card block (Leaflet
+  `website`, PCKT `website`, ProseMirror `embed`) whose target is a post becomes a native post
+  embed, and a profile / feed / list / starter-pack link becomes an entity card hydrated from
+  the public AppView. When a record can't be resolved — deleted, blocked, AppView down — the
+  ordinary link card stands in, so a dead reference never leaves a hole in the article.
 - Sticky top bar: back, byline, follow, like, share; reading-progress bar. On mobile it
   pins below the shell's top bar whenever that one is revealed, so the two stack instead
   of overlapping.

--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -150,7 +150,8 @@ Sections, top to bottom:
   Magazine editions are the one exception: they bind their own lightbox to the rendered `<img>`
   elements.
 - **Bluesky web-client links resolve to their records.** `bsky.app` and the clients forked from
-  its `social-app` codebase — Witchsky, Mu, deer.social — share one URL grammar and address the
+  its `social-app` codebase — Witchsky, Mu, deer.social, Blacksky — share one URL grammar and
+  address the
   same AT Protocol records, so a link to any of them is a link to the _record_, not to a
   third-party page. The host list lives in
   [`lib/atproto/bsky-clients.ts`](src/lib/atproto/bsky-clients.ts) and is shared with the

--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -151,9 +151,12 @@ Sections, top to bottom:
   elements.
 - **Bluesky web-client links resolve to their records.** `bsky.app` and the clients forked from
   its `social-app` codebase — Witchsky, Mu, deer.social, Blacksky — share one URL grammar and
-  address the
-  same AT Protocol records, so a link to any of them is a link to the _record_, not to a
-  third-party page. The host list lives in
+  address the same AT Protocol records, so a link to any of them is a link to the _record_, not
+  to a third-party page. **Embeds are branded with the client the link came from** — its name beside
+  the record kind, and its own `theme-color` run through the same Radix scale generator the
+  magazine palette uses, so the border tint and brand text stay contrast-safe in light and dark
+  (never the raw hex). A client with no published brand color is branded by name only. The
+  client table lives in
   [`lib/atproto/bsky-clients.ts`](src/lib/atproto/bsky-clients.ts) and is shared with the
   extension's manifest generation; adding a fork there lights it up everywhere at once. Inline
   profile links become mention chips routed to `/u/$did`; a link-card block (Leaflet

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -833,7 +833,7 @@ Backend/API exists; UI or copy is missing.
       `iframe-embed.tsx`. The converter carries it natively to Leaflet and as a sandboxed
       `<iframe srcdoc>` to Markpub; Offprint and pckt have no block for it and report it dropped.
 - [x] **Alternate Bluesky client embeds** — links to `social-app` forks (Witchsky, Mu,
-      deer.social) were only ever plain link cards, so an article citing
+      deer.social, Blacksky) were only ever plain link cards, so an article citing
       `witchsky.app/profile/…/feed/…` showed a bare "Witchsky" card. The client host list moved
       into [`lib/atproto/bsky-clients.ts`](src/lib/atproto/bsky-clients.ts) — shared with the
       extension's [`manifest-hosts.ts`](../extension/src/lib/manifest-hosts.ts), which used to

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -846,6 +846,13 @@ Backend/API exists; UI or copy is missing.
       everything else renders an entity card hydrated from the public AppView
       ([`bsky-entities.ts`](src/server/atproto/bsky-entities.ts)). Unresolvable records fall back
       to the original link card.
+- [x] **Brand client embeds** — `BSKY_WEB_CLIENTS` carries each client's name plus its published
+      `theme-color` / manifest `theme_color`, and the host list derives from that table so there
+      is one place to add a fork. Entity cards show the client name beside the record kind and
+      take an accent-tinted border; a post from a fork gets a "View on <client>" line, since
+      `bsky-react-post` owns the post card's markup and links it back to bsky.app. The raw brand
+      hex is never painted — it goes through `buildMagazinePalette`, the same Radix generator
+      behind publication cards, for contrast-safe light + dark values.
 - [x] **`at.markpub.markdown`** — full [Markpub.at](https://markpub.at/) support: dedicated
       renderer (`src/lib/markpub/*`, [`markpub-content.tsx`](src/components/reader/content/renderers/markpub-content.tsx)),
       flavor/extensions, facet/lens preprocessing, ingest-time `text.textBlob` fetch

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -832,6 +832,20 @@ Backend/API exists; UI or copy is missing.
       `srcdoc` iframe sandboxed to `allow-scripts` only, sharing the sizing frame with
       `iframe-embed.tsx`. The converter carries it natively to Leaflet and as a sandboxed
       `<iframe srcdoc>` to Markpub; Offprint and pckt have no block for it and report it dropped.
+- [x] **Alternate Bluesky client embeds** — links to `social-app` forks (Witchsky, Mu,
+      deer.social) were only ever plain link cards, so an article citing
+      `witchsky.app/profile/…/feed/…` showed a bare "Witchsky" card. The client host list moved
+      into [`lib/atproto/bsky-clients.ts`](src/lib/atproto/bsky-clients.ts) — shared with the
+      extension's [`manifest-hosts.ts`](../extension/src/lib/manifest-hosts.ts), which used to
+      carry its own copy — behind `parseBskyClientUrl`, which maps a client URL onto the record
+      it addresses (profile / post / feed / list / starter pack). `actorLinkIdent` and
+      `parseInternalRoute` now accept every fork, so inline profile links become mention chips
+      routed to `/u/$did`; link-card blocks upgrade through
+      [`bsky-client-embed.tsx`](src/components/reader/content/renderers/shared/bsky-client-embed.tsx)
+      — posts reuse the existing Bluesky post embed (now handle-addressable, not DID-only),
+      everything else renders an entity card hydrated from the public AppView
+      ([`bsky-entities.ts`](src/server/atproto/bsky-entities.ts)). Unresolvable records fall back
+      to the original link card.
 - [x] **`at.markpub.markdown`** — full [Markpub.at](https://markpub.at/) support: dedicated
       renderer (`src/lib/markpub/*`, [`markpub-content.tsx`](src/components/reader/content/renderers/markpub-content.tsx)),
       flavor/extensions, facet/lens preprocessing, ingest-time `text.textBlob` fetch

--- a/apps/standard-reader/src/components/reader/content/renderers/pckt-website.tsx
+++ b/apps/standard-reader/src/components/reader/content/renderers/pckt-website.tsx
@@ -2,22 +2,25 @@
 
 import * as stylex from "@stylexjs/stylex";
 
+import { parseBskyClientUrl } from "#/lib/atproto/bsky-clients";
 import { normalizeImageAlt } from "#/lib/document/structured-content/image";
 import type { PcktWebsiteBlock } from "#/lib/pckt/types";
 
 import { articleBodyStyles } from "../body-styles";
+import { BskyClientEmbedView } from "./shared/bsky-client-embed";
 import { WebsiteCardBody } from "./structured-views";
 
 export function PcktWebsiteBlockView({ block }: { block: PcktWebsiteBlock }) {
-  if (!block.src) return null;
+  const src = block.src;
+  if (!src) return null;
 
   const title = block.title?.trim();
   const description = block.description?.trim();
   const previewImage = block.previewImage?.trim();
 
-  return (
+  const card = (
     <a
-      href={block.src}
+      href={src}
       target="_blank"
       rel="noreferrer"
       {...stylex.props(articleBodyStyles.websiteCard)}
@@ -34,4 +37,13 @@ export function PcktWebsiteBlockView({ block }: { block: PcktWebsiteBlock }) {
       <WebsiteCardBody title={title} description={description} />
     </a>
   );
+
+  const clientRef = parseBskyClientUrl(src);
+  if (clientRef) {
+    return (
+      <BskyClientEmbedView url={src} clientRef={clientRef} fallback={card} />
+    );
+  }
+
+  return card;
 }

--- a/apps/standard-reader/src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+++ b/apps/standard-reader/src/components/reader/content/renderers/shared/bsky-client-embed.tsx
@@ -20,12 +20,17 @@ import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import type { ReactNode } from "react";
+import { use, useMemo } from "react";
 import { useHover } from "react-aria";
 
 import { initials } from "#/components/reader/format";
 import { bskyApi } from "#/integrations/tanstack-query/api-bsky.functions";
 import type { BskyClientRef } from "#/lib/atproto/bsky-clients";
+import { bskyClientBrand } from "#/lib/atproto/bsky-clients";
 import { normalizeAuthorRef } from "#/lib/author-profile";
+import { buildMagazinePalette } from "#/lib/collections/radix-theme";
+import { useTheme } from "#/lib/use-theme";
+import { MagazineColorContext } from "#/magazine/context";
 import type { BskyEntityCard } from "#/server/atproto/bsky-entities";
 
 import { BskyPostView } from "./bsky-post-embed";
@@ -49,23 +54,45 @@ export function BskyClientEmbedView({
   clientRef: BskyClientRef;
   fallback: ReactNode;
 }) {
+  const brandVars = useClientBrandVars(clientRef.host);
+  const brand = bskyClientBrand(clientRef.host);
+
   if (clientRef.kind === "post") {
     return (
       <BskyPostView
         ident={clientRef.ident}
         rkey={clientRef.rkey}
         notFound={fallback}
+        // The post card is `bsky-react-post`'s own markup and its internal
+        // links all point at bsky.app, so a fork gets an attribution line
+        // beneath it. bsky.app needs none — the card already reads as Bluesky.
+        caption={
+          brand.name === "Bluesky" ? null : (
+            <ClientAttribution url={url} host={clientRef.host} />
+          )
+        }
       />
     );
   }
-  return <BskyEntityCardView url={url} fallback={fallback} />;
+  return (
+    <BskyEntityCardView
+      url={url}
+      host={clientRef.host}
+      brandVars={brandVars}
+      fallback={fallback}
+    />
+  );
 }
 
 function BskyEntityCardView({
   url,
+  host,
+  brandVars,
   fallback,
 }: {
   url: string;
+  host: string;
+  brandVars: Record<string, string> | null;
   fallback: ReactNode;
 }) {
   const { hoverProps, isHovered } = useHover({});
@@ -85,6 +112,9 @@ function BskyEntityCardView({
       <div {...stylex.props(styles.meta)}>
         <p {...stylex.props(styles.kind)}>
           <EntityKindLabel card={card} />
+          <span {...stylex.props(styles.brand)}>
+            {bskyClientBrand(host).name}
+          </span>
         </p>
         <p {...stylex.props(styles.title)}>{card.title}</p>
         {card.description ? (
@@ -98,6 +128,7 @@ function BskyEntityCardView({
   );
 
   const cardStyles = stylex.props(styles.card, isHovered && styles.cardHovered);
+  const style = { ...cardStyles.style, ...brandVars };
 
   // A profile is somebody we have a page for; everything else opens in the
   // client the link came from.
@@ -107,7 +138,8 @@ function BskyEntityCardView({
         to="/u/$did"
         params={{ did: normalizeAuthorRef(card.did) }}
         {...hoverProps}
-        {...cardStyles}
+        className={cardStyles.className}
+        style={style}
       >
         {body}
       </Link>
@@ -120,9 +152,63 @@ function BskyEntityCardView({
       target="_blank"
       rel="noreferrer"
       {...hoverProps}
-      {...cardStyles}
+      className={cardStyles.className}
+      style={style}
     >
       {body}
+    </a>
+  );
+}
+
+/**
+ * Card-scoped CSS variables carrying the client's brand color. The raw brand
+ * color is never painted directly — it goes through the same Radix scale
+ * generator the magazine palette uses, which yields a border tint and a text
+ * color that stay contrast-safe in light *and* dark. Returns null when the
+ * client publishes no brand color, so the card keeps the reader's own border.
+ */
+function useClientBrandVars(host: string): Record<string, string> | null {
+  const magazine = use(MagazineColorContext);
+  const { resolvedScheme } = useTheme();
+  const dark = magazine ? magazine.dark : resolvedScheme === "dark";
+
+  const { accent } = bskyClientBrand(host);
+  return useMemo(() => {
+    if (!accent) return null;
+    const palette = buildMagazinePalette({
+      accent,
+      accentForeground: null,
+      background: null,
+      fontBody: null,
+      fontTitle: null,
+      foreground: null,
+    });
+    if (!palette) return null;
+    const vars = dark ? palette.dark : palette.light;
+    return {
+      // Radix step 8 is the *hovered* border and too loud at rest, so mix it
+      // back toward the surface — matching how publication cards are tinted.
+      "--client-border": `color-mix(in oklab, ${vars["--accent"]} 55%, ${vars["--paper"]})`,
+      // Step 10 is the contrast-safe text step for the accent.
+      "--client-ink": vars["--accent-ink"] ?? "",
+    };
+  }, [accent, dark]);
+}
+
+/** "View on Witchsky" — brand attribution for an embed we didn't draw. */
+function ClientAttribution({ url, host }: { url: string; host: string }) {
+  const brandVars = useClientBrandVars(host);
+  const { name } = bskyClientBrand(host);
+  const props = stylex.props(styles.attribution);
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noreferrer"
+      className={props.className}
+      style={{ ...props.style, ...brandVars }}
+    >
+      <Trans>View on {name}</Trans>
     </a>
   );
 }
@@ -183,7 +269,7 @@ function EntityStat({ card }: { card: BskyEntityCard }) {
 const styles = stylex.create({
   card: {
     padding: spacing["4"],
-    borderColor: uiColor.border1,
+    borderColor: `var(--client-border, ${uiColor.border1})`,
     borderRadius: radius.md,
     borderStyle: "solid",
     borderWidth: 1,
@@ -213,7 +299,11 @@ const styles = stylex.create({
     minWidth: 0,
   },
   kind: {
+    columnGap: gap.xs,
+    alignItems: "baseline",
     color: uiColor.text1,
+    display: "flex",
+    flexWrap: "wrap",
     fontFamily: fontFamily.sans,
     fontSize: fontSize.xs,
     fontWeight: fontWeight.semibold,
@@ -221,6 +311,13 @@ const styles = stylex.create({
     textTransform: "uppercase",
     marginBottom: spacing["0"],
     marginTop: spacing["0"],
+  },
+  /** Client name beside the kind, painted in that client's brand color. */
+  brand: {
+    color: `var(--client-ink, ${uiColor.text1})`,
+    // Separator drawn in CSS so it stays out of the translation catalog.
+    // oxlint-disable-next-line @stylexjs/no-legacy-contextual-styles
+    "::before": { content: "'· '" },
   },
   title: {
     color: primaryColor.text2,
@@ -252,5 +349,21 @@ const styles = stylex.create({
     fontSize: fontSize.sm,
     marginBottom: spacing["0"],
     marginTop: spacing["0"],
+  },
+  /**
+   * Sits directly under a post embed, which carries its own bottom margin —
+   * so pull up into it rather than adding more space below the post.
+   */
+  attribution: {
+    color: `var(--client-ink, ${uiColor.text1})`,
+    display: "block",
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.xs,
+    fontWeight: fontWeight.semibold,
+    letterSpacing: "0.06em",
+    textDecoration: "none",
+    textTransform: "uppercase",
+    marginBottom: spacing["6"],
+    marginTop: `calc(-1 * ${spacing["4"]})`,
   },
 });

--- a/apps/standard-reader/src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+++ b/apps/standard-reader/src/components/reader/content/renderers/shared/bsky-client-embed.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { Plural, Trans } from "@lingui/react/macro";
+import { Avatar } from "@standard-reader/design-system/avatar";
+import { animationDuration } from "@standard-reader/design-system/theme/animations.stylex";
+import {
+  primaryColor,
+  uiColor,
+} from "@standard-reader/design-system/theme/color.stylex";
+import { radius } from "@standard-reader/design-system/theme/radius.stylex";
+import { gap } from "@standard-reader/design-system/theme/semantic-spacing.stylex";
+import { spacing } from "@standard-reader/design-system/theme/spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+} from "@standard-reader/design-system/theme/typography.stylex";
+import * as stylex from "@stylexjs/stylex";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import type { ReactNode } from "react";
+import { useHover } from "react-aria";
+
+import { initials } from "#/components/reader/format";
+import { bskyApi } from "#/integrations/tanstack-query/api-bsky.functions";
+import type { BskyClientRef } from "#/lib/atproto/bsky-clients";
+import { normalizeAuthorRef } from "#/lib/author-profile";
+import type { BskyEntityCard } from "#/server/atproto/bsky-entities";
+
+import { BskyPostView } from "./bsky-post-embed";
+
+/**
+ * A link block whose target is a Bluesky web client — `bsky.app` or one of its
+ * forks (Witchsky, mu.social, …). Those URLs address AT Protocol records, not
+ * third-party pages, so render the record itself: a post becomes a post embed,
+ * and a profile / feed / list / starter pack becomes an entity card.
+ *
+ * While the record loads (and if it can't be resolved at all) `fallback` — the
+ * ordinary link card the block would otherwise have rendered — stands in, so a
+ * dead or blocked record never leaves a hole in the article.
+ */
+export function BskyClientEmbedView({
+  url,
+  clientRef,
+  fallback,
+}: {
+  url: string;
+  clientRef: BskyClientRef;
+  fallback: ReactNode;
+}) {
+  if (clientRef.kind === "post") {
+    return (
+      <BskyPostView
+        ident={clientRef.ident}
+        rkey={clientRef.rkey}
+        notFound={fallback}
+      />
+    );
+  }
+  return <BskyEntityCardView url={url} fallback={fallback} />;
+}
+
+function BskyEntityCardView({
+  url,
+  fallback,
+}: {
+  url: string;
+  fallback: ReactNode;
+}) {
+  const { hoverProps, isHovered } = useHover({});
+  const { data: card } = useQuery(bskyApi.getEntityCardQueryOptions(url));
+
+  if (!card) return <>{fallback}</>;
+
+  const body = (
+    <>
+      <Avatar
+        size="lg"
+        src={card.avatarUrl ?? undefined}
+        fallback={initials(card.title)}
+        alt=""
+        style={styles.avatar}
+      />
+      <div {...stylex.props(styles.meta)}>
+        <p {...stylex.props(styles.kind)}>
+          <EntityKindLabel card={card} />
+        </p>
+        <p {...stylex.props(styles.title)}>{card.title}</p>
+        {card.description ? (
+          <p {...stylex.props(styles.description)}>{card.description}</p>
+        ) : null}
+        <p {...stylex.props(styles.byline)}>
+          <EntityByline card={card} />
+        </p>
+      </div>
+    </>
+  );
+
+  const cardStyles = stylex.props(styles.card, isHovered && styles.cardHovered);
+
+  // A profile is somebody we have a page for; everything else opens in the
+  // client the link came from.
+  if (card.kind === "profile" && card.did) {
+    return (
+      <Link
+        to="/u/$did"
+        params={{ did: normalizeAuthorRef(card.did) }}
+        {...hoverProps}
+        {...cardStyles}
+      >
+        {body}
+      </Link>
+    );
+  }
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noreferrer"
+      {...hoverProps}
+      {...cardStyles}
+    >
+      {body}
+    </a>
+  );
+}
+
+/** Eyebrow naming what kind of record the card is showing. */
+function EntityKindLabel({ card }: { card: BskyEntityCard }) {
+  switch (card.kind) {
+    case "profile": {
+      return <Trans>Profile</Trans>;
+    }
+    case "feed": {
+      return <Trans>Feed</Trans>;
+    }
+    case "list": {
+      return <Trans>List</Trans>;
+    }
+    case "starterPack": {
+      return <Trans>Starter pack</Trans>;
+    }
+  }
+}
+
+/**
+ * Owner plus the one count that matters for this kind — followers for a
+ * profile, likes for a feed, members for a list, joins for a starter pack.
+ */
+function EntityByline({ card }: { card: BskyEntityCard }) {
+  const owner = card.creatorDisplayName ?? card.creatorHandle;
+  const stat = card.count == null ? null : <EntityStat card={card} />;
+
+  return (
+    <>
+      {owner ? <span>{owner}</span> : null}
+      {owner && stat ? " · " : null}
+      {stat}
+    </>
+  );
+}
+
+function EntityStat({ card }: { card: BskyEntityCard }) {
+  const value = card.count ?? 0;
+  switch (card.kind) {
+    case "profile": {
+      return <Plural value={value} one="# follower" other="# followers" />;
+    }
+    case "feed": {
+      return <Plural value={value} one="# like" other="# likes" />;
+    }
+    case "list": {
+      return <Plural value={value} one="# member" other="# members" />;
+    }
+    case "starterPack": {
+      return <Plural value={value} one="# join" other="# joins" />;
+    }
+  }
+}
+
+const styles = stylex.create({
+  card: {
+    padding: spacing["4"],
+    borderColor: uiColor.border1,
+    borderRadius: radius.md,
+    borderStyle: "solid",
+    borderWidth: 1,
+    cornerShape: "squircle",
+    textDecoration: "none",
+    alignItems: "flex-start",
+    backgroundColor: uiColor.component1,
+    columnGap: gap.md,
+    display: "flex",
+    transitionDuration: animationDuration.default,
+    transitionProperty: "background-color",
+    transitionTimingFunction: "ease",
+    marginBottom: spacing["6"],
+    marginTop: spacing["0"],
+  },
+  cardHovered: {
+    backgroundColor: uiColor.component2,
+  },
+  avatar: {
+    flexShrink: 0,
+  },
+  meta: {
+    display: "flex",
+    flexDirection: "column",
+    flexGrow: 1,
+    rowGap: spacing["1"],
+    minWidth: 0,
+  },
+  kind: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.xs,
+    fontWeight: fontWeight.semibold,
+    letterSpacing: "0.06em",
+    textTransform: "uppercase",
+    marginBottom: spacing["0"],
+    marginTop: spacing["0"],
+  },
+  title: {
+    color: primaryColor.text2,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.lg,
+    fontWeight: fontWeight.semibold,
+    lineHeight: lineHeight.sm,
+    marginBottom: spacing["0"],
+    marginTop: spacing["0"],
+  },
+  description: {
+    overflow: "hidden",
+    // oxlint-disable-next-line @stylexjs/valid-styles
+    WebkitBoxOrient: "vertical",
+    // oxlint-disable-next-line @stylexjs/valid-styles
+    WebkitLineClamp: 3,
+    color: uiColor.text1,
+    display: "-webkit-box",
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.sm,
+    lineHeight: lineHeight.base,
+    marginBottom: spacing["0"],
+    marginTop: spacing["0"],
+    whiteSpace: "pre-wrap",
+  },
+  byline: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.sm,
+    marginBottom: spacing["0"],
+    marginTop: spacing["0"],
+  },
+});

--- a/apps/standard-reader/src/components/reader/content/renderers/shared/bsky-post-embed.tsx
+++ b/apps/standard-reader/src/components/reader/content/renderers/shared/bsky-post-embed.tsx
@@ -26,16 +26,20 @@ export function BskyPostEmbedView({
  * a handle — a link from a web client (`bsky.app/profile/<handle>/post/<rkey>`
  * and its forks) can carry either. `notFound` stands in when the post can't be
  * fetched (deleted, blocked); it defaults to nothing, matching how an author's
- * explicit post block behaves when its target disappears.
+ * explicit post block behaves when its target disappears. `caption` renders
+ * beneath the post — `bsky-react-post` owns the card's own markup, so this is
+ * the only place to add anything to it.
  */
 export function BskyPostView({
   ident,
   rkey,
   notFound = null,
+  caption = null,
 }: {
   ident: string | undefined;
   rkey: string | undefined;
   notFound?: ReactNode;
+  caption?: ReactNode;
 }) {
   const magazine = use(MagazineColorContext);
   const { resolvedScheme } = useTheme();
@@ -47,19 +51,22 @@ export function BskyPostView({
   if (!ident || !rkey) return null;
 
   return (
-    <div
-      {...stylex.props(articleBodyStyles.bskyPostEmbed)}
-      data-bsky-post-embed
-      data-magazine-bsky={magazine ? "" : undefined}
-      data-theme={colorScheme}
-    >
-      <Post
-        {...(ident.startsWith("did:") ? { did: ident } : { handle: ident })}
-        id={rkey}
-        apiUrl={bskyPostApiUrl(ident, rkey)}
-        fallback={<PostSkeleton />}
-        components={{ PostNotFound: () => <>{notFound}</> }}
-      />
-    </div>
+    <>
+      <div
+        {...stylex.props(articleBodyStyles.bskyPostEmbed)}
+        data-bsky-post-embed
+        data-magazine-bsky={magazine ? "" : undefined}
+        data-theme={colorScheme}
+      >
+        <Post
+          {...(ident.startsWith("did:") ? { did: ident } : { handle: ident })}
+          id={rkey}
+          apiUrl={bskyPostApiUrl(ident, rkey)}
+          fallback={<PostSkeleton />}
+          components={{ PostNotFound: () => <>{notFound}</> }}
+        />
+      </div>
+      {caption}
+    </>
   );
 }

--- a/apps/standard-reader/src/components/reader/content/renderers/shared/bsky-post-embed.tsx
+++ b/apps/standard-reader/src/components/reader/content/renderers/shared/bsky-post-embed.tsx
@@ -2,6 +2,7 @@
 
 import * as stylex from "@stylexjs/stylex";
 import { Post, PostSkeleton } from "bsky-react-post";
+import type { ReactNode } from "react";
 import { use } from "react";
 
 import "bsky-react-post/theme.css";
@@ -16,6 +17,26 @@ export function BskyPostEmbedView({
 }: {
   postUri: string | undefined;
 }) {
+  const ref = postUri ? parseBskyPostRef(postUri) : null;
+  return <BskyPostView ident={ref?.did} rkey={ref?.id} />;
+}
+
+/**
+ * An embedded Bluesky post addressed by repo + record key. `ident` is a DID or
+ * a handle — a link from a web client (`bsky.app/profile/<handle>/post/<rkey>`
+ * and its forks) can carry either. `notFound` stands in when the post can't be
+ * fetched (deleted, blocked); it defaults to nothing, matching how an author's
+ * explicit post block behaves when its target disappears.
+ */
+export function BskyPostView({
+  ident,
+  rkey,
+  notFound = null,
+}: {
+  ident: string | undefined;
+  rkey: string | undefined;
+  notFound?: ReactNode;
+}) {
   const magazine = use(MagazineColorContext);
   const { resolvedScheme } = useTheme();
   const colorScheme = magazine
@@ -23,10 +44,7 @@ export function BskyPostEmbedView({
       ? "dark"
       : "light"
     : resolvedScheme;
-  if (!postUri) return null;
-
-  const ref = parseBskyPostRef(postUri);
-  if (!ref) return null;
+  if (!ident || !rkey) return null;
 
   return (
     <div
@@ -36,11 +54,11 @@ export function BskyPostEmbedView({
       data-theme={colorScheme}
     >
       <Post
-        did={ref.did}
-        id={ref.id}
-        apiUrl={bskyPostApiUrl(ref.did, ref.id)}
+        {...(ident.startsWith("did:") ? { did: ident } : { handle: ident })}
+        id={rkey}
+        apiUrl={bskyPostApiUrl(ident, rkey)}
         fallback={<PostSkeleton />}
-        components={{ PostNotFound: () => <></> }}
+        components={{ PostNotFound: () => <>{notFound}</> }}
       />
     </div>
   );

--- a/apps/standard-reader/src/components/reader/content/renderers/structured-views.tsx
+++ b/apps/standard-reader/src/components/reader/content/renderers/structured-views.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from "react";
 
 import { HighlightedPlaintext } from "#/components/reader/quote-highlight-context";
 import { useQuoteHighlightTracker } from "#/components/reader/quote-highlight-tracker";
+import { parseBskyClientUrl } from "#/lib/atproto/bsky-clients";
 import { normalizeImageAlt } from "#/lib/document/structured-content/image";
 import type {
   StructuredListItem,
@@ -15,6 +16,7 @@ import type {
 import type { QuoteHighlightRange } from "#/lib/quote-highlight-text";
 
 import { articleBodyStyles } from "../body-styles";
+import { BskyClientEmbedView } from "./shared/bsky-client-embed";
 import { HighlightedFacetedPlaintext } from "./shared/faceted-text";
 
 export function WebsiteCardBody({
@@ -241,7 +243,7 @@ export function StructuredWebsiteView({
     ? (tracker?.consume(cardDescription.length) ?? null)
     : null;
 
-  return (
+  const card = (
     <a
       href={src}
       target="_blank"
@@ -265,4 +267,15 @@ export function StructuredWebsiteView({
       />
     </a>
   );
+
+  // The quote-highlight tracker has already consumed this block's text above,
+  // so swapping in an embed here doesn't shift later blocks' offsets.
+  const clientRef = parseBskyClientUrl(src);
+  if (clientRef) {
+    return (
+      <BskyClientEmbedView url={src} clientRef={clientRef} fallback={card} />
+    );
+  }
+
+  return card;
 }

--- a/apps/standard-reader/src/integrations/tanstack-query/api-bsky.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-bsky.functions.ts
@@ -1,6 +1,10 @@
+import { queryOptions } from "@tanstack/react-query";
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 
+import { parseBskyClientUrl } from "#/lib/atproto/bsky-clients";
+import type { BskyEntityCard } from "#/server/atproto/bsky-entities";
+import { getBskyEntityCard } from "#/server/atproto/bsky-entities";
 import { getPosts } from "#/server/atproto/bsky-posts";
 
 const getEmbedPostsInput = z.object({
@@ -25,6 +29,33 @@ const getEmbedPosts = createServerFn({ method: "GET" })
     }));
   });
 
+const getEntityCardInput = z.object({
+  /** A `bsky.app` (or fork) URL — parsed server-side. */
+  url: z.string().min(1).max(2048),
+});
+
+/**
+ * Hydrate the AT Protocol record behind a Bluesky web client link so it can
+ * render as a native embed. Returns null when the URL is not a record link or
+ * the record can't be resolved — the caller falls back to a plain link card.
+ */
+const getEntityCard = createServerFn({ method: "GET" })
+  .validator(getEntityCardInput)
+  .handler(async ({ data }): Promise<BskyEntityCard | null> => {
+    const ref = parseBskyClientUrl(data.url);
+    return ref ? getBskyEntityCard(ref) : null;
+  });
+
+function getEntityCardQueryOptions(url: string) {
+  return queryOptions({
+    queryKey: ["bsky", "entity", url] as const,
+    queryFn: async () => getEntityCard({ data: { url } }),
+    staleTime: 300_000,
+  });
+}
+
 export const bskyApi = {
   getEmbedPosts,
+  getEntityCard,
+  getEntityCardQueryOptions,
 };

--- a/apps/standard-reader/src/lib/atproto/bsky-clients.test.ts
+++ b/apps/standard-reader/src/lib/atproto/bsky-clients.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  bskyClientProfileIdent,
+  bskyClientRefAtUri,
+  isBskyClientHost,
+  parseBskyClientUrl,
+} from "./bsky-clients";
+
+describe("isBskyClientHost", () => {
+  it("accepts bsky.app and the social-app forks", () => {
+    expect(isBskyClientHost("bsky.app")).toBe(true);
+    expect(isBskyClientHost("Witchsky.app")).toBe(true);
+    expect(isBskyClientHost("mu.social")).toBe(true);
+    expect(isBskyClientHost("deer.social")).toBe(true);
+  });
+
+  it("rejects lookalikes and unrelated hosts", () => {
+    expect(isBskyClientHost("example.com")).toBe(false);
+    // A subdomain is a different site, not a client we know the grammar of.
+    expect(isBskyClientHost("evil.bsky.app")).toBe(false);
+    expect(isBskyClientHost("bsky.app.evil.com")).toBe(false);
+  });
+});
+
+describe("parseBskyClientUrl", () => {
+  it("parses a profile on an alternate client", () => {
+    expect(
+      parseBskyClientUrl("https://witchsky.app/profile/did:plc:d4t4psds4x5z"),
+    ).toEqual({
+      host: "witchsky.app",
+      ident: "did:plc:d4t4psds4x5z",
+      kind: "profile",
+    });
+  });
+
+  it("parses posts, feeds, lists, and starter packs", () => {
+    expect(
+      parseBskyClientUrl(
+        "https://mu.social/profile/alice.bsky.social/post/3ab",
+      ),
+    ).toEqual({
+      host: "mu.social",
+      ident: "alice.bsky.social",
+      kind: "post",
+      rkey: "3ab",
+    });
+    expect(
+      parseBskyClientUrl(
+        "https://witchsky.app/profile/did:plc:vpkhqolt662u/feed/infreq",
+      ),
+    ).toEqual({
+      host: "witchsky.app",
+      ident: "did:plc:vpkhqolt662u",
+      kind: "feed",
+      rkey: "infreq",
+    });
+    // `social-app` spells the list route `/lists/`, not `/list/`.
+    expect(
+      parseBskyClientUrl(
+        "https://bsky.app/profile/alice.bsky.social/lists/xyz",
+      ),
+    ).toEqual({
+      host: "bsky.app",
+      ident: "alice.bsky.social",
+      kind: "list",
+      rkey: "xyz",
+    });
+    expect(
+      parseBskyClientUrl(
+        "https://bsky.app/starter-pack/alice.bsky.social/pack",
+      ),
+    ).toEqual({
+      host: "bsky.app",
+      ident: "alice.bsky.social",
+      kind: "starterPack",
+      rkey: "pack",
+    });
+  });
+
+  it("tolerates trailing slashes, query strings, and `@`-prefixed handles", () => {
+    expect(
+      parseBskyClientUrl(
+        "https://witchsky.app/profile/@alice.bsky.social/?x=1",
+      ),
+    ).toEqual({
+      host: "witchsky.app",
+      ident: "alice.bsky.social",
+      kind: "profile",
+    });
+  });
+
+  it("returns null for client pages that are not records", () => {
+    expect(parseBskyClientUrl("https://witchsky.app/")).toBeNull();
+    expect(parseBskyClientUrl("https://bsky.app/search?q=art")).toBeNull();
+    expect(parseBskyClientUrl("https://bsky.app/settings")).toBeNull();
+    // Not a handle (no dot) and not a DID — `social-app` reserves these.
+    expect(parseBskyClientUrl("https://bsky.app/profile/me")).toBeNull();
+    // Unknown sub-resource under a profile.
+    expect(
+      parseBskyClientUrl("https://bsky.app/profile/alice.bsky.social/likes"),
+    ).toBeNull();
+  });
+
+  it("returns null for non-client URLs", () => {
+    expect(
+      parseBskyClientUrl("https://example.com/profile/alice.bsky.social"),
+    ).toBeNull();
+    expect(
+      parseBskyClientUrl("at://did:plc:abc/app.bsky.feed.post/1"),
+    ).toBeNull();
+    expect(parseBskyClientUrl("")).toBeNull();
+  });
+});
+
+describe("bskyClientRefAtUri", () => {
+  it("builds the AT-URI for each record kind", () => {
+    const ref = parseBskyClientUrl(
+      "https://witchsky.app/profile/did:plc:vpk/feed/infreq",
+    );
+    expect(ref && bskyClientRefAtUri(ref)).toBe(
+      "at://did:plc:vpk/app.bsky.feed.generator/infreq",
+    );
+
+    const list = parseBskyClientUrl(
+      "https://mu.social/profile/did:plc:vpk/lists/abc",
+    );
+    expect(list && bskyClientRefAtUri(list)).toBe(
+      "at://did:plc:vpk/app.bsky.graph.list/abc",
+    );
+  });
+
+  it("returns null when the URL carried a handle instead of a DID", () => {
+    const ref = parseBskyClientUrl(
+      "https://bsky.app/profile/alice.bsky.social/post/3ab",
+    );
+    expect(ref && bskyClientRefAtUri(ref)).toBeNull();
+  });
+
+  it("returns null for a bare profile — there is no record to address", () => {
+    const ref = parseBskyClientUrl("https://bsky.app/profile/did:plc:abc");
+    expect(ref && bskyClientRefAtUri(ref)).toBeNull();
+  });
+});
+
+describe("bskyClientProfileIdent", () => {
+  it("returns the ident only for a bare profile", () => {
+    expect(
+      bskyClientProfileIdent("https://mu.social/profile/alice.bsky.social"),
+    ).toBe("alice.bsky.social");
+    expect(
+      bskyClientProfileIdent(
+        "https://mu.social/profile/alice.bsky.social/post/3ab",
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/standard-reader/src/lib/atproto/bsky-clients.test.ts
+++ b/apps/standard-reader/src/lib/atproto/bsky-clients.test.ts
@@ -13,6 +13,7 @@ describe("isBskyClientHost", () => {
     expect(isBskyClientHost("Witchsky.app")).toBe(true);
     expect(isBskyClientHost("mu.social")).toBe(true);
     expect(isBskyClientHost("deer.social")).toBe(true);
+    expect(isBskyClientHost("blacksky.community")).toBe(true);
   });
 
   it("rejects lookalikes and unrelated hosts", () => {
@@ -20,6 +21,8 @@ describe("isBskyClientHost", () => {
     // A subdomain is a different site, not a client we know the grammar of.
     expect(isBskyClientHost("evil.bsky.app")).toBe(false);
     expect(isBskyClientHost("bsky.app.evil.com")).toBe(false);
+    // Blacksky's WordPress site, not their client — `/profile/…` 404s there.
+    expect(isBskyClientHost("blackskyweb.xyz")).toBe(false);
   });
 });
 

--- a/apps/standard-reader/src/lib/atproto/bsky-clients.test.ts
+++ b/apps/standard-reader/src/lib/atproto/bsky-clients.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  BSKY_WEB_CLIENT_HOSTS,
+  bskyClientBrand,
   bskyClientProfileIdent,
   bskyClientRefAtUri,
   isBskyClientHost,
@@ -23,6 +25,56 @@ describe("isBskyClientHost", () => {
     expect(isBskyClientHost("bsky.app.evil.com")).toBe(false);
     // Blacksky's WordPress site, not their client — `/profile/…` 404s there.
     expect(isBskyClientHost("blackskyweb.xyz")).toBe(false);
+  });
+
+  it("does not treat Object prototype keys as clients", () => {
+    // The client table is an object literal, so a plain `host in table` check
+    // would pass `constructor` — a legal hostname (`https://constructor/`).
+    expect(isBskyClientHost("constructor")).toBe(false);
+    expect(isBskyClientHost("valueOf")).toBe(false);
+    expect(isBskyClientHost("__proto__")).toBe(false);
+  });
+});
+
+describe("bskyClientBrand", () => {
+  it("names and colors each known client", () => {
+    expect(bskyClientBrand("witchsky.app")).toEqual({
+      accent: "#ED5345",
+      name: "Witchsky",
+    });
+    expect(bskyClientBrand("Blacksky.Community").name).toBe("Blacksky");
+    expect(bskyClientBrand("bsky.app").name).toBe("Bluesky");
+  });
+
+  it("carries a null accent for a client that publishes no brand color", () => {
+    expect(bskyClientBrand("mu.social")).toEqual({
+      accent: null,
+      name: "Mu",
+    });
+  });
+
+  it("falls back to the bare host, never a prototype value", () => {
+    expect(bskyClientBrand("example.com")).toEqual({
+      accent: null,
+      name: "example.com",
+    });
+    expect(bskyClientBrand("constructor")).toEqual({
+      accent: null,
+      name: "constructor",
+    });
+  });
+
+  it("gives every known client a name and a usable accent", () => {
+    expect(BSKY_WEB_CLIENT_HOSTS.length).toBeGreaterThan(0);
+    for (const host of BSKY_WEB_CLIENT_HOSTS) {
+      // Hosts are lowercase, so `bskyClientBrand` never has to normalize a key
+      // that the table itself got wrong.
+      expect(host).toBe(host.toLowerCase());
+      const { name, accent } = bskyClientBrand(host);
+      expect(name).not.toBe("");
+      // The accent is fed to the Radix scale generator, which needs real hex.
+      if (accent !== null) expect(accent).toMatch(/^#[0-9a-f]{6}$/i);
+    }
   });
 });
 

--- a/apps/standard-reader/src/lib/atproto/bsky-clients.ts
+++ b/apps/standard-reader/src/lib/atproto/bsky-clients.ts
@@ -22,6 +22,9 @@ export const BSKY_WEB_CLIENT_HOSTS = [
   "deer.social",
   "witchsky.app",
   "mu.social",
+  // Blacksky's client. Not `blackskyweb.xyz` — that is their WordPress site,
+  // and it is the host their articles usually link to.
+  "blacksky.community",
 ] as const;
 
 const HOSTS = new Set<string>(BSKY_WEB_CLIENT_HOSTS);

--- a/apps/standard-reader/src/lib/atproto/bsky-clients.ts
+++ b/apps/standard-reader/src/lib/atproto/bsky-clients.ts
@@ -1,0 +1,151 @@
+/**
+ * Bluesky web clients — `bsky.app` plus the alternate clients forked from its
+ * `social-app` codebase (Witchsky, mu.social, deer.social, …). They all share
+ * the same URL grammar (`/profile/<ident>`, `/profile/<ident>/post/<rkey>`, …)
+ * and address the same AT Protocol records, so a link to any of them is a link
+ * to the *record*, not to a third-party website.
+ *
+ * Keep this module dependency-free: it is imported by the browser extension's
+ * manifest generation, which loads outside the app's bundler.
+ */
+
+/**
+ * Hosts whose URLs address AT Protocol records via the `social-app` grammar.
+ * Adding a fork here makes every link to it resolve in-app: profile links
+ * become mention chips routed to `/u/$did`, and post / feed / list / starter
+ * pack cards become native embeds.
+ */
+export const BSKY_WEB_CLIENT_HOSTS = [
+  "bsky.app",
+  "staging.bsky.app",
+  "main.bsky.dev",
+  "deer.social",
+  "witchsky.app",
+  "mu.social",
+] as const;
+
+const HOSTS = new Set<string>(BSKY_WEB_CLIENT_HOSTS);
+
+/** True when `hostname` is a known Bluesky web client (case-insensitive). */
+export function isBskyClientHost(hostname: string): boolean {
+  return HOSTS.has(hostname.trim().toLowerCase());
+}
+
+/** The AT Protocol record kinds a `social-app` URL can address. */
+export type BskyClientRefKind =
+  | "profile"
+  | "post"
+  | "feed"
+  | "list"
+  | "starterPack";
+
+/**
+ * A record addressed by a Bluesky web client URL. `ident` is whatever the URL
+ * carried — a DID or a handle — and `rkey` is absent only for `profile`.
+ */
+export interface BskyClientRef {
+  kind: BskyClientRefKind;
+  /** Client host the link pointed at, e.g. `witchsky.app`. */
+  host: string;
+  /** DID or handle of the record's repo. */
+  ident: string;
+  /** Record key, for everything but a bare profile. */
+  rkey?: string;
+}
+
+/** `app.bsky.*` collection each ref kind lives in (`profile` has no record). */
+const COLLECTION: Record<Exclude<BskyClientRefKind, "profile">, string> = {
+  feed: "app.bsky.feed.generator",
+  list: "app.bsky.graph.list",
+  post: "app.bsky.feed.post",
+  starterPack: "app.bsky.graph.starterpack",
+};
+
+/** Path segment `social-app` uses for each record kind under `/profile/…`. */
+const PROFILE_SUBPATH: Record<string, BskyClientRefKind> = {
+  feed: "feed",
+  lists: "list",
+  post: "post",
+};
+
+function cleanIdent(raw: string): string | null {
+  let ident: string;
+  try {
+    ident = decodeURIComponent(raw);
+  } catch {
+    ident = raw;
+  }
+  ident = ident.trim();
+  if (ident.startsWith("@")) ident = ident.slice(1);
+  // A handle needs a dot; a DID is taken verbatim. Guards against `/profile/`
+  // junk (`me`, `settings`, …) resolving to a bogus record reference.
+  if (!ident) return null;
+  if (!ident.startsWith("did:") && !ident.includes(".")) return null;
+  return ident;
+}
+
+/**
+ * Parse a Bluesky web client URL into the AT Protocol record it addresses.
+ * Returns null for any other URL, including client pages that are not records
+ * (`/settings`, `/search`, a bare `https://witchsky.app/`).
+ */
+export function parseBskyClientUrl(url: string): BskyClientRef | null {
+  const trimmed = url.trim();
+  if (!trimmed || !/^https?:\/\//i.test(trimmed)) return null;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return null;
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  if (!isBskyClientHost(host)) return null;
+
+  const segments = parsed.pathname.split("/").filter(Boolean);
+
+  // `/starter-pack/<ident>/<rkey>` — the one record route outside `/profile`.
+  if (segments[0] === "starter-pack" && segments.length === 3) {
+    const ident = cleanIdent(segments[1] ?? "");
+    const rkey = segments[2];
+    if (!ident || !rkey) return null;
+    return { host, ident, kind: "starterPack", rkey };
+  }
+
+  if (segments[0] !== "profile") return null;
+
+  const ident = cleanIdent(segments[1] ?? "");
+  if (!ident) return null;
+
+  if (segments.length === 2) return { host, ident, kind: "profile" };
+
+  if (segments.length === 4) {
+    const kind = PROFILE_SUBPATH[segments[2] ?? ""];
+    const rkey = segments[3];
+    if (!kind || !rkey) return null;
+    return { host, ident, kind, rkey };
+  }
+
+  return null;
+}
+
+/**
+ * AT-URI for a parsed ref, or null when the ident is a handle (an AT-URI needs
+ * a DID) or the ref is a bare profile.
+ */
+export function bskyClientRefAtUri(ref: BskyClientRef): string | null {
+  if (ref.kind === "profile" || !ref.rkey) return null;
+  if (!ref.ident.startsWith("did:")) return null;
+  return `at://${ref.ident}/${COLLECTION[ref.kind]}/${ref.rkey}`;
+}
+
+/**
+ * If `url` is a Bluesky client link to a *bare profile*, return the user's
+ * ident (handle or DID). A post, feed, or list is about that object rather
+ * than a mention of its owner, so those return null.
+ */
+export function bskyClientProfileIdent(url: string): string | null {
+  const ref = parseBskyClientUrl(url);
+  return ref?.kind === "profile" ? ref.ident : null;
+}

--- a/apps/standard-reader/src/lib/atproto/bsky-clients.ts
+++ b/apps/standard-reader/src/lib/atproto/bsky-clients.ts
@@ -9,29 +9,65 @@
  * manifest generation, which loads outside the app's bundler.
  */
 
+/** How a client is named and colored when an embed is branded with it. */
+export interface BskyClientBrand {
+  /** Client name as it calls itself, shown on the embed. */
+  name: string;
+  /**
+   * The client's own brand color — its `<meta name="theme-color">` or published
+   * manifest `theme_color`. Null when the client publishes neither, in which
+   * case a branded embed keeps the reader's default border.
+   *
+   * Never used raw: it is run through the Radix scale generator so the embed
+   * gets a properly contrasted tint in both light and dark.
+   */
+  accent: string | null;
+}
+
 /**
- * Hosts whose URLs address AT Protocol records via the `social-app` grammar.
- * Adding a fork here makes every link to it resolve in-app: profile links
- * become mention chips routed to `/u/$did`, and post / feed / list / starter
- * pack cards become native embeds.
+ * Every client whose URLs address AT Protocol records via the `social-app`
+ * grammar, keyed by host. **This table is the one place to add a fork** — the
+ * host list below derives from it, and so does the extension's manifest. Adding
+ * an entry makes links to that client resolve in-app: profile links become
+ * mention chips routed to `/u/$did`, and post / feed / list / starter pack
+ * links become native embeds branded with the client's name and color.
  */
-export const BSKY_WEB_CLIENT_HOSTS = [
-  "bsky.app",
-  "staging.bsky.app",
-  "main.bsky.dev",
-  "deer.social",
-  "witchsky.app",
-  "mu.social",
+export const BSKY_WEB_CLIENTS: Readonly<Record<string, BskyClientBrand>> = {
+  // Bluesky publishes no theme-color meta; #0085FF is its brand blue
+  // (`primary_500` in the social-app palette).
+  "bsky.app": { accent: "#0085FF", name: "Bluesky" },
+  "staging.bsky.app": { accent: "#0085FF", name: "Bluesky" },
+  "main.bsky.dev": { accent: "#0085FF", name: "Bluesky" },
+  "deer.social": { accent: "#4B9B6C", name: "deer.social" },
+  "witchsky.app": { accent: "#ED5345", name: "Witchsky" },
+  // No reachable theme-color or manifest — branded by name only.
+  "mu.social": { accent: null, name: "Mu" },
   // Blacksky's client. Not `blackskyweb.xyz` — that is their WordPress site,
   // and it is the host their articles usually link to.
-  "blacksky.community",
-] as const;
+  "blacksky.community": { accent: "#6060E9", name: "Blacksky" },
+};
 
+/** Hosts of every known client, derived from {@link BSKY_WEB_CLIENTS}. */
+export const BSKY_WEB_CLIENT_HOSTS: ReadonlyArray<string> =
+  Object.keys(BSKY_WEB_CLIENTS);
+
+// A Set, not `host in BSKY_WEB_CLIENTS`: `in` walks the prototype chain, so a
+// URL whose hostname is `constructor` or `valueOf` would pass as a client.
 const HOSTS = new Set<string>(BSKY_WEB_CLIENT_HOSTS);
 
 /** True when `hostname` is a known Bluesky web client (case-insensitive). */
 export function isBskyClientHost(hostname: string): boolean {
   return HOSTS.has(hostname.trim().toLowerCase());
+}
+
+/**
+ * Branding for a client host. Unknown hosts fall back to the bare host as the
+ * name with no accent, so a caller never has to null-check.
+ */
+export function bskyClientBrand(host: string): BskyClientBrand {
+  const key = host.trim().toLowerCase();
+  const brand = HOSTS.has(key) ? BSKY_WEB_CLIENTS[key] : undefined;
+  return brand ?? { accent: null, name: key };
 }
 
 /** The AT Protocol record kinds a `social-app` URL can address. */

--- a/apps/standard-reader/src/lib/internal-route.ts
+++ b/apps/standard-reader/src/lib/internal-route.ts
@@ -1,3 +1,4 @@
+import { bskyClientProfileIdent } from "#/lib/atproto/bsky-clients";
 import { STANDARD_NSID } from "#/lib/atproto/nsids";
 import { normalizeAuthorRef } from "#/lib/author-profile";
 import { getPublicUrlClient } from "#/lib/public-url";
@@ -28,8 +29,6 @@ export type InternalRoute =
 const ARTICLE_PATH = /^\/a\/([^/]+)\/([^/]+)\/?$/;
 const PUBLICATION_PATH = /^\/p\/([^/]+)\/([^/]+)\/?$/;
 const AUTHOR_PATH = /^\/u\/([^/]+)\/?$/;
-const BSKY_PROFILE_PATH = /^\/profile\/([^/]+)\/?$/;
-const BSKY_PROFILE_HOSTS = new Set(["bsky.app", "staging.bsky.app"]);
 
 function parseAtUri(href: string): InternalRoute | null {
   if (!href.startsWith("at://")) return null;
@@ -127,14 +126,11 @@ export function parseInternalRoute(
       return parsePathname(url.pathname);
     }
 
-    if (BSKY_PROFILE_HOSTS.has(url.hostname)) {
-      const match = BSKY_PROFILE_PATH.exec(url.pathname);
-      if (match?.[1]) {
-        return {
-          to: "/u/$did",
-          params: { did: normalizeAuthorRef(decodeURIComponent(match[1])) },
-        };
-      }
+    // A profile on any Bluesky web client — bsky.app or one of its forks
+    // (Witchsky, mu.social, …) — is the same person, so route it in-app.
+    const bskyIdent = bskyClientProfileIdent(trimmed);
+    if (bskyIdent) {
+      return { to: "/u/$did", params: { did: normalizeAuthorRef(bskyIdent) } };
     }
 
     return null;

--- a/apps/standard-reader/src/lib/leaflet/bsky.ts
+++ b/apps/standard-reader/src/lib/leaflet/bsky.ts
@@ -36,8 +36,13 @@ export function bskyPostUrl(
   return `https://${host}/profile/${ref.did}/post/${ref.id}`;
 }
 
-/** Local API route used by `bsky-react-post` (returns `{ data: thread }`). */
-export function bskyPostApiUrl(did: string, id: string): string {
-  const params = new URLSearchParams({ did, id });
+/**
+ * Local API route used by `bsky-react-post` (returns `{ data: thread }`).
+ * `ident` is a DID or a handle — a client URL can carry either.
+ */
+export function bskyPostApiUrl(ident: string, id: string): string {
+  const params = new URLSearchParams(
+    ident.startsWith("did:") ? { did: ident, id } : { handle: ident, id },
+  );
   return `/api/bsky/post?${params}`;
 }

--- a/apps/standard-reader/src/lib/leaflet/publication-mentions.test.ts
+++ b/apps/standard-reader/src/lib/leaflet/publication-mentions.test.ts
@@ -337,4 +337,16 @@ describe("actorLinkIdent", () => {
     expect(actorLinkIdent("/u/did:plc:abc123")).toBe("did:plc:abc123");
     expect(actorLinkIdent("/u/alice.bsky.social")).toBe("alice.bsky.social");
   });
+
+  it("treats alternate Bluesky clients the same as bsky.app", () => {
+    expect(
+      actorLinkIdent("https://witchsky.app/profile/did:plc:d4t4psds4x5z"),
+    ).toBe("did:plc:d4t4psds4x5z");
+    expect(actorLinkIdent("https://mu.social/profile/alice.bsky.social")).toBe(
+      "alice.bsky.social",
+    );
+    expect(
+      actorLinkIdent("https://witchsky.app/profile/did:plc:vpk/feed/infreq"),
+    ).toBeNull();
+  });
 });

--- a/apps/standard-reader/src/lib/leaflet/publication-mentions.ts
+++ b/apps/standard-reader/src/lib/leaflet/publication-mentions.ts
@@ -1,3 +1,4 @@
+import { bskyClientProfileIdent } from "#/lib/atproto/bsky-clients";
 import { STANDARD_NSID } from "#/lib/atproto/nsids";
 import { normalizeAuthorRef } from "#/lib/author-profile";
 
@@ -109,56 +110,34 @@ export function mentionUrlKey(url: string): string {
   return `url:${normalizeMentionUrl(url)}`;
 }
 
-const BSKY_PROFILE_HOSTS = new Set(["bsky.app", "staging.bsky.app"]);
-
 /**
  * If a `#link` facet's target is a *user profile*, return the user's ident
  * (handle or DID) so the segment can render as an actor mention (avatar chip +
  * hovercard, linking in-app to `/u/$did`) instead of a bare off-site link.
  * Recognizes an in-app author path (`/u/<handle-or-did>`, relative) and a bare
- * Bluesky profile link (`bsky.app/profile/<handle-or-did>`). Returns null for
- * any other link.
+ * profile link on any Bluesky web client (`bsky.app/profile/<handle-or-did>`
+ * and its forks — see {@link parseBskyClientUrl}). Returns null for any other
+ * link.
+ *
+ * ONLY a bare profile counts as a person reference. A post
+ * (`/profile/<ident>/post/…`), list, or feed is about that object, not a
+ * mention of its owner — those render as embeds instead.
  */
 export function actorLinkIdent(uri: string): string | null {
   const trimmed = uri.trim();
   if (!trimmed) return null;
 
-  let host: string | null = null;
-  let pathname = trimmed;
   if (/^https?:\/\//i.test(trimmed)) {
-    try {
-      const url = new URL(trimmed);
-      host = url.hostname.toLowerCase();
-      pathname = url.pathname;
-    } catch {
-      return null;
-    }
-  } else {
-    // Relative path: drop any query/hash before matching.
-    pathname = trimmed.split(/[?#]/)[0] ?? trimmed;
-  }
-
-  if (host && BSKY_PROFILE_HOSTS.has(host)) {
-    // ONLY a bare profile counts as a person reference. A post
-    // (`/profile/<ident>/post/…`), list, or feed is about that object, not a
-    // mention of its owner — keep it a plain link to the original.
-    const match = /^\/profile\/([^/]+)\/?$/.exec(pathname);
-    if (match?.[1]) {
-      const ident = normalizeAuthorRef(decodeURIComponent(match[1]));
-      // A handle needs a dot; a DID is taken verbatim. Guards against
-      // `/profile/` junk resolving to a bogus mention.
-      if (ident.startsWith("did:") || ident.includes(".")) return ident;
-    }
-    return null;
+    const ident = bskyClientProfileIdent(trimmed);
+    return ident ? normalizeAuthorRef(ident) || null : null;
   }
 
   // Only trust a relative `/u/<ident>` path (single segment) — a full off-site
   // URL that happens to carry a `/u/` segment is not our profile route.
-  if (host === null) {
-    const match = /^\/u\/([^/]+)\/?$/.exec(pathname);
-    if (match?.[1])
-      return normalizeAuthorRef(decodeURIComponent(match[1])) || null;
-  }
+  const pathname = trimmed.split(/[?#]/)[0] ?? trimmed;
+  const match = /^\/u\/([^/]+)\/?$/.exec(pathname);
+  if (match?.[1])
+    return normalizeAuthorRef(decodeURIComponent(match[1])) || null;
   return null;
 }
 

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -2665,6 +2665,10 @@ msgstr "إعادة ترتيب {itemTitle}"
 msgid "Back to feedback"
 msgstr "العودة إلى الملاحظات"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "View on {name}"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "{pubTotal, plural, one {# publication} other {# publications}}"
 msgstr "{pubTotal, plural, zero {لا منشورات} one {منشورة واحدة} two {منشورتان} few {# منشورات} many {# منشورة} other {# منشورة}}"

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -99,6 +99,10 @@ msgstr "عرض المحتوى في Standard Reader"
 msgid "Articles gaining attention across the network right now."
 msgstr "مقالات تحظى بالاهتمام عبر الشبكة الآن."
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# member} other {# members}}"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Add an article"
 msgstr "إضافة مقال"
@@ -410,9 +414,9 @@ msgstr ""
 msgid "{years}y ago"
 msgstr ""
 
-#: src/components/reader/reorder-lists-modal.tsx
-#~ msgid "List"
-#~ msgstr "قائمة"
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "List"
+msgstr "قائمة"
 
 #: src/components/appearance-settings.tsx
 msgid "The spacing between things — tighter for more on screen, looser for more room to read."
@@ -1971,6 +1975,7 @@ msgstr "اللغة المستخدمة في واجهة القارئ. تُعرض �
 #~ msgid "Following, saving, recommending, and — once you follow more than a handful of publications — keeping the whole thing tidy."
 #~ msgstr ""
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 #: src/components/user-settings-view.tsx
 msgid "Feed"
 msgstr ""
@@ -3253,6 +3258,10 @@ msgstr ""
 msgid "e.g. Dispatches from the Atmosphere"
 msgstr "مثال: رسائل من Atmosphere"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# join} other {# joins}}"
+msgstr ""
+
 #: src/components/docs/introduction-docs-page.tsx
 msgid "the AT Protocol schemas that define Standard records and the shared definitions they build on."
 msgstr ""
@@ -3560,6 +3569,10 @@ msgstr "وضع المعاينة"
 #: src/components/NavbarAuth.tsx
 #: src/components/site-legal-links.tsx
 msgid "Guide"
+msgstr ""
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# like} other {# likes}}"
 msgstr ""
 
 #: src/routes/_layout.collections.new.tsx
@@ -4042,6 +4055,10 @@ msgstr ""
 msgid "{0}+ articles"
 msgstr "أكثر من {0} مقال"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "Starter pack"
+msgstr ""
+
 #: src/routes/_layout.feedback.return.tsx
 msgid "That link expired."
 msgstr "انتهت صلاحية ذلك الرابط."
@@ -4335,6 +4352,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "Cited in"
 msgstr "مذكور في"
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# follower} other {# followers}}"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "A couple of publications worth discovering."
@@ -5953,6 +5974,10 @@ msgstr "انقر على «تشغيل المثال» لجلب استجابة حي
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "At the bottom of settings, <0>Personal data</0> deletes categories of records outright: your reading history, your saved articles, or the publication lists you made. Each asks for confirmation and explains what will change."
+msgstr ""
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "Profile"
 msgstr ""
 
 #: src/components/reader/friend-publishers.tsx

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -123,12 +123,12 @@ msgid "Every renderer takes one input for the document — the content payload o
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "One tap from the reading view, on any device, instantly in sync. Your library is always where you left it."
-msgstr "نقرة واحدة من وضع القراءة، على أي جهاز، ومزامنة فورية. مكتبتك دائمًا حيث تركتها."
+#~ msgid "One tap from the reading view, on any device, instantly in sync. Your library is always where you left it."
+#~ msgstr "نقرة واحدة من وضع القراءة، على أي جهاز، ومزامنة فورية. مكتبتك دائمًا حيث تركتها."
 
 #: src/components/reader/about-view.tsx
-msgid "Curated lists & collections"
-msgstr "قوائم ومجموعات منسّقة"
+#~ msgid "Curated lists & collections"
+#~ msgstr "قوائم ومجموعات منسّقة"
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Vue 3."
@@ -179,6 +179,7 @@ msgstr ""
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
 #: src/components/docs/lexicon-docs-intro.tsx
+#: src/components/reader/about-view.tsx
 msgid "Lexicons"
 msgstr "Lexicons"
 
@@ -256,6 +257,10 @@ msgstr "يرجى إضافة عنوان."
 #~ msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Follow it and it starts appearing in your feeds like any other."
 #~ msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -302,8 +307,8 @@ msgid "(this is what Standard Reader itself uses)"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
-msgstr "ولا يبدو الأمر منغلقًا أبدًا. نربط كل مقال بالنقاش الدائر عبر Atmosphere — الشبكة المفتوحة خارج هذا التطبيق — فنجمع منشورات Bluesky وردودها حول المقال، والملاحظات المتروكة في هوامشه، وسائر ما يستشهد به، بهدوء أسفل ما تقرأه."
+#~ msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+#~ msgstr "ولا يبدو الأمر منغلقًا أبدًا. نربط كل مقال بالنقاش الدائر عبر Atmosphere — الشبكة المفتوحة خارج هذا التطبيق — فنجمع منشورات Bluesky وردودها حول المقال، والملاحظات المتروكة في هوامشه، وسائر ما يستشهد به، بهدوء أسفل ما تقرأه."
 
 #: src/components/guide/guide-shell.tsx
 msgid "Still stuck, or something here doesn't match what you see? <0>Tell us on the feedback board</0> — questions are welcome there, not just bug reports."
@@ -316,6 +321,10 @@ msgstr "جارٍ التشغيل…"
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Your Home feed is built from subscriptions. Three is a good start."
 msgstr "تُبنى تغذية الرئيسية من اشتراكاتك. ثلاثة اشتراكات بداية جيدة."
+
+#: src/components/reader/about-view.tsx
+msgid "A note in the margin"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Colors"
@@ -389,6 +398,10 @@ msgstr "جارٍ الاشتراك…"
 msgid "People"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Every piece is a door to the next one"
+msgstr ""
+
 #: src/routes/_layout.friends.tsx
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 msgstr ""
@@ -417,6 +430,7 @@ msgstr ""
 msgid "Switch to light paper"
 msgstr "التبديل إلى الورق الفاتح"
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Bluesky"
 msgstr "على Bluesky"
@@ -426,8 +440,8 @@ msgid "Set these now, or change them any time in Settings."
 msgstr "اضبطها الآن، أو غيّرها في أي وقت من الإعدادات."
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
-msgstr "يتوقف معظم القرّاء عند ما اشتركوا فيه بالفعل. أما Standard Reader فيعتبر العثور على مفضّلتك التالية جزءًا من مهمته. تصفّح كل المنشورات على الشبكة — لا تلك القليلة التي سمعت بها فقط."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
+#~ msgstr "يتوقف معظم القرّاء عند ما اشتركوا فيه بالفعل. أما Standard Reader فيعتبر العثور على مفضّلتك التالية جزءًا من مهمته. تصفّح كل المنشورات على الشبكة — لا تلك القليلة التي سمعت بها فقط."
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Open <0>Collections</0> in the sidebar and start a new one."
@@ -682,8 +696,8 @@ msgid "Making a collection"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Read the guide"
-msgstr ""
+#~ msgid "Read the guide"
+#~ msgstr ""
 
 #: src/components/reader/app-shell.tsx
 #: src/components/site-legal-links.tsx
@@ -811,6 +825,10 @@ msgstr "خصوصية الإضافة"
 msgid "Signing in"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Public API — no key required"
+msgstr ""
+
 #: src/components/reading-settings-preview.tsx
 msgid "Loading voice sample"
 msgstr "جارٍ تحميل عينة الصوت"
@@ -874,6 +892,11 @@ msgstr "إعادة المحاولة"
 
 #: src/lib/guide/navigation.ts
 msgid "Welcome"
+msgstr ""
+
+#. placeholder {0}: SUPPORTED_CONTENT_FORMATS.size
+#: src/components/reader/about-view.tsx
+msgid "An article is a record in its author’s own repository, and every publishing tool on the network writes that record a little differently. Standard Reader reads {0} of those content formats and renders them all into the same calm page — so a reader never has to care which tool a writer chose."
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -1003,6 +1026,10 @@ msgstr ""
 msgid "Bookmarks"
 msgstr "المحفوظات"
 
+#: src/components/reader/about-view.tsx
+msgid "None of this is ours. We gather it from the Atmosphere — the open network these apps all share — and show it under the piece it’s about. Every line links back to where it was actually written, no account or comment box required, and it works whether or not the author ever opted in."
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Saved to {savedName} on {appLabel}."
 msgstr "حُفِظ في {savedName} على {appLabel}."
@@ -1057,6 +1084,10 @@ msgstr "غرفة قراءة هادئة للويب المفتوح. لنأخذ د�
 #: src/routes/_layout.collections.index.tsx
 msgid "New series"
 msgstr "سلسلة جديدة"
+
+#: src/components/reader/about-view.tsx
+msgid "Blogs never really solved the conversation. Comment boxes belonged to the blog, went unread, filled with spam, and vanished when the site did. So the talking moved somewhere else — and stopped being attached to the writing at all."
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "These deletions remove the records from your account itself, not just from our copy — which is why they cannot be undone. Deleting your reading history, for example, makes everything look unread again everywhere."
@@ -1130,6 +1161,10 @@ msgstr ""
 msgid "Under that, <0>Cited in</0> lists other articles that link to this one, and <1>Related reading</1> suggests pieces from across the network on the same subjects — usually from publications you have not met yet."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Essays and serialized writing"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 #~ msgid "Following your first publications"
@@ -1182,8 +1217,8 @@ msgid "Custom"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Read the API docs"
-msgstr "اقرأ وثائق API"
+#~ msgid "Read the API docs"
+#~ msgstr "اقرأ وثائق API"
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Select <0>Listen</0> in the top bar and the article is read aloud. The first time takes a few seconds to warm up; after that it starts straight away."
@@ -1198,8 +1233,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Shareable everywhere"
-msgstr "قابل للمشاركة في كل مكان"
+#~ msgid "Shareable everywhere"
+#~ msgstr "قابل للمشاركة في كل مكان"
 
 #: src/magazine/Magazine.tsx
 msgid "Close table of contents"
@@ -1232,6 +1267,10 @@ msgstr ""
 
 #: src/components/docs/introduction-docs-page.tsx
 msgid "how to make a site discoverable on Standard and have its content read inline, without adopting a platform."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across every publication on the network, not just the handful you’ve heard of."
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -1303,6 +1342,10 @@ msgstr ""
 msgid "To move several at once, open <0>Subscriptions</0>, select the rows you want, and add them all to a list in one action. That is much faster than doing it publication by publication."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Blocks, pages, and footnotes"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Appearance"
 msgstr "المظهر"
@@ -1354,6 +1397,10 @@ msgstr "الحساب"
 msgid "Collapse all lists"
 msgstr "طيّ كل القوائم"
 
+#: src/components/reader/about-view.tsx
+msgid "Four essays covering the same ground, from publications you don’t follow yet."
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "We couldn’t find that article."
 msgstr "تعذّر العثور على ذلك المقال."
@@ -1388,6 +1435,10 @@ msgstr "مجموعتك"
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“…made to be read, and not to be measured.”"
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -1505,6 +1556,10 @@ msgstr "بحث سريع في النص الكامل"
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "اسم المجموعة"
+
+#: src/components/reader/about-view.tsx
+msgid "+{UNNAMED_FORMAT_COUNT} more"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1698,8 +1753,8 @@ msgid "What every control on an article does — including having it read aloud 
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "The reading experience"
-msgstr "تجربة القراءة"
+#~ msgid "The reading experience"
+#~ msgstr "تجربة القراءة"
 
 #: src/routes/_layout.tsx
 msgid "Loading page"
@@ -1736,6 +1791,10 @@ msgstr ""
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "Collections live under <0>Collections</0> in the sidebar. Because publishing one writes a new kind of record to your account, the first time you make one you will be asked to grant an extra permission — that is the <1>Upgrade permissions</1> prompt, and it only appears once."
 #~ msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Also read natively:"
+msgstr ""
 
 #. placeholder {0}: pub.name
 #: src/components/reader/article-below-fold.tsx
@@ -1777,8 +1836,8 @@ msgstr "أنت مشترك في كل منشورة على هذه الصفحة — 
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
-msgstr "تحت كل مقال ترى النقاش من عموم الشبكة المفتوحة — منشورات Bluesky وردودها، وملاحظات الهوامش، وروابط من مقالات أخرى تستشهد به، وقراءات ذات صلة. كلها للقراءة فقط، وكلها تعود بالرابط إلى المصدر."
+#~ msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+#~ msgstr "تحت كل مقال ترى النقاش من عموم الشبكة المفتوحة — منشورات Bluesky وردودها، وملاحظات الهوامش، وروابط من مقالات أخرى تستشهد به، وقراءات ذات صلة. كلها للقراءة فقط، وكلها تعود بالرابط إلى المصدر."
 
 #: src/routes/_layout.latest.tsx
 msgid "Show all subscriptions"
@@ -1831,8 +1890,8 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, zero {لا مطابقات} one {مطابقة واحدة} two {مطابقتان} few {# مطابقات} many {# مطابقة} other {# مطابقة}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
-msgstr "تحصل المنشورات والقوائم والمجموعات على رابط أنيق مع بطاقة معاينة غنية — إضافةً إلى زر اشتراك يمكن للمنشورة وضعه على موقعها."
+#~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
+#~ msgstr "تحصل المنشورات والقوائم والمجموعات على رابط أنيق مع بطاقة معاينة غنية — إضافةً إلى زر اشتراك يمكن للمنشورة وضعه على موقعها."
 
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Search topics"
@@ -1857,6 +1916,10 @@ msgstr "المقالات في المجموعة"
 #: src/components/user-settings-view.tsx
 msgid "System"
 msgstr "النظام"
+
+#: src/components/reader/about-view.tsx
+msgid "Every feed, directory, and search query the app itself runs."
+msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Could not save to {appLabel}"
@@ -1964,8 +2027,8 @@ msgid "Never used"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Building something on the same index? There’s a public API."
-msgstr "أتبني شيئًا على الفهرس نفسه؟ هناك API عامة."
+#~ msgid "Building something on the same index? There’s a public API."
+#~ msgstr "أتبني شيئًا على الفهرس نفسه؟ هناك API عامة."
 
 #: src/components/reader/comments/comments-section.tsx
 msgid "Discussion"
@@ -2196,6 +2259,10 @@ msgstr "المكان الذي تُنشر فيه هذه المجموعة — يت
 msgid "No apps connected"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Nothing about it is fixed. Set the measure, the type size, and the typeface to whatever your eyes want, in light or dark, and the setting follows you to every article you open after it."
+msgstr ""
+
 #: src/components/reader/markdown-field.tsx
 msgid "Edit"
 msgstr "تحرير"
@@ -2215,6 +2282,10 @@ msgstr "استعلامات وإجراءات XRPC العامة لنموذج ال�
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Save theme"
 msgstr "حفظ السمة"
+
+#: src/components/reader/about-view.tsx
+msgid "A reply"
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "your day: one featured article, then what is new from the publications you subscribe to."
@@ -2397,6 +2468,10 @@ msgstr ""
 #~ msgid "Carry on browsing. The overlay appears where it is useful and stays out of the way where it is not."
 #~ msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "And if your reader of choice is one you already have, any slice of the network comes with its own feed — pipe it straight in and never open this app at all."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "To email your digest, Standard Reader needs your account email address. We'll ask your PDS to share it — you'll be sent to your login to approve the request, then brought right back here. Your email is used only to send the weekly digest, and you can turn it off any time."
 msgstr "لإرسال ملخصك بالبريد، يحتاج Standard Reader إلى عنوان بريد حسابك. سنطلب من PDS مشاركته — ستُنقل إلى صفحة تسجيل الدخول للموافقة على الطلب، ثم تعود إلى هنا مباشرة. يُستخدم بريدك فقط لإرسال الملخص الأسبوعي، ويمكنك إيقافه في أي وقت."
@@ -2406,7 +2481,6 @@ msgid "Where your reading is kept, who else can see it, what you agreed to when 
 msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
-#: src/components/reader/about-view.tsx
 #: src/lib/guide/navigation.ts
 msgid "Discovery"
 msgstr "الاكتشاف"
@@ -2533,6 +2607,10 @@ msgstr "في الاحتفاظ بدفتر اقتباسات"
 msgid "Most reading apps keep your list of follows on their own servers. If the app shuts down, your list goes with it."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Keep the good sentence"
+msgstr ""
+
 #: src/routes/_layout.u.$did.tsx
 msgid "Featured in"
 msgstr "ظهر في"
@@ -2624,8 +2702,8 @@ msgid "Paper"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
-msgstr "بدّل إعدادًا واحدًا لتُفتح روابط المقالات على موقع المنشورة نفسها. اقرأ حيثما يناسبك."
+#~ msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
+#~ msgstr "بدّل إعدادًا واحدًا لتُفتح روابط المقالات على موقع المنشورة نفسها. اقرأ حيثما يناسبك."
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Discover is the directory of every publication the network knows about — not a curated shelf. It runs top to bottom from most personal to most complete:"
@@ -2690,8 +2768,12 @@ msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, zero {متابع} one {متابع} two {متابعان} few {متابعين} many {متابعًا} other {متابع}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
-msgstr "يكتفي معظم القرّاء بما اشتركوا فيه بالفعل. أما Standard Reader فيعتبر العثور على مفضّلتك التالية جزءًا من مهمته. تصفّح كل المنشورات على الشبكة وعددها {countLabel} — لا الحفنة التي سمعت بها فقط."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgstr "يكتفي معظم القرّاء بما اشتركوا فيه بالفعل. أما Standard Reader فيعتبر العثور على مفضّلتك التالية جزءًا من مهمته. تصفّح كل المنشورات على الشبكة وعددها {countLabel} — لا الحفنة التي سمعت بها فقط."
+
+#: src/components/reader/about-view.tsx
+msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself, and every save, like, and subscribe is instantly in sync with whatever device you read on next."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labels"
@@ -2767,6 +2849,10 @@ msgstr ""
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Upgrade to author Collections"
 msgstr "ترقية لتأليف المجموعات"
+
+#: src/components/reader/about-view.tsx
+msgid "Render a document in your own app —"
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "Your social actions (follows, likes, saves, lists) are written to your AT Protocol repository and are visible according to the network's rules and your account settings. Our Postgres database holds a network read-model, app session state, and cached public metadata — not the canonical copies of publications."
@@ -2872,12 +2958,20 @@ msgstr "آخر تحديث في 13 يونيو 2026"
 msgid "{shown, plural, one {# match} other {# matches}}"
 msgstr "{shown, plural, zero {لا توجد نتائج} one {نتيجة واحدة} two {نتيجتان} few {# نتائج} many {# نتيجة} other {# نتيجة}}"
 
+#: src/components/reader/about-view.tsx
+msgid "Select a passage and share it as a typeset card that links back to the article — or keep reading and pick up exactly where you left off next time."
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "People you follow write here"
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Good writing rarely turns up while you are already in a reading app. The extension puts saving and subscribing on every page you visit."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Drop a Standard document into your own app, in your own framework."
 msgstr ""
 
 #: src/magazine/flow.tsx
@@ -3051,6 +3145,10 @@ msgstr ""
 #: src/components/docs/docs-publishing-nav.tsx
 #~ msgid "Publishing guide"
 #~ msgstr "دليل النشر"
+
+#: src/components/reader/about-view.tsx
+msgid "Prefer the original? Flip one setting and article links open on the publication’s own site instead — Standard Reader will still keep your place."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "<0>Share</0> copies a link, or posts the article to Bluesky with a proper preview card. On a phone it can hand off to whatever you normally share with."
@@ -3425,6 +3523,10 @@ msgstr "حدث خطأ ما."
 msgid "The best of what you subscribe to"
 msgstr "أفضل ما في اشتراكاتك"
 
+#: src/components/reader/about-view.tsx
+msgid "Under this article"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Note"
 msgstr "ملاحظة"
@@ -3526,6 +3628,7 @@ msgstr "جارٍ إنشاء الصوت… {percent}٪"
 
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
+#: src/components/reader/about-view.tsx
 msgid "Renderers"
 msgstr ""
 
@@ -3565,8 +3668,8 @@ msgid "What Standard Reader is"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Prefer the original?"
-msgstr "تفضّل النسخة الأصلية؟"
+#~ msgid "Prefer the original?"
+#~ msgstr "تفضّل النسخة الأصلية؟"
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Could not add to list"
@@ -3787,6 +3890,10 @@ msgstr "اخترنا هذه اللغة بناءً على متصفحك. يمكن�
 
 #: src/routes/mcp/authorize.tsx
 msgid "Nothing has been shared. Head back to the app you came from and try connecting again."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“This is the whole argument in one clause. Worth sitting with.”"
 msgstr ""
 
 #: src/components/reader/text-selection-toolbar.tsx
@@ -4013,8 +4120,8 @@ msgid "Save and subscribe from anywhere on the web, without breaking your stride
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Integrations"
-msgstr "التكاملات"
+#~ msgid "Integrations"
+#~ msgstr "التكاملات"
 
 #. placeholder {0}: person.subscriberCount
 #. placeholder {0}: pub.subscriberCount
@@ -4137,6 +4244,10 @@ msgstr ""
 msgid "This request can't be completed here, so we're returning you to the app that sent you."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Read the docs"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No people in this list — add some from the edit dialog."
 msgstr "لا أشخاص في هذه القائمة — أضف بعضهم من نافذة التحرير."
@@ -4167,8 +4278,8 @@ msgid "Browse publications"
 msgstr "تصفّح المنشورات"
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
-msgstr "لا يحبس Standard Reader قراءتك داخل تطبيق واحد. كل جزء من الشبكة يأتي بتغذية RSS خاصة به — وجّهها مباشرة إلى أي قارئ تستخدمه بالفعل."
+#~ msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
+#~ msgstr "لا يحبس Standard Reader قراءتك داخل تطبيق واحد. كل جزء من الشبكة يأتي بتغذية RSS خاصة به — وجّهها مباشرة إلى أي قارئ تستخدمه بالفعل."
 
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Choose images"
@@ -4236,6 +4347,10 @@ msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That image is too detailed to fit under 1 MB. Try cropping it first."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“Been thinking about this all week. The measurement is the part that ruins it — not the writing.”"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -4310,13 +4425,17 @@ msgstr "تعذّر تحميل الملاحظات <0>({0})</0>. أعد المحا
 msgid "No publications match this tag yet."
 msgstr "لا منشورات تطابق هذا الوسم بعد."
 
+#: src/components/reader/about-view.tsx
+msgid "Written wherever they write"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "If you already know what you are looking for, the <0>Add publication</0> button opens a single field that does three things at once. Leave it empty and it shows what is trending. Type a few words and it searches the directory. Paste a handle or a domain — <1>@stdout.dev</1>, <2>stdout.dev</2> — and it looks that author up directly."
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "The conversation, gathered"
-msgstr "الحوار، مجموعًا في مكان واحد"
+#~ msgid "The conversation, gathered"
+#~ msgstr "الحوار، مجموعًا في مكان واحد"
 
 #: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
@@ -4344,8 +4463,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Save, like, subscribe — everywhere"
-msgstr "احفظ وأعجب واشترك — في كل مكان"
+#~ msgid "Save, like, subscribe — everywhere"
+#~ msgstr "احفظ وأعجب واشترك — في كل مكان"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe?"
@@ -4402,6 +4521,7 @@ msgstr ""
 
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
+#: src/components/reader/about-view.tsx
 msgid "API"
 msgstr "API"
 
@@ -4415,6 +4535,10 @@ msgstr "استبدال الأيقونة"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unfollow"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Standard Reader doesn’t ask you to move in. It goes out to the web you already use, and hands your reading back in whatever shape suits you."
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx
@@ -4473,6 +4597,10 @@ msgstr "المصادقة"
 
 #: src/components/reader/terms-view.tsx
 msgid "Changes to these terms"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Short-form posts and long reads"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -4541,6 +4669,10 @@ msgstr ""
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "إذا ثبّت إضافة المتصفح من {SITE_NAME}، فإنها تستخدم الحساب وملف تعريف الارتباط نفسه المستخدم في هذا الموقع. ترسل الإضافة عناوين URL للصفحات إلى نقاط النهاية <0>/api/extension/*</0> لمطابقة الفهرس، وتحفظ إعدادات الطبقة العلوية في مساحة تخزين الإضافات بمتصفحك. راجع <1>سياسة خصوصية الإضافة</1> للتفاصيل الخاصة بالإضافة وحدها."
+
+#: src/components/reader/about-view.tsx
+msgid "And when a run of them turns out to be good together, collect them into a named list — a playlist for reading. Anyone can add the whole thing to their own reader in a single tap."
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "Remove {memberName} from list"
@@ -4698,8 +4830,8 @@ msgid "Saves a link to your <0>{appLabel}</0> collection."
 msgstr "يحفظ رابطًا في مجموعتك على <0>{appLabel}</0>."
 
 #: src/components/reader/about-view.tsx
-msgid "In your inbox"
-msgstr "في بريدك الوارد"
+#~ msgid "In your inbox"
+#~ msgstr "في بريدك الوارد"
 
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Drag to change the order your subscriptions appear in the sidebar."
@@ -4713,6 +4845,7 @@ msgstr "المظهر وتفضيلات القراءة والبيانات الشخ
 msgid "Authority for <0>app.standard-reader</0> resolves via DNS <1>_lexicon.*</1> TXT records to the publishing account."
 msgstr "تُحَل صلاحية <0>app.standard-reader</0> عبر سجلات DNS TXT من نوع <1>_lexicon.*</1> إلى حساب النشر."
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Margin"
 msgstr "على Margin"
@@ -4749,6 +4882,10 @@ msgstr "تعذّر حل هذا المُعرِّف."
 msgid "Good to know"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across all {countLabel} publications on the network, not just the handful you’ve heard of."
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Sharing a review on the <0>ATStore</0> will help both us and other users see what you think about Standard Reader."
 msgstr "مشاركة مراجعة على <0>ATStore</0> تساعدنا وتساعد بقية المستخدمين على معرفة رأيك في Standard Reader."
@@ -4756,6 +4893,10 @@ msgstr "مشاركة مراجعة على <0>ATStore</0> تساعدنا وتسا�
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "On Bluesky, quiet badges mark the people whose writing you can read here."
 #~ msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Publish labels others can subscribe to, or consume the ones we do."
+msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "The full account is on the <0>extension privacy page</0>."
@@ -4888,13 +5029,17 @@ msgstr "لا شيء للقراءة هنا بعد."
 msgid "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
 msgstr "جهات التصنيف هي خدمات إشراف تشترك فيها عبر DID. اشترك لترى تصنيفاتها — ولتشويش المنشورات المصنّفة أو إخفائها — أثناء القراءة."
 
+#: src/components/reader/about-view.tsx
+msgid "The part blogging always missed"
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "The older link rels"
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader meets you where you read"
-msgstr "‏Standard Reader يلتقيك حيث تقرأ"
+#~ msgid "Standard Reader meets you where you read"
+#~ msgstr "‏Standard Reader يلتقيك حيث تقرأ"
 
 #: src/components/appearance-settings.tsx
 msgid "Reset appearance"
@@ -5088,6 +5233,10 @@ msgstr ""
 #: src/routes/_layout.latest.tsx
 msgid "All caught up"
 msgstr "لا جديد"
+
+#: src/components/reader/about-view.tsx
+msgid "Everything here is linkable, too. Publications, lists, and collections each get a clean URL with a rich preview card — plus a subscribe button a publication can drop straight onto its own site."
+msgstr ""
 
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Reorder subscriptions"
@@ -5284,6 +5433,7 @@ msgstr "ابحث في الشبكة"
 msgid "Search Google Fonts"
 msgstr "ابحث في Google Fonts"
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/article-below-fold.tsx
 msgid "Related reading"
 msgstr "قراءات ذات صلة"
@@ -5522,8 +5672,8 @@ msgid "If something is confusing, broken, or missing, the <0>feedback board</0> 
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
-msgstr "امتداد متصفح خفيف يتيح لك حفظ المنشورات والاشتراك فيها أثناء تصفّحك للويب — بشارات خفيفة على bsky.app وطبقة بنقرة واحدة على أي صفحة تزورها. قائمة قراءتك تملأ نفسها."
+#~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+#~ msgstr "امتداد متصفح خفيف يتيح لك حفظ المنشورات والاشتراك فيها أثناء تصفّحك للويب — بشارات خفيفة على bsky.app وطبقة بنقرة واحدة على أي صفحة تزورها. قائمة قراءتك تملأ نفسها."
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -5763,8 +5913,8 @@ msgid "Open any article while signed in and it'll show up here. Your history liv
 msgstr "افتح أي مقالة وأنت مسجّل الدخول وستظهر هنا. سجلّك محفوظ في مستودعك على شكل سجلات <0>app.standard-reader.read</0>."
 
 #: src/components/reader/about-view.tsx
-msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
-msgstr "أنشئ قوائم منشورات مسمّاة وقابلة للمشاركة — قائمة تشغيل للقراءة. يمكن لأي شخص إضافة قائمتك إلى قارئه بنقرة واحدة."
+#~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
+#~ msgstr "أنشئ قوائم منشورات مسمّاة وقابلة للمشاركة — قائمة تشغيل للقراءة. يمكن لأي شخص إضافة قائمتك إلى قارئه بنقرة واحدة."
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
@@ -5852,6 +6002,7 @@ msgstr ""
 #: src/components/docs/introduction-docs-page.tsx
 #: src/components/docs/labelers-docs-page.tsx
 #: src/components/labelers-settings-view.tsx
+#: src/components/reader/about-view.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/user-settings-view.tsx
 msgid "Labelers"
@@ -5862,8 +6013,8 @@ msgid "Choose your language"
 msgstr "اختر لغتك"
 
 #: src/components/reader/about-view.tsx
-msgid "Find the ones you didn't know you wanted"
-msgstr "اكتشف ما لم تكن تعرف أنك تريده"
+#~ msgid "Find the ones you didn't know you wanted"
+#~ msgstr "اكتشف ما لم تكن تعرف أنك تريده"
 
 #: src/components/labeler-detail-view.tsx
 msgid "Hide"
@@ -5949,8 +6100,8 @@ msgid "Supported content formats"
 msgstr "صيغ المحتوى المدعومة"
 
 #: src/components/reader/about-view.tsx
-msgid "Plays nice with the open web"
-msgstr "منسجم مع الويب المفتوح"
+#~ msgid "Plays nice with the open web"
+#~ msgstr "منسجم مع الويب المفتوح"
 
 #: src/components/reader/privacy-view.tsx
 msgid "What we collect"
@@ -5975,6 +6126,10 @@ msgstr "هل يعجبك Standard Reader؟"
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Use original link"
 msgstr "استخدام الرابط الأصلي"
+
+#: src/components/reader/about-view.tsx
+msgid "Everything this app runs on is public. The schemas are open, the read-model is queryable, and the renderer that draws these pages is published for you to use — so a reading app, a search tool, or a better client than this one is a weekend, not a platform deal."
+msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "Every publication page also serves a themed, embeddable subscribe widget — an iframe you can drop on your own site so visitors can subscribe without leaving your page. The easiest way to get it: open your publication's page on Standard Reader, use <0>Share → Embed subscribe</0>, pick landscape or portrait, and copy the snippet — no account or ownership check required to generate it."
@@ -6117,6 +6272,10 @@ msgstr "لا نقاش بعد."
 msgid "A single publication"
 msgstr "منشورة واحدة"
 
+#: src/components/reader/about-view.tsx
+msgid "Build on the same index"
+msgstr ""
+
 #: src/routes/extension.connected.tsx
 msgid "Return to the Standard Reader extension — this tab will close automatically."
 msgstr "عُد إلى إضافة Standard Reader — ستُغلق هذه العلامة تلقائيًا."
@@ -6224,6 +6383,10 @@ msgstr ""
 #: src/components/reader/publication-latest-note.tsx
 msgid "Latest note"
 msgstr "أحدث ملاحظة"
+
+#: src/components/reader/about-view.tsx
+msgid "The record schemas a publication, document, or follow is made of."
+msgstr ""
 
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6377,6 +6540,10 @@ msgstr "أفقي"
 msgid "Edit collection"
 msgstr "تحرير المجموعة"
 
+#: src/components/reader/about-view.tsx
+msgid "That is a real response from the endpoint this page just called — no key, no sign-up, no rate-limit form. The same is true of every feed, directory, and search query the reader itself runs."
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "After that, following is one button. Anywhere you see a publication — a card in a feed, the top of an article, a publication's own page — there is a <0>Follow</0> button next to its name. Select it again to stop following. Nothing else changes: the button just decides whether new writing from that publication reaches your Home and Latest."
 #~ msgstr ""
@@ -6425,8 +6592,12 @@ msgid "Opening the issue…"
 msgstr "جارٍ فتح العدد…"
 
 #: src/components/reader/about-view.tsx
-msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
-msgstr "لا يطلب منك أن تترك بقية الويب خلفك. بل يمد يده إليها — ويبقى مواطنًا صالحًا في الشبكة الأوسع."
+msgid "However you like to read it"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+#~ msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+#~ msgstr "لا يطلب منك أن تترك بقية الويب خلفك. بل يمد يده إليها — ويبقى مواطنًا صالحًا في الشبكة الأوسع."
 
 #: src/routes/_layout.collections.edit.$rkey.tsx
 msgid "We couldn’t load that collection to edit."
@@ -6488,6 +6659,10 @@ msgstr "يفهرس Standard Reader سجلات <0>site.standard.document</0> و<1
 #: src/components/reader/list-edit-modal.tsx
 msgid "e.g. Tech, Friends, Cooking"
 msgstr "مثل: تقنية، أصدقاء، طبخ"
+
+#: src/components/reader/about-view.tsx
+msgid "Semble"
+msgstr ""
 
 #. placeholder {0}: fmt.relativeTime(connection.lastUsedAt)
 #: src/components/user-settings-view.tsx
@@ -6631,6 +6806,10 @@ msgstr "مفعّل"
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Two other pieces link to this one — you can read them from here."
 msgstr ""
 
 #: src/components/reader/page-reader-bar.tsx
@@ -6790,6 +6969,10 @@ msgstr ""
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Finding your way around"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Cited by"
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -99,6 +99,10 @@ msgstr "Inhalte in Standard Reader darstellen"
 msgid "Articles gaining attention across the network right now."
 msgstr "Artikel, die gerade im Netzwerk Aufmerksamkeit gewinnen."
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# member} other {# members}}"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Add an article"
 msgstr "Artikel hinzufügen"
@@ -410,9 +414,9 @@ msgstr ""
 msgid "{years}y ago"
 msgstr ""
 
-#: src/components/reader/reorder-lists-modal.tsx
-#~ msgid "List"
-#~ msgstr "Liste"
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "List"
+msgstr "Liste"
 
 #: src/components/appearance-settings.tsx
 msgid "The spacing between things — tighter for more on screen, looser for more room to read."
@@ -1971,6 +1975,7 @@ msgstr "Die Sprache der Leseroberfläche. Artikel werden in der Sprache angezeig
 #~ msgid "Following, saving, recommending, and — once you follow more than a handful of publications — keeping the whole thing tidy."
 #~ msgstr ""
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 #: src/components/user-settings-view.tsx
 msgid "Feed"
 msgstr ""
@@ -3253,6 +3258,10 @@ msgstr ""
 msgid "e.g. Dispatches from the Atmosphere"
 msgstr "z. B. Dispatches from the Atmosphere"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# join} other {# joins}}"
+msgstr ""
+
 #: src/components/docs/introduction-docs-page.tsx
 msgid "the AT Protocol schemas that define Standard records and the shared definitions they build on."
 msgstr ""
@@ -3560,6 +3569,10 @@ msgstr "Vorschaumodus"
 #: src/components/NavbarAuth.tsx
 #: src/components/site-legal-links.tsx
 msgid "Guide"
+msgstr ""
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# like} other {# likes}}"
 msgstr ""
 
 #: src/routes/_layout.collections.new.tsx
@@ -4042,6 +4055,10 @@ msgstr ""
 msgid "{0}+ articles"
 msgstr "{0}+ Artikel"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "Starter pack"
+msgstr ""
+
 #: src/routes/_layout.feedback.return.tsx
 msgid "That link expired."
 msgstr "Dieser Link ist abgelaufen."
@@ -4335,6 +4352,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "Cited in"
 msgstr "Zitiert in"
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# follower} other {# followers}}"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "A couple of publications worth discovering."
@@ -5953,6 +5974,10 @@ msgstr "Klicken Sie auf „Beispiel ausführen“, um mit Ihrer Sitzung eine Liv
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "At the bottom of settings, <0>Personal data</0> deletes categories of records outright: your reading history, your saved articles, or the publication lists you made. Each asks for confirmation and explains what will change."
+msgstr ""
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "Profile"
 msgstr ""
 
 #: src/components/reader/friend-publishers.tsx

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -123,12 +123,12 @@ msgid "Every renderer takes one input for the document — the content payload o
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "One tap from the reading view, on any device, instantly in sync. Your library is always where you left it."
-msgstr "Ein Tippen aus der Leseansicht, auf jedem Gerät, sofort synchron. Ihre Bibliothek ist immer dort, wo Sie aufgehört haben."
+#~ msgid "One tap from the reading view, on any device, instantly in sync. Your library is always where you left it."
+#~ msgstr "Ein Tippen aus der Leseansicht, auf jedem Gerät, sofort synchron. Ihre Bibliothek ist immer dort, wo Sie aufgehört haben."
 
 #: src/components/reader/about-view.tsx
-msgid "Curated lists & collections"
-msgstr "Kuratierte Listen & Sammlungen"
+#~ msgid "Curated lists & collections"
+#~ msgstr "Kuratierte Listen & Sammlungen"
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Vue 3."
@@ -179,6 +179,7 @@ msgstr ""
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
 #: src/components/docs/lexicon-docs-intro.tsx
+#: src/components/reader/about-view.tsx
 msgid "Lexicons"
 msgstr "Lexicons"
 
@@ -256,6 +257,10 @@ msgstr "Bitte fügen Sie einen Titel hinzu."
 #~ msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Follow it and it starts appearing in your feeds like any other."
 #~ msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -302,8 +307,8 @@ msgid "(this is what Standard Reader itself uses)"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
-msgstr "Und es wirkt nie abgeschottet. Wir verbinden jeden Artikel mit dem Gespräch in der Atmosphere – dem offenen Netzwerk jenseits dieser App – und sammeln die Bluesky-Beiträge und Antworten zu einem Text, die Notizen an seinen Rändern und die anderen Texte, die ihn zitieren, unauffällig unter dem, was Sie gerade lesen."
+#~ msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+#~ msgstr "Und es wirkt nie abgeschottet. Wir verbinden jeden Artikel mit dem Gespräch in der Atmosphere – dem offenen Netzwerk jenseits dieser App – und sammeln die Bluesky-Beiträge und Antworten zu einem Text, die Notizen an seinen Rändern und die anderen Texte, die ihn zitieren, unauffällig unter dem, was Sie gerade lesen."
 
 #: src/components/guide/guide-shell.tsx
 msgid "Still stuck, or something here doesn't match what you see? <0>Tell us on the feedback board</0> — questions are welcome there, not just bug reports."
@@ -316,6 +321,10 @@ msgstr "läuft …"
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Your Home feed is built from subscriptions. Three is a good start."
 msgstr "Ihr Home-Feed entsteht aus Abos. Drei sind ein guter Anfang."
+
+#: src/components/reader/about-view.tsx
+msgid "A note in the margin"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Colors"
@@ -389,6 +398,10 @@ msgstr "Wird abonniert …"
 msgid "People"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Every piece is a door to the next one"
+msgstr ""
+
 #: src/routes/_layout.friends.tsx
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 msgstr ""
@@ -417,6 +430,7 @@ msgstr ""
 msgid "Switch to light paper"
 msgstr "Zu hellem Papier wechseln"
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Bluesky"
 msgstr "auf Bluesky"
@@ -426,8 +440,8 @@ msgid "Set these now, or change them any time in Settings."
 msgstr "Legen Sie das jetzt fest oder ändern Sie es jederzeit in den Einstellungen."
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
-msgstr "Die meisten Leser bleiben bei dem, was sie schon abonniert haben. Für Standard Reader gehört es zur Aufgabe, Ihren nächsten Favoriten zu finden. Stöbern Sie in allen Publikationen im Netzwerk – nicht nur in den wenigen, von denen Sie schon gehört haben."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
+#~ msgstr "Die meisten Leser bleiben bei dem, was sie schon abonniert haben. Für Standard Reader gehört es zur Aufgabe, Ihren nächsten Favoriten zu finden. Stöbern Sie in allen Publikationen im Netzwerk – nicht nur in den wenigen, von denen Sie schon gehört haben."
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Open <0>Collections</0> in the sidebar and start a new one."
@@ -682,8 +696,8 @@ msgid "Making a collection"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Read the guide"
-msgstr ""
+#~ msgid "Read the guide"
+#~ msgstr ""
 
 #: src/components/reader/app-shell.tsx
 #: src/components/site-legal-links.tsx
@@ -811,6 +825,10 @@ msgstr "Datenschutz der Erweiterung"
 msgid "Signing in"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Public API — no key required"
+msgstr ""
+
 #: src/components/reading-settings-preview.tsx
 msgid "Loading voice sample"
 msgstr "Stimmprobe wird geladen"
@@ -874,6 +892,11 @@ msgstr "Erneut versuchen"
 
 #: src/lib/guide/navigation.ts
 msgid "Welcome"
+msgstr ""
+
+#. placeholder {0}: SUPPORTED_CONTENT_FORMATS.size
+#: src/components/reader/about-view.tsx
+msgid "An article is a record in its author’s own repository, and every publishing tool on the network writes that record a little differently. Standard Reader reads {0} of those content formats and renders them all into the same calm page — so a reader never has to care which tool a writer chose."
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -1003,6 +1026,10 @@ msgstr ""
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
+#: src/components/reader/about-view.tsx
+msgid "None of this is ours. We gather it from the Atmosphere — the open network these apps all share — and show it under the piece it’s about. Every line links back to where it was actually written, no account or comment box required, and it works whether or not the author ever opted in."
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Saved to {savedName} on {appLabel}."
 msgstr "In {savedName} auf {appLabel} gespeichert."
@@ -1057,6 +1084,10 @@ msgstr "Ein ruhiger Leseraum für das offene Web. Nehmen wir uns zwei Minuten, u
 #: src/routes/_layout.collections.index.tsx
 msgid "New series"
 msgstr "Neue Reihe"
+
+#: src/components/reader/about-view.tsx
+msgid "Blogs never really solved the conversation. Comment boxes belonged to the blog, went unread, filled with spam, and vanished when the site did. So the talking moved somewhere else — and stopped being attached to the writing at all."
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "These deletions remove the records from your account itself, not just from our copy — which is why they cannot be undone. Deleting your reading history, for example, makes everything look unread again everywhere."
@@ -1130,6 +1161,10 @@ msgstr ""
 msgid "Under that, <0>Cited in</0> lists other articles that link to this one, and <1>Related reading</1> suggests pieces from across the network on the same subjects — usually from publications you have not met yet."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Essays and serialized writing"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 #~ msgid "Following your first publications"
@@ -1182,8 +1217,8 @@ msgid "Custom"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Read the API docs"
-msgstr "API-Doku lesen"
+#~ msgid "Read the API docs"
+#~ msgstr "API-Doku lesen"
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Select <0>Listen</0> in the top bar and the article is read aloud. The first time takes a few seconds to warm up; after that it starts straight away."
@@ -1198,8 +1233,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Shareable everywhere"
-msgstr "Überall teilbar"
+#~ msgid "Shareable everywhere"
+#~ msgstr "Überall teilbar"
 
 #: src/magazine/Magazine.tsx
 msgid "Close table of contents"
@@ -1232,6 +1267,10 @@ msgstr ""
 
 #: src/components/docs/introduction-docs-page.tsx
 msgid "how to make a site discoverable on Standard and have its content read inline, without adopting a platform."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across every publication on the network, not just the handful you’ve heard of."
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -1303,6 +1342,10 @@ msgstr ""
 msgid "To move several at once, open <0>Subscriptions</0>, select the rows you want, and add them all to a list in one action. That is much faster than doing it publication by publication."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Blocks, pages, and footnotes"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Appearance"
 msgstr "Darstellung"
@@ -1354,6 +1397,10 @@ msgstr "Konto"
 msgid "Collapse all lists"
 msgstr "Alle Listen einklappen"
 
+#: src/components/reader/about-view.tsx
+msgid "Four essays covering the same ground, from publications you don’t follow yet."
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "We couldn’t find that article."
 msgstr "Dieser Artikel wurde nicht gefunden."
@@ -1388,6 +1435,10 @@ msgstr "Ihre Sammlung"
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“…made to be read, and not to be measured.”"
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -1505,6 +1556,10 @@ msgstr "Schnelle Volltextsuche"
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "Name der Sammlung"
+
+#: src/components/reader/about-view.tsx
+msgid "+{UNNAMED_FORMAT_COUNT} more"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1698,8 +1753,8 @@ msgid "What every control on an article does — including having it read aloud 
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "The reading experience"
-msgstr "Das Leseerlebnis"
+#~ msgid "The reading experience"
+#~ msgstr "Das Leseerlebnis"
 
 #: src/routes/_layout.tsx
 msgid "Loading page"
@@ -1736,6 +1791,10 @@ msgstr ""
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "Collections live under <0>Collections</0> in the sidebar. Because publishing one writes a new kind of record to your account, the first time you make one you will be asked to grant an extra permission — that is the <1>Upgrade permissions</1> prompt, and it only appears once."
 #~ msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Also read natively:"
+msgstr ""
 
 #. placeholder {0}: pub.name
 #: src/components/reader/article-below-fold.tsx
@@ -1777,8 +1836,8 @@ msgstr "Sie haben jede Publikation auf dieser Seite abonniert – scrollen Sie w
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
-msgstr "Unter jedem Artikel sehen Sie die Diskussion aus dem gesamten offenen Netzwerk – Bluesky-Posts und -Antworten, Randnotizen, Links aus anderen Texten, die ihn zitieren, und verwandte Lektüre. Alles nur lesend, alles mit Link zur Quelle."
+#~ msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+#~ msgstr "Unter jedem Artikel sehen Sie die Diskussion aus dem gesamten offenen Netzwerk – Bluesky-Posts und -Antworten, Randnotizen, Links aus anderen Texten, die ihn zitieren, und verwandte Lektüre. Alles nur lesend, alles mit Link zur Quelle."
 
 #: src/routes/_layout.latest.tsx
 msgid "Show all subscriptions"
@@ -1831,8 +1890,8 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {# Treffer} other {# Treffer}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
-msgstr "Publikationen, Listen und Sammlungen bekommen jeweils einen sauberen Link mit einer schönen Vorschaukarte – plus einen Abo-Button, den eine Publikation auf ihrer eigenen Website einbauen kann."
+#~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
+#~ msgstr "Publikationen, Listen und Sammlungen bekommen jeweils einen sauberen Link mit einer schönen Vorschaukarte – plus einen Abo-Button, den eine Publikation auf ihrer eigenen Website einbauen kann."
 
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Search topics"
@@ -1857,6 +1916,10 @@ msgstr "Artikel in der Sammlung"
 #: src/components/user-settings-view.tsx
 msgid "System"
 msgstr "System"
+
+#: src/components/reader/about-view.tsx
+msgid "Every feed, directory, and search query the app itself runs."
+msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Could not save to {appLabel}"
@@ -1964,8 +2027,8 @@ msgid "Never used"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Building something on the same index? There’s a public API."
-msgstr "Sie bauen etwas auf demselben Index? Es gibt eine öffentliche API."
+#~ msgid "Building something on the same index? There’s a public API."
+#~ msgstr "Sie bauen etwas auf demselben Index? Es gibt eine öffentliche API."
 
 #: src/components/reader/comments/comments-section.tsx
 msgid "Discussion"
@@ -2196,6 +2259,10 @@ msgstr "Wo diese Sammlung erscheint – Follower der Reihe erhalten sie."
 msgid "No apps connected"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Nothing about it is fixed. Set the measure, the type size, and the typeface to whatever your eyes want, in light or dark, and the setting follows you to every article you open after it."
+msgstr ""
+
 #: src/components/reader/markdown-field.tsx
 msgid "Edit"
 msgstr "Bearbeiten"
@@ -2215,6 +2282,10 @@ msgstr "Öffentliche XRPC-Queries und -Procedures für das indexierte Lesemodell
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Save theme"
 msgstr "Theme speichern"
+
+#: src/components/reader/about-view.tsx
+msgid "A reply"
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "your day: one featured article, then what is new from the publications you subscribe to."
@@ -2397,6 +2468,10 @@ msgstr ""
 #~ msgid "Carry on browsing. The overlay appears where it is useful and stays out of the way where it is not."
 #~ msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "And if your reader of choice is one you already have, any slice of the network comes with its own feed — pipe it straight in and never open this app at all."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "To email your digest, Standard Reader needs your account email address. We'll ask your PDS to share it — you'll be sent to your login to approve the request, then brought right back here. Your email is used only to send the weekly digest, and you can turn it off any time."
 msgstr "Um Ihren Digest per E-Mail zu senden, benötigt Standard Reader die E-Mail-Adresse Ihres Kontos. Wir fragen Ihren PDS danach – Sie werden zur Anmeldung geleitet, um die Anfrage zu bestätigen, und kommen direkt hierher zurück. Ihre E-Mail-Adresse wird nur für den wöchentlichen Digest verwendet und Sie können ihn jederzeit abschalten."
@@ -2406,7 +2481,6 @@ msgid "Where your reading is kept, who else can see it, what you agreed to when 
 msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
-#: src/components/reader/about-view.tsx
 #: src/lib/guide/navigation.ts
 msgid "Discovery"
 msgstr "Entdecken"
@@ -2533,6 +2607,10 @@ msgstr "Über das Führen eines Commonplace Books"
 msgid "Most reading apps keep your list of follows on their own servers. If the app shuts down, your list goes with it."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Keep the good sentence"
+msgstr ""
+
 #: src/routes/_layout.u.$did.tsx
 msgid "Featured in"
 msgstr "Erschienen in"
@@ -2624,8 +2702,8 @@ msgid "Paper"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
-msgstr "Eine Einstellung umlegen und Artikellinks öffnen stattdessen die Website der Publikation. Lesen Sie dort, wo es sich für Sie richtig anfühlt."
+#~ msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
+#~ msgstr "Eine Einstellung umlegen und Artikellinks öffnen stattdessen die Website der Publikation. Lesen Sie dort, wo es sich für Sie richtig anfühlt."
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Discover is the directory of every publication the network knows about — not a curated shelf. It runs top to bottom from most personal to most complete:"
@@ -2690,8 +2768,12 @@ msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {Follower} other {Follower}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
-msgstr "Die meisten Leser bleiben bei dem, was sie schon abonniert haben. Standard Reader sieht es als Teil seiner Aufgabe, Ihren nächsten Favoriten zu finden. Stöbern Sie durch alle {countLabel} Publikationen im Netzwerk – nicht nur die paar, die Sie kennen."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgstr "Die meisten Leser bleiben bei dem, was sie schon abonniert haben. Standard Reader sieht es als Teil seiner Aufgabe, Ihren nächsten Favoriten zu finden. Stöbern Sie durch alle {countLabel} Publikationen im Netzwerk – nicht nur die paar, die Sie kennen."
+
+#: src/components/reader/about-view.tsx
+msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself, and every save, like, and subscribe is instantly in sync with whatever device you read on next."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labels"
@@ -2767,6 +2849,10 @@ msgstr ""
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Upgrade to author Collections"
 msgstr "Upgrade, um Sammlungen zu erstellen"
+
+#: src/components/reader/about-view.tsx
+msgid "Render a document in your own app —"
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "Your social actions (follows, likes, saves, lists) are written to your AT Protocol repository and are visible according to the network's rules and your account settings. Our Postgres database holds a network read-model, app session state, and cached public metadata — not the canonical copies of publications."
@@ -2872,12 +2958,20 @@ msgstr "Zuletzt aktualisiert am 13. Juni 2026"
 msgid "{shown, plural, one {# match} other {# matches}}"
 msgstr "{shown, plural, one {# Treffer} other {# Treffer}}"
 
+#: src/components/reader/about-view.tsx
+msgid "Select a passage and share it as a typeset card that links back to the article — or keep reading and pick up exactly where you left off next time."
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "People you follow write here"
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Good writing rarely turns up while you are already in a reading app. The extension puts saving and subscribing on every page you visit."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Drop a Standard document into your own app, in your own framework."
 msgstr ""
 
 #: src/magazine/flow.tsx
@@ -3051,6 +3145,10 @@ msgstr ""
 #: src/components/docs/docs-publishing-nav.tsx
 #~ msgid "Publishing guide"
 #~ msgstr "Leitfaden zum Veröffentlichen"
+
+#: src/components/reader/about-view.tsx
+msgid "Prefer the original? Flip one setting and article links open on the publication’s own site instead — Standard Reader will still keep your place."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "<0>Share</0> copies a link, or posts the article to Bluesky with a proper preview card. On a phone it can hand off to whatever you normally share with."
@@ -3425,6 +3523,10 @@ msgstr "Etwas ist schiefgelaufen."
 msgid "The best of what you subscribe to"
 msgstr "Das Beste aus Ihren Abos"
 
+#: src/components/reader/about-view.tsx
+msgid "Under this article"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Note"
 msgstr "Notiz"
@@ -3526,6 +3628,7 @@ msgstr "Audio wird erzeugt… {percent} %"
 
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
+#: src/components/reader/about-view.tsx
 msgid "Renderers"
 msgstr ""
 
@@ -3565,8 +3668,8 @@ msgid "What Standard Reader is"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Prefer the original?"
-msgstr "Lieber das Original?"
+#~ msgid "Prefer the original?"
+#~ msgstr "Lieber das Original?"
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Could not add to list"
@@ -3787,6 +3890,10 @@ msgstr "Diese Sprache wurde anhand Ihres Browsers gewählt. Sie können sie jede
 
 #: src/routes/mcp/authorize.tsx
 msgid "Nothing has been shared. Head back to the app you came from and try connecting again."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“This is the whole argument in one clause. Worth sitting with.”"
 msgstr ""
 
 #: src/components/reader/text-selection-toolbar.tsx
@@ -4013,8 +4120,8 @@ msgid "Save and subscribe from anywhere on the web, without breaking your stride
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Integrations"
-msgstr "Integrationen"
+#~ msgid "Integrations"
+#~ msgstr "Integrationen"
 
 #. placeholder {0}: person.subscriberCount
 #. placeholder {0}: pub.subscriberCount
@@ -4137,6 +4244,10 @@ msgstr ""
 msgid "This request can't be completed here, so we're returning you to the app that sent you."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Read the docs"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No people in this list — add some from the edit dialog."
 msgstr "Keine Personen in dieser Liste — fügen Sie welche über den Bearbeiten-Dialog hinzu."
@@ -4167,8 +4278,8 @@ msgid "Browse publications"
 msgstr "Publikationen durchstöbern"
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
-msgstr "Standard Reader sperrt Ihre Lektüre nicht in eine App. Jeder Ausschnitt des Netzwerks hat einen eigenen RSS-Feed — leiten Sie ihn direkt in den Reader, den Sie ohnehin nutzen."
+#~ msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
+#~ msgstr "Standard Reader sperrt Ihre Lektüre nicht in eine App. Jeder Ausschnitt des Netzwerks hat einen eigenen RSS-Feed — leiten Sie ihn direkt in den Reader, den Sie ohnehin nutzen."
 
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Choose images"
@@ -4236,6 +4347,10 @@ msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That image is too detailed to fit under 1 MB. Try cropping it first."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“Been thinking about this all week. The measurement is the part that ruins it — not the writing.”"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -4310,13 +4425,17 @@ msgstr "Feedback konnte nicht geladen werden <0>({0})</0>. Versuchen Sie es glei
 msgid "No publications match this tag yet."
 msgstr "Noch keine Publikationen zu diesem Tag."
 
+#: src/components/reader/about-view.tsx
+msgid "Written wherever they write"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "If you already know what you are looking for, the <0>Add publication</0> button opens a single field that does three things at once. Leave it empty and it shows what is trending. Type a few words and it searches the directory. Paste a handle or a domain — <1>@stdout.dev</1>, <2>stdout.dev</2> — and it looks that author up directly."
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "The conversation, gathered"
-msgstr "Das Gespräch, gebündelt"
+#~ msgid "The conversation, gathered"
+#~ msgstr "Das Gespräch, gebündelt"
 
 #: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
@@ -4344,8 +4463,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Save, like, subscribe — everywhere"
-msgstr "Speichern, liken, abonnieren – überall"
+#~ msgid "Save, like, subscribe — everywhere"
+#~ msgstr "Speichern, liken, abonnieren – überall"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe?"
@@ -4402,6 +4521,7 @@ msgstr ""
 
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
+#: src/components/reader/about-view.tsx
 msgid "API"
 msgstr "API"
 
@@ -4415,6 +4535,10 @@ msgstr "Symbol ersetzen"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unfollow"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Standard Reader doesn’t ask you to move in. It goes out to the web you already use, and hands your reading back in whatever shape suits you."
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx
@@ -4473,6 +4597,10 @@ msgstr "Anmeldung"
 
 #: src/components/reader/terms-view.tsx
 msgid "Changes to these terms"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Short-form posts and long reads"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -4541,6 +4669,10 @@ msgstr ""
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "Wenn Sie die Browser-Erweiterung von {SITE_NAME} installieren, nutzt sie dasselbe Konto und Sitzungs-Cookie wie diese Seite. Die Erweiterung sendet Seiten-URLs zum Index-Abgleich an unsere <0>/api/extension/*</0>-Endpunkte und speichert Overlay-Einstellungen im Erweiterungsspeicher Ihres Browsers. Details, die nur für die Erweiterung gelten, finden Sie in der <1>Datenschutzerklärung der Erweiterung</1>."
+
+#: src/components/reader/about-view.tsx
+msgid "And when a run of them turns out to be good together, collect them into a named list — a playlist for reading. Anyone can add the whole thing to their own reader in a single tap."
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "Remove {memberName} from list"
@@ -4698,8 +4830,8 @@ msgid "Saves a link to your <0>{appLabel}</0> collection."
 msgstr "Speichert einen Link in Ihrer <0>{appLabel}</0>-Sammlung."
 
 #: src/components/reader/about-view.tsx
-msgid "In your inbox"
-msgstr "In Ihrem Postfach"
+#~ msgid "In your inbox"
+#~ msgstr "In Ihrem Postfach"
 
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Drag to change the order your subscriptions appear in the sidebar."
@@ -4713,6 +4845,7 @@ msgstr "Darstellung, Leseeinstellungen und persönliche Daten."
 msgid "Authority for <0>app.standard-reader</0> resolves via DNS <1>_lexicon.*</1> TXT records to the publishing account."
 msgstr "Die Autorität für <0>app.standard-reader</0> wird über DNS-TXT-Einträge <1>_lexicon.*</1> zum veröffentlichenden Konto aufgelöst."
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Margin"
 msgstr "auf Margin"
@@ -4749,6 +4882,10 @@ msgstr "Dieses Handle konnte nicht aufgelöst werden."
 msgid "Good to know"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across all {countLabel} publications on the network, not just the handful you’ve heard of."
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Sharing a review on the <0>ATStore</0> will help both us and other users see what you think about Standard Reader."
 msgstr "Eine Bewertung im <0>ATStore</0> hilft uns und anderen Nutzern zu sehen, was Sie von Standard Reader halten."
@@ -4756,6 +4893,10 @@ msgstr "Eine Bewertung im <0>ATStore</0> hilft uns und anderen Nutzern zu sehen,
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "On Bluesky, quiet badges mark the people whose writing you can read here."
 #~ msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Publish labels others can subscribe to, or consume the ones we do."
+msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "The full account is on the <0>extension privacy page</0>."
@@ -4888,13 +5029,17 @@ msgstr "Hier gibt es noch nichts zu lesen."
 msgid "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
 msgstr "Labeler sind Moderationsdienste, die Sie per DID abonnieren. Abonnieren Sie sie, um beim Lesen ihre Label zu sehen – und gelabelte Beiträge unkenntlich zu machen oder auszublenden."
 
+#: src/components/reader/about-view.tsx
+msgid "The part blogging always missed"
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "The older link rels"
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader meets you where you read"
-msgstr "Standard Reader ist da, wo Sie lesen"
+#~ msgid "Standard Reader meets you where you read"
+#~ msgstr "Standard Reader ist da, wo Sie lesen"
 
 #: src/components/appearance-settings.tsx
 msgid "Reset appearance"
@@ -5088,6 +5233,10 @@ msgstr ""
 #: src/routes/_layout.latest.tsx
 msgid "All caught up"
 msgstr "Alles gelesen"
+
+#: src/components/reader/about-view.tsx
+msgid "Everything here is linkable, too. Publications, lists, and collections each get a clean URL with a rich preview card — plus a subscribe button a publication can drop straight onto its own site."
+msgstr ""
 
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Reorder subscriptions"
@@ -5284,6 +5433,7 @@ msgstr "Netzwerk durchsuchen"
 msgid "Search Google Fonts"
 msgstr "Google Fonts durchsuchen"
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/article-below-fold.tsx
 msgid "Related reading"
 msgstr "Passend dazu"
@@ -5522,8 +5672,8 @@ msgid "If something is confusing, broken, or missing, the <0>feedback board</0> 
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
-msgstr "Eine schlanke Browser-Erweiterung lässt Sie Publikationen speichern und abonnieren, während Sie im Web unterwegs sind – mit dezenten Badges auf bsky.app und einem Overlay mit einem Klick auf jeder Seite. Ihre Leseliste füllt sich von selbst."
+#~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+#~ msgstr "Eine schlanke Browser-Erweiterung lässt Sie Publikationen speichern und abonnieren, während Sie im Web unterwegs sind – mit dezenten Badges auf bsky.app und einem Overlay mit einem Klick auf jeder Seite. Ihre Leseliste füllt sich von selbst."
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -5763,8 +5913,8 @@ msgid "Open any article while signed in and it'll show up here. Your history liv
 msgstr "Öffnen Sie angemeldet einen beliebigen Artikel und er erscheint hier. Ihr Verlauf liegt als <0>app.standard-reader.read</0>-Records in Ihrem Repo."
 
 #: src/components/reader/about-view.tsx
-msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
-msgstr "Erstellen Sie benannte, teilbare Listen von Publikationen — eine Playlist zum Lesen. Jeder kann Ihre Liste mit einem Tipp in den eigenen Reader übernehmen."
+#~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
+#~ msgstr "Erstellen Sie benannte, teilbare Listen von Publikationen — eine Playlist zum Lesen. Jeder kann Ihre Liste mit einem Tipp in den eigenen Reader übernehmen."
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
@@ -5852,6 +6002,7 @@ msgstr ""
 #: src/components/docs/introduction-docs-page.tsx
 #: src/components/docs/labelers-docs-page.tsx
 #: src/components/labelers-settings-view.tsx
+#: src/components/reader/about-view.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/user-settings-view.tsx
 msgid "Labelers"
@@ -5862,8 +6013,8 @@ msgid "Choose your language"
 msgstr "Sprache auswählen"
 
 #: src/components/reader/about-view.tsx
-msgid "Find the ones you didn't know you wanted"
-msgstr "Finden Sie, was Sie noch gar nicht vermisst haben"
+#~ msgid "Find the ones you didn't know you wanted"
+#~ msgstr "Finden Sie, was Sie noch gar nicht vermisst haben"
 
 #: src/components/labeler-detail-view.tsx
 msgid "Hide"
@@ -5949,8 +6100,8 @@ msgid "Supported content formats"
 msgstr "Unterstützte Inhaltsformate"
 
 #: src/components/reader/about-view.tsx
-msgid "Plays nice with the open web"
-msgstr "Versteht sich mit dem offenen Web"
+#~ msgid "Plays nice with the open web"
+#~ msgstr "Versteht sich mit dem offenen Web"
 
 #: src/components/reader/privacy-view.tsx
 msgid "What we collect"
@@ -5975,6 +6126,10 @@ msgstr "Gefällt Ihnen Standard Reader?"
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Use original link"
 msgstr "Originallink verwenden"
+
+#: src/components/reader/about-view.tsx
+msgid "Everything this app runs on is public. The schemas are open, the read-model is queryable, and the renderer that draws these pages is published for you to use — so a reading app, a search tool, or a better client than this one is a weekend, not a platform deal."
+msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "Every publication page also serves a themed, embeddable subscribe widget — an iframe you can drop on your own site so visitors can subscribe without leaving your page. The easiest way to get it: open your publication's page on Standard Reader, use <0>Share → Embed subscribe</0>, pick landscape or portrait, and copy the snippet — no account or ownership check required to generate it."
@@ -6117,6 +6272,10 @@ msgstr "Noch keine Diskussion."
 msgid "A single publication"
 msgstr "Eine einzelne Publikation"
 
+#: src/components/reader/about-view.tsx
+msgid "Build on the same index"
+msgstr ""
+
 #: src/routes/extension.connected.tsx
 msgid "Return to the Standard Reader extension — this tab will close automatically."
 msgstr "Zurück zur Standard-Reader-Erweiterung — dieser Tab schließt sich automatisch."
@@ -6224,6 +6383,10 @@ msgstr ""
 #: src/components/reader/publication-latest-note.tsx
 msgid "Latest note"
 msgstr "Neueste Notiz"
+
+#: src/components/reader/about-view.tsx
+msgid "The record schemas a publication, document, or follow is made of."
+msgstr ""
 
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6377,6 +6540,10 @@ msgstr "Querformat"
 msgid "Edit collection"
 msgstr "Sammlung bearbeiten"
 
+#: src/components/reader/about-view.tsx
+msgid "That is a real response from the endpoint this page just called — no key, no sign-up, no rate-limit form. The same is true of every feed, directory, and search query the reader itself runs."
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "After that, following is one button. Anywhere you see a publication — a card in a feed, the top of an article, a publication's own page — there is a <0>Follow</0> button next to its name. Select it again to stop following. Nothing else changes: the button just decides whether new writing from that publication reaches your Home and Latest."
 #~ msgstr ""
@@ -6425,8 +6592,12 @@ msgid "Opening the issue…"
 msgstr "Ausgabe wird geöffnet…"
 
 #: src/components/reader/about-view.tsx
-msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
-msgstr "Sie müssen den Rest des Webs nicht hinter sich lassen. Der Reader greift danach — und bleibt ein guter Bürger im weiteren Netzwerk."
+msgid "However you like to read it"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+#~ msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+#~ msgstr "Sie müssen den Rest des Webs nicht hinter sich lassen. Der Reader greift danach — und bleibt ein guter Bürger im weiteren Netzwerk."
 
 #: src/routes/_layout.collections.edit.$rkey.tsx
 msgid "We couldn’t load that collection to edit."
@@ -6488,6 +6659,10 @@ msgstr "Standard Reader indexiert <0>site.standard.document</0>- und <1>site.sta
 #: src/components/reader/list-edit-modal.tsx
 msgid "e.g. Tech, Friends, Cooking"
 msgstr "z. B. Technik, Freunde, Kochen"
+
+#: src/components/reader/about-view.tsx
+msgid "Semble"
+msgstr ""
 
 #. placeholder {0}: fmt.relativeTime(connection.lastUsedAt)
 #: src/components/user-settings-view.tsx
@@ -6631,6 +6806,10 @@ msgstr "An"
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Two other pieces link to this one — you can read them from here."
 msgstr ""
 
 #: src/components/reader/page-reader-bar.tsx
@@ -6790,6 +6969,10 @@ msgstr ""
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Finding your way around"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Cited by"
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -2665,6 +2665,10 @@ msgstr "{itemTitle} umsortieren"
 msgid "Back to feedback"
 msgstr "Zurück zum Feedback"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "View on {name}"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "{pubTotal, plural, one {# publication} other {# publications}}"
 msgstr "{pubTotal, plural, one {# Publikation} other {# Publikationen}}"

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -123,12 +123,12 @@ msgid "Every renderer takes one input for the document — the content payload o
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "One tap from the reading view, on any device, instantly in sync. Your library is always where you left it."
-msgstr ""
+#~ msgid "One tap from the reading view, on any device, instantly in sync. Your library is always where you left it."
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Curated lists & collections"
-msgstr ""
+#~ msgid "Curated lists & collections"
+#~ msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Vue 3."
@@ -179,6 +179,7 @@ msgstr ""
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
 #: src/components/docs/lexicon-docs-intro.tsx
+#: src/components/reader/about-view.tsx
 msgid "Lexicons"
 msgstr ""
 
@@ -256,6 +257,10 @@ msgstr ""
 #~ msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Follow it and it starts appearing in your feeds like any other."
 #~ msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -302,8 +307,8 @@ msgid "(this is what Standard Reader itself uses)"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
-msgstr ""
+#~ msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+#~ msgstr ""
 
 #: src/components/guide/guide-shell.tsx
 msgid "Still stuck, or something here doesn't match what you see? <0>Tell us on the feedback board</0> — questions are welcome there, not just bug reports."
@@ -315,6 +320,10 @@ msgstr ""
 
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Your Home feed is built from subscriptions. Three is a good start."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "A note in the margin"
 msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
@@ -389,6 +398,10 @@ msgstr ""
 msgid "People"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Every piece is a door to the next one"
+msgstr ""
+
 #: src/routes/_layout.friends.tsx
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 msgstr ""
@@ -417,6 +430,7 @@ msgstr ""
 msgid "Switch to light paper"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Bluesky"
 msgstr ""
@@ -426,8 +440,8 @@ msgid "Set these now, or change them any time in Settings."
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
-msgstr ""
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
+#~ msgstr ""
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Open <0>Collections</0> in the sidebar and start a new one."
@@ -682,8 +696,8 @@ msgid "Making a collection"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Read the guide"
-msgstr ""
+#~ msgid "Read the guide"
+#~ msgstr ""
 
 #: src/components/reader/app-shell.tsx
 #: src/components/site-legal-links.tsx
@@ -811,6 +825,10 @@ msgstr ""
 msgid "Signing in"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Public API — no key required"
+msgstr ""
+
 #: src/components/reading-settings-preview.tsx
 msgid "Loading voice sample"
 msgstr ""
@@ -874,6 +892,11 @@ msgstr ""
 
 #: src/lib/guide/navigation.ts
 msgid "Welcome"
+msgstr ""
+
+#. placeholder {0}: SUPPORTED_CONTENT_FORMATS.size
+#: src/components/reader/about-view.tsx
+msgid "An article is a record in its author’s own repository, and every publishing tool on the network writes that record a little differently. Standard Reader reads {0} of those content formats and renders them all into the same calm page — so a reader never has to care which tool a writer chose."
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -1003,6 +1026,10 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "None of this is ours. We gather it from the Atmosphere — the open network these apps all share — and show it under the piece it’s about. Every line links back to where it was actually written, no account or comment box required, and it works whether or not the author ever opted in."
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Saved to {savedName} on {appLabel}."
 msgstr ""
@@ -1056,6 +1083,10 @@ msgstr ""
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.index.tsx
 msgid "New series"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Blogs never really solved the conversation. Comment boxes belonged to the blog, went unread, filled with spam, and vanished when the site did. So the talking moved somewhere else — and stopped being attached to the writing at all."
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
@@ -1130,6 +1161,10 @@ msgstr ""
 msgid "Under that, <0>Cited in</0> lists other articles that link to this one, and <1>Related reading</1> suggests pieces from across the network on the same subjects — usually from publications you have not met yet."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Essays and serialized writing"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 #~ msgid "Following your first publications"
@@ -1182,8 +1217,8 @@ msgid "Custom"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Read the API docs"
-msgstr ""
+#~ msgid "Read the API docs"
+#~ msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Select <0>Listen</0> in the top bar and the article is read aloud. The first time takes a few seconds to warm up; after that it starts straight away."
@@ -1198,8 +1233,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Shareable everywhere"
-msgstr ""
+#~ msgid "Shareable everywhere"
+#~ msgstr ""
 
 #: src/magazine/Magazine.tsx
 msgid "Close table of contents"
@@ -1232,6 +1267,10 @@ msgstr ""
 
 #: src/components/docs/introduction-docs-page.tsx
 msgid "how to make a site discoverable on Standard and have its content read inline, without adopting a platform."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across every publication on the network, not just the handful you’ve heard of."
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -1303,6 +1342,10 @@ msgstr ""
 msgid "To move several at once, open <0>Subscriptions</0>, select the rows you want, and add them all to a list in one action. That is much faster than doing it publication by publication."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Blocks, pages, and footnotes"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Appearance"
 msgstr ""
@@ -1354,6 +1397,10 @@ msgstr ""
 msgid "Collapse all lists"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Four essays covering the same ground, from publications you don’t follow yet."
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "We couldn’t find that article."
 msgstr ""
@@ -1388,6 +1435,10 @@ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“…made to be read, and not to be measured.”"
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -1504,6 +1555,10 @@ msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "+{UNNAMED_FORMAT_COUNT} more"
 msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
@@ -1698,8 +1753,8 @@ msgid "What every control on an article does — including having it read aloud 
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "The reading experience"
-msgstr ""
+#~ msgid "The reading experience"
+#~ msgstr ""
 
 #: src/routes/_layout.tsx
 msgid "Loading page"
@@ -1736,6 +1791,10 @@ msgstr ""
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "Collections live under <0>Collections</0> in the sidebar. Because publishing one writes a new kind of record to your account, the first time you make one you will be asked to grant an extra permission — that is the <1>Upgrade permissions</1> prompt, and it only appears once."
 #~ msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Also read natively:"
+msgstr ""
 
 #. placeholder {0}: pub.name
 #: src/components/reader/article-below-fold.tsx
@@ -1777,8 +1836,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
-msgstr ""
+#~ msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+#~ msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "Show all subscriptions"
@@ -1831,8 +1890,8 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
-msgstr ""
+#~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
+#~ msgstr ""
 
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Search topics"
@@ -1856,6 +1915,10 @@ msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "System"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Every feed, directory, and search query the app itself runs."
 msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
@@ -1964,8 +2027,8 @@ msgid "Never used"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Building something on the same index? There’s a public API."
-msgstr ""
+#~ msgid "Building something on the same index? There’s a public API."
+#~ msgstr ""
 
 #: src/components/reader/comments/comments-section.tsx
 msgid "Discussion"
@@ -2196,6 +2259,10 @@ msgstr ""
 msgid "No apps connected"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Nothing about it is fixed. Set the measure, the type size, and the typeface to whatever your eyes want, in light or dark, and the setting follows you to every article you open after it."
+msgstr ""
+
 #: src/components/reader/markdown-field.tsx
 msgid "Edit"
 msgstr ""
@@ -2214,6 +2281,10 @@ msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Save theme"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "A reply"
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -2397,6 +2468,10 @@ msgstr ""
 #~ msgid "Carry on browsing. The overlay appears where it is useful and stays out of the way where it is not."
 #~ msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "And if your reader of choice is one you already have, any slice of the network comes with its own feed — pipe it straight in and never open this app at all."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "To email your digest, Standard Reader needs your account email address. We'll ask your PDS to share it — you'll be sent to your login to approve the request, then brought right back here. Your email is used only to send the weekly digest, and you can turn it off any time."
 msgstr ""
@@ -2406,7 +2481,6 @@ msgid "Where your reading is kept, who else can see it, what you agreed to when 
 msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
-#: src/components/reader/about-view.tsx
 #: src/lib/guide/navigation.ts
 msgid "Discovery"
 msgstr ""
@@ -2533,6 +2607,10 @@ msgstr ""
 msgid "Most reading apps keep your list of follows on their own servers. If the app shuts down, your list goes with it."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Keep the good sentence"
+msgstr ""
+
 #: src/routes/_layout.u.$did.tsx
 msgid "Featured in"
 msgstr "[Ϝḗḗααṭŭŭřḗḗḓ īīƞ]"
@@ -2624,8 +2702,8 @@ msgid "Paper"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
-msgstr ""
+#~ msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
+#~ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Discover is the directory of every publication the network knows about — not a curated shelf. It runs top to bottom from most personal to most complete:"
@@ -2690,7 +2768,11 @@ msgid "{0, plural, one {follower} other {followers}}"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself, and every save, like, and subscribe is instantly in sync with whatever device you read on next."
 msgstr ""
 
 #: src/components/labeler-detail-view.tsx
@@ -2766,6 +2848,10 @@ msgstr ""
 
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Upgrade to author Collections"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Render a document in your own app —"
 msgstr ""
 
 #: src/components/reader/privacy-view.tsx
@@ -2872,12 +2958,20 @@ msgstr ""
 msgid "{shown, plural, one {# match} other {# matches}}"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Select a passage and share it as a typeset card that links back to the article — or keep reading and pick up exactly where you left off next time."
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "People you follow write here"
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Good writing rarely turns up while you are already in a reading app. The extension puts saving and subscribing on every page you visit."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Drop a Standard document into your own app, in your own framework."
 msgstr ""
 
 #: src/magazine/flow.tsx
@@ -3051,6 +3145,10 @@ msgstr ""
 #: src/components/docs/docs-publishing-nav.tsx
 #~ msgid "Publishing guide"
 #~ msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Prefer the original? Flip one setting and article links open on the publication’s own site instead — Standard Reader will still keep your place."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "<0>Share</0> copies a link, or posts the article to Bluesky with a proper preview card. On a phone it can hand off to whatever you normally share with."
@@ -3425,6 +3523,10 @@ msgstr ""
 msgid "The best of what you subscribe to"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Under this article"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Note"
 msgstr ""
@@ -3526,6 +3628,7 @@ msgstr ""
 
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
+#: src/components/reader/about-view.tsx
 msgid "Renderers"
 msgstr ""
 
@@ -3565,8 +3668,8 @@ msgid "What Standard Reader is"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Prefer the original?"
-msgstr ""
+#~ msgid "Prefer the original?"
+#~ msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Could not add to list"
@@ -3787,6 +3890,10 @@ msgstr ""
 
 #: src/routes/mcp/authorize.tsx
 msgid "Nothing has been shared. Head back to the app you came from and try connecting again."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“This is the whole argument in one clause. Worth sitting with.”"
 msgstr ""
 
 #: src/components/reader/text-selection-toolbar.tsx
@@ -4013,8 +4120,8 @@ msgid "Save and subscribe from anywhere on the web, without breaking your stride
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Integrations"
-msgstr ""
+#~ msgid "Integrations"
+#~ msgstr ""
 
 #. placeholder {0}: person.subscriberCount
 #. placeholder {0}: pub.subscriberCount
@@ -4137,6 +4244,10 @@ msgstr ""
 msgid "This request can't be completed here, so we're returning you to the app that sent you."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Read the docs"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No people in this list — add some from the edit dialog."
 msgstr ""
@@ -4167,8 +4278,8 @@ msgid "Browse publications"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
-msgstr ""
+#~ msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
+#~ msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Choose images"
@@ -4236,6 +4347,10 @@ msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That image is too detailed to fit under 1 MB. Try cropping it first."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“Been thinking about this all week. The measurement is the part that ruins it — not the writing.”"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -4310,13 +4425,17 @@ msgstr ""
 msgid "No publications match this tag yet."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Written wherever they write"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "If you already know what you are looking for, the <0>Add publication</0> button opens a single field that does three things at once. Leave it empty and it shows what is trending. Type a few words and it searches the directory. Paste a handle or a domain — <1>@stdout.dev</1>, <2>stdout.dev</2> — and it looks that author up directly."
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "The conversation, gathered"
-msgstr ""
+#~ msgid "The conversation, gathered"
+#~ msgstr ""
 
 #: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
@@ -4344,8 +4463,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Save, like, subscribe — everywhere"
-msgstr ""
+#~ msgid "Save, like, subscribe — everywhere"
+#~ msgstr ""
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe?"
@@ -4402,6 +4521,7 @@ msgstr ""
 
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
+#: src/components/reader/about-view.tsx
 msgid "API"
 msgstr ""
 
@@ -4415,6 +4535,10 @@ msgstr ""
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unfollow"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Standard Reader doesn’t ask you to move in. It goes out to the web you already use, and hands your reading back in whatever shape suits you."
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx
@@ -4473,6 +4597,10 @@ msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Changes to these terms"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Short-form posts and long reads"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -4540,6 +4668,10 @@ msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "And when a run of them turns out to be good together, collect them into a named list — a playlist for reading. Anyone can add the whole thing to their own reader in a single tap."
 msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
@@ -4698,8 +4830,8 @@ msgid "Saves a link to your <0>{appLabel}</0> collection."
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "In your inbox"
-msgstr ""
+#~ msgid "In your inbox"
+#~ msgstr ""
 
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Drag to change the order your subscriptions appear in the sidebar."
@@ -4713,6 +4845,7 @@ msgstr ""
 msgid "Authority for <0>app.standard-reader</0> resolves via DNS <1>_lexicon.*</1> TXT records to the publishing account."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Margin"
 msgstr ""
@@ -4749,6 +4882,10 @@ msgstr ""
 msgid "Good to know"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across all {countLabel} publications on the network, not just the handful you’ve heard of."
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Sharing a review on the <0>ATStore</0> will help both us and other users see what you think about Standard Reader."
 msgstr ""
@@ -4756,6 +4893,10 @@ msgstr ""
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "On Bluesky, quiet badges mark the people whose writing you can read here."
 #~ msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Publish labels others can subscribe to, or consume the ones we do."
+msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "The full account is on the <0>extension privacy page</0>."
@@ -4888,13 +5029,17 @@ msgstr ""
 msgid "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "The part blogging always missed"
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "The older link rels"
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader meets you where you read"
-msgstr ""
+#~ msgid "Standard Reader meets you where you read"
+#~ msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Reset appearance"
@@ -5087,6 +5232,10 @@ msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "All caught up"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Everything here is linkable, too. Publications, lists, and collections each get a clean URL with a rich preview card — plus a subscribe button a publication can drop straight onto its own site."
 msgstr ""
 
 #: src/components/reader/reorder-subscriptions-modal.tsx
@@ -5284,6 +5433,7 @@ msgstr ""
 msgid "Search Google Fonts"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/article-below-fold.tsx
 msgid "Related reading"
 msgstr ""
@@ -5522,8 +5672,8 @@ msgid "If something is confusing, broken, or missing, the <0>feedback board</0> 
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
-msgstr ""
+#~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+#~ msgstr ""
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -5763,8 +5913,8 @@ msgid "Open any article while signed in and it'll show up here. Your history liv
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
-msgstr ""
+#~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
+#~ msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
@@ -5852,6 +6002,7 @@ msgstr ""
 #: src/components/docs/introduction-docs-page.tsx
 #: src/components/docs/labelers-docs-page.tsx
 #: src/components/labelers-settings-view.tsx
+#: src/components/reader/about-view.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/user-settings-view.tsx
 msgid "Labelers"
@@ -5862,8 +6013,8 @@ msgid "Choose your language"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Find the ones you didn't know you wanted"
-msgstr ""
+#~ msgid "Find the ones you didn't know you wanted"
+#~ msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Hide"
@@ -5949,8 +6100,8 @@ msgid "Supported content formats"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Plays nice with the open web"
-msgstr ""
+#~ msgid "Plays nice with the open web"
+#~ msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "What we collect"
@@ -5974,6 +6125,10 @@ msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Use original link"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Everything this app runs on is public. The schemas are open, the read-model is queryable, and the renderer that draws these pages is published for you to use — so a reading app, a search tool, or a better client than this one is a weekend, not a platform deal."
 msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
@@ -6117,6 +6272,10 @@ msgstr ""
 msgid "A single publication"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Build on the same index"
+msgstr ""
+
 #: src/routes/extension.connected.tsx
 msgid "Return to the Standard Reader extension — this tab will close automatically."
 msgstr ""
@@ -6223,6 +6382,10 @@ msgstr ""
 
 #: src/components/reader/publication-latest-note.tsx
 msgid "Latest note"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "The record schemas a publication, document, or follow is made of."
 msgstr ""
 
 #: src/components/guide/pages/personalizing-guide-page.tsx
@@ -6377,6 +6540,10 @@ msgstr ""
 msgid "Edit collection"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "That is a real response from the endpoint this page just called — no key, no sign-up, no rate-limit form. The same is true of every feed, directory, and search query the reader itself runs."
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "After that, following is one button. Anywhere you see a publication — a card in a feed, the top of an article, a publication's own page — there is a <0>Follow</0> button next to its name. Select it again to stop following. Nothing else changes: the button just decides whether new writing from that publication reaches your Home and Latest."
 #~ msgstr ""
@@ -6425,8 +6592,12 @@ msgid "Opening the issue…"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+msgid "However you like to read it"
 msgstr ""
+
+#: src/components/reader/about-view.tsx
+#~ msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+#~ msgstr ""
 
 #: src/routes/_layout.collections.edit.$rkey.tsx
 msgid "We couldn’t load that collection to edit."
@@ -6487,6 +6658,10 @@ msgstr ""
 #: src/components/reader/add-to-list-modal.tsx
 #: src/components/reader/list-edit-modal.tsx
 msgid "e.g. Tech, Friends, Cooking"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Semble"
 msgstr ""
 
 #. placeholder {0}: fmt.relativeTime(connection.lastUsedAt)
@@ -6631,6 +6806,10 @@ msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Two other pieces link to this one — you can read them from here."
 msgstr ""
 
 #: src/components/reader/page-reader-bar.tsx
@@ -6790,6 +6969,10 @@ msgstr ""
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Finding your way around"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Cited by"
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -99,6 +99,10 @@ msgstr ""
 msgid "Articles gaining attention across the network right now."
 msgstr ""
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# member} other {# members}}"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Add an article"
 msgstr ""
@@ -410,9 +414,9 @@ msgstr ""
 msgid "{years}y ago"
 msgstr ""
 
-#: src/components/reader/reorder-lists-modal.tsx
-#~ msgid "List"
-#~ msgstr ""
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "List"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "The spacing between things — tighter for more on screen, looser for more room to read."
@@ -1971,6 +1975,7 @@ msgstr ""
 #~ msgid "Following, saving, recommending, and — once you follow more than a handful of publications — keeping the whole thing tidy."
 #~ msgstr ""
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 #: src/components/user-settings-view.tsx
 msgid "Feed"
 msgstr ""
@@ -3253,6 +3258,10 @@ msgstr ""
 msgid "e.g. Dispatches from the Atmosphere"
 msgstr ""
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# join} other {# joins}}"
+msgstr ""
+
 #: src/components/docs/introduction-docs-page.tsx
 msgid "the AT Protocol schemas that define Standard records and the shared definitions they build on."
 msgstr ""
@@ -3560,6 +3569,10 @@ msgstr ""
 #: src/components/NavbarAuth.tsx
 #: src/components/site-legal-links.tsx
 msgid "Guide"
+msgstr ""
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# like} other {# likes}}"
 msgstr ""
 
 #: src/routes/_layout.collections.new.tsx
@@ -4042,6 +4055,10 @@ msgstr ""
 msgid "{0}+ articles"
 msgstr ""
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "Starter pack"
+msgstr ""
+
 #: src/routes/_layout.feedback.return.tsx
 msgid "That link expired."
 msgstr ""
@@ -4334,6 +4351,10 @@ msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Cited in"
+msgstr ""
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# follower} other {# followers}}"
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -5953,6 +5974,10 @@ msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "At the bottom of settings, <0>Personal data</0> deletes categories of records outright: your reading history, your saved articles, or the publication lists you made. Each asks for confirmation and explains what will change."
+msgstr ""
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "Profile"
 msgstr ""
 
 #: src/components/reader/friend-publishers.tsx

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -2665,6 +2665,10 @@ msgstr ""
 msgid "Back to feedback"
 msgstr ""
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "View on {name}"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "{pubTotal, plural, one {# publication} other {# publications}}"
 msgstr ""

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -2665,6 +2665,10 @@ msgstr "Reorder {itemTitle}"
 msgid "Back to feedback"
 msgstr "Back to feedback"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "View on {name}"
+msgstr "View on {name}"
+
 #: src/routes/_layout.search.tsx
 msgid "{pubTotal, plural, one {# publication} other {# publications}}"
 msgstr "{pubTotal, plural, one {# publication} other {# publications}}"

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -123,12 +123,12 @@ msgid "Every renderer takes one input for the document — the content payload o
 msgstr "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0> — and an optional <1>components</1> map. The format is detected from the payload's <2>$type</2>. With no <3>components</3> prop, a document renders as unstyled semantic HTML."
 
 #: src/components/reader/about-view.tsx
-msgid "One tap from the reading view, on any device, instantly in sync. Your library is always where you left it."
-msgstr "One tap from the reading view, on any device, instantly in sync. Your library is always where you left it."
+#~ msgid "One tap from the reading view, on any device, instantly in sync. Your library is always where you left it."
+#~ msgstr "One tap from the reading view, on any device, instantly in sync. Your library is always where you left it."
 
 #: src/components/reader/about-view.tsx
-msgid "Curated lists & collections"
-msgstr "Curated lists & collections"
+#~ msgid "Curated lists & collections"
+#~ msgstr "Curated lists & collections"
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Vue 3."
@@ -179,6 +179,7 @@ msgstr "Disconnect"
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
 #: src/components/docs/lexicon-docs-intro.tsx
+#: src/components/reader/about-view.tsx
 msgid "Lexicons"
 msgstr "Lexicons"
 
@@ -256,6 +257,10 @@ msgstr "Please add a title."
 #~ msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Follow it and it starts appearing in your feeds like any other."
 #~ msgstr "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Follow it and it starts appearing in your feeds like any other."
 
+#: src/components/reader/about-view.tsx
+msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
+msgstr "There’s an MCP server on the same host, so you can point an agent at the network too."
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr "Filter by name, handle, or topic"
@@ -302,8 +307,8 @@ msgid "(this is what Standard Reader itself uses)"
 msgstr "(this is what Standard Reader itself uses)"
 
 #: src/components/reader/about-view.tsx
-msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
-msgstr "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+#~ msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+#~ msgstr "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
 
 #: src/components/guide/guide-shell.tsx
 msgid "Still stuck, or something here doesn't match what you see? <0>Tell us on the feedback board</0> — questions are welcome there, not just bug reports."
@@ -316,6 +321,10 @@ msgstr "running…"
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Your Home feed is built from subscriptions. Three is a good start."
 msgstr "Your Home feed is built from subscriptions. Three is a good start."
+
+#: src/components/reader/about-view.tsx
+msgid "A note in the margin"
+msgstr "A note in the margin"
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Colors"
@@ -389,6 +398,10 @@ msgstr "Subscribing…"
 msgid "People"
 msgstr "People"
 
+#: src/components/reader/about-view.tsx
+msgid "Every piece is a door to the next one"
+msgstr "Every piece is a door to the next one"
+
 #: src/routes/_layout.friends.tsx
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 msgstr "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
@@ -417,6 +430,7 @@ msgstr "Following, saving, recommending, and your reading history."
 msgid "Switch to light paper"
 msgstr "Switch to light paper"
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Bluesky"
 msgstr "on Bluesky"
@@ -426,8 +440,8 @@ msgid "Set these now, or change them any time in Settings."
 msgstr "Set these now, or change them any time in Settings."
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
-msgstr "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
+#~ msgstr "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Open <0>Collections</0> in the sidebar and start a new one."
@@ -682,8 +696,8 @@ msgid "Making a collection"
 msgstr "Making a collection"
 
 #: src/components/reader/about-view.tsx
-msgid "Read the guide"
-msgstr "Read the guide"
+#~ msgid "Read the guide"
+#~ msgstr "Read the guide"
 
 #: src/components/reader/app-shell.tsx
 #: src/components/site-legal-links.tsx
@@ -811,6 +825,10 @@ msgstr "Extension privacy"
 msgid "Signing in"
 msgstr "Signing in"
 
+#: src/components/reader/about-view.tsx
+msgid "Public API — no key required"
+msgstr "Public API — no key required"
+
 #: src/components/reading-settings-preview.tsx
 msgid "Loading voice sample"
 msgstr "Loading voice sample"
@@ -875,6 +893,11 @@ msgstr "Retry"
 #: src/lib/guide/navigation.ts
 msgid "Welcome"
 msgstr "Welcome"
+
+#. placeholder {0}: SUPPORTED_CONTENT_FORMATS.size
+#: src/components/reader/about-view.tsx
+msgid "An article is a record in its author’s own repository, and every publishing tool on the network writes that record a little differently. Standard Reader reads {0} of those content formats and renders them all into the same calm page — so a reader never has to care which tool a writer chose."
+msgstr "An article is a record in its author’s own repository, and every publishing tool on the network writes that record a little differently. Standard Reader reads {0} of those content formats and renders them all into the same calm page — so a reader never has to care which tool a writer chose."
 
 #: src/components/user-settings-view.tsx
 msgid "Delete history"
@@ -1003,6 +1026,10 @@ msgstr "Standard Reader is a reader for online magazines, newsletters, and perso
 msgid "Bookmarks"
 msgstr "Bookmarks"
 
+#: src/components/reader/about-view.tsx
+msgid "None of this is ours. We gather it from the Atmosphere — the open network these apps all share — and show it under the piece it’s about. Every line links back to where it was actually written, no account or comment box required, and it works whether or not the author ever opted in."
+msgstr "None of this is ours. We gather it from the Atmosphere — the open network these apps all share — and show it under the piece it’s about. Every line links back to where it was actually written, no account or comment box required, and it works whether or not the author ever opted in."
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Saved to {savedName} on {appLabel}."
 msgstr "Saved to {savedName} on {appLabel}."
@@ -1057,6 +1084,10 @@ msgstr "A calm reading room for the open web. Let's take two minutes to make it 
 #: src/routes/_layout.collections.index.tsx
 msgid "New series"
 msgstr "New series"
+
+#: src/components/reader/about-view.tsx
+msgid "Blogs never really solved the conversation. Comment boxes belonged to the blog, went unread, filled with spam, and vanished when the site did. So the talking moved somewhere else — and stopped being attached to the writing at all."
+msgstr "Blogs never really solved the conversation. Comment boxes belonged to the blog, went unread, filled with spam, and vanished when the site did. So the talking moved somewhere else — and stopped being attached to the writing at all."
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "These deletions remove the records from your account itself, not just from our copy — which is why they cannot be undone. Deleting your reading history, for example, makes everything look unread again everywhere."
@@ -1130,6 +1161,10 @@ msgstr "This is the fastest way from “I liked this one piece” to “who else
 msgid "Under that, <0>Cited in</0> lists other articles that link to this one, and <1>Related reading</1> suggests pieces from across the network on the same subjects — usually from publications you have not met yet."
 msgstr "Under that, <0>Cited in</0> lists other articles that link to this one, and <1>Related reading</1> suggests pieces from across the network on the same subjects — usually from publications you have not met yet."
 
+#: src/components/reader/about-view.tsx
+msgid "Essays and serialized writing"
+msgstr "Essays and serialized writing"
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 #~ msgid "Following your first publications"
@@ -1182,8 +1217,8 @@ msgid "Custom"
 msgstr "Custom"
 
 #: src/components/reader/about-view.tsx
-msgid "Read the API docs"
-msgstr "Read the API docs"
+#~ msgid "Read the API docs"
+#~ msgstr "Read the API docs"
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Select <0>Listen</0> in the top bar and the article is read aloud. The first time takes a few seconds to warm up; after that it starts straight away."
@@ -1198,8 +1233,8 @@ msgstr "Paste that link anywhere that unfurls a preview — Bluesky, a chat, a d
 #~ msgstr "Reorder lists…"
 
 #: src/components/reader/about-view.tsx
-msgid "Shareable everywhere"
-msgstr "Shareable everywhere"
+#~ msgid "Shareable everywhere"
+#~ msgstr "Shareable everywhere"
 
 #: src/magazine/Magazine.tsx
 msgid "Close table of contents"
@@ -1233,6 +1268,10 @@ msgstr "Rendering Standard Site documents"
 #: src/components/docs/introduction-docs-page.tsx
 msgid "how to make a site discoverable on Standard and have its content read inline, without adopting a platform."
 msgstr "how to make a site discoverable on Standard and have its content read inline, without adopting a platform."
+
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across every publication on the network, not just the handful you’ve heard of."
+msgstr "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across every publication on the network, not just the handful you’ve heard of."
 
 #: src/components/reader/terms-view.tsx
 msgid "For more about how {SITE_NAME} works, see the <0>About</0> page. For questions about these terms for this deployment, contact the operator of the site at the URL above."
@@ -1303,6 +1342,10 @@ msgstr "Recommending an article"
 msgid "To move several at once, open <0>Subscriptions</0>, select the rows you want, and add them all to a list in one action. That is much faster than doing it publication by publication."
 msgstr "To move several at once, open <0>Subscriptions</0>, select the rows you want, and add them all to a list in one action. That is much faster than doing it publication by publication."
 
+#: src/components/reader/about-view.tsx
+msgid "Blocks, pages, and footnotes"
+msgstr "Blocks, pages, and footnotes"
+
 #: src/components/user-settings-view.tsx
 msgid "Appearance"
 msgstr "Appearance"
@@ -1354,6 +1397,10 @@ msgstr "Account"
 msgid "Collapse all lists"
 msgstr "Collapse all lists"
 
+#: src/components/reader/about-view.tsx
+msgid "Four essays covering the same ground, from publications you don’t follow yet."
+msgstr "Four essays covering the same ground, from publications you don’t follow yet."
+
 #: src/components/reader/article-view.tsx
 msgid "We couldn’t find that article."
 msgstr "We couldn’t find that article."
@@ -1389,6 +1436,10 @@ msgstr "your collection"
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
 msgstr "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
+
+#: src/components/reader/about-view.tsx
+msgid "“…made to be read, and not to be measured.”"
+msgstr "“…made to be read, and not to be measured.”"
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "If you already know what you want, <0>Discover</0> lists everything on the network, and <1>Finding things to read</1> covers every way to get there."
@@ -1505,6 +1556,10 @@ msgstr "Fast full-text search"
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "Collection name"
+
+#: src/components/reader/about-view.tsx
+msgid "+{UNNAMED_FORMAT_COUNT} more"
+msgstr "+{UNNAMED_FORMAT_COUNT} more"
 
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1698,8 +1753,8 @@ msgid "What every control on an article does — including having it read aloud 
 msgstr "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 
 #: src/components/reader/about-view.tsx
-msgid "The reading experience"
-msgstr "The reading experience"
+#~ msgid "The reading experience"
+#~ msgstr "The reading experience"
 
 #: src/routes/_layout.tsx
 msgid "Loading page"
@@ -1736,6 +1791,10 @@ msgstr "The <0>Reading</0> section governs article bodies only, on top of whatev
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "Collections live under <0>Collections</0> in the sidebar. Because publishing one writes a new kind of record to your account, the first time you make one you will be asked to grant an extra permission — that is the <1>Upgrade permissions</1> prompt, and it only appears once."
 #~ msgstr "Collections live under <0>Collections</0> in the sidebar. Because publishing one writes a new kind of record to your account, the first time you make one you will be asked to grant an extra permission — that is the <1>Upgrade permissions</1> prompt, and it only appears once."
+
+#: src/components/reader/about-view.tsx
+msgid "Also read natively:"
+msgstr "Also read natively:"
 
 #. placeholder {0}: pub.name
 #: src/components/reader/article-below-fold.tsx
@@ -1777,8 +1836,8 @@ msgstr "You're subscribed to every publication on this page — scroll for more,
 #~ msgstr "Managing everything you follow"
 
 #: src/components/reader/about-view.tsx
-msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
-msgstr "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+#~ msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+#~ msgstr "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
 
 #: src/routes/_layout.latest.tsx
 msgid "Show all subscriptions"
@@ -1831,8 +1890,8 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {# match} other {# matches}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
-msgstr "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
+#~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
+#~ msgstr "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
 
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Search topics"
@@ -1857,6 +1916,10 @@ msgstr "Articles in collection"
 #: src/components/user-settings-view.tsx
 msgid "System"
 msgstr "System"
+
+#: src/components/reader/about-view.tsx
+msgid "Every feed, directory, and search query the app itself runs."
+msgstr "Every feed, directory, and search query the app itself runs."
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Could not save to {appLabel}"
@@ -1964,8 +2027,8 @@ msgid "Never used"
 msgstr "Never used"
 
 #: src/components/reader/about-view.tsx
-msgid "Building something on the same index? There’s a public API."
-msgstr "Building something on the same index? There’s a public API."
+#~ msgid "Building something on the same index? There’s a public API."
+#~ msgstr "Building something on the same index? There’s a public API."
 
 #: src/components/reader/comments/comments-section.tsx
 msgid "Discussion"
@@ -2196,6 +2259,10 @@ msgstr "Where this collection is published — followers of the series receive i
 msgid "No apps connected"
 msgstr "No apps connected"
 
+#: src/components/reader/about-view.tsx
+msgid "Nothing about it is fixed. Set the measure, the type size, and the typeface to whatever your eyes want, in light or dark, and the setting follows you to every article you open after it."
+msgstr "Nothing about it is fixed. Set the measure, the type size, and the typeface to whatever your eyes want, in light or dark, and the setting follows you to every article you open after it."
+
 #: src/components/reader/markdown-field.tsx
 msgid "Edit"
 msgstr "Edit"
@@ -2215,6 +2282,10 @@ msgstr "Public XRPC queries and procedures for the Standard Reader indexed read-
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Save theme"
 msgstr "Save theme"
+
+#: src/components/reader/about-view.tsx
+msgid "A reply"
+msgstr "A reply"
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "your day: one featured article, then what is new from the publications you subscribe to."
@@ -2397,6 +2468,10 @@ msgstr "Disconnecting it"
 #~ msgid "Carry on browsing. The overlay appears where it is useful and stays out of the way where it is not."
 #~ msgstr "Carry on browsing. The overlay appears where it is useful and stays out of the way where it is not."
 
+#: src/components/reader/about-view.tsx
+msgid "And if your reader of choice is one you already have, any slice of the network comes with its own feed — pipe it straight in and never open this app at all."
+msgstr "And if your reader of choice is one you already have, any slice of the network comes with its own feed — pipe it straight in and never open this app at all."
+
 #: src/components/user-settings-view.tsx
 msgid "To email your digest, Standard Reader needs your account email address. We'll ask your PDS to share it — you'll be sent to your login to approve the request, then brought right back here. Your email is used only to send the weekly digest, and you can turn it off any time."
 msgstr "To email your digest, Standard Reader needs your account email address. We'll ask your PDS to share it — you'll be sent to your login to approve the request, then brought right back here. Your email is used only to send the weekly digest, and you can turn it off any time."
@@ -2406,7 +2481,6 @@ msgid "Where your reading is kept, who else can see it, what you agreed to when 
 msgstr "Where your reading is kept, who else can see it, what you agreed to when you signed in, and how to take it back."
 
 #: src/components/guide/pages/publishing-guide-page.tsx
-#: src/components/reader/about-view.tsx
 #: src/lib/guide/navigation.ts
 msgid "Discovery"
 msgstr "Discovery"
@@ -2533,6 +2607,10 @@ msgstr "On keeping a commonplace book"
 msgid "Most reading apps keep your list of follows on their own servers. If the app shuts down, your list goes with it."
 msgstr "Most reading apps keep your list of follows on their own servers. If the app shuts down, your list goes with it."
 
+#: src/components/reader/about-view.tsx
+msgid "Keep the good sentence"
+msgstr "Keep the good sentence"
+
 #: src/routes/_layout.u.$did.tsx
 msgid "Featured in"
 msgstr "Featured in"
@@ -2624,8 +2702,8 @@ msgid "Paper"
 msgstr "Paper"
 
 #: src/components/reader/about-view.tsx
-msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
-msgstr "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
+#~ msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
+#~ msgstr "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Discover is the directory of every publication the network knows about — not a curated shelf. It runs top to bottom from most personal to most complete:"
@@ -2690,8 +2768,12 @@ msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {follower} other {followers}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
-msgstr "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgstr "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+
+#: src/components/reader/about-view.tsx
+msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself, and every save, like, and subscribe is instantly in sync with whatever device you read on next."
+msgstr "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself, and every save, like, and subscribe is instantly in sync with whatever device you read on next."
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labels"
@@ -2767,6 +2849,10 @@ msgstr "The first time you sign in, a short setup walks you through it: pick a f
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Upgrade to author Collections"
 msgstr "Upgrade to author Collections"
+
+#: src/components/reader/about-view.tsx
+msgid "Render a document in your own app —"
+msgstr "Render a document in your own app —"
 
 #: src/components/reader/privacy-view.tsx
 msgid "Your social actions (follows, likes, saves, lists) are written to your AT Protocol repository and are visible according to the network's rules and your account settings. Our Postgres database holds a network read-model, app session state, and cached public metadata — not the canonical copies of publications."
@@ -2872,6 +2958,10 @@ msgstr "Last updated June 13, 2026"
 msgid "{shown, plural, one {# match} other {# matches}}"
 msgstr "{shown, plural, one {# match} other {# matches}}"
 
+#: src/components/reader/about-view.tsx
+msgid "Select a passage and share it as a typeset card that links back to the article — or keep reading and pick up exactly where you left off next time."
+msgstr "Select a passage and share it as a typeset card that links back to the article — or keep reading and pick up exactly where you left off next time."
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "People you follow write here"
 msgstr "People you follow write here"
@@ -2879,6 +2969,10 @@ msgstr "People you follow write here"
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Good writing rarely turns up while you are already in a reading app. The extension puts saving and subscribing on every page you visit."
 msgstr "Good writing rarely turns up while you are already in a reading app. The extension puts saving and subscribing on every page you visit."
+
+#: src/components/reader/about-view.tsx
+msgid "Drop a Standard document into your own app, in your own framework."
+msgstr "Drop a Standard document into your own app, in your own framework."
 
 #: src/magazine/flow.tsx
 msgid "Original"
@@ -3051,6 +3145,10 @@ msgstr "Drag the pieces into the order you want them read, and publish."
 #: src/components/docs/docs-publishing-nav.tsx
 #~ msgid "Publishing guide"
 #~ msgstr "Publishing guide"
+
+#: src/components/reader/about-view.tsx
+msgid "Prefer the original? Flip one setting and article links open on the publication’s own site instead — Standard Reader will still keep your place."
+msgstr "Prefer the original? Flip one setting and article links open on the publication’s own site instead — Standard Reader will still keep your place."
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "<0>Share</0> copies a link, or posts the article to Bluesky with a proper preview card. On a phone it can hand off to whatever you normally share with."
@@ -3425,6 +3523,10 @@ msgstr "Something went wrong."
 msgid "The best of what you subscribe to"
 msgstr "The best of what you subscribe to"
 
+#: src/components/reader/about-view.tsx
+msgid "Under this article"
+msgstr "Under this article"
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Note"
 msgstr "Note"
@@ -3526,6 +3628,7 @@ msgstr "Generating audio… {percent}%"
 
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
+#: src/components/reader/about-view.tsx
 msgid "Renderers"
 msgstr "Renderers"
 
@@ -3565,8 +3668,8 @@ msgid "What Standard Reader is"
 msgstr "What Standard Reader is"
 
 #: src/components/reader/about-view.tsx
-msgid "Prefer the original?"
-msgstr "Prefer the original?"
+#~ msgid "Prefer the original?"
+#~ msgstr "Prefer the original?"
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Could not add to list"
@@ -3788,6 +3891,10 @@ msgstr "We picked this language from your browser. You can switch it anytime."
 #: src/routes/mcp/authorize.tsx
 msgid "Nothing has been shared. Head back to the app you came from and try connecting again."
 msgstr "Nothing has been shared. Head back to the app you came from and try connecting again."
+
+#: src/components/reader/about-view.tsx
+msgid "“This is the whole argument in one clause. Worth sitting with.”"
+msgstr "“This is the whole argument in one clause. Worth sitting with.”"
 
 #: src/components/reader/text-selection-toolbar.tsx
 msgid "Dismiss selection"
@@ -4013,8 +4120,8 @@ msgid "Save and subscribe from anywhere on the web, without breaking your stride
 msgstr "Save and subscribe from anywhere on the web, without breaking your stride."
 
 #: src/components/reader/about-view.tsx
-msgid "Integrations"
-msgstr "Integrations"
+#~ msgid "Integrations"
+#~ msgstr "Integrations"
 
 #. placeholder {0}: person.subscriberCount
 #. placeholder {0}: pub.subscriberCount
@@ -4137,6 +4244,10 @@ msgstr "Assemble articles into a magazine edition others can read and follow."
 msgid "This request can't be completed here, so we're returning you to the app that sent you."
 msgstr "This request can't be completed here, so we're returning you to the app that sent you."
 
+#: src/components/reader/about-view.tsx
+msgid "Read the docs"
+msgstr "Read the docs"
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No people in this list — add some from the edit dialog."
 msgstr "No people in this list — add some from the edit dialog."
@@ -4167,8 +4278,8 @@ msgid "Browse publications"
 msgstr "Browse publications"
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
-msgstr "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
+#~ msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
+#~ msgstr "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
 
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Choose images"
@@ -4237,6 +4348,10 @@ msgstr "Grouping editions into a series"
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That image is too detailed to fit under 1 MB. Try cropping it first."
 msgstr "That image is too detailed to fit under 1 MB. Try cropping it first."
+
+#: src/components/reader/about-view.tsx
+msgid "“Been thinking about this all week. The measurement is the part that ruins it — not the writing.”"
+msgstr "“Been thinking about this all week. The measurement is the part that ruins it — not the writing.”"
 
 #: src/components/reader/share-menu.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -4310,13 +4425,17 @@ msgstr "Could not load feedback <0>({0})</0>. Try again in a moment."
 msgid "No publications match this tag yet."
 msgstr "No publications match this tag yet."
 
+#: src/components/reader/about-view.tsx
+msgid "Written wherever they write"
+msgstr "Written wherever they write"
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "If you already know what you are looking for, the <0>Add publication</0> button opens a single field that does three things at once. Leave it empty and it shows what is trending. Type a few words and it searches the directory. Paste a handle or a domain — <1>@stdout.dev</1>, <2>stdout.dev</2> — and it looks that author up directly."
 msgstr "If you already know what you are looking for, the <0>Add publication</0> button opens a single field that does three things at once. Leave it empty and it shows what is trending. Type a few words and it searches the directory. Paste a handle or a domain — <1>@stdout.dev</1>, <2>stdout.dev</2> — and it looks that author up directly."
 
 #: src/components/reader/about-view.tsx
-msgid "The conversation, gathered"
-msgstr "The conversation, gathered"
+#~ msgid "The conversation, gathered"
+#~ msgstr "The conversation, gathered"
 
 #: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
@@ -4344,8 +4463,8 @@ msgstr "Publish AT Protocol labels that Standard Reader shows — and can warn o
 #~ msgstr "The exact override mechanism is idiomatic per framework — a components object of functions in React, Vue and Solid, <0>lit-html</0> templates in Lit, snippets in Svelte, or <1><ng-template></1> refs in Angular — but the split and the vocabulary are the same everywhere. See each package's README for the framework-specific shape."
 
 #: src/components/reader/about-view.tsx
-msgid "Save, like, subscribe — everywhere"
-msgstr "Save, like, subscribe — everywhere"
+#~ msgid "Save, like, subscribe — everywhere"
+#~ msgstr "Save, like, subscribe — everywhere"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe?"
@@ -4402,6 +4521,7 @@ msgstr "<0>Shared</0> components render the block and inline vocabulary that eve
 
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
+#: src/components/reader/about-view.tsx
 msgid "API"
 msgstr "API"
 
@@ -4416,6 +4536,10 @@ msgstr "Replace icon"
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unfollow"
 msgstr "Unfollow"
+
+#: src/components/reader/about-view.tsx
+msgid "Standard Reader doesn’t ask you to move in. It goes out to the web you already use, and hands your reading back in whatever shape suits you."
+msgstr "Standard Reader doesn’t ask you to move in. It goes out to the web you already use, and hands your reading back in whatever shape suits you."
 
 #: src/routes/mcp/authorize.tsx
 msgid "Read your library"
@@ -4474,6 +4598,10 @@ msgstr "Authentication"
 #: src/components/reader/terms-view.tsx
 msgid "Changes to these terms"
 msgstr "Changes to these terms"
+
+#: src/components/reader/about-view.tsx
+msgid "Short-form posts and long reads"
+msgstr "Short-form posts and long reads"
 
 #: src/components/reader/about-view.tsx
 msgid "Worth discovering"
@@ -4541,6 +4669,10 @@ msgstr "Text, borders and every other step are derived from these two colors."
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
+
+#: src/components/reader/about-view.tsx
+msgid "And when a run of them turns out to be good together, collect them into a named list — a playlist for reading. Anyone can add the whole thing to their own reader in a single tap."
+msgstr "And when a run of them turns out to be good together, collect them into a named list — a playlist for reading. Anyone can add the whole thing to their own reader in a single tap."
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "Remove {memberName} from list"
@@ -4698,8 +4830,8 @@ msgid "Saves a link to your <0>{appLabel}</0> collection."
 msgstr "Saves a link to your <0>{appLabel}</0> collection."
 
 #: src/components/reader/about-view.tsx
-msgid "In your inbox"
-msgstr "In your inbox"
+#~ msgid "In your inbox"
+#~ msgstr "In your inbox"
 
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Drag to change the order your subscriptions appear in the sidebar."
@@ -4713,6 +4845,7 @@ msgstr "Appearance, reading preferences, and personal data."
 msgid "Authority for <0>app.standard-reader</0> resolves via DNS <1>_lexicon.*</1> TXT records to the publishing account."
 msgstr "Authority for <0>app.standard-reader</0> resolves via DNS <1>_lexicon.*</1> TXT records to the publishing account."
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Margin"
 msgstr "on Margin"
@@ -4749,6 +4882,10 @@ msgstr "Couldn't resolve that handle."
 msgid "Good to know"
 msgstr "Good to know"
 
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across all {countLabel} publications on the network, not just the handful you’ve heard of."
+msgstr "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across all {countLabel} publications on the network, not just the handful you’ve heard of."
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Sharing a review on the <0>ATStore</0> will help both us and other users see what you think about Standard Reader."
 msgstr "Sharing a review on the <0>ATStore</0> will help both us and other users see what you think about Standard Reader."
@@ -4756,6 +4893,10 @@ msgstr "Sharing a review on the <0>ATStore</0> will help both us and other users
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "On Bluesky, quiet badges mark the people whose writing you can read here."
 #~ msgstr "On Bluesky, quiet badges mark the people whose writing you can read here."
+
+#: src/components/reader/about-view.tsx
+msgid "Publish labels others can subscribe to, or consume the ones we do."
+msgstr "Publish labels others can subscribe to, or consume the ones we do."
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "The full account is on the <0>extension privacy page</0>."
@@ -4888,13 +5029,17 @@ msgstr "Nothing to read here yet."
 msgid "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
 msgstr "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
 
+#: src/components/reader/about-view.tsx
+msgid "The part blogging always missed"
+msgstr "The part blogging always missed"
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "The older link rels"
 #~ msgstr "The older link rels"
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader meets you where you read"
-msgstr "Standard Reader meets you where you read"
+#~ msgid "Standard Reader meets you where you read"
+#~ msgstr "Standard Reader meets you where you read"
 
 #: src/components/appearance-settings.tsx
 msgid "Reset appearance"
@@ -5088,6 +5233,10 @@ msgstr "Type size, shape, and density"
 #: src/routes/_layout.latest.tsx
 msgid "All caught up"
 msgstr "All caught up"
+
+#: src/components/reader/about-view.tsx
+msgid "Everything here is linkable, too. Publications, lists, and collections each get a clean URL with a rich preview card — plus a subscribe button a publication can drop straight onto its own site."
+msgstr "Everything here is linkable, too. Publications, lists, and collections each get a clean URL with a rich preview card — plus a subscribe button a publication can drop straight onto its own site."
 
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Reorder subscriptions"
@@ -5284,6 +5433,7 @@ msgstr "Search the network"
 msgid "Search Google Fonts"
 msgstr "Search Google Fonts"
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/article-below-fold.tsx
 msgid "Related reading"
 msgstr "Related reading"
@@ -5522,8 +5672,8 @@ msgid "If something is confusing, broken, or missing, the <0>feedback board</0> 
 msgstr "If something is confusing, broken, or missing, the <0>feedback board</0> is the place to say so. It takes bug reports, feature requests, and plain questions, and you can read and vote on what other people have already asked for."
 
 #: src/components/reader/about-view.tsx
-msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
-msgstr "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+#~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+#~ msgstr "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -5763,8 +5913,8 @@ msgid "Open any article while signed in and it'll show up here. Your history liv
 msgstr "Open any article while signed in and it'll show up here. Your history lives in your repo as <0>app.standard-reader.read</0> records."
 
 #: src/components/reader/about-view.tsx
-msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
-msgstr "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
+#~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
+#~ msgstr "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
@@ -5852,6 +6002,7 @@ msgstr "Uploading images…"
 #: src/components/docs/introduction-docs-page.tsx
 #: src/components/docs/labelers-docs-page.tsx
 #: src/components/labelers-settings-view.tsx
+#: src/components/reader/about-view.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/user-settings-view.tsx
 msgid "Labelers"
@@ -5862,8 +6013,8 @@ msgid "Choose your language"
 msgstr "Choose your language"
 
 #: src/components/reader/about-view.tsx
-msgid "Find the ones you didn't know you wanted"
-msgstr "Find the ones you didn't know you wanted"
+#~ msgid "Find the ones you didn't know you wanted"
+#~ msgstr "Find the ones you didn't know you wanted"
 
 #: src/components/labeler-detail-view.tsx
 msgid "Hide"
@@ -5949,8 +6100,8 @@ msgid "Supported content formats"
 msgstr "Supported content formats"
 
 #: src/components/reader/about-view.tsx
-msgid "Plays nice with the open web"
-msgstr "Plays nice with the open web"
+#~ msgid "Plays nice with the open web"
+#~ msgstr "Plays nice with the open web"
 
 #: src/components/reader/privacy-view.tsx
 msgid "What we collect"
@@ -5975,6 +6126,10 @@ msgstr "Do you like Standard Reader?"
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Use original link"
 msgstr "Use original link"
+
+#: src/components/reader/about-view.tsx
+msgid "Everything this app runs on is public. The schemas are open, the read-model is queryable, and the renderer that draws these pages is published for you to use — so a reading app, a search tool, or a better client than this one is a weekend, not a platform deal."
+msgstr "Everything this app runs on is public. The schemas are open, the read-model is queryable, and the renderer that draws these pages is published for you to use — so a reading app, a search tool, or a better client than this one is a weekend, not a platform deal."
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "Every publication page also serves a themed, embeddable subscribe widget — an iframe you can drop on your own site so visitors can subscribe without leaving your page. The easiest way to get it: open your publication's page on Standard Reader, use <0>Share → Embed subscribe</0>, pick landscape or portrait, and copy the snippet — no account or ownership check required to generate it."
@@ -6117,6 +6272,10 @@ msgstr "No discussion yet."
 msgid "A single publication"
 msgstr "A single publication"
 
+#: src/components/reader/about-view.tsx
+msgid "Build on the same index"
+msgstr "Build on the same index"
+
 #: src/routes/extension.connected.tsx
 msgid "Return to the Standard Reader extension — this tab will close automatically."
 msgstr "Return to the Standard Reader extension — this tab will close automatically."
@@ -6224,6 +6383,10 @@ msgstr "Save and like articles, follow publications and readers, mark things rea
 #: src/components/reader/publication-latest-note.tsx
 msgid "Latest note"
 msgstr "Latest note"
+
+#: src/components/reader/about-view.tsx
+msgid "The record schemas a publication, document, or follow is made of."
+msgstr "The record schemas a publication, document, or follow is made of."
 
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6377,6 +6540,10 @@ msgstr "Landscape"
 msgid "Edit collection"
 msgstr "Edit collection"
 
+#: src/components/reader/about-view.tsx
+msgid "That is a real response from the endpoint this page just called — no key, no sign-up, no rate-limit form. The same is true of every feed, directory, and search query the reader itself runs."
+msgstr "That is a real response from the endpoint this page just called — no key, no sign-up, no rate-limit form. The same is true of every feed, directory, and search query the reader itself runs."
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "After that, following is one button. Anywhere you see a publication — a card in a feed, the top of an article, a publication's own page — there is a <0>Follow</0> button next to its name. Select it again to stop following. Nothing else changes: the button just decides whether new writing from that publication reaches your Home and Latest."
 #~ msgstr "After that, following is one button. Anywhere you see a publication — a card in a feed, the top of an article, a publication's own page — there is a <0>Follow</0> button next to its name. Select it again to stop following. Nothing else changes: the button just decides whether new writing from that publication reaches your Home and Latest."
@@ -6425,8 +6592,12 @@ msgid "Opening the issue…"
 msgstr "Opening the issue…"
 
 #: src/components/reader/about-view.tsx
-msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
-msgstr "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+msgid "However you like to read it"
+msgstr "However you like to read it"
+
+#: src/components/reader/about-view.tsx
+#~ msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+#~ msgstr "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
 
 #: src/routes/_layout.collections.edit.$rkey.tsx
 msgid "We couldn’t load that collection to edit."
@@ -6488,6 +6659,10 @@ msgstr "Standard Reader indexes <0>site.standard.document</0> and <1>site.standa
 #: src/components/reader/list-edit-modal.tsx
 msgid "e.g. Tech, Friends, Cooking"
 msgstr "e.g. Tech, Friends, Cooking"
+
+#: src/components/reader/about-view.tsx
+msgid "Semble"
+msgstr "Semble"
 
 #. placeholder {0}: fmt.relativeTime(connection.lastUsedAt)
 #: src/components/user-settings-view.tsx
@@ -6632,6 +6807,10 @@ msgstr "On"
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."
 msgstr "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."
+
+#: src/components/reader/about-view.tsx
+msgid "Two other pieces link to this one — you can read them from here."
+msgstr "Two other pieces link to this one — you can read them from here."
 
 #: src/components/reader/page-reader-bar.tsx
 msgid "Stop reading"
@@ -6791,6 +6970,10 @@ msgstr "They are public. Not advertised, not put in a feed — but readable by a
 #: src/lib/guide/navigation.ts
 msgid "Finding your way around"
 msgstr "Finding your way around"
+
+#: src/components/reader/about-view.tsx
+msgid "Cited by"
+msgstr "Cited by"
 
 #: src/routes/mcp/authorize.tsx
 msgid "Signed in as"

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -99,6 +99,10 @@ msgstr "Rendering Content in Standard Reader"
 msgid "Articles gaining attention across the network right now."
 msgstr "Articles gaining attention across the network right now."
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# member} other {# members}}"
+msgstr "{value, plural, one {# member} other {# members}}"
+
 #: src/components/reader/collection-builder.tsx
 msgid "Add an article"
 msgstr "Add an article"
@@ -410,9 +414,9 @@ msgstr "Publications written by the people you follow on Bluesky, minus the ones
 msgid "{years}y ago"
 msgstr "{years}y ago"
 
-#: src/components/reader/reorder-lists-modal.tsx
-#~ msgid "List"
-#~ msgstr "List"
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "List"
+msgstr "List"
 
 #: src/components/appearance-settings.tsx
 msgid "The spacing between things — tighter for more on screen, looser for more room to read."
@@ -1971,6 +1975,7 @@ msgstr "The language used for the reader interface. Articles are shown in the la
 #~ msgid "Following, saving, recommending, and — once you follow more than a handful of publications — keeping the whole thing tidy."
 #~ msgstr "Following, saving, recommending, and — once you follow more than a handful of publications — keeping the whole thing tidy."
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 #: src/components/user-settings-view.tsx
 msgid "Feed"
 msgstr "Feed"
@@ -3253,6 +3258,10 @@ msgstr "You agree not to use {SITE_NAME} to:"
 msgid "e.g. Dispatches from the Atmosphere"
 msgstr "e.g. Dispatches from the Atmosphere"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# join} other {# joins}}"
+msgstr "{value, plural, one {# join} other {# joins}}"
+
 #: src/components/docs/introduction-docs-page.tsx
 msgid "the AT Protocol schemas that define Standard records and the shared definitions they build on."
 msgstr "the AT Protocol schemas that define Standard records and the shared definitions they build on."
@@ -3561,6 +3570,10 @@ msgstr "Preview mode"
 #: src/components/site-legal-links.tsx
 msgid "Guide"
 msgstr "Guide"
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# like} other {# likes}}"
+msgstr "{value, plural, one {# like} other {# likes}}"
 
 #: src/routes/_layout.collections.new.tsx
 msgid "On your first collection we create one series to hold them — a special collection you can subscribe to, rename, and theme later."
@@ -4042,6 +4055,10 @@ msgstr "Home, Latest, Discover, search, and topics."
 msgid "{0}+ articles"
 msgstr "{0}+ articles"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "Starter pack"
+msgstr "Starter pack"
+
 #: src/routes/_layout.feedback.return.tsx
 msgid "That link expired."
 msgstr "That link expired."
@@ -4335,6 +4352,10 @@ msgstr "Bluesky didn't answer in time, so this list may be incomplete. Reload to
 #: src/components/reader/article-below-fold.tsx
 msgid "Cited in"
 msgstr "Cited in"
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# follower} other {# followers}}"
+msgstr "{value, plural, one {# follower} other {# followers}}"
 
 #: src/components/user-settings-view.tsx
 msgid "A couple of publications worth discovering."
@@ -5954,6 +5975,10 @@ msgstr "Click Run example to fetch a live response with your session."
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "At the bottom of settings, <0>Personal data</0> deletes categories of records outright: your reading history, your saved articles, or the publication lists you made. Each asks for confirmation and explains what will change."
 msgstr "At the bottom of settings, <0>Personal data</0> deletes categories of records outright: your reading history, your saved articles, or the publication lists you made. Each asks for confirmation and explains what will change."
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "Profile"
+msgstr "Profile"
 
 #: src/components/reader/friend-publishers.tsx
 msgid "{publicationCount, plural, one {# publication} other {# publications}}"

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -2665,6 +2665,10 @@ msgstr "Reordenar {itemTitle}"
 msgid "Back to feedback"
 msgstr "Volver a los comentarios"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "View on {name}"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "{pubTotal, plural, one {# publication} other {# publications}}"
 msgstr "{pubTotal, plural, one {# publicación} other {# publicaciones}}"

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -99,6 +99,10 @@ msgstr "Cómo se muestra el contenido en Standard Reader"
 msgid "Articles gaining attention across the network right now."
 msgstr "Artículos que están ganando atención en la red ahora mismo."
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# member} other {# members}}"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Add an article"
 msgstr "Añadir un artículo"
@@ -410,9 +414,9 @@ msgstr ""
 msgid "{years}y ago"
 msgstr ""
 
-#: src/components/reader/reorder-lists-modal.tsx
-#~ msgid "List"
-#~ msgstr "Lista"
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "List"
+msgstr "Lista"
 
 #: src/components/appearance-settings.tsx
 msgid "The spacing between things — tighter for more on screen, looser for more room to read."
@@ -1971,6 +1975,7 @@ msgstr "El idioma de la interfaz del lector. Los artículos se muestran en el id
 #~ msgid "Following, saving, recommending, and — once you follow more than a handful of publications — keeping the whole thing tidy."
 #~ msgstr ""
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 #: src/components/user-settings-view.tsx
 msgid "Feed"
 msgstr ""
@@ -3253,6 +3258,10 @@ msgstr ""
 msgid "e.g. Dispatches from the Atmosphere"
 msgstr "p. ej. Crónicas desde la Atmosphere"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# join} other {# joins}}"
+msgstr ""
+
 #: src/components/docs/introduction-docs-page.tsx
 msgid "the AT Protocol schemas that define Standard records and the shared definitions they build on."
 msgstr ""
@@ -3560,6 +3569,10 @@ msgstr "Modo de vista previa"
 #: src/components/NavbarAuth.tsx
 #: src/components/site-legal-links.tsx
 msgid "Guide"
+msgstr ""
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# like} other {# likes}}"
 msgstr ""
 
 #: src/routes/_layout.collections.new.tsx
@@ -4042,6 +4055,10 @@ msgstr ""
 msgid "{0}+ articles"
 msgstr "Más de {0} artículos"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "Starter pack"
+msgstr ""
+
 #: src/routes/_layout.feedback.return.tsx
 msgid "That link expired."
 msgstr "Ese enlace caducó."
@@ -4335,6 +4352,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "Cited in"
 msgstr "Citado en"
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# follower} other {# followers}}"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "A couple of publications worth discovering."
@@ -5953,6 +5974,10 @@ msgstr "Haga clic en Ejecutar ejemplo para obtener una respuesta en vivo con su 
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "At the bottom of settings, <0>Personal data</0> deletes categories of records outright: your reading history, your saved articles, or the publication lists you made. Each asks for confirmation and explains what will change."
+msgstr ""
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "Profile"
 msgstr ""
 
 #: src/components/reader/friend-publishers.tsx

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -123,12 +123,12 @@ msgid "Every renderer takes one input for the document — the content payload o
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "One tap from the reading view, on any device, instantly in sync. Your library is always where you left it."
-msgstr "Un toque desde la vista de lectura, en cualquier dispositivo, sincronizado al instante. Su biblioteca siempre está donde la dejó."
+#~ msgid "One tap from the reading view, on any device, instantly in sync. Your library is always where you left it."
+#~ msgstr "Un toque desde la vista de lectura, en cualquier dispositivo, sincronizado al instante. Su biblioteca siempre está donde la dejó."
 
 #: src/components/reader/about-view.tsx
-msgid "Curated lists & collections"
-msgstr "Listas y colecciones seleccionadas"
+#~ msgid "Curated lists & collections"
+#~ msgstr "Listas y colecciones seleccionadas"
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Vue 3."
@@ -179,6 +179,7 @@ msgstr ""
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
 #: src/components/docs/lexicon-docs-intro.tsx
+#: src/components/reader/about-view.tsx
 msgid "Lexicons"
 msgstr "Lexicons"
 
@@ -256,6 +257,10 @@ msgstr "Añada un título."
 #~ msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Follow it and it starts appearing in your feeds like any other."
 #~ msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -302,8 +307,8 @@ msgid "(this is what Standard Reader itself uses)"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
-msgstr "Y nunca se siente aislado. Conectamos cada artículo con la conversación que ocurre en la Atmosphere —la red abierta más allá de esta app—, reuniendo los posts y respuestas de Bluesky sobre una pieza, las notas dejadas en sus márgenes y los demás textos que la citan, discretamente bajo lo que está leyendo."
+#~ msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+#~ msgstr "Y nunca se siente aislado. Conectamos cada artículo con la conversación que ocurre en la Atmosphere —la red abierta más allá de esta app—, reuniendo los posts y respuestas de Bluesky sobre una pieza, las notas dejadas en sus márgenes y los demás textos que la citan, discretamente bajo lo que está leyendo."
 
 #: src/components/guide/guide-shell.tsx
 msgid "Still stuck, or something here doesn't match what you see? <0>Tell us on the feedback board</0> — questions are welcome there, not just bug reports."
@@ -316,6 +321,10 @@ msgstr "en curso…"
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Your Home feed is built from subscriptions. Three is a good start."
 msgstr "Su feed de Inicio se construye con sus suscripciones. Tres es un buen comienzo."
+
+#: src/components/reader/about-view.tsx
+msgid "A note in the margin"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Colors"
@@ -389,6 +398,10 @@ msgstr "Suscribiendo…"
 msgid "People"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Every piece is a door to the next one"
+msgstr ""
+
 #: src/routes/_layout.friends.tsx
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 msgstr ""
@@ -417,6 +430,7 @@ msgstr ""
 msgid "Switch to light paper"
 msgstr "Cambiar a papel claro"
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Bluesky"
 msgstr "en Bluesky"
@@ -426,8 +440,8 @@ msgid "Set these now, or change them any time in Settings."
 msgstr "Configúrelos ahora o cámbielos cuando quiera en Configuración."
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
-msgstr "La mayoría de los lectores se quedan en lo que ya siguen. Standard Reader considera que encontrar su próximo favorito es parte del trabajo. Explore todas las publicaciones de la red, no solo el puñado del que ya ha oído hablar."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
+#~ msgstr "La mayoría de los lectores se quedan en lo que ya siguen. Standard Reader considera que encontrar su próximo favorito es parte del trabajo. Explore todas las publicaciones de la red, no solo el puñado del que ya ha oído hablar."
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Open <0>Collections</0> in the sidebar and start a new one."
@@ -682,8 +696,8 @@ msgid "Making a collection"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Read the guide"
-msgstr ""
+#~ msgid "Read the guide"
+#~ msgstr ""
 
 #: src/components/reader/app-shell.tsx
 #: src/components/site-legal-links.tsx
@@ -811,6 +825,10 @@ msgstr "Privacidad de la extensión"
 msgid "Signing in"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Public API — no key required"
+msgstr ""
+
 #: src/components/reading-settings-preview.tsx
 msgid "Loading voice sample"
 msgstr "Cargando muestra de voz"
@@ -874,6 +892,11 @@ msgstr "Reintentar"
 
 #: src/lib/guide/navigation.ts
 msgid "Welcome"
+msgstr ""
+
+#. placeholder {0}: SUPPORTED_CONTENT_FORMATS.size
+#: src/components/reader/about-view.tsx
+msgid "An article is a record in its author’s own repository, and every publishing tool on the network writes that record a little differently. Standard Reader reads {0} of those content formats and renders them all into the same calm page — so a reader never has to care which tool a writer chose."
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -1003,6 +1026,10 @@ msgstr ""
 msgid "Bookmarks"
 msgstr "Marcadores"
 
+#: src/components/reader/about-view.tsx
+msgid "None of this is ours. We gather it from the Atmosphere — the open network these apps all share — and show it under the piece it’s about. Every line links back to where it was actually written, no account or comment box required, and it works whether or not the author ever opted in."
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Saved to {savedName} on {appLabel}."
 msgstr "Guardado en {savedName} en {appLabel}."
@@ -1057,6 +1084,10 @@ msgstr "Una sala de lectura tranquila para la web abierta. Dediquemos dos minuto
 #: src/routes/_layout.collections.index.tsx
 msgid "New series"
 msgstr "Nueva serie"
+
+#: src/components/reader/about-view.tsx
+msgid "Blogs never really solved the conversation. Comment boxes belonged to the blog, went unread, filled with spam, and vanished when the site did. So the talking moved somewhere else — and stopped being attached to the writing at all."
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "These deletions remove the records from your account itself, not just from our copy — which is why they cannot be undone. Deleting your reading history, for example, makes everything look unread again everywhere."
@@ -1130,6 +1161,10 @@ msgstr ""
 msgid "Under that, <0>Cited in</0> lists other articles that link to this one, and <1>Related reading</1> suggests pieces from across the network on the same subjects — usually from publications you have not met yet."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Essays and serialized writing"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 #~ msgid "Following your first publications"
@@ -1182,8 +1217,8 @@ msgid "Custom"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Read the API docs"
-msgstr "Leer la documentación de la API"
+#~ msgid "Read the API docs"
+#~ msgstr "Leer la documentación de la API"
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Select <0>Listen</0> in the top bar and the article is read aloud. The first time takes a few seconds to warm up; after that it starts straight away."
@@ -1198,8 +1233,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Shareable everywhere"
-msgstr "Se puede compartir en cualquier sitio"
+#~ msgid "Shareable everywhere"
+#~ msgstr "Se puede compartir en cualquier sitio"
 
 #: src/magazine/Magazine.tsx
 msgid "Close table of contents"
@@ -1232,6 +1267,10 @@ msgstr ""
 
 #: src/components/docs/introduction-docs-page.tsx
 msgid "how to make a site discoverable on Standard and have its content read inline, without adopting a platform."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across every publication on the network, not just the handful you’ve heard of."
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -1303,6 +1342,10 @@ msgstr ""
 msgid "To move several at once, open <0>Subscriptions</0>, select the rows you want, and add them all to a list in one action. That is much faster than doing it publication by publication."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Blocks, pages, and footnotes"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Appearance"
 msgstr "Apariencia"
@@ -1354,6 +1397,10 @@ msgstr "Cuenta"
 msgid "Collapse all lists"
 msgstr "Contraer todas las listas"
 
+#: src/components/reader/about-view.tsx
+msgid "Four essays covering the same ground, from publications you don’t follow yet."
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "We couldn’t find that article."
 msgstr "No encontramos ese artículo."
@@ -1388,6 +1435,10 @@ msgstr "su colección"
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“…made to be read, and not to be measured.”"
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -1505,6 +1556,10 @@ msgstr "Búsqueda rápida de texto completo"
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "Nombre de la colección"
+
+#: src/components/reader/about-view.tsx
+msgid "+{UNNAMED_FORMAT_COUNT} more"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1698,8 +1753,8 @@ msgid "What every control on an article does — including having it read aloud 
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "The reading experience"
-msgstr "La experiencia de lectura"
+#~ msgid "The reading experience"
+#~ msgstr "La experiencia de lectura"
 
 #: src/routes/_layout.tsx
 msgid "Loading page"
@@ -1736,6 +1791,10 @@ msgstr ""
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "Collections live under <0>Collections</0> in the sidebar. Because publishing one writes a new kind of record to your account, the first time you make one you will be asked to grant an extra permission — that is the <1>Upgrade permissions</1> prompt, and it only appears once."
 #~ msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Also read natively:"
+msgstr ""
 
 #. placeholder {0}: pub.name
 #: src/components/reader/article-below-fold.tsx
@@ -1777,8 +1836,8 @@ msgstr "Está suscrito a todas las publicaciones de esta página: siga desplazá
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
-msgstr "Debajo de cada artículo verá la conversación de toda la red abierta: publicaciones y respuestas de Bluesky, notas al margen, enlaces desde otros textos que lo citan y lecturas relacionadas. Todo de solo lectura y todo enlazado a la fuente."
+#~ msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+#~ msgstr "Debajo de cada artículo verá la conversación de toda la red abierta: publicaciones y respuestas de Bluesky, notas al margen, enlaces desde otros textos que lo citan y lecturas relacionadas. Todo de solo lectura y todo enlazado a la fuente."
 
 #: src/routes/_layout.latest.tsx
 msgid "Show all subscriptions"
@@ -1831,8 +1890,8 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {# coincidencia} other {# coincidencias}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
-msgstr "Las publicaciones, las listas y las colecciones tienen cada una un enlace limpio con una tarjeta de vista previa enriquecida, además de un botón de suscripción que una publicación puede colocar en su propio sitio."
+#~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
+#~ msgstr "Las publicaciones, las listas y las colecciones tienen cada una un enlace limpio con una tarjeta de vista previa enriquecida, además de un botón de suscripción que una publicación puede colocar en su propio sitio."
 
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Search topics"
@@ -1857,6 +1916,10 @@ msgstr "Artículos de la colección"
 #: src/components/user-settings-view.tsx
 msgid "System"
 msgstr "Sistema"
+
+#: src/components/reader/about-view.tsx
+msgid "Every feed, directory, and search query the app itself runs."
+msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Could not save to {appLabel}"
@@ -1964,8 +2027,8 @@ msgid "Never used"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Building something on the same index? There’s a public API."
-msgstr "¿Está creando algo sobre el mismo índice? Hay una API pública."
+#~ msgid "Building something on the same index? There’s a public API."
+#~ msgstr "¿Está creando algo sobre el mismo índice? Hay una API pública."
 
 #: src/components/reader/comments/comments-section.tsx
 msgid "Discussion"
@@ -2196,6 +2259,10 @@ msgstr "Dónde se publica esta colección: quienes siguen la serie la reciben."
 msgid "No apps connected"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Nothing about it is fixed. Set the measure, the type size, and the typeface to whatever your eyes want, in light or dark, and the setting follows you to every article you open after it."
+msgstr ""
+
 #: src/components/reader/markdown-field.tsx
 msgid "Edit"
 msgstr "Editar"
@@ -2215,6 +2282,10 @@ msgstr "Consultas y procedimientos XRPC públicos para el modelo de lectura inde
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Save theme"
 msgstr "Guardar tema"
+
+#: src/components/reader/about-view.tsx
+msgid "A reply"
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "your day: one featured article, then what is new from the publications you subscribe to."
@@ -2397,6 +2468,10 @@ msgstr ""
 #~ msgid "Carry on browsing. The overlay appears where it is useful and stays out of the way where it is not."
 #~ msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "And if your reader of choice is one you already have, any slice of the network comes with its own feed — pipe it straight in and never open this app at all."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "To email your digest, Standard Reader needs your account email address. We'll ask your PDS to share it — you'll be sent to your login to approve the request, then brought right back here. Your email is used only to send the weekly digest, and you can turn it off any time."
 msgstr "Para enviarle su resumen por correo, Standard Reader necesita la dirección de correo de su cuenta. Se la pediremos a su PDS: irá a su inicio de sesión para aprobar la solicitud y volverá aquí de inmediato. Su correo se usa únicamente para enviar el resumen semanal y puede desactivarlo cuando quiera."
@@ -2406,7 +2481,6 @@ msgid "Where your reading is kept, who else can see it, what you agreed to when 
 msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
-#: src/components/reader/about-view.tsx
 #: src/lib/guide/navigation.ts
 msgid "Discovery"
 msgstr "Descubrimiento"
@@ -2533,6 +2607,10 @@ msgstr "Sobre llevar un cuaderno de citas"
 msgid "Most reading apps keep your list of follows on their own servers. If the app shuts down, your list goes with it."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Keep the good sentence"
+msgstr ""
+
 #: src/routes/_layout.u.$did.tsx
 msgid "Featured in"
 msgstr "Aparece en"
@@ -2624,8 +2702,8 @@ msgid "Paper"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
-msgstr "Cambie un ajuste y los enlaces de los artículos se abrirán en el sitio propio de la publicación. Lea donde mejor le funcione."
+#~ msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
+#~ msgstr "Cambie un ajuste y los enlaces de los artículos se abrirán en el sitio propio de la publicación. Lea donde mejor le funcione."
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Discover is the directory of every publication the network knows about — not a curated shelf. It runs top to bottom from most personal to most complete:"
@@ -2690,8 +2768,12 @@ msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {seguidor} other {seguidores}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
-msgstr "La mayoría de los lectores se quedan en lo que ya siguen. Standard Reader considera que encontrar su próximo favorito es parte del trabajo. Explore las {countLabel} publicaciones de la red, no solo el puñado del que ha oído hablar."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgstr "La mayoría de los lectores se quedan en lo que ya siguen. Standard Reader considera que encontrar su próximo favorito es parte del trabajo. Explore las {countLabel} publicaciones de la red, no solo el puñado del que ha oído hablar."
+
+#: src/components/reader/about-view.tsx
+msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself, and every save, like, and subscribe is instantly in sync with whatever device you read on next."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labels"
@@ -2767,6 +2849,10 @@ msgstr ""
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Upgrade to author Collections"
 msgstr "Mejorar el plan para crear colecciones"
+
+#: src/components/reader/about-view.tsx
+msgid "Render a document in your own app —"
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "Your social actions (follows, likes, saves, lists) are written to your AT Protocol repository and are visible according to the network's rules and your account settings. Our Postgres database holds a network read-model, app session state, and cached public metadata — not the canonical copies of publications."
@@ -2872,12 +2958,20 @@ msgstr "Última actualización: 13 de junio de 2026"
 msgid "{shown, plural, one {# match} other {# matches}}"
 msgstr "{shown, plural, one {# coincidencia} other {# coincidencias}}"
 
+#: src/components/reader/about-view.tsx
+msgid "Select a passage and share it as a typeset card that links back to the article — or keep reading and pick up exactly where you left off next time."
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "People you follow write here"
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Good writing rarely turns up while you are already in a reading app. The extension puts saving and subscribing on every page you visit."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Drop a Standard document into your own app, in your own framework."
 msgstr ""
 
 #: src/magazine/flow.tsx
@@ -3051,6 +3145,10 @@ msgstr ""
 #: src/components/docs/docs-publishing-nav.tsx
 #~ msgid "Publishing guide"
 #~ msgstr "Guía de publicación"
+
+#: src/components/reader/about-view.tsx
+msgid "Prefer the original? Flip one setting and article links open on the publication’s own site instead — Standard Reader will still keep your place."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "<0>Share</0> copies a link, or posts the article to Bluesky with a proper preview card. On a phone it can hand off to whatever you normally share with."
@@ -3425,6 +3523,10 @@ msgstr "Algo salió mal."
 msgid "The best of what you subscribe to"
 msgstr "Lo mejor de lo que sigue"
 
+#: src/components/reader/about-view.tsx
+msgid "Under this article"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Note"
 msgstr "Nota"
@@ -3526,6 +3628,7 @@ msgstr "Generando audio… {percent} %"
 
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
+#: src/components/reader/about-view.tsx
 msgid "Renderers"
 msgstr ""
 
@@ -3565,8 +3668,8 @@ msgid "What Standard Reader is"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Prefer the original?"
-msgstr "¿Prefiere el original?"
+#~ msgid "Prefer the original?"
+#~ msgstr "¿Prefiere el original?"
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Could not add to list"
@@ -3787,6 +3890,10 @@ msgstr "Elegimos este idioma según su navegador. Puede cambiarlo cuando quiera.
 
 #: src/routes/mcp/authorize.tsx
 msgid "Nothing has been shared. Head back to the app you came from and try connecting again."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“This is the whole argument in one clause. Worth sitting with.”"
 msgstr ""
 
 #: src/components/reader/text-selection-toolbar.tsx
@@ -4013,8 +4120,8 @@ msgid "Save and subscribe from anywhere on the web, without breaking your stride
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Integrations"
-msgstr "Integraciones"
+#~ msgid "Integrations"
+#~ msgstr "Integraciones"
 
 #. placeholder {0}: person.subscriberCount
 #. placeholder {0}: pub.subscriberCount
@@ -4137,6 +4244,10 @@ msgstr ""
 msgid "This request can't be completed here, so we're returning you to the app that sent you."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Read the docs"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No people in this list — add some from the edit dialog."
 msgstr "No hay personas en esta lista; añada algunas desde el cuadro de edición."
@@ -4167,8 +4278,8 @@ msgid "Browse publications"
 msgstr "Explorar publicaciones"
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
-msgstr "Standard Reader no encierra su lectura en una sola app. Cualquier parte de la red viene con su propio feed RSS: conéctelo directamente al lector que ya usa."
+#~ msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
+#~ msgstr "Standard Reader no encierra su lectura en una sola app. Cualquier parte de la red viene con su propio feed RSS: conéctelo directamente al lector que ya usa."
 
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Choose images"
@@ -4236,6 +4347,10 @@ msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That image is too detailed to fit under 1 MB. Try cropping it first."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“Been thinking about this all week. The measurement is the part that ruins it — not the writing.”"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -4310,13 +4425,17 @@ msgstr "No se pudieron cargar los comentarios <0>({0})</0>. Inténtelo de nuevo 
 msgid "No publications match this tag yet."
 msgstr "Todavía no hay publicaciones con esta etiqueta."
 
+#: src/components/reader/about-view.tsx
+msgid "Written wherever they write"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "If you already know what you are looking for, the <0>Add publication</0> button opens a single field that does three things at once. Leave it empty and it shows what is trending. Type a few words and it searches the directory. Paste a handle or a domain — <1>@stdout.dev</1>, <2>stdout.dev</2> — and it looks that author up directly."
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "The conversation, gathered"
-msgstr "La conversación, reunida"
+#~ msgid "The conversation, gathered"
+#~ msgstr "La conversación, reunida"
 
 #: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
@@ -4344,8 +4463,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Save, like, subscribe — everywhere"
-msgstr "Guardar, dar me gusta, suscribirse: en todas partes"
+#~ msgid "Save, like, subscribe — everywhere"
+#~ msgstr "Guardar, dar me gusta, suscribirse: en todas partes"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe?"
@@ -4402,6 +4521,7 @@ msgstr ""
 
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
+#: src/components/reader/about-view.tsx
 msgid "API"
 msgstr "API"
 
@@ -4415,6 +4535,10 @@ msgstr "Reemplazar ícono"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unfollow"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Standard Reader doesn’t ask you to move in. It goes out to the web you already use, and hands your reading back in whatever shape suits you."
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx
@@ -4473,6 +4597,10 @@ msgstr "Autenticación"
 
 #: src/components/reader/terms-view.tsx
 msgid "Changes to these terms"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Short-form posts and long reads"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -4541,6 +4669,10 @@ msgstr ""
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "Si instala la extensión de navegador de {SITE_NAME}, esta usa la misma cuenta y cookie de sesión que este sitio. La extensión envía las URL de las páginas a nuestros endpoints <0>/api/extension/*</0> para cotejar el índice y guarda los ajustes de la superposición en el almacenamiento de extensiones del navegador. Consulte la <1>política de privacidad de la extensión</1> para conocer los detalles que aplican solo a la extensión."
+
+#: src/components/reader/about-view.tsx
+msgid "And when a run of them turns out to be good together, collect them into a named list — a playlist for reading. Anyone can add the whole thing to their own reader in a single tap."
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "Remove {memberName} from list"
@@ -4698,8 +4830,8 @@ msgid "Saves a link to your <0>{appLabel}</0> collection."
 msgstr "Guarda un enlace en su colección de <0>{appLabel}</0>."
 
 #: src/components/reader/about-view.tsx
-msgid "In your inbox"
-msgstr "En su bandeja de entrada"
+#~ msgid "In your inbox"
+#~ msgstr "En su bandeja de entrada"
 
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Drag to change the order your subscriptions appear in the sidebar."
@@ -4713,6 +4845,7 @@ msgstr "Apariencia, preferencias de lectura y datos personales."
 msgid "Authority for <0>app.standard-reader</0> resolves via DNS <1>_lexicon.*</1> TXT records to the publishing account."
 msgstr "La autoridad de <0>app.standard-reader</0> se resuelve mediante registros TXT de DNS <1>_lexicon.*</1> hacia la cuenta que publica."
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Margin"
 msgstr "en Margin"
@@ -4749,6 +4882,10 @@ msgstr "No se pudo resolver ese handle."
 msgid "Good to know"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across all {countLabel} publications on the network, not just the handful you’ve heard of."
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Sharing a review on the <0>ATStore</0> will help both us and other users see what you think about Standard Reader."
 msgstr "Compartir una reseña en <0>ATStore</0> nos ayudará, tanto a nosotros como a otros usuarios, a saber qué opina de Standard Reader."
@@ -4756,6 +4893,10 @@ msgstr "Compartir una reseña en <0>ATStore</0> nos ayudará, tanto a nosotros c
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "On Bluesky, quiet badges mark the people whose writing you can read here."
 #~ msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Publish labels others can subscribe to, or consume the ones we do."
+msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "The full account is on the <0>extension privacy page</0>."
@@ -4888,13 +5029,17 @@ msgstr "Todavía no hay nada que leer aquí."
 msgid "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
 msgstr "Los etiquetadores son servicios de moderación a los que se suscribe por DID. Suscríbase para ver sus etiquetas — y difuminar u ocultar las publicaciones etiquetadas — mientras lee."
 
+#: src/components/reader/about-view.tsx
+msgid "The part blogging always missed"
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "The older link rels"
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader meets you where you read"
-msgstr "Standard Reader lo acompaña donde lee"
+#~ msgid "Standard Reader meets you where you read"
+#~ msgstr "Standard Reader lo acompaña donde lee"
 
 #: src/components/appearance-settings.tsx
 msgid "Reset appearance"
@@ -5088,6 +5233,10 @@ msgstr ""
 #: src/routes/_layout.latest.tsx
 msgid "All caught up"
 msgstr "Todo al día"
+
+#: src/components/reader/about-view.tsx
+msgid "Everything here is linkable, too. Publications, lists, and collections each get a clean URL with a rich preview card — plus a subscribe button a publication can drop straight onto its own site."
+msgstr ""
 
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Reorder subscriptions"
@@ -5284,6 +5433,7 @@ msgstr "Buscar en la red"
 msgid "Search Google Fonts"
 msgstr "Buscar en Google Fonts"
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/article-below-fold.tsx
 msgid "Related reading"
 msgstr "Lecturas relacionadas"
@@ -5522,8 +5672,8 @@ msgid "If something is confusing, broken, or missing, the <0>feedback board</0> 
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
-msgstr "Una extensión de navegador ligera le permite guardar publicaciones y suscribirse a ellas mientras navega por la web, con distintivos sutiles en bsky.app y una superposición de un clic en cualquier página que visite. Su lista de lectura se llena sola."
+#~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+#~ msgstr "Una extensión de navegador ligera le permite guardar publicaciones y suscribirse a ellas mientras navega por la web, con distintivos sutiles en bsky.app y una superposición de un clic en cualquier página que visite. Su lista de lectura se llena sola."
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -5763,8 +5913,8 @@ msgid "Open any article while signed in and it'll show up here. Your history liv
 msgstr "Abra cualquier artículo con la sesión iniciada y aparecerá aquí. Su historial vive en su repositorio como registros <0>app.standard-reader.read</0>."
 
 #: src/components/reader/about-view.tsx
-msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
-msgstr "Cree listas de publicaciones con nombre y fáciles de compartir: una playlist para leer. Cualquiera puede añadir su lista a su propio lector con un solo toque."
+#~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
+#~ msgstr "Cree listas de publicaciones con nombre y fáciles de compartir: una playlist para leer. Cualquiera puede añadir su lista a su propio lector con un solo toque."
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
@@ -5852,6 +6002,7 @@ msgstr ""
 #: src/components/docs/introduction-docs-page.tsx
 #: src/components/docs/labelers-docs-page.tsx
 #: src/components/labelers-settings-view.tsx
+#: src/components/reader/about-view.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/user-settings-view.tsx
 msgid "Labelers"
@@ -5862,8 +6013,8 @@ msgid "Choose your language"
 msgstr "Elija su idioma"
 
 #: src/components/reader/about-view.tsx
-msgid "Find the ones you didn't know you wanted"
-msgstr "Encuentre las que no sabía que quería"
+#~ msgid "Find the ones you didn't know you wanted"
+#~ msgstr "Encuentre las que no sabía que quería"
 
 #: src/components/labeler-detail-view.tsx
 msgid "Hide"
@@ -5949,8 +6100,8 @@ msgid "Supported content formats"
 msgstr "Formatos de contenido compatibles"
 
 #: src/components/reader/about-view.tsx
-msgid "Plays nice with the open web"
-msgstr "Se lleva bien con la web abierta"
+#~ msgid "Plays nice with the open web"
+#~ msgstr "Se lleva bien con la web abierta"
 
 #: src/components/reader/privacy-view.tsx
 msgid "What we collect"
@@ -5975,6 +6126,10 @@ msgstr "¿Le gusta Standard Reader?"
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Use original link"
 msgstr "Usar el enlace original"
+
+#: src/components/reader/about-view.tsx
+msgid "Everything this app runs on is public. The schemas are open, the read-model is queryable, and the renderer that draws these pages is published for you to use — so a reading app, a search tool, or a better client than this one is a weekend, not a platform deal."
+msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "Every publication page also serves a themed, embeddable subscribe widget — an iframe you can drop on your own site so visitors can subscribe without leaving your page. The easiest way to get it: open your publication's page on Standard Reader, use <0>Share → Embed subscribe</0>, pick landscape or portrait, and copy the snippet — no account or ownership check required to generate it."
@@ -6117,6 +6272,10 @@ msgstr "Aún no hay conversación."
 msgid "A single publication"
 msgstr "Una sola publicación"
 
+#: src/components/reader/about-view.tsx
+msgid "Build on the same index"
+msgstr ""
+
 #: src/routes/extension.connected.tsx
 msgid "Return to the Standard Reader extension — this tab will close automatically."
 msgstr "Vuelva a la extensión de Standard Reader: esta pestaña se cerrará automáticamente."
@@ -6224,6 +6383,10 @@ msgstr ""
 #: src/components/reader/publication-latest-note.tsx
 msgid "Latest note"
 msgstr "Última nota"
+
+#: src/components/reader/about-view.tsx
+msgid "The record schemas a publication, document, or follow is made of."
+msgstr ""
 
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6377,6 +6540,10 @@ msgstr "Horizontal"
 msgid "Edit collection"
 msgstr "Editar colección"
 
+#: src/components/reader/about-view.tsx
+msgid "That is a real response from the endpoint this page just called — no key, no sign-up, no rate-limit form. The same is true of every feed, directory, and search query the reader itself runs."
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "After that, following is one button. Anywhere you see a publication — a card in a feed, the top of an article, a publication's own page — there is a <0>Follow</0> button next to its name. Select it again to stop following. Nothing else changes: the button just decides whether new writing from that publication reaches your Home and Latest."
 #~ msgstr ""
@@ -6425,8 +6592,12 @@ msgid "Opening the issue…"
 msgstr "Abriendo el número…"
 
 #: src/components/reader/about-view.tsx
-msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
-msgstr "No le pide dejar atrás el resto de la web. Se acerca a ella y sigue siendo un buen ciudadano de la red en general."
+msgid "However you like to read it"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+#~ msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+#~ msgstr "No le pide dejar atrás el resto de la web. Se acerca a ella y sigue siendo un buen ciudadano de la red en general."
 
 #: src/routes/_layout.collections.edit.$rkey.tsx
 msgid "We couldn’t load that collection to edit."
@@ -6488,6 +6659,10 @@ msgstr "Standard Reader indexa registros <0>site.standard.document</0> y <1>site
 #: src/components/reader/list-edit-modal.tsx
 msgid "e.g. Tech, Friends, Cooking"
 msgstr "p. ej. Tecnología, Amigos, Cocina"
+
+#: src/components/reader/about-view.tsx
+msgid "Semble"
+msgstr ""
 
 #. placeholder {0}: fmt.relativeTime(connection.lastUsedAt)
 #: src/components/user-settings-view.tsx
@@ -6631,6 +6806,10 @@ msgstr "Activado"
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Two other pieces link to this one — you can read them from here."
 msgstr ""
 
 #: src/components/reader/page-reader-bar.tsx
@@ -6790,6 +6969,10 @@ msgstr ""
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Finding your way around"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Cited by"
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -123,12 +123,12 @@ msgid "Every renderer takes one input for the document — the content payload o
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "One tap from the reading view, on any device, instantly in sync. Your library is always where you left it."
-msgstr "Un geste depuis la vue de lecture, sur n’importe quel appareil, synchronisé instantanément. Votre bibliothèque reste toujours là où vous l’avez laissée."
+#~ msgid "One tap from the reading view, on any device, instantly in sync. Your library is always where you left it."
+#~ msgstr "Un geste depuis la vue de lecture, sur n’importe quel appareil, synchronisé instantanément. Votre bibliothèque reste toujours là où vous l’avez laissée."
 
 #: src/components/reader/about-view.tsx
-msgid "Curated lists & collections"
-msgstr "Listes et collections triées sur le volet"
+#~ msgid "Curated lists & collections"
+#~ msgstr "Listes et collections triées sur le volet"
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Vue 3."
@@ -179,6 +179,7 @@ msgstr ""
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
 #: src/components/docs/lexicon-docs-intro.tsx
+#: src/components/reader/about-view.tsx
 msgid "Lexicons"
 msgstr "Lexicons"
 
@@ -256,6 +257,10 @@ msgstr "Veuillez ajouter un titre."
 #~ msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Follow it and it starts appearing in your feeds like any other."
 #~ msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -302,8 +307,8 @@ msgid "(this is what Standard Reader itself uses)"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
-msgstr "Et rien n’y semble cloisonné. Nous relions chaque article à la conversation qui se tient dans l’Atmosphere — le réseau ouvert au-delà de cette application — en rassemblant les posts et réponses Bluesky à son sujet, les notes laissées dans ses marges et les autres textes qui le citent, discrètement sous ce que vous lisez."
+#~ msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+#~ msgstr "Et rien n’y semble cloisonné. Nous relions chaque article à la conversation qui se tient dans l’Atmosphere — le réseau ouvert au-delà de cette application — en rassemblant les posts et réponses Bluesky à son sujet, les notes laissées dans ses marges et les autres textes qui le citent, discrètement sous ce que vous lisez."
 
 #: src/components/guide/guide-shell.tsx
 msgid "Still stuck, or something here doesn't match what you see? <0>Tell us on the feedback board</0> — questions are welcome there, not just bug reports."
@@ -316,6 +321,10 @@ msgstr "en cours…"
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Your Home feed is built from subscriptions. Three is a good start."
 msgstr "Votre fil d’accueil se construit à partir de vos abonnements. Trois, c’est un bon début."
+
+#: src/components/reader/about-view.tsx
+msgid "A note in the margin"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Colors"
@@ -389,6 +398,10 @@ msgstr "Abonnement en cours…"
 msgid "People"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Every piece is a door to the next one"
+msgstr ""
+
 #: src/routes/_layout.friends.tsx
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 msgstr ""
@@ -417,6 +430,7 @@ msgstr ""
 msgid "Switch to light paper"
 msgstr "Passer au papier clair"
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Bluesky"
 msgstr "sur Bluesky"
@@ -426,8 +440,8 @@ msgid "Set these now, or change them any time in Settings."
 msgstr "Réglez cela maintenant, ou modifiez-le à tout moment dans les Paramètres."
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
-msgstr "La plupart des lecteurs s’arrêtent à ce qu’ils suivent déjà. Standard Reader considère la découverte de votre prochain coup de cœur comme faisant partie du travail. Parcourez toutes les publications du réseau — pas seulement celles dont vous avez entendu parler."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
+#~ msgstr "La plupart des lecteurs s’arrêtent à ce qu’ils suivent déjà. Standard Reader considère la découverte de votre prochain coup de cœur comme faisant partie du travail. Parcourez toutes les publications du réseau — pas seulement celles dont vous avez entendu parler."
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Open <0>Collections</0> in the sidebar and start a new one."
@@ -682,8 +696,8 @@ msgid "Making a collection"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Read the guide"
-msgstr ""
+#~ msgid "Read the guide"
+#~ msgstr ""
 
 #: src/components/reader/app-shell.tsx
 #: src/components/site-legal-links.tsx
@@ -811,6 +825,10 @@ msgstr "Confidentialité de l’extension"
 msgid "Signing in"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Public API — no key required"
+msgstr ""
+
 #: src/components/reading-settings-preview.tsx
 msgid "Loading voice sample"
 msgstr "Chargement de l’extrait de voix"
@@ -874,6 +892,11 @@ msgstr "Réessayer"
 
 #: src/lib/guide/navigation.ts
 msgid "Welcome"
+msgstr ""
+
+#. placeholder {0}: SUPPORTED_CONTENT_FORMATS.size
+#: src/components/reader/about-view.tsx
+msgid "An article is a record in its author’s own repository, and every publishing tool on the network writes that record a little differently. Standard Reader reads {0} of those content formats and renders them all into the same calm page — so a reader never has to care which tool a writer chose."
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -1003,6 +1026,10 @@ msgstr ""
 msgid "Bookmarks"
 msgstr "Signets"
 
+#: src/components/reader/about-view.tsx
+msgid "None of this is ours. We gather it from the Atmosphere — the open network these apps all share — and show it under the piece it’s about. Every line links back to where it was actually written, no account or comment box required, and it works whether or not the author ever opted in."
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Saved to {savedName} on {appLabel}."
 msgstr "Enregistré dans {savedName} sur {appLabel}."
@@ -1057,6 +1084,10 @@ msgstr "Un salon de lecture paisible pour le web ouvert. Prenons deux minutes po
 #: src/routes/_layout.collections.index.tsx
 msgid "New series"
 msgstr "Nouvelle série"
+
+#: src/components/reader/about-view.tsx
+msgid "Blogs never really solved the conversation. Comment boxes belonged to the blog, went unread, filled with spam, and vanished when the site did. So the talking moved somewhere else — and stopped being attached to the writing at all."
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "These deletions remove the records from your account itself, not just from our copy — which is why they cannot be undone. Deleting your reading history, for example, makes everything look unread again everywhere."
@@ -1130,6 +1161,10 @@ msgstr ""
 msgid "Under that, <0>Cited in</0> lists other articles that link to this one, and <1>Related reading</1> suggests pieces from across the network on the same subjects — usually from publications you have not met yet."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Essays and serialized writing"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 #~ msgid "Following your first publications"
@@ -1182,8 +1217,8 @@ msgid "Custom"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Read the API docs"
-msgstr "Lire la documentation de l’API"
+#~ msgid "Read the API docs"
+#~ msgstr "Lire la documentation de l’API"
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Select <0>Listen</0> in the top bar and the article is read aloud. The first time takes a few seconds to warm up; after that it starts straight away."
@@ -1198,8 +1233,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Shareable everywhere"
-msgstr "Partageable partout"
+#~ msgid "Shareable everywhere"
+#~ msgstr "Partageable partout"
 
 #: src/magazine/Magazine.tsx
 msgid "Close table of contents"
@@ -1232,6 +1267,10 @@ msgstr ""
 
 #: src/components/docs/introduction-docs-page.tsx
 msgid "how to make a site discoverable on Standard and have its content read inline, without adopting a platform."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across every publication on the network, not just the handful you’ve heard of."
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -1303,6 +1342,10 @@ msgstr ""
 msgid "To move several at once, open <0>Subscriptions</0>, select the rows you want, and add them all to a list in one action. That is much faster than doing it publication by publication."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Blocks, pages, and footnotes"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Appearance"
 msgstr "Apparence"
@@ -1354,6 +1397,10 @@ msgstr "Compte"
 msgid "Collapse all lists"
 msgstr "Réduire toutes les listes"
 
+#: src/components/reader/about-view.tsx
+msgid "Four essays covering the same ground, from publications you don’t follow yet."
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "We couldn’t find that article."
 msgstr "Article introuvable."
@@ -1388,6 +1435,10 @@ msgstr "votre collection"
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“…made to be read, and not to be measured.”"
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -1505,6 +1556,10 @@ msgstr "Recherche plein texte rapide"
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "Nom de la collection"
+
+#: src/components/reader/about-view.tsx
+msgid "+{UNNAMED_FORMAT_COUNT} more"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1698,8 +1753,8 @@ msgid "What every control on an article does — including having it read aloud 
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "The reading experience"
-msgstr "L'expérience de lecture"
+#~ msgid "The reading experience"
+#~ msgstr "L'expérience de lecture"
 
 #: src/routes/_layout.tsx
 msgid "Loading page"
@@ -1736,6 +1791,10 @@ msgstr ""
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "Collections live under <0>Collections</0> in the sidebar. Because publishing one writes a new kind of record to your account, the first time you make one you will be asked to grant an extra permission — that is the <1>Upgrade permissions</1> prompt, and it only appears once."
 #~ msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Also read natively:"
+msgstr ""
 
 #. placeholder {0}: pub.name
 #: src/components/reader/article-below-fold.tsx
@@ -1777,8 +1836,8 @@ msgstr "Vous êtes abonné à toutes les publications de cette page — faites d
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
-msgstr "Sous chaque article, vous retrouvez les discussions de tout le réseau ouvert : publications et réponses Bluesky, notes en marge, liens d'autres articles qui le citent et lectures associées. Le tout en lecture seule, avec un lien vers la source."
+#~ msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+#~ msgstr "Sous chaque article, vous retrouvez les discussions de tout le réseau ouvert : publications et réponses Bluesky, notes en marge, liens d'autres articles qui le citent et lectures associées. Le tout en lecture seule, avec un lien vers la source."
 
 #: src/routes/_layout.latest.tsx
 msgid "Show all subscriptions"
@@ -1831,8 +1890,8 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {# résultat} other {# résultats}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
-msgstr "Publications, listes et collections disposent chacune d'un lien épuré avec un aperçu enrichi — ainsi que d'un bouton d'abonnement qu'une publication peut installer sur son propre site."
+#~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
+#~ msgstr "Publications, listes et collections disposent chacune d'un lien épuré avec un aperçu enrichi — ainsi que d'un bouton d'abonnement qu'une publication peut installer sur son propre site."
 
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Search topics"
@@ -1857,6 +1916,10 @@ msgstr "Articles de la collection"
 #: src/components/user-settings-view.tsx
 msgid "System"
 msgstr "Système"
+
+#: src/components/reader/about-view.tsx
+msgid "Every feed, directory, and search query the app itself runs."
+msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Could not save to {appLabel}"
@@ -1964,8 +2027,8 @@ msgid "Never used"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Building something on the same index? There’s a public API."
-msgstr "Vous construisez quelque chose sur le même index ? Il existe une API publique."
+#~ msgid "Building something on the same index? There’s a public API."
+#~ msgstr "Vous construisez quelque chose sur le même index ? Il existe une API publique."
 
 #: src/components/reader/comments/comments-section.tsx
 msgid "Discussion"
@@ -2196,6 +2259,10 @@ msgstr "Où cette collection est publiée — les abonnés de la série la recev
 msgid "No apps connected"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Nothing about it is fixed. Set the measure, the type size, and the typeface to whatever your eyes want, in light or dark, and the setting follows you to every article you open after it."
+msgstr ""
+
 #: src/components/reader/markdown-field.tsx
 msgid "Edit"
 msgstr "Modifier"
@@ -2215,6 +2282,10 @@ msgstr "Requêtes et procédures XRPC publiques du modèle de lecture indexé de
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Save theme"
 msgstr "Enregistrer le thème"
+
+#: src/components/reader/about-view.tsx
+msgid "A reply"
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "your day: one featured article, then what is new from the publications you subscribe to."
@@ -2397,6 +2468,10 @@ msgstr ""
 #~ msgid "Carry on browsing. The overlay appears where it is useful and stays out of the way where it is not."
 #~ msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "And if your reader of choice is one you already have, any slice of the network comes with its own feed — pipe it straight in and never open this app at all."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "To email your digest, Standard Reader needs your account email address. We'll ask your PDS to share it — you'll be sent to your login to approve the request, then brought right back here. Your email is used only to send the weekly digest, and you can turn it off any time."
 msgstr "Pour vous envoyer votre digest par e-mail, Standard Reader a besoin de l'adresse e-mail de votre compte. Nous demanderons à votre PDS de la partager : vous serez redirigé vers votre page de connexion pour approuver la demande, puis ramené ici. Votre adresse sert uniquement à l'envoi du digest hebdomadaire, et vous pouvez le désactiver à tout moment."
@@ -2406,7 +2481,6 @@ msgid "Where your reading is kept, who else can see it, what you agreed to when 
 msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
-#: src/components/reader/about-view.tsx
 #: src/lib/guide/navigation.ts
 msgid "Discovery"
 msgstr "Découverte"
@@ -2533,6 +2607,10 @@ msgstr "Tenir un carnet de lectures"
 msgid "Most reading apps keep your list of follows on their own servers. If the app shuts down, your list goes with it."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Keep the good sentence"
+msgstr ""
+
 #: src/routes/_layout.u.$did.tsx
 msgid "Featured in"
 msgstr "Publié dans"
@@ -2624,8 +2702,8 @@ msgid "Paper"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
-msgstr "Modifiez un seul réglage et les liens des articles s'ouvriront sur le site de la publication elle-même. Lisez là où vous vous sentez bien."
+#~ msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
+#~ msgstr "Modifiez un seul réglage et les liens des articles s'ouvriront sur le site de la publication elle-même. Lisez là où vous vous sentez bien."
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Discover is the directory of every publication the network knows about — not a curated shelf. It runs top to bottom from most personal to most complete:"
@@ -2690,8 +2768,12 @@ msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {abonné} other {abonnés}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
-msgstr "La plupart des lecteurs s'arrêtent à ce à quoi ils sont déjà abonnés. Standard Reader considère que vous aider à trouver votre prochain coup de cœur fait partie du travail. Parcourez les {countLabel} publications du réseau — pas seulement la poignée dont vous avez entendu parler."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgstr "La plupart des lecteurs s'arrêtent à ce à quoi ils sont déjà abonnés. Standard Reader considère que vous aider à trouver votre prochain coup de cœur fait partie du travail. Parcourez les {countLabel} publications du réseau — pas seulement la poignée dont vous avez entendu parler."
+
+#: src/components/reader/about-view.tsx
+msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself, and every save, like, and subscribe is instantly in sync with whatever device you read on next."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labels"
@@ -2767,6 +2849,10 @@ msgstr ""
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Upgrade to author Collections"
 msgstr "Passer à l’offre supérieure pour créer des collections"
+
+#: src/components/reader/about-view.tsx
+msgid "Render a document in your own app —"
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "Your social actions (follows, likes, saves, lists) are written to your AT Protocol repository and are visible according to the network's rules and your account settings. Our Postgres database holds a network read-model, app session state, and cached public metadata — not the canonical copies of publications."
@@ -2872,12 +2958,20 @@ msgstr "Dernière mise à jour le 13 juin 2026"
 msgid "{shown, plural, one {# match} other {# matches}}"
 msgstr "{shown, plural, one {# résultat} other {# résultats}}"
 
+#: src/components/reader/about-view.tsx
+msgid "Select a passage and share it as a typeset card that links back to the article — or keep reading and pick up exactly where you left off next time."
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "People you follow write here"
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Good writing rarely turns up while you are already in a reading app. The extension puts saving and subscribing on every page you visit."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Drop a Standard document into your own app, in your own framework."
 msgstr ""
 
 #: src/magazine/flow.tsx
@@ -3051,6 +3145,10 @@ msgstr ""
 #: src/components/docs/docs-publishing-nav.tsx
 #~ msgid "Publishing guide"
 #~ msgstr "Guide de publication"
+
+#: src/components/reader/about-view.tsx
+msgid "Prefer the original? Flip one setting and article links open on the publication’s own site instead — Standard Reader will still keep your place."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "<0>Share</0> copies a link, or posts the article to Bluesky with a proper preview card. On a phone it can hand off to whatever you normally share with."
@@ -3425,6 +3523,10 @@ msgstr "Une erreur s’est produite."
 msgid "The best of what you subscribe to"
 msgstr "Le meilleur de vos abonnements"
 
+#: src/components/reader/about-view.tsx
+msgid "Under this article"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Note"
 msgstr "Note"
@@ -3526,6 +3628,7 @@ msgstr "Génération de l’audio… {percent} %"
 
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
+#: src/components/reader/about-view.tsx
 msgid "Renderers"
 msgstr ""
 
@@ -3565,8 +3668,8 @@ msgid "What Standard Reader is"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Prefer the original?"
-msgstr "Vous préférez l’original ?"
+#~ msgid "Prefer the original?"
+#~ msgstr "Vous préférez l’original ?"
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Could not add to list"
@@ -3787,6 +3890,10 @@ msgstr "Nous avons choisi cette langue d'après votre navigateur. Vous pouvez en
 
 #: src/routes/mcp/authorize.tsx
 msgid "Nothing has been shared. Head back to the app you came from and try connecting again."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“This is the whole argument in one clause. Worth sitting with.”"
 msgstr ""
 
 #: src/components/reader/text-selection-toolbar.tsx
@@ -4013,8 +4120,8 @@ msgid "Save and subscribe from anywhere on the web, without breaking your stride
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Integrations"
-msgstr "Intégrations"
+#~ msgid "Integrations"
+#~ msgstr "Intégrations"
 
 #. placeholder {0}: person.subscriberCount
 #. placeholder {0}: pub.subscriberCount
@@ -4137,6 +4244,10 @@ msgstr ""
 msgid "This request can't be completed here, so we're returning you to the app that sent you."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Read the docs"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No people in this list — add some from the edit dialog."
 msgstr "Aucune personne dans cette liste — ajoutez-en depuis la fenêtre de modification."
@@ -4167,8 +4278,8 @@ msgid "Browse publications"
 msgstr "Parcourir les publications"
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
-msgstr "Standard Reader n’enferme pas votre lecture dans une seule application. Chaque partie du réseau dispose de son propre flux RSS — branchez-le directement sur le lecteur que vous utilisez déjà."
+#~ msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
+#~ msgstr "Standard Reader n’enferme pas votre lecture dans une seule application. Chaque partie du réseau dispose de son propre flux RSS — branchez-le directement sur le lecteur que vous utilisez déjà."
 
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Choose images"
@@ -4236,6 +4347,10 @@ msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That image is too detailed to fit under 1 MB. Try cropping it first."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“Been thinking about this all week. The measurement is the part that ruins it — not the writing.”"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -4310,13 +4425,17 @@ msgstr "Impossible de charger les retours <0>({0})</0>. Réessayez dans un insta
 msgid "No publications match this tag yet."
 msgstr "Aucune publication ne correspond encore à ce tag."
 
+#: src/components/reader/about-view.tsx
+msgid "Written wherever they write"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "If you already know what you are looking for, the <0>Add publication</0> button opens a single field that does three things at once. Leave it empty and it shows what is trending. Type a few words and it searches the directory. Paste a handle or a domain — <1>@stdout.dev</1>, <2>stdout.dev</2> — and it looks that author up directly."
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "The conversation, gathered"
-msgstr "La conversation, rassemblée"
+#~ msgid "The conversation, gathered"
+#~ msgstr "La conversation, rassemblée"
 
 #: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
@@ -4344,8 +4463,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Save, like, subscribe — everywhere"
-msgstr "Enregistrer, aimer, s'abonner — partout"
+#~ msgid "Save, like, subscribe — everywhere"
+#~ msgstr "Enregistrer, aimer, s'abonner — partout"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe?"
@@ -4402,6 +4521,7 @@ msgstr ""
 
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
+#: src/components/reader/about-view.tsx
 msgid "API"
 msgstr "API"
 
@@ -4415,6 +4535,10 @@ msgstr "Remplacer l'icône"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unfollow"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Standard Reader doesn’t ask you to move in. It goes out to the web you already use, and hands your reading back in whatever shape suits you."
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx
@@ -4473,6 +4597,10 @@ msgstr "Authentification"
 
 #: src/components/reader/terms-view.tsx
 msgid "Changes to these terms"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Short-form posts and long reads"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -4541,6 +4669,10 @@ msgstr ""
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "Si vous installez l'extension de navigateur {SITE_NAME}, elle utilise le même compte et le même cookie de session que ce site. L'extension envoie les URL des pages à nos points de terminaison <0>/api/extension/*</0> pour la correspondance avec l'index et conserve les réglages de la surcouche dans le stockage d'extension de votre navigateur. Consultez la <1>politique de confidentialité de l'extension</1> pour les détails qui la concernent uniquement."
+
+#: src/components/reader/about-view.tsx
+msgid "And when a run of them turns out to be good together, collect them into a named list — a playlist for reading. Anyone can add the whole thing to their own reader in a single tap."
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "Remove {memberName} from list"
@@ -4698,8 +4830,8 @@ msgid "Saves a link to your <0>{appLabel}</0> collection."
 msgstr "Enregistre un lien dans votre collection <0>{appLabel}</0>."
 
 #: src/components/reader/about-view.tsx
-msgid "In your inbox"
-msgstr "Dans votre boîte de réception"
+#~ msgid "In your inbox"
+#~ msgstr "Dans votre boîte de réception"
 
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Drag to change the order your subscriptions appear in the sidebar."
@@ -4713,6 +4845,7 @@ msgstr "Apparence, préférences de lecture et données personnelles."
 msgid "Authority for <0>app.standard-reader</0> resolves via DNS <1>_lexicon.*</1> TXT records to the publishing account."
 msgstr "L'autorité pour <0>app.standard-reader</0> se résout via les enregistrements TXT DNS <1>_lexicon.*</1> vers le compte de publication."
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Margin"
 msgstr "sur Margin"
@@ -4749,6 +4882,10 @@ msgstr "Impossible de résoudre cet identifiant."
 msgid "Good to know"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across all {countLabel} publications on the network, not just the handful you’ve heard of."
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Sharing a review on the <0>ATStore</0> will help both us and other users see what you think about Standard Reader."
 msgstr "Partager un avis sur l'<0>ATStore</0> nous aidera, ainsi que les autres utilisateurs, à savoir ce que vous pensez de Standard Reader."
@@ -4756,6 +4893,10 @@ msgstr "Partager un avis sur l'<0>ATStore</0> nous aidera, ainsi que les autres 
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "On Bluesky, quiet badges mark the people whose writing you can read here."
 #~ msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Publish labels others can subscribe to, or consume the ones we do."
+msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "The full account is on the <0>extension privacy page</0>."
@@ -4888,13 +5029,17 @@ msgstr "Rien à lire ici pour l'instant."
 msgid "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
 msgstr "Les services d'étiquetage sont des services de modération auxquels vous vous abonnez par DID. Abonnez-vous pour voir leurs étiquettes — et flouter ou masquer les publications étiquetées — pendant votre lecture."
 
+#: src/components/reader/about-view.tsx
+msgid "The part blogging always missed"
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "The older link rels"
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader meets you where you read"
-msgstr "Standard Reader vous rejoint là où vous lisez"
+#~ msgid "Standard Reader meets you where you read"
+#~ msgstr "Standard Reader vous rejoint là où vous lisez"
 
 #: src/components/appearance-settings.tsx
 msgid "Reset appearance"
@@ -5088,6 +5233,10 @@ msgstr ""
 #: src/routes/_layout.latest.tsx
 msgid "All caught up"
 msgstr "Tout est à jour"
+
+#: src/components/reader/about-view.tsx
+msgid "Everything here is linkable, too. Publications, lists, and collections each get a clean URL with a rich preview card — plus a subscribe button a publication can drop straight onto its own site."
+msgstr ""
 
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Reorder subscriptions"
@@ -5284,6 +5433,7 @@ msgstr "Rechercher sur le réseau"
 msgid "Search Google Fonts"
 msgstr "Rechercher dans Google Fonts"
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/article-below-fold.tsx
 msgid "Related reading"
 msgstr "Lectures associées"
@@ -5522,8 +5672,8 @@ msgid "If something is confusing, broken, or missing, the <0>feedback board</0> 
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
-msgstr "Une extension de navigateur légère vous permet d'enregistrer des publications et de vous y abonner pendant votre navigation — avec de discrets badges sur bsky.app et une surcouche accessible en un clic sur n'importe quelle page. Votre liste de lecture se remplit toute seule."
+#~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+#~ msgstr "Une extension de navigateur légère vous permet d'enregistrer des publications et de vous y abonner pendant votre navigation — avec de discrets badges sur bsky.app et une surcouche accessible en un clic sur n'importe quelle page. Votre liste de lecture se remplit toute seule."
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -5763,8 +5913,8 @@ msgid "Open any article while signed in and it'll show up here. Your history liv
 msgstr "Ouvrez un article en étant connecté et il apparaîtra ici. Votre historique vit dans votre dépôt sous forme d'enregistrements <0>app.standard-reader.read</0>."
 
 #: src/components/reader/about-view.tsx
-msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
-msgstr "Composez des listes de publications nommées et partageables — une playlist de lecture. N'importe qui peut ajouter votre liste à son propre lecteur en un seul geste."
+#~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
+#~ msgstr "Composez des listes de publications nommées et partageables — une playlist de lecture. N'importe qui peut ajouter votre liste à son propre lecteur en un seul geste."
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
@@ -5852,6 +6002,7 @@ msgstr ""
 #: src/components/docs/introduction-docs-page.tsx
 #: src/components/docs/labelers-docs-page.tsx
 #: src/components/labelers-settings-view.tsx
+#: src/components/reader/about-view.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/user-settings-view.tsx
 msgid "Labelers"
@@ -5862,8 +6013,8 @@ msgid "Choose your language"
 msgstr "Choisissez votre langue"
 
 #: src/components/reader/about-view.tsx
-msgid "Find the ones you didn't know you wanted"
-msgstr "Trouvez ceux que vous ne saviez pas vouloir"
+#~ msgid "Find the ones you didn't know you wanted"
+#~ msgstr "Trouvez ceux que vous ne saviez pas vouloir"
 
 #: src/components/labeler-detail-view.tsx
 msgid "Hide"
@@ -5949,8 +6100,8 @@ msgid "Supported content formats"
 msgstr "Formats de contenu pris en charge"
 
 #: src/components/reader/about-view.tsx
-msgid "Plays nice with the open web"
-msgstr "En bonne entente avec le web ouvert"
+#~ msgid "Plays nice with the open web"
+#~ msgstr "En bonne entente avec le web ouvert"
 
 #: src/components/reader/privacy-view.tsx
 msgid "What we collect"
@@ -5975,6 +6126,10 @@ msgstr "Vous aimez Standard Reader ?"
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Use original link"
 msgstr "Utiliser le lien d'origine"
+
+#: src/components/reader/about-view.tsx
+msgid "Everything this app runs on is public. The schemas are open, the read-model is queryable, and the renderer that draws these pages is published for you to use — so a reading app, a search tool, or a better client than this one is a weekend, not a platform deal."
+msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "Every publication page also serves a themed, embeddable subscribe widget — an iframe you can drop on your own site so visitors can subscribe without leaving your page. The easiest way to get it: open your publication's page on Standard Reader, use <0>Share → Embed subscribe</0>, pick landscape or portrait, and copy the snippet — no account or ownership check required to generate it."
@@ -6117,6 +6272,10 @@ msgstr "Aucune discussion pour l'instant."
 msgid "A single publication"
 msgstr "Une seule publication"
 
+#: src/components/reader/about-view.tsx
+msgid "Build on the same index"
+msgstr ""
+
 #: src/routes/extension.connected.tsx
 msgid "Return to the Standard Reader extension — this tab will close automatically."
 msgstr "Retournez à l'extension Standard Reader — cet onglet se fermera automatiquement."
@@ -6224,6 +6383,10 @@ msgstr ""
 #: src/components/reader/publication-latest-note.tsx
 msgid "Latest note"
 msgstr "Dernière note"
+
+#: src/components/reader/about-view.tsx
+msgid "The record schemas a publication, document, or follow is made of."
+msgstr ""
 
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6377,6 +6540,10 @@ msgstr "Paysage"
 msgid "Edit collection"
 msgstr "Modifier la collection"
 
+#: src/components/reader/about-view.tsx
+msgid "That is a real response from the endpoint this page just called — no key, no sign-up, no rate-limit form. The same is true of every feed, directory, and search query the reader itself runs."
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "After that, following is one button. Anywhere you see a publication — a card in a feed, the top of an article, a publication's own page — there is a <0>Follow</0> button next to its name. Select it again to stop following. Nothing else changes: the button just decides whether new writing from that publication reaches your Home and Latest."
 #~ msgstr ""
@@ -6425,8 +6592,12 @@ msgid "Opening the issue…"
 msgstr "Ouverture du numéro…"
 
 #: src/components/reader/about-view.tsx
-msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
-msgstr "Il ne vous demande pas de laisser le reste du web derrière vous. Il va à sa rencontre — et reste un bon citoyen du réseau au sens large."
+msgid "However you like to read it"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+#~ msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+#~ msgstr "Il ne vous demande pas de laisser le reste du web derrière vous. Il va à sa rencontre — et reste un bon citoyen du réseau au sens large."
 
 #: src/routes/_layout.collections.edit.$rkey.tsx
 msgid "We couldn’t load that collection to edit."
@@ -6488,6 +6659,10 @@ msgstr "Standard Reader indexe les enregistrements <0>site.standard.document</0>
 #: src/components/reader/list-edit-modal.tsx
 msgid "e.g. Tech, Friends, Cooking"
 msgstr "ex. Tech, Amis, Cuisine"
+
+#: src/components/reader/about-view.tsx
+msgid "Semble"
+msgstr ""
 
 #. placeholder {0}: fmt.relativeTime(connection.lastUsedAt)
 #: src/components/user-settings-view.tsx
@@ -6631,6 +6806,10 @@ msgstr "Activé"
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Two other pieces link to this one — you can read them from here."
 msgstr ""
 
 #: src/components/reader/page-reader-bar.tsx
@@ -6790,6 +6969,10 @@ msgstr ""
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Finding your way around"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Cited by"
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -99,6 +99,10 @@ msgstr "Le rendu du contenu dans Standard Reader"
 msgid "Articles gaining attention across the network right now."
 msgstr "Les articles qui font parler d’eux sur le réseau en ce moment."
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# member} other {# members}}"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Add an article"
 msgstr "Ajouter un article"
@@ -410,9 +414,9 @@ msgstr ""
 msgid "{years}y ago"
 msgstr ""
 
-#: src/components/reader/reorder-lists-modal.tsx
-#~ msgid "List"
-#~ msgstr "Liste"
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "List"
+msgstr "Liste"
 
 #: src/components/appearance-settings.tsx
 msgid "The spacing between things — tighter for more on screen, looser for more room to read."
@@ -1971,6 +1975,7 @@ msgstr "La langue de l'interface du lecteur. Les articles sont affichés dans la
 #~ msgid "Following, saving, recommending, and — once you follow more than a handful of publications — keeping the whole thing tidy."
 #~ msgstr ""
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 #: src/components/user-settings-view.tsx
 msgid "Feed"
 msgstr ""
@@ -3253,6 +3258,10 @@ msgstr ""
 msgid "e.g. Dispatches from the Atmosphere"
 msgstr "ex. Chroniques de l’Atmosphere"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# join} other {# joins}}"
+msgstr ""
+
 #: src/components/docs/introduction-docs-page.tsx
 msgid "the AT Protocol schemas that define Standard records and the shared definitions they build on."
 msgstr ""
@@ -3560,6 +3569,10 @@ msgstr "Mode aperçu"
 #: src/components/NavbarAuth.tsx
 #: src/components/site-legal-links.tsx
 msgid "Guide"
+msgstr ""
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# like} other {# likes}}"
 msgstr ""
 
 #: src/routes/_layout.collections.new.tsx
@@ -4042,6 +4055,10 @@ msgstr ""
 msgid "{0}+ articles"
 msgstr "{0}+ articles"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "Starter pack"
+msgstr ""
+
 #: src/routes/_layout.feedback.return.tsx
 msgid "That link expired."
 msgstr "Ce lien a expiré."
@@ -4335,6 +4352,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "Cited in"
 msgstr "Cité dans"
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# follower} other {# followers}}"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "A couple of publications worth discovering."
@@ -5953,6 +5974,10 @@ msgstr "Cliquez sur Exécuter l'exemple pour obtenir une réponse en direct avec
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "At the bottom of settings, <0>Personal data</0> deletes categories of records outright: your reading history, your saved articles, or the publication lists you made. Each asks for confirmation and explains what will change."
+msgstr ""
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "Profile"
 msgstr ""
 
 #: src/components/reader/friend-publishers.tsx

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -2665,6 +2665,10 @@ msgstr "Réorganiser {itemTitle}"
 msgid "Back to feedback"
 msgstr "Retour aux retours"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "View on {name}"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "{pubTotal, plural, one {# publication} other {# publications}}"
 msgstr "{pubTotal, plural, one {# publication} other {# publications}}"

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -123,12 +123,12 @@ msgid "Every renderer takes one input for the document — the content payload o
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "One tap from the reading view, on any device, instantly in sync. Your library is always where you left it."
-msgstr "どの端末でも、閲覧画面からワンタップで即座に同期。ライブラリはいつでも続きから。"
+#~ msgid "One tap from the reading view, on any device, instantly in sync. Your library is always where you left it."
+#~ msgstr "どの端末でも、閲覧画面からワンタップで即座に同期。ライブラリはいつでも続きから。"
 
 #: src/components/reader/about-view.tsx
-msgid "Curated lists & collections"
-msgstr "厳選リストとコレクション"
+#~ msgid "Curated lists & collections"
+#~ msgstr "厳選リストとコレクション"
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Vue 3."
@@ -179,6 +179,7 @@ msgstr ""
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
 #: src/components/docs/lexicon-docs-intro.tsx
+#: src/components/reader/about-view.tsx
 msgid "Lexicons"
 msgstr "レキシコン"
 
@@ -256,6 +257,10 @@ msgstr "タイトルを入力してください。"
 #~ msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Follow it and it starts appearing in your feeds like any other."
 #~ msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -302,8 +307,8 @@ msgid "(this is what Standard Reader itself uses)"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
-msgstr "そして閉じた場所にはなりません。それぞれの記事を Atmosphere（このアプリの外に広がるオープンなネットワーク）で交わされる会話につなぎ、その記事についての Bluesky の投稿や返信、余白に残されたメモ、引用している他の文章を、読んでいるものの下にそっと集めます。"
+#~ msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+#~ msgstr "そして閉じた場所にはなりません。それぞれの記事を Atmosphere（このアプリの外に広がるオープンなネットワーク）で交わされる会話につなぎ、その記事についての Bluesky の投稿や返信、余白に残されたメモ、引用している他の文章を、読んでいるものの下にそっと集めます。"
 
 #: src/components/guide/guide-shell.tsx
 msgid "Still stuck, or something here doesn't match what you see? <0>Tell us on the feedback board</0> — questions are welcome there, not just bug reports."
@@ -316,6 +321,10 @@ msgstr "実行中…"
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Your Home feed is built from subscriptions. Three is a good start."
 msgstr "ホームフィードは購読から作られます。まずは3つから始めましょう。"
+
+#: src/components/reader/about-view.tsx
+msgid "A note in the margin"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Colors"
@@ -389,6 +398,10 @@ msgstr "購読しています…"
 msgid "People"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Every piece is a door to the next one"
+msgstr ""
+
 #: src/routes/_layout.friends.tsx
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 msgstr ""
@@ -417,6 +430,7 @@ msgstr ""
 msgid "Switch to light paper"
 msgstr "明るい紙に切り替える"
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Bluesky"
 msgstr "Bluesky で"
@@ -426,8 +440,8 @@ msgid "Set these now, or change them any time in Settings."
 msgstr "今すぐ設定するか、あとで設定からいつでも変更できます。"
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
-msgstr "多くのリーダーは、すでに購読しているものを見せて終わりです。Standard Reader は次のお気に入りを見つけることも役目だと考えています。名前を知っている一握りだけでなく、ネットワーク上のすべての発行物を見てまわりましょう。"
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
+#~ msgstr "多くのリーダーは、すでに購読しているものを見せて終わりです。Standard Reader は次のお気に入りを見つけることも役目だと考えています。名前を知っている一握りだけでなく、ネットワーク上のすべての発行物を見てまわりましょう。"
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Open <0>Collections</0> in the sidebar and start a new one."
@@ -682,8 +696,8 @@ msgid "Making a collection"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Read the guide"
-msgstr ""
+#~ msgid "Read the guide"
+#~ msgstr ""
 
 #: src/components/reader/app-shell.tsx
 #: src/components/site-legal-links.tsx
@@ -811,6 +825,10 @@ msgstr "拡張機能のプライバシー"
 msgid "Signing in"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Public API — no key required"
+msgstr ""
+
 #: src/components/reading-settings-preview.tsx
 msgid "Loading voice sample"
 msgstr "音声サンプルを読み込み中"
@@ -874,6 +892,11 @@ msgstr "再試行"
 
 #: src/lib/guide/navigation.ts
 msgid "Welcome"
+msgstr ""
+
+#. placeholder {0}: SUPPORTED_CONTENT_FORMATS.size
+#: src/components/reader/about-view.tsx
+msgid "An article is a record in its author’s own repository, and every publishing tool on the network writes that record a little differently. Standard Reader reads {0} of those content formats and renders them all into the same calm page — so a reader never has to care which tool a writer chose."
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -1003,6 +1026,10 @@ msgstr ""
 msgid "Bookmarks"
 msgstr "ブックマーク"
 
+#: src/components/reader/about-view.tsx
+msgid "None of this is ours. We gather it from the Atmosphere — the open network these apps all share — and show it under the piece it’s about. Every line links back to where it was actually written, no account or comment box required, and it works whether or not the author ever opted in."
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Saved to {savedName} on {appLabel}."
 msgstr "{appLabel} の {savedName} に保存しました。"
@@ -1057,6 +1084,10 @@ msgstr "オープンウェブのための静かな読書室。2分だけ使っ�
 #: src/routes/_layout.collections.index.tsx
 msgid "New series"
 msgstr "新しいシリーズ"
+
+#: src/components/reader/about-view.tsx
+msgid "Blogs never really solved the conversation. Comment boxes belonged to the blog, went unread, filled with spam, and vanished when the site did. So the talking moved somewhere else — and stopped being attached to the writing at all."
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "These deletions remove the records from your account itself, not just from our copy — which is why they cannot be undone. Deleting your reading history, for example, makes everything look unread again everywhere."
@@ -1130,6 +1161,10 @@ msgstr ""
 msgid "Under that, <0>Cited in</0> lists other articles that link to this one, and <1>Related reading</1> suggests pieces from across the network on the same subjects — usually from publications you have not met yet."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Essays and serialized writing"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 #~ msgid "Following your first publications"
@@ -1182,8 +1217,8 @@ msgid "Custom"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Read the API docs"
-msgstr "API ドキュメントを読む"
+#~ msgid "Read the API docs"
+#~ msgstr "API ドキュメントを読む"
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Select <0>Listen</0> in the top bar and the article is read aloud. The first time takes a few seconds to warm up; after that it starts straight away."
@@ -1198,8 +1233,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Shareable everywhere"
-msgstr "どこでも共有できる"
+#~ msgid "Shareable everywhere"
+#~ msgstr "どこでも共有できる"
 
 #: src/magazine/Magazine.tsx
 msgid "Close table of contents"
@@ -1232,6 +1267,10 @@ msgstr ""
 
 #: src/components/docs/introduction-docs-page.tsx
 msgid "how to make a site discoverable on Standard and have its content read inline, without adopting a platform."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across every publication on the network, not just the handful you’ve heard of."
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -1303,6 +1342,10 @@ msgstr ""
 msgid "To move several at once, open <0>Subscriptions</0>, select the rows you want, and add them all to a list in one action. That is much faster than doing it publication by publication."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Blocks, pages, and footnotes"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Appearance"
 msgstr "外観"
@@ -1354,6 +1397,10 @@ msgstr "アカウント"
 msgid "Collapse all lists"
 msgstr "すべてのリストを折りたたむ"
 
+#: src/components/reader/about-view.tsx
+msgid "Four essays covering the same ground, from publications you don’t follow yet."
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "We couldn’t find that article."
 msgstr "その記事は見つかりませんでした。"
@@ -1388,6 +1435,10 @@ msgstr "自分のコレクション"
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“…made to be read, and not to be measured.”"
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -1505,6 +1556,10 @@ msgstr "高速な全文検索"
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "コレクション名"
+
+#: src/components/reader/about-view.tsx
+msgid "+{UNNAMED_FORMAT_COUNT} more"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1698,8 +1753,8 @@ msgid "What every control on an article does — including having it read aloud 
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "The reading experience"
-msgstr "読書体験"
+#~ msgid "The reading experience"
+#~ msgstr "読書体験"
 
 #: src/routes/_layout.tsx
 msgid "Loading page"
@@ -1736,6 +1791,10 @@ msgstr ""
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "Collections live under <0>Collections</0> in the sidebar. Because publishing one writes a new kind of record to your account, the first time you make one you will be asked to grant an extra permission — that is the <1>Upgrade permissions</1> prompt, and it only appears once."
 #~ msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Also read natively:"
+msgstr ""
 
 #. placeholder {0}: pub.name
 #: src/components/reader/article-below-fold.tsx
@@ -1777,8 +1836,8 @@ msgstr "このページの発行物はすべて購読済みです。さらにス
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
-msgstr "各記事の下では、オープンなネットワーク全体の反応をまとめて確認できます。Bluesky の投稿や返信、マージンノート、その記事を引用した他の記事からのリンク、関連する読み物などです。すべて読み取り専用で、元の投稿へリンクしています。"
+#~ msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+#~ msgstr "各記事の下では、オープンなネットワーク全体の反応をまとめて確認できます。Bluesky の投稿や返信、マージンノート、その記事を引用した他の記事からのリンク、関連する読み物などです。すべて読み取り専用で、元の投稿へリンクしています。"
 
 #: src/routes/_layout.latest.tsx
 msgid "Show all subscriptions"
@@ -1831,8 +1890,8 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {# 件の一致} other {# 件の一致}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
-msgstr "発行物・リスト・コレクションのそれぞれに、リッチなプレビューカード付きのすっきりしたリンクが用意されます。発行物が自分のサイトに設置できる購読ボタンも使えます。"
+#~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
+#~ msgstr "発行物・リスト・コレクションのそれぞれに、リッチなプレビューカード付きのすっきりしたリンクが用意されます。発行物が自分のサイトに設置できる購読ボタンも使えます。"
 
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Search topics"
@@ -1857,6 +1916,10 @@ msgstr "コレクション内の記事"
 #: src/components/user-settings-view.tsx
 msgid "System"
 msgstr "システム"
+
+#: src/components/reader/about-view.tsx
+msgid "Every feed, directory, and search query the app itself runs."
+msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Could not save to {appLabel}"
@@ -1964,8 +2027,8 @@ msgid "Never used"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Building something on the same index? There’s a public API."
-msgstr "同じインデックスを使って何かを作りますか？公開 API があります。"
+#~ msgid "Building something on the same index? There’s a public API."
+#~ msgstr "同じインデックスを使って何かを作りますか？公開 API があります。"
 
 #: src/components/reader/comments/comments-section.tsx
 msgid "Discussion"
@@ -2196,6 +2259,10 @@ msgstr "このコレクションを公開する場所です。シリーズのフ
 msgid "No apps connected"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Nothing about it is fixed. Set the measure, the type size, and the typeface to whatever your eyes want, in light or dark, and the setting follows you to every article you open after it."
+msgstr ""
+
 #: src/components/reader/markdown-field.tsx
 msgid "Edit"
 msgstr "編集"
@@ -2215,6 +2282,10 @@ msgstr "Standard Reader のインデックス済み読み取りモデル向け�
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Save theme"
 msgstr "テーマを保存"
+
+#: src/components/reader/about-view.tsx
+msgid "A reply"
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "your day: one featured article, then what is new from the publications you subscribe to."
@@ -2397,6 +2468,10 @@ msgstr ""
 #~ msgid "Carry on browsing. The overlay appears where it is useful and stays out of the way where it is not."
 #~ msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "And if your reader of choice is one you already have, any slice of the network comes with its own feed — pipe it straight in and never open this app at all."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "To email your digest, Standard Reader needs your account email address. We'll ask your PDS to share it — you'll be sent to your login to approve the request, then brought right back here. Your email is used only to send the weekly digest, and you can turn it off any time."
 msgstr "ダイジェストをメールで送るには、Standard Reader にアカウントのメールアドレスが必要です。PDS に共有を依頼するため、ログイン画面で許可していただき、その後ここに戻ります。メールアドレスは週刊ダイジェストの送信にのみ使用され、いつでもオフにできます。"
@@ -2406,7 +2481,6 @@ msgid "Where your reading is kept, who else can see it, what you agreed to when 
 msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
-#: src/components/reader/about-view.tsx
 #: src/lib/guide/navigation.ts
 msgid "Discovery"
 msgstr "ディスカバリー"
@@ -2533,6 +2607,10 @@ msgstr "備忘録をつけるということ"
 msgid "Most reading apps keep your list of follows on their own servers. If the app shuts down, your list goes with it."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Keep the good sentence"
+msgstr ""
+
 #: src/routes/_layout.u.$did.tsx
 msgid "Featured in"
 msgstr "掲載先"
@@ -2624,8 +2702,8 @@ msgid "Paper"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
-msgstr "設定を一つ切り替えるだけで、記事のリンクが発行物自身のサイトで開くようになります。心地よい場所で読んでください。"
+#~ msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
+#~ msgstr "設定を一つ切り替えるだけで、記事のリンクが発行物自身のサイトで開くようになります。心地よい場所で読んでください。"
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Discover is the directory of every publication the network knows about — not a curated shelf. It runs top to bottom from most personal to most complete:"
@@ -2690,8 +2768,12 @@ msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {フォロワー} other {フォロワー}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
-msgstr "多くのリーダーは、すでに購読しているものまでしか見せてくれません。Standard Reader は、次のお気に入りを見つけることも役目のうちだと考えています。名前を知っている一握りだけでなく、ネットワーク上の {countLabel} 件すべての発行物を見てまわれます。"
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgstr "多くのリーダーは、すでに購読しているものまでしか見せてくれません。Standard Reader は、次のお気に入りを見つけることも役目のうちだと考えています。名前を知っている一握りだけでなく、ネットワーク上の {countLabel} 件すべての発行物を見てまわれます。"
+
+#: src/components/reader/about-view.tsx
+msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself, and every save, like, and subscribe is instantly in sync with whatever device you read on next."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labels"
@@ -2767,6 +2849,10 @@ msgstr ""
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Upgrade to author Collections"
 msgstr "コレクションを作成するにはアップグレード"
+
+#: src/components/reader/about-view.tsx
+msgid "Render a document in your own app —"
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "Your social actions (follows, likes, saves, lists) are written to your AT Protocol repository and are visible according to the network's rules and your account settings. Our Postgres database holds a network read-model, app session state, and cached public metadata — not the canonical copies of publications."
@@ -2872,12 +2958,20 @@ msgstr "最終更新: 2026年6月13日"
 msgid "{shown, plural, one {# match} other {# matches}}"
 msgstr "{shown, plural, one {# 件の一致} other {# 件の一致}}"
 
+#: src/components/reader/about-view.tsx
+msgid "Select a passage and share it as a typeset card that links back to the article — or keep reading and pick up exactly where you left off next time."
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "People you follow write here"
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Good writing rarely turns up while you are already in a reading app. The extension puts saving and subscribing on every page you visit."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Drop a Standard document into your own app, in your own framework."
 msgstr ""
 
 #: src/magazine/flow.tsx
@@ -3051,6 +3145,10 @@ msgstr ""
 #: src/components/docs/docs-publishing-nav.tsx
 #~ msgid "Publishing guide"
 #~ msgstr "公開ガイド"
+
+#: src/components/reader/about-view.tsx
+msgid "Prefer the original? Flip one setting and article links open on the publication’s own site instead — Standard Reader will still keep your place."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "<0>Share</0> copies a link, or posts the article to Bluesky with a proper preview card. On a phone it can hand off to whatever you normally share with."
@@ -3425,6 +3523,10 @@ msgstr "問題が発生しました。"
 msgid "The best of what you subscribe to"
 msgstr "購読中の発行物のベスト"
 
+#: src/components/reader/about-view.tsx
+msgid "Under this article"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Note"
 msgstr "メモ"
@@ -3526,6 +3628,7 @@ msgstr "音声を生成中… {percent}%"
 
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
+#: src/components/reader/about-view.tsx
 msgid "Renderers"
 msgstr ""
 
@@ -3565,8 +3668,8 @@ msgid "What Standard Reader is"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Prefer the original?"
-msgstr "オリジナルで読みますか？"
+#~ msgid "Prefer the original?"
+#~ msgstr "オリジナルで読みますか？"
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Could not add to list"
@@ -3787,6 +3890,10 @@ msgstr "ブラウザの設定に基づいてこの言語を選びました。い
 
 #: src/routes/mcp/authorize.tsx
 msgid "Nothing has been shared. Head back to the app you came from and try connecting again."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“This is the whole argument in one clause. Worth sitting with.”"
 msgstr ""
 
 #: src/components/reader/text-selection-toolbar.tsx
@@ -4013,8 +4120,8 @@ msgid "Save and subscribe from anywhere on the web, without breaking your stride
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Integrations"
-msgstr "連携"
+#~ msgid "Integrations"
+#~ msgstr "連携"
 
 #. placeholder {0}: person.subscriberCount
 #. placeholder {0}: pub.subscriberCount
@@ -4137,6 +4244,10 @@ msgstr ""
 msgid "This request can't be completed here, so we're returning you to the app that sent you."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Read the docs"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No people in this list — add some from the edit dialog."
 msgstr "このリストにユーザーがいません。編集ダイアログから追加してください。"
@@ -4167,8 +4278,8 @@ msgid "Browse publications"
 msgstr "発行物を見る"
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
-msgstr "Standard Reader は読書を1つのアプリに閉じ込めません。ネットワークのどの断面にも独自の RSS フィードが付いてくるので、すでに使っているリーダーにそのまま流し込めます。"
+#~ msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
+#~ msgstr "Standard Reader は読書を1つのアプリに閉じ込めません。ネットワークのどの断面にも独自の RSS フィードが付いてくるので、すでに使っているリーダーにそのまま流し込めます。"
 
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Choose images"
@@ -4236,6 +4347,10 @@ msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That image is too detailed to fit under 1 MB. Try cropping it first."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“Been thinking about this all week. The measurement is the part that ruins it — not the writing.”"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -4310,13 +4425,17 @@ msgstr "フィードバックを読み込めませんでした <0>({0})</0>。�
 msgid "No publications match this tag yet."
 msgstr "このタグに一致する発行物はまだありません。"
 
+#: src/components/reader/about-view.tsx
+msgid "Written wherever they write"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "If you already know what you are looking for, the <0>Add publication</0> button opens a single field that does three things at once. Leave it empty and it shows what is trending. Type a few words and it searches the directory. Paste a handle or a domain — <1>@stdout.dev</1>, <2>stdout.dev</2> — and it looks that author up directly."
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "The conversation, gathered"
-msgstr "語られていることの、まとめ"
+#~ msgid "The conversation, gathered"
+#~ msgstr "語られていることの、まとめ"
 
 #: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
@@ -4344,8 +4463,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Save, like, subscribe — everywhere"
-msgstr "保存も、いいねも、購読も、どこでも"
+#~ msgid "Save, like, subscribe — everywhere"
+#~ msgstr "保存も、いいねも、購読も、どこでも"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe?"
@@ -4402,6 +4521,7 @@ msgstr ""
 
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
+#: src/components/reader/about-view.tsx
 msgid "API"
 msgstr "API"
 
@@ -4415,6 +4535,10 @@ msgstr "アイコンを差し替え"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unfollow"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Standard Reader doesn’t ask you to move in. It goes out to the web you already use, and hands your reading back in whatever shape suits you."
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx
@@ -4473,6 +4597,10 @@ msgstr "認証"
 
 #: src/components/reader/terms-view.tsx
 msgid "Changes to these terms"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Short-form posts and long reads"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -4541,6 +4669,10 @@ msgstr ""
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "{SITE_NAME} のブラウザ拡張機能をインストールすると、このサイトと同じアカウントとセッションクッキーが使われます。拡張機能はインデックス照合のためにページの URL を <0>/api/extension/*</0> エンドポイントへ送信し、オーバーレイの設定はブラウザの拡張機能ストレージに保存します。拡張機能のみに適用される詳細は<1>拡張機能のプライバシーポリシー</1>をご覧ください。"
+
+#: src/components/reader/about-view.tsx
+msgid "And when a run of them turns out to be good together, collect them into a named list — a playlist for reading. Anyone can add the whole thing to their own reader in a single tap."
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "Remove {memberName} from list"
@@ -4698,8 +4830,8 @@ msgid "Saves a link to your <0>{appLabel}</0> collection."
 msgstr "リンクを <0>{appLabel}</0> コレクションに保存します。"
 
 #: src/components/reader/about-view.tsx
-msgid "In your inbox"
-msgstr "受信トレイに"
+#~ msgid "In your inbox"
+#~ msgstr "受信トレイに"
 
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Drag to change the order your subscriptions appear in the sidebar."
@@ -4713,6 +4845,7 @@ msgstr "外観、読書設定、個人データ。"
 msgid "Authority for <0>app.standard-reader</0> resolves via DNS <1>_lexicon.*</1> TXT records to the publishing account."
 msgstr "<0>app.standard-reader</0> の権限は、DNS の <1>_lexicon.*</1> TXT レコードを経由して公開元アカウントに解決されます。"
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Margin"
 msgstr "Margin で"
@@ -4749,6 +4882,10 @@ msgstr "そのハンドルを解決できませんでした。"
 msgid "Good to know"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across all {countLabel} publications on the network, not just the handful you’ve heard of."
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Sharing a review on the <0>ATStore</0> will help both us and other users see what you think about Standard Reader."
 msgstr "<0>ATStore</0> でレビューを共有していただくと、Standard Reader についてのご意見を私たちにも他のユーザーにも届けられます。"
@@ -4756,6 +4893,10 @@ msgstr "<0>ATStore</0> でレビューを共有していただくと、Standard 
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "On Bluesky, quiet badges mark the people whose writing you can read here."
 #~ msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Publish labels others can subscribe to, or consume the ones we do."
+msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "The full account is on the <0>extension privacy page</0>."
@@ -4888,13 +5029,17 @@ msgstr "ここにはまだ読むものがありません。"
 msgid "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
 msgstr "ラベラーは DID を指定して購読するモデレーションサービスです。購読すると、読書中にラベルを確認したり、ラベル付きの投稿をぼかしたり非表示にしたりできます。"
 
+#: src/components/reader/about-view.tsx
+msgid "The part blogging always missed"
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "The older link rels"
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader meets you where you read"
-msgstr "Standard Reader は、読む場所に寄り添います"
+#~ msgid "Standard Reader meets you where you read"
+#~ msgstr "Standard Reader は、読む場所に寄り添います"
 
 #: src/components/appearance-settings.tsx
 msgid "Reset appearance"
@@ -5088,6 +5233,10 @@ msgstr ""
 #: src/routes/_layout.latest.tsx
 msgid "All caught up"
 msgstr "すべて読み終えました"
+
+#: src/components/reader/about-view.tsx
+msgid "Everything here is linkable, too. Publications, lists, and collections each get a clean URL with a rich preview card — plus a subscribe button a publication can drop straight onto its own site."
+msgstr ""
 
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Reorder subscriptions"
@@ -5284,6 +5433,7 @@ msgstr "ネットワークを検索"
 msgid "Search Google Fonts"
 msgstr "Google Fonts を検索"
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/article-below-fold.tsx
 msgid "Related reading"
 msgstr "関連する記事"
@@ -5522,8 +5672,8 @@ msgid "If something is confusing, broken, or missing, the <0>feedback board</0> 
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
-msgstr "軽量なブラウザ拡張機能を使えば、ウェブを見ている最中でも発行物を保存・購読できます。bsky.app 上のさりげないバッジと、どのページでもワンクリックで開くオーバーレイ付き。読むものリストが自然に埋まっていきます。"
+#~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+#~ msgstr "軽量なブラウザ拡張機能を使えば、ウェブを見ている最中でも発行物を保存・購読できます。bsky.app 上のさりげないバッジと、どのページでもワンクリックで開くオーバーレイ付き。読むものリストが自然に埋まっていきます。"
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -5763,8 +5913,8 @@ msgid "Open any article while signed in and it'll show up here. Your history liv
 msgstr "サインイン状態で記事を開くと、ここに表示されます。履歴はリポジトリ内に <0>app.standard-reader.read</0> レコードとして保存されます。"
 
 #: src/components/reader/about-view.tsx
-msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
-msgstr "名前を付けて共有できる発行物のリストを作りましょう。読書のプレイリストです。だれでもワンタップで自分のリーダーに追加できます。"
+#~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
+#~ msgstr "名前を付けて共有できる発行物のリストを作りましょう。読書のプレイリストです。だれでもワンタップで自分のリーダーに追加できます。"
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
@@ -5852,6 +6002,7 @@ msgstr ""
 #: src/components/docs/introduction-docs-page.tsx
 #: src/components/docs/labelers-docs-page.tsx
 #: src/components/labelers-settings-view.tsx
+#: src/components/reader/about-view.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/user-settings-view.tsx
 msgid "Labelers"
@@ -5862,8 +6013,8 @@ msgid "Choose your language"
 msgstr "言語を選択"
 
 #: src/components/reader/about-view.tsx
-msgid "Find the ones you didn't know you wanted"
-msgstr "自分でも気づいていなかったお気に入りを見つけよう"
+#~ msgid "Find the ones you didn't know you wanted"
+#~ msgstr "自分でも気づいていなかったお気に入りを見つけよう"
 
 #: src/components/labeler-detail-view.tsx
 msgid "Hide"
@@ -5949,8 +6100,8 @@ msgid "Supported content formats"
 msgstr "対応するコンテンツ形式"
 
 #: src/components/reader/about-view.tsx
-msgid "Plays nice with the open web"
-msgstr "オープンな Web と相性よく"
+#~ msgid "Plays nice with the open web"
+#~ msgstr "オープンな Web と相性よく"
 
 #: src/components/reader/privacy-view.tsx
 msgid "What we collect"
@@ -5975,6 +6126,10 @@ msgstr "Standard Reader は気に入りましたか？"
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Use original link"
 msgstr "元のリンクを使う"
+
+#: src/components/reader/about-view.tsx
+msgid "Everything this app runs on is public. The schemas are open, the read-model is queryable, and the renderer that draws these pages is published for you to use — so a reading app, a search tool, or a better client than this one is a weekend, not a platform deal."
+msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "Every publication page also serves a themed, embeddable subscribe widget — an iframe you can drop on your own site so visitors can subscribe without leaving your page. The easiest way to get it: open your publication's page on Standard Reader, use <0>Share → Embed subscribe</0>, pick landscape or portrait, and copy the snippet — no account or ownership check required to generate it."
@@ -6117,6 +6272,10 @@ msgstr "まだ議論はありません。"
 msgid "A single publication"
 msgstr "単一の発行物"
 
+#: src/components/reader/about-view.tsx
+msgid "Build on the same index"
+msgstr ""
+
 #: src/routes/extension.connected.tsx
 msgid "Return to the Standard Reader extension — this tab will close automatically."
 msgstr "Standard Reader の拡張機能に戻ってください。このタブは自動的に閉じます。"
@@ -6224,6 +6383,10 @@ msgstr ""
 #: src/components/reader/publication-latest-note.tsx
 msgid "Latest note"
 msgstr "最新のノート"
+
+#: src/components/reader/about-view.tsx
+msgid "The record schemas a publication, document, or follow is made of."
+msgstr ""
 
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6377,6 +6540,10 @@ msgstr "横長"
 msgid "Edit collection"
 msgstr "コレクションを編集"
 
+#: src/components/reader/about-view.tsx
+msgid "That is a real response from the endpoint this page just called — no key, no sign-up, no rate-limit form. The same is true of every feed, directory, and search query the reader itself runs."
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "After that, following is one button. Anywhere you see a publication — a card in a feed, the top of an article, a publication's own page — there is a <0>Follow</0> button next to its name. Select it again to stop following. Nothing else changes: the button just decides whether new writing from that publication reaches your Home and Latest."
 #~ msgstr ""
@@ -6425,8 +6592,12 @@ msgid "Opening the issue…"
 msgstr "号を開いています…"
 
 #: src/components/reader/about-view.tsx
-msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
-msgstr "Web のほかの部分を手放すことを求めたりはしません。むしろそこに手を伸ばし、広いネットワークのよき一員であり続けます。"
+msgid "However you like to read it"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+#~ msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+#~ msgstr "Web のほかの部分を手放すことを求めたりはしません。むしろそこに手を伸ばし、広いネットワークのよき一員であり続けます。"
 
 #: src/routes/_layout.collections.edit.$rkey.tsx
 msgid "We couldn’t load that collection to edit."
@@ -6488,6 +6659,10 @@ msgstr "Standard Reader は AT Proto リポジトリから <0>site.standard.docu
 #: src/components/reader/list-edit-modal.tsx
 msgid "e.g. Tech, Friends, Cooking"
 msgstr "例：テクノロジー、友だち、料理"
+
+#: src/components/reader/about-view.tsx
+msgid "Semble"
+msgstr ""
 
 #. placeholder {0}: fmt.relativeTime(connection.lastUsedAt)
 #: src/components/user-settings-view.tsx
@@ -6631,6 +6806,10 @@ msgstr "オン"
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Two other pieces link to this one — you can read them from here."
 msgstr ""
 
 #: src/components/reader/page-reader-bar.tsx
@@ -6790,6 +6969,10 @@ msgstr ""
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Finding your way around"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Cited by"
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -2665,6 +2665,10 @@ msgstr "{itemTitle} を並べ替え"
 msgid "Back to feedback"
 msgstr "フィードバックに戻る"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "View on {name}"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "{pubTotal, plural, one {# publication} other {# publications}}"
 msgstr "{pubTotal, plural, one {# 件の発行物} other {# 件の発行物}}"

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -99,6 +99,10 @@ msgstr "Standard Reader でのコンテンツ表示"
 msgid "Articles gaining attention across the network right now."
 msgstr "いまネットワークで注目を集めている記事です。"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# member} other {# members}}"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Add an article"
 msgstr "記事を追加"
@@ -410,9 +414,9 @@ msgstr ""
 msgid "{years}y ago"
 msgstr ""
 
-#: src/components/reader/reorder-lists-modal.tsx
-#~ msgid "List"
-#~ msgstr "リスト"
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "List"
+msgstr "リスト"
 
 #: src/components/appearance-settings.tsx
 msgid "The spacing between things — tighter for more on screen, looser for more room to read."
@@ -1971,6 +1975,7 @@ msgstr "リーダーのインターフェースに使用する言語です。記
 #~ msgid "Following, saving, recommending, and — once you follow more than a handful of publications — keeping the whole thing tidy."
 #~ msgstr ""
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 #: src/components/user-settings-view.tsx
 msgid "Feed"
 msgstr ""
@@ -3253,6 +3258,10 @@ msgstr ""
 msgid "e.g. Dispatches from the Atmosphere"
 msgstr "例: Dispatches from the Atmosphere"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# join} other {# joins}}"
+msgstr ""
+
 #: src/components/docs/introduction-docs-page.tsx
 msgid "the AT Protocol schemas that define Standard records and the shared definitions they build on."
 msgstr ""
@@ -3560,6 +3569,10 @@ msgstr "プレビューモード"
 #: src/components/NavbarAuth.tsx
 #: src/components/site-legal-links.tsx
 msgid "Guide"
+msgstr ""
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# like} other {# likes}}"
 msgstr ""
 
 #: src/routes/_layout.collections.new.tsx
@@ -4042,6 +4055,10 @@ msgstr ""
 msgid "{0}+ articles"
 msgstr "{0}+ 件の記事"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "Starter pack"
+msgstr ""
+
 #: src/routes/_layout.feedback.return.tsx
 msgid "That link expired."
 msgstr "このリンクは期限切れです。"
@@ -4335,6 +4352,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "Cited in"
 msgstr "引用元"
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# follower} other {# followers}}"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "A couple of publications worth discovering."
@@ -5953,6 +5974,10 @@ msgstr "「例を実行」をクリックすると、セッションを使って
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "At the bottom of settings, <0>Personal data</0> deletes categories of records outright: your reading history, your saved articles, or the publication lists you made. Each asks for confirmation and explains what will change."
+msgstr ""
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "Profile"
 msgstr ""
 
 #: src/components/reader/friend-publishers.tsx

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -123,12 +123,12 @@ msgid "Every renderer takes one input for the document — the content payload o
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "One tap from the reading view, on any device, instantly in sync. Your library is always where you left it."
-msgstr "읽기 화면에서 한 번만 탭하면 모든 기기에 즉시 동기화됩니다. 라이브러리는 항상 멈춘 그 자리에 있습니다."
+#~ msgid "One tap from the reading view, on any device, instantly in sync. Your library is always where you left it."
+#~ msgstr "읽기 화면에서 한 번만 탭하면 모든 기기에 즉시 동기화됩니다. 라이브러리는 항상 멈춘 그 자리에 있습니다."
 
 #: src/components/reader/about-view.tsx
-msgid "Curated lists & collections"
-msgstr "큐레이션된 리스트 & 컬렉션"
+#~ msgid "Curated lists & collections"
+#~ msgstr "큐레이션된 리스트 & 컬렉션"
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Vue 3."
@@ -179,6 +179,7 @@ msgstr ""
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
 #: src/components/docs/lexicon-docs-intro.tsx
+#: src/components/reader/about-view.tsx
 msgid "Lexicons"
 msgstr "Lexicon"
 
@@ -256,6 +257,10 @@ msgstr "제목을 입력하세요."
 #~ msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Follow it and it starts appearing in your feeds like any other."
 #~ msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -302,8 +307,8 @@ msgid "(this is what Standard Reader itself uses)"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
-msgstr "그리고 결코 닫혀 있다고 느껴지지 않습니다. 저희는 각 글을 Atmosphere — 이 앱 너머의 열린 네트워크 — 에서 벌어지는 대화와 연결해, 그 글에 대한 Bluesky 게시물과 답글, 여백에 남겨진 메모, 그리고 그 글을 인용한 다른 글들을 읽고 있는 화면 아래에 조용히 모아 둡니다."
+#~ msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+#~ msgstr "그리고 결코 닫혀 있다고 느껴지지 않습니다. 저희는 각 글을 Atmosphere — 이 앱 너머의 열린 네트워크 — 에서 벌어지는 대화와 연결해, 그 글에 대한 Bluesky 게시물과 답글, 여백에 남겨진 메모, 그리고 그 글을 인용한 다른 글들을 읽고 있는 화면 아래에 조용히 모아 둡니다."
 
 #: src/components/guide/guide-shell.tsx
 msgid "Still stuck, or something here doesn't match what you see? <0>Tell us on the feedback board</0> — questions are welcome there, not just bug reports."
@@ -316,6 +321,10 @@ msgstr "실행 중…"
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Your Home feed is built from subscriptions. Three is a good start."
 msgstr "홈 피드는 구독을 바탕으로 만들어집니다. 세 개면 시작하기 좋습니다."
+
+#: src/components/reader/about-view.tsx
+msgid "A note in the margin"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Colors"
@@ -389,6 +398,10 @@ msgstr "구독하는 중…"
 msgid "People"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Every piece is a door to the next one"
+msgstr ""
+
 #: src/routes/_layout.friends.tsx
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 msgstr ""
@@ -417,6 +430,7 @@ msgstr ""
 msgid "Switch to light paper"
 msgstr "밝은 종이로 전환"
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Bluesky"
 msgstr "Bluesky에서"
@@ -426,8 +440,8 @@ msgid "Set these now, or change them any time in Settings."
 msgstr "지금 설정하거나 설정에서 언제든지 변경하세요."
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
-msgstr "대부분의 리더는 이미 구독한 것에서 멈춥니다. Standard Reader는 다음에 좋아할 것을 찾아주는 일까지 자기 몫으로 여깁니다. 이름을 들어본 몇 곳뿐 아니라 네트워크의 모든 발행물을 둘러보세요."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
+#~ msgstr "대부분의 리더는 이미 구독한 것에서 멈춥니다. Standard Reader는 다음에 좋아할 것을 찾아주는 일까지 자기 몫으로 여깁니다. 이름을 들어본 몇 곳뿐 아니라 네트워크의 모든 발행물을 둘러보세요."
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Open <0>Collections</0> in the sidebar and start a new one."
@@ -682,8 +696,8 @@ msgid "Making a collection"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Read the guide"
-msgstr ""
+#~ msgid "Read the guide"
+#~ msgstr ""
 
 #: src/components/reader/app-shell.tsx
 #: src/components/site-legal-links.tsx
@@ -811,6 +825,10 @@ msgstr "확장 프로그램 개인정보 보호"
 msgid "Signing in"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Public API — no key required"
+msgstr ""
+
 #: src/components/reading-settings-preview.tsx
 msgid "Loading voice sample"
 msgstr "음성 샘플 불러오는 중"
@@ -874,6 +892,11 @@ msgstr "다시 시도"
 
 #: src/lib/guide/navigation.ts
 msgid "Welcome"
+msgstr ""
+
+#. placeholder {0}: SUPPORTED_CONTENT_FORMATS.size
+#: src/components/reader/about-view.tsx
+msgid "An article is a record in its author’s own repository, and every publishing tool on the network writes that record a little differently. Standard Reader reads {0} of those content formats and renders them all into the same calm page — so a reader never has to care which tool a writer chose."
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -1003,6 +1026,10 @@ msgstr ""
 msgid "Bookmarks"
 msgstr "북마크"
 
+#: src/components/reader/about-view.tsx
+msgid "None of this is ours. We gather it from the Atmosphere — the open network these apps all share — and show it under the piece it’s about. Every line links back to where it was actually written, no account or comment box required, and it works whether or not the author ever opted in."
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Saved to {savedName} on {appLabel}."
 msgstr "{appLabel}의 {savedName}에 저장했습니다."
@@ -1057,6 +1084,10 @@ msgstr "열린 웹을 위한 차분한 독서 공간. 2분만 들여 나에게 �
 #: src/routes/_layout.collections.index.tsx
 msgid "New series"
 msgstr "새 시리즈"
+
+#: src/components/reader/about-view.tsx
+msgid "Blogs never really solved the conversation. Comment boxes belonged to the blog, went unread, filled with spam, and vanished when the site did. So the talking moved somewhere else — and stopped being attached to the writing at all."
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "These deletions remove the records from your account itself, not just from our copy — which is why they cannot be undone. Deleting your reading history, for example, makes everything look unread again everywhere."
@@ -1130,6 +1161,10 @@ msgstr ""
 msgid "Under that, <0>Cited in</0> lists other articles that link to this one, and <1>Related reading</1> suggests pieces from across the network on the same subjects — usually from publications you have not met yet."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Essays and serialized writing"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 #~ msgid "Following your first publications"
@@ -1182,8 +1217,8 @@ msgid "Custom"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Read the API docs"
-msgstr "API 문서 보기"
+#~ msgid "Read the API docs"
+#~ msgstr "API 문서 보기"
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Select <0>Listen</0> in the top bar and the article is read aloud. The first time takes a few seconds to warm up; after that it starts straight away."
@@ -1198,8 +1233,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Shareable everywhere"
-msgstr "어디서나 공유 가능"
+#~ msgid "Shareable everywhere"
+#~ msgstr "어디서나 공유 가능"
 
 #: src/magazine/Magazine.tsx
 msgid "Close table of contents"
@@ -1232,6 +1267,10 @@ msgstr ""
 
 #: src/components/docs/introduction-docs-page.tsx
 msgid "how to make a site discoverable on Standard and have its content read inline, without adopting a platform."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across every publication on the network, not just the handful you’ve heard of."
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -1303,6 +1342,10 @@ msgstr ""
 msgid "To move several at once, open <0>Subscriptions</0>, select the rows you want, and add them all to a list in one action. That is much faster than doing it publication by publication."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Blocks, pages, and footnotes"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Appearance"
 msgstr "화면 설정"
@@ -1354,6 +1397,10 @@ msgstr "계정"
 msgid "Collapse all lists"
 msgstr "모든 목록 접기"
 
+#: src/components/reader/about-view.tsx
+msgid "Four essays covering the same ground, from publications you don’t follow yet."
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "We couldn’t find that article."
 msgstr "해당 글을 찾을 수 없습니다."
@@ -1388,6 +1435,10 @@ msgstr "내 컬렉션"
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“…made to be read, and not to be measured.”"
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -1505,6 +1556,10 @@ msgstr "빠른 전문 검색"
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "컬렉션 이름"
+
+#: src/components/reader/about-view.tsx
+msgid "+{UNNAMED_FORMAT_COUNT} more"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1698,8 +1753,8 @@ msgid "What every control on an article does — including having it read aloud 
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "The reading experience"
-msgstr "읽기 경험"
+#~ msgid "The reading experience"
+#~ msgstr "읽기 경험"
 
 #: src/routes/_layout.tsx
 msgid "Loading page"
@@ -1736,6 +1791,10 @@ msgstr ""
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "Collections live under <0>Collections</0> in the sidebar. Because publishing one writes a new kind of record to your account, the first time you make one you will be asked to grant an extra permission — that is the <1>Upgrade permissions</1> prompt, and it only appears once."
 #~ msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Also read natively:"
+msgstr ""
 
 #. placeholder {0}: pub.name
 #: src/components/reader/article-below-fold.tsx
@@ -1777,8 +1836,8 @@ msgstr "이 페이지의 모든 발행물을 구독 중입니다. 더 보려면 
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
-msgstr "각 아티클 아래에서 열린 네트워크 전체의 논의를 볼 수 있습니다. Bluesky 게시물과 답글, 마진 노트, 이 글을 인용한 다른 글의 링크, 관련 읽을거리까지. 모두 읽기 전용이며 원본으로 연결됩니다."
+#~ msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+#~ msgstr "각 아티클 아래에서 열린 네트워크 전체의 논의를 볼 수 있습니다. Bluesky 게시물과 답글, 마진 노트, 이 글을 인용한 다른 글의 링크, 관련 읽을거리까지. 모두 읽기 전용이며 원본으로 연결됩니다."
 
 #: src/routes/_layout.latest.tsx
 msgid "Show all subscriptions"
@@ -1831,8 +1890,8 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {검색 결과 #개} other {검색 결과 #개}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
-msgstr "발행물, 리스트, 컬렉션마다 리치 미리보기 카드가 달린 깔끔한 링크가 생깁니다. 발행물이 자체 사이트에 넣을 수 있는 구독 버튼도 함께 제공됩니다."
+#~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
+#~ msgstr "발행물, 리스트, 컬렉션마다 리치 미리보기 카드가 달린 깔끔한 링크가 생깁니다. 발행물이 자체 사이트에 넣을 수 있는 구독 버튼도 함께 제공됩니다."
 
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Search topics"
@@ -1857,6 +1916,10 @@ msgstr "컬렉션 내 아티클"
 #: src/components/user-settings-view.tsx
 msgid "System"
 msgstr "시스템"
+
+#: src/components/reader/about-view.tsx
+msgid "Every feed, directory, and search query the app itself runs."
+msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Could not save to {appLabel}"
@@ -1964,8 +2027,8 @@ msgid "Never used"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Building something on the same index? There’s a public API."
-msgstr "같은 인덱스로 무언가 만들고 있나요? 공개 API가 있습니다."
+#~ msgid "Building something on the same index? There’s a public API."
+#~ msgstr "같은 인덱스로 무언가 만들고 있나요? 공개 API가 있습니다."
 
 #: src/components/reader/comments/comments-section.tsx
 msgid "Discussion"
@@ -2196,6 +2259,10 @@ msgstr "이 컬렉션이 게시되는 곳입니다. 시리즈 팔로워에게 �
 msgid "No apps connected"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Nothing about it is fixed. Set the measure, the type size, and the typeface to whatever your eyes want, in light or dark, and the setting follows you to every article you open after it."
+msgstr ""
+
 #: src/components/reader/markdown-field.tsx
 msgid "Edit"
 msgstr "수정"
@@ -2215,6 +2282,10 @@ msgstr "Standard Reader 인덱스 읽기 모델을 위한 공개 XRPC 쿼리와 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Save theme"
 msgstr "테마 저장"
+
+#: src/components/reader/about-view.tsx
+msgid "A reply"
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "your day: one featured article, then what is new from the publications you subscribe to."
@@ -2397,6 +2468,10 @@ msgstr ""
 #~ msgid "Carry on browsing. The overlay appears where it is useful and stays out of the way where it is not."
 #~ msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "And if your reader of choice is one you already have, any slice of the network comes with its own feed — pipe it straight in and never open this app at all."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "To email your digest, Standard Reader needs your account email address. We'll ask your PDS to share it — you'll be sent to your login to approve the request, then brought right back here. Your email is used only to send the weekly digest, and you can turn it off any time."
 msgstr "다이제스트를 보내려면 Standard Reader에 계정 이메일 주소가 필요합니다. PDS에 공유를 요청하며, 로그인 화면에서 승인한 뒤 바로 이곳으로 돌아옵니다. 이메일은 주간 다이제스트 발송에만 사용되고 언제든 끌 수 있습니다."
@@ -2406,7 +2481,6 @@ msgid "Where your reading is kept, who else can see it, what you agreed to when 
 msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
-#: src/components/reader/about-view.tsx
 #: src/lib/guide/navigation.ts
 msgid "Discovery"
 msgstr "발견"
@@ -2533,6 +2607,10 @@ msgstr "비망록을 쓴다는 것"
 msgid "Most reading apps keep your list of follows on their own servers. If the app shuts down, your list goes with it."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Keep the good sentence"
+msgstr ""
+
 #: src/routes/_layout.u.$did.tsx
 msgid "Featured in"
 msgstr "게재 매체"
@@ -2624,8 +2702,8 @@ msgid "Paper"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
-msgstr "설정 하나만 바꾸면 글 링크가 해당 발행물의 사이트에서 열립니다. 편한 곳에서 읽으세요."
+#~ msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
+#~ msgstr "설정 하나만 바꾸면 글 링크가 해당 발행물의 사이트에서 열립니다. 편한 곳에서 읽으세요."
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Discover is the directory of every publication the network knows about — not a curated shelf. It runs top to bottom from most personal to most complete:"
@@ -2690,8 +2768,12 @@ msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {팔로워} other {팔로워}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
-msgstr "대부분의 리더는 이미 구독한 것에서 멈춥니다. Standard Reader는 다음에 좋아할 글을 찾아 주는 것까지 자기 일로 여깁니다. 네트워크의 발행물 {countLabel}곳을 모두 둘러보세요 — 이름을 들어본 몇 곳만이 아니라요."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgstr "대부분의 리더는 이미 구독한 것에서 멈춥니다. Standard Reader는 다음에 좋아할 글을 찾아 주는 것까지 자기 일로 여깁니다. 네트워크의 발행물 {countLabel}곳을 모두 둘러보세요 — 이름을 들어본 몇 곳만이 아니라요."
+
+#: src/components/reader/about-view.tsx
+msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself, and every save, like, and subscribe is instantly in sync with whatever device you read on next."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labels"
@@ -2767,6 +2849,10 @@ msgstr ""
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Upgrade to author Collections"
 msgstr "업그레이드하고 컬렉션 만들기"
+
+#: src/components/reader/about-view.tsx
+msgid "Render a document in your own app —"
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "Your social actions (follows, likes, saves, lists) are written to your AT Protocol repository and are visible according to the network's rules and your account settings. Our Postgres database holds a network read-model, app session state, and cached public metadata — not the canonical copies of publications."
@@ -2872,12 +2958,20 @@ msgstr "2026년 6월 13일 최종 업데이트"
 msgid "{shown, plural, one {# match} other {# matches}}"
 msgstr "{shown, plural, one {#개 일치} other {#개 일치}}"
 
+#: src/components/reader/about-view.tsx
+msgid "Select a passage and share it as a typeset card that links back to the article — or keep reading and pick up exactly where you left off next time."
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "People you follow write here"
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Good writing rarely turns up while you are already in a reading app. The extension puts saving and subscribing on every page you visit."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Drop a Standard document into your own app, in your own framework."
 msgstr ""
 
 #: src/magazine/flow.tsx
@@ -3051,6 +3145,10 @@ msgstr ""
 #: src/components/docs/docs-publishing-nav.tsx
 #~ msgid "Publishing guide"
 #~ msgstr "발행 가이드"
+
+#: src/components/reader/about-view.tsx
+msgid "Prefer the original? Flip one setting and article links open on the publication’s own site instead — Standard Reader will still keep your place."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "<0>Share</0> copies a link, or posts the article to Bluesky with a proper preview card. On a phone it can hand off to whatever you normally share with."
@@ -3425,6 +3523,10 @@ msgstr "문제가 발생했습니다."
 msgid "The best of what you subscribe to"
 msgstr "구독 중인 곳의 가장 좋은 글"
 
+#: src/components/reader/about-view.tsx
+msgid "Under this article"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Note"
 msgstr "노트"
@@ -3526,6 +3628,7 @@ msgstr "오디오 생성 중… {percent}%"
 
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
+#: src/components/reader/about-view.tsx
 msgid "Renderers"
 msgstr ""
 
@@ -3565,8 +3668,8 @@ msgid "What Standard Reader is"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Prefer the original?"
-msgstr "원문으로 볼까요?"
+#~ msgid "Prefer the original?"
+#~ msgstr "원문으로 볼까요?"
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Could not add to list"
@@ -3787,6 +3890,10 @@ msgstr "브라우저 설정에 따라 이 언어를 선택했습니다. 언제�
 
 #: src/routes/mcp/authorize.tsx
 msgid "Nothing has been shared. Head back to the app you came from and try connecting again."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“This is the whole argument in one clause. Worth sitting with.”"
 msgstr ""
 
 #: src/components/reader/text-selection-toolbar.tsx
@@ -4013,8 +4120,8 @@ msgid "Save and subscribe from anywhere on the web, without breaking your stride
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Integrations"
-msgstr "연동"
+#~ msgid "Integrations"
+#~ msgstr "연동"
 
 #. placeholder {0}: person.subscriberCount
 #. placeholder {0}: pub.subscriberCount
@@ -4137,6 +4244,10 @@ msgstr ""
 msgid "This request can't be completed here, so we're returning you to the app that sent you."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Read the docs"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No people in this list — add some from the edit dialog."
 msgstr "이 목록에 사람이 없습니다 — 편집 대화상자에서 추가하세요."
@@ -4167,8 +4278,8 @@ msgid "Browse publications"
 msgstr "발행물 둘러보기"
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
-msgstr "Standard Reader는 당신의 읽기를 하나의 앱에 가두지 않습니다. 네트워크의 어느 부분이든 자체 RSS 피드를 제공하니, 이미 쓰고 있는 리더로 바로 연결하세요."
+#~ msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
+#~ msgstr "Standard Reader는 당신의 읽기를 하나의 앱에 가두지 않습니다. 네트워크의 어느 부분이든 자체 RSS 피드를 제공하니, 이미 쓰고 있는 리더로 바로 연결하세요."
 
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Choose images"
@@ -4236,6 +4347,10 @@ msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That image is too detailed to fit under 1 MB. Try cropping it first."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“Been thinking about this all week. The measurement is the part that ruins it — not the writing.”"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -4310,13 +4425,17 @@ msgstr "의견을 불러오지 못했습니다 <0>({0})</0>. 잠시 후 다시 �
 msgid "No publications match this tag yet."
 msgstr "아직 이 태그와 일치하는 발행물이 없습니다."
 
+#: src/components/reader/about-view.tsx
+msgid "Written wherever they write"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "If you already know what you are looking for, the <0>Add publication</0> button opens a single field that does three things at once. Leave it empty and it shows what is trending. Type a few words and it searches the directory. Paste a handle or a domain — <1>@stdout.dev</1>, <2>stdout.dev</2> — and it looks that author up directly."
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "The conversation, gathered"
-msgstr "한자리에 모인 대화"
+#~ msgid "The conversation, gathered"
+#~ msgstr "한자리에 모인 대화"
 
 #: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
@@ -4344,8 +4463,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Save, like, subscribe — everywhere"
-msgstr "저장, 좋아요, 구독 — 어디서나"
+#~ msgid "Save, like, subscribe — everywhere"
+#~ msgstr "저장, 좋아요, 구독 — 어디서나"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe?"
@@ -4402,6 +4521,7 @@ msgstr ""
 
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
+#: src/components/reader/about-view.tsx
 msgid "API"
 msgstr "API"
 
@@ -4415,6 +4535,10 @@ msgstr "아이콘 교체"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unfollow"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Standard Reader doesn’t ask you to move in. It goes out to the web you already use, and hands your reading back in whatever shape suits you."
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx
@@ -4473,6 +4597,10 @@ msgstr "인증"
 
 #: src/components/reader/terms-view.tsx
 msgid "Changes to these terms"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Short-form posts and long reads"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -4541,6 +4669,10 @@ msgstr ""
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "{SITE_NAME} 브라우저 확장 프로그램을 설치하면 이 사이트와 동일한 계정 및 세션 쿠키를 사용합니다. 확장 프로그램은 색인 매칭을 위해 페이지 URL을 <0>/api/extension/*</0> 엔드포인트로 전송하고, 오버레이 설정은 브라우저의 확장 프로그램 저장소에 보관합니다. 확장 프로그램에만 적용되는 자세한 내용은 <1>확장 프로그램 개인정보 처리방침</1>을 참고하세요."
+
+#: src/components/reader/about-view.tsx
+msgid "And when a run of them turns out to be good together, collect them into a named list — a playlist for reading. Anyone can add the whole thing to their own reader in a single tap."
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "Remove {memberName} from list"
@@ -4698,8 +4830,8 @@ msgid "Saves a link to your <0>{appLabel}</0> collection."
 msgstr "<0>{appLabel}</0> 컬렉션에 링크를 저장합니다."
 
 #: src/components/reader/about-view.tsx
-msgid "In your inbox"
-msgstr "내 받은 글"
+#~ msgid "In your inbox"
+#~ msgstr "내 받은 글"
 
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Drag to change the order your subscriptions appear in the sidebar."
@@ -4713,6 +4845,7 @@ msgstr "화면, 읽기 환경설정, 개인 정보."
 msgid "Authority for <0>app.standard-reader</0> resolves via DNS <1>_lexicon.*</1> TXT records to the publishing account."
 msgstr "<0>app.standard-reader</0>의 권한은 DNS <1>_lexicon.*</1> TXT 레코드를 통해 발행 계정으로 확인됩니다."
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Margin"
 msgstr "Margin에서"
@@ -4749,6 +4882,10 @@ msgstr "해당 핸들을 확인하지 못했습니다."
 msgid "Good to know"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across all {countLabel} publications on the network, not just the handful you’ve heard of."
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Sharing a review on the <0>ATStore</0> will help both us and other users see what you think about Standard Reader."
 msgstr "<0>ATStore</0>에 리뷰를 남겨 주시면 저희와 다른 사용자 모두 Standard Reader에 대한 생각을 알 수 있습니다."
@@ -4756,6 +4893,10 @@ msgstr "<0>ATStore</0>에 리뷰를 남겨 주시면 저희와 다른 사용자 
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "On Bluesky, quiet badges mark the people whose writing you can read here."
 #~ msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Publish labels others can subscribe to, or consume the ones we do."
+msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "The full account is on the <0>extension privacy page</0>."
@@ -4888,13 +5029,17 @@ msgstr "아직 읽을 글이 없습니다."
 msgid "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
 msgstr "라벨러는 DID로 구독하는 모더레이션 서비스입니다. 구독하면 읽는 동안 해당 라벨을 확인하고, 라벨이 붙은 게시물을 흐리게 하거나 숨길 수 있습니다."
 
+#: src/components/reader/about-view.tsx
+msgid "The part blogging always missed"
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "The older link rels"
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader meets you where you read"
-msgstr "Standard Reader는 당신이 읽는 곳으로 찾아갑니다"
+#~ msgid "Standard Reader meets you where you read"
+#~ msgstr "Standard Reader는 당신이 읽는 곳으로 찾아갑니다"
 
 #: src/components/appearance-settings.tsx
 msgid "Reset appearance"
@@ -5088,6 +5233,10 @@ msgstr ""
 #: src/routes/_layout.latest.tsx
 msgid "All caught up"
 msgstr "모두 확인했습니다"
+
+#: src/components/reader/about-view.tsx
+msgid "Everything here is linkable, too. Publications, lists, and collections each get a clean URL with a rich preview card — plus a subscribe button a publication can drop straight onto its own site."
+msgstr ""
 
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Reorder subscriptions"
@@ -5284,6 +5433,7 @@ msgstr "네트워크 검색"
 msgid "Search Google Fonts"
 msgstr "Google Fonts 검색"
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/article-below-fold.tsx
 msgid "Related reading"
 msgstr "함께 읽기"
@@ -5522,8 +5672,8 @@ msgid "If something is confusing, broken, or missing, the <0>feedback board</0> 
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
-msgstr "가벼운 브라우저 확장 프로그램으로 웹을 둘러보다가 바로 발행물을 저장하고 구독할 수 있습니다. bsky.app에는 은은한 배지가, 방문하는 어떤 페이지에서든 원클릭 오버레이가 나타납니다. 읽을 목록이 저절로 채워집니다."
+#~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+#~ msgstr "가벼운 브라우저 확장 프로그램으로 웹을 둘러보다가 바로 발행물을 저장하고 구독할 수 있습니다. bsky.app에는 은은한 배지가, 방문하는 어떤 페이지에서든 원클릭 오버레이가 나타납니다. 읽을 목록이 저절로 채워집니다."
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -5763,8 +5913,8 @@ msgid "Open any article while signed in and it'll show up here. Your history liv
 msgstr "로그인한 상태로 글을 열면 여기에 표시됩니다. 기록은 내 저장소에 <0>app.standard-reader.read</0> 레코드로 보관됩니다."
 
 #: src/components/reader/about-view.tsx
-msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
-msgstr "이름을 붙여 공유할 수 있는 발행물 목록을 만드세요. 읽기용 플레이리스트입니다. 누구나 한 번의 탭으로 자기 리더에 추가할 수 있습니다."
+#~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
+#~ msgstr "이름을 붙여 공유할 수 있는 발행물 목록을 만드세요. 읽기용 플레이리스트입니다. 누구나 한 번의 탭으로 자기 리더에 추가할 수 있습니다."
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
@@ -5852,6 +6002,7 @@ msgstr ""
 #: src/components/docs/introduction-docs-page.tsx
 #: src/components/docs/labelers-docs-page.tsx
 #: src/components/labelers-settings-view.tsx
+#: src/components/reader/about-view.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/user-settings-view.tsx
 msgid "Labelers"
@@ -5862,8 +6013,8 @@ msgid "Choose your language"
 msgstr "언어 선택"
 
 #: src/components/reader/about-view.tsx
-msgid "Find the ones you didn't know you wanted"
-msgstr "원하는 줄 몰랐던 것들을 찾아보세요"
+#~ msgid "Find the ones you didn't know you wanted"
+#~ msgstr "원하는 줄 몰랐던 것들을 찾아보세요"
 
 #: src/components/labeler-detail-view.tsx
 msgid "Hide"
@@ -5949,8 +6100,8 @@ msgid "Supported content formats"
 msgstr "지원하는 콘텐츠 형식"
 
 #: src/components/reader/about-view.tsx
-msgid "Plays nice with the open web"
-msgstr "열린 웹과 잘 어울립니다"
+#~ msgid "Plays nice with the open web"
+#~ msgstr "열린 웹과 잘 어울립니다"
 
 #: src/components/reader/privacy-view.tsx
 msgid "What we collect"
@@ -5975,6 +6126,10 @@ msgstr "Standard Reader가 마음에 드시나요?"
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Use original link"
 msgstr "원본 링크 사용"
+
+#: src/components/reader/about-view.tsx
+msgid "Everything this app runs on is public. The schemas are open, the read-model is queryable, and the renderer that draws these pages is published for you to use — so a reading app, a search tool, or a better client than this one is a weekend, not a platform deal."
+msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "Every publication page also serves a themed, embeddable subscribe widget — an iframe you can drop on your own site so visitors can subscribe without leaving your page. The easiest way to get it: open your publication's page on Standard Reader, use <0>Share → Embed subscribe</0>, pick landscape or portrait, and copy the snippet — no account or ownership check required to generate it."
@@ -6117,6 +6272,10 @@ msgstr "아직 토론이 없습니다."
 msgid "A single publication"
 msgstr "단일 발행물"
 
+#: src/components/reader/about-view.tsx
+msgid "Build on the same index"
+msgstr ""
+
 #: src/routes/extension.connected.tsx
 msgid "Return to the Standard Reader extension — this tab will close automatically."
 msgstr "Standard Reader 확장 프로그램으로 돌아가세요 — 이 탭은 자동으로 닫힙니다."
@@ -6224,6 +6383,10 @@ msgstr ""
 #: src/components/reader/publication-latest-note.tsx
 msgid "Latest note"
 msgstr "최근 노트"
+
+#: src/components/reader/about-view.tsx
+msgid "The record schemas a publication, document, or follow is made of."
+msgstr ""
 
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6377,6 +6540,10 @@ msgstr "가로"
 msgid "Edit collection"
 msgstr "컬렉션 편집"
 
+#: src/components/reader/about-view.tsx
+msgid "That is a real response from the endpoint this page just called — no key, no sign-up, no rate-limit form. The same is true of every feed, directory, and search query the reader itself runs."
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "After that, following is one button. Anywhere you see a publication — a card in a feed, the top of an article, a publication's own page — there is a <0>Follow</0> button next to its name. Select it again to stop following. Nothing else changes: the button just decides whether new writing from that publication reaches your Home and Latest."
 #~ msgstr ""
@@ -6425,8 +6592,12 @@ msgid "Opening the issue…"
 msgstr "호를 여는 중…"
 
 #: src/components/reader/about-view.tsx
-msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
-msgstr "웹의 나머지를 등지라고 요구하지 않습니다. 오히려 손을 내밀며, 더 넓은 네트워크의 좋은 구성원으로 남습니다."
+msgid "However you like to read it"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+#~ msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+#~ msgstr "웹의 나머지를 등지라고 요구하지 않습니다. 오히려 손을 내밀며, 더 넓은 네트워크의 좋은 구성원으로 남습니다."
 
 #: src/routes/_layout.collections.edit.$rkey.tsx
 msgid "We couldn’t load that collection to edit."
@@ -6488,6 +6659,10 @@ msgstr "Standard Reader는 AT Proto 저장소에서 <0>site.standard.document</0
 #: src/components/reader/list-edit-modal.tsx
 msgid "e.g. Tech, Friends, Cooking"
 msgstr "예: 기술, 친구, 요리"
+
+#: src/components/reader/about-view.tsx
+msgid "Semble"
+msgstr ""
 
 #. placeholder {0}: fmt.relativeTime(connection.lastUsedAt)
 #: src/components/user-settings-view.tsx
@@ -6631,6 +6806,10 @@ msgstr "켬"
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Two other pieces link to this one — you can read them from here."
 msgstr ""
 
 #: src/components/reader/page-reader-bar.tsx
@@ -6790,6 +6969,10 @@ msgstr ""
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Finding your way around"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Cited by"
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -2665,6 +2665,10 @@ msgstr "{itemTitle} 순서 변경"
 msgid "Back to feedback"
 msgstr "피드백으로 돌아가기"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "View on {name}"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "{pubTotal, plural, one {# publication} other {# publications}}"
 msgstr "{pubTotal, plural, one {발행물 #개} other {발행물 #개}}"

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -99,6 +99,10 @@ msgstr "Standard Reader의 콘텐츠 렌더링"
 msgid "Articles gaining attention across the network right now."
 msgstr "지금 네트워크 전반에서 주목받고 있는 글입니다."
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# member} other {# members}}"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Add an article"
 msgstr "글 추가"
@@ -410,9 +414,9 @@ msgstr ""
 msgid "{years}y ago"
 msgstr ""
 
-#: src/components/reader/reorder-lists-modal.tsx
-#~ msgid "List"
-#~ msgstr "목록"
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "List"
+msgstr "목록"
 
 #: src/components/appearance-settings.tsx
 msgid "The spacing between things — tighter for more on screen, looser for more room to read."
@@ -1971,6 +1975,7 @@ msgstr "리더 인터페이스에 사용할 언어입니다. 아티클은 작성
 #~ msgid "Following, saving, recommending, and — once you follow more than a handful of publications — keeping the whole thing tidy."
 #~ msgstr ""
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 #: src/components/user-settings-view.tsx
 msgid "Feed"
 msgstr ""
@@ -3253,6 +3258,10 @@ msgstr ""
 msgid "e.g. Dispatches from the Atmosphere"
 msgstr "예: Dispatches from the Atmosphere"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# join} other {# joins}}"
+msgstr ""
+
 #: src/components/docs/introduction-docs-page.tsx
 msgid "the AT Protocol schemas that define Standard records and the shared definitions they build on."
 msgstr ""
@@ -3560,6 +3569,10 @@ msgstr "미리보기 모드"
 #: src/components/NavbarAuth.tsx
 #: src/components/site-legal-links.tsx
 msgid "Guide"
+msgstr ""
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# like} other {# likes}}"
 msgstr ""
 
 #: src/routes/_layout.collections.new.tsx
@@ -4042,6 +4055,10 @@ msgstr ""
 msgid "{0}+ articles"
 msgstr "아티클 {0}개 이상"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "Starter pack"
+msgstr ""
+
 #: src/routes/_layout.feedback.return.tsx
 msgid "That link expired."
 msgstr "링크가 만료되었습니다."
@@ -4335,6 +4352,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "Cited in"
 msgstr "인용된 곳"
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# follower} other {# followers}}"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "A couple of publications worth discovering."
@@ -5953,6 +5974,10 @@ msgstr "예제 실행을 누르면 내 세션으로 실시간 응답을 가져�
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "At the bottom of settings, <0>Personal data</0> deletes categories of records outright: your reading history, your saved articles, or the publication lists you made. Each asks for confirmation and explains what will change."
+msgstr ""
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "Profile"
 msgstr ""
 
 #: src/components/reader/friend-publishers.tsx

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -99,6 +99,10 @@ msgstr "Apresentação de conteúdos no Standard Reader"
 msgid "Articles gaining attention across the network right now."
 msgstr "Artigos ganhando atenção na rede neste momento."
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# member} other {# members}}"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Add an article"
 msgstr "Adicionar um artigo"
@@ -410,9 +414,9 @@ msgstr "Publicações escritas pelas pessoas que você segue no Bluesky, exceto 
 msgid "{years}y ago"
 msgstr ""
 
-#: src/components/reader/reorder-lists-modal.tsx
-#~ msgid "List"
-#~ msgstr "Lista"
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "List"
+msgstr "Lista"
 
 #: src/components/appearance-settings.tsx
 msgid "The spacing between things — tighter for more on screen, looser for more room to read."
@@ -1971,6 +1975,7 @@ msgstr "O idioma utilizado na interface do leitor. Os artigos são apresentados 
 #~ msgid "Following, saving, recommending, and — once you follow more than a handful of publications — keeping the whole thing tidy."
 #~ msgstr ""
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 #: src/components/user-settings-view.tsx
 msgid "Feed"
 msgstr ""
@@ -3253,6 +3258,10 @@ msgstr "Você concorda em não usar o {SITE_NAME} para:"
 msgid "e.g. Dispatches from the Atmosphere"
 msgstr "por ex. Relatos da Atmosfera"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# join} other {# joins}}"
+msgstr ""
+
 #: src/components/docs/introduction-docs-page.tsx
 msgid "the AT Protocol schemas that define Standard records and the shared definitions they build on."
 msgstr "os esquemas do Protocolo AT que definem registros Standard e as definições compartilhadas nas quais eles se baseiam."
@@ -3560,6 +3569,10 @@ msgstr "Modo de pré-visualização"
 #: src/components/NavbarAuth.tsx
 #: src/components/site-legal-links.tsx
 msgid "Guide"
+msgstr ""
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# like} other {# likes}}"
 msgstr ""
 
 #: src/routes/_layout.collections.new.tsx
@@ -4042,6 +4055,10 @@ msgstr ""
 msgid "{0}+ articles"
 msgstr "{0}+ artigos"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "Starter pack"
+msgstr ""
+
 #: src/routes/_layout.feedback.return.tsx
 msgid "That link expired."
 msgstr "Esse link expirou."
@@ -4335,6 +4352,10 @@ msgstr "Bluesky não respondeu a tempo, então esta lista pode estar incompleta.
 #: src/components/reader/article-below-fold.tsx
 msgid "Cited in"
 msgstr "Citado em"
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# follower} other {# followers}}"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "A couple of publications worth discovering."
@@ -5953,6 +5974,10 @@ msgstr "Clique em Executar exemplo para obter uma resposta ao vivo com a sua ses
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "At the bottom of settings, <0>Personal data</0> deletes categories of records outright: your reading history, your saved articles, or the publication lists you made. Each asks for confirmation and explains what will change."
+msgstr ""
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "Profile"
 msgstr ""
 
 #: src/components/reader/friend-publishers.tsx

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -123,12 +123,12 @@ msgid "Every renderer takes one input for the document — the content payload o
 msgstr "Cada renderizador recebe uma entrada para o documento — o conteúdo de um <0>site.standard.document</0> — e um mapa opcional de <1>components</1>. O formato é detectado a partir do campo <2>$type</2> do conteúdo. Sem a propriedade <3>components</3>, o documento é renderizado como HTML semântico sem estilos."
 
 #: src/components/reader/about-view.tsx
-msgid "One tap from the reading view, on any device, instantly in sync. Your library is always where you left it."
-msgstr "Um toque a partir da vista de leitura, em qualquer dispositivo, sincronizado de imediato. A sua biblioteca está sempre onde a deixou."
+#~ msgid "One tap from the reading view, on any device, instantly in sync. Your library is always where you left it."
+#~ msgstr "Um toque a partir da vista de leitura, em qualquer dispositivo, sincronizado de imediato. A sua biblioteca está sempre onde a deixou."
 
 #: src/components/reader/about-view.tsx
-msgid "Curated lists & collections"
-msgstr "Listas e coleções curadas"
+#~ msgid "Curated lists & collections"
+#~ msgstr "Listas e coleções curadas"
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Vue 3."
@@ -179,6 +179,7 @@ msgstr ""
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
 #: src/components/docs/lexicon-docs-intro.tsx
+#: src/components/reader/about-view.tsx
 msgid "Lexicons"
 msgstr "Léxicos"
 
@@ -256,6 +257,10 @@ msgstr "Adicione um título."
 #~ msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Follow it and it starts appearing in your feeds like any other."
 #~ msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr "Filtrar por nome, nome de usuário, ou tema"
@@ -302,8 +307,8 @@ msgid "(this is what Standard Reader itself uses)"
 msgstr "(é o que o próprio Standard Reader utiliza)"
 
 #: src/components/reader/about-view.tsx
-msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
-msgstr "E nunca parece um mundo fechado. Ligamos cada artigo à conversa que decorre em toda a Atmosfera — a rede aberta para além desta aplicação — reunindo as publicações e respostas do Bluesky sobre um texto, as notas deixadas nas suas margens e os outras escritas que o citam, discretamente abaixo do que está lendo."
+#~ msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+#~ msgstr "E nunca parece um mundo fechado. Ligamos cada artigo à conversa que decorre em toda a Atmosfera — a rede aberta para além desta aplicação — reunindo as publicações e respostas do Bluesky sobre um texto, as notas deixadas nas suas margens e os outras escritas que o citam, discretamente abaixo do que está lendo."
 
 #: src/components/guide/guide-shell.tsx
 msgid "Still stuck, or something here doesn't match what you see? <0>Tell us on the feedback board</0> — questions are welcome there, not just bug reports."
@@ -316,6 +321,10 @@ msgstr "em execução…"
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Your Home feed is built from subscriptions. Three is a good start."
 msgstr "O seu feed de Início é construído a partir das inscrições. Três é um bom começo."
+
+#: src/components/reader/about-view.tsx
+msgid "A note in the margin"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Colors"
@@ -389,6 +398,10 @@ msgstr "Se inscrevendo…"
 msgid "People"
 msgstr "Pessoas"
 
+#: src/components/reader/about-view.tsx
+msgid "Every piece is a door to the next one"
+msgstr ""
+
 #: src/routes/_layout.friends.tsx
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 msgstr "Publicações escritas pelas pessoas que você segue no Bluesky, exceto as que você já está inscrito."
@@ -417,6 +430,7 @@ msgstr ""
 msgid "Switch to light paper"
 msgstr "Mudar para papel claro"
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Bluesky"
 msgstr "no Bluesky"
@@ -426,8 +440,8 @@ msgid "Set these now, or change them any time in Settings."
 msgstr "Defina isto agora ou altere quando quiser nas Configurações."
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
-msgstr "A maioria dos leitores para no que já está inscrito. O Standard Reader trata a descoberta do seu próximo favorito como parte do trabalho. Explore todas as publicações da rede — não apenas as de que já ouviu falar."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
+#~ msgstr "A maioria dos leitores para no que já está inscrito. O Standard Reader trata a descoberta do seu próximo favorito como parte do trabalho. Explore todas as publicações da rede — não apenas as de que já ouviu falar."
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Open <0>Collections</0> in the sidebar and start a new one."
@@ -682,8 +696,8 @@ msgid "Making a collection"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Read the guide"
-msgstr ""
+#~ msgid "Read the guide"
+#~ msgstr ""
 
 #: src/components/reader/app-shell.tsx
 #: src/components/site-legal-links.tsx
@@ -811,6 +825,10 @@ msgstr "Privacidade da extensão"
 msgid "Signing in"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Public API — no key required"
+msgstr ""
+
 #: src/components/reading-settings-preview.tsx
 msgid "Loading voice sample"
 msgstr "Carregando amostra de voz"
@@ -874,6 +892,11 @@ msgstr "Tentar novamente"
 
 #: src/lib/guide/navigation.ts
 msgid "Welcome"
+msgstr ""
+
+#. placeholder {0}: SUPPORTED_CONTENT_FORMATS.size
+#: src/components/reader/about-view.tsx
+msgid "An article is a record in its author’s own repository, and every publishing tool on the network writes that record a little differently. Standard Reader reads {0} of those content formats and renders them all into the same calm page — so a reader never has to care which tool a writer chose."
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -1003,6 +1026,10 @@ msgstr ""
 msgid "Bookmarks"
 msgstr "Salvos"
 
+#: src/components/reader/about-view.tsx
+msgid "None of this is ours. We gather it from the Atmosphere — the open network these apps all share — and show it under the piece it’s about. Every line links back to where it was actually written, no account or comment box required, and it works whether or not the author ever opted in."
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Saved to {savedName} on {appLabel}."
 msgstr "Salvo em {savedName} no {appLabel}."
@@ -1057,6 +1084,10 @@ msgstr "Uma sala de leitura tranquila para a web aberta. Vamos levar dois minuto
 #: src/routes/_layout.collections.index.tsx
 msgid "New series"
 msgstr "Nova série"
+
+#: src/components/reader/about-view.tsx
+msgid "Blogs never really solved the conversation. Comment boxes belonged to the blog, went unread, filled with spam, and vanished when the site did. So the talking moved somewhere else — and stopped being attached to the writing at all."
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "These deletions remove the records from your account itself, not just from our copy — which is why they cannot be undone. Deleting your reading history, for example, makes everything look unread again everywhere."
@@ -1130,6 +1161,10 @@ msgstr ""
 msgid "Under that, <0>Cited in</0> lists other articles that link to this one, and <1>Related reading</1> suggests pieces from across the network on the same subjects — usually from publications you have not met yet."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Essays and serialized writing"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 #~ msgid "Following your first publications"
@@ -1182,8 +1217,8 @@ msgid "Custom"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Read the API docs"
-msgstr "Ler a documentação da API"
+#~ msgid "Read the API docs"
+#~ msgstr "Ler a documentação da API"
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Select <0>Listen</0> in the top bar and the article is read aloud. The first time takes a few seconds to warm up; after that it starts straight away."
@@ -1198,8 +1233,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Shareable everywhere"
-msgstr "Partilhável em todo o lado"
+#~ msgid "Shareable everywhere"
+#~ msgstr "Partilhável em todo o lado"
 
 #: src/magazine/Magazine.tsx
 msgid "Close table of contents"
@@ -1233,6 +1268,10 @@ msgstr "Renderização de documentos Standard Site"
 #: src/components/docs/introduction-docs-page.tsx
 msgid "how to make a site discoverable on Standard and have its content read inline, without adopting a platform."
 msgstr "como tornar um site detectável no Standard e permitir que seu conteúdo seja lido diretamente na plataforma, sem precisar adotar a plataforma em si."
+
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across every publication on the network, not just the handful you’ve heard of."
+msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "For more about how {SITE_NAME} works, see the <0>About</0> page. For questions about these terms for this deployment, contact the operator of the site at the URL above."
@@ -1303,6 +1342,10 @@ msgstr ""
 msgid "To move several at once, open <0>Subscriptions</0>, select the rows you want, and add them all to a list in one action. That is much faster than doing it publication by publication."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Blocks, pages, and footnotes"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Appearance"
 msgstr "Aparência"
@@ -1354,6 +1397,10 @@ msgstr "Conta"
 msgid "Collapse all lists"
 msgstr "Fechar todas as listas"
 
+#: src/components/reader/about-view.tsx
+msgid "Four essays covering the same ground, from publications you don’t follow yet."
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "We couldn’t find that article."
 msgstr "Não foi possível encontrar esse artigo."
@@ -1388,6 +1435,10 @@ msgstr "a sua coleção"
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“…made to be read, and not to be measured.”"
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -1505,6 +1556,10 @@ msgstr "Pesquisa rápida em texto integral"
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "Nome da coleção"
+
+#: src/components/reader/about-view.tsx
+msgid "+{UNNAMED_FORMAT_COUNT} more"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1698,8 +1753,8 @@ msgid "What every control on an article does — including having it read aloud 
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "The reading experience"
-msgstr "A experiência de leitura"
+#~ msgid "The reading experience"
+#~ msgstr "A experiência de leitura"
 
 #: src/routes/_layout.tsx
 msgid "Loading page"
@@ -1736,6 +1791,10 @@ msgstr ""
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "Collections live under <0>Collections</0> in the sidebar. Because publishing one writes a new kind of record to your account, the first time you make one you will be asked to grant an extra permission — that is the <1>Upgrade permissions</1> prompt, and it only appears once."
 #~ msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Also read natively:"
+msgstr ""
 
 #. placeholder {0}: pub.name
 #: src/components/reader/article-below-fold.tsx
@@ -1777,8 +1836,8 @@ msgstr "Você se inscreveu em todas as publicações desta página — continue 
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
-msgstr "Abaixo de cada artigo veja a discussão através da rede aberta — publicações e respostas no Bluesky, anotações no Margin, outros textos que o citam e leituras relacionadas. Tudo em modo apenas de leitura, tudo com conexão direto à origem."
+#~ msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+#~ msgstr "Abaixo de cada artigo veja a discussão através da rede aberta — publicações e respostas no Bluesky, anotações no Margin, outros textos que o citam e leituras relacionadas. Tudo em modo apenas de leitura, tudo com conexão direto à origem."
 
 #: src/routes/_layout.latest.tsx
 msgid "Show all subscriptions"
@@ -1831,8 +1890,8 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {# resultado} other {# resultados}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
-msgstr "Publicações, listas e coleções, cada uma têm um link com um cartão de pré-visualização — mais um botão de inscrição que uma publicação pode colocar no seu próprio site."
+#~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
+#~ msgstr "Publicações, listas e coleções, cada uma têm um link com um cartão de pré-visualização — mais um botão de inscrição que uma publicação pode colocar no seu próprio site."
 
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Search topics"
@@ -1857,6 +1916,10 @@ msgstr "Artigos na coleção"
 #: src/components/user-settings-view.tsx
 msgid "System"
 msgstr "Sistema"
+
+#: src/components/reader/about-view.tsx
+msgid "Every feed, directory, and search query the app itself runs."
+msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Could not save to {appLabel}"
@@ -1964,8 +2027,8 @@ msgid "Never used"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Building something on the same index? There’s a public API."
-msgstr "Está a construir algo sobre o mesmo índice? Existe uma API pública."
+#~ msgid "Building something on the same index? There’s a public API."
+#~ msgstr "Está a construir algo sobre o mesmo índice? Existe uma API pública."
 
 #: src/components/reader/comments/comments-section.tsx
 msgid "Discussion"
@@ -2196,6 +2259,10 @@ msgstr "Onde esta coleção é publicada — seguidores da série receberão."
 msgid "No apps connected"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Nothing about it is fixed. Set the measure, the type size, and the typeface to whatever your eyes want, in light or dark, and the setting follows you to every article you open after it."
+msgstr ""
+
 #: src/components/reader/markdown-field.tsx
 msgid "Edit"
 msgstr "Editar"
@@ -2215,6 +2282,10 @@ msgstr "Consultas e procedimentos XRPC públicos para o modelo de leitura indexa
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Save theme"
 msgstr "Salvar tema"
+
+#: src/components/reader/about-view.tsx
+msgid "A reply"
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "your day: one featured article, then what is new from the publications you subscribe to."
@@ -2397,6 +2468,10 @@ msgstr ""
 #~ msgid "Carry on browsing. The overlay appears where it is useful and stays out of the way where it is not."
 #~ msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "And if your reader of choice is one you already have, any slice of the network comes with its own feed — pipe it straight in and never open this app at all."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "To email your digest, Standard Reader needs your account email address. We'll ask your PDS to share it — you'll be sent to your login to approve the request, then brought right back here. Your email is used only to send the weekly digest, and you can turn it off any time."
 msgstr "Para lhe enviar o resumo por e-mail, o Standard Reader precisa do endereço de e-mail da sua conta. Vamos pedir ao seu PDS que o compartilhe — será encaminhado para a sua página de início de sessão para aprovar o pedido e voltará para aqui. O seu e-mail é utilizado apenas para enviar o resumo semanal e pode desativá-lo quando quiser."
@@ -2406,7 +2481,6 @@ msgid "Where your reading is kept, who else can see it, what you agreed to when 
 msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
-#: src/components/reader/about-view.tsx
 #: src/lib/guide/navigation.ts
 msgid "Discovery"
 msgstr "Descoberta"
@@ -2533,6 +2607,10 @@ msgstr "Sobre manter um caderno de apontamentos"
 msgid "Most reading apps keep your list of follows on their own servers. If the app shuts down, your list goes with it."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Keep the good sentence"
+msgstr ""
+
 #: src/routes/_layout.u.$did.tsx
 msgid "Featured in"
 msgstr "Aparece em"
@@ -2624,8 +2702,8 @@ msgid "Paper"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
-msgstr "Mude uma definição e as ligações dos artigos passam a abrir no site da própria publicação. Leia onde lhe fizer mais sentido."
+#~ msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
+#~ msgstr "Mude uma definição e as ligações dos artigos passam a abrir no site da própria publicação. Leia onde lhe fizer mais sentido."
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Discover is the directory of every publication the network knows about — not a curated shelf. It runs top to bottom from most personal to most complete:"
@@ -2690,8 +2768,12 @@ msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {seguidor} other {seguidores}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
-msgstr "A maioria dos leitores ficam apenas nas suas inscrições. O Standard Reader trata a descoberta do seu próximo favorito como parte do trabalho. Explore todas as {countLabel} publicações da rede — não apenas as poucas de que já ouviu falar."
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgstr "A maioria dos leitores ficam apenas nas suas inscrições. O Standard Reader trata a descoberta do seu próximo favorito como parte do trabalho. Explore todas as {countLabel} publicações da rede — não apenas as poucas de que já ouviu falar."
+
+#: src/components/reader/about-view.tsx
+msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself, and every save, like, and subscribe is instantly in sync with whatever device you read on next."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labels"
@@ -2767,6 +2849,10 @@ msgstr ""
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Upgrade to author Collections"
 msgstr "Fazer upgrade para criar Coleções"
+
+#: src/components/reader/about-view.tsx
+msgid "Render a document in your own app —"
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "Your social actions (follows, likes, saves, lists) are written to your AT Protocol repository and are visible according to the network's rules and your account settings. Our Postgres database holds a network read-model, app session state, and cached public metadata — not the canonical copies of publications."
@@ -2872,12 +2958,20 @@ msgstr "Última atualização em 13 de junho de 2026"
 msgid "{shown, plural, one {# match} other {# matches}}"
 msgstr "{shown, plural, one {# resultado} other {# resultados}}"
 
+#: src/components/reader/about-view.tsx
+msgid "Select a passage and share it as a typeset card that links back to the article — or keep reading and pick up exactly where you left off next time."
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "People you follow write here"
 msgstr "Pessoas que você segue escrevem aqui"
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Good writing rarely turns up while you are already in a reading app. The extension puts saving and subscribing on every page you visit."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Drop a Standard document into your own app, in your own framework."
 msgstr ""
 
 #: src/magazine/flow.tsx
@@ -3051,6 +3145,10 @@ msgstr ""
 #: src/components/docs/docs-publishing-nav.tsx
 #~ msgid "Publishing guide"
 #~ msgstr "Guia de publicação"
+
+#: src/components/reader/about-view.tsx
+msgid "Prefer the original? Flip one setting and article links open on the publication’s own site instead — Standard Reader will still keep your place."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "<0>Share</0> copies a link, or posts the article to Bluesky with a proper preview card. On a phone it can hand off to whatever you normally share with."
@@ -3425,6 +3523,10 @@ msgstr "Algo deu errado."
 msgid "The best of what you subscribe to"
 msgstr "O melhor das suas inscrições"
 
+#: src/components/reader/about-view.tsx
+msgid "Under this article"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Note"
 msgstr "Nota"
@@ -3526,6 +3628,7 @@ msgstr "A gerar áudio… {percent}%"
 
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
+#: src/components/reader/about-view.tsx
 msgid "Renderers"
 msgstr "Renderizadores"
 
@@ -3565,8 +3668,8 @@ msgid "What Standard Reader is"
 msgstr "O que Standard Reader é"
 
 #: src/components/reader/about-view.tsx
-msgid "Prefer the original?"
-msgstr "Prefere o original?"
+#~ msgid "Prefer the original?"
+#~ msgstr "Prefere o original?"
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Could not add to list"
@@ -3787,6 +3890,10 @@ msgstr "Escolhemos este idioma com base no seu navegador. Pode alterá-lo quando
 
 #: src/routes/mcp/authorize.tsx
 msgid "Nothing has been shared. Head back to the app you came from and try connecting again."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“This is the whole argument in one clause. Worth sitting with.”"
 msgstr ""
 
 #: src/components/reader/text-selection-toolbar.tsx
@@ -4013,8 +4120,8 @@ msgid "Save and subscribe from anywhere on the web, without breaking your stride
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Integrations"
-msgstr "Integrações"
+#~ msgid "Integrations"
+#~ msgstr "Integrações"
 
 #. placeholder {0}: person.subscriberCount
 #. placeholder {0}: pub.subscriberCount
@@ -4137,6 +4244,10 @@ msgstr ""
 msgid "This request can't be completed here, so we're returning you to the app that sent you."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Read the docs"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No people in this list — add some from the edit dialog."
 msgstr "Sem pessoas nesta lista — adicione algumas na janela de edição."
@@ -4167,8 +4278,8 @@ msgid "Browse publications"
 msgstr "Explorar publicações"
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
-msgstr "O Standard Reader não prende a sua leitura dentro de uma só aplicação. Qualquer parte da rede vem com o seu próprio feed RSS — encaminhe-o diretamente para o leitor que já usa."
+#~ msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
+#~ msgstr "O Standard Reader não prende a sua leitura dentro de uma só aplicação. Qualquer parte da rede vem com o seu próprio feed RSS — encaminhe-o diretamente para o leitor que já usa."
 
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Choose images"
@@ -4236,6 +4347,10 @@ msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That image is too detailed to fit under 1 MB. Try cropping it first."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“Been thinking about this all week. The measurement is the part that ruins it — not the writing.”"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -4310,13 +4425,17 @@ msgstr "Não foi possível carregar o feedback <0>({0})</0>. Tente novamente daq
 msgid "No publications match this tag yet."
 msgstr "Ainda não há publicações com esta etiqueta."
 
+#: src/components/reader/about-view.tsx
+msgid "Written wherever they write"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "If you already know what you are looking for, the <0>Add publication</0> button opens a single field that does three things at once. Leave it empty and it shows what is trending. Type a few words and it searches the directory. Paste a handle or a domain — <1>@stdout.dev</1>, <2>stdout.dev</2> — and it looks that author up directly."
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "The conversation, gathered"
-msgstr "A conversa, reunida"
+#~ msgid "The conversation, gathered"
+#~ msgstr "A conversa, reunida"
 
 #: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
@@ -4344,8 +4463,8 @@ msgstr "publicar rótulos do AT Protocol que o Standard Reader exibe — e com b
 #~ msgstr "O mecanismo exato de substituição é idiomático para cada framework — um objeto de funções de componentes no React, Vue e Solid; templates <0>lit-html</0> no Lit; snippets no Svelte; ou refs <1><ng-template></1> no Angular —, mas a divisão e a terminologia são as mesmas em todos eles. Consulte o arquivo README de cada pacote para verificar a estrutura específica do framework."
 
 #: src/components/reader/about-view.tsx
-msgid "Save, like, subscribe — everywhere"
-msgstr "Salvar, recomendar, se inscrever — em todo lugar"
+#~ msgid "Save, like, subscribe — everywhere"
+#~ msgstr "Salvar, recomendar, se inscrever — em todo lugar"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe?"
@@ -4402,6 +4521,7 @@ msgstr "Componentes <0>compartilhados</0> renderizam o vocabulário de blocos e 
 
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
+#: src/components/reader/about-view.tsx
 msgid "API"
 msgstr "API"
 
@@ -4416,6 +4536,10 @@ msgstr "Substituir ícone"
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unfollow"
 msgstr "Deixar de seguir"
+
+#: src/components/reader/about-view.tsx
+msgid "Standard Reader doesn’t ask you to move in. It goes out to the web you already use, and hands your reading back in whatever shape suits you."
+msgstr ""
 
 #: src/routes/mcp/authorize.tsx
 msgid "Read your library"
@@ -4474,6 +4598,10 @@ msgstr "Autenticação"
 #: src/components/reader/terms-view.tsx
 msgid "Changes to these terms"
 msgstr "Alterações a estes termos"
+
+#: src/components/reader/about-view.tsx
+msgid "Short-form posts and long reads"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Worth discovering"
@@ -4541,6 +4669,10 @@ msgstr ""
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "Se instalar a extensão de navegador do {SITE_NAME}, esta usa a mesma conta e o mesmo cookie de sessão que este site. A extensão envia URLs de páginas para os nossos endpoints <0>/api/extension/*</0> para correspondência com o índice e guarda as configurações da sobreposição no armazenamento de extensões do seu navegador. Consulte a <1>política de privacidade da extensão</1> para detalhes que se aplicam apenas à extensão."
+
+#: src/components/reader/about-view.tsx
+msgid "And when a run of them turns out to be good together, collect them into a named list — a playlist for reading. Anyone can add the whole thing to their own reader in a single tap."
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "Remove {memberName} from list"
@@ -4698,8 +4830,8 @@ msgid "Saves a link to your <0>{appLabel}</0> collection."
 msgstr "Salva um link na sua coleção <0>{appLabel}</0>."
 
 #: src/components/reader/about-view.tsx
-msgid "In your inbox"
-msgstr "Na sua caixa de entrada"
+#~ msgid "In your inbox"
+#~ msgstr "Na sua caixa de entrada"
 
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Drag to change the order your subscriptions appear in the sidebar."
@@ -4713,6 +4845,7 @@ msgstr "Aspeto, preferências de leitura e dados pessoais."
 msgid "Authority for <0>app.standard-reader</0> resolves via DNS <1>_lexicon.*</1> TXT records to the publishing account."
 msgstr "A autoridade de <0>app.standard-reader</0> resolve-se através de registos TXT de DNS <1>_lexicon.*</1> para a conta que publica."
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Margin"
 msgstr "no Margin"
@@ -4749,6 +4882,10 @@ msgstr "Não foi possível resolver esse identificador."
 msgid "Good to know"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across all {countLabel} publications on the network, not just the handful you’ve heard of."
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Sharing a review on the <0>ATStore</0> will help both us and other users see what you think about Standard Reader."
 msgstr "Compartilhar uma avalição na <0>ATStore</0> ajuda-nos a nós e aos outros usuários a saber o que pensa do Standard Reader."
@@ -4756,6 +4893,10 @@ msgstr "Compartilhar uma avalição na <0>ATStore</0> ajuda-nos a nós e aos out
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "On Bluesky, quiet badges mark the people whose writing you can read here."
 #~ msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Publish labels others can subscribe to, or consume the ones we do."
+msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "The full account is on the <0>extension privacy page</0>."
@@ -4888,13 +5029,17 @@ msgstr "Ainda não há nada para ler aqui."
 msgid "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
 msgstr "Os rotuladores são serviços de moderação em que se inscreve por DID. Inscreva-se para ver seus rótulos — e desfocar ou ocultar publicações rotuladas — enquanto lê."
 
+#: src/components/reader/about-view.tsx
+msgid "The part blogging always missed"
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "The older link rels"
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader meets you where you read"
-msgstr "O Standard Reader vai ter consigo onde quer que leia"
+#~ msgid "Standard Reader meets you where you read"
+#~ msgstr "O Standard Reader vai ter consigo onde quer que leia"
 
 #: src/components/appearance-settings.tsx
 msgid "Reset appearance"
@@ -5088,6 +5233,10 @@ msgstr ""
 #: src/routes/_layout.latest.tsx
 msgid "All caught up"
 msgstr "Tudo em dia"
+
+#: src/components/reader/about-view.tsx
+msgid "Everything here is linkable, too. Publications, lists, and collections each get a clean URL with a rich preview card — plus a subscribe button a publication can drop straight onto its own site."
+msgstr ""
 
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Reorder subscriptions"
@@ -5284,6 +5433,7 @@ msgstr "Pesquisar na rede"
 msgid "Search Google Fonts"
 msgstr "Pesquisar Fontes do Google"
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/article-below-fold.tsx
 msgid "Related reading"
 msgstr "Leituras relacionadas"
@@ -5522,8 +5672,8 @@ msgid "If something is confusing, broken, or missing, the <0>feedback board</0> 
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
-msgstr "Uma extensão de navegador leve que lhe permite salvar e se inscrever em publicações enquanto navega pela web — com discretos botões no bsky.app e uma sobreposição de um clique em qualquer página onde estiver. A sua lista de leitura enche-se sozinha."
+#~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+#~ msgstr "Uma extensão de navegador leve que lhe permite salvar e se inscrever em publicações enquanto navega pela web — com discretos botões no bsky.app e uma sobreposição de um clique em qualquer página onde estiver. A sua lista de leitura enche-se sozinha."
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -5763,8 +5913,8 @@ msgid "Open any article while signed in and it'll show up here. Your history liv
 msgstr "Abra qualquer artigo com sessão iniciada e ele aparecerá aqui. O seu histórico vive no seu repositório como registos <0>app.standard-reader.read</0>."
 
 #: src/components/reader/about-view.tsx
-msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
-msgstr "Crie listas de publicações com nome e partilháveis — uma playlist para ler. Qualquer pessoa pode adicionar a sua lista ao próprio leitor com um só toque."
+#~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
+#~ msgstr "Crie listas de publicações com nome e partilháveis — uma playlist para ler. Qualquer pessoa pode adicionar a sua lista ao próprio leitor com um só toque."
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
@@ -5852,6 +6002,7 @@ msgstr ""
 #: src/components/docs/introduction-docs-page.tsx
 #: src/components/docs/labelers-docs-page.tsx
 #: src/components/labelers-settings-view.tsx
+#: src/components/reader/about-view.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/user-settings-view.tsx
 msgid "Labelers"
@@ -5862,8 +6013,8 @@ msgid "Choose your language"
 msgstr "Escolha o seu idioma"
 
 #: src/components/reader/about-view.tsx
-msgid "Find the ones you didn't know you wanted"
-msgstr "Descubra os que não sabia que queria"
+#~ msgid "Find the ones you didn't know you wanted"
+#~ msgstr "Descubra os que não sabia que queria"
 
 #: src/components/labeler-detail-view.tsx
 msgid "Hide"
@@ -5949,8 +6100,8 @@ msgid "Supported content formats"
 msgstr "Formatos de conteúdo suportados"
 
 #: src/components/reader/about-view.tsx
-msgid "Plays nice with the open web"
-msgstr "Dá-se bem com a web aberta"
+#~ msgid "Plays nice with the open web"
+#~ msgstr "Dá-se bem com a web aberta"
 
 #: src/components/reader/privacy-view.tsx
 msgid "What we collect"
@@ -5975,6 +6126,10 @@ msgstr "Gosta do Standard Reader?"
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Use original link"
 msgstr "Usar o link original"
+
+#: src/components/reader/about-view.tsx
+msgid "Everything this app runs on is public. The schemas are open, the read-model is queryable, and the renderer that draws these pages is published for you to use — so a reading app, a search tool, or a better client than this one is a weekend, not a platform deal."
+msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "Every publication page also serves a themed, embeddable subscribe widget — an iframe you can drop on your own site so visitors can subscribe without leaving your page. The easiest way to get it: open your publication's page on Standard Reader, use <0>Share → Embed subscribe</0>, pick landscape or portrait, and copy the snippet — no account or ownership check required to generate it."
@@ -6117,6 +6272,10 @@ msgstr "Ainda não há discussão."
 msgid "A single publication"
 msgstr "Uma única publicação"
 
+#: src/components/reader/about-view.tsx
+msgid "Build on the same index"
+msgstr ""
+
 #: src/routes/extension.connected.tsx
 msgid "Return to the Standard Reader extension — this tab will close automatically."
 msgstr "Volte à extensão do Standard Reader — este separador fecha automaticamente."
@@ -6224,6 +6383,10 @@ msgstr ""
 #: src/components/reader/publication-latest-note.tsx
 msgid "Latest note"
 msgstr "Nota mais recente"
+
+#: src/components/reader/about-view.tsx
+msgid "The record schemas a publication, document, or follow is made of."
+msgstr ""
 
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6377,6 +6540,10 @@ msgstr "Horizontal"
 msgid "Edit collection"
 msgstr "Editar coleção"
 
+#: src/components/reader/about-view.tsx
+msgid "That is a real response from the endpoint this page just called — no key, no sign-up, no rate-limit form. The same is true of every feed, directory, and search query the reader itself runs."
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "After that, following is one button. Anywhere you see a publication — a card in a feed, the top of an article, a publication's own page — there is a <0>Follow</0> button next to its name. Select it again to stop following. Nothing else changes: the button just decides whether new writing from that publication reaches your Home and Latest."
 #~ msgstr ""
@@ -6425,8 +6592,12 @@ msgid "Opening the issue…"
 msgstr "A abrir a edição…"
 
 #: src/components/reader/about-view.tsx
-msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
-msgstr "Não lhe pede que deixe o resto da web para trás. Estende-lhe a mão — e continua a ser um bom cidadão da rede mais ampla."
+msgid "However you like to read it"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+#~ msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+#~ msgstr "Não lhe pede que deixe o resto da web para trás. Estende-lhe a mão — e continua a ser um bom cidadão da rede mais ampla."
 
 #: src/routes/_layout.collections.edit.$rkey.tsx
 msgid "We couldn’t load that collection to edit."
@@ -6488,6 +6659,10 @@ msgstr "O Standard Reader indexa registos <0>site.standard.document</0> e <1>sit
 #: src/components/reader/list-edit-modal.tsx
 msgid "e.g. Tech, Friends, Cooking"
 msgstr "por exemplo Tecnologia, Amigos, Culinária"
+
+#: src/components/reader/about-view.tsx
+msgid "Semble"
+msgstr ""
 
 #. placeholder {0}: fmt.relativeTime(connection.lastUsedAt)
 #: src/components/user-settings-view.tsx
@@ -6631,6 +6806,10 @@ msgstr "Ligado"
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Two other pieces link to this one — you can read them from here."
 msgstr ""
 
 #: src/components/reader/page-reader-bar.tsx
@@ -6790,6 +6969,10 @@ msgstr ""
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Finding your way around"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Cited by"
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -2665,6 +2665,10 @@ msgstr "Reordenar {itemTitle}"
 msgid "Back to feedback"
 msgstr "Voltar a feedback"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "View on {name}"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "{pubTotal, plural, one {# publication} other {# publications}}"
 msgstr "{pubTotal, plural, one {# publicação} other {# publicações}}"

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -2665,6 +2665,10 @@ msgstr "重新排序 {itemTitle}"
 msgid "Back to feedback"
 msgstr "返回反馈"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "View on {name}"
+msgstr ""
+
 #: src/routes/_layout.search.tsx
 msgid "{pubTotal, plural, one {# publication} other {# publications}}"
 msgstr "{pubTotal, plural, one {# 个刊物} other {# 个刊物}}"

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -123,12 +123,12 @@ msgid "Every renderer takes one input for the document — the content payload o
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "One tap from the reading view, on any device, instantly in sync. Your library is always where you left it."
-msgstr "在阅读视图中轻点一次，任何设备即刻同步。你的书库始终停在你离开的地方。"
+#~ msgid "One tap from the reading view, on any device, instantly in sync. Your library is always where you left it."
+#~ msgstr "在阅读视图中轻点一次，任何设备即刻同步。你的书库始终停在你离开的地方。"
 
 #: src/components/reader/about-view.tsx
-msgid "Curated lists & collections"
-msgstr "精选列表与合集"
+#~ msgid "Curated lists & collections"
+#~ msgstr "精选列表与合集"
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Vue 3."
@@ -179,6 +179,7 @@ msgstr ""
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
 #: src/components/docs/lexicon-docs-intro.tsx
+#: src/components/reader/about-view.tsx
 msgid "Lexicons"
 msgstr "Lexicon"
 
@@ -256,6 +257,10 @@ msgstr "请添加标题。"
 #~ msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Follow it and it starts appearing in your feeds like any other."
 #~ msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -302,8 +307,8 @@ msgid "(this is what Standard Reader itself uses)"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
-msgstr "而且它从不封闭。我们把每篇文章与 Atmosphere（这个应用之外的开放网络）中正在发生的讨论连接起来——汇集关于它的 Bluesky 帖子与回复、留在页边的批注，以及引用过它的其他写作，安静地呈现在你阅读的内容下方。"
+#~ msgid "And it never feels sealed off. We connect each article to the conversation happening across the Atmosphere — the open network beyond this app — gathering the Bluesky posts and replies about a piece, the notes left in its margins, and the other writing that cites it, quietly beneath what you’re reading."
+#~ msgstr "而且它从不封闭。我们把每篇文章与 Atmosphere（这个应用之外的开放网络）中正在发生的讨论连接起来——汇集关于它的 Bluesky 帖子与回复、留在页边的批注，以及引用过它的其他写作，安静地呈现在你阅读的内容下方。"
 
 #: src/components/guide/guide-shell.tsx
 msgid "Still stuck, or something here doesn't match what you see? <0>Tell us on the feedback board</0> — questions are welcome there, not just bug reports."
@@ -316,6 +321,10 @@ msgstr "运行中…"
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Your Home feed is built from subscriptions. Three is a good start."
 msgstr "你的主页信息流由订阅构成。先订阅三个是个不错的开始。"
+
+#: src/components/reader/about-view.tsx
+msgid "A note in the margin"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Colors"
@@ -389,6 +398,10 @@ msgstr "正在订阅…"
 msgid "People"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Every piece is a door to the next one"
+msgstr ""
+
 #: src/routes/_layout.friends.tsx
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 msgstr ""
@@ -417,6 +430,7 @@ msgstr ""
 msgid "Switch to light paper"
 msgstr "切换到浅色纸张"
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Bluesky"
 msgstr "在 Bluesky 上"
@@ -426,8 +440,8 @@ msgid "Set these now, or change them any time in Settings."
 msgstr "现在设置，或随时在「设置」中更改。"
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
-msgstr "大多数阅读器止步于你已订阅的内容。Standard Reader 把帮你找到下一个心头好当作分内事。浏览网络上的每一个刊物——不只是你听说过的那几个。"
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse every publications on the network — not just the handful you've heard of."
+#~ msgstr "大多数阅读器止步于你已订阅的内容。Standard Reader 把帮你找到下一个心头好当作分内事。浏览网络上的每一个刊物——不只是你听说过的那几个。"
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Open <0>Collections</0> in the sidebar and start a new one."
@@ -682,8 +696,8 @@ msgid "Making a collection"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Read the guide"
-msgstr ""
+#~ msgid "Read the guide"
+#~ msgstr ""
 
 #: src/components/reader/app-shell.tsx
 #: src/components/site-legal-links.tsx
@@ -811,6 +825,10 @@ msgstr "扩展隐私"
 msgid "Signing in"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Public API — no key required"
+msgstr ""
+
 #: src/components/reading-settings-preview.tsx
 msgid "Loading voice sample"
 msgstr "正在加载语音样本"
@@ -874,6 +892,11 @@ msgstr "重试"
 
 #: src/lib/guide/navigation.ts
 msgid "Welcome"
+msgstr ""
+
+#. placeholder {0}: SUPPORTED_CONTENT_FORMATS.size
+#: src/components/reader/about-view.tsx
+msgid "An article is a record in its author’s own repository, and every publishing tool on the network writes that record a little differently. Standard Reader reads {0} of those content formats and renders them all into the same calm page — so a reader never has to care which tool a writer chose."
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -1003,6 +1026,10 @@ msgstr ""
 msgid "Bookmarks"
 msgstr "书签"
 
+#: src/components/reader/about-view.tsx
+msgid "None of this is ours. We gather it from the Atmosphere — the open network these apps all share — and show it under the piece it’s about. Every line links back to where it was actually written, no account or comment box required, and it works whether or not the author ever opted in."
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Saved to {savedName} on {appLabel}."
 msgstr "已保存到 {appLabel} 上的 {savedName}。"
@@ -1057,6 +1084,10 @@ msgstr "一间为开放网络而设的安静阅读室。花两分钟把它变成
 #: src/routes/_layout.collections.index.tsx
 msgid "New series"
 msgstr "新建系列"
+
+#: src/components/reader/about-view.tsx
+msgid "Blogs never really solved the conversation. Comment boxes belonged to the blog, went unread, filled with spam, and vanished when the site did. So the talking moved somewhere else — and stopped being attached to the writing at all."
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "These deletions remove the records from your account itself, not just from our copy — which is why they cannot be undone. Deleting your reading history, for example, makes everything look unread again everywhere."
@@ -1130,6 +1161,10 @@ msgstr ""
 msgid "Under that, <0>Cited in</0> lists other articles that link to this one, and <1>Related reading</1> suggests pieces from across the network on the same subjects — usually from publications you have not met yet."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Essays and serialized writing"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 #~ msgid "Following your first publications"
@@ -1182,8 +1217,8 @@ msgid "Custom"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Read the API docs"
-msgstr "阅读 API 文档"
+#~ msgid "Read the API docs"
+#~ msgstr "阅读 API 文档"
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Select <0>Listen</0> in the top bar and the article is read aloud. The first time takes a few seconds to warm up; after that it starts straight away."
@@ -1198,8 +1233,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Shareable everywhere"
-msgstr "随处可分享"
+#~ msgid "Shareable everywhere"
+#~ msgstr "随处可分享"
 
 #: src/magazine/Magazine.tsx
 msgid "Close table of contents"
@@ -1232,6 +1267,10 @@ msgstr ""
 
 #: src/components/docs/introduction-docs-page.tsx
 msgid "how to make a site discoverable on Standard and have its content read inline, without adopting a platform."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across every publication on the network, not just the handful you’ve heard of."
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -1303,6 +1342,10 @@ msgstr ""
 msgid "To move several at once, open <0>Subscriptions</0>, select the rows you want, and add them all to a list in one action. That is much faster than doing it publication by publication."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Blocks, pages, and footnotes"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Appearance"
 msgstr "外观"
@@ -1354,6 +1397,10 @@ msgstr "账户"
 msgid "Collapse all lists"
 msgstr "折叠所有列表"
 
+#: src/components/reader/about-view.tsx
+msgid "Four essays covering the same ground, from publications you don’t follow yet."
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "We couldn’t find that article."
 msgstr "我们找不到该文章。"
@@ -1388,6 +1435,10 @@ msgstr "你的合集"
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“…made to be read, and not to be measured.”"
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -1505,6 +1556,10 @@ msgstr "快速全文搜索"
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "合集名称"
+
+#: src/components/reader/about-view.tsx
+msgid "+{UNNAMED_FORMAT_COUNT} more"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1698,8 +1753,8 @@ msgid "What every control on an article does — including having it read aloud 
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "The reading experience"
-msgstr "阅读体验"
+#~ msgid "The reading experience"
+#~ msgstr "阅读体验"
 
 #: src/routes/_layout.tsx
 msgid "Loading page"
@@ -1736,6 +1791,10 @@ msgstr ""
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "Collections live under <0>Collections</0> in the sidebar. Because publishing one writes a new kind of record to your account, the first time you make one you will be asked to grant an extra permission — that is the <1>Upgrade permissions</1> prompt, and it only appears once."
 #~ msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Also read natively:"
+msgstr ""
 
 #. placeholder {0}: pub.name
 #: src/components/reader/article-below-fold.tsx
@@ -1777,8 +1836,8 @@ msgstr "本页所有刊物你都已订阅——继续滚动查看更多，或关
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
-msgstr "每篇文章下方都能看到来自开放网络的讨论——Bluesky 的帖子与回复、页边笔记、引用它的其他文章链接，以及相关阅读。全部只读，且都链接回原始出处。"
+#~ msgid "Under each article you see the discussion from across the open network — Bluesky posts and replies, margin notes, links from other pieces that cite it, and related reading. All read-only, all linking back to the source."
+#~ msgstr "每篇文章下方都能看到来自开放网络的讨论——Bluesky 的帖子与回复、页边笔记、引用它的其他文章链接，以及相关阅读。全部只读，且都链接回原始出处。"
 
 #: src/routes/_layout.latest.tsx
 msgid "Show all subscriptions"
@@ -1831,8 +1890,8 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {# 条匹配} other {# 条匹配}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
-msgstr "刊物、列表和合集都有简洁的链接与丰富的预览卡片——刊物还能把订阅按钮放到自己的网站上。"
+#~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
+#~ msgstr "刊物、列表和合集都有简洁的链接与丰富的预览卡片——刊物还能把订阅按钮放到自己的网站上。"
 
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Search topics"
@@ -1857,6 +1916,10 @@ msgstr "合集中的文章"
 #: src/components/user-settings-view.tsx
 msgid "System"
 msgstr "跟随系统"
+
+#: src/components/reader/about-view.tsx
+msgid "Every feed, directory, and search query the app itself runs."
+msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Could not save to {appLabel}"
@@ -1964,8 +2027,8 @@ msgid "Never used"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Building something on the same index? There’s a public API."
-msgstr "想基于同一份索引做点什么？我们提供公开 API。"
+#~ msgid "Building something on the same index? There’s a public API."
+#~ msgstr "想基于同一份索引做点什么？我们提供公开 API。"
 
 #: src/components/reader/comments/comments-section.tsx
 msgid "Discussion"
@@ -2196,6 +2259,10 @@ msgstr "此合集发布到哪里——关注该系列的读者将会收到。"
 msgid "No apps connected"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Nothing about it is fixed. Set the measure, the type size, and the typeface to whatever your eyes want, in light or dark, and the setting follows you to every article you open after it."
+msgstr ""
+
 #: src/components/reader/markdown-field.tsx
 msgid "Edit"
 msgstr "编辑"
@@ -2215,6 +2282,10 @@ msgstr "面向 Standard Reader 索引读模型的公开 XRPC 查询与操作。"
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Save theme"
 msgstr "保存主题"
+
+#: src/components/reader/about-view.tsx
+msgid "A reply"
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "your day: one featured article, then what is new from the publications you subscribe to."
@@ -2397,6 +2468,10 @@ msgstr ""
 #~ msgid "Carry on browsing. The overlay appears where it is useful and stays out of the way where it is not."
 #~ msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "And if your reader of choice is one you already have, any slice of the network comes with its own feed — pipe it straight in and never open this app at all."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "To email your digest, Standard Reader needs your account email address. We'll ask your PDS to share it — you'll be sent to your login to approve the request, then brought right back here. Your email is used only to send the weekly digest, and you can turn it off any time."
 msgstr "要给你发送每周摘要，Standard Reader 需要你的账号邮箱地址。我们会向你的 PDS 请求共享——你将前往登录页批准该请求，随后自动返回此处。你的邮箱仅用于发送每周摘要，你可以随时关闭。"
@@ -2406,7 +2481,6 @@ msgid "Where your reading is kept, who else can see it, what you agreed to when 
 msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
-#: src/components/reader/about-view.tsx
 #: src/lib/guide/navigation.ts
 msgid "Discovery"
 msgstr "发现"
@@ -2533,6 +2607,10 @@ msgstr "关于记录随想札记"
 msgid "Most reading apps keep your list of follows on their own servers. If the app shuts down, your list goes with it."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Keep the good sentence"
+msgstr ""
+
 #: src/routes/_layout.u.$did.tsx
 msgid "Featured in"
 msgstr "刊载于"
@@ -2624,8 +2702,8 @@ msgid "Paper"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
-msgstr "改一个设置，文章链接就会改为在刊物自己的网站打开。想在哪读就在哪读。"
+#~ msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
+#~ msgstr "改一个设置，文章链接就会改为在刊物自己的网站打开。想在哪读就在哪读。"
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Discover is the directory of every publication the network knows about — not a curated shelf. It runs top to bottom from most personal to most complete:"
@@ -2690,8 +2768,12 @@ msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {位关注者} other {位关注者}}"
 
 #: src/components/reader/about-view.tsx
-msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
-msgstr "大多数阅读器止步于你已经订阅的内容。Standard Reader 把帮你找到下一个心头好也当作本职。浏览网络上全部 {countLabel} 个刊物——不只是你听说过的那几个。"
+#~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
+#~ msgstr "大多数阅读器止步于你已经订阅的内容。Standard Reader 把帮你找到下一个心头好也当作本职。浏览网络上全部 {countLabel} 个刊物——不只是你听说过的那几个。"
+
+#: src/components/reader/about-view.tsx
+msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself, and every save, like, and subscribe is instantly in sync with whatever device you read on next."
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labels"
@@ -2767,6 +2849,10 @@ msgstr ""
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Upgrade to author Collections"
 msgstr "升级以创作合集"
+
+#: src/components/reader/about-view.tsx
+msgid "Render a document in your own app —"
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "Your social actions (follows, likes, saves, lists) are written to your AT Protocol repository and are visible according to the network's rules and your account settings. Our Postgres database holds a network read-model, app session state, and cached public metadata — not the canonical copies of publications."
@@ -2872,12 +2958,20 @@ msgstr "最后更新于 2026 年 6 月 13 日"
 msgid "{shown, plural, one {# match} other {# matches}}"
 msgstr "{shown, plural, one {# 个匹配项} other {# 个匹配项}}"
 
+#: src/components/reader/about-view.tsx
+msgid "Select a passage and share it as a typeset card that links back to the article — or keep reading and pick up exactly where you left off next time."
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "People you follow write here"
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Good writing rarely turns up while you are already in a reading app. The extension puts saving and subscribing on every page you visit."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Drop a Standard document into your own app, in your own framework."
 msgstr ""
 
 #: src/magazine/flow.tsx
@@ -3051,6 +3145,10 @@ msgstr ""
 #: src/components/docs/docs-publishing-nav.tsx
 #~ msgid "Publishing guide"
 #~ msgstr "发布指南"
+
+#: src/components/reader/about-view.tsx
+msgid "Prefer the original? Flip one setting and article links open on the publication’s own site instead — Standard Reader will still keep your place."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "<0>Share</0> copies a link, or posts the article to Bluesky with a proper preview card. On a phone it can hand off to whatever you normally share with."
@@ -3425,6 +3523,10 @@ msgstr "出错了。"
 msgid "The best of what you subscribe to"
 msgstr "你订阅内容中的精选"
 
+#: src/components/reader/about-view.tsx
+msgid "Under this article"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Note"
 msgstr "备注"
@@ -3526,6 +3628,7 @@ msgstr "正在生成音频… {percent}%"
 
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
+#: src/components/reader/about-view.tsx
 msgid "Renderers"
 msgstr ""
 
@@ -3565,8 +3668,8 @@ msgid "What Standard Reader is"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Prefer the original?"
-msgstr "更喜欢原文？"
+#~ msgid "Prefer the original?"
+#~ msgstr "更喜欢原文？"
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Could not add to list"
@@ -3787,6 +3890,10 @@ msgstr "我们根据您的浏览器选择了此语言，您可以随时切换。
 
 #: src/routes/mcp/authorize.tsx
 msgid "Nothing has been shared. Head back to the app you came from and try connecting again."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“This is the whole argument in one clause. Worth sitting with.”"
 msgstr ""
 
 #: src/components/reader/text-selection-toolbar.tsx
@@ -4013,8 +4120,8 @@ msgid "Save and subscribe from anywhere on the web, without breaking your stride
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Integrations"
-msgstr "集成"
+#~ msgid "Integrations"
+#~ msgstr "集成"
 
 #. placeholder {0}: person.subscriberCount
 #. placeholder {0}: pub.subscriberCount
@@ -4137,6 +4244,10 @@ msgstr ""
 msgid "This request can't be completed here, so we're returning you to the app that sent you."
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Read the docs"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No people in this list — add some from the edit dialog."
 msgstr "此列表中没有人——可在编辑对话框中添加。"
@@ -4167,8 +4278,8 @@ msgid "Browse publications"
 msgstr "浏览刊物"
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
-msgstr "Standard Reader 不会把你的阅读困在一个应用里。网络的任何一部分都自带 RSS 源——直接接入你已经在用的阅读器即可。"
+#~ msgid "Standard Reader doesn’t trap your reading inside one app. Any slice of the network comes with its own RSS feed — pipe it straight into whatever reader you already use."
+#~ msgstr "Standard Reader 不会把你的阅读困在一个应用里。网络的任何一部分都自带 RSS 源——直接接入你已经在用的阅读器即可。"
 
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Choose images"
@@ -4236,6 +4347,10 @@ msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That image is too detailed to fit under 1 MB. Try cropping it first."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "“Been thinking about this all week. The measurement is the part that ruins it — not the writing.”"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -4310,13 +4425,17 @@ msgstr "无法加载反馈 <0>（{0}）</0>。请稍后重试。"
 msgid "No publications match this tag yet."
 msgstr "暂时没有符合此标签的刊物。"
 
+#: src/components/reader/about-view.tsx
+msgid "Written wherever they write"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "If you already know what you are looking for, the <0>Add publication</0> button opens a single field that does three things at once. Leave it empty and it shows what is trending. Type a few words and it searches the directory. Paste a handle or a domain — <1>@stdout.dev</1>, <2>stdout.dev</2> — and it looks that author up directly."
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "The conversation, gathered"
-msgstr "汇集在一起的讨论"
+#~ msgid "The conversation, gathered"
+#~ msgstr "汇集在一起的讨论"
 
 #: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.latest.tsx
@@ -4344,8 +4463,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Save, like, subscribe — everywhere"
-msgstr "保存、点赞、订阅——随处可用"
+#~ msgid "Save, like, subscribe — everywhere"
+#~ msgstr "保存、点赞、订阅——随处可用"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe?"
@@ -4402,6 +4521,7 @@ msgstr ""
 
 #: src/components/docs/docs-nav-areas.ts
 #: src/components/docs/introduction-docs-page.tsx
+#: src/components/reader/about-view.tsx
 msgid "API"
 msgstr "API"
 
@@ -4415,6 +4535,10 @@ msgstr "更换图标"
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unfollow"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Standard Reader doesn’t ask you to move in. It goes out to the web you already use, and hands your reading back in whatever shape suits you."
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx
@@ -4473,6 +4597,10 @@ msgstr "身份验证"
 
 #: src/components/reader/terms-view.tsx
 msgid "Changes to these terms"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Short-form posts and long reads"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -4541,6 +4669,10 @@ msgstr ""
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "如果你安装了 {SITE_NAME} 浏览器扩展，它会使用与本站相同的账号和会话 cookie。扩展会将页面 URL 发送到我们的 <0>/api/extension/*</0> 端点用于索引匹配，并将浮层设置保存在浏览器的扩展存储中。详情请参阅仅适用于扩展的<1>扩展隐私政策</1>。"
+
+#: src/components/reader/about-view.tsx
+msgid "And when a run of them turns out to be good together, collect them into a named list — a playlist for reading. Anyone can add the whole thing to their own reader in a single tap."
+msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "Remove {memberName} from list"
@@ -4698,8 +4830,8 @@ msgid "Saves a link to your <0>{appLabel}</0> collection."
 msgstr "将链接保存到你的 <0>{appLabel}</0> 合集。"
 
 #: src/components/reader/about-view.tsx
-msgid "In your inbox"
-msgstr "在你的收件箱中"
+#~ msgid "In your inbox"
+#~ msgstr "在你的收件箱中"
 
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Drag to change the order your subscriptions appear in the sidebar."
@@ -4713,6 +4845,7 @@ msgstr "外观、阅读偏好和个人数据。"
 msgid "Authority for <0>app.standard-reader</0> resolves via DNS <1>_lexicon.*</1> TXT records to the publishing account."
 msgstr "<0>app.standard-reader</0> 的权威通过 DNS <1>_lexicon.*</1> TXT 记录解析到发布账号。"
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/comments/comment-card.tsx
 msgid "on Margin"
 msgstr "在 Margin 上"
@@ -4749,6 +4882,10 @@ msgstr "无法解析该 handle。"
 msgid "Good to know"
 msgstr ""
 
+#: src/components/reader/about-view.tsx
+msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across all {countLabel} publications on the network, not just the handful you’ve heard of."
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Sharing a review on the <0>ATStore</0> will help both us and other users see what you think about Standard Reader."
 msgstr "在 <0>ATStore</0> 上分享评价，能帮助我们和其他用户了解你对 Standard Reader 的看法。"
@@ -4756,6 +4893,10 @@ msgstr "在 <0>ATStore</0> 上分享评价，能帮助我们和其他用户了�
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "On Bluesky, quiet badges mark the people whose writing you can read here."
 #~ msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Publish labels others can subscribe to, or consume the ones we do."
+msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "The full account is on the <0>extension privacy page</0>."
@@ -4888,13 +5029,17 @@ msgstr "这里还没有可读的内容。"
 msgid "Labelers are moderation services you subscribe to by DID. Subscribe to see their labels — and blur or hide labeled posts — while you read."
 msgstr "标注服务是你通过 DID 订阅的审核服务。订阅后，你在阅读时就能看到它们的标签，并模糊或隐藏被标注的帖子。"
 
+#: src/components/reader/about-view.tsx
+msgid "The part blogging always missed"
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "The older link rels"
 #~ msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "Standard Reader meets you where you read"
-msgstr "Standard Reader 随你所读之处而至"
+#~ msgid "Standard Reader meets you where you read"
+#~ msgstr "Standard Reader 随你所读之处而至"
 
 #: src/components/appearance-settings.tsx
 msgid "Reset appearance"
@@ -5088,6 +5233,10 @@ msgstr ""
 #: src/routes/_layout.latest.tsx
 msgid "All caught up"
 msgstr "已全部读完"
+
+#: src/components/reader/about-view.tsx
+msgid "Everything here is linkable, too. Publications, lists, and collections each get a clean URL with a rich preview card — plus a subscribe button a publication can drop straight onto its own site."
+msgstr ""
 
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Reorder subscriptions"
@@ -5284,6 +5433,7 @@ msgstr "搜索全网"
 msgid "Search Google Fonts"
 msgstr "搜索 Google Fonts"
 
+#: src/components/reader/about-view.tsx
 #: src/components/reader/article-below-fold.tsx
 msgid "Related reading"
 msgstr "相关阅读"
@@ -5522,8 +5672,8 @@ msgid "If something is confusing, broken, or missing, the <0>feedback board</0> 
 msgstr ""
 
 #: src/components/reader/about-view.tsx
-msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
-msgstr "轻量的浏览器扩展让你在网上浏览时随手保存和订阅刊物——在 bsky.app 上显示低调的徽标，在你访问的任何页面上提供一键浮层。你的阅读清单会自己充实起来。"
+#~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+#~ msgstr "轻量的浏览器扩展让你在网上浏览时随手保存和订阅刊物——在 bsky.app 上显示低调的徽标，在你访问的任何页面上提供一键浮层。你的阅读清单会自己充实起来。"
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -5763,8 +5913,8 @@ msgid "Open any article while signed in and it'll show up here. Your history liv
 msgstr "登录后打开任意文章，它就会出现在这里。你的阅读记录以 <0>app.standard-reader.read</0> 记录形式存放在你的仓库中。"
 
 #: src/components/reader/about-view.tsx
-msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
-msgstr "建立有名字、可分享的刊物列表——像阅读歌单一样。任何人都能一键把你的列表加进自己的阅读器。"
+#~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
+#~ msgstr "建立有名字、可分享的刊物列表——像阅读歌单一样。任何人都能一键把你的列表加进自己的阅读器。"
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
@@ -5852,6 +6002,7 @@ msgstr ""
 #: src/components/docs/introduction-docs-page.tsx
 #: src/components/docs/labelers-docs-page.tsx
 #: src/components/labelers-settings-view.tsx
+#: src/components/reader/about-view.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/user-settings-view.tsx
 msgid "Labelers"
@@ -5862,8 +6013,8 @@ msgid "Choose your language"
 msgstr "选择您的语言"
 
 #: src/components/reader/about-view.tsx
-msgid "Find the ones you didn't know you wanted"
-msgstr "发现你未曾想到却正合心意的内容"
+#~ msgid "Find the ones you didn't know you wanted"
+#~ msgstr "发现你未曾想到却正合心意的内容"
 
 #: src/components/labeler-detail-view.tsx
 msgid "Hide"
@@ -5949,8 +6100,8 @@ msgid "Supported content formats"
 msgstr "支持的内容格式"
 
 #: src/components/reader/about-view.tsx
-msgid "Plays nice with the open web"
-msgstr "与开放网络友好共处"
+#~ msgid "Plays nice with the open web"
+#~ msgstr "与开放网络友好共处"
 
 #: src/components/reader/privacy-view.tsx
 msgid "What we collect"
@@ -5975,6 +6126,10 @@ msgstr "喜欢 Standard Reader 吗？"
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Use original link"
 msgstr "使用原始链接"
+
+#: src/components/reader/about-view.tsx
+msgid "Everything this app runs on is public. The schemas are open, the read-model is queryable, and the renderer that draws these pages is published for you to use — so a reading app, a search tool, or a better client than this one is a weekend, not a platform deal."
+msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "Every publication page also serves a themed, embeddable subscribe widget — an iframe you can drop on your own site so visitors can subscribe without leaving your page. The easiest way to get it: open your publication's page on Standard Reader, use <0>Share → Embed subscribe</0>, pick landscape or portrait, and copy the snippet — no account or ownership check required to generate it."
@@ -6117,6 +6272,10 @@ msgstr "暂无讨论。"
 msgid "A single publication"
 msgstr "单个刊物"
 
+#: src/components/reader/about-view.tsx
+msgid "Build on the same index"
+msgstr ""
+
 #: src/routes/extension.connected.tsx
 msgid "Return to the Standard Reader extension — this tab will close automatically."
 msgstr "返回 Standard Reader 扩展——此标签页将自动关闭。"
@@ -6224,6 +6383,10 @@ msgstr ""
 #: src/components/reader/publication-latest-note.tsx
 msgid "Latest note"
 msgstr "最新笔记"
+
+#: src/components/reader/about-view.tsx
+msgid "The record schemas a publication, document, or follow is made of."
+msgstr ""
 
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6377,6 +6540,10 @@ msgstr "横版"
 msgid "Edit collection"
 msgstr "编辑合集"
 
+#: src/components/reader/about-view.tsx
+msgid "That is a real response from the endpoint this page just called — no key, no sign-up, no rate-limit form. The same is true of every feed, directory, and search query the reader itself runs."
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "After that, following is one button. Anywhere you see a publication — a card in a feed, the top of an article, a publication's own page — there is a <0>Follow</0> button next to its name. Select it again to stop following. Nothing else changes: the button just decides whether new writing from that publication reaches your Home and Latest."
 #~ msgstr ""
@@ -6425,8 +6592,12 @@ msgid "Opening the issue…"
 msgstr "正在打开本期…"
 
 #: src/components/reader/about-view.tsx
-msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
-msgstr "它不要求你抛下网络的其余部分，而是主动伸手连接——始终做更广网络中的好公民。"
+msgid "However you like to read it"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+#~ msgid "It doesn't ask you to leave the rest of the web behind. It reaches out to it — and stays a good citizen of the wider network."
+#~ msgstr "它不要求你抛下网络的其余部分，而是主动伸手连接——始终做更广网络中的好公民。"
 
 #: src/routes/_layout.collections.edit.$rkey.tsx
 msgid "We couldn’t load that collection to edit."
@@ -6488,6 +6659,10 @@ msgstr "Standard Reader 从 AT Proto 仓库中收录 <0>site.standard.document</
 #: src/components/reader/list-edit-modal.tsx
 msgid "e.g. Tech, Friends, Cooking"
 msgstr "例如：科技、朋友、烹饪"
+
+#: src/components/reader/about-view.tsx
+msgid "Semble"
+msgstr ""
 
 #. placeholder {0}: fmt.relativeTime(connection.lastUsedAt)
 #: src/components/user-settings-view.tsx
@@ -6631,6 +6806,10 @@ msgstr "开"
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Two other pieces link to this one — you can read them from here."
 msgstr ""
 
 #: src/components/reader/page-reader-bar.tsx
@@ -6790,6 +6969,10 @@ msgstr ""
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Finding your way around"
+msgstr ""
+
+#: src/components/reader/about-view.tsx
+msgid "Cited by"
 msgstr ""
 
 #: src/routes/mcp/authorize.tsx

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -99,6 +99,10 @@ msgstr "在 Standard Reader 中渲染内容"
 msgid "Articles gaining attention across the network right now."
 msgstr "此刻正在全网获得关注的文章。"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# member} other {# members}}"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Add an article"
 msgstr "添加文章"
@@ -410,9 +414,9 @@ msgstr ""
 msgid "{years}y ago"
 msgstr ""
 
-#: src/components/reader/reorder-lists-modal.tsx
-#~ msgid "List"
-#~ msgstr "列表"
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "List"
+msgstr "列表"
 
 #: src/components/appearance-settings.tsx
 msgid "The spacing between things — tighter for more on screen, looser for more room to read."
@@ -1971,6 +1975,7 @@ msgstr "阅读器界面所用的语言。文章仍以其原文语言显示。"
 #~ msgid "Following, saving, recommending, and — once you follow more than a handful of publications — keeping the whole thing tidy."
 #~ msgstr ""
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 #: src/components/user-settings-view.tsx
 msgid "Feed"
 msgstr ""
@@ -3253,6 +3258,10 @@ msgstr ""
 msgid "e.g. Dispatches from the Atmosphere"
 msgstr "例如：来自 Atmosphere 的快讯"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# join} other {# joins}}"
+msgstr ""
+
 #: src/components/docs/introduction-docs-page.tsx
 msgid "the AT Protocol schemas that define Standard records and the shared definitions they build on."
 msgstr ""
@@ -3560,6 +3569,10 @@ msgstr "预览模式"
 #: src/components/NavbarAuth.tsx
 #: src/components/site-legal-links.tsx
 msgid "Guide"
+msgstr ""
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# like} other {# likes}}"
 msgstr ""
 
 #: src/routes/_layout.collections.new.tsx
@@ -4042,6 +4055,10 @@ msgstr ""
 msgid "{0}+ articles"
 msgstr "{0}+ 篇文章"
 
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "Starter pack"
+msgstr ""
+
 #: src/routes/_layout.feedback.return.tsx
 msgid "That link expired."
 msgstr "该链接已过期。"
@@ -4335,6 +4352,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "Cited in"
 msgstr "被引用于"
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "{value, plural, one {# follower} other {# followers}}"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "A couple of publications worth discovering."
@@ -5953,6 +5974,10 @@ msgstr "点击「运行示例」，用你的会话获取实时响应。"
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "At the bottom of settings, <0>Personal data</0> deletes categories of records outright: your reading history, your saved articles, or the publication lists you made. Each asks for confirmation and explains what will change."
+msgstr ""
+
+#: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
+msgid "Profile"
 msgstr ""
 
 #: src/components/reader/friend-publishers.tsx

--- a/apps/standard-reader/src/routes/_layout.l.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/_layout.l.$did.$rkey.tsx
@@ -240,7 +240,7 @@ const styles = stylex.create({
   heroActs: {
     alignItems: "center",
     columnGap: spacing["1.5"],
-    display: { [HERO_DESKTOP]: "flex", default: "none", },
+    display: { [HERO_DESKTOP]: "flex", default: "none" },
     flexWrap: "wrap",
     justifyContent: "flex-end",
     rowGap: spacing["2.5"],
@@ -248,7 +248,7 @@ const styles = stylex.create({
   },
   heroActsMobile: {
     alignItems: "center",
-    display: { [HERO_DESKTOP]: "none", default: "flex", },
+    display: { [HERO_DESKTOP]: "none", default: "flex" },
     flexShrink: 0,
     justifyContent: "flex-end",
     paddingTop: spacing["1"],

--- a/apps/standard-reader/src/routes/_layout.u.$did.tsx
+++ b/apps/standard-reader/src/routes/_layout.u.$did.tsx
@@ -250,14 +250,14 @@ const styles = stylex.create({
   },
   heroActsMobile: {
     columnGap: spacing["1.5"],
-    display: { [HERO_DESKTOP]: "none", default: "flex", },
+    display: { [HERO_DESKTOP]: "none", default: "flex" },
     flexWrap: "wrap",
     rowGap: spacing["1.5"],
   },
   heroActs: {
     alignItems: "center",
     columnGap: spacing["1.5"],
-    display: { [HERO_DESKTOP]: "flex", default: "none", },
+    display: { [HERO_DESKTOP]: "flex", default: "none" },
     flexShrink: 0,
     flexWrap: "wrap",
     justifyContent: "flex-end",

--- a/apps/standard-reader/src/server/atproto/bsky-entities.ts
+++ b/apps/standard-reader/src/server/atproto/bsky-entities.ts
@@ -1,0 +1,200 @@
+/**
+ * Hydrate the AT Protocol records a Bluesky web client URL can address —
+ * profiles, feed generators, lists, and starter packs — via the public AppView
+ * (no auth required). Used to turn a link to `bsky.app` or one of its forks
+ * (Witchsky, mu.social, …) into a native embed instead of a bare link card.
+ */
+
+import type { BskyClientRef } from "#/lib/atproto/bsky-clients";
+import { bskyClientRefAtUri } from "#/lib/atproto/bsky-clients";
+
+const PUBLIC_APPVIEW = "https://public.api.bsky.app";
+const FETCH_TIMEOUT_MS = 8000;
+
+/** The record kinds that render as an entity card (posts have their own embed). */
+export type BskyEntityKind = "profile" | "feed" | "list" | "starterPack";
+
+export interface BskyEntityCard {
+  kind: BskyEntityKind;
+  /** `at://` URI of the record — or the DID, for a profile. */
+  uri: string;
+  /** In-app destination for a profile card; null for the other kinds. */
+  did: string | null;
+  title: string;
+  description: string | null;
+  avatarUrl: string | null;
+  /** Owner of the record. Null on a profile card — the card *is* the owner. */
+  creatorHandle: string | null;
+  creatorDisplayName: string | null;
+  /**
+   * Followers for a profile, likes for a feed, members for a list, joins for a
+   * starter pack — the component labels it by `kind`.
+   */
+  count: number | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function str(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function num(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+async function appview(
+  method: string,
+  params: Record<string, string>,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const url = new URL(`/xrpc/${method}`, PUBLIC_APPVIEW);
+    for (const [key, value] of Object.entries(params)) {
+      url.searchParams.set(key, value);
+    }
+    const res = await fetch(url, {
+      headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    const body: unknown = await res.json();
+    return isRecord(body) ? body : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Creator fields shared by feed / list / starter pack views. */
+function creatorOf(value: unknown): {
+  creatorHandle: string | null;
+  creatorDisplayName: string | null;
+} {
+  const creator = isRecord(value) ? value : null;
+  return {
+    creatorDisplayName: str(creator?.displayName),
+    creatorHandle: str(creator?.handle),
+  };
+}
+
+async function fetchProfile(ident: string): Promise<BskyEntityCard | null> {
+  const body = await appview("app.bsky.actor.getProfile", { actor: ident });
+  const did = str(body?.did);
+  if (!did) return null;
+  const handle = str(body?.handle);
+  return {
+    avatarUrl: str(body?.avatar),
+    count: num(body?.followersCount),
+    creatorDisplayName: null,
+    creatorHandle: null,
+    description: str(body?.description),
+    did,
+    kind: "profile",
+    title: str(body?.displayName) ?? (handle ? `@${handle}` : did),
+    uri: did,
+  };
+}
+
+async function fetchFeedGenerator(
+  atUri: string,
+): Promise<BskyEntityCard | null> {
+  const body = await appview("app.bsky.feed.getFeedGenerator", {
+    feed: atUri,
+  });
+  const view = isRecord(body?.view) ? body.view : null;
+  const title = str(view?.displayName);
+  if (!view || !title) return null;
+  return {
+    ...creatorOf(view.creator),
+    avatarUrl: str(view.avatar),
+    count: num(view.likeCount),
+    description: str(view.description),
+    did: null,
+    kind: "feed",
+    title,
+    uri: str(view.uri) ?? atUri,
+  };
+}
+
+async function fetchList(atUri: string): Promise<BskyEntityCard | null> {
+  const body = await appview("app.bsky.graph.getList", {
+    limit: "1",
+    list: atUri,
+  });
+  const view = isRecord(body?.list) ? body.list : null;
+  const title = str(view?.name);
+  if (!view || !title) return null;
+  return {
+    ...creatorOf(view.creator),
+    avatarUrl: str(view.avatar),
+    count: num(view.listItemCount),
+    description: str(view.description),
+    did: null,
+    kind: "list",
+    title,
+    uri: str(view.uri) ?? atUri,
+  };
+}
+
+async function fetchStarterPack(atUri: string): Promise<BskyEntityCard | null> {
+  const body = await appview("app.bsky.graph.getStarterPack", {
+    starterPack: atUri,
+  });
+  const view = isRecord(body?.starterPack) ? body.starterPack : null;
+  const record = isRecord(view?.record) ? view.record : null;
+  const title = str(record?.name);
+  if (!view || !title) return null;
+  return {
+    ...creatorOf(view.creator),
+    // Starter packs carry no avatar of their own — the creator's stands in.
+    avatarUrl: str(isRecord(view.creator) ? view.creator.avatar : null),
+    count: num(view.joinedAllTimeCount),
+    description: str(record?.description),
+    did: null,
+    kind: "starterPack",
+    title,
+    uri: str(view.uri) ?? atUri,
+  };
+}
+
+async function resolveHandle(handle: string): Promise<string | null> {
+  const body = await appview("com.atproto.identity.resolveHandle", { handle });
+  const did = str(body?.did);
+  return did?.startsWith("did:") ? did : null;
+}
+
+/**
+ * Hydrate the record a Bluesky client link addresses. Returns null when the
+ * record can't be resolved (deleted, blocked, or the AppView is down) so the
+ * caller can fall back to a plain link card. Posts are not handled here — they
+ * render through the existing Bluesky post embed.
+ */
+export async function getBskyEntityCard(
+  ref: BskyClientRef,
+): Promise<BskyEntityCard | null> {
+  if (ref.kind === "post") return null;
+  if (ref.kind === "profile") return fetchProfile(ref.ident);
+
+  // Every other kind is addressed by AT-URI, which needs a DID.
+  let ident = ref.ident;
+  if (!ident.startsWith("did:")) {
+    const did = await resolveHandle(ident.toLowerCase());
+    if (!did) return null;
+    ident = did;
+  }
+  const atUri = bskyClientRefAtUri({ ...ref, ident });
+  if (!atUri) return null;
+
+  switch (ref.kind) {
+    case "feed": {
+      return fetchFeedGenerator(atUri);
+    }
+    case "list": {
+      return fetchList(atUri);
+    }
+    case "starterPack": {
+      return fetchStarterPack(atUri);
+    }
+  }
+}

--- a/packages/renderer-core/src/document/structured-content/prosemirror.ts
+++ b/packages/renderer-core/src/document/structured-content/prosemirror.ts
@@ -156,7 +156,8 @@ function asBlock(node: unknown): StructuredRenderableBlock | null {
         : null;
     }
     case "embed": {
-      // External embed (observed: bsky.app post URLs) — render as a link card.
+      // External embed (observed: bsky.app post URLs) — emitted as a website
+      // block; renderers may upgrade a known AT-Proto URL to a native embed.
       return typeof node.url === "string"
         ? { kind: "website", src: node.url }
         : null;


### PR DESCRIPTION
## Summary

Adds support for rendering Bluesky web client URLs (bsky.app, Witchsky, mu.social, etc.) as native embeds instead of generic link cards. Profile links become mention chips, and post/feed/list/starter pack links render as rich entity cards with metadata fetched from the public AppView API.

## Key Changes

- **New module `lib/atproto/bsky-clients.ts`**: Defines the AT Protocol record kinds that Bluesky web clients address and provides utilities to parse their URLs and normalize identifiers. Kept dependency-free for use by the browser extension's manifest generation.

- **New module `server/atproto/bsky-entities.ts`**: Server-side hydration of entity cards (profiles, feeds, lists, starter packs) via the public AppView API. Handles timeouts gracefully and returns null when records cannot be resolved.

- **New component `BskyClientEmbedView`**: Renders Bluesky web client links as native embeds. Posts delegate to the existing `BskyPostView`; other entity kinds render as rich cards with avatar, title, description, creator info, and follower/member counts.

- **Integration with TanStack Query**: Added `getEntityCardQueryOptions` to `api-bsky.functions.ts` to fetch and cache entity card data.

- **Updated link rendering**: Modified `pckt-website.tsx` to detect Bluesky client URLs and render them via `BskyClientEmbedView` instead of the default link card fallback.

- **Updated internal routing**: Modified `internal-route.ts` and `publication-mentions.ts` to use the new `bskyClientProfileIdent` utility for consistent profile identifier handling.

- **Localization**: Added new message strings for member/follower counts (plural form) and MCP server mention across all supported languages (en, ar, de, es, fr, ja, ko, pt, zh, en-XA).

- **Deprecated strings**: Marked several about-view strings as obsolete (`#~`) as the UI copy is being refactored.

- **Tests**: Added comprehensive test coverage for URL parsing and identifier normalization in `bsky-clients.test.ts`.

- **Documentation**: Updated `APP_VISION.md` and `TODO.md` to reflect the new feature and mark related tasks as complete.

## Implementation Details

- The module gracefully falls back to the original link card (`fallback` prop) if a record cannot be resolved or times out, ensuring dead/blocked records never leave holes in articles.
- Entity card fetches use an 8-second timeout to prevent slow AppView responses from blocking article rendering.
- The `BSKY_WEB_CLIENT_HOSTS` list is exported for reuse by the browser extension's manifest generation, avoiding duplication.
- Profile links are routed to the internal `/u/$did` path for consistent in-app navigation.

https://claude.ai/code/session_01PUYtiR9AnumyhNPaaXoqLk