### PR TITLE
Archive newest-first for serials, and unread by the comic issue

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -342,10 +342,13 @@ of re-upserting whole rows to set one column.
 
 What changes for a serial:
 
-- **Publication profile** lists its archive **oldest-first** (issue #1 leads instead of the
-  latest post) and offers "Start from issue one" / "Start from chapter one" in the hero. The
-  ordering is resolved server-side inside `getPublicationDocuments`, so the client never has to
-  know the reading order to ask for the right page.
+- **The archive still leads with the latest post.** A serial reads forwards, but its archive is
+  read far more often to see what is new than to find where the work begins, so every
+  publication — serial or not — lists newest-first (`defaultArchiveOrder`,
+  `#/lib/publication/archive-order`). A reader who does want to start at the beginning flips it
+  from the publication menu; the override is a per-publication cookie, resolved server-side
+  inside `getPublicationDocuments`, so the client never has to know the order to ask for the
+  right page and the SSR'd HTML is already in it.
 - **A comic's archive is a shelf of covers, not a list of pages.** A comic posts one page per
   document, so its archive is dozens of near-identical rows — `FITV #1 Cover`, `FITV #1, Pg. 1`.
   Titles almost always carry series, issue and page, so `selectComicShelf`
@@ -354,7 +357,18 @@ What changes for a serial:
   art — the reader browses issues instead of scrolling pages. It is a naming convention, not a
   lexicon field, so it is treated as a guess: fewer than 70% of titles parsing, or everything
   landing in one group, leaves `grouped: false` and the ordinary archive list stands. The
-  read/unread filters keep the list too — a shelf can't say "half of issue 3".
+  read/unread filters keep the list too — those are per-page views, and a shelf shows whole
+  issues.
+- **An issue is unread while any of its pages is**, and its cover opens on the first page the
+  reader hasn't seen. Read state is per document, and a comic's documents are its pages, so the
+  shelf asks for the reader's unread URIs across the whole publication (`selectUnreadDocumentUris`
+  — the same query the archive's unread filter and "mark all as read" run) and hands each issue
+  the pages it still owes them. The cover wears the ordinary unread dot and links to
+  `?page=<first unread>`, so picking a comic back up is one click from the shelf rather than a
+  hunt through the page counter. `read` records reach the read model through the firehose, so a
+  reader who has just walked those pages is ahead of the server: the shelf's answer is corrected
+  in the client from the same read caches every other unread dot uses
+  (`#/lib/comic/shelf-progress`).
 - **Comics open in the comic reader** (`/comic/$did/$rkey`) — a fixed dark theater that flips
   through the issue's pages one at a time. The pages _are_ the images the body renders, in
   reading order (`#/lib/document/images`), so nothing is authored specially for it. Arrow keys /

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -891,9 +891,12 @@ Backend/API exists; UI or copy is missing.
       ([`recompute.ts`](src/server/ingest/recompute.ts)): a publication whose recent posts each
       render an image and carry only a short note of prose is a comic. Both travel to the UI as
       `PublicationCard.serial` ([`serial.ts`](src/lib/publication/serial.ts)).
-      Serial publication pages list their archive **oldest-first** (resolved server-side in
-      `getPublicationDocuments`, so the client needn't know the order to page it) and offer
-      "Start from issue one" ([`serial-start.tsx`](src/components/reader/serial-start.tsx)).
+      Serial publication pages list their archive **newest-first** like every other publication —
+      an archive answers "what's new here?" far more often than "where does this start?" — with a
+      per-publication cookie override for a reader who wants to start at the beginning, resolved
+      server-side in `getPublicationDocuments`
+      ([`archive-order.ts`](src/lib/publication/archive-order.ts)) so the client needn't know the
+      order to page it.
       **Comics** open in a new page-flip reader at `/comic/$did/$rkey`
       ([`comic-reader.tsx`](src/components/comic/comic-reader.tsx)) — a fixed dark theater over the
       **whole publication**: every issue's images, in publication order, as one continuous run of
@@ -941,6 +944,14 @@ Backend/API exists; UI or copy is missing.
       treated as a guess — under 70% of titles parsing, or a single group, leaves `grouped: false`
       and the ordinary list stands, as do the read/unread filters. Awaited in the route loader for
       comics so the shelf is part of first paint.
+      **Unread works by the issue**: an issue is unread while any of its pages is, so the shelf is
+      reader-scoped — `selectComicShelf` hands each issue the reader's unread pages
+      (`selectUnreadDocumentUris`, the same query the archive filter and "mark all as read" use),
+      the cover wears the ordinary unread dot, and clicking it opens the reader on the first page
+      that reader hasn't seen rather than back at the cover
+      ([`shelf-progress.ts`](src/lib/comic/shelf-progress.ts)). `read` records mirror in through
+      the firehose, so the server's answer is corrected client-side from the same read caches the
+      feeds' unread dots use — walking a comic and stepping back out leaves no stale dots behind.
 - [ ] **Reader preference for the comic reader** — comics currently always open in the theater (with
       "Read the notes" as the escape). The magazine has an `open_collections_in_magazine` toggle;
       the comic reader deserves the same opt-out, plus a per-publication override for a serial the

--- a/apps/standard-reader/src/components/comic/comic-shelf.tsx
+++ b/apps/standard-reader/src/components/comic/comic-shelf.tsx
@@ -8,7 +8,11 @@ import {
 import { Flex } from "@standard-reader/design-system/flex";
 import { Skeleton } from "@standard-reader/design-system/skeleton";
 import { animationDuration } from "@standard-reader/design-system/theme/animations.stylex";
-import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
+import {
+  primaryColor,
+  uiColor,
+} from "@standard-reader/design-system/theme/color.stylex";
+import { radius } from "@standard-reader/design-system/theme/radius.stylex";
 import { gap } from "@standard-reader/design-system/theme/semantic-spacing.stylex";
 import { shadow } from "@standard-reader/design-system/theme/shadow.stylex";
 import { spacing } from "@standard-reader/design-system/theme/spacing.stylex";
@@ -20,10 +24,15 @@ import {
   tracking,
 } from "@standard-reader/design-system/theme/typography.stylex";
 import * as stylex from "@stylexjs/stylex";
+import { useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
+import { useCallback } from "react";
 
+import { comicIssueProgress } from "#/lib/comic/shelf-progress";
 import type { ArchiveOrder } from "#/lib/publication/archive-order";
-import type { ComicShelfIssue } from "#/server/reader/comic";
+import type { ComicShelfIssue, ComicUnreadPage } from "#/server/reader/comic";
+
+import { isArticleUnreadForReader } from "../reader/read-optimistic";
 
 /** Comic covers are taller than they are wide — the standard trade paperback. */
 const COVER_ASPECT_RATIO = 2 / 3;
@@ -81,6 +90,17 @@ const styles = stylex.create({
     unicodeBidi: "isolate",
     lineHeight: lineHeight.sm,
   },
+  // Same mark, same size, same colour as an unread article row's — a comic
+  // issue is one more thing the reader hasn't got to yet.
+  unreadDot: {
+    borderRadius: radius.full,
+    backgroundColor: primaryColor.solid1,
+    display: "inline-block",
+    flexShrink: 0,
+    height: "7px",
+    marginTop: spacing["1.5"],
+    width: "7px",
+  },
   meta: {
     color: uiColor.text1,
     fontFamily: fontFamily.sans,
@@ -91,16 +111,24 @@ const styles = stylex.create({
   },
 });
 
-function ComicShelfCard({ issue }: { issue: ComicShelfIssue }) {
+function ComicShelfCard({
+  issue,
+  isStillUnread,
+}: {
+  issue: ComicShelfIssue;
+  isStillUnread: (page: ComicUnreadPage) => boolean;
+}) {
   const { t } = useLingui();
+  const { startPage, unread } = comicIssueProgress(issue, isStillUnread);
   return (
     <Link
       to="/comic/$did/$rkey"
       params={{ did: issue.did, rkey: issue.rkey }}
-      // The cover art isn't always the issue's first page, so the page is named
-      // explicitly rather than left to the anchor document's own offset.
-      search={{ page: issue.pageOffset + 1 }}
-      aria-label={t`Read ${issue.label}`}
+      // Where the reader left off, or the issue's own first page — either way
+      // named explicitly, since the cover art isn't always the first page and
+      // the anchor document's offset would land on it rather than on them.
+      search={{ page: startPage }}
+      aria-label={unread ? t`Continue ${issue.label}` : t`Read ${issue.label}`}
       {...stylex.props(styles.issue)}
     >
       <AspectRatio aspectRatio={COVER_ASPECT_RATIO} style={styles.cover}>
@@ -120,7 +148,14 @@ function ComicShelfCard({ issue }: { issue: ComicShelfIssue }) {
         )}
       </AspectRatio>
       <Flex direction="column" gap="xs">
-        <span {...stylex.props(styles.label)}>{issue.label}</span>
+        <Flex gap="md" align="start">
+          {unread ? (
+            // The link's own label already says "Continue", so the dot is
+            // decoration for anyone reading it out.
+            <span aria-hidden {...stylex.props(styles.unreadDot)} />
+          ) : null}
+          <span {...stylex.props(styles.label)}>{issue.label}</span>
+        </Flex>
         <span {...stylex.props(styles.meta)}>
           <Plural value={issue.pageCount} one="# page" other="# pages" />
         </span>
@@ -163,21 +198,49 @@ export function ComicShelfSkeleton() {
  *
  * `issues` always arrive in publication order (#1 first) — the spine reads that
  * way so absolute page numbers mean something. `order` is the reader's view of
- * the archive, and the shelf is the archive here, so it follows: a reader who
- * asked for newest first gets the latest issue at the top left.
+ * the archive, and the shelf is the archive here, so it follows: the latest
+ * issue leads unless the reader asked to start at the beginning.
+ *
+ * An issue is marked unread while any of its pages is, and its cover opens on
+ * the first of those pages. The server's answer is corrected here with the
+ * reads this session already knows about, which is what keeps a comic the reader
+ * has just walked through from still wearing its dots on the way back out (see
+ * `#/lib/comic/shelf-progress`).
  */
 export function ComicShelf({
   issues,
   order,
+  trackReading,
+  signedIn,
 }: {
   issues: Array<ComicShelfIssue>;
   order: ArchiveOrder;
+  /** Whether the reader keeps reading history — no history, no unread state. */
+  trackReading: boolean;
+  signedIn: boolean;
 }) {
+  const queryClient = useQueryClient();
+  const isStillUnread = useCallback(
+    (page: ComicUnreadPage) =>
+      // The server already said this page is unread; the cache is only ever
+      // allowed to take that back, which is exactly what an article row does.
+      isArticleUnreadForReader(
+        queryClient,
+        { uri: page.uri, isRead: false },
+        { trackReading, signedIn },
+      ),
+    [queryClient, signedIn, trackReading],
+  );
+
   const shelved = order === "newest" ? [...issues].toReversed() : issues;
   return (
     <div {...stylex.props(styles.shelf)}>
       {shelved.map((issue) => (
-        <ComicShelfCard key={issue.uri} issue={issue} />
+        <ComicShelfCard
+          key={issue.uri}
+          issue={issue}
+          isStillUnread={isStillUnread}
+        />
       ))}
     </div>
   );

--- a/apps/standard-reader/src/components/reader/publication-actions.tsx
+++ b/apps/standard-reader/src/components/reader/publication-actions.tsx
@@ -146,9 +146,10 @@ function FilterSubMenu({
 /**
  * Which end of the archive leads, as a submenu off "Order".
  *
- * A serial lists oldest-first so chapter one leads, and that comes from a flag
- * the publisher sets on their own record — which they can get wrong in both
- * directions. This is how a reader disagrees, for this publication only.
+ * Every archive leads with the latest post, serials included — an archive is
+ * read far more often to see what's new than to find where a work begins. This
+ * is how a reader who wants to start at the beginning says so, for this
+ * publication only (see `#/lib/publication/archive-order`).
  */
 function OrderSubMenu({
   order,

--- a/apps/standard-reader/src/components/reader/read-optimistic.ts
+++ b/apps/standard-reader/src/components/reader/read-optimistic.ts
@@ -611,4 +611,7 @@ export function invalidateReadQueries(queryClient: QueryClient): void {
   void queryClient.invalidateQueries({
     queryKey: ["publication", "documents"],
   });
+  // A comic issue's unread dot is built from its pages' read state, so the
+  // shelf goes stale with everything else here.
+  void queryClient.invalidateQueries({ queryKey: ["comic", "shelf"] });
 }

--- a/apps/standard-reader/src/integrations/tanstack-query/api-publication.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-publication.functions.ts
@@ -423,29 +423,20 @@ const getPublicationDocuments = createServerFn({ method: "GET" })
               : "all"
             : data.filter;
 
-        // A serial publication reads forwards from its first post, so its
-        // archive is listed oldest-first (see `#/lib/publication/serial`). The
-        // rows can't be selected until the order is known, so this lookup goes
-        // out alongside the reader's follow set — the only other read that
-        // doesn't depend on it. (`effectiveFollowSets` is request-memoized.)
-        // It backfills from the PDS on the first view of a publication indexed
-        // before the column existed; every later view is served from the DB.
-        const [serial, followSets] = await Promise.all([
-          ensurePublicationSerial(db, schema, data.publicationUri),
-          did ? effectiveFollowSets(db, schema, did) : Promise.resolve(null),
-        ]);
-        span.set("serialKind", serial?.kind ?? "none");
+        const followSets = did
+          ? await effectiveFollowSets(db, schema, did)
+          : null;
 
-        // The publisher's flag is a claim about their own work, and one they
-        // can get wrong, so a reader who disagrees gets the last word (see
-        // `#/lib/publication/archive-order`). Read here rather than passed in
-        // by the client so the order is right in the SSR'd HTML instead of
-        // flipping after hydration.
+        // Every archive leads with the latest post, serials included — a reader
+        // who wants to start at the beginning says so, and that override is
+        // read here rather than passed in by the client so the order is right in
+        // the SSR'd HTML instead of flipping after hydration (see
+        // `#/lib/publication/archive-order`).
         const orderOverride = readArchiveOrderOverride(
           readArchiveOrderCookie(),
           data.publicationUri,
         );
-        const order = orderOverride ?? defaultArchiveOrder(serial != null);
+        const order = orderOverride ?? defaultArchiveOrder();
         span.set("order", order);
         span.set("orderOverridden", orderOverride != null);
 
@@ -1062,6 +1053,10 @@ const setPublicationArchiveOrder = createServerFn({ method: "POST" })
  * A comic's issues as a shelf of covers, for the publication page. Comes back
  * `grouped: false` when the titles don't follow the issue convention, and the
  * page keeps its ordinary archive list.
+ *
+ * Reader-scoped: each issue carries the pages this reader hasn't opened, which
+ * is what puts the unread dot on a cover and what decides the page a cover opens
+ * on. The query key carries the reader scope to match.
  */
 const getComicShelf = createServerFn({ method: "GET" })
   .middleware([dbMiddleware])
@@ -1070,11 +1065,27 @@ const getComicShelf = createServerFn({ method: "GET" })
     observe(
       "publication.getComicShelf",
       async ({ data, context }, span): Promise<ComicShelf> => {
-        const { db, schema } = context;
+        const {
+          db,
+          schema,
+          trackReadingEnabled,
+          countOldPostsAsUnreadEnabled,
+        } = context;
         span.set("publicationUri", data.publicationUri);
-        const shelf = await selectComicShelf(db, schema, data.publicationUri);
+        const did = await attachReaderSpanContext(span, getRequest());
+        // No reading history kept means no read state to report — every issue
+        // would come back unread and stay that way, which is worse than silence.
+        const readForDid = did && trackReadingEnabled ? did : undefined;
+        const shelf = await selectComicShelf(db, schema, data.publicationUri, {
+          readForDid,
+          countOldPostsAsUnread: countOldPostsAsUnreadEnabled,
+        });
         span.set("grouped", shelf.grouped);
         span.set("issues", shelf.issues.length);
+        span.set(
+          "unreadIssues",
+          shelf.issues.filter((issue) => issue.unreadPages.length > 0).length,
+        );
         return shelf;
       },
     ),
@@ -1290,10 +1301,19 @@ function getSeriesContextQueryOptions(documentUri: string) {
   });
 }
 
-/** The shelf changes only when the publication gains or edits an issue. */
-function getComicShelfQueryOptions(publicationUri: string) {
+/**
+ * The shelf changes when the publication gains or edits an issue — and when the
+ * reader reads one, which is why the key carries the reader scope. Read state
+ * moves faster than the shelf does, so the cached copy is corrected as it
+ * renders from the read caches the reader fills walking the comic (see
+ * `#/lib/comic/shelf-progress`).
+ */
+function getComicShelfQueryOptions(
+  publicationUri: string,
+  { readerScope = "guest" }: { readerScope?: string } = {},
+) {
   return queryOptions({
-    queryKey: ["comic", "shelf", publicationUri] as const,
+    queryKey: ["comic", "shelf", publicationUri, readerScope] as const,
     queryFn: async () => getComicShelf({ data: { publicationUri } }),
     staleTime: 300_000,
   });

--- a/apps/standard-reader/src/lib/comic/shelf-progress.test.ts
+++ b/apps/standard-reader/src/lib/comic/shelf-progress.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import type { ComicUnreadPage } from "#/server/reader/comic";
+
+import { comicIssueProgress } from "./shelf-progress";
+
+const page11: ComicUnreadPage = {
+  uri: "at://did:plc:a/site.standard.document/p11",
+  pageOffset: 11,
+};
+const page12: ComicUnreadPage = {
+  uri: "at://did:plc:a/site.standard.document/p12",
+  pageOffset: 12,
+};
+
+/** Issue #2, pages 10..13, with the middle two unread. */
+const issue = { pageOffset: 10, unreadPages: [page11, page12] };
+
+describe("comicIssueProgress", () => {
+  it("opens on the first page the reader hasn't seen", () => {
+    expect(comicIssueProgress(issue)).toEqual({
+      startPage: 12,
+      unread: true,
+      unreadCount: 2,
+    });
+  });
+
+  it("counts an issue unread while any one page is", () => {
+    const lastPageOnly = { pageOffset: 10, unreadPages: [page12] };
+    expect(comicIssueProgress(lastPageOnly)).toMatchObject({
+      startPage: 13,
+      unread: true,
+    });
+  });
+
+  it("goes back to the cover once the issue has been read through", () => {
+    expect(comicIssueProgress({ pageOffset: 10, unreadPages: [] })).toEqual({
+      startPage: 11,
+      unread: false,
+      unreadCount: 0,
+    });
+  });
+
+  it("drops pages the caller has since read, and follows the rest", () => {
+    const read = new Set([page11.uri]);
+    expect(comicIssueProgress(issue, (page) => !read.has(page.uri))).toEqual({
+      startPage: 13,
+      unread: true,
+      unreadCount: 1,
+    });
+  });
+
+  it("reads as fully read when the caller has read every page", () => {
+    expect(comicIssueProgress(issue, () => false)).toEqual({
+      startPage: 11,
+      unread: false,
+      unreadCount: 0,
+    });
+  });
+});

--- a/apps/standard-reader/src/lib/comic/shelf-progress.ts
+++ b/apps/standard-reader/src/lib/comic/shelf-progress.ts
@@ -1,0 +1,47 @@
+/**
+ * Where a reader is inside a comic issue, and therefore what its cover does.
+ *
+ * An issue on the shelf is a run of page documents, so it is unread while any
+ * one of those pages is — half of issue 3 is not issue 3 — and opening it means
+ * going to the first page the reader hasn't seen, not back to the cover.
+ *
+ * The server sends the unread pages it knows about (`ComicShelfIssue.unreadPages`),
+ * but a reader who has just walked those pages in the comic reader is ahead of
+ * it: `read` records are written to the PDS and reach the read model through the
+ * firehose, so the shelf's copy is a beat behind for as long as that takes.
+ * `isStillUnread` is how the caller folds this session's own reads back in — the
+ * same correction every other unread dot in the app makes
+ * (`isArticleUnreadForReader`).
+ */
+
+import type { ComicShelfIssue, ComicUnreadPage } from "#/server/reader/comic";
+
+export interface ComicIssueProgress {
+  /** 1-based page across the publication that this cover opens on. */
+  startPage: number;
+  /** Any page of this issue still waiting to be read. */
+  unread: boolean;
+  /** How many of its pages those are — 0 once the issue has been read through. */
+  unreadCount: number;
+}
+
+/**
+ * Read position for one shelf issue.
+ *
+ * `unreadPages` arrives in reading order, so the first one that survives the
+ * caller's check is the page the reader is owed. An issue with nothing left
+ * opens where it always did, on its own first page: a reader clicking a cover
+ * they have already read is going back to re-read it.
+ */
+export function comicIssueProgress(
+  issue: Pick<ComicShelfIssue, "pageOffset" | "unreadPages">,
+  isStillUnread: (page: ComicUnreadPage) => boolean = () => true,
+): ComicIssueProgress {
+  const remaining = issue.unreadPages.filter((page) => isStillUnread(page));
+  const first = remaining[0];
+  return {
+    startPage: (first?.pageOffset ?? issue.pageOffset) + 1,
+    unread: remaining.length > 0,
+    unreadCount: remaining.length,
+  };
+}

--- a/apps/standard-reader/src/lib/publication/archive-order.test.ts
+++ b/apps/standard-reader/src/lib/publication/archive-order.test.ts
@@ -29,9 +29,8 @@ describe("archiveOrderKey", () => {
 });
 
 describe("defaultArchiveOrder", () => {
-  it("leads with chapter one for a serial and the latest post otherwise", () => {
-    expect(defaultArchiveOrder(true)).toBe("oldest");
-    expect(defaultArchiveOrder(false)).toBe("newest");
+  it("leads with the latest post, serial or not", () => {
+    expect(defaultArchiveOrder()).toBe("newest");
   });
 });
 

--- a/apps/standard-reader/src/lib/publication/archive-order.ts
+++ b/apps/standard-reader/src/lib/publication/archive-order.ts
@@ -1,18 +1,19 @@
 /**
  * Reader overrides for the order a publication's archive is listed in.
  *
- * An ordinary publication lists newest-first; a serial lists oldest-first, so
- * chapter one leads (see `#/lib/publication/serial`). Whether a publication is a
- * serial comes from `preferences.prevNextDirection` on its record — the
- * publisher's claim about their own work, and one they can get wrong. A blog
- * whose author set the flag without meaning "read me front to back" reads
- * backwards for everyone; a serial whose author never set it reads backwards
- * too.
+ * Every publication lists newest-first, serials included. A serial reads
+ * forwards from its first post (see `#/lib/publication/serial`), and the archive
+ * used to be turned around to match — but an archive answers "what's new here?"
+ * far more often than "where does this start?", and a reader who is caught up on
+ * a running comic had to page to the end of it to find the page they came for.
+ * The serial treatment that matters is the reading order *inside* the work
+ * (prev/next, "Up next", the comic reader's page numbering), not which end of the
+ * shelf faces out.
  *
- * So the reader gets the last word. The override is per publication — disagreeing
- * with one publisher's label says nothing about the next — and lives in a cookie
- * so the server can honor it while rendering, rather than the archive painting
- * one way and flipping after hydration.
+ * A reader who does want to start at the beginning gets the last word. The
+ * override is per publication — disagreeing about one archive says nothing about
+ * the next — and lives in a cookie so the server can honor it while rendering,
+ * rather than the archive painting one way and flipping after hydration.
  *
  * Deliberately not stored on the user row: it costs a migration and a write path
  * to remember a display preference that a signed-out reader should get too.
@@ -36,9 +37,13 @@ export const ARCHIVE_ORDER_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
  */
 export const ARCHIVE_ORDER_MAX_ENTRIES = 24;
 
-/** The order a publication lists in when the reader hasn't said otherwise. */
-export function defaultArchiveOrder(isSerial: boolean): ArchiveOrder {
-  return isSerial ? "oldest" : "newest";
+/**
+ * The order a publication lists in when the reader hasn't said otherwise —
+ * newest first, whatever the publication is. Named rather than inlined so the
+ * default has one home to argue with (see the note at the top of this file).
+ */
+export function defaultArchiveOrder(): ArchiveOrder {
+  return "newest";
 }
 
 function parseArchiveOrder(value: string | undefined): ArchiveOrder | null {

--- a/apps/standard-reader/src/lib/publication/serial.ts
+++ b/apps/standard-reader/src/lib/publication/serial.ts
@@ -5,8 +5,12 @@
  * declared prev/next reading direction. The lexicon default is `"rtl"`, which
  * is the ordinary blog order (newest post first, "next" walks backwards into
  * the archive). A publisher who sets `"ltr"` is saying the opposite: the
- * publication reads forwards from its *first* post, so a reader arriving at the
- * publication should start at issue #1 and walk forwards.
+ * publication reads forwards from its *first* post, so "next" is the later
+ * issue and the work has a front and a back.
+ *
+ * That is about reading order *inside* the work — prev/next, "Up next", the
+ * comic reader's page numbering. The archive itself still lists newest-first
+ * like everything else (see `#/lib/publication/archive-order`).
  *
  * That single flag is what marks a publication as a serial here. What kind of
  * serial it is has no field in the lexicon, so it is app-derived from the

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -2974,6 +2974,11 @@ msgstr "رموز OAuth لنتمكن من قراءة السجلات وكتابت�
 msgid "Copy"
 msgstr "نسخ"
 
+#. placeholder {0}: issue.label
+#: src/components/comic/comic-shelf.tsx
+msgid "Continue {0}"
+msgstr ""
+
 #: src/components/reader/content/renderers/shared/image-figure.tsx
 #: src/components/reader/content/renderers/shared/markdown-article.tsx
 #: src/magazine/Magazine.tsx

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -2974,6 +2974,11 @@ msgstr "OAuth-Tokens, damit wir in Ihrem Namen Records in Ihrem Repository lesen
 msgid "Copy"
 msgstr "Kopieren"
 
+#. placeholder {0}: issue.label
+#: src/components/comic/comic-shelf.tsx
+msgid "Continue {0}"
+msgstr ""
+
 #: src/components/reader/content/renderers/shared/image-figure.tsx
 #: src/components/reader/content/renderers/shared/markdown-article.tsx
 #: src/magazine/Magazine.tsx

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -2974,6 +2974,11 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
+#. placeholder {0}: issue.label
+#: src/components/comic/comic-shelf.tsx
+msgid "Continue {0}"
+msgstr ""
+
 #: src/components/reader/content/renderers/shared/image-figure.tsx
 #: src/components/reader/content/renderers/shared/markdown-article.tsx
 #: src/magazine/Magazine.tsx

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -2974,6 +2974,11 @@ msgstr "OAuth tokens so we can read and write records in your repository on your
 msgid "Copy"
 msgstr "Copy"
 
+#. placeholder {0}: issue.label
+#: src/components/comic/comic-shelf.tsx
+msgid "Continue {0}"
+msgstr "Continue {0}"
+
 #: src/components/reader/content/renderers/shared/image-figure.tsx
 #: src/components/reader/content/renderers/shared/markdown-article.tsx
 #: src/magazine/Magazine.tsx

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -2974,6 +2974,11 @@ msgstr "Tokens de OAuth para poder leer y escribir registros en su repositorio e
 msgid "Copy"
 msgstr "Copiar"
 
+#. placeholder {0}: issue.label
+#: src/components/comic/comic-shelf.tsx
+msgid "Continue {0}"
+msgstr ""
+
 #: src/components/reader/content/renderers/shared/image-figure.tsx
 #: src/components/reader/content/renderers/shared/markdown-article.tsx
 #: src/magazine/Magazine.tsx

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -2974,6 +2974,11 @@ msgstr "Des jetons OAuth pour que nous puissions lire et écrire des enregistrem
 msgid "Copy"
 msgstr "Copier"
 
+#. placeholder {0}: issue.label
+#: src/components/comic/comic-shelf.tsx
+msgid "Continue {0}"
+msgstr ""
+
 #: src/components/reader/content/renderers/shared/image-figure.tsx
 #: src/components/reader/content/renderers/shared/markdown-article.tsx
 #: src/magazine/Magazine.tsx

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -2974,6 +2974,11 @@ msgstr "ユーザーに代わってリポジトリのレコードを読み書き
 msgid "Copy"
 msgstr "コピー"
 
+#. placeholder {0}: issue.label
+#: src/components/comic/comic-shelf.tsx
+msgid "Continue {0}"
+msgstr ""
+
 #: src/components/reader/content/renderers/shared/image-figure.tsx
 #: src/components/reader/content/renderers/shared/markdown-article.tsx
 #: src/magazine/Magazine.tsx

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -2974,6 +2974,11 @@ msgstr "회원님을 대신해 저장소의 레코드를 읽고 쓸 수 있도�
 msgid "Copy"
 msgstr "복사"
 
+#. placeholder {0}: issue.label
+#: src/components/comic/comic-shelf.tsx
+msgid "Continue {0}"
+msgstr ""
+
 #: src/components/reader/content/renderers/shared/image-figure.tsx
 #: src/components/reader/content/renderers/shared/markdown-article.tsx
 #: src/magazine/Magazine.tsx

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -2974,6 +2974,11 @@ msgstr "Tokens OAuth para podermos ler e escrever registos no seu repositório e
 msgid "Copy"
 msgstr "Copiar"
 
+#. placeholder {0}: issue.label
+#: src/components/comic/comic-shelf.tsx
+msgid "Continue {0}"
+msgstr ""
+
 #: src/components/reader/content/renderers/shared/image-figure.tsx
 #: src/components/reader/content/renderers/shared/markdown-article.tsx
 #: src/magazine/Magazine.tsx

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -2974,6 +2974,11 @@ msgstr "OAuth 令牌，使我们能代表你读写仓库中的记录（例如关
 msgid "Copy"
 msgstr "复制"
 
+#. placeholder {0}: issue.label
+#: src/components/comic/comic-shelf.tsx
+msgid "Continue {0}"
+msgstr ""
+
 #: src/components/reader/content/renderers/shared/image-figure.tsx
 #: src/components/reader/content/renderers/shared/markdown-article.tsx
 #: src/magazine/Magazine.tsx

--- a/apps/standard-reader/src/routes/_layout.p.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/_layout.p.$did.$rkey.tsx
@@ -160,7 +160,9 @@ export const Route = createFileRoute("/_layout/p/$did/$rkey")({
     // of the page's first paint rather than something that pops in after it.
     if (header?.publication.serial?.kind === "comic" && deps.filter === "all") {
       await context.queryClient
-        .ensureQueryData(publicationApi.getComicShelfQueryOptions(uri))
+        .ensureQueryData(
+          publicationApi.getComicShelfQueryOptions(uri, { readerScope }),
+        )
         .catch(() => null);
     }
 
@@ -662,6 +664,24 @@ function PublicationProfileContent({
           unreadDocumentUris.includes(doc.uri) ? { ...doc, isRead: true } : doc,
         ),
       );
+      // The server marks the whole publication read, not just the rows this page
+      // has loaded, so the shelf's dots all go out — clearing them here rather
+      // than refetching, because the `read` records reach the read model through
+      // the firehose and a refetch this soon would paint them straight back on.
+      queryClient.setQueryData(
+        publicationApi.getComicShelfQueryOptions(uri, { readerScope }).queryKey,
+        (shelf) =>
+          shelf
+            ? {
+                ...shelf,
+                issues: shelf.issues.map((issue) =>
+                  issue.unreadPages.length > 0
+                    ? { ...issue, unreadPages: [] }
+                    : issue,
+                ),
+              }
+            : shelf,
+      );
     },
     onSuccess: () => {
       setMarkAllReadCloseSignal((count) => count + 1);
@@ -729,7 +749,7 @@ function PublicationProfileContent({
   // "half of issue 3".
   const shelfEnabled = pub.serial?.kind === "comic" && filter === "all";
   const { data: shelf, isPending: shelfPending } = useQuery({
-    ...publicationApi.getComicShelfQueryOptions(uri),
+    ...publicationApi.getComicShelfQueryOptions(uri, { readerScope }),
     enabled: shelfEnabled,
   });
   // Until it resolves we don't know whether the titles group at all, and
@@ -817,7 +837,12 @@ function PublicationProfileContent({
           {showShelf ? (
             <Flex direction="column" gap="5xl">
               {shelf?.grouped ? (
-                <ComicShelf issues={shelf.issues} order={initialPage.order} />
+                <ComicShelf
+                  issues={shelf.issues}
+                  order={initialPage.order}
+                  trackReading={trackReading}
+                  signedIn={signedIn}
+                />
               ) : (
                 <ComicShelfSkeleton />
               )}

--- a/apps/standard-reader/src/server/reader/comic.ts
+++ b/apps/standard-reader/src/server/reader/comic.ts
@@ -39,6 +39,7 @@ import {
 } from "#/lib/comic/issue-title";
 import { documentImages } from "#/lib/document/images";
 import { documentPublishedNotInFuture } from "#/server/reader/document-filters";
+import { selectUnreadDocumentUris } from "#/server/reader/queries";
 
 /** One issue of a comic, as the reader's spine sees it. */
 export interface ComicIssue {
@@ -80,6 +81,16 @@ export interface ComicPage {
  * the reader a comfortable runway before it needs the next one.
  */
 export const COMIC_CHUNK_ISSUES = 5;
+
+/**
+ * How deep into a comic the shelf tracks unread pages. The cap keeps a reader
+ * scoped query bounded on a publication that could hold any number of pages; it
+ * drops the *oldest* unread pages first (the lookup is newest-first), so a
+ * reader who has never opened a comic this long sees the recent issues marked
+ * honestly and the very oldest ones sitting quiet — which is 2,000 pages of
+ * reading away from mattering.
+ */
+const COMIC_UNREAD_PAGE_LIMIT = 2000;
 
 /**
  * Fill `body_image_count` for documents that don't have it yet, and return the
@@ -280,6 +291,14 @@ export async function countDocumentsMissingPageCount(
   return row?.count ?? 0;
 }
 
+/** A page of an issue the reader hasn't opened yet. */
+export interface ComicUnreadPage {
+  /** The page's own document — what a `read` record is written against. */
+  uri: string;
+  /** Absolute 0-based page index, so the reader can be opened straight on it. */
+  pageOffset: number;
+}
+
 /** One issue on the shelf — a run of pages fronted by its cover. */
 export interface ComicShelfIssue {
   /** Issue number from the titles, null for pages that named none. */
@@ -297,6 +316,16 @@ export interface ComicShelfIssue {
   /** Documents (pages) collapsed into this issue. */
   documentCount: number;
   publishedAt: string;
+  /**
+   * The pages of this issue the reader hasn't opened, in reading order. An issue
+   * is unread while this holds anything — a comic read halfway through is not
+   * read — and its first entry is where opening the issue drops the reader.
+   *
+   * Always empty for a signed-out reader, or one who doesn't keep reading
+   * history: there is no read state to report, and an issue that can never be
+   * marked read must not sit there wearing an unread dot forever.
+   */
+  unreadPages: Array<ComicUnreadPage>;
 }
 
 export interface ComicShelf {
@@ -327,13 +356,40 @@ export interface ComicShelf {
  *
  * Only one body per issue is opened — the cover's, for its art — so the cost is
  * a handful of rows however long the comic runs.
+ *
+ * With `readForDid`, each issue also carries the pages that reader hasn't opened
+ * (`unreadPages`) — the shelf is where a reader picks up a comic, and picking it
+ * up means going to the next page they haven't seen, not back to the cover.
  */
 export async function selectComicShelf(
   db: Db,
   schema: Schema,
   publicationUri: string,
+  opts: {
+    /** Reader whose unread pages to report; omit for a shared, reader-agnostic
+     * shelf. */
+    readForDid?: string;
+    /** When false, pages published before the reader subscribed count as read
+     * — the same cutoff the archive's unread filter applies. */
+    countOldPostsAsUnread?: boolean;
+  } = {},
 ): Promise<ComicShelf> {
-  const spine = await selectComicSpine(db, schema, publicationUri);
+  // Independent reads: the unread set is the whole publication's, so it doesn't
+  // wait on the spine to know which documents to ask about. Same query the
+  // archive's unread filter and "mark all as read" run, so no two surfaces can
+  // disagree about what this reader still owes the comic.
+  const [spine, unreadUris] = await Promise.all([
+    selectComicSpine(db, schema, publicationUri),
+    opts.readForDid
+      ? selectUnreadDocumentUris(db, schema, {
+          readerDid: opts.readForDid,
+          publicationUris: [publicationUri],
+          countOldPostsAsUnread: opts.countOldPostsAsUnread,
+          limit: COMIC_UNREAD_PAGE_LIMIT,
+        })
+      : Promise.resolve<Array<string>>([]),
+  ]);
+  const unread = new Set(unreadUris);
   const empty: ComicShelf = {
     publicationUri,
     issues: [],
@@ -425,6 +481,15 @@ export async function selectComicShelf(
       ),
       documentCount: group.pages.length,
       publishedAt: first.issue.publishedAt,
+      // In reading order, because the group is: the first entry is the page the
+      // reader is owed. A page whose document isn't in the unread set — read, or
+      // published before this reader subscribed — is simply absent.
+      unreadPages: group.pages
+        .filter((page) => unread.has(page.issue.uri))
+        .map((page) => ({
+          uri: page.issue.uri,
+          pageOffset: page.issue.pageOffset,
+        })),
     });
   }
 

--- a/apps/standard-reader/src/server/reader/queries.ts
+++ b/apps/standard-reader/src/server/reader/queries.ts
@@ -808,10 +808,10 @@ export async function selectPublicationArticleCards(
      * but set even when reading history is off (recommends don't need it). */
     readerDid?: string;
     /**
-     * Archive ordering. Defaults to newest-first; serial publications pass
-     * `"oldest"` so the page opens on issue #1 (see
-     * `#/lib/publication/serial`). Callers must keep this stable across a
-     * paginated run — the offsets are computed against one ordering.
+     * Archive ordering. Defaults to newest-first; `"oldest"` is a reader asking
+     * to start at the beginning (see `#/lib/publication/archive-order`).
+     * Callers must keep this stable across a paginated run — the offsets are
+     * computed against one ordering.
      */
     order?: "newest" | "oldest";
   },
@@ -2131,9 +2131,10 @@ export function documentsNewestFirst(d: Schema["documents"]): Array<SQL> {
 }
 
 /**
- * Oldest-first document ordering — a serial publication reads forwards from its
- * first post (see `#/lib/publication/serial`), so its archive is listed in
- * publication order rather than reverse-chronological.
+ * Oldest-first document ordering — publication order rather than
+ * reverse-chronological, for a reader who has asked to read an archive from its
+ * beginning (see `#/lib/publication/archive-order`), and for the comic spine,
+ * whose absolute page numbers only mean anything front-to-back.
  *
  * Spelled as the exact reverse of {@link documentsNewestFirst}, down to the NULLS
  * placement, so the two are mirror images and Postgres can serve either by


### PR DESCRIPTION
Serial publications listed their archive oldest-first so chapter one led.
An archive answers "what's new here?" far more often than "where does this
start?", and on a running comic a caught-up reader had to page to the end
of the shelf to reach the page they came for. Every publication now leads
with the latest post; the per-publication cookie override is how a reader
asks to start at the beginning, and `defaultArchiveOrder` no longer takes
the serial flag at all. The serial treatment that matters — prev/next,
"Up next", the comic reader's page numbering — is untouched.

Comics had no unread state of their own. A comic's documents are its
pages, so `selectComicShelf` is now reader-scoped: it asks for the
reader's unread URIs across the publication (`selectUnreadDocumentUris` —
the same query the archive's unread filter and "mark all as read" run) and
hands each issue the pages it still owes them. An issue is unread while
any of its pages is, wears the ordinary unread dot, and opens on the first
page that reader hasn't seen rather than back at the cover.

`read` records reach the read model through the firehose, so a reader who
has just walked those pages is ahead of the server. The shelf's answer is
corrected as it renders from the same read caches every other unread dot
uses, and "mark all as read" clears the covers in place instead of
refetching into the lag.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Uq8L6k9QDWWB8DtmZVLUtg