### PR TITLE
Resolve a serial's kind on demand, not only its direction

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -334,6 +334,15 @@ default `"rtl"` for a record that states nothing, which is what keeps the two ap
 `ensurePublicationSerial` (`#/server/reader/series`) reads the record from the PDS once, writes
 what it says, and derives the kind on the spot if it turns out to be a serial. Standard
 `backfillXFromRepo` behaviour: one PDS read per publication, ever, then the DB serves it.
+
+**Both columns count as unresolved, not just the direction** (`needsSerialResolution`,
+`#/lib/publication/serial`). A row reading `"ltr"` with no `serial_kind` is a serial the sweep
+hasn't judged yet, and `resolveSerialPublication` renders it as a **book** — the right thing to
+draw, and the wrong thing to stop asking about, because everything a comic gets hangs off
+`serial.kind`: the shelf of covers, the redirect into the page-flip reader. The two read paths
+that surface those (`selectPublicationHeader` and `getArticle`) resolve on demand whenever either
+column is missing, so a comic can't sit reading as a book until the next hourly sweep. An ordinary
+blog (`"rtl"`) is resolved whatever its kind says, which keeps this off the common path.
 `pnpm backfill:serial` warms them all up front so no reader pays that first read. It scopes itself
 to the publications that could answer — `prevNextDirection` is Leaflet's field, so only Leaflet
 publications still holding a NULL are visited — reads their records from Slingshot rather than

--- a/apps/standard-reader/src/integrations/tanstack-query/api-publication.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-publication.functions.ts
@@ -17,6 +17,7 @@ import {
   readArchiveOrderOverride,
   withArchiveOrderOverride,
 } from "#/lib/publication/archive-order";
+import { needsSerialResolution } from "#/lib/publication/serial";
 import type { CodeHighlightsByScheme } from "#/lib/theme";
 import {
   getReaderContextForRequest,
@@ -646,12 +647,20 @@ const getArticle = createServerFn({ method: "GET" })
           },
         );
 
-        // A publication indexed before `prev_next_direction` existed carries no
+        // A publication whose serial columns aren't resolved yet carries no
         // serial metadata until something looks. Back it in here as well as on
         // the publication page, so a reader who lands straight on a comic issue
         // from a shared link still gets the comic reader rather than a column of
-        // stacked pages. One PDS read per publication, ever.
-        if (detail?.publication && sourceRow.pubPrevNextDirection == null) {
+        // stacked pages — this route's redirect into it reads `serial.kind`,
+        // which is `"book"` for a serial the sweep hasn't classified. One PDS
+        // read per publication, ever.
+        if (
+          detail?.publication &&
+          needsSerialResolution(
+            sourceRow.pubPrevNextDirection,
+            sourceRow.pubSerialKind,
+          )
+        ) {
           detail.publication = {
             ...detail.publication,
             serial: await ensurePublicationSerial(

--- a/apps/standard-reader/src/lib/publication/serial.test.ts
+++ b/apps/standard-reader/src/lib/publication/serial.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   isSerialDirection,
+  needsSerialResolution,
   parsePrevNextDirection,
   parseSerialKind,
   resolveSerialPublication,
@@ -67,5 +68,31 @@ describe("resolveSerialPublication", () => {
     // A stale `serial_kind` on a publication that flipped back to `rtl` must
     // not resurrect the serial treatment.
     expect(resolveSerialPublication("rtl", "comic")).toBeNull();
+  });
+});
+
+describe("needsSerialResolution", () => {
+  it("asks again for a row that was never mirrored", () => {
+    expect(needsSerialResolution(null, null)).toBe(true);
+    expect(needsSerialResolution(undefined, "comic")).toBe(true);
+    expect(needsSerialResolution("sideways", "comic")).toBe(true);
+  });
+
+  it("asks again for a serial whose kind nobody has judged", () => {
+    // The case that loses a comic its shelf and its reader: rendered as a
+    // book by `resolveSerialPublication`, but not actually resolved.
+    expect(needsSerialResolution("ltr", null)).toBe(true);
+    expect(needsSerialResolution("ltr", "nonsense")).toBe(true);
+    expect(resolveSerialPublication("ltr", null)).toEqual({ kind: "book" });
+  });
+
+  it("is done once the serial has both", () => {
+    expect(needsSerialResolution("ltr", "comic")).toBe(false);
+    expect(needsSerialResolution("ltr", "book")).toBe(false);
+  });
+
+  it("never re-asks about an ordinary blog", () => {
+    expect(needsSerialResolution("rtl", null)).toBe(false);
+    expect(needsSerialResolution("rtl", "comic")).toBe(false);
   });
 });

--- a/apps/standard-reader/src/lib/publication/serial.ts
+++ b/apps/standard-reader/src/lib/publication/serial.ts
@@ -73,3 +73,30 @@ export function resolveSerialPublication(
   if (!isSerialDirection(prevNextDirection)) return null;
   return { kind: parseSerialKind(serialKind) ?? "book" };
 }
+
+/**
+ * Whether a publication's stored serial columns still need resolving from the
+ * record and its posts (`ensurePublicationSerial`).
+ *
+ * There are two ways to be unresolved, and only checking the first one is a trap.
+ * A NULL `prevNextDirection` means the row was indexed before the column existed
+ * — nothing is known. But a row that says `"ltr"` with no `serialKind` is *also*
+ * unresolved: it is a serial whose kind the hourly sweep hasn't judged yet, and
+ * {@link resolveSerialPublication} answers `"book"` for it, because prose is the
+ * safe default to *render*. It is not a safe default to stop looking at: a comic
+ * left reading as a book loses its shelf of covers and its page-flip reader, and
+ * nothing on the read path would ever ask again.
+ *
+ * An ordinary blog (`"rtl"`) is fully resolved whatever `serialKind` says, so
+ * this stays false for almost every publication — which is what keeps the
+ * on-demand resolution off the common path.
+ */
+export function needsSerialResolution(
+  prevNextDirection: unknown,
+  serialKind: unknown,
+): boolean {
+  if (parsePrevNextDirection(prevNextDirection) == null) return true;
+  return (
+    isSerialDirection(prevNextDirection) && parseSerialKind(serialKind) == null
+  );
+}

--- a/apps/standard-reader/src/server/reader/publication-header.ts
+++ b/apps/standard-reader/src/server/reader/publication-header.ts
@@ -12,6 +12,7 @@ import {
   publicationCardColumns,
   toPublicationCard,
 } from "#/integrations/tanstack-query/api-shapes";
+import { needsSerialResolution } from "#/lib/publication/serial";
 import { publicationFontsFromThemeJson } from "#/server/fonts/publication-fonts.server";
 import { publicationBackgroundImage } from "#/server/reader/publication-background";
 import { ensurePublicationSerial } from "#/server/reader/series";
@@ -60,15 +61,17 @@ export async function selectPublicationHeader(
 
   if (!row) return null;
 
-  // The hero's serial treatment ("A serial comic", "Start from issue one") reads
-  // off this card, while the archive's reading order is resolved separately in
-  // `getPublicationDocuments` — and the two run in parallel. Without this, the
-  // very first view of a publication whose `prev_next_direction` was never
-  // mirrored paints a half-applied page: the archive correctly oldest-first, but
-  // no serial hero, because this query raced the backfill the other one did.
-  // A no-op (one indexed read) once the column is populated.
+  // Everything a comic gets — the shelf of covers instead of an archive list,
+  // the redirect into the page-flip reader — hangs off `serial.kind`, and this
+  // is the query the publication page reads it from. So this is where a
+  // publication whose serial columns aren't resolved yet gets resolved: a NULL
+  // direction (indexed before the column existed), or a serial the hourly sweep
+  // hasn't classified, which `resolveSerialPublication` renders as a book and
+  // would otherwise stay one for as long as the sweep took to reach it. A no-op
+  // (one indexed read) once the columns are populated, and never entered at all
+  // for an ordinary blog.
   const publication = toPublicationCard(row);
-  if (row.prevNextDirection == null) {
+  if (needsSerialResolution(row.prevNextDirection, row.serialKind)) {
     publication.serial = await ensurePublicationSerial(db, schema, row.uri);
   }
 


### PR DESCRIPTION
**Correction:** I opened this believing it explained a broken comic view on the publication page. It didn't — the publication page is fine, and my diagnosis was wrong. What's below is a real but *latent* gap, not a fix for anything currently visible. Merge it as hardening or close it; it isn't urgent either way.

## The gap

Everything a comic gets keys off `publication.serial.kind === "comic"` — the shelf of covers, the `/a/` → `/comic/` redirect, the "open comic" button. That comes from `resolveSerialPublication(prevNextDirection, serialKind)`, which answers `"book"` when the direction says `"ltr"` but `serial_kind` is still NULL. That default is right for *rendering* an unclassified serial (prose only adds an "Up next" link; it doesn't reroute anyone into a comic reader), and wrong as a reason to stop looking.

`serial_kind` is filled by the hourly `recomputeSerialKinds` sweep, and on demand by `ensurePublicationSerial`. Before #118, `getPublicationDocuments` called that unconditionally on every publication-page load, which healed those rows as a side effect. #118 removed the call — correctly, since the archive order no longer depends on the serial flag — but the two remaining callers are gated on the direction alone:

```ts
if (row.prevNextDirection == null) {
  publication.serial = await ensurePublicationSerial(db, schema, row.uri);
}
```

So a row with a known direction and an unknown kind is never asked about again on the read path. It still resolves — the hourly sweep gets there — but a comic published between sweeps reads as a book until it does, and on a database the sweep has never run against, indefinitely.

## The change

`needsSerialResolution(prevNextDirection, serialKind)` names both ways a row can be unresolved: never mirrored, or a serial whose kind nobody has judged. Both read paths that surface comic treatment — `selectPublicationHeader` and `getArticle` — use it, so they can't drift apart again.

An ordinary blog (`"rtl"`) counts as resolved whatever its kind column says, so this stays off the common path: no extra work for publications that aren't serials, and one indexed read (then nothing) for the rest.

## Verification

Four unit tests on the predicate, including the case above asserted next to the `"book"` fallback that causes it. `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test` (667 passed). Not exercised against a real database — this environment has none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq8L6k9QDWWB8DtmZVLUtg