### PR TITLE
Mirror the reader's own writes into Neon instead of waiting for the tap

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -625,6 +625,22 @@ source of truth; Neon holds a derived view for speed and cross-network querying.
   `/saved`, distinct from likes.
 - **Read / unread:** an `app.standard-reader.read` record per article; opening an article
   marks it read. **Reading history** at `/history` lists these newest-first.
+- **The write path mirrors personal state into Neon itself**
+  (`src/server/reader/personal-state-mirror.ts`) — reads, bookmarks, and likes — rather than
+  waiting for the tap to replay them. These are the toggles a reader watches change in the moment
+  (unread dots, feed counts, the history list, the saved queue, the heart and its count), and
+  routing them through a shared, back-pressured ingest queue meant that during a tap backlog an
+  article stayed unread for hours after it was read. Every write path (server fns, XRPC — and so
+  MCP + the extension) upserts the same row ingest would, keyed by the same record AT-URI,
+  immediately after the PDS commits. The tap's later replay overwrites it with identical values, so
+  the mirror converges on the repo rather than competing with it, and a mirror failure just degrades
+  to waiting for the tap. Two details carry the correctness: removals delete **by record AT-URI**,
+  not by `(owner, document)`, because the write path only deletes the record at its own
+  deterministic rkey — another client's record for the same document has to keep its row; and reads
+  mirror **per committed `applyWrites` batch**, so a "mark all read" that fails partway reflects
+  exactly what is durable. Follows and subscriptions already did this by calling ingest's `upsertX`
+  helpers from the write handler; these three get their own module because reads are written in bulk
+  and because a request should use the pooled `context.db`, not ingest's singleton.
 - **Public by default:** reads, bookmarks, likes, follows, and lists are all public AT Proto
   records in the user's repo (like Bluesky likes or follows). `/history` and `/saved` are
   signed-in convenience views — not privacy boundaries.

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -191,6 +191,22 @@ Check items off as they land.
 
 ## 1. Data ingestion — tap → Neon
 
+- [x] **Personal state no longer waits on the ingest queue** (2026-08-01). With the ingest worker
+      backlogged, a reader's own read/unread state — the one thing they watch change in the moment —
+      queued behind everyone else's backfill, so articles stayed unread for hours after being read.
+      The write path now mirrors its own records into Neon
+      (`#/server/reader/personal-state-mirror`), keyed by the same record AT-URI ingest uses, so the
+      tap's later replay overwrites identical values instead of being the only way the row appears.
+      Covers **reads** (`markRead` / `markUnread` / `markPublicationAllRead` /
+      `markFollowsAllUnreadRead`, plus the batched `markDocumentsRead` — which mirrors per committed
+      `applyWrites` batch, so a partial failure reflects exactly what's durable), **bookmarks**
+      (`bookmarkDocument` / `unbookmarkDocument`) and **likes** (`recommendDocument` /
+      `unrecommendDocument` — article like counts are a live count over `recommends`, so the number
+      moves with the heart), on both the server fns and the XRPC procedures behind MCP + the
+      extension. Removals delete by record AT-URI, not by `(owner, document)`, so another client's
+      record for the same document keeps its row. Best-effort: a mirror failure degrades to the old
+      wait-for-tap behavior, never fails the write.
+
 - [x] **Bridged repos on their own tap** (2026-07-31). Bridgy Fed began publishing
       `site.standard.document` for every site it mirrors; ~969k documents landed in one day
       (99.98% of that day's inserts) across 909 `*.brid.gy` repos, and the backfill saturated

--- a/apps/standard-reader/src/integrations/tanstack-query/api-reader.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-reader.functions.ts
@@ -33,6 +33,14 @@ import { ensureTracked } from "#/server/ingest/tap-client";
 import { observe } from "#/server/observability/log";
 import { syncFollowedPublications } from "#/server/reader/followed-publications-sync.server";
 import { markDocumentsRead } from "#/server/reader/mark-documents-read";
+import {
+  mirrorBookmarkRemoved,
+  mirrorBookmarkSaved,
+  mirrorReadRemoved,
+  mirrorReadsMarked,
+  mirrorRecommendAdded,
+  mirrorRecommendRemoved,
+} from "#/server/reader/personal-state-mirror";
 import { selectUnreadDocumentUris } from "#/server/reader/queries";
 import { attachViewerRecommendedToArticles } from "#/server/reader/recommended-by";
 import { effectiveFollowSets } from "#/server/reader/saved-lists";
@@ -706,7 +714,7 @@ const recommendDocument = createServerFn({ method: "POST" })
   .middleware([dbMiddleware])
   .validator(documentInput)
   .handler(
-    observe("reader.recommendDocument", async ({ data }, span) => {
+    observe("reader.recommendDocument", async ({ context, data }, span) => {
       span.set("documentUri", data.documentUri);
       const session = await getAtprotoSessionForRequest(getRequest());
       if (!session) {
@@ -714,12 +722,19 @@ const recommendDocument = createServerFn({ method: "POST" })
       }
       span.set("did", session.did);
 
-      await putRecommendRecord(
+      const createdAt = new Date().toISOString();
+      const { cid } = await putRecommendRecord(
         session.client,
         session.did,
         data.documentUri,
-        new Date().toISOString(),
+        createdAt,
       );
+      await mirrorRecommendAdded(context.db, context.schema, {
+        cid,
+        createdAt,
+        documentUri: data.documentUri,
+        recommenderDid: session.did,
+      });
       await trackReaderRepo(session.did);
       return { ok: true as const };
     }),
@@ -729,7 +744,7 @@ const unrecommendDocument = createServerFn({ method: "POST" })
   .middleware([dbMiddleware])
   .validator(documentInput)
   .handler(
-    observe("reader.unrecommendDocument", async ({ data }, span) => {
+    observe("reader.unrecommendDocument", async ({ context, data }, span) => {
       span.set("documentUri", data.documentUri);
       const session = await getAtprotoSessionForRequest(getRequest());
       if (!session) {
@@ -742,6 +757,10 @@ const unrecommendDocument = createServerFn({ method: "POST" })
         session.did,
         data.documentUri,
       );
+      await mirrorRecommendRemoved(context.db, context.schema, {
+        documentUri: data.documentUri,
+        recommenderDid: session.did,
+      });
       return { ok: true as const };
     }),
   );
@@ -834,12 +853,20 @@ const markRead = createServerFn({ method: "POST" })
         return { ok: true as const };
       }
 
-      await putReadRecord(
+      const createdAt = new Date().toISOString();
+      const { cid } = await putReadRecord(
         session.client,
         session.did,
         data.documentUri,
-        new Date().toISOString(),
+        createdAt,
       );
+      // Reflect the read in our own read-model now — the tap replay of this
+      // same record is idempotent, and waiting on it can take hours.
+      await mirrorReadsMarked(context.db, context.schema, {
+        createdAt,
+        ownerDid: session.did,
+        reads: [{ cid, documentUri: data.documentUri }],
+      });
       await trackReaderRepo(session.did);
       return { ok: true as const };
     }),
@@ -863,6 +890,10 @@ const markUnread = createServerFn({ method: "POST" })
       }
 
       await deleteReadRecord(session.client, session.did, data.documentUri);
+      await mirrorReadRemoved(context.db, context.schema, {
+        documentUri: data.documentUri,
+        ownerDid: session.did,
+      });
       return { ok: true as const };
     }),
   );
@@ -1039,7 +1070,7 @@ const bookmarkDocument = createServerFn({ method: "POST" })
   .middleware([dbMiddleware])
   .validator(documentInput)
   .handler(
-    observe("reader.bookmarkDocument", async ({ data }, span) => {
+    observe("reader.bookmarkDocument", async ({ context, data }, span) => {
       span.set("documentUri", data.documentUri);
       const session = await getAtprotoSessionForRequest(getRequest());
       if (!session) {
@@ -1047,12 +1078,19 @@ const bookmarkDocument = createServerFn({ method: "POST" })
       }
       span.set("did", session.did);
 
-      await putBookmarkRecord(
+      const createdAt = new Date().toISOString();
+      const { cid } = await putBookmarkRecord(
         session.client,
         session.did,
         data.documentUri,
-        new Date().toISOString(),
+        createdAt,
       );
+      await mirrorBookmarkSaved(context.db, context.schema, {
+        cid,
+        createdAt,
+        documentUri: data.documentUri,
+        ownerDid: session.did,
+      });
       await trackReaderRepo(session.did);
       return { ok: true as const };
     }),
@@ -1062,7 +1100,7 @@ const unbookmarkDocument = createServerFn({ method: "POST" })
   .middleware([dbMiddleware])
   .validator(documentInput)
   .handler(
-    observe("reader.unbookmarkDocument", async ({ data }, span) => {
+    observe("reader.unbookmarkDocument", async ({ context, data }, span) => {
       span.set("documentUri", data.documentUri);
       const session = await getAtprotoSessionForRequest(getRequest());
       if (!session) {
@@ -1071,6 +1109,10 @@ const unbookmarkDocument = createServerFn({ method: "POST" })
       span.set("did", session.did);
 
       await deleteBookmarkRecord(session.client, session.did, data.documentUri);
+      await mirrorBookmarkRemoved(context.db, context.schema, {
+        documentUri: data.documentUri,
+        ownerDid: session.did,
+      });
       return { ok: true as const };
     }),
   );
@@ -1170,8 +1212,10 @@ const markPublicationAllRead = createServerFn({ method: "POST" })
         span.set("count", documentUris.length);
         return markDocumentsRead({
           client: session.client,
+          db: context.db,
           did: session.did,
           documentUris,
+          schema: context.schema,
           trackReading,
         });
       },
@@ -1208,8 +1252,10 @@ const markFollowsAllUnreadRead = createServerFn({ method: "POST" })
       span.set("count", documentUris.length);
       return markDocumentsRead({
         client: session.client,
+        db: context.db,
         did: session.did,
         documentUris,
+        schema: context.schema,
         trackReading,
       });
     }),

--- a/apps/standard-reader/src/server/reader/mark-documents-read.test.ts
+++ b/apps/standard-reader/src/server/reader/mark-documents-read.test.ts
@@ -1,6 +1,8 @@
 import type { Client } from "@atcute/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import * as schema from "#/db/schema";
+import type { Db, Schema } from "#/integrations/tanstack-query/api-shapes";
 import { APPLY_WRITES_MAX_BATCH } from "#/server/atproto/repo-records";
 import { markDocumentsRead } from "#/server/reader/mark-documents-read";
 
@@ -12,6 +14,27 @@ interface RecordedWrite {
   collection: string;
   rkey: string;
   value: { subject: string; createdAt: string };
+}
+
+interface MirroredRow {
+  documentUri: string;
+  ownerDid: string;
+  uri: string;
+}
+
+/** Minimal stand-in for the read-model handles the mirror writes through. */
+function fakeDb(): { db: Db; mirrored: Array<Array<MirroredRow>> } {
+  const mirrored: Array<Array<MirroredRow>> = [];
+  const db = {
+    insert: () => ({
+      values: (rows: Array<MirroredRow>) => ({
+        onConflictDoUpdate: async () => {
+          mirrored.push(rows);
+        },
+      }),
+    }),
+  };
+  return { db: db as unknown as Db, mirrored };
 }
 
 function fakeClient(): {
@@ -43,12 +66,15 @@ describe("markDocumentsRead", () => {
 
   it("splits a backlog into batches within the applyWrites cap", async () => {
     const { client, batches } = fakeClient();
+    const { db } = fakeDb();
     const documentUris = uris(450);
 
     const result = await markDocumentsRead({
       client,
+      db,
       did: "did:plc:reader",
       documentUris,
+      schema: schema as Schema,
       trackReading: true,
     });
 
@@ -57,14 +83,44 @@ describe("markDocumentsRead", () => {
     expect(result.documentUris).toEqual(documentUris);
   });
 
-  it("writes every document exactly once across batches", async () => {
-    const { client, batches } = fakeClient();
+  it("mirrors each committed batch into the read-model", async () => {
+    const { client } = fakeClient();
+    const { db, mirrored } = fakeDb();
     const documentUris = uris(450);
 
     await markDocumentsRead({
       client,
+      db,
       did: "did:plc:reader",
       documentUris,
+      schema: schema as Schema,
+      trackReading: true,
+    });
+
+    // One mirror write per applyWrites batch, covering every document once.
+    expect(mirrored.map((rows) => rows.length)).toEqual([200, 200, 50]);
+    expect(mirrored.flat().map((row) => row.documentUri)).toEqual(documentUris);
+    // Rows are keyed by the record AT-URI ingest will replay, so the tap's
+    // later upsert collides with ours instead of duplicating it.
+    expect(new Set(mirrored.flat().map((row) => row.uri)).size).toBe(
+      documentUris.length,
+    );
+    expect(
+      mirrored.flat().every((row) => row.ownerDid === "did:plc:reader"),
+    ).toBe(true);
+  });
+
+  it("writes every document exactly once across batches", async () => {
+    const { client, batches } = fakeClient();
+    const { db } = fakeDb();
+    const documentUris = uris(450);
+
+    await markDocumentsRead({
+      client,
+      db,
+      did: "did:plc:reader",
+      documentUris,
+      schema: schema as Schema,
       trackReading: true,
     });
 
@@ -79,11 +135,14 @@ describe("markDocumentsRead", () => {
 
   it("sends a single batch when the backlog fits the cap", async () => {
     const { client, batches } = fakeClient();
+    const { db } = fakeDb();
 
     await markDocumentsRead({
       client,
+      db,
       did: "did:plc:reader",
       documentUris: uris(APPLY_WRITES_MAX_BATCH),
+      schema: schema as Schema,
       trackReading: true,
     });
 
@@ -112,30 +171,40 @@ describe("markDocumentsRead", () => {
       },
     };
 
+    const { db, mirrored } = fakeDb();
+
     await expect(
       markDocumentsRead({
         client: client as unknown as Client,
+        db,
         did: "did:plc:reader",
         documentUris: uris(450),
+        schema: schema as Schema,
         trackReading: true,
       }),
     ).rejects.toThrow(/RateLimitExceeded/);
 
     // Stopped at the failing batch rather than pressing on into the rate limit.
     expect(batches).toEqual([200, 200]);
+    // The one batch that did commit is mirrored; the failed one is not.
+    expect(mirrored.map((rows) => rows.length)).toEqual([200]);
   });
 
   it("writes nothing when read tracking is disabled", async () => {
     const { client, batches } = fakeClient();
+    const { db, mirrored } = fakeDb();
 
     const result = await markDocumentsRead({
       client,
+      db,
       did: "did:plc:reader",
       documentUris: uris(10),
+      schema: schema as Schema,
       trackReading: false,
     });
 
     expect(batches).toHaveLength(0);
+    expect(mirrored).toHaveLength(0);
     expect(result.markedCount).toBe(0);
   });
 });

--- a/apps/standard-reader/src/server/reader/mark-documents-read.ts
+++ b/apps/standard-reader/src/server/reader/mark-documents-read.ts
@@ -1,5 +1,6 @@
 import type { Client } from "@atcute/client";
 
+import type { Db, Schema } from "#/integrations/tanstack-query/api-shapes";
 import { COLLECTION } from "#/lib/atproto/nsids";
 import {
   APPLY_WRITES_MAX_BATCH,
@@ -7,6 +8,7 @@ import {
   subjectRkey,
 } from "#/server/atproto/repo-records";
 import { ensureTracked } from "#/server/ingest/tap-client";
+import { mirrorReadsMarked } from "#/server/reader/personal-state-mirror";
 
 export interface MarkDocumentsReadResult {
   markedCount: number;
@@ -27,8 +29,11 @@ export async function markDocumentsRead(options: {
   did: string;
   documentUris: Array<string>;
   trackReading: boolean;
+  /** Read-model handles, so each committed batch is mirrored immediately. */
+  db: Db;
+  schema: Schema;
 }): Promise<MarkDocumentsReadResult> {
-  const { client, did, documentUris, trackReading } = options;
+  const { client, db, did, documentUris, schema, trackReading } = options;
   if (documentUris.length === 0 || !trackReading) {
     return { markedCount: 0, documentUris: [] };
   }
@@ -46,7 +51,7 @@ export async function markDocumentsRead(options: {
     // A failure here propagates, but earlier batches are already durable on the
     // PDS — read records are additive and keyed by subject, so a retry re-marks
     // only what's still unread rather than duplicating work.
-    await repoApplyWrites(client, {
+    const results = await repoApplyWrites(client, {
       repo: did,
       writes: batch.map((documentUri) => ({
         $type: "com.atproto.repo.applyWrites#create",
@@ -57,6 +62,18 @@ export async function markDocumentsRead(options: {
           subject: documentUri,
           createdAt,
         },
+      })),
+    });
+
+    // Mirror per batch rather than once at the end: a later batch that throws
+    // leaves the reader with the earlier ones already reflected in the UI,
+    // matching what is durable on the PDS.
+    await mirrorReadsMarked(db, schema, {
+      createdAt,
+      ownerDid: did,
+      reads: batch.map((documentUri, index) => ({
+        cid: results[index]?.cid ?? null,
+        documentUri,
       })),
     });
     marked.push(...batch);

--- a/apps/standard-reader/src/server/reader/personal-state-mirror.test.ts
+++ b/apps/standard-reader/src/server/reader/personal-state-mirror.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from "vitest";
+
+import * as schema from "#/db/schema";
+import type { Db, Schema } from "#/integrations/tanstack-query/api-shapes";
+import { COLLECTION } from "#/lib/atproto/nsids";
+import { subjectRkey } from "#/server/atproto/repo-records";
+import {
+  bookmarkRecordUri,
+  mirrorBookmarkRemoved,
+  mirrorBookmarkSaved,
+  mirrorReadRemoved,
+  mirrorReadsMarked,
+  mirrorRecommendAdded,
+  mirrorRecommendRemoved,
+  readRecordUri,
+  recommendRecordUri,
+} from "#/server/reader/personal-state-mirror";
+
+const READER = "did:plc:reader";
+const DOC = "at://did:plc:pub/site.standard.document/doc1";
+const CREATED_AT = "2026-08-01T12:00:00.000Z";
+
+function capturingDb(): {
+  db: Db;
+  inserted: Array<Array<Record<string, unknown>>>;
+  deletes: number;
+} {
+  const inserted: Array<Array<Record<string, unknown>>> = [];
+  const state = { deletes: 0 };
+  const db = {
+    delete: () => ({
+      where: async () => {
+        state.deletes += 1;
+      },
+    }),
+    insert: () => ({
+      values: (
+        rows: Array<Record<string, unknown>> | Record<string, unknown>,
+      ) => ({
+        onConflictDoUpdate: async () => {
+          inserted.push(Array.isArray(rows) ? rows : [rows]);
+        },
+      }),
+    }),
+  };
+  return {
+    db: db as unknown as Db,
+    get deletes() {
+      return state.deletes;
+    },
+    inserted,
+  };
+}
+
+async function boom(): Promise<never> {
+  throw new Error("connection terminated");
+}
+
+function throwingDb(): Db {
+  return {
+    delete: () => ({ where: boom }),
+    insert: () => ({ values: () => ({ onConflictDoUpdate: boom }) }),
+  } as unknown as Db;
+}
+
+describe("record URIs", () => {
+  it("match the AT-URIs the PDS assigns, so ingest's replay collides", () => {
+    // Same `(repo, collection, subject-hash rkey)` the write path sends to
+    // `putRecord`/`applyWrites` — and therefore the URI on the firehose event.
+    const rkey = subjectRkey(DOC);
+    expect(readRecordUri(READER, DOC)).toBe(
+      `at://${READER}/${COLLECTION.read}/${rkey}`,
+    );
+    expect(bookmarkRecordUri(READER, DOC)).toBe(
+      `at://${READER}/${COLLECTION.bookmark}/${rkey}`,
+    );
+    expect(recommendRecordUri(READER, DOC)).toBe(
+      `at://${READER}/${COLLECTION.recommend}/${rkey}`,
+    );
+  });
+});
+
+describe("mirrorReadsMarked", () => {
+  it("writes the same columns ingest's upsertRead would", async () => {
+    const { db, inserted } = capturingDb();
+
+    await mirrorReadsMarked(db, schema as Schema, {
+      createdAt: CREATED_AT,
+      ownerDid: READER,
+      reads: [{ cid: "bafyreiread", documentUri: DOC }],
+    });
+
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]?.[0]).toEqual({
+      cid: "bafyreiread",
+      createdAt: new Date(CREATED_AT),
+      deleted: false,
+      documentDid: "did:plc:pub",
+      documentUri: DOC,
+      ownerDid: READER,
+      rkey: subjectRkey(DOC),
+      uri: readRecordUri(READER, DOC),
+    });
+  });
+
+  it("tolerates a PDS that returned no CID", async () => {
+    const { db, inserted } = capturingDb();
+
+    await mirrorReadsMarked(db, schema as Schema, {
+      createdAt: CREATED_AT,
+      ownerDid: READER,
+      reads: [{ documentUri: DOC }],
+    });
+
+    expect(inserted[0]?.[0]?.cid).toBeNull();
+  });
+
+  it("does nothing for an empty batch", async () => {
+    const { db, inserted } = capturingDb();
+
+    await mirrorReadsMarked(db, schema as Schema, {
+      createdAt: CREATED_AT,
+      ownerDid: READER,
+      reads: [],
+    });
+
+    expect(inserted).toHaveLength(0);
+  });
+
+  it("swallows a read-model failure — the PDS write already committed", async () => {
+    await expect(
+      mirrorReadsMarked(throwingDb(), schema as Schema, {
+        createdAt: CREATED_AT,
+        ownerDid: READER,
+        reads: [{ documentUri: DOC }],
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("mirrorBookmarkSaved", () => {
+  it("writes the same columns ingest's upsertBookmark would", async () => {
+    const { db, inserted } = capturingDb();
+
+    await mirrorBookmarkSaved(db, schema as Schema, {
+      cid: "bafyreibookmark",
+      createdAt: CREATED_AT,
+      documentUri: DOC,
+      ownerDid: READER,
+    });
+
+    expect(inserted[0]?.[0]).toEqual({
+      cid: "bafyreibookmark",
+      createdAt: new Date(CREATED_AT),
+      deleted: false,
+      documentDid: "did:plc:pub",
+      documentUri: DOC,
+      ownerDid: READER,
+      rkey: subjectRkey(DOC),
+      uri: bookmarkRecordUri(READER, DOC),
+    });
+  });
+
+  it("swallows a read-model failure", async () => {
+    await expect(
+      mirrorBookmarkSaved(throwingDb(), schema as Schema, {
+        createdAt: CREATED_AT,
+        documentUri: DOC,
+        ownerDid: READER,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("mirrorRecommendAdded", () => {
+  it("writes the same columns ingest's upsertRecommend would", async () => {
+    const { db, inserted } = capturingDb();
+
+    await mirrorRecommendAdded(db, schema as Schema, {
+      cid: "bafyreirecommend",
+      createdAt: CREATED_AT,
+      documentUri: DOC,
+      recommenderDid: READER,
+    });
+
+    // `recommends` keys the owner as `recommender_did`, not `owner_did`.
+    expect(inserted[0]?.[0]).toEqual({
+      cid: "bafyreirecommend",
+      createdAt: new Date(CREATED_AT),
+      deleted: false,
+      documentDid: "did:plc:pub",
+      documentUri: DOC,
+      recommenderDid: READER,
+      rkey: subjectRkey(DOC),
+      uri: recommendRecordUri(READER, DOC),
+    });
+  });
+
+  it("swallows a read-model failure", async () => {
+    await expect(
+      mirrorRecommendAdded(throwingDb(), schema as Schema, {
+        createdAt: CREATED_AT,
+        documentUri: DOC,
+        recommenderDid: READER,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("removals", () => {
+  it("delete the mirrored row for each collection", async () => {
+    const capture = capturingDb();
+
+    await mirrorReadRemoved(capture.db, schema as Schema, {
+      documentUri: DOC,
+      ownerDid: READER,
+    });
+    await mirrorBookmarkRemoved(capture.db, schema as Schema, {
+      documentUri: DOC,
+      ownerDid: READER,
+    });
+    await mirrorRecommendRemoved(capture.db, schema as Schema, {
+      documentUri: DOC,
+      recommenderDid: READER,
+    });
+
+    expect(capture.deletes).toBe(3);
+  });
+
+  it("swallow a read-model failure", async () => {
+    await expect(
+      mirrorReadRemoved(throwingDb(), schema as Schema, {
+        documentUri: DOC,
+        ownerDid: READER,
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      mirrorBookmarkRemoved(throwingDb(), schema as Schema, {
+        documentUri: DOC,
+        ownerDid: READER,
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      mirrorRecommendRemoved(throwingDb(), schema as Schema, {
+        documentUri: DOC,
+        recommenderDid: READER,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/standard-reader/src/server/reader/personal-state-mirror.ts
+++ b/apps/standard-reader/src/server/reader/personal-state-mirror.ts
@@ -1,0 +1,359 @@
+import { and, eq, inArray, sql } from "drizzle-orm";
+
+import type { Db, Schema } from "#/integrations/tanstack-query/api-shapes";
+import { COLLECTION } from "#/lib/atproto/nsids";
+import { subjectRkey } from "#/server/atproto/repo-records";
+import { buildAtUri, didFromAtUri } from "#/server/atproto/uri";
+import { logEvent } from "#/server/observability/log";
+
+/**
+ * Eagerly mirror a reader's own personal-state writes — reads, bookmarks, and
+ * likes — into the Neon read-model, instead of waiting for the tap ingester to
+ * replay them.
+ *
+ * The repo on the PDS is still the source of truth and the tap is still the
+ * general read path (`CLAUDE.md` — "never hit the PDS for reads"). But the tap
+ * is a shared, back-pressured queue: when it is backlogged, a reader's *own*
+ * state — the toggles they watch change in the moment — lagged by however deep
+ * the queue was, which readers experienced as an article staying unread for
+ * hours after they read it. We already know exactly what the PDS committed at
+ * write time, so we write the same row the tap would have written and let the
+ * tap's later replay land on top of it.
+ *
+ * That replay is idempotent: rows are keyed by the record AT-URI, and both this
+ * module and {@link file://./../ingest/handlers.ts} derive that URI from the
+ * same deterministic `(repo, collection, subject-hash rkey)`, so ingest's
+ * `upsertX` overwrites our row with identical values rather than duplicating
+ * it. Ordering is likewise safe by construction: firehose events for one repo
+ * are replayed in commit order, so a stale queued `create` can briefly resurrect
+ * a row we removed here, and the `delete` immediately behind it in the same
+ * backlog removes it again. The mirror converges on the repo, never diverges
+ * from it.
+ *
+ * Removals delete **by record AT-URI**, not by `(owner, document)`. The write
+ * path only ever deletes the record at its own deterministic rkey, so another
+ * client's record for the same document survives on the PDS — and its mirrored
+ * row has to survive with it. Clearing the edge instead would show the reader an
+ * un-liked heart that the next reconcile sweep flips back.
+ *
+ * Mirroring is best-effort: it runs *after* the PDS write has committed, so a
+ * failure here degrades to the pre-existing behavior (wait for the tap) rather
+ * than failing a write the reader already made.
+ *
+ * Follows and subscriptions already do this by calling ingest's `upsertX`
+ * helpers straight from the write handler. These three get their own module
+ * because reads are written in bulk — "mark all read" can be thousands of
+ * records — so the mirror has to batch, and because these run in a request,
+ * where the pooled `context.db` handle belongs rather than ingest's singleton.
+ */
+
+/** The AT-URI a `collection` record about `documentUri` takes in `ownerDid`'s repo. */
+function edgeRecordUri(
+  ownerDid: string,
+  collection: string,
+  documentUri: string,
+): string {
+  return buildAtUri(ownerDid, collection, subjectRkey(documentUri));
+}
+
+/** The AT-URI of the read record for `documentUri` in `ownerDid`'s repo. */
+export function readRecordUri(ownerDid: string, documentUri: string): string {
+  return edgeRecordUri(ownerDid, COLLECTION.read, documentUri);
+}
+
+/** The AT-URI of the bookmark record for `documentUri` in `ownerDid`'s repo. */
+export function bookmarkRecordUri(
+  ownerDid: string,
+  documentUri: string,
+): string {
+  return edgeRecordUri(ownerDid, COLLECTION.bookmark, documentUri);
+}
+
+/** The AT-URI of the recommend record for `documentUri` in `ownerDid`'s repo. */
+export function recommendRecordUri(
+  ownerDid: string,
+  documentUri: string,
+): string {
+  return edgeRecordUri(ownerDid, COLLECTION.recommend, documentUri);
+}
+
+/** One record the PDS accepted, as far as the mirror needs to know it. */
+export interface MirroredEdge {
+  documentUri: string;
+  /** Record CID, when the PDS returned one (`applyWrites` may omit results). */
+  cid?: string | null;
+}
+
+/**
+ * Rows per INSERT. Marking a large backlog read is already chunked to the
+ * PDS `applyWrites` cap (200); this keeps a single mirror statement bounded
+ * for callers that hand us a whole batch at once.
+ */
+const MIRROR_INSERT_CHUNK = 200;
+
+/** Columns shared by the `reads`, `bookmarks`, and `recommends` mirrors. */
+function edgeValues(
+  ownerDid: string,
+  collection: string,
+  edge: MirroredEdge,
+  createdAt: Date,
+) {
+  return {
+    cid: edge.cid ?? null,
+    createdAt,
+    deleted: false,
+    documentDid: didFromAtUri(edge.documentUri),
+    documentUri: edge.documentUri,
+    rkey: subjectRkey(edge.documentUri),
+    uri: edgeRecordUri(ownerDid, collection, edge.documentUri),
+  };
+}
+
+/**
+ * What an upsert overwrites when the row is already there — either because the
+ * tap got here first, or because the reader re-wrote the record (re-opening an
+ * article rewrites its read with a fresh `createdAt`).
+ */
+const CONFLICT_SET = {
+  cid: sql`excluded.cid`,
+  createdAt: sql`excluded.created_at`,
+  deleted: false,
+  documentDid: sql`excluded.document_did`,
+  updatedAt: sql`now()`,
+};
+
+/** Run a mirror write, logging rather than throwing — see the module JSDoc. */
+async function bestEffort(
+  event: string,
+  attrs: { did: string; count: number },
+  write: () => Promise<void>,
+): Promise<void> {
+  try {
+    await write();
+  } catch (error) {
+    // The PDS write is already durable; the tap will still replay it.
+    logEvent(event, {
+      ...attrs,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function chunked<T>(items: Array<T>, size: number): Array<Array<T>> {
+  const chunks: Array<Array<T>> = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+// ── Reads (app.standard-reader.read) ────────────────────────────────────────
+
+/**
+ * Upsert `reads` rows for records just written to `ownerDid`'s repo.
+ *
+ * Mirrors ingest's `upsertRead` exactly — same URI, same columns — so whichever
+ * lands second is a no-op in content.
+ */
+export async function mirrorReadsMarked(
+  db: Db,
+  schema: Schema,
+  options: {
+    ownerDid: string;
+    reads: Array<MirroredEdge>;
+    /** `createdAt` written into the records (ISO 8601). */
+    createdAt: string;
+  },
+): Promise<void> {
+  const { createdAt, ownerDid, reads } = options;
+  if (reads.length === 0) return;
+
+  const readAt = new Date(createdAt);
+  const rows = reads.map((read) => ({
+    ...edgeValues(ownerDid, COLLECTION.read, read, readAt),
+    ownerDid,
+  }));
+
+  await bestEffort(
+    "reader.mirrorReadsFailed",
+    { count: rows.length, did: ownerDid },
+    async () => {
+      for (const chunk of chunked(rows, MIRROR_INSERT_CHUNK)) {
+        await db
+          .insert(schema.reads)
+          .values(chunk)
+          .onConflictDoUpdate({ set: CONFLICT_SET, target: schema.reads.uri });
+      }
+    },
+  );
+}
+
+/** Remove the mirrored `reads` row for a record just deleted from the repo. */
+export async function mirrorReadRemoved(
+  db: Db,
+  schema: Schema,
+  options: { ownerDid: string; documentUri: string },
+): Promise<void> {
+  await mirrorReadsRemoved(db, schema, {
+    documentUris: [options.documentUri],
+    ownerDid: options.ownerDid,
+  });
+}
+
+/** Remove mirrored `reads` rows for records just deleted from the repo. */
+export async function mirrorReadsRemoved(
+  db: Db,
+  schema: Schema,
+  options: { ownerDid: string; documentUris: Array<string> },
+): Promise<void> {
+  const { documentUris, ownerDid } = options;
+  if (documentUris.length === 0) return;
+
+  const uris = documentUris.map((documentUri) =>
+    readRecordUri(ownerDid, documentUri),
+  );
+
+  await bestEffort(
+    "reader.mirrorUnreadFailed",
+    { count: uris.length, did: ownerDid },
+    async () => {
+      await db
+        .delete(schema.reads)
+        .where(
+          and(
+            eq(schema.reads.ownerDid, ownerDid),
+            inArray(schema.reads.uri, uris),
+          ),
+        );
+    },
+  );
+}
+
+// ── Bookmarks (app.standard-reader.bookmark) ────────────────────────────────
+
+/** Upsert the `bookmarks` row for a record just written to `ownerDid`'s repo. */
+export async function mirrorBookmarkSaved(
+  db: Db,
+  schema: Schema,
+  options: {
+    ownerDid: string;
+    documentUri: string;
+    cid?: string | null;
+    /** `createdAt` written into the record (ISO 8601). */
+    createdAt: string;
+  },
+): Promise<void> {
+  const { cid, createdAt, documentUri, ownerDid } = options;
+  const row = {
+    ...edgeValues(
+      ownerDid,
+      COLLECTION.bookmark,
+      { cid, documentUri },
+      new Date(createdAt),
+    ),
+    ownerDid,
+  };
+
+  await bestEffort(
+    "reader.mirrorBookmarkFailed",
+    { count: 1, did: ownerDid },
+    async () => {
+      await db.insert(schema.bookmarks).values(row).onConflictDoUpdate({
+        set: CONFLICT_SET,
+        target: schema.bookmarks.uri,
+      });
+    },
+  );
+}
+
+/** Remove the mirrored `bookmarks` row for a record just deleted from the repo. */
+export async function mirrorBookmarkRemoved(
+  db: Db,
+  schema: Schema,
+  options: { ownerDid: string; documentUri: string },
+): Promise<void> {
+  const { documentUri, ownerDid } = options;
+
+  await bestEffort(
+    "reader.mirrorUnbookmarkFailed",
+    { count: 1, did: ownerDid },
+    async () => {
+      await db
+        .delete(schema.bookmarks)
+        .where(
+          and(
+            eq(schema.bookmarks.ownerDid, ownerDid),
+            eq(schema.bookmarks.uri, bookmarkRecordUri(ownerDid, documentUri)),
+          ),
+        );
+    },
+  );
+}
+
+// ── Likes (site.standard.graph.recommend) ───────────────────────────────────
+
+/**
+ * Upsert the `recommends` row for a record just written to `recommenderDid`'s
+ * repo. Article like counts are a live count over this table
+ * (`documentRecommendCountSql`), so the count moves with the heart.
+ */
+export async function mirrorRecommendAdded(
+  db: Db,
+  schema: Schema,
+  options: {
+    recommenderDid: string;
+    documentUri: string;
+    cid?: string | null;
+    /** `createdAt` written into the record (ISO 8601). */
+    createdAt: string;
+  },
+): Promise<void> {
+  const { cid, createdAt, documentUri, recommenderDid } = options;
+  const row = {
+    ...edgeValues(
+      recommenderDid,
+      COLLECTION.recommend,
+      { cid, documentUri },
+      new Date(createdAt),
+    ),
+    recommenderDid,
+  };
+
+  await bestEffort(
+    "reader.mirrorRecommendFailed",
+    { count: 1, did: recommenderDid },
+    async () => {
+      await db.insert(schema.recommends).values(row).onConflictDoUpdate({
+        set: CONFLICT_SET,
+        target: schema.recommends.uri,
+      });
+    },
+  );
+}
+
+/** Remove the mirrored `recommends` row for a record just deleted from the repo. */
+export async function mirrorRecommendRemoved(
+  db: Db,
+  schema: Schema,
+  options: { recommenderDid: string; documentUri: string },
+): Promise<void> {
+  const { documentUri, recommenderDid } = options;
+
+  await bestEffort(
+    "reader.mirrorUnrecommendFailed",
+    { count: 1, did: recommenderDid },
+    async () => {
+      await db
+        .delete(schema.recommends)
+        .where(
+          and(
+            eq(schema.recommends.recommenderDid, recommenderDid),
+            eq(
+              schema.recommends.uri,
+              recommendRecordUri(recommenderDid, documentUri),
+            ),
+          ),
+        );
+    },
+  );
+}

--- a/apps/standard-reader/src/server/xrpc/handlers/writes.ts
+++ b/apps/standard-reader/src/server/xrpc/handlers/writes.ts
@@ -31,6 +31,13 @@ import {
   upsertUserFollow,
 } from "#/server/ingest/handlers";
 import { markDocumentsRead } from "#/server/reader/mark-documents-read";
+import {
+  mirrorBookmarkRemoved,
+  mirrorBookmarkSaved,
+  mirrorReadRemoved,
+  mirrorRecommendAdded,
+  mirrorRecommendRemoved,
+} from "#/server/reader/personal-state-mirror";
 import { selectUnreadDocumentUris } from "#/server/reader/queries";
 import {
   effectiveFollowUris,
@@ -244,12 +251,19 @@ export async function handleRecommendDocument(ctx: XrpcRequestContext) {
   const auth = requireAuthClient(ctx);
   requireScopes(auth, [XRPC_WRITE_SCOPES.recommend]);
   const documentUri = requireBodyField(ctx.body, "document");
-  await putRecommendRecord(
+  const createdAt = new Date().toISOString();
+  const { cid } = await putRecommendRecord(
     auth.client,
     auth.did,
     documentUri,
-    new Date().toISOString(),
+    createdAt,
   );
+  await mirrorRecommendAdded(ctx.db, ctx.schema, {
+    cid,
+    createdAt,
+    documentUri,
+    recommenderDid: auth.did,
+  });
   return {};
 }
 
@@ -258,6 +272,10 @@ export async function handleUnrecommendDocument(ctx: XrpcRequestContext) {
   requireScopes(auth, [XRPC_WRITE_SCOPES.recommend]);
   const documentUri = requireBodyField(ctx.body, "document");
   await deleteRecommendRecord(auth.client, auth.did, documentUri);
+  await mirrorRecommendRemoved(ctx.db, ctx.schema, {
+    documentUri,
+    recommenderDid: auth.did,
+  });
   return {};
 }
 
@@ -268,8 +286,10 @@ export async function handleMarkRead(ctx: XrpcRequestContext) {
   if (!ctx.trackReadingEnabled) return {};
   await markDocumentsRead({
     client: auth.client,
+    db: ctx.db,
     did: auth.did,
     documentUris: [documentUri],
+    schema: ctx.schema,
     trackReading: true,
   });
   return {};
@@ -281,6 +301,10 @@ export async function handleMarkUnread(ctx: XrpcRequestContext) {
   const documentUri = requireBodyField(ctx.body, "document");
   if (!ctx.trackReadingEnabled) return {};
   await deleteReadRecord(auth.client, auth.did, documentUri);
+  await mirrorReadRemoved(ctx.db, ctx.schema, {
+    documentUri,
+    ownerDid: auth.did,
+  });
   return {};
 }
 
@@ -297,8 +321,10 @@ export async function handleMarkAllRead(ctx: XrpcRequestContext) {
     : [];
   return markDocumentsRead({
     client: auth.client,
+    db: ctx.db,
     did: auth.did,
     documentUris,
+    schema: ctx.schema,
     trackReading: ctx.trackReadingEnabled,
   });
 }
@@ -316,8 +342,10 @@ export async function handleMarkPublicationAllRead(ctx: XrpcRequestContext) {
     : [];
   return markDocumentsRead({
     client: auth.client,
+    db: ctx.db,
     did: auth.did,
     documentUris,
+    schema: ctx.schema,
     trackReading: ctx.trackReadingEnabled,
   });
 }
@@ -326,12 +354,19 @@ export async function handleBookmarkDocument(ctx: XrpcRequestContext) {
   const auth = requireAuthClient(ctx);
   requireScopes(auth, [XRPC_WRITE_SCOPES.bookmark]);
   const documentUri = requireBodyField(ctx.body, "document");
-  await putBookmarkRecord(
+  const createdAt = new Date().toISOString();
+  const { cid } = await putBookmarkRecord(
     auth.client,
     auth.did,
     documentUri,
-    new Date().toISOString(),
+    createdAt,
   );
+  await mirrorBookmarkSaved(ctx.db, ctx.schema, {
+    cid,
+    createdAt,
+    documentUri,
+    ownerDid: auth.did,
+  });
   return {};
 }
 
@@ -340,6 +375,10 @@ export async function handleUnbookmarkDocument(ctx: XrpcRequestContext) {
   requireScopes(auth, [XRPC_WRITE_SCOPES.bookmark]);
   const documentUri = requireBodyField(ctx.body, "document");
   await deleteBookmarkRecord(auth.client, auth.did, documentUri);
+  await mirrorBookmarkRemoved(ctx.db, ctx.schema, {
+    documentUri,
+    ownerDid: auth.did,
+  });
   return {};
 }
 


### PR DESCRIPTION
Readers were reporting hours between marking an article read and the app agreeing that they had. The read-model is fed entirely by the tap ingester, so a reader's own read/unread state — the one thing they watch change in the moment — queued behind everyone else's backfill on a shared, back-pressured worker. Nothing was lost; it just arrived long after the reader had stopped believing it would.

The write path already knows exactly what the PDS committed, so it no longer has to ask the ingester to tell it later. After each write commits, it upserts the same row ingest would have written, keyed by the same record AT-URI — `(repo, collection, subject-hash rkey)` derived identically on both sides. The tap's replay then overwrites identical values rather than being the only way the row appears.

## What's mirrored

| Collection | Table | Entry points |
| --- | --- | --- |
| `app.standard-reader.read` | `reads` | `markRead`, `markUnread`, `markPublicationAllRead`, `markFollowsAllUnreadRead`, `markDocumentsRead` |
| `app.standard-reader.bookmark` | `bookmarks` | `bookmarkDocument`, `unbookmarkDocument` |
| `site.standard.graph.recommend` | `recommends` | `recommendDocument`, `unrecommendDocument` |

Each on both the server fns and the XRPC procedures, so MCP and the extension are covered too. Article like counts are a live count over `recommends` (`documentRecommendCountSql`), so the count moves with the heart, not just its fill state.

Follows and subscriptions already did this by calling ingest's `upsertX` helpers from the write handler. These three get their own module (`src/server/reader/personal-state-mirror.ts`) because reads are written in bulk — "mark all read" can be thousands of records — and because a request belongs on the pooled `context.db`, not on ingest's singleton.

## Why this is safe against the tap

Ordering is safe by construction: firehose events for one repo replay in commit order, so a stale queued `create` can briefly resurrect a row a removal cleared, and the `delete` immediately behind it in the same backlog clears it again. The mirror converges on the repo; it cannot diverge from it.

Two details carry the correctness:

- **Removals delete by record AT-URI**, not by `(owner, document)`. The write path only ever deletes the record at its own deterministic rkey, so another client's record for the same document survives on the PDS — and its mirrored row has to survive with it. Clearing the edge would show an un-liked heart that the next reconcile sweep flips back, the same shape as the "mark all as read could revert" bug. The `ownerDid` predicate stays in the `WHERE` as a guard so a mirror call can only ever touch the caller's own rows.
- **Reads mirror per committed `applyWrites` batch.** A "mark all read" that hits a PDS rate limit partway through reflects exactly what is durable, rather than all or nothing.

Mirroring is best-effort and runs *after* the PDS write, so a read-model failure degrades to the old wait-for-the-tap behavior and never fails a write the reader already made. Failures log `reader.mirror*Failed` with the DID and record count.

## Not included

This does not unclog the ingest worker itself — it stops user-visible personal state from being held hostage by it. If publications and documents are also arriving late, that is still the backlog and worth its own look. Lists, list-saves, and sidebar prefs still go through the tap alone.

## Testing

- `personal-state-mirror.test.ts` (new, 10 tests): asserts the exact column set each mirror writes matches what ingest's `upsertX` writes, that the derived record URIs match what the PDS assigns, that a missing CID is tolerated, and that every mirror swallows a read-model failure.
- `mark-documents-read.test.ts`: new coverage that each committed batch is mirrored once, and that a partial failure mirrors only the batch that committed.
- Full app suite: 706 passed / 6 skipped. `tsc --noEmit`, oxlint, and oxfmt clean on all changed files. (The 2 repo-wide oxlint errors in `scripts/tmp-drain.ts` are pre-existing on `main`.)

No migration — this writes existing tables through existing columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
