### PR TITLE
Hold the comic reader's chrome until the first page turn

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -383,7 +383,9 @@ What changes for a serial:
   reading order (`#/lib/document/images`), so nothing is authored specially for it. Arrow keys /
   space / Page keys, `Home` / `End`, tap-zones and swipe all page; the current page lives in the
   URL (page turns replace the history entry, so Back leaves the reader). Past the last page is
-  an end card with the next issue. The article route redirects a comic issue here unless
+  an end card with the next issue. The floating chrome **stays until the reader turns their first
+  page** — on arrival the bars are the introduction, and a countdown running under it takes that
+  away from anyone reading at their own pace — and only then starts stepping aside on an idle beat. The article route redirects a comic issue here unless
   `?view=reader` — which is also the "Read the notes" escape, because a comic's prose commentary
   belongs to the reading view, not the theater.
   The top bar carries a **full-screen toggle** (`f`, or the button at its end) that puts the

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -904,9 +904,11 @@ Backend/API exists; UI or copy is missing.
       than stopping at the end of each issue. Pages are the images each body renders
       ([`images.ts`](src/lib/document/images.ts)); keyboard / tap-zone / swipe paging, the page in
       the URL, each issue marked read as the reader enters it. The **chrome floats over the art and
-      auto-hides**: the bars show themselves on entry, step aside after an idle beat, and come back
-      on a middle-zone tap, a mouse move, or Tab — they stay put for the loading, empty and back-cover
-      states, and pin open under pointer or focus. The top bar ends with a **full-screen toggle**
+      auto-hides**: the bars show themselves on entry and stay until the reader turns their first
+      page — a comic nobody has paged through yet is still being introduced, and a countdown under
+      that introduction takes it from anyone reading at their own pace — then step aside after an
+      idle beat and come back on a middle-zone tap, a mouse move, or Tab. They also stay put for the
+      loading, empty and back-cover states, and pin open under pointer or focus. The top bar ends with a **full-screen toggle**
       (`f`, or the button) that puts the theater element full screen so the browser's own chrome
       leaves the art alone ([`use-fullscreen.ts`](src/components/comic/use-fullscreen.ts)) —
       unprefixed API only (the app targets `baseline 2024`), absent rather than disabled where the

--- a/apps/standard-reader/src/components/comic/comic-reader.tsx
+++ b/apps/standard-reader/src/components/comic/comic-reader.tsx
@@ -540,6 +540,15 @@ export function ComicReader({
   const visibleRef = useRef(true);
   const activityRef = useRef(0);
 
+  // Stepping aside waits for the reader to start reading. A comic that has just
+  // opened is a page nobody has turned yet: the bars are the introduction — what
+  // this is, where they are in it, how to leave — and a countdown running under
+  // that introduction takes it away from anyone who reads it at their own pace,
+  // or who set the comic down for a moment before starting. The first page turn
+  // is the reader saying they have the idea, and only then does the idle window
+  // start running.
+  const [hasPaged, setHasPaged] = useState(false);
+
   const setChrome = useCallback((next: boolean) => {
     visibleRef.current = next;
     setChromeVisible(next);
@@ -560,13 +569,13 @@ export function ComicReader({
     setChrome(!visibleRef.current);
   }, [noteActivity, setChrome]);
 
-  // Nothing to get out of the way of until there is a page to read: the loading
-  // state, the empty note and the back cover are all things the reader is meant
-  // to act on, so the chrome stays put for them. An open note is the same case —
-  // the bars would fade out under a translucent scrim, then be back the moment
-  // it closes.
+  // Nothing to get out of the way of until there is a page to read *and* a
+  // reader turning them: the loading state, the empty note and the back cover
+  // are all things the reader is meant to act on, an open note would fade the
+  // bars out under a translucent scrim only to bring them back the moment it
+  // closes, and a comic nobody has paged through yet is still being introduced.
   const chromeCanRest =
-    totalPages > 0 && !isSpinePending && !atEnd && !noteOpen;
+    hasPaged && totalPages > 0 && !isSpinePending && !atEnd && !noteOpen;
 
   useEffect(() => {
     if (!chromeVisible || chromeHeld || !chromeCanRest) return;
@@ -602,6 +611,11 @@ export function ComicReader({
       // A page turn is not a request for the chrome back — but if it is already
       // out, tapping through pages shouldn't make it vanish mid-tap.
       noteActivity();
+      // ...and it is what starts the chrome's idle window, whether the turn came
+      // from a swipe, a tap zone, a footer button or a key. Only a turn that
+      // actually moves: this sits past the early return, so pressing previous on
+      // page one doesn't count as reading the comic.
+      setHasPaged(true);
       onPageChange(clamped + 1);
     },
     [index, lastIndex, noteActivity, onPageChange],


### PR DESCRIPTION
**Stacked on #119**, which is where the comic reader work is accumulating. Review the top commit for this change alone.

The bars showed themselves on arrival and started their 2.6s countdown immediately, so a reader who opened a comic and just looked at it — or set it down mid-thought — lost the introduction before using it. On arrival the chrome *is* the introduction: what this is, where they are in it, how to get back out.

The idle window now starts on the **first page turn**, whatever turned it — a swipe, a tap zone, a footer button, or a key. One line in `goTo` and one term in `chromeCanRest`:

```ts
const chromeCanRest =
  hasPaged && totalPages > 0 && !isSpinePending && !atEnd && !noteOpen;
```

A turn that moves nothing (previous on page one) doesn't count, since the flag sits past `goTo`'s early return. Everything else about the chrome is unchanged: the middle-zone tap still toggles it by hand at any time, a mouse move and Tab still call it back, and it still stays put for the loading, empty, back-cover and open-note states.

## Verification

`pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test` (682 passed), `pnpm build`.

Not observed in a browser — no `.env`/database here to open a comic with, and the vitest config doesn't run the Lingui macro transform, so `ComicReader` can't be render-tested as things stand. The change is two lines of state, but the *feel* of it is the whole point, so it's worth a look on the preview.

`APP_VISION.md` and `TODO.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq8L6k9QDWWB8DtmZVLUtg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uq8L6k9QDWWB8DtmZVLUtg)_