### PR TITLE
Resolve Leaflet comment quotes anchored inside list items

### DIFF
--- a/apps/standard-reader/src/lib/leaflet/comment.test.ts
+++ b/apps/standard-reader/src/lib/leaflet/comment.test.ts
@@ -30,6 +30,42 @@ function content(...paragraphs: Array<string>) {
   };
 }
 
+/**
+ * A document with a single list block (`pub.leaflet.blocks.unorderedList` or
+ * `orderedList`) whose items are plain text, matching how Leaflet's editor
+ * nests list-item plaintext under `children[].content` rather than directly
+ * on the block.
+ */
+function listContent(
+  kind: "unorderedList" | "orderedList",
+  items: Array<string>,
+) {
+  const itemType =
+    kind === "unorderedList"
+      ? LEAFLET_BLOCK.unorderedListItem
+      : LEAFLET_BLOCK.orderedListItem;
+  return {
+    $type: LEAFLET_CONTENT,
+    pages: [
+      {
+        $type: LEAFLET_PAGE.linearDocument,
+        blocks: [
+          {
+            $type: LEAFLET_PAGE.linearDocumentBlock,
+            block: {
+              $type: LEAFLET_BLOCK[kind],
+              children: items.map((plaintext) => ({
+                $type: itemType,
+                content: { $type: LEAFLET_BLOCK.text, plaintext },
+              })),
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
 function quote(
   startBlock: Array<number>,
   startOffset: number,
@@ -149,6 +185,62 @@ describe("extractLeafletQuoteText", () => {
     const text = extractLeafletQuoteText(long, anchor([0], 0, [0], 900));
     expect(text).toHaveLength(601);
     expect(text?.endsWith("…")).toBe(true);
+  });
+
+  it("slices a range inside an unordered list item", () => {
+    const listDoc = listContent("unorderedList", [
+      "first item text",
+      "second item, this is the one we quote",
+      "third item",
+    ]);
+    expect(
+      extractLeafletQuoteText(listDoc, anchor([0, 1], 0, [0, 1], 12)),
+    ).toBe("second item,");
+  });
+
+  it("slices a range inside an ordered list item", () => {
+    const listDoc = listContent("orderedList", ["only item here"]);
+    expect(extractLeafletQuoteText(listDoc, anchor([0, 0], 5, [0, 0], 9))).toBe(
+      "item",
+    );
+  });
+
+  it("matches a live pub.leaflet.comment quote anchored inside a list item", () => {
+    // Regression fixture for at://did:plc:fip3nyk6tjo3senpq4ei2cxw/pub.leaflet.comment/3mruv73dqlk22,
+    // whose attachment anchors quote.start/end at block [29, 2] — block 29 is
+    // an unorderedList, and 2 indexes its third `children` entry.
+    const items = [
+      "@-mention and rich text links for link notes",
+      "let me map a domain to my link blog",
+      "for regular Skyreader, when sharing to Semble I want to add a comment / create a note in Semble. I think you can probably combine your link blog share with share to semble?",
+    ];
+    const listDoc = {
+      $type: LEAFLET_CONTENT,
+      pages: [
+        {
+          $type: LEAFLET_PAGE.linearDocument,
+          blocks: [
+            ...Array.from({ length: 29 }, () => ({
+              $type: LEAFLET_PAGE.linearDocumentBlock,
+              block: { $type: LEAFLET_BLOCK.text, plaintext: "filler" },
+            })),
+            {
+              $type: LEAFLET_PAGE.linearDocumentBlock,
+              block: {
+                $type: LEAFLET_BLOCK.unorderedList,
+                children: items.map((plaintext) => ({
+                  $type: LEAFLET_BLOCK.unorderedListItem,
+                  content: { $type: LEAFLET_BLOCK.text, plaintext },
+                })),
+              },
+            },
+          ],
+        },
+      ],
+    };
+    expect(
+      extractLeafletQuoteText(listDoc, anchor([29, 2], 0, [29, 2], 172)),
+    ).toBe(items[2]);
   });
 
   it("returns null when the anchor cannot be resolved", () => {

--- a/apps/standard-reader/src/lib/leaflet/comment.ts
+++ b/apps/standard-reader/src/lib/leaflet/comment.ts
@@ -164,13 +164,21 @@ function blockAtPath(
   if (!block) return null;
   if (rest.length === 0) return block;
 
-  // Nested paths address blocks inside an embedded page.
-  return blockAtPath(block.blocks, rest);
+  // Nested paths address blocks inside an embedded page, or list items
+  // inside a `pub.leaflet.blocks.unorderedList` / `orderedList` container —
+  // those keep their items under `children`, not `blocks`.
+  const nested = Array.isArray(block.blocks) ? block.blocks : block.children;
+  return blockAtPath(nested, rest);
 }
 
 function blockPlaintext(block: Record<string, unknown> | null): string | null {
   if (!block) return null;
-  return typeof block.plaintext === "string" ? block.plaintext : null;
+  if (typeof block.plaintext === "string") return block.plaintext;
+  // List items carry their text on `content` rather than directly on the item.
+  if (isRecord(block.content) && typeof block.content.plaintext === "string") {
+    return block.content.plaintext;
+  }
+  return null;
 }
 
 function rootBlocks(content: unknown): unknown {


### PR DESCRIPTION
Discussion: at://did:plc:fip3nyk6tjo3senpq4ei2cxw/app.userinput.discussion/3mruvo2ucxcjt

## Original request

> Title: Render quotes from Leaflet comments
>
> Sometimes a Leaflet comment includes a quote from the post. Would be nice if the Reader could render them too, so the comment has its full context. BUT, when I looked the raw data, it might be challenging to convert it, since the quote data is just the numbers of the text position inside the document.
>
> For example, my recent comment here includes a quote (you can see it properly when you open it inside Leaflet): https://standard-reader.app/a/did:plc:2cxgdrgtsmrbqnjkwyplmp43/3mnnwcdentk2c
> And here is the comment data: https://pdsls.dev/at://did:plc:fip3nyk6tjo3senpq4ei2cxw/pub.leaflet.comment/3mruv73dqlk22

## What I found

The reporter assumed this needed new UI/feature work, but Standard Reader already has a full pipeline for this: `pub.leaflet.comment`'s `#linearDocumentQuote` attachment (block-path + character offset into the document's `pub.leaflet.content`) is parsed in `src/lib/leaflet/comment.ts`, resolved against the DB-mirrored document body (`documents.contentJson`) by `extractLeafletQuoteText()`, and rendered as a `<blockquote>` in `CommentCard` — the exact same styled quote block used for Bluesky/Margin quote comments. It's covered by existing unit tests in `comment.test.ts`.

So this wasn't a missing feature — it was a bug in that existing resolver. I fetched the reporter's own example record directly from their PDS (`pub.leaflet.comment/3mruv73dqlk22`, quote anchor `block: [29, 2]`) and the document it quotes (`site.standard.document/3mnnwcdentk2c`). Block `29` in that document is a `pub.leaflet.blocks.unorderedList`, and path index `2` selects its third list item. `extractLeafletQuoteText()`'s block-path walker (`blockAtPath`) only ever recursed into a block's `.blocks` field (for embedded pages) and read `.plaintext` directly off the resolved block — but Leaflet list blocks keep their items under `children`, and each item's text lives at `children[i].content.plaintext`, not on the item itself. So any quote anchored inside a list item (like the reporter's own comment) silently failed to resolve, `extractLeafletQuoteText` returned `null`, and the comment rendered as a plain reply with no quoted context — exactly what was reported.

**Fix**: `blockAtPath` now falls back to a block's `.children` when `.blocks` isn't present, and `blockPlaintext` now reads `.content.plaintext` for list items. This required no UI changes — the `<blockquote>` rendering path already existed and works unmodified once the extractor returns text instead of `null`. Since the fix is a pure data/logic correction with no visual dimension, I implemented it directly rather than running `/impeccable craft`.

Added regression tests in `comment.test.ts`, including one built directly from the reporter's live record (document blocks padded to index 29, an `unorderedList` with the same three item texts, quote anchor `[29, 2]` offsets `0`–`172`) asserting it now resolves to the expected quoted text.

`pnpm build && pnpm lint && pnpm typecheck && pnpm test` all pass locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YFgj2HSrxe8ecs7TAq2G9k)_