### PR TITLE
Show a page's note over the comic instead of away from it

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -382,6 +382,18 @@ What changes for a serial:
   (`#/components/comic/use-fullscreen`). The button is absent, not disabled, where the browser
   won't do it — iOS Safari reserves full screen for `<video>` — and its state follows
   `fullscreenchange`, since Escape, F11 and the OS all exit without asking the app.
+- **A page's note reads over the page.** Comic posts often publish a line or two beside the art —
+  a caption, a process note, a word about next week — and in the theater that writing had nowhere
+  to go but the reading view, a navigation away from the page it was written about. The top bar's
+  note button lays it over the art instead (`#/components/comic/comic-page-note`): a translucent
+  dark scrim, the prose in the theater's own type, and a "Read the full post" escape to the
+  reading view. The note travels on the page (`ComicPage.note`), extracted in the chunk query that
+  already opens the body, and is the body's plaintext **minus the pages' own alt text** — the
+  extractors narrate image blocks by their alt, which describes the page the reader is already
+  looking at (`#/lib/comic/page-note`). Most pages carry none, so the control is disabled rather
+  than absent: a bar that reshuffled on every page turn is worse than a quiet button. The overlay
+  is a React Aria modal portalled **into the theater**, not `document.body`, so it survives full
+  screen.
 - **Books get "Up next"** under the article: the following chapter, or a note that the reader has
   caught up. Position ("3 of 12") and neighbours come from `getSeriesContext`
   (`#/server/reader/series`), loaded client-side after the article paints like the other

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -911,7 +911,15 @@ Backend/API exists; UI or copy is missing.
       leaves the art alone ([`use-fullscreen.ts`](src/components/comic/use-fullscreen.ts)) —
       unprefixed API only (the app targets `baseline 2024`), absent rather than disabled where the
       browser refuses element full screen (iOS Safari), and driven off `fullscreenchange` so
-      Escape, F11 and the OS keep the icon honest. The stage keeps `touch-action: pan-y pinch-zoom`
+      Escape, F11 and the OS keep the icon honest. Beside it, a **note button** lays the writing a
+      page published with over the art
+      ([`comic-page-note.tsx`](src/components/comic/comic-page-note.tsx)) — a translucent scrim,
+      the prose in the theater's own type, and a "Read the full post" escape — so a caption no
+      longer costs a navigation to the reading view. The note rides on `ComicPage` from the chunk
+      query that already opens each body, and is the body plaintext minus the pages' own alt text
+      ([`page-note.ts`](src/lib/comic/page-note.ts)), since the extractors narrate images by their
+      alt. It is a React Aria modal portalled into the theater rather than `document.body`, which
+      is what keeps it on screen in full screen. The stage keeps `touch-action: pan-y pinch-zoom`
       so a dense page can be pinched into, and **flips to `manipulation` while zoomed** — reserving
       horizontal drags for the swipe is what makes paging work at rest, but it pins a zoomed reader
       to a single vertical track, and swipe stands down at that scale anyway (as it does while a

--- a/apps/standard-reader/src/components/comic/comic-page-note.tsx
+++ b/apps/standard-reader/src/components/comic/comic-page-note.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { Trans, useLingui } from "@lingui/react/macro";
+import { IconButton } from "@standard-reader/design-system/icon-button";
+import {
+  animationDuration,
+  animationTimingFunction,
+  animations,
+} from "@standard-reader/design-system/theme/animations.stylex";
+import { gap } from "@standard-reader/design-system/theme/semantic-spacing.stylex";
+import { spacing } from "@standard-reader/design-system/theme/spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+  tracking,
+} from "@standard-reader/design-system/theme/typography.stylex";
+import * as stylex from "@stylexjs/stylex";
+import { FileText, X } from "lucide-react";
+import type { RefObject } from "react";
+import { useCallback } from "react";
+import { UNSAFE_PortalProvider } from "react-aria";
+import { Dialog, Modal, ModalOverlay } from "react-aria-components";
+
+import { comicNoteParagraphs } from "#/lib/comic/page-note";
+
+import { documentLinkParams } from "../reader/format";
+import { ButtonLink } from "../router-links";
+import { ICON_SIZE, ICON_STROKE } from "./theater-palette";
+import { theaterColor } from "./theater.stylex";
+
+const styles = stylex.create({
+  // The scrim carries the padding, not the panel: `isDismissable` closes on a
+  // press that lands outside the modal element, so any space the panel owns is
+  // space a tap-to-close doesn't work in — which on a phone was all of it.
+  overlay: {
+    inset: 0,
+    animationDuration: animationDuration.default,
+    animationName: animations.fadeIn,
+    animationTimingFunction: animationTimingFunction.easeOut,
+    alignItems: "center",
+    backdropFilter: "blur(6px)",
+    backgroundColor: theaterColor.noteScrim,
+    boxSizing: "border-box",
+    display: "flex",
+    justifyContent: "center",
+    opacity: { default: 1, ":is([data-exiting])": 0 },
+    paddingInlineEnd: spacing["6"],
+    paddingInlineStart: spacing["6"],
+    // Clear of both bars, which are still there under the scrim.
+    paddingBottom: spacing["20"],
+    paddingTop: spacing["20"],
+    // Over the chrome, not merely over the art: the bars belong to the page
+    // underneath, and reading a note is not paging through a comic.
+    position: "absolute",
+    zIndex: 3,
+    transitionDuration: { ":is([data-exiting])": animationDuration.fast },
+    transitionProperty: "opacity",
+    transitionTimingFunction: animationTimingFunction.easeIn,
+  },
+  modal: {
+    outline: "none",
+    display: "flex",
+    // The panel is the readable column, not a card: no surface of its own, so
+    // the art stays visible right up to the edge of the type. It hugs its own
+    // content, which is what leaves the rest of the scrim tappable.
+    maxHeight: "100%",
+    maxWidth: "38rem",
+    minHeight: 0,
+    width: "100%",
+  },
+  dialog: {
+    outline: "none",
+    display: "flex",
+    flexDirection: "column",
+    minHeight: 0,
+    rowGap: gap["4xl"],
+    width: "100%",
+  },
+  head: {
+    alignItems: "flex-start",
+    columnGap: gap["2xl"],
+    display: "flex",
+    justifyContent: "space-between",
+  },
+  kicker: {
+    color: theaterColor.chrome,
+    fontFamily: fontFamily.sans,
+    fontSize: "0.68rem",
+    fontWeight: fontWeight.medium,
+    letterSpacing: tracking.wide,
+    paddingTop: spacing["1.5"],
+    textTransform: "uppercase",
+    // A single-line label beside a button: order its own characters, keep the
+    // row's alignment.
+    unicodeBidi: "isolate",
+  },
+  // The note can outrun the screen — a process note runs long — so the column
+  // scrolls inside the panel rather than the panel growing past the viewport.
+  body: {
+    display: "flex",
+    flexDirection: "column",
+    minHeight: 0,
+    overflowY: "auto",
+    overscrollBehavior: "contain",
+    rowGap: gap["3xl"],
+  },
+  paragraph: {
+    color: theaterColor.chromeStrong,
+    fontFamily: fontFamily.serif,
+    fontSize: fontSize.lg,
+    lineHeight: lineHeight.base,
+    marginBottom: spacing["0"],
+    marginTop: spacing["0"],
+    // Prose in an unknown language, so it takes its own direction — unlike the
+    // single-line labels around it, which stay aligned to the chrome.
+    textWrap: "pretty",
+  },
+  actions: {
+    display: "flex",
+    justifyContent: "flex-start",
+  },
+  // The theater's palette is fixed, so the design-system buttons in it take
+  // these colours instead of the app's UI scale (as the reader's chrome does).
+  control: {
+    backgroundColor: {
+      default: "transparent",
+      ":hover": theaterColor.surface,
+    },
+    color: theaterColor.chromeStrong,
+    flexShrink: 0,
+    borderColor: theaterColor.rule,
+    boxShadow: "none",
+  },
+});
+
+export interface ComicPageNoteProps {
+  /** The prose published with this page, or null when there is none. */
+  note: string | null;
+  /** The page's own post — named in the kicker and linked for the full text. */
+  issueTitle: string;
+  issueUri: string | null;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  /**
+   * The theater element. React Aria portals its overlays to `document.body`,
+   * which is *outside* the element the reader puts full screen — a note opened
+   * in full screen would render to a part of the page the browser isn't
+   * painting. Re-pointing the portal at the theater keeps the note inside the
+   * thing on screen.
+   */
+  container: RefObject<HTMLElement | null>;
+}
+
+/**
+ * The writing that came with a comic page, over the page itself.
+ *
+ * Comic posts often carry a line or two beside the art — a caption, a note on
+ * the process, a word about next week. In the theater that text had nowhere to
+ * go: the reader shows images, and the prose lived only in the reading view, a
+ * navigation away from the page it was written about. This lays it over the art
+ * instead, so the page is still there while the note is read.
+ *
+ * Plain paragraphs rather than the article renderer: the theater is a fixed
+ * dark room with its own type, and the note is a few lines of prose, not a
+ * document. Anything richer than that — links, headings, a real body — is what
+ * the "Read the full post" escape is for.
+ */
+export function ComicPageNote({
+  note,
+  issueTitle,
+  issueUri,
+  isOpen,
+  onOpenChange,
+  container,
+}: ComicPageNoteProps) {
+  const { t } = useLingui();
+  const getContainer = useCallback(() => container.current, [container]);
+  const paragraphs = comicNoteParagraphs(note);
+  const postParams = issueUri ? documentLinkParams(issueUri) : null;
+
+  return (
+    <UNSAFE_PortalProvider getContainer={getContainer}>
+      <ModalOverlay
+        isOpen={isOpen && paragraphs.length > 0}
+        onOpenChange={onOpenChange}
+        isDismissable
+        {...stylex.props(styles.overlay)}
+      >
+        <Modal {...stylex.props(styles.modal)}>
+          <Dialog
+            aria-label={t`Note for ${issueTitle}`}
+            {...stylex.props(styles.dialog)}
+          >
+            {({ close }) => (
+              <>
+                <div {...stylex.props(styles.head)}>
+                  <span {...stylex.props(styles.kicker)}>{issueTitle}</span>
+                  <IconButton
+                    variant="tertiary"
+                    aria-label={t`Close the note`}
+                    onPress={close}
+                    style={styles.control}
+                  >
+                    <X aria-hidden size={ICON_SIZE} strokeWidth={ICON_STROKE} />
+                  </IconButton>
+                </div>
+
+                <div {...stylex.props(styles.body)}>
+                  {paragraphs.map((paragraph, index) => (
+                    <p
+                      // Paragraphs of a note have no identity beyond their
+                      // position, and the whole list is replaced together.
+                      key={index}
+                      dir="auto"
+                      {...stylex.props(styles.paragraph)}
+                    >
+                      {paragraph}
+                    </p>
+                  ))}
+                </div>
+
+                {postParams ? (
+                  <div {...stylex.props(styles.actions)}>
+                    <ButtonLink
+                      variant="tertiary"
+                      to="/a/$did/$rkey"
+                      params={postParams}
+                      search={{ view: "reader" }}
+                      style={styles.control}
+                    >
+                      <FileText
+                        aria-hidden
+                        size={ICON_SIZE}
+                        strokeWidth={ICON_STROKE}
+                      />
+                      <Trans>Read the full post</Trans>
+                    </ButtonLink>
+                  </div>
+                ) : null}
+              </>
+            )}
+          </Dialog>
+        </Modal>
+      </ModalOverlay>
+    </UNSAFE_PortalProvider>
+  );
+}

--- a/apps/standard-reader/src/components/comic/comic-reader.tsx
+++ b/apps/standard-reader/src/components/comic/comic-reader.tsx
@@ -24,6 +24,7 @@ import {
   ChevronRight,
   FileText,
   Maximize,
+  MessageSquareText,
   Minimize,
   X,
 } from "lucide-react";
@@ -36,21 +37,12 @@ import { useTrackReadingHistory } from "#/lib/use-track-reading-history";
 import { documentLinkParams, publicationLinkParams } from "../reader/format";
 import { applyMarkReadOptimisticUpdate } from "../reader/read-optimistic";
 import { ButtonLink, IconButtonLink } from "../router-links";
+import { ComicPageNote } from "./comic-page-note";
+import { ICON_SIZE, ICON_STROKE } from "./theater-palette";
+import { theaterColor } from "./theater.stylex";
 import { issueAtPage, pageOfIssue, useComicPages } from "./use-comic-pages";
 import { useFullscreen } from "./use-fullscreen";
 import { usePagePreload } from "./use-page-preload";
-
-/**
- * The theater is one fixed look in both colour schemes: art is the whole point,
- * and a page of comic reads against near-black whatever the rest of the app is
- * doing. Same reasoning (and the same shape of literal) as the design system's
- * lightbox, which is the other surface that exists to show one image.
- */
-const THEATER_BACKDROP = "light-dark(rgb(9, 8, 10), rgb(4, 4, 6))";
-const THEATER_CHROME = "rgba(255, 255, 255, 0.62)";
-const THEATER_CHROME_STRONG = "rgba(255, 255, 255, 0.92)";
-const THEATER_RULE = "rgba(255, 255, 255, 0.14)";
-const THEATER_SURFACE = "rgba(255, 255, 255, 0.08)";
 
 /**
  * The bars float over the art now, so they carry their own legibility: a scrim
@@ -87,13 +79,10 @@ const CHROME_IDLE_MS = 2600;
  */
 const ZOOMED_SCALE = 1.01;
 
-const ICON_SIZE = 18;
-const ICON_STROKE = 1.75;
-
 const styles = stylex.create({
   theater: {
     inset: 0,
-    backgroundColor: THEATER_BACKDROP,
+    backgroundColor: theaterColor.backdrop,
     // `dvh`, so collapsing mobile browser chrome doesn't crop the page.
     height: "100dvh",
     position: "fixed",
@@ -172,13 +161,16 @@ const styles = stylex.create({
   chromeControl: {
     backgroundColor: {
       default: "transparent",
-      [HOVER_CAPABLE]: { default: "transparent", ":hover": THEATER_SURFACE },
+      [HOVER_CAPABLE]: {
+        default: "transparent",
+        ":hover": theaterColor.surface,
+      },
       ":is([data-disabled])": "transparent",
     },
-    color: THEATER_CHROME_STRONG,
+    color: theaterColor.chromeStrong,
     flexShrink: 0,
     opacity: { default: 1, ":is([data-disabled])": 0.35 },
-    borderColor: THEATER_RULE,
+    borderColor: theaterColor.rule,
     boxShadow: "none",
   },
   titles: {
@@ -193,7 +185,7 @@ const styles = stylex.create({
     rowGap: gap.xs,
   },
   kicker: {
-    color: THEATER_CHROME,
+    color: theaterColor.chrome,
     fontFamily: fontFamily.sans,
     fontSize: "0.65rem",
     fontWeight: fontWeight.medium,
@@ -207,7 +199,7 @@ const styles = stylex.create({
     whiteSpace: "nowrap",
   },
   title: {
-    color: THEATER_CHROME_STRONG,
+    color: theaterColor.chromeStrong,
     fontFamily: fontFamily.serif,
     fontSize: fontSize.base,
     fontWeight: fontWeight.semibold,
@@ -290,7 +282,7 @@ const styles = stylex.create({
     width: "auto",
   },
   counter: {
-    color: THEATER_CHROME,
+    color: theaterColor.chrome,
     fontFamily: fontFamily.sans,
     fontSize: fontSize.xs,
     fontVariantNumeric: "tabular-nums",
@@ -313,7 +305,7 @@ const styles = stylex.create({
     width: "100%",
   },
   endKicker: {
-    color: THEATER_CHROME,
+    color: theaterColor.chrome,
     fontFamily: fontFamily.sans,
     fontSize: "0.68rem",
     fontWeight: fontWeight.medium,
@@ -321,7 +313,7 @@ const styles = stylex.create({
     textTransform: "uppercase",
   },
   endTitle: {
-    color: THEATER_CHROME_STRONG,
+    color: theaterColor.chromeStrong,
     fontFamily: fontFamily.serif,
     fontSize: fontSize["2xl"],
     fontWeight: fontWeight.semibold,
@@ -329,7 +321,7 @@ const styles = stylex.create({
     unicodeBidi: "isolate",
   },
   endDek: {
-    color: THEATER_CHROME,
+    color: theaterColor.chrome,
     fontFamily: fontFamily.serif,
     fontSize: fontSize.base,
     lineHeight: lineHeight.sm,
@@ -344,7 +336,7 @@ const styles = stylex.create({
   },
   pagePlaceholder: {
     alignItems: "center",
-    color: THEATER_CHROME,
+    color: theaterColor.chrome,
     display: "flex",
     fontFamily: fontFamily.sans,
     fontSize: fontSize.sm,
@@ -353,7 +345,7 @@ const styles = stylex.create({
     width: "100%",
   },
   emptyNote: {
-    color: THEATER_CHROME,
+    color: theaterColor.chrome,
     fontFamily: fontFamily.serif,
     fontSize: fontSize.lg,
     fontStyle: "italic",
@@ -525,6 +517,19 @@ export function ComicReader({
     toggle: toggleFullscreen,
   } = useFullscreen(theaterRef);
 
+  // The writing this page published with, if it published any. It travels on
+  // the page itself, so a page still loading simply has no note yet — which
+  // reads the same as a page that never had one, and both leave the control
+  // disabled rather than making it appear and vanish while the reader pages.
+  const note = current?.note ?? null;
+  const [noteOpen, setNoteOpen] = useState(false);
+
+  // A note belongs to the page it was written about, so it closes when the
+  // reader turns away from it rather than following them through the comic.
+  useEffect(() => {
+    setNoteOpen(false);
+  }, [issueUri]);
+
   // The chrome shows itself, then steps aside. A comic is read by looking at
   // it, and on a phone two permanent bars are the loudest thing on screen — so
   // they introduce the reader's controls once and then leave, and the middle of
@@ -557,8 +562,11 @@ export function ComicReader({
 
   // Nothing to get out of the way of until there is a page to read: the loading
   // state, the empty note and the back cover are all things the reader is meant
-  // to act on, so the chrome stays put for them.
-  const chromeCanRest = totalPages > 0 && !isSpinePending && !atEnd;
+  // to act on, so the chrome stays put for them. An open note is the same case —
+  // the bars would fade out under a translucent scrim, then be back the moment
+  // it closes.
+  const chromeCanRest =
+    totalPages > 0 && !isSpinePending && !atEnd && !noteOpen;
 
   useEffect(() => {
     if (!chromeVisible || chromeHeld || !chromeCanRest) return;
@@ -605,6 +613,10 @@ export function ComicReader({
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.metaKey || event.ctrlKey || event.altKey) return;
+      // The note owns the keyboard while it is up — paging the comic behind it
+      // would move a page the reader can't see. Escape is the dialog's own
+      // (react-aria closes on it), which is why nothing here handles it.
+      if (noteOpen) return;
       switch (event.key) {
         // Hidden chrome is out of the tab order, so reaching for it has to put
         // it back. Not prevented: this Tab still moves focus, and the next one
@@ -654,7 +666,15 @@ export function ComicReader({
     };
     globalThis.addEventListener("keydown", onKeyDown);
     return () => globalThis.removeEventListener("keydown", onKeyDown);
-  }, [goNext, goPrevious, goTo, lastIndex, revealChrome, toggleFullscreen]);
+  }, [
+    goNext,
+    goPrevious,
+    goTo,
+    lastIndex,
+    noteOpen,
+    revealChrome,
+    toggleFullscreen,
+  ]);
 
   // A mouse has no equivalent of the middle-third tap, so moving it is what
   // brings the chrome back — the same bargain a video player makes. Touch moves
@@ -886,6 +906,25 @@ export function ComicReader({
             </div>
           </div>
 
+          {/* Beside the article link, because they answer the same question at
+              different depths: the note is the words this page came with, the
+              link is the whole post they came from. Disabled rather than
+              absent, so the bar doesn't reshuffle every time a page with a note
+              turns into one without. */}
+          <IconButton
+            variant="tertiary"
+            aria-label={t`Read the note with this page`}
+            isDisabled={note == null}
+            onPress={() => setNoteOpen(true)}
+            style={styles.chromeControl}
+          >
+            <MessageSquareText
+              aria-hidden
+              size={ICON_SIZE}
+              strokeWidth={ICON_STROKE}
+            />
+          </IconButton>
+
           {notesParams ? (
             <IconButtonLink
               variant="tertiary"
@@ -980,6 +1019,17 @@ export function ComicReader({
           </div>
         ) : null}
       </div>
+
+      {/* Rendered last so it lands over the chrome as well as the art, and
+          portalled into the theater above so full screen keeps it on screen. */}
+      <ComicPageNote
+        note={note}
+        issueTitle={currentIssue?.title ?? publicationName ?? ""}
+        issueUri={issueUri}
+        isOpen={noteOpen}
+        onOpenChange={setNoteOpen}
+        container={theaterRef}
+      />
     </div>
   );
 }

--- a/apps/standard-reader/src/components/comic/theater-palette.ts
+++ b/apps/standard-reader/src/components/comic/theater-palette.ts
@@ -1,0 +1,7 @@
+/**
+ * Icon metrics for the theater's controls, so every bar and overlay in the
+ * comic reader draws the same weight of icon. The colours live in
+ * `theater.stylex.tsx` — StyleX needs them as tokens, not constants.
+ */
+export const ICON_SIZE = 18;
+export const ICON_STROKE = 1.75;

--- a/apps/standard-reader/src/components/comic/theater.stylex.tsx
+++ b/apps/standard-reader/src/components/comic/theater.stylex.tsx
@@ -1,0 +1,31 @@
+import * as stylex from "@stylexjs/stylex";
+
+/**
+ * The comic theater's palette.
+ *
+ * One fixed look in both colour schemes: art is the whole point, and a page of
+ * comic reads against near-black whatever the rest of the app is doing. Same
+ * reasoning (and the same shape of value) as the design system's lightbox, the
+ * other surface that exists to show one image.
+ *
+ * Tokens rather than exported string constants because the theater is no longer
+ * one component — the note overlay lays its own surface over the same art and
+ * has to read as part of the same room — and because StyleX only accepts a raw
+ * colour where it can see the literal. An imported constant it cannot follow is
+ * a lint error; a token is the shape the linter (and the design system) expects
+ * a shared colour to take.
+ */
+export const theaterColor = stylex.defineVars({
+  backdrop: "light-dark(rgb(9, 8, 10), rgb(4, 4, 6))",
+  chrome: "rgba(255, 255, 255, 0.62)",
+  chromeStrong: "rgba(255, 255, 255, 0.92)",
+  rule: "rgba(255, 255, 255, 0.14)",
+  surface: "rgba(255, 255, 255, 0.08)",
+  /**
+   * The note's scrim. The page it belongs to should still be there behind the
+   * words — that is the whole reason it isn't simply the reading view — but a
+   * paragraph has to stay readable over a bright panel, so it is dark enough to
+   * carry type and no darker.
+   */
+  noteScrim: "rgba(6, 5, 8, 0.86)",
+});

--- a/apps/standard-reader/src/lib/comic/page-note.test.ts
+++ b/apps/standard-reader/src/lib/comic/page-note.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { comicNoteParagraphs, comicPageNote } from "./page-note";
+
+describe("comicNoteParagraphs", () => {
+  it("splits on the blank line the extractors join blocks with", () => {
+    expect(comicNoteParagraphs("One.\n\nTwo.\n\n\nThree.")).toEqual([
+      "One.",
+      "Two.",
+      "Three.",
+    ]);
+  });
+
+  it("keeps a soft line break inside its paragraph", () => {
+    expect(comicNoteParagraphs("A line\nand its wrap")).toEqual([
+      "A line\nand its wrap",
+    ]);
+  });
+
+  it("has nothing to render for a page with no note", () => {
+    expect(comicNoteParagraphs(null)).toEqual([]);
+    expect(comicNoteParagraphs("   \n\n  ")).toEqual([]);
+  });
+});
+
+describe("comicPageNote", () => {
+  const alt = "Ilya stands in the doorway, backlit.";
+
+  it("drops the alt text of the page it is describing", () => {
+    expect(comicPageNote(`${alt}\n\nBack next Tuesday.`, [{ alt }])).toBe(
+      "Back next Tuesday.",
+    );
+  });
+
+  it("ignores how the alt was whitespaced", () => {
+    const spaced = "Ilya stands   in the\ndoorway, backlit.";
+    expect(comicPageNote(`${spaced}\n\nBack next Tuesday.`, [{ alt }])).toBe(
+      "Back next Tuesday.",
+    );
+  });
+
+  it("subtracts every page's alt from a post that carries several", () => {
+    const body = `${alt}\n\nSecond panel.\n\nThanks for reading.`;
+    const images = [{ alt }, { alt: "Second panel." }];
+    expect(comicPageNote(body, images)).toBe("Thanks for reading.");
+  });
+
+  it("comes back null when the post is art and nothing else", () => {
+    expect(comicPageNote(alt, [{ alt }])).toBeNull();
+    expect(comicPageNote(null, [{ alt }])).toBeNull();
+    expect(comicPageNote("", [])).toBeNull();
+  });
+
+  it("keeps a note whole when the images carry no alt at all", () => {
+    expect(comicPageNote("Back next Tuesday.", [{ alt: "" }])).toBe(
+      "Back next Tuesday.",
+    );
+  });
+
+  it("keeps the remaining paragraphs in order", () => {
+    const body = `${alt}\n\nOne.\n\nTwo.`;
+    expect(comicPageNote(body, [{ alt }])).toBe("One.\n\nTwo.");
+  });
+});

--- a/apps/standard-reader/src/lib/comic/page-note.ts
+++ b/apps/standard-reader/src/lib/comic/page-note.ts
@@ -1,0 +1,50 @@
+/**
+ * The prose a comic page's post carries alongside the art.
+ *
+ * A comic page is a document like any other: an image block, and often a few
+ * lines from the author — a caption, a process note, an apology for the late
+ * update. The theater shows the art, so that writing had nowhere to go but the
+ * reading view, a navigation away from the page it belongs to.
+ *
+ * The body's plaintext is already extracted for every content format
+ * (`documentExtractedText`), but it narrates image blocks by their alt text —
+ * correct for search and for a screen reader walking the article, wrong here,
+ * where the alt describes the page the reader is looking at. So the pages' own
+ * alt text is subtracted from it, which is format-agnostic and exact: the
+ * extractor inserts those lines verbatim, so they come back out verbatim.
+ */
+
+/** Extractors join blocks with a blank line; that is the paragraph boundary. */
+const PARAGRAPH_BREAK = /\n{2,}/;
+
+/** Whitespace-insensitive form, for comparing a paragraph against an alt. */
+function normalize(text: string): string {
+  return text.replaceAll(/\s+/g, " ").trim();
+}
+
+/** A note's paragraphs, for rendering. Empty when there is no note. */
+export function comicNoteParagraphs(note: string | null): Array<string> {
+  if (!note) return [];
+  return note
+    .split(PARAGRAPH_BREAK)
+    .map((paragraph) => paragraph.trim())
+    .filter(Boolean);
+}
+
+/**
+ * The note for one page: its post's body text, minus the alt text of the images
+ * that post contributes as pages. Null when nothing is left — which is the
+ * common case, since most comic pages are art and nothing else.
+ */
+export function comicPageNote(
+  bodyText: string | null | undefined,
+  images: Array<{ alt: string }>,
+): string | null {
+  const alts = new Set(
+    images.map((image) => normalize(image.alt)).filter(Boolean),
+  );
+  const paragraphs = comicNoteParagraphs(bodyText ?? null).filter(
+    (paragraph) => !alts.has(normalize(paragraph)),
+  );
+  return paragraphs.length > 0 ? paragraphs.join("\n\n") : null;
+}

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -933,6 +933,10 @@ msgstr ""
 msgid "Nothing saved yet"
 msgstr "لا شيء محفوظ بعد"
 
+#: src/components/comic/comic-page-note.tsx
+msgid "Read the full post"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
 msgstr ""
@@ -2659,6 +2663,10 @@ msgstr "النهاية."
 msgid "We couldn't find that author."
 msgstr "تعذّر العثور على ذلك الكاتب."
 
+#: src/components/comic/comic-reader.tsx
+msgid "Read the note with this page"
+msgstr ""
+
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "You come across something worth reading in the middle of doing something else. Without the extension that means copying a link and finding somewhere to put it. With it, saving is one click, wherever you are."
 msgstr ""
@@ -3685,6 +3693,10 @@ msgstr "زر الاستماع يقرأ أي مقال بصوت مسموع على 
 #. placeholder {0}: next.title
 #: src/components/reader/series-up-next.tsx
 msgid "Read the next instalment: {0}"
+msgstr ""
+
+#: src/components/comic/comic-page-note.tsx
+msgid "Note for {issueTitle}"
 msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
@@ -6938,6 +6950,10 @@ msgstr "أوصِ بهذا المقال"
 #: src/components/reader/about-view.tsx
 msgid "Stop"
 msgstr "إيقاف"
+
+#: src/components/comic/comic-page-note.tsx
+msgid "Close the note"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/components/user-settings-view.tsx

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -933,6 +933,10 @@ msgstr ""
 msgid "Nothing saved yet"
 msgstr "Noch nichts gespeichert"
 
+#: src/components/comic/comic-page-note.tsx
+msgid "Read the full post"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
 msgstr ""
@@ -2659,6 +2663,10 @@ msgstr "Ende."
 msgid "We couldn't find that author."
 msgstr "Wir konnten diesen Autor nicht finden."
 
+#: src/components/comic/comic-reader.tsx
+msgid "Read the note with this page"
+msgstr ""
+
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "You come across something worth reading in the middle of doing something else. Without the extension that means copying a link and finding somewhere to put it. With it, saving is one click, wherever you are."
 msgstr ""
@@ -3685,6 +3693,10 @@ msgstr "Ein Vorlesen-Button liest jeden Artikel direkt auf Ihrem Gerät vor und 
 #. placeholder {0}: next.title
 #: src/components/reader/series-up-next.tsx
 msgid "Read the next instalment: {0}"
+msgstr ""
+
+#: src/components/comic/comic-page-note.tsx
+msgid "Note for {issueTitle}"
 msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
@@ -6938,6 +6950,10 @@ msgstr "Diesen Artikel empfehlen"
 #: src/components/reader/about-view.tsx
 msgid "Stop"
 msgstr "Stopp"
+
+#: src/components/comic/comic-page-note.tsx
+msgid "Close the note"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/components/user-settings-view.tsx

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -933,6 +933,10 @@ msgstr ""
 msgid "Nothing saved yet"
 msgstr ""
 
+#: src/components/comic/comic-page-note.tsx
+msgid "Read the full post"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
 msgstr ""
@@ -2659,6 +2663,10 @@ msgstr ""
 msgid "We couldn't find that author."
 msgstr ""
 
+#: src/components/comic/comic-reader.tsx
+msgid "Read the note with this page"
+msgstr ""
+
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "You come across something worth reading in the middle of doing something else. Without the extension that means copying a link and finding somewhere to put it. With it, saving is one click, wherever you are."
 msgstr ""
@@ -3685,6 +3693,10 @@ msgstr ""
 #. placeholder {0}: next.title
 #: src/components/reader/series-up-next.tsx
 msgid "Read the next instalment: {0}"
+msgstr ""
+
+#: src/components/comic/comic-page-note.tsx
+msgid "Note for {issueTitle}"
 msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
@@ -6937,6 +6949,10 @@ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Stop"
+msgstr ""
+
+#: src/components/comic/comic-page-note.tsx
+msgid "Close the note"
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -933,6 +933,10 @@ msgstr "These are separate from the app-wide appearance settings, which is delib
 msgid "Nothing saved yet"
 msgstr "Nothing saved yet"
 
+#: src/components/comic/comic-page-note.tsx
+msgid "Read the full post"
+msgstr "Read the full post"
+
 #: src/components/user-settings-view.tsx
 msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
 msgstr "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
@@ -2659,6 +2663,10 @@ msgstr "The End."
 msgid "We couldn't find that author."
 msgstr "We couldn't find that author."
 
+#: src/components/comic/comic-reader.tsx
+msgid "Read the note with this page"
+msgstr "Read the note with this page"
+
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "You come across something worth reading in the middle of doing something else. Without the extension that means copying a link and finding somewhere to put it. With it, saving is one click, wherever you are."
 msgstr "You come across something worth reading in the middle of doing something else. Without the extension that means copying a link and finding somewhere to put it. With it, saving is one click, wherever you are."
@@ -3686,6 +3694,10 @@ msgstr "A Listen button reads any article aloud, right on your device, and highl
 #: src/components/reader/series-up-next.tsx
 msgid "Read the next instalment: {0}"
 msgstr "Read the next instalment: {0}"
+
+#: src/components/comic/comic-page-note.tsx
+msgid "Note for {issueTitle}"
+msgstr "Note for {issueTitle}"
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Something went wrong while preparing your review."
@@ -6938,6 +6950,10 @@ msgstr "Recommend this article"
 #: src/components/reader/about-view.tsx
 msgid "Stop"
 msgstr "Stop"
+
+#: src/components/comic/comic-page-note.tsx
+msgid "Close the note"
+msgstr "Close the note"
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/components/user-settings-view.tsx

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -933,6 +933,10 @@ msgstr ""
 msgid "Nothing saved yet"
 msgstr "Todavía no hay nada guardado"
 
+#: src/components/comic/comic-page-note.tsx
+msgid "Read the full post"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
 msgstr ""
@@ -2659,6 +2663,10 @@ msgstr "Fin."
 msgid "We couldn't find that author."
 msgstr "No encontramos a ese autor."
 
+#: src/components/comic/comic-reader.tsx
+msgid "Read the note with this page"
+msgstr ""
+
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "You come across something worth reading in the middle of doing something else. Without the extension that means copying a link and finding somewhere to put it. With it, saving is one click, wherever you are."
 msgstr ""
@@ -3685,6 +3693,10 @@ msgstr "Un botón de Escuchar lee cualquier artículo en voz alta, directamente 
 #. placeholder {0}: next.title
 #: src/components/reader/series-up-next.tsx
 msgid "Read the next instalment: {0}"
+msgstr ""
+
+#: src/components/comic/comic-page-note.tsx
+msgid "Note for {issueTitle}"
 msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
@@ -6938,6 +6950,10 @@ msgstr "Recomendar este artículo"
 #: src/components/reader/about-view.tsx
 msgid "Stop"
 msgstr "Detener"
+
+#: src/components/comic/comic-page-note.tsx
+msgid "Close the note"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/components/user-settings-view.tsx

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -933,6 +933,10 @@ msgstr ""
 msgid "Nothing saved yet"
 msgstr "Rien d’enregistré pour l’instant"
 
+#: src/components/comic/comic-page-note.tsx
+msgid "Read the full post"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
 msgstr ""
@@ -2659,6 +2663,10 @@ msgstr "Fin."
 msgid "We couldn't find that author."
 msgstr "Nous n'avons pas trouvé cet auteur."
 
+#: src/components/comic/comic-reader.tsx
+msgid "Read the note with this page"
+msgstr ""
+
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "You come across something worth reading in the middle of doing something else. Without the extension that means copying a link and finding somewhere to put it. With it, saving is one click, wherever you are."
 msgstr ""
@@ -3685,6 +3693,10 @@ msgstr "Un bouton Écouter lit n’importe quel article à voix haute, directeme
 #. placeholder {0}: next.title
 #: src/components/reader/series-up-next.tsx
 msgid "Read the next instalment: {0}"
+msgstr ""
+
+#: src/components/comic/comic-page-note.tsx
+msgid "Note for {issueTitle}"
 msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
@@ -6938,6 +6950,10 @@ msgstr "Recommander cet article"
 #: src/components/reader/about-view.tsx
 msgid "Stop"
 msgstr "Arrêter"
+
+#: src/components/comic/comic-page-note.tsx
+msgid "Close the note"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/components/user-settings-view.tsx

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -933,6 +933,10 @@ msgstr ""
 msgid "Nothing saved yet"
 msgstr "まだ何も保存されていません"
 
+#: src/components/comic/comic-page-note.tsx
+msgid "Read the full post"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
 msgstr ""
@@ -2659,6 +2663,10 @@ msgstr "完。"
 msgid "We couldn't find that author."
 msgstr "その著者は見つかりませんでした。"
 
+#: src/components/comic/comic-reader.tsx
+msgid "Read the note with this page"
+msgstr ""
+
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "You come across something worth reading in the middle of doing something else. Without the extension that means copying a link and finding somewhere to put it. With it, saving is one click, wherever you are."
 msgstr ""
@@ -3685,6 +3693,10 @@ msgstr "「読み上げ」ボタンで、どの記事もデバイス上で音声
 #. placeholder {0}: next.title
 #: src/components/reader/series-up-next.tsx
 msgid "Read the next instalment: {0}"
+msgstr ""
+
+#: src/components/comic/comic-page-note.tsx
+msgid "Note for {issueTitle}"
 msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
@@ -6938,6 +6950,10 @@ msgstr "この記事をおすすめする"
 #: src/components/reader/about-view.tsx
 msgid "Stop"
 msgstr "停止"
+
+#: src/components/comic/comic-page-note.tsx
+msgid "Close the note"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/components/user-settings-view.tsx

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -933,6 +933,10 @@ msgstr ""
 msgid "Nothing saved yet"
 msgstr "아직 저장한 항목이 없습니다"
 
+#: src/components/comic/comic-page-note.tsx
+msgid "Read the full post"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
 msgstr ""
@@ -2659,6 +2663,10 @@ msgstr "끝."
 msgid "We couldn't find that author."
 msgstr "해당 작가를 찾을 수 없습니다."
 
+#: src/components/comic/comic-reader.tsx
+msgid "Read the note with this page"
+msgstr ""
+
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "You come across something worth reading in the middle of doing something else. Without the extension that means copying a link and finding somewhere to put it. With it, saving is one click, wherever you are."
 msgstr ""
@@ -3685,6 +3693,10 @@ msgstr "듣기 버튼을 누르면 어떤 글이든 기기에서 바로 읽어 �
 #. placeholder {0}: next.title
 #: src/components/reader/series-up-next.tsx
 msgid "Read the next instalment: {0}"
+msgstr ""
+
+#: src/components/comic/comic-page-note.tsx
+msgid "Note for {issueTitle}"
 msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
@@ -6938,6 +6950,10 @@ msgstr "이 글 추천하기"
 #: src/components/reader/about-view.tsx
 msgid "Stop"
 msgstr "정지"
+
+#: src/components/comic/comic-page-note.tsx
+msgid "Close the note"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/components/user-settings-view.tsx

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -933,6 +933,10 @@ msgstr ""
 msgid "Nothing saved yet"
 msgstr "Ainda não há nada salvo"
 
+#: src/components/comic/comic-page-note.tsx
+msgid "Read the full post"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
 msgstr ""
@@ -2659,6 +2663,10 @@ msgstr "Fim."
 msgid "We couldn't find that author."
 msgstr "Não conseguimos encontrar esse autor."
 
+#: src/components/comic/comic-reader.tsx
+msgid "Read the note with this page"
+msgstr ""
+
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "You come across something worth reading in the middle of doing something else. Without the extension that means copying a link and finding somewhere to put it. With it, saving is one click, wherever you are."
 msgstr ""
@@ -3685,6 +3693,10 @@ msgstr "Um botão Ouvir lê qualquer artigo em voz alta, no seu próprio disposi
 #. placeholder {0}: next.title
 #: src/components/reader/series-up-next.tsx
 msgid "Read the next instalment: {0}"
+msgstr ""
+
+#: src/components/comic/comic-page-note.tsx
+msgid "Note for {issueTitle}"
 msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
@@ -6938,6 +6950,10 @@ msgstr "Recomendar este artigo"
 #: src/components/reader/about-view.tsx
 msgid "Stop"
 msgstr "Parar"
+
+#: src/components/comic/comic-page-note.tsx
+msgid "Close the note"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/components/user-settings-view.tsx

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -933,6 +933,10 @@ msgstr ""
 msgid "Nothing saved yet"
 msgstr "尚未保存任何内容"
 
+#: src/components/comic/comic-page-note.tsx
+msgid "Read the full post"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
 msgstr ""
@@ -2659,6 +2663,10 @@ msgstr "全文完。"
 msgid "We couldn't find that author."
 msgstr "找不到该作者。"
 
+#: src/components/comic/comic-reader.tsx
+msgid "Read the note with this page"
+msgstr ""
+
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "You come across something worth reading in the middle of doing something else. Without the extension that means copying a link and finding somewhere to put it. With it, saving is one click, wherever you are."
 msgstr ""
@@ -3685,6 +3693,10 @@ msgstr "「朗读」按钮可在你的设备上直接朗读任意文章，并逐
 #. placeholder {0}: next.title
 #: src/components/reader/series-up-next.tsx
 msgid "Read the next instalment: {0}"
+msgstr ""
+
+#: src/components/comic/comic-page-note.tsx
+msgid "Note for {issueTitle}"
 msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
@@ -6938,6 +6950,10 @@ msgstr "推荐这篇文章"
 #: src/components/reader/about-view.tsx
 msgid "Stop"
 msgstr "停止"
+
+#: src/components/comic/comic-page-note.tsx
+msgid "Close the note"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/components/user-settings-view.tsx

--- a/apps/standard-reader/src/server/reader/comic.ts
+++ b/apps/standard-reader/src/server/reader/comic.ts
@@ -37,7 +37,9 @@ import {
   parseComicIssueTitle,
   titlesLookLikeIssues,
 } from "#/lib/comic/issue-title";
+import { comicPageNote } from "#/lib/comic/page-note";
 import { documentImages } from "#/lib/document/images";
+import { documentExtractedText } from "#/lib/document/search-text";
 import { documentPublishedNotInFuture } from "#/server/reader/document-filters";
 import { selectUnreadDocumentUris } from "#/server/reader/queries";
 
@@ -73,6 +75,17 @@ export interface ComicPage {
   issueTitle: string;
   /** 1-based page number within its own issue. */
   pageInIssue: number;
+  /**
+   * The prose this page's post carries beside the art (`#/lib/comic/page-note`),
+   * or null when the post is art and nothing else — which is most of them.
+   *
+   * Carried per page rather than per issue: it belongs to the post, and a post
+   * that contributes several pages says the same thing about all of them, so
+   * every one of its pages can show it. The repetition costs a duplicate string
+   * in the payload for the rare multi-image post, and saves the reader having to
+   * map a page back to a document to find out whether there is anything to read.
+   */
+  note: string | null;
 }
 
 /**
@@ -203,6 +216,11 @@ export async function selectComicSpine(
  * than trusted from `body_image_count`: if a publisher edits an issue between
  * the spine load and the chunk load, the stored count is briefly stale, and the
  * pages themselves are the truth. The count is refreshed when they disagree.
+ *
+ * The chunk also carries each page's note — the prose its post published with
+ * the art. It rides here because this is the one query that opens the bodies
+ * anyway; asking for it separately would re-read the same rows to answer a
+ * question this one already has in hand.
  */
 export async function selectComicPages(
   db: Db,
@@ -227,6 +245,7 @@ export async function selectComicPages(
       did: d.did,
       contentJson: d.contentJson,
       contentFormat: d.contentFormat,
+      textContent: d.textContent,
     })
     .from(d)
     .where(
@@ -248,6 +267,16 @@ export async function selectComicPages(
       contentFormat: row.contentFormat,
     });
 
+    // The body we can parse is preferred over the stored text: `text_content`
+    // is the *search* blob (record text plus extracted body), and old backfills
+    // are known to have compounded copies into it — fine for a search index,
+    // not for something a reader is asked to read. It stands in only when the
+    // body yields no text at all.
+    const bodyText =
+      documentExtractedText(row.contentJson as JsonValue, row.contentFormat) ??
+      row.textContent;
+    const note = comicPageNote(bodyText, images);
+
     for (const [i, image] of images.entries()) {
       pages.push({
         index: issue.pageOffset + i,
@@ -257,6 +286,7 @@ export async function selectComicPages(
         issueUri: issue.uri,
         issueTitle: issue.title,
         pageInIssue: i + 1,
+        note,
       });
     }
 


### PR DESCRIPTION
**Stacked on #119** — both changes edit the same top bar, so this is based on that branch rather than `main`. GitHub will retarget it to `main` when #119 merges; review the [second commit](https://github.com/hipstersmoothie/standard-reader/pull/120/commits) for this change alone.

Comic posts often publish a line or two beside the art — a caption, a note on the process, a word about next week. The theater shows images, so that writing lived only in the reading view: a navigation away from the page it was written about, and back again. The top bar's new note button lays it over the art instead.

## The overlay

- Translucent dark scrim over the page (with a little blur, so busy line work doesn't fight the type) — the art stays visible behind the words, which is the whole reason this isn't just the reading view.
- The prose in the theater's own serif, the post's title as a kicker, a close button, and a **"Read the full post"** escape to the reading view for anything richer than paragraphs.
- A React Aria modal (`ModalOverlay` / `Modal` / `Dialog`) portalled **into the theater** rather than `document.body` — a portal outside the full-screen element renders to a part of the page the browser isn't painting. Same `UNSAFE_PortalProvider` mechanism `PublicationThemeScope` already uses.
- The **scrim** carries the padding, not the panel: `isDismissable` closes on a press outside the modal element, so any space the panel owned was space a tap-to-close didn't work in — which on a phone was all of it.
- While it's open, the reader's paging keys stand down and the chrome stops auto-hiding (it would fade out under a translucent scrim and be back the moment the note closed). Escape is the dialog's own.

## Where the text comes from

`ComicPage.note`, extracted in `selectComicPages` — the one query that already opens each body, so nothing re-reads those rows.

The interesting part is what gets subtracted. `documentExtractedText` narrates image blocks by their alt text, which is right for search and for a screen reader walking the article, and wrong here: the alt describes the page the reader is looking at. So `comicPageNote` drops any paragraph matching one of the page's own alts (`#/lib/comic/page-note`). That's format-agnostic and exact — the extractor inserts those lines verbatim, so they come back out verbatim. The stored `text_content` column stands in only when the body yields no text at all; it's the *search* blob, and old backfills are known to have compounded copies into it.

Most pages have no note, so the button is **disabled rather than absent** — a bar that reshuffled on every page turn is worse than a quiet button.

## Also

The theater's palette moves from module constants to StyleX tokens (`theater.stylex.tsx`) now that two components paint with it. StyleX only accepts a raw colour where it can see the literal, so an imported constant is a lint error — a token is the shape the linter and the design system both expect a shared colour to take.

## Verification

`pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test` (678 passed), `pnpm build`, `pnpm i18n:extract` for the four new strings. Ten unit tests cover the note extraction: alt subtraction (including whitespace-insensitive matching and multi-image posts), paragraph splitting, and the art-and-nothing-else case.

**Not verified by rendering.** This environment has no `.env`/database, so the comic route can't load a publication to open, and the vitest config doesn't run the Lingui macro transform — which is why the repo has no component-render tests to add to. The overlay's behaviour is reasoned from the React Aria API and the existing portal usage in the app, not observed. Happy to add the macro transform to `vitest.config.ts` as a follow-up if you want component tests to become possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq8L6k9QDWWB8DtmZVLUtg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uq8L6k9QDWWB8DtmZVLUtg)_