### PR TITLE
Give repo repair its own service, and a daily lap

### DIFF
--- a/.agents/skills/railway-inspect/SKILL.md
+++ b/.agents/skills/railway-inspect/SKILL.md
@@ -18,9 +18,14 @@ alone (they describe intent; the CLI shows reality).
 
 ## Standard Reader Railway topology
 
-The `standard-reader` Railway project runs four long-lived services plus an
-hourly cron, sharing a single Neon Postgres read-model. GitHub auto-deploys on
+The `standard-reader` Railway project runs four long-lived services plus two
+hourly crons, sharing a single Neon Postgres read-model. GitHub auto-deploys on
 push to `main`. Every service uses the `RAILPACK` builder.
+
+Note the split between the two crons: `recompute-cron` is only a *trigger* — it
+POSTs the ingest worker and the work runs there. `reconcile-cron` does its work
+in its own process, on purpose, so repo repair never competes with the live tap
+stream it exists to backstop.
 
 | Service          | Start command                                      | Config file            | Healthcheck / notes                                                   |
 | ---------------- | -------------------------------------------------- | ---------------------- | --------------------------------------------------------------------- |
@@ -28,6 +33,7 @@ push to `main`. Every service uses the `RAILPACK` builder.
 | `tap`            | `ghcr.io/.../tap` Docker image on a `/data` volume | (Docker, no railpack)  | Long-running firehose consumer; admin API on `:2480` (private)         |
 | `ingest`         | `pnpm ingest:start` (= `tsx src/server/ingest/service.ts`) | `railway.ingest.json`  | Binds `[::]:3099`; consumes `tap.railway.internal:2480`               |
 | `recompute-cron` | `node scripts/recompute-cron.mjs`                 | `railway.cron.json`    | `0 * * * *`; POSTs the ingest worker's `/api/ingest/recompute`; `restartPolicyType: NEVER` |
+| `reconcile-cron` | `pnpm reconcile:repos`                            | `railway.reconcile.json` | `20 * * * *`; PDS repair round-robin, runs in its own process (does **not** call ingest); `restartPolicyType: NEVER` |
 
 **Runbook gotcha:** Railway auto-detects only the root `railway.json`. Every
 non-web service needs its **Config File Path** set explicitly (Dashboard →
@@ -177,6 +183,12 @@ If a deploy is misbehaving, check that these are present and correct:
   `TAP_SIGNAL_COLLECTION`, `TAP_COLLECTION_FILTERS`, `TAP_DATABASE_URL`
 - `recompute-cron`: `INGEST_WEBHOOK_SECRET`, `INGEST_PORT` / service URL for
   the POST target
+- `reconcile-cron`: `DATABASE_URL`, `TAP_API_URL`, `TAP_ADMIN_PASSWORD`,
+  `HONEYCOMB_API_KEY`. It reaches the DB and PDSes directly rather than going
+  through ingest, so it needs the DB URL itself — plus tap's admin credentials,
+  because repairing a record can newly track its author's repo. Optional:
+  `RECONCILE_LAP_HOURS` (default 24), `RECONCILE_INTERVAL_HOURS` (default 1),
+  `RECONCILE_BATCH` (explicit override; skips the fleet-size derivation)
 
 ### 5. Drilling into a running service
 

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -12,7 +12,7 @@ Check items off as they land.
 - [x] Set up env management (`.env` for `DATABASE_URL`, AT Proto OAuth secrets, tap config) + `.env.example`.
 - [x] Confirm Neon project + connection (`src/db/index.ts`) and Drizzle migration flow (`drizzle.config.ts`, `drizzle/`).
 - [x] Decide deployment target (Node server output) and wire CI for lint/format/typecheck/build (`.github/workflows/ci.yml`).
-- [x] **Production deploy (Railway).** Four services in the `standard-reader` project (GitHub
+- [x] **Production deploy (Railway).** Services in the `standard-reader` project (GitHub
       auto-deploy on push to `main`), sharing the existing Neon read-model DB:
   - `web` — TanStack Start + Nitro (`pnpm build` → `pnpm start` = `node .output/server/index.mjs`);
     pre-deploy `pnpm db:migrate`; healthcheck `/api/auth/atproto/metadata.json`; custom domain
@@ -23,10 +23,17 @@ Check items off as they land.
     `[::]:3099`, consumes `tap.railway.internal:2480`. Config file `railway.ingest.json`.
   - `recompute-cron` — `node scripts/recompute-cron.mjs` on `0 * * * *`, POSTs the ingest worker's
     `/api/ingest/recompute` over private networking. Config file `railway.cron.json`.
+  - `reconcile-cron` — `pnpm reconcile:repos` on `20 * * * *`, the PDS repair round-robin. Unlike
+    `recompute-cron` it does the work in its own process rather than POSTing ingest: repair
+    enumerates and rewrites whole repos, and running that on the ingest worker made the backstop
+    compete with the live tap stream it backstops. Batch is derived from the fleet count so one
+    full lap stays ~24h as the fleet grows (`RECONCILE_LAP_HOURS` /
+    `RECONCILE_INTERVAL_HOURS`). Config file `railway.reconcile.json`.
   - **Runbook gotcha:** Railway auto-detects only the root `railway.json`, so every non-web service
     in this monorepo needs its **Config File Path** set explicitly (Dashboard → service → Settings →
     Config-as-code, or `serviceInstanceUpdate{ railwayConfigFile }` via the GraphQL API) to
-    `railway.ingest.json` / `railway.cron.json`; otherwise it silently falls back to the web build.
+    `railway.ingest.json` / `railway.cron.json` / `railway.reconcile.json`; otherwise it silently
+    falls back to the web build.
     Shared `INGEST_WEBHOOK_SECRET` = `TAP_ADMIN_PASSWORD`; `PUBLIC_URL=https://standard-reader.app`;
     `ATPROTO_PRIVATE_KEY_JWK` is the ES256 private JWK. Prod DB was reset to a clean schema (drop
     `public` + `drizzle`, then `pnpm db:migrate`) before first backfill.

--- a/apps/standard-reader/package.json
+++ b/apps/standard-reader/package.json
@@ -21,6 +21,8 @@
     "perf:explain": "FEED_PERF_TEST=1 vitest run src/server/reader/queries.explain.test.ts",
     "ingest:dev": "tsx --env-file=.env --require @opentelemetry/auto-instrumentations-node/register src/server/ingest/service.ts",
     "ingest:start": "tsx --require @opentelemetry/auto-instrumentations-node/register src/server/ingest/service.ts",
+    "reconcile:repos": "tsx --require @opentelemetry/auto-instrumentations-node/register scripts/reconcile-repos-cron.ts",
+    "reconcile:repos:dev": "tsx --env-file=.env scripts/reconcile-repos-cron.ts",
     "digest:send": "tsx scripts/send-weekly-digest.ts",
     "digest:send:dev": "tsx --env-file=.env scripts/send-weekly-digest.ts",
     "thread:post": "tsx scripts/post-weekly-thread.ts",

--- a/apps/standard-reader/scripts/reconcile-repos-cron.ts
+++ b/apps/standard-reader/scripts/reconcile-repos-cron.ts
@@ -1,0 +1,98 @@
+/**
+ * PDS reconcile round-robin — the read-model's repair sweep.
+ *
+ * tap is the primary write path: every create/update/delete streams into the
+ * read-model live. This is the backstop for when that fails *silently*, which
+ * it does — a tap subscription can stop delivering a repo while still
+ * reporting `state: "active"` with no error and no retries, and because "no
+ * events" and "no changes" are indistinguishable downstream, nothing in the
+ * ingest worker can notice. So we ask each repo's PDS for its head rev,
+ * compare it to `last_seen_rev`, and re-mirror anything that drifted.
+ *
+ * **Why this is its own process.** The sweep used to run inside the ingest
+ * worker (a 30-minute timer plus a batch on every hourly recompute). Repairing
+ * a repo means enumerating its records and rewriting the changed ones, so that
+ * put the repair in direct competition with the live stream it exists to
+ * backstop — on a worker already pinned at its in-flight cap. Worse, the two
+ * schedules together only managed ~100 repos an hour against a fleet of
+ * ~10,000, so a record tap dropped stayed invisible for up to four days.
+ * Out here the sweep gets its own process, and the batch is sized from the
+ * fleet rather than fixed.
+ *
+ * **Batch sizing.** A constant can't hold a lap length as the fleet grows, so
+ * the batch is derived: one lap is `RECONCILE_LAP_HOURS`, this process runs
+ * every `RECONCILE_INTERVAL_HOURS`, so it takes that fraction of the fleet.
+ * At the default daily lap, the worst case for an unnoticed missing article
+ * goes from ~4 days to ~24 hours.
+ *
+ * Env:
+ *   RECONCILE_LAP_HOURS       hours for one full lap of the fleet (default 24)
+ *   RECONCILE_INTERVAL_HOURS  how often this cron fires (default 1)
+ *   RECONCILE_BATCH           explicit repo count, skips the derivation
+ */
+
+import {
+  countReconcilableRepos,
+  reconcilePublisherReposBatch,
+} from "../src/server/ingest/repo-sync.ts";
+import { logEvent } from "../src/server/observability/log.ts";
+
+function envNumber(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+  const value = Number(raw);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+const lapHours = envNumber("RECONCILE_LAP_HOURS", 24);
+const intervalHours = envNumber("RECONCILE_INTERVAL_HOURS", 1);
+const tracked = await countReconcilableRepos();
+// At least one repo per run: a fleet smaller than the lap divisor would
+// otherwise round to zero and the sweep would silently do nothing.
+const batch =
+  envNumber("RECONCILE_BATCH", 0) ||
+  Math.max(1, Math.ceil((tracked * intervalHours) / lapHours));
+
+console.info(
+  `[reconcile-cron] ${tracked} tracked repos, ${lapHours}h lap, ${intervalHours}h interval -> batch ${batch}`,
+);
+
+const startedAt = Date.now();
+try {
+  const result = await reconcilePublisherReposBatch(batch);
+  const ms = Date.now() - startedAt;
+  // `results` holds only the repos that actually enumerated (the rev gate
+  // returns early for untouched ones), so it doubles as the changed count.
+  logEvent("ingest.reconcileReposCron", {
+    attempted: result.attempted,
+    batch,
+    changed: result.results.length,
+    goneMarked: result.goneMarked,
+    lapHours,
+    migrated: result.migrated,
+    ms,
+    ok: true,
+    prunedDocuments: result.prunedDocuments,
+    prunedPublications: result.prunedPublications,
+    tracked,
+  });
+  console.info(
+    `[reconcile-cron] attempted=${result.attempted} changed=${result.results.length} ` +
+      `gone=${result.goneMarked} migrated=${result.migrated} ` +
+      `pruned=${result.prunedPublications}p/${result.prunedDocuments}d in ${ms}ms`,
+  );
+} catch (error: unknown) {
+  logEvent("ingest.reconcileReposCron", {
+    batch,
+    error: error instanceof Error ? error.message : String(error),
+    ms: Date.now() - startedAt,
+    ok: false,
+    tracked,
+  });
+  throw error;
+}
+
+// eslint-disable-next-line unicorn/no-process-exit
+process.exit(0);

--- a/apps/standard-reader/scripts/tmp-drain.ts
+++ b/apps/standard-reader/scripts/tmp-drain.ts
@@ -59,6 +59,7 @@ async function worker(): Promise<void> {
 
 await Promise.all(Array.from({ length: CONCURRENCY }, () => worker()));
 console.log(
-  `\nDONE in ${Math.round((Date.now() - started) / 60000)}m — repaired=${repaired} documents=${docs} readerRecords=${readerRecords} failed=${failed}`,
+  `\nDONE in ${Math.round((Date.now() - started) / 60_000)}m — repaired=${repaired} documents=${docs} readerRecords=${readerRecords} failed=${failed}`,
 );
+// eslint-disable-next-line unicorn/no-process-exit
 process.exit(0);

--- a/apps/standard-reader/src/server/ingest/consumer.ts
+++ b/apps/standard-reader/src/server/ingest/consumer.ts
@@ -48,6 +48,31 @@ import {
 const STREAM_ID = "tap";
 
 /**
+ * Collections already reported by {@link handleRecord}'s default branch.
+ *
+ * tap's own subscription filter is what makes that branch unreachable, so a hit
+ * means the filter and this dispatcher disagree — worth knowing. But the
+ * disagreement arrives at firehose volume: if a chatty collection ever slips
+ * through, a per-event log would bury every other line in the service (and the
+ * telemetry bill) under it. One line per collection per process names the leak,
+ * which is the part we can't get anywhere else; tap already knows the rate.
+ */
+const reportedUnmodeledCollections = new Set<string>();
+
+function noteUnmodeledCollection(collection: string, uri: string): void {
+  if (reportedUnmodeledCollections.has(collection)) {
+    return;
+  }
+  reportedUnmodeledCollections.add(collection);
+  logEvent("ingest.recordDropped", {
+    collection,
+    ok: false,
+    reason: "unmodeled-collection",
+    uri,
+  });
+}
+
+/**
  * Apply one record event to the read-model.
  *
  * Exported because the PDS reconcile sweep replays records through this very
@@ -75,7 +100,22 @@ export async function handleRecord(payload: TapRecordPayload): Promise<void> {
   }
 
   if (!record) {
-    // create/update with no body — nothing to map.
+    // A create/update with no body — nothing to map, and nothing downstream
+    // will ever notice on its own: the caller treats "returned without
+    // throwing" as applied and acks the event, so the record is gone for good
+    // until the PDS reconcile round-robin happens past this repo (days, at the
+    // current sweep rate). Every other way a record fails to land leaves a
+    // trace — a dead-letter row, a withheld ack — this one leaves none, so it
+    // has to announce itself.
+    logEvent("ingest.recordDropped", {
+      action,
+      collection,
+      did,
+      ok: false,
+      reason: "no-record-body",
+      rkey,
+      uri,
+    });
     return;
   }
 
@@ -222,6 +262,7 @@ export async function handleRecord(payload: TapRecordPayload): Promise<void> {
     }
     default: {
       // A collection we don't model (tap filtering should prevent this).
+      noteUnmodeledCollection(collection, uri);
       return;
     }
   }

--- a/apps/standard-reader/src/server/ingest/recompute.ts
+++ b/apps/standard-reader/src/server/ingest/recompute.ts
@@ -46,7 +46,6 @@ import {
 } from "../atproto/identity.ts";
 import { replayDeadLetters } from "./consumer.ts";
 import { reconcileDocumentDup, reconcilePublicationGroup } from "./handlers.ts";
-import { reconcilePublisherReposBatch } from "./repo-sync.ts";
 
 /**
  * Recompute the derived per-publication aggregates (subscriber/document/
@@ -879,13 +878,13 @@ export async function recomputeDerived(): Promise<void> {
   } catch {
     // Replay is best-effort; the rows persist and the next sweep retries.
   }
-  // PDS is the source of truth for deletes tap missed (dead-letter cap, stream
-  // gaps, out-of-order backfill). Round-robin a batch each sweep.
-  try {
-    await reconcilePublisherReposBatch();
-  } catch {
-    // Best-effort; the background timer retries between sweeps.
-  }
+  // The PDS round-robin used to run here too, a batch per sweep. It moved to
+  // its own cron service (`scripts/reconcile-repos-cron.ts`): repairing a repo
+  // means enumerating it and rewriting every changed record, and doing that
+  // inside the ingest worker put the repair in direct competition with the live
+  // tap stream it exists to backstop — the worker sits pinned at its in-flight
+  // cap as it is. Nothing schedules repair from this process any more.
+
   // Re-resolve any actor stranded at `null`/`handle.invalid` so a handle change
   // that never arrived as a usable identity event still self-heals (issue #4).
   try {

--- a/apps/standard-reader/src/server/ingest/repo-sync.ts
+++ b/apps/standard-reader/src/server/ingest/repo-sync.ts
@@ -50,36 +50,27 @@ const DELETE_CHUNK = 500;
  * nothing for that; only overlapping the waiting does.
  *
  * Kept deliberately modest. Most repos resolve to a handful of shared PDS
- * hosts, so this is really this many requests deep against those few hosts,
- * and the same worker is serving live ingest at the same time.
+ * hosts, so this is really this many requests deep against those few hosts.
  */
 const RECONCILE_CONCURRENCY = 8;
 
-/** Publisher repos reconciled per hourly recompute sweep. */
-const RECONCILE_BATCH_DEFAULT = 50;
-/** Publisher repos reconciled on each ingest timer tick. */
-const RECONCILE_TICK_BATCH = 5;
 /**
- * How often the ingest worker runs background PDS reconcile.
+ * Repos per batch when the caller doesn't say.
  *
- * Delete-gap repair (catching deletes tap missed) doesn't need to be
- * minute-fresh — a stale-deleted publication lingering in the read-model for
- * half an hour is low-impact, and the hourly recompute sweep already covers
- * the full set once an hour. 30 min spreads load without the 288-tick/day
- * noise of a 5-min interval (and the 400 storm for gone repos that drove
- * the `gone` state).
+ * Only manual callers land here — the scheduled sweep
+ * (`scripts/reconcile-repos-cron.ts`) sizes its own batch from the fleet count
+ * so the lap length stays fixed as the fleet grows, which a constant can't do.
  */
-export const RECONCILE_INTERVAL_MS = 30 * 60_000;
+const RECONCILE_BATCH_DEFAULT = 50;
 
 /**
  * Backoff after a reconcile failure (transient fetch error, or a PDS that
  * can't be resolved). Doubles per consecutive failure up to the cap, so a
- * persistently-broken DID stops being retried every tick — previously a
- * handful of permanently-failing DIDs could fill the entire
- * `RECONCILE_TICK_BATCH` every 30 minutes, forever, starving healthy repos
- * out of the round-robin.
+ * persistently-broken DID stops being retried every sweep — previously a
+ * handful of permanently-failing DIDs could fill the entire batch, forever,
+ * starving healthy repos out of the round-robin.
  */
-const RECONCILE_FAIL_BACKOFF_MS = RECONCILE_INTERVAL_MS;
+const RECONCILE_FAIL_BACKOFF_MS = 30 * 60_000;
 const RECONCILE_FAIL_BACKOFF_MAX_MS = 24 * 60 * 60_000;
 
 function nextRetryAfter(failCount: number): Date {
@@ -130,6 +121,21 @@ export interface RepoReconcileResult {
   upsertedDocuments: number;
   prunedPublications: number;
   prunedDocuments: number;
+  /**
+   * Records the PDS holds that the read-model had never mirrored at all — the
+   * repair's measure of what tap failed to deliver.
+   *
+   * Deliberately narrower than `upsertedDocuments`, which also counts records
+   * we already held at a stale CID (a missed *update*, less user-visible than a
+   * missed *create* — the article exists, it's just out of date). Counted with
+   * `has`, not a truthy CID, so a row deduped away by `dedupeRecords` reads as
+   * mirrored: we saw that record, we chose to drop it.
+   *
+   * Only meaningful when the reconcile actually upserts (`upsert && !dryRun`);
+   * 0 otherwise.
+   */
+  unmirroredPublications: number;
+  unmirroredDocuments: number;
   skipped?: boolean;
   /** True when the PDS reported the repo is permanently gone (after the
    * migration retry in `listRepoRecords` already failed to find a new PDS). */
@@ -222,6 +228,24 @@ function changedRecords(
     if (!record.cid) return true;
     return known.get(record.uri) !== record.cid;
   });
+}
+
+/**
+ * How many of `listed` the read-model has never held under any CID.
+ *
+ * This is the repair measuring the live stream's loss rate. A record here is
+ * one tap never delivered — not one it delivered and we then reconsidered, so
+ * `has` rather than a CID comparison: {@link dedupeRecords} soft-deletes
+ * identical-content duplicates, and those rows stay in the map and stay
+ * uncounted. Otherwise every repair of a repo that once published a duplicate
+ * would report a permanent phantom gap.
+ */
+function unmirroredCount(
+  listed: Array<{ uri: string; value?: Record<string, unknown> }>,
+  known: Map<string, string | null>,
+): number {
+  return listed.filter((record) => record.value && !known.has(record.uri))
+    .length;
 }
 
 /**
@@ -412,6 +436,8 @@ export async function reconcileRepoFromPds(
       prunedDocuments: 0,
       prunedPublications: 0,
       skipped: true,
+      unmirroredDocuments: 0,
+      unmirroredPublications: 0,
       upsertedDocuments: 0,
     };
   }
@@ -434,16 +460,20 @@ export async function reconcileRepoFromPds(
       pdsPublications: 0,
       prunedDocuments: 0,
       prunedPublications: 0,
+      unmirroredDocuments: 0,
+      unmirroredPublications: 0,
       upsertedDocuments: 0,
     };
   }
   const pubs = pubResult.records;
   const livePubUris = new Set(pubs.map((record) => record.uri));
+  let unmirroredPublications = 0;
   if (upsert && !dryRun) {
     const known = await mirroredCids(
       publications,
       pubs.map((record) => record.uri),
     );
+    unmirroredPublications = unmirroredCount(pubs, known);
     for (const record of changedRecords(pubs, known)) {
       await upsertPublication(
         record.uri,
@@ -473,17 +503,21 @@ export async function reconcileRepoFromPds(
       pdsPublications: pubs.length,
       prunedDocuments: 0,
       prunedPublications: 0,
+      unmirroredDocuments: 0,
+      unmirroredPublications,
       upsertedDocuments: 0,
     };
   }
   const docs = docResult.records;
   const liveDocUris = new Set(docs.map((record) => record.uri));
   let upsertedDocuments = 0;
+  let unmirroredDocuments = 0;
   if (upsert && !dryRun) {
     const known = await mirroredCids(
       documents,
       docs.map((record) => record.uri),
     );
+    unmirroredDocuments = unmirroredCount(docs, known);
     for (const record of changedRecords(docs, known)) {
       await upsertDocument(
         record.uri,
@@ -533,6 +567,8 @@ export async function reconcileRepoFromPds(
     pdsPublications: pubs.length,
     prunedDocuments: pruned.documents,
     prunedPublications: pruned.publications,
+    unmirroredDocuments,
+    unmirroredPublications,
     upsertedDocuments,
     migrated: migrated || undefined,
     migratedFrom,
@@ -722,6 +758,8 @@ export async function repairRepoIfAdvanced(
       prunedDocuments: 0,
       prunedPublications: 0,
       unchanged: true,
+      unmirroredDocuments: 0,
+      unmirroredPublications: 0,
       upsertedDocuments: 0,
     };
   }
@@ -827,6 +865,24 @@ export async function reconcilePublisherReposBatch(
         });
         return;
       }
+      // What the repair had to insert from scratch is the only measurement we
+      // have of the live stream's loss rate. tap reports a dropped repo as
+      // healthy (`state: "active"`, no error, no retries) and the ingester
+      // acks the events it never got, so nothing on the write path can tell
+      // us; this is the read-back that can. `pdsDocuments` rides along because
+      // the ratio is what separates the two shapes: a handful out of hundreds
+      // is stream loss, all-of-them is a repo whose first backfill the
+      // round-robin simply reached first.
+      if (result.unmirroredDocuments > 0 || result.unmirroredPublications > 0) {
+        logEvent("ingest.repoStreamGap", {
+          did: repo.did,
+          ok: false,
+          pdsDocuments: result.pdsDocuments,
+          pdsPublications: result.pdsPublications,
+          unmirroredDocuments: result.unmirroredDocuments,
+          unmirroredPublications: result.unmirroredPublications,
+        });
+      }
       if (result.migrated) {
         migrated += 1;
         logEvent("ingest.repoReconcile", {
@@ -872,16 +928,11 @@ export async function reconcilePublisherReposBatch(
   };
 }
 
-/** Periodic background reconcile — smaller batch than the hourly sweep. */
-export function startPublisherRepoReconcile(): { stop: () => void } {
-  const run = () => {
-    void reconcilePublisherReposBatch(RECONCILE_TICK_BATCH).catch(
-      (error: unknown) => {
-        console.warn("[ingest] publisher repo reconcile failed", error);
-      },
-    );
-  };
-  const timer = setInterval(run, RECONCILE_INTERVAL_MS);
-  timer.unref?.();
-  return { stop: () => clearInterval(timer) };
+/** Repos eligible for the round-robin — the denominator of one full lap. */
+export async function countReconcilableRepos(): Promise<number> {
+  const [row] = await db
+    .select({ count: sql<number>`count(*)::int`.mapWith(Number) })
+    .from(trackedRepos)
+    .where(ne(trackedRepos.backfillState, BACKFILL_STATE.gone));
+  return row?.count ?? 0;
 }

--- a/apps/standard-reader/src/server/ingest/service.ts
+++ b/apps/standard-reader/src/server/ingest/service.ts
@@ -20,7 +20,6 @@ import {
   markRepoGone,
   reconcilePublisherReposBatch,
   reconcileRepoFromPds,
-  startPublisherRepoReconcile,
 } from "./repo-sync.ts";
 import {
   reconcilePendingTrackedRepos,
@@ -621,7 +620,10 @@ const bridgeTapChannel = ingestConfig.tapBridgeApiUrl
 const pendingTrackedReconcile = startPendingTrackedReconcile(
   reconcileTrackedWithBackfill,
 );
-const publisherRepoReconcile = startPublisherRepoReconcile();
+// The PDS repair round-robin deliberately does *not* run here — it is its own
+// cron service (`scripts/reconcile-repos-cron.ts`). Repair enumerates and
+// rewrites whole repos, and running that beside the live tap channels made the
+// backstop compete with the stream it backstops.
 const labelSync = startLabelSync();
 const labelerDiscovery = startLabelerDiscovery();
 
@@ -629,7 +631,6 @@ for (const signal of ["SIGINT", "SIGTERM"] as const) {
   process.on(signal, () => {
     server.close(async () => {
       pendingTrackedReconcile.stop();
-      publisherRepoReconcile.stop();
       labelSync.stop();
       labelerDiscovery.stop();
       await tapChannel.destroy();

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "perf:explain": "pnpm --filter standard-reader perf:explain",
     "ingest:dev": "pnpm --filter standard-reader ingest:dev",
     "ingest:start": "pnpm --filter standard-reader ingest:start",
+    "reconcile:repos": "pnpm --filter standard-reader reconcile:repos",
+    "reconcile:repos:dev": "pnpm --filter standard-reader reconcile:repos:dev",
     "digest:send": "pnpm --filter standard-reader digest:send",
     "digest:send:dev": "pnpm --filter standard-reader digest:send:dev",
     "thread:post": "pnpm --filter standard-reader thread:post",

--- a/railway.reconcile.json
+++ b/railway.reconcile.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "RAILPACK",
+    "buildCommand": "echo 'reconcile-cron runs TypeScript via tsx; no build step'"
+  },
+  "deploy": {
+    "startCommand": "pnpm reconcile:repos",
+    "cronSchedule": "20 * * * *",
+    "restartPolicyType": "NEVER"
+  }
+}


### PR DESCRIPTION
## Why

A reader reported an article that was live on their PDS but missing from Reader: [`site.standard.document/3mrzba3giok2m`](https://standard-reader.app/a/did:plc:bpotnohnlgcj3fbmp7ugx4en/3mrzba3giok2m) on `@youronly.one`.

The record was fine. tap had the repo at a rev *past* the commit that created it and reported itself perfectly healthy — `state: "active"`, `error: ""`, `retries: 0`. There was no `ingest_dead_letter` row and no error log, because a dropped event and a quiet repo are indistinguishable downstream. Sampling 25 recently-active repos against their PDSes found the same gap on several more (crownnote.com was missing 186 documents).

The backstop for exactly this already exists — `repairRepoIfAdvanced` compares each repo's head rev to `last_seen_rev` and re-mirrors the drift. It just couldn't get there in time. Between the ingest worker's 30-minute timer (5 repos) and a batch of 50 on each hourly recompute, the round-robin was doing **~100 repos/hour against ~10,000 tracked — a four-day lap**. `youronly.one`'s `tracked_repos.updated_at` was 16 hours stale when the report came in.

## What changed

**Repair moves off the ingest worker into its own cron service.** Repairing a repo means enumerating it and rewriting every changed record, so running it beside the live tap channels put the backstop in direct competition with the stream it backstops — on a worker that already sits pinned at `inflight=12` (its cap) on nearly every heartbeat. Note the contrast with `recompute-cron`, which is only a *trigger*: it POSTs the ingest worker and the work still runs there. This one does its work in its own process, which is the whole point.

**The batch is derived from the fleet, not fixed.** A constant can't hold a lap length as the fleet grows, so: one lap is `RECONCILE_LAP_HOURS`, the cron fires every `RECONCILE_INTERVAL_HOURS`, and it takes that fraction of the fleet. At today's 10,359 repos the default daily lap is **432/hour**, taking the worst case for an unnoticed missing article from ~4 days to **~24 hours**.

I left `RECONCILE_CONCURRENCY` at 8 and only dropped the half of its comment that justified it by "the same worker is serving live ingest" — no longer true. The other half still holds (most repos cluster on a few PDS hosts), and 432/hour finishes in minutes at 8-deep.

### Two new logs, so next time we don't infer this from a hand-run diff

- **`ingest.repoStreamGap`** — records the repair had to insert *from scratch*, which is the only measurement of the live stream's loss rate we have. Deliberately narrower than `upsertedDocuments` (which also counts stale-CID updates — a missed *update* is less user-visible than a missed *create*). Counted by URI presence rather than CID, so rows soft-deleted by `dedupeRecords` don't read as a permanent phantom gap. Reported next to the repo's total, because the ratio is what separates stream loss from a first backfill.
- **`ingest.recordDropped`** — `handleRecord`'s two paths that return without doing anything while the caller acks the event as applied: a create/update with no record body, and an unmodeled collection. The latter logs once per collection per process — if tap's filter ever slips, that arrives at firehose volume.

## Verification

Smoke-run against prod with `RECONCILE_BATCH=12`: attempted 12, 8 enumerated, 141s. `repoStreamGap` fired on three real repos — **4/118, 8/4337, 36/12079** documents. Small ratios on large repos: dropped events, not missing backfills.

Also repaired the reported article and the other affected publishers by hand while diagnosing, so those are already live.

Typecheck, format, lint clean; 11 ingest tests pass.

## Deploy — needs a Railway step

1. New service in `standard-reader`, same repo/branch.
2. **Settings → Config-as-code → `railway.reconcile.json`.** Without this Railway silently deploys the web build (the known footgun).
3. Env: `DATABASE_URL`, `TAP_API_URL`, `TAP_ADMIN_PASSWORD`, `HONEYCOMB_API_KEY`. It needs tap's credentials because repairing a record can newly track its author's repo.

⚠️ **Until that service exists, nothing schedules repair at all** — the ingest-side timers are gone in this PR. Worth landing both together.

## Found along the way, not fixed here

Four repos fail repair with their PDS returning `400 InvalidRequest` on `listRecords` — records whose `tags` exceed the lexicon's `maxGraphemes: 128`, so the PDS won't serve the collection at all. The failure backoff handles it, but those repos can *never* be repaired: enumeration fails before it starts, so any event tap drops for them is permanent. Separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)