### PR TITLE
Add Topics — auto-derived topic areas for Discover

### DIFF
--- a/apps/standard-reader/.env.example
+++ b/apps/standard-reader/.env.example
@@ -282,6 +282,34 @@ CLAUDE_ROUTINE_TOKEN=""
 # DIGEST_SEND_DELAY_MS="1500"  # throttle between sends
 
 # ──────────────────────────────────────────────────────────────────────────────
+# Topic naming (recompute sweep)
+# ──────────────────────────────────────────────────────────────────────────────
+# Server-only, needed by the `ingest` service. The sweep clusters the tag
+# co-occurrence graph into topics and asks Claude to name each new cluster
+# (`src/server/ingest/topic-naming.ts`). Names are cached by cluster
+# identity, so a steady-state sweep makes roughly no requests — only the first
+# run, and later only genuinely new topics.
+#
+# Optional: without a key every topic falls back to a deterministic name
+# (its most central tag, title-cased), so a local sweep still works.
+# ANTHROPIC_API_KEY="sk-ant-…"
+#
+# Optional: override the naming model (default `claude-opus-5`).
+# TOPIC_NAMING_MODEL="claude-opus-5"
+#
+# Semantic tag edges. Off unless set to "1". When on, the sweep embeds each tag
+# by the titles of articles carrying it and adds edges between tags that mean
+# the same thing but never co-occur — without it `typescript` and `css` end up
+# in separate topics, because the people who tag one are not the people who
+# tag the other. Vectors are cached in `tag_embeddings`, so only the first run
+# pays for the model (~4 min for the whole vocabulary; ~40s once warm).
+# TOPIC_EMBEDDINGS="1"
+#
+# Optional: override the embedding model (default `Xenova/all-MiniLM-L6-v2`).
+# Changing it re-embeds every tag.
+# TOPIC_EMBEDDING_MODEL="Xenova/all-MiniLM-L6-v2"
+
+# ──────────────────────────────────────────────────────────────────────────────
 # Weekly "hottest articles" Bluesky thread (thread-cron)
 # ──────────────────────────────────────────────────────────────────────────────
 # Server-only. The self-contained `thread-cron` Railway service posts a weekly

--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -95,13 +95,41 @@ Detail screens
 
 Sections, top to bottom:
 
-1. **Recommended for you** — tuned to your follows (horizontal scroll of pub cards).
-2. **Followed by people you follow** — social proof.
-3. **Trending publications** — most active this week (ranked rows).
-4. **All publications** — full directory with:
-   - topic chips (All + 8 topics),
+1. **Trending publications** — most active this week (ranked rows).
+2. **Topics** — a rail of topic areas the network clusters into, with a **See all**
+   link to the full index. See [Topics](#topics) below.
+3. **Recommended for you** — tuned to your follows (horizontal scroll of pub cards).
+4. **Followed by people you follow** — social proof.
+5. **All publications** — full directory with:
+   - tag chips (All + 8 tags),
    - sort (Readers / Active / A–Z),
    - grid ⇄ list toggle.
+
+### Topics
+
+A **topic** is a cluster of related tags presented as one browsable area — the answer
+to a granularity problem. The directory's tag chips rank a 450k-tag vocabulary by raw
+frequency,
+which puts the network's atproto-native topics (`atproto`, `bluesky`, `atmosphere`) on top
+of a page meant to represent the whole network. Clustering rebalances it: atproto becomes
+_one_ topic among ~45, next to Film and Festivals, Wildlife and Nature, Pacific
+Northwest Local News, Mental Health, and Brazilian Politics.
+
+Topics are **derived, never curated** — see
+[Topic derivation](#topic-derivation) for how.
+
+- `/topics` — every published topic, with search over names, descriptions, and
+  member tags (the whole set ships in one response, so filtering is instant).
+- `/topics/$slug` — one topic:
+  - **Masthead** with its model-written name and description, publication and writer counts.
+  - **Sub-areas** — its member tags, each linking to the existing `/tag/$tag` page, so a
+    topic is a way _down_ into a narrower view rather than a replacement for one.
+  - **Articles** tab — everything published across the topic's tags
+    (Newest / Trending / Most liked).
+  - **Publications** tab — its publications (Best fit / Readers / Active / A–Z), where
+    _best fit_ ranks by how much of the topic's tag vocabulary a publication covers.
+- Slugs are permanent. A topic that drifts, gets renamed, or drops below the quality
+  bar keeps its URL.
 
 ### Search
 
@@ -111,7 +139,7 @@ Sections, top to bottom:
 
 ### Tag directory
 
-- Route `/tag/$tag`; linked from topic chips on article cards, publication cards, and
+- Route `/tag/$tag`; linked from tag chips on article cards, publication cards, and
   article kickers.
 - **Articles** tab: indexed, published articles carrying the tag (case-insensitive) on
   discover-eligible publications, with a **Recent / Trending / Most popular** sort select
@@ -1121,7 +1149,7 @@ AT Proto network (standard.site publications, profiles, follows)
   schedule. It is a cache — never the source of truth.
   - **Network-wide aggregates never run on the request path.** A count over the whole corpus is
     an unbounded scan no index can serve, and at ~1.4M documents / 2.2GB it also evicts the
-    buffer cache the feed queries depend on. `discover_topic_counts` (Discover topic chips) and
+    buffer cache the feed queries depend on. `discover_topic_counts` (Discover tag chips) and
     `network_stats` (the Latest "All" badge) exist so those reads are single-row lookups; the
     sweep already walks these tables, so maintaining them is near-free marginal work. Add a
     scalar here rather than counting live.
@@ -1152,6 +1180,74 @@ hand-tuned lists:
   corpus — recommending them reads as noise. They stay fully reachable everywhere else: the
   directory, search, trending, follows, and their own pages. Filtered in SQL, so the rail still
   fills to its limit.
+
+### Topic derivation
+
+Topics (`topics`, `topic_tags`, `topic_publications`) are rebuilt by
+`recomputeTopics()` each sweep, from the tag co-occurrence graph. Four decisions carry
+the quality, each settled by measuring against the live corpus rather than by taste:
+
+- **Edges are counted per publisher, not per article.** Two tags are related when they
+  appear on the same article — but the pair counts once per publisher. Counting articles
+  lets one author manufacture relatedness out of a tagging habit: a single
+  fediverse-hosted music blog tagging every post `fediverse` + `j-pop` produced 55
+  article-level co-occurrences, enough to make `fediverse` the Music cluster's
+  14th-strongest member. Per-publisher counting caps that blog at 1, and `fediverse`'s
+  neighbours become activitypub, mastodon, peertube, pixelfed, indieweb.
+- **Clustering is weighted label propagation** over cosine-weighted edges, sparsified to
+  each tag's 12 strongest neighbours (unsparsified, weak hub tags like `news` fuse
+  unrelated clusters). Visitation order is sorted and every tie breaks on label, because a
+  topic's identity is matched across sweeps by tag overlap — randomized order would
+  churn URLs hourly. Any cluster over 150 tags is re-split on a tightened subgraph: label
+  propagation has no size control and produced a 429-tag "topic" that had absorbed
+  musicians, actors and junk tags, which is not a topic but what is left when weak edges
+  chain everything together.
+- **Semantic edges fill in what behaviour cannot.** Co-occurrence is blind to a subject
+  whose publishers split: `typescript / javascript / npm` and `css / html / tailwind` are
+  two halves of web development that essentially never share a publisher, so counting alone
+  left one half too small to publish. Each tag is embedded (`tag_embeddings`, MiniLM) and
+  near-duplicate pairs become extra edges — additively, never replacing a behavioural edge,
+  and rescaled onto the co-occurrence weight range so they cannot dominate the neighbour cut.
+  Crucially the tag is embedded **by the titles of articles carrying it**, not by its own
+  name: on bare words the model compares spellings, and the ordering inverts exactly wrong
+  (`música`/`music` 0.723 against `typescript`/`css` 0.116 — no threshold works). In context,
+  `typescript`/`web development` scores 0.517 while `música`/`music` falls to 0.354, so the
+  0.45 floor joins the web-dev halves and leaves every language-specific topic intact.
+- **The quality bar is author concentration, not counts.** A cluster publishes at ≥14 tags,
+  ≥10 publications, ≥5 distinct authors, and **no more than 50% of its publications from a
+  single repo**. That last one is the load-bearing test: the network's three
+  highest-frequency tags (`chart`, `weekly`, `song` — 700+ publications each) are one bot
+  network publishing from one DID, and it clears every count-based threshold, including a
+  distinct-author floor (measured: 769 publications across 8 DIDs, one of them 99.5%).
+  Real topics measure 1–4% top-author share.
+- **Names are model-written, cached by cluster identity.** The deterministic alternative —
+  the cluster's most frequent tag — names a cluster of `ev / volkswagen / ford / bmw /
+toyota / porsche` **"Opinion"**. So a model reads the top tags and writes an English name
+  and one-line description; only new or materially-drifted clusters are sent, so a
+  steady-state sweep makes ~no requests. Every failure path (no API key, error, refusal)
+  falls back to the deterministic label rather than failing the sweep.
+
+Topic **publications** are precomputed; topic **documents** are resolved live
+through the tag GIN index, via a `MATERIALIZED` CTE that forces the tag predicate to be
+evaluated before the date sort — without it Postgres walks `documents_published_idx` and
+discards tens of thousands of rows per page (1.65s → 18ms).
+
+**Bridgy Fed's passive web bridge shapes the clusters but is never shown.** A
+`*.web.brid.gy` repo is a website Bridgy discovered and mirrored — nobody at that site asked
+to be here — so no bridged publication or article appears in a topic. But the bridge is
+**75% of the tagged corpus** (999k of 1.33M documents), and it is often the only evidence
+the network has that two tags belong together.
+
+So the split is: **the graph learns from everything; only opt-in publications and authors are
+shown.** Measured — excluding the bridge from the graph too collapses it from 4,498 tags to
+502 and leaves **5** publishable topics; keeping it as an unseen clustering signal gives
+**44**, with none of it visible. `*.ap.brid.gy` is never excluded: those authors chose to
+bridge.
+
+The exclusion is tested on **the document's author**, not its publication. Most bridged
+content arrives as _loose_ documents with no publication row at all — 82% of one topic's
+matches — so a publication-level test let nearly all of it through while the topic's own
+publication list looked clean.
 
 ---
 

--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -130,6 +130,12 @@ Topics are **derived, never curated** — see
     _best fit_ ranks by how much of the topic's tag vocabulary a publication covers.
 - Slugs are permanent. A topic that drifts, gets renamed, or drops below the quality
   bar keeps its URL.
+- **No dead links.** A topic can stop existing honestly — its tags drift apart, or its
+  cluster merges into a neighbour — and its tags and memberships go with it. Rather
+  than 404, the sweep records the closest surviving topic by tag overlap in
+  `superseded_by` and `/topics/$slug` redirects there (301), following the pointer
+  transitively since merges chain. Nothing close enough redirects to the index. Only a
+  slug the table has never held is a genuine 404, so a typo still errors.
 - **Publication is sticky.** The quality bar is an _entry_ test; re-applying it
   unchanged every run would make a topic sitting near a threshold flap in and out,
   and a public URL that 404s on alternate days is worse than a topic that is a

--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -130,6 +130,12 @@ Topics are **derived, never curated** — see
     _best fit_ ranks by how much of the topic's tag vocabulary a publication covers.
 - Slugs are permanent. A topic that drifts, gets renamed, or drops below the quality
   bar keeps its URL.
+- **Publication is sticky.** The quality bar is an _entry_ test; re-applying it
+  unchanged every run would make a topic sitting near a threshold flap in and out,
+  and a public URL that 404s on alternate days is worse than a topic that is a
+  little thin. Once published, a topic stays published while it still clears 70% of
+  each count threshold (and 0.6 top-author share), so only one that has genuinely
+  fallen apart is unlisted.
 
 ### Search
 
@@ -1184,8 +1190,13 @@ hand-tuned lists:
 ### Topic derivation
 
 Topics (`topics`, `topic_tags`, `topic_publications`) are rebuilt by
-`recomputeTopics()` each sweep, from the tag co-occurrence graph. Four decisions carry
-the quality, each settled by measuring against the live corpus rather than by taste:
+`recomputeTopics()` on its own **daily** cron (`scripts/topics-cron.ts`, the
+`topics-cron` Railway service — not the hourly sweep, which only rebuilds the tag
+counts it reads), from the tag co-occurrence graph. See
+[`DEPLOY_TOPICS.md`](./DEPLOY_TOPICS.md) for the services and environment it needs.
+
+Four decisions carry the quality, each settled by measuring against the live corpus
+rather than by taste:
 
 - **Edges are counted per publisher, not per article.** Two tags are related when they
   appear on the same article — but the pair counts once per publisher. Counting articles

--- a/apps/standard-reader/DEPLOY_TOPICS.md
+++ b/apps/standard-reader/DEPLOY_TOPICS.md
@@ -1,0 +1,133 @@
+# Deploying Topics
+
+Everything here is **post-merge**. The PR itself ships code, a migration, and a
+cron entrypoint; none of it does anything until the steps below are done.
+
+Ordered so the site is never in a broken state: the schema goes first, the app
+comes up with an empty (therefore hidden) Topics section, and the derivation
+fills it in.
+
+---
+
+## 0. Reconcile the migration ledger — **before merging**
+
+Only needed because this feature's tables were created on prod by hand during
+development, under three migrations that were later consolidated into one
+(`0032_topics.sql`). Prod's `drizzle.__drizzle_migrations` still lists the three
+superseded ones, so `pnpm db:migrate` would try to `CREATE TABLE` over tables
+that already exist — the pre-deploy command fails and the deploy stops.
+
+This also unblocks CI, which branches the Neon database from prod and applies
+migrations to the branch.
+
+```sql
+BEGIN;
+
+-- ALTER TABLE ... RENAME leaves the primary key index under the old name.
+ALTER INDEX IF EXISTS communities_pkey RENAME TO topics_pkey;
+
+DELETE FROM drizzle.__drizzle_migrations
+ WHERE created_at IN (1785563248288, 1785571959144, 1785604772535);
+
+INSERT INTO drizzle.__drizzle_migrations (hash, created_at)
+VALUES ('5cf42a71e8ef7ad4336cf7ab86292020af9da9cb56c7c66d9df938a2dd78fdb9',
+        1785605558412);
+
+COMMIT;
+```
+
+The hash is `sha256(drizzle/0032_topics.sql)` and the timestamp is that entry's
+`when` in `drizzle/meta/_journal.json` — the same pair `drizzle-kit migrate`
+would have written. Verify with:
+
+```bash
+node -e "console.log(require('crypto').createHash('sha256')
+  .update(require('fs').readFileSync('apps/standard-reader/drizzle/0032_topics.sql','utf8'))
+  .digest('hex'))"
+```
+
+Then delete the PR's stale Neon branch so CI re-creates it from the fixed prod
+state, and confirm `pnpm db:migrate` against prod reports nothing to apply.
+
+**This step is one-time.** Nothing about the feature needs it again; a fresh
+database just runs `0032_topics.sql` normally.
+
+---
+
+## 1. Environment variables
+
+All server-only — no `VITE_` prefix. Set on the **service that runs the topics
+cron** (step 2). The web and ingest services do not need any of them.
+
+| Variable                | Required       | Default                   | What it does                                                                                                                                                                                                       |
+| ----------------------- | -------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ANTHROPIC_API_KEY`     | no, but wanted | —                         | Enables model-authored topic names and descriptions. Without it every topic falls back to a title-cased dominant tag (`opinion` for a cars cluster, `linux` for a maker cluster), and the next run retries naming. |
+| `TOPIC_NAMING_MODEL`    | no             | `claude-opus-5`           | Naming model. Naming is cached by cluster identity, so volume is tiny; drop to `claude-haiku-4-5` if the first run's cost is unwelcome.                                                                            |
+| `TOPIC_EMBEDDINGS`      | no             | off                       | `1` adds semantic edges between tags that mean the same thing but never co-occur. This is what unifies web dev (`javascript`, `typescript`, `react`, `css`…) and merges `música` with `music`. Recommended on.     |
+| `TOPIC_EMBEDDING_MODEL` | no             | `Xenova/all-MiniLM-L6-v2` | Runs locally via `@huggingface/transformers` — no API key, but the model downloads on first use and the pass needs the memory to run it.                                                                           |
+
+`ANTHROPIC_API_KEY` is the only one that costs money. The first run names every
+cluster (~85 calls at `effort: "low"`); after that it names only clusters that
+are new or whose tag set drifted below 0.8 Jaccard, which is normally zero.
+
+---
+
+## 2. The `topics-cron` service
+
+Topic derivation is **not** part of the hourly recompute sweep — it clusters the
+whole tag graph and calls the naming model, which is minutes of work whose
+output barely moves hour to hour. It gets its own Railway service, following the
+shape of `reconcile-cron`.
+
+| Setting       | Value                                                          |
+| ------------- | -------------------------------------------------------------- |
+| Service name  | `topics-cron`                                                  |
+| Start command | `pnpm topics:cron`                                             |
+| Schedule      | daily — `0 4 * * *` (off-peak; the exact hour does not matter) |
+| Region        | same as the others (`us-west2`)                                |
+| Needs         | `DATABASE_URL`, plus the variables in step 1                   |
+
+It reads `discover_topic_counts`, which the hourly sweep rebuilds, so it only
+needs those counts to exist — not to have just been refreshed. There is no
+ordering constraint against any other service.
+
+Runtime: ~4 minutes cold (first run, all clusters named), ~40 seconds once
+naming is cached.
+
+---
+
+## 3. First run
+
+```bash
+# Dry run first — derives and prints what would be published, writes nothing
+# and makes no API calls.
+pnpm topics:derive          # published only
+pnpm topics:derive --all    # including clusters that missed the bar
+```
+
+Then trigger the cron service once by hand rather than waiting for its
+schedule, and check:
+
+- **`/discover`** shows a Topics rail with a **See all** link.
+- **`/topics`** lists ~85 topics; search matches on tags (`vinyl` should find
+  Music even though the card never shows that tag).
+- No topic contains `chart`, `weekly`, or `song` — those are one operator's
+  publication fleet, and the top-author-share rule exists to exclude it.
+- No `*.web.brid.gy` publication or article appears anywhere in the feature.
+
+---
+
+## 4. Rolling back
+
+The feature is entirely additive: nothing outside `/topics`, the Discover rail,
+and the derivation reads these tables.
+
+- **Hide it** — `UPDATE topics SET published = false;`. Both surfaces render
+  nothing (the rail hides itself when empty) and every `/topics/$slug` 404s.
+  The next cron run republishes.
+- **Stop rebuilding it** — pause or delete the `topics-cron` service. The last
+  derived set stays live and static.
+- **Remove it** — revert the PR; the tables can be dropped separately whenever.
+
+No reader data lives in these tables. Everything in them is derived from
+`documents` and `publications` and can be rebuilt by one cron run.

--- a/apps/standard-reader/DEPLOY_TOPICS.md
+++ b/apps/standard-reader/DEPLOY_TOPICS.md
@@ -26,12 +26,18 @@ BEGIN;
 -- ALTER TABLE ... RENAME leaves the primary key index under the old name.
 ALTER INDEX IF EXISTS communities_pkey RENAME TO topics_pkey;
 
+-- The one column the hand-built tables predate.
+ALTER TABLE topics ADD COLUMN IF NOT EXISTS superseded_by text;
+ALTER TABLE topics DROP CONSTRAINT IF EXISTS topics_superseded_by_topics_slug_fk;
+ALTER TABLE topics ADD CONSTRAINT topics_superseded_by_topics_slug_fk
+  FOREIGN KEY (superseded_by) REFERENCES topics(slug) ON DELETE SET NULL;
+
 DELETE FROM drizzle.__drizzle_migrations
  WHERE created_at IN (1785563248288, 1785571959144, 1785604772535);
 
 INSERT INTO drizzle.__drizzle_migrations (hash, created_at)
-VALUES ('5cf42a71e8ef7ad4336cf7ab86292020af9da9cb56c7c66d9df938a2dd78fdb9',
-        1785605558412);
+VALUES ('e1a1de621169c8946dd72493ca28aebccc354a86a68f1afe0e4a550027060e87',
+        1785607674037);
 
 COMMIT;
 ```

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -472,7 +472,11 @@ Build each on hip-ui components + StyleX tokens (no raw HTML/inline styles).
 - [x] App shell: desktop persistent left sidebar; mobile top bar + bottom tab nav; Following list.
 - [x] **Home** — masthead (date + unread count), featured lead, latest unread rows, right rail (Trending articles + You might follow).
 - [x] **Latest** — chronological list, segmented Unread / Subscriptions / All-network filter with counts (Unread = unread docs from subs, Subscriptions = all docs from subs, All = whole network).
-- [x] **Discover** — Recommended / Followed-by-people-you-follow / Trending / All (chips, sort, grid⇄list toggle).
+- [x] **Discover** — Trending / Topics / Recommended / Followed-by-people-you-follow / All (chips, sort, grid⇄list toggle).
+- [x] **Topics** — `/topics` index (client-side search over names, descriptions, and
+      member tags) and `/topics/$slug` (Articles + Publications tabs, sub-area chips into
+      `/tag/$tag`). `TopicCard` mirrors `PubCard`; `PubGridList` generalized into
+      `EntityGridList` so both share the keyboard/routing shell.
 - [x] **Search** — editorial field, live results split into Publications + Articles. Route `/search` with URL `?q=`; paginated search APIs with full counts; load more (publications) + infinite scroll (articles); reuses `PubDirectoryRow` + `ArticleRow`.
 - [x] **Search result snippets** — `ts_headline` excerpts in `searchArticles` /
       `searchPublications`; highlighted `<mark>` terms in `ArticleRow` and
@@ -827,7 +831,7 @@ Build each on hip-ui components + StyleX tokens (no raw HTML/inline styles).
       stays with the publisher's `.well-known`). `/collection/...` emits the same pair for the
       collection manifest document. Part of the site.standard spec and still the only thing many
       clients read — kept permanently, not a migration step.
-- [x] **`at:` record meta tags** — the community convention adopted across the network in 2026
+- [x] **`at:` record meta tags** — the topic convention adopted across the network in 2026
       (`at:canonical` / `at:alternate` / `at:author`), emitted _alongside_ the rels above.
       `/a/...`, `/p/...`, `/l/...`, `/u/...` and `/collection/...` declare their records via an
       `atMeta` key on loader data; `AtRecordMeta` renders them as raw tags in `RootDocument`'s
@@ -845,6 +849,39 @@ Build each on hip-ui components + StyleX tokens (no raw HTML/inline styles).
       recency gate; per-publication + per-author diversity caps on rail reads.
 - [x] **Cold start** — popularity fallback (`trending_score` incl. likes) excluding the trending set (rails stay distinct).
 - [x] **Readers also follow** — co-subscription + co-recommend affinity on publication profiles.
+- [x] **Topics** — auto-derived topic clusters, so Discover stops being ranked by raw tag
+      frequency (which put atproto-native topics on top of a page meant to represent the whole
+      network). `recomputeTopics()` clusters the tag co-occurrence graph each sweep via
+      weighted label propagation and names each cluster with Claude, cached by cluster identity;
+      slugs are permanent across drift and renames. Edges count **per publisher, not per article**
+      (one blogger's tagging habit had made `fediverse` a Music tag), and the quality bar turns on
+      **author concentration** rather than counts (the top-3 network tags are one bot network on a
+      single DID that clears every count threshold). Surfaces: a personalized rail on `/discover`,
+      the `/topics` index with search, and `/topics/$slug` with Articles + Publications
+      tabs and sub-area chips back into `/tag/$tag`.
+      Bridgy Fed's passive `*.web.brid.gy` mirrors are never _shown_ — no bridged publication or
+      article appears in a topic — but they do feed the co-occurrence graph, because they are
+      75% of the tagged corpus and excluding them there too leaves only 5 publishable topics
+      instead of 44. The test is on the document's **author**, not its publication: most bridged
+      content is loose documents with no publication row, so a publication-level test missed 82% of
+      it. (`*.ap.brid.gy` is never excluded — those authors opted in.)
+      Ops: `pnpm topics:derive` inspects read-only; `pnpm topics:recompute` runs the pass.
+- [x] **Topics — mega-cluster splitting + junk tags** — clusters over 150 tags are re-split on
+      a tightened subgraph (429 → 124 max), and placeholder tags (`uncategorized`, `read more`,
+      `@gmail.com`, bare numbers, single letters) never enter the vocabulary.
+- [x] **Topics — semantic tag edges** — `tag_embeddings` + MiniLM, embedding each tag by the
+      titles of articles carrying it, so subjects whose publishers split still cluster together
+      (`typescript`+`css` are now one Web Development topic). Off unless
+      `TOPIC_EMBEDDINGS=1`; ~4 min to build the cache, ~40s per sweep after.
+- [ ] **Topics — near-duplicate clusters** — some areas still split in two where a reader
+      sees one: "Decentralized Social Web" (431 pubs) sits next to "The Decentralized Social Web"
+      (79). Semantic edges reduced this a lot but did not remove it; the remaining fix is a merge
+      pass over cluster similarity, or the editorial overrides below.
+- [ ] **Topics — sidebar entry** — deliberately deferred: needs a new `SidebarNavId`, which is
+      persisted in readers' `sidebarPref` records and must stay stable, so it wants its own change.
+- [ ] **Topics — editorial overrides** — a `topic_overrides` table keyed by slug (rename,
+      re-describe, hide, pin) for when a model-written name needs correcting. The schema is already
+      shaped for it; not built because the generated names have held up.
 
 ---
 

--- a/apps/standard-reader/drizzle/0032_topics.sql
+++ b/apps/standard-reader/drizzle/0032_topics.sql
@@ -1,0 +1,47 @@
+CREATE TABLE "tag_embeddings" (
+	"tag" text PRIMARY KEY NOT NULL,
+	"embedding" double precision[] NOT NULL,
+	"model" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "topic_publications" (
+	"topic_slug" text NOT NULL,
+	"publication_uri" text NOT NULL,
+	"score" double precision DEFAULT 0 NOT NULL,
+	"matched_tag_count" integer DEFAULT 0 NOT NULL,
+	CONSTRAINT "topic_publications_topic_slug_publication_uri_pk" PRIMARY KEY("topic_slug","publication_uri")
+);
+--> statement-breakpoint
+CREATE TABLE "topic_tags" (
+	"topic_slug" text NOT NULL,
+	"tag" text NOT NULL,
+	"weight" double precision DEFAULT 0 NOT NULL,
+	CONSTRAINT "topic_tags_topic_slug_tag_pk" PRIMARY KEY("topic_slug","tag")
+);
+--> statement-breakpoint
+CREATE TABLE "topics" (
+	"slug" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"signature_tags" text[] NOT NULL,
+	"tag_count" integer DEFAULT 0 NOT NULL,
+	"publication_count" integer DEFAULT 0 NOT NULL,
+	"author_count" integer DEFAULT 0 NOT NULL,
+	"document_count" integer DEFAULT 0 NOT NULL,
+	"score" double precision DEFAULT 0 NOT NULL,
+	"published" boolean DEFAULT false NOT NULL,
+	"name_model" text,
+	"named_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "topic_publications" ADD CONSTRAINT "topic_publications_topic_slug_topics_slug_fk" FOREIGN KEY ("topic_slug") REFERENCES "public"."topics"("slug") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "topic_publications" ADD CONSTRAINT "topic_publications_publication_uri_publications_uri_fk" FOREIGN KEY ("publication_uri") REFERENCES "public"."publications"("uri") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "topic_tags" ADD CONSTRAINT "topic_tags_topic_slug_topics_slug_fk" FOREIGN KEY ("topic_slug") REFERENCES "public"."topics"("slug") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "topic_publications_rank_idx" ON "topic_publications" USING btree ("topic_slug","score" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "topic_publications_pub_idx" ON "topic_publications" USING btree ("publication_uri");--> statement-breakpoint
+CREATE INDEX "topic_tags_tag_idx" ON "topic_tags" USING btree ("tag");--> statement-breakpoint
+CREATE INDEX "topic_tags_weight_idx" ON "topic_tags" USING btree ("topic_slug","weight" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "topics_published_score_idx" ON "topics" USING btree ("published","score" DESC NULLS LAST);

--- a/apps/standard-reader/drizzle/0032_topics.sql
+++ b/apps/standard-reader/drizzle/0032_topics.sql
@@ -31,6 +31,7 @@ CREATE TABLE "topics" (
 	"document_count" integer DEFAULT 0 NOT NULL,
 	"score" double precision DEFAULT 0 NOT NULL,
 	"published" boolean DEFAULT false NOT NULL,
+	"superseded_by" text,
 	"name_model" text,
 	"named_at" timestamp with time zone,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
@@ -40,6 +41,7 @@ CREATE TABLE "topics" (
 ALTER TABLE "topic_publications" ADD CONSTRAINT "topic_publications_topic_slug_topics_slug_fk" FOREIGN KEY ("topic_slug") REFERENCES "public"."topics"("slug") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "topic_publications" ADD CONSTRAINT "topic_publications_publication_uri_publications_uri_fk" FOREIGN KEY ("publication_uri") REFERENCES "public"."publications"("uri") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "topic_tags" ADD CONSTRAINT "topic_tags_topic_slug_topics_slug_fk" FOREIGN KEY ("topic_slug") REFERENCES "public"."topics"("slug") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "topics" ADD CONSTRAINT "topics_superseded_by_topics_slug_fk" FOREIGN KEY ("superseded_by") REFERENCES "public"."topics"("slug") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "topic_publications_rank_idx" ON "topic_publications" USING btree ("topic_slug","score" DESC NULLS LAST);--> statement-breakpoint
 CREATE INDEX "topic_publications_pub_idx" ON "topic_publications" USING btree ("publication_uri");--> statement-breakpoint
 CREATE INDEX "topic_tags_tag_idx" ON "topic_tags" USING btree ("tag");--> statement-breakpoint

--- a/apps/standard-reader/drizzle/meta/0032_snapshot.json
+++ b/apps/standard-reader/drizzle/meta/0032_snapshot.json
@@ -1,0 +1,4732 @@
+{
+  "id": "97b01f54-0272-4b30-9b59-c849a02d9bdd",
+  "prevId": "7e046621-a7f4-4488-9114-3297daffa82b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_mode": {
+          "name": "theme_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appearance": {
+          "name": "appearance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale_hint_seen": {
+          "name": "locale_hint_seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reader_voice": {
+          "name": "reader_voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_links_externally": {
+          "name": "open_links_externally",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_collections_in_magazine": {
+          "name": "open_collections_in_magazine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reading_typography": {
+          "name": "reading_typography",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_reading_history": {
+          "name": "track_reading_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count_old_posts_as_unread": {
+          "name": "count_old_posts_as_unread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_publication_theme": {
+          "name": "use_publication_theme",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hide_feed_metrics": {
+          "name": "hide_feed_metrics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feed_pagination": {
+          "name": "feed_pagination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_scope": {
+          "name": "home_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_hidden_tabs": {
+          "name": "profile_hidden_tabs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_show_likes": {
+          "name": "profile_show_likes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_authoring_enabled": {
+          "name": "collections_authoring_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userinput_feedback_enabled": {
+          "name": "userinput_feedback_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "margin_save_enabled": {
+          "name": "margin_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semble_save_enabled": {
+          "name": "semble_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "atstore_review_prompt_dismissed": {
+          "name": "atstore_review_prompt_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_enabled": {
+          "name": "weekly_digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_subscriptions": {
+          "name": "weekly_digest_section_subscriptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_network": {
+          "name": "weekly_digest_section_network",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_saved": {
+          "name": "weekly_digest_section_saved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_recommendations": {
+          "name": "weekly_digest_section_recommendations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_last_sent_at": {
+          "name": "weekly_digest_last_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_welcome_sent_at": {
+          "name": "weekly_digest_welcome_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_labelers_imported_at": {
+          "name": "bsky_labelers_imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_did_unique": {
+          "name": "user_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "did"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pds": {
+          "name": "pds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_url": {
+          "name": "banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_uri": {
+          "name": "bsky_profile_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_cid": {
+          "name": "bsky_profile_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_fetched_at": {
+          "name": "profile_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_handle_idx": {
+          "name": "profiles_handle_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_handle_trgm_idx": {
+          "name": "profiles_handle_trgm_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "profiles_display_name_trgm_idx": {
+          "name": "profiles_display_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publications": {
+      "name": "publications",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_cid": {
+          "name": "icon_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_mime": {
+          "name": "icon_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent": {
+          "name": "theme_accent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_background": {
+          "name": "theme_background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_foreground": {
+          "name": "theme_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent_foreground": {
+          "name": "theme_accent_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_json": {
+          "name": "theme_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_in_discover": {
+          "name": "show_in_discover",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "prev_next_direction": {
+          "name": "prev_next_direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_kind": {
+          "name": "serial_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_publication": {
+          "name": "collections_publication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_checked_at": {
+          "name": "verification_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(name, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(topic, '')), 'B')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publications_did_idx": {
+          "name": "publications_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_name_idx": {
+          "name": "publications_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_discover_idx": {
+          "name": "publications_discover_idx",
+          "columns": [
+            {
+              "expression": "show_in_discover",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_topic_idx": {
+          "name": "publications_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_url_idx": {
+          "name": "publications_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_serial_idx": {
+          "name": "publications_serial_idx",
+          "columns": [
+            {
+              "expression": "prev_next_direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_search_idx": {
+          "name": "publications_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_contributors": {
+      "name": "document_contributors",
+      "schema": "",
+      "columns": {
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "document_contributors_did_idx": {
+          "name": "document_contributors_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_contributors_document_uri_documents_uri_fk": {
+          "name": "document_contributors_document_uri_documents_uri_fk",
+          "tableFrom": "document_contributors",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_contributors_document_uri_did_pk": {
+          "name": "document_contributors_document_uri_did_pk",
+          "columns": [
+            "document_uri",
+            "did"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_uri": {
+          "name": "site_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_json": {
+          "name": "collection_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_renderable_body": {
+          "name": "has_renderable_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "body_image_count": {
+          "name": "body_image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_cid": {
+          "name": "cover_image_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_mime": {
+          "name": "cover_image_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backlink_count": {
+          "name": "backlink_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_count_prev": {
+          "name": "backlink_count_prev",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_synced_at": {
+          "name": "backlink_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_recomputed_at": {
+          "name": "trending_recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_recommender_count": {
+          "name": "distinct_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bsky_post_uri": {
+          "name": "bsky_post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_post_cid": {
+          "name": "bsky_post_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_updated_at": {
+          "name": "record_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(title, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(immutable_array_to_string(tags), '')), 'B') || setweight(to_tsvector('english', coalesce(text_content, '')), 'C')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documents_did_idx": {
+          "name": "documents_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_did_published_idx": {
+          "name": "documents_did_published_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"published_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_publication_published_idx": {
+          "name": "documents_publication_published_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_published_idx": {
+          "name": "documents_published_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_featured_idx": {
+          "name": "documents_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_site_idx": {
+          "name": "documents_site_idx",
+          "columns": [
+            {
+              "expression": "site_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_search_idx": {
+          "name": "documents_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "documents_trending_idx": {
+          "name": "documents_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_idx": {
+          "name": "documents_canonical_url_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_trgm_idx": {
+          "name": "documents_canonical_url_trgm_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommends": {
+      "name": "recommends",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommender_did": {
+          "name": "recommender_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recommends_document_idx": {
+          "name": "recommends_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_recommender_idx": {
+          "name": "recommends_recommender_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_edge_idx": {
+          "name": "recommends_edge_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_doc_recommender_created_idx": {
+          "name": "recommends_doc_recommender_created_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recommends\".\"deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_did": {
+          "name": "publication_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_publication_idx": {
+          "name": "subscriptions_publication_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_subscriber_idx": {
+          "name": "subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_edge_idx": {
+          "name": "subscriptions_edge_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follower_did": {
+          "name": "follower_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excluded_publications": {
+          "name": "excluded_publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_subject_idx": {
+          "name": "user_follows_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_edge_idx": {
+          "name": "user_follows_edge_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_owner_idx": {
+          "name": "bookmarks_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_document_idx": {
+          "name": "bookmarks_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_edge_idx": {
+          "name": "bookmarks_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reads": {
+      "name": "reads",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reads_owner_idx": {
+          "name": "reads_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_document_idx": {
+          "name": "reads_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_edge_idx": {
+          "name": "reads_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidebar_prefs": {
+      "name": "sidebar_prefs",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_order": {
+          "name": "list_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "tree_order": {
+          "name": "tree_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "subscription_sort": {
+          "name": "subscription_sort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customize_nav": {
+          "name": "customize_nav",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_nav": {
+          "name": "hidden_nav",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_saves": {
+      "name": "list_saves",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saver_did": {
+          "name": "saver_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_owner_did": {
+          "name": "list_owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "list_saves_saver_idx": {
+          "name": "list_saves_saver_idx",
+          "columns": [
+            {
+              "expression": "saver_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "list_saves_list_uri_idx": {
+          "name": "list_saves_list_uri_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lists": {
+      "name": "lists",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publications": {
+          "name": "publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "users": {
+          "name": "users",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lists_owner_idx": {
+          "name": "lists_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rkey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_corecommends": {
+      "name": "publication_corecommends",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_recommender_count": {
+          "name": "co_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_corecomm_rank_idx": {
+          "name": "publication_corecomm_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_corecommends_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_corecommends_related_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_corecommends_publication_uri_related_publication_uri_pk": {
+          "name": "publication_corecommends_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_cosubscriptions": {
+      "name": "publication_cosubscriptions",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_subscriber_count": {
+          "name": "co_subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_cosub_rank_idx": {
+          "name": "publication_cosub_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_cosubscriptions_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_cosubscriptions_related_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_cosubscriptions_publication_uri_related_publication_uri_pk": {
+          "name": "publication_cosubscriptions_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_stats": {
+      "name": "publication_stats",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommend_count": {
+          "name": "recommend_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_document_at": {
+          "name": "last_document_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documents_7d": {
+          "name": "documents_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_7d": {
+          "name": "subscribers_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_7d": {
+          "name": "recommends_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "documents_prev_7d": {
+          "name": "documents_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_prev_7d": {
+          "name": "subscribers_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_prev_7d": {
+          "name": "recommends_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlinks_7d": {
+          "name": "backlinks_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_velocity": {
+          "name": "trending_velocity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_window_start": {
+          "name": "trending_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_stats_subscribers_idx": {
+          "name": "publication_stats_subscribers_idx",
+          "columns": [
+            {
+              "expression": "subscriber_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_active_idx": {
+          "name": "publication_stats_active_idx",
+          "columns": [
+            {
+              "expression": "last_document_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_trending_idx": {
+          "name": "publication_stats_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_stats_publication_uri_publications_uri_fk": {
+          "name": "publication_stats_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_stats",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_stats": {
+      "name": "network_stats",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discover_topic_counts": {
+      "name": "discover_topic_counts",
+      "schema": "",
+      "columns": {
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discover_topic_counts_count_idx": {
+          "name": "discover_topic_counts_count_idx",
+          "columns": [
+            {
+              "expression": "publication_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discover_topic_counts_topic_trgm_idx": {
+          "name": "discover_topic_counts_topic_trgm_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag_embeddings": {
+      "name": "tag_embeddings",
+      "schema": "",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "double precision[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_publications": {
+      "name": "topic_publications",
+      "schema": "",
+      "columns": {
+        "topic_slug": {
+          "name": "topic_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "matched_tag_count": {
+          "name": "matched_tag_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "topic_publications_rank_idx": {
+          "name": "topic_publications_rank_idx",
+          "columns": [
+            {
+              "expression": "topic_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_publications_pub_idx": {
+          "name": "topic_publications_pub_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_publications_topic_slug_topics_slug_fk": {
+          "name": "topic_publications_topic_slug_topics_slug_fk",
+          "tableFrom": "topic_publications",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "topic_publications_publication_uri_publications_uri_fk": {
+          "name": "topic_publications_publication_uri_publications_uri_fk",
+          "tableFrom": "topic_publications",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_publications_topic_slug_publication_uri_pk": {
+          "name": "topic_publications_topic_slug_publication_uri_pk",
+          "columns": [
+            "topic_slug",
+            "publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_tags": {
+      "name": "topic_tags",
+      "schema": "",
+      "columns": {
+        "topic_slug": {
+          "name": "topic_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "topic_tags_tag_idx": {
+          "name": "topic_tags_tag_idx",
+          "columns": [
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_tags_weight_idx": {
+          "name": "topic_tags_weight_idx",
+          "columns": [
+            {
+              "expression": "topic_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weight",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_tags_topic_slug_topics_slug_fk": {
+          "name": "topic_tags_topic_slug_topics_slug_fk",
+          "tableFrom": "topic_tags",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_tags_topic_slug_tag_pk": {
+          "name": "topic_tags_topic_slug_tag_pk",
+          "columns": [
+            "topic_slug",
+            "tag"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_tags": {
+          "name": "signature_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_count": {
+          "name": "tag_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author_count": {
+          "name": "author_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name_model": {
+          "name": "name_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "named_at": {
+          "name": "named_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topics_published_score_idx": {
+          "name": "topics_published_score_idx",
+          "columns": [
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_dead_letter": {
+      "name": "ingest_dead_letter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retries": {
+          "name": "retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingest_dead_letter_collection_idx": {
+          "name": "ingest_dead_letter_collection_idx",
+          "columns": [
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_state": {
+      "name": "ingest_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_processed": {
+          "name": "events_processed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_repos": {
+      "name": "tracked_repos",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_to_tap_at": {
+          "name": "added_to_tap_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_state": {
+          "name": "backfill_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_seen_rev": {
+          "name": "last_seen_rev",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_fail_count": {
+          "name": "reconcile_fail_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconcile_retry_after": {
+          "name": "reconcile_retry_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tracked_repos_state_idx": {
+          "name": "tracked_repos_state_idx",
+          "columns": [
+            {
+              "expression": "backfill_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_labels": {
+      "name": "document_labels",
+      "schema": "",
+      "columns": {
+        "src": {
+          "name": "src",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "val": {
+          "name": "val",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cts": {
+          "name": "cts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_labels_uri_idx": {
+          "name": "document_labels_uri_idx",
+          "columns": [
+            {
+              "expression": "uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_labels_src_idx": {
+          "name": "document_labels_src_idx",
+          "columns": [
+            {
+              "expression": "src",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "document_labels_src_uri_val_pk": {
+          "name": "document_labels_src_uri_val_pk",
+          "columns": [
+            "src",
+            "uri",
+            "val"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_sync_state": {
+      "name": "label_sync_state",
+      "schema": "",
+      "columns": {
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_count": {
+          "name": "stored_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rejected_count": {
+          "name": "rejected_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_services": {
+      "name": "labeler_services",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_endpoint": {
+          "name": "service_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels_standard_site": {
+          "name": "labels_standard_site",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels_probed_at": {
+          "name": "labels_probed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reachable": {
+          "name": "reachable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_value_definitions": {
+          "name": "label_value_definitions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_services_labeler_idx": {
+          "name": "labeler_services_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_subscriptions": {
+      "name": "labeler_subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefs": {
+          "name": "prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_subscriptions_subscriber_idx": {
+          "name": "labeler_subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labeler_subscriptions_labeler_idx": {
+          "name": "labeler_subscriptions_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_auth_code": {
+      "name": "mcp_auth_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_auth_code_expires_at_idx": {
+          "name": "mcp_auth_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_auth_code_client_id_mcp_client_id_fk": {
+          "name": "mcp_auth_code_client_id_mcp_client_id_fk",
+          "tableFrom": "mcp_auth_code",
+          "tableTo": "mcp_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_auth_code_user_id_user_id_fk": {
+          "name": "mcp_auth_code_user_id_user_id_fk",
+          "tableFrom": "mcp_auth_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_client": {
+      "name": "mcp_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_uri": {
+          "name": "client_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_uri": {
+          "name": "logo_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_token": {
+      "name": "mcp_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_token_user_id_idx": {
+          "name": "mcp_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_expires_at_idx": {
+          "name": "mcp_token_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_client_id_mcp_client_id_fk": {
+          "name": "mcp_token_client_id_mcp_client_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "mcp_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_user_id_user_id_fk": {
+          "name": "mcp_token_user_id_user_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_token_access_token_hash_unique": {
+          "name": "mcp_token_access_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token_hash"
+          ]
+        },
+        "mcp_token_refresh_token_hash_unique": {
+          "name": "mcp_token_refresh_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_shares": {
+      "name": "quote_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_text": {
+          "name": "quote_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quote_shares_document_uri_idx": {
+          "name": "quote_shares_document_uri_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_draft": {
+      "name": "feedback_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feedback_draft_user_idx": {
+          "name": "feedback_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_draft_expires_idx": {
+          "name": "feedback_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_draft_user_id_user_id_fk": {
+          "name": "feedback_draft_user_id_user_id_fk",
+          "tableFrom": "feedback_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upvote_draft": {
+      "name": "upvote_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "upvote_draft_user_idx": {
+          "name": "upvote_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upvote_draft_expires_idx": {
+          "name": "upvote_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upvote_draft_user_id_user_id_fk": {
+          "name": "upvote_draft_user_id_user_id_fk",
+          "tableFrom": "upvote_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.save_draft": {
+      "name": "save_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_app": {
+          "name": "target_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_uri": {
+          "name": "collection_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_cid": {
+          "name": "collection_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_collection_name": {
+          "name": "new_collection_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motivation": {
+          "name": "motivation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passage": {
+          "name": "passage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "save_draft_user_idx": {
+          "name": "save_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "save_draft_expires_idx": {
+          "name": "save_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "save_draft_user_id_user_id_fk": {
+          "name": "save_draft_user_id_user_id_fk",
+          "tableFrom": "save_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/standard-reader/drizzle/meta/0032_snapshot.json
+++ b/apps/standard-reader/drizzle/meta/0032_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "97b01f54-0272-4b30-9b59-c849a02d9bdd",
+  "id": "3d5ba137-4765-4e0a-957b-d9246c30d8d2",
   "prevId": "7e046621-a7f4-4488-9114-3297daffa82b",
   "version": "7",
   "dialect": "postgresql",
@@ -3271,6 +3271,12 @@
           "notNull": true,
           "default": false
         },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "name_model": {
           "name": "name_model",
           "type": "text",
@@ -3321,7 +3327,21 @@
           "with": {}
         }
       },
-      "foreignKeys": {},
+      "foreignKeys": {
+        "topics_superseded_by_topics_slug_fk": {
+          "name": "topics_superseded_by_topics_slug_fk",
+          "tableFrom": "topics",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "superseded_by"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},

--- a/apps/standard-reader/drizzle/meta/_journal.json
+++ b/apps/standard-reader/drizzle/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1785540601952,
       "tag": "0031_last_the_hunter",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1785605558412,
+      "tag": "0032_topics",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/standard-reader/drizzle/meta/_journal.json
+++ b/apps/standard-reader/drizzle/meta/_journal.json
@@ -229,7 +229,7 @@
     {
       "idx": 32,
       "version": "7",
-      "when": 1785605558412,
+      "when": 1785607674037,
       "tag": "0032_topics",
       "breakpoints": true
     }

--- a/apps/standard-reader/package.json
+++ b/apps/standard-reader/package.json
@@ -23,6 +23,8 @@
     "ingest:start": "tsx --require @opentelemetry/auto-instrumentations-node/register src/server/ingest/service.ts",
     "reconcile:repos": "tsx --require @opentelemetry/auto-instrumentations-node/register scripts/reconcile-repos-cron.ts",
     "reconcile:repos:dev": "tsx --env-file=.env scripts/reconcile-repos-cron.ts",
+    "topics:cron": "tsx --require @opentelemetry/auto-instrumentations-node/register scripts/topics-cron.ts",
+    "topics:cron:dev": "tsx --env-file=.env scripts/topics-cron.ts",
     "digest:send": "tsx scripts/send-weekly-digest.ts",
     "digest:send:dev": "tsx --env-file=.env scripts/send-weekly-digest.ts",
     "thread:post": "tsx scripts/post-weekly-thread.ts",

--- a/apps/standard-reader/package.json
+++ b/apps/standard-reader/package.json
@@ -14,8 +14,8 @@
     "perf:discover-fixtures": "pnpm exec tsx --env-file=.env scripts/perf-discover-fixtures.ts",
     "api-docs:examples": "pnpm exec tsx --env-file=.env scripts/run-api-docs-examples.ts",
     "perf:test": "playwright test",
-    "perf:test:guest": "playwright test --grep \"load regression \u2014 guest\"",
-    "perf:test:signed-in": "playwright test --grep \"load regression \u2014 signed in\"",
+    "perf:test:guest": "playwright test --grep \"load regression — guest\"",
+    "perf:test:signed-in": "playwright test --grep \"load regression — signed in\"",
     "perf:view": "node scripts/perf-view.mjs",
     "guide:shots": "playwright test --config=screenshots.config.ts",
     "perf:explain": "FEED_PERF_TEST=1 vitest run src/server/reader/queries.explain.test.ts",
@@ -36,6 +36,8 @@
     "backfill:lists": "pnpm exec tsx --env-file=.env scripts/backfill-lists.ts",
     "backfill:bot-flags": "pnpm exec tsx --env-file=.env scripts/backfill-bot-flags.ts",
     "backfill:serial": "pnpm exec tsx --env-file=.env scripts/backfill-serial-publications.ts",
+    "topics:derive": "pnpm exec tsx --env-file=.env scripts/derive-topics.ts",
+    "topics:recompute": "pnpm exec tsx --env-file=.env scripts/recompute-topics.ts",
     "scan:unsupported-blocks": "pnpm exec tsx --env-file=.env scripts/scan-unsupported-blocks.ts",
     "scan:discussion-sources": "pnpm exec tsx --env-file=.env scripts/scan-discussion-sources.ts",
     "scan:comics": "pnpm exec tsx --env-file=.env scripts/scan-comic-publications.ts",
@@ -75,6 +77,7 @@
     "fonts:generate": "node scripts/generate-font-fallbacks.mjs"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.115.0",
     "@atcute/atproto": "^4.0.3",
     "@atcute/client": "^5.1.1",
     "@atcute/identity-resolver": "^2.0.1",

--- a/apps/standard-reader/scripts/derive-topics.ts
+++ b/apps/standard-reader/scripts/derive-topics.ts
@@ -1,0 +1,72 @@
+/* eslint-disable no-console -- this script's whole output is its console report */
+/**
+ * Inspect the topic derivation without writing anything.
+ *
+ * Runs the clustering and the quality bar against the live read-model and
+ * prints what *would* be published, so the bar can be tuned against real data
+ * (and regressions like a single-operator publication fleet forming the biggest
+ * "topic" can be spotted) before the sweep persists anything.
+ *
+ * Read-only: naming and persistence are skipped entirely, so this makes no API
+ * calls and no writes.
+ *
+ *   pnpm topics:derive           # published topics only
+ *   pnpm topics:derive --all     # include the clusters that missed the bar
+ */
+import { deriveTopics } from "../src/server/ingest/recompute-topics.ts";
+
+const showAll = process.argv.includes("--all");
+
+const started = Date.now();
+const derivation = await deriveTopics();
+const elapsed = Date.now() - started;
+
+const published = derivation.candidates.filter(
+  (candidate) => candidate.published,
+);
+const rejected = derivation.candidates.filter(
+  (candidate) => !candidate.published,
+);
+
+console.log(
+  [
+    `graph      ${derivation.tags} tags, ${derivation.edges} edges`,
+    `clusters   ${derivation.clusters} total`,
+    `dropped    ${derivation.droppedByTags} too few tags, ` +
+      `${derivation.droppedByPublications} too few publications, ` +
+      `${derivation.droppedByAuthors} too few authors, ` +
+      `${derivation.droppedByConcentration} one-operator fleets`,
+    `published  ${published.length}`,
+    `elapsed    ${(elapsed / 1000).toFixed(1)}s`,
+  ].join("\n"),
+);
+
+function describe(candidate: (typeof derivation.candidates)[number]): string {
+  const head = candidate.signature.slice(0, 10).join(", ");
+  const share = `${Math.round(candidate.topAuthorShare * 100)}% top author`;
+  return (
+    `\n[${candidate.tags.length} tags · ${candidate.publications.length} pubs · ` +
+    `${candidate.authorCount} authors · ${share} · ${candidate.documentCount} docs]\n  ${head}`
+  );
+}
+
+console.log("\n=== published ===");
+for (const candidate of [...published].toSorted(
+  (a, b) => b.authorCount - a.authorCount,
+)) {
+  console.log(describe(candidate));
+}
+
+if (showAll) {
+  console.log("\n=== rejected: too few publications or authors ===");
+  for (const candidate of rejected) console.log(describe(candidate));
+
+  console.log("\n=== rejected: too few tags ===");
+  for (const tags of derivation.belowTagBar) {
+    console.log(`\n[${tags.length} tags]\n  ${tags.slice(0, 10).join(", ")}`);
+  }
+}
+
+// eslint-disable-next-line unicorn/no-process-exit
+process.exit(0);
+/* eslint-enable no-console */

--- a/apps/standard-reader/scripts/recompute-topics.ts
+++ b/apps/standard-reader/scripts/recompute-topics.ts
@@ -1,0 +1,24 @@
+/* eslint-disable no-console -- this script's whole output is its console report */
+/**
+ * Run the topic derivation pass on its own and persist the result.
+ *
+ * The same pass the hourly sweep runs (`recomputeDerived`), exposed separately
+ * so it can be triggered and inspected without waiting for a sweep — useful
+ * right after a deploy that changes the clustering, and for checking that a
+ * second run leaves slugs alone.
+ *
+ *   pnpm topics:recompute
+ *
+ * Writes. For a read-only look at what would be published, use
+ * `pnpm topics:derive`.
+ */
+import { recomputeTopics } from "../src/server/ingest/recompute-topics.ts";
+
+const started = Date.now();
+const summary = await recomputeTopics();
+
+console.log({ ...summary, elapsedMs: Date.now() - started });
+
+// eslint-disable-next-line unicorn/no-process-exit
+process.exit(0);
+/* eslint-enable no-console */

--- a/apps/standard-reader/scripts/topics-cron.ts
+++ b/apps/standard-reader/scripts/topics-cron.ts
@@ -1,0 +1,52 @@
+/**
+ * Topic derivation — the daily rebuild of `/topics`.
+ *
+ * **Why this is its own process.** Derivation used to sit inside the hourly
+ * recompute sweep, which was the wrong home twice over. It is minutes of work
+ * — clustering the whole tag graph, embedding tag contexts, and calling the
+ * naming model — so running it hourly put a long, bursty job in front of the
+ * aggregate refresh that feeds every article card. And it is work whose output
+ * barely moves: the tag graph is built from the whole corpus, so an hour of new
+ * documents shifts almost no edge weights and re-derives the same clusters.
+ *
+ * Daily is the natural cadence. Nothing downstream needs topics to be fresher
+ * than that, and the sweep's own caching means a run that finds no drift makes
+ * no naming calls at all.
+ *
+ * Reads `discover_topic_counts` for its vocabulary, which the hourly sweep
+ * rebuilds — so this only needs the counts to exist, not to have just run.
+ *
+ * Env:
+ *   ANTHROPIC_API_KEY       enables naming; without it clusters fall back to a
+ *                           deterministic name and the next run retries
+ *   TOPIC_NAMING_MODEL      naming model (default `claude-opus-5`)
+ *   TOPIC_EMBEDDINGS        `1` to add semantic edges from tag context
+ *   TOPIC_EMBEDDING_MODEL   embedding model (default `Xenova/all-MiniLM-L6-v2`)
+ */
+
+import { recomputeTopics } from "../src/server/ingest/recompute-topics.ts";
+import { logEvent } from "../src/server/observability/log.ts";
+
+const startedAt = Date.now();
+
+try {
+  const summary = await recomputeTopics();
+  const durationMs = Date.now() - startedAt;
+
+  logEvent("topics.cron", { durationMs, ...summary });
+  console.info(
+    `[topics-cron] ${summary.published} published from ${summary.clusters} clusters ` +
+      `(${summary.tags} tags, ${summary.edges} edges, ${summary.semanticEdges} semantic), ` +
+      `${summary.named} named, in ${Math.round(durationMs / 1000)}s`,
+  );
+} catch (error) {
+  // Topics are a discovery surface, not core data: the previously published
+  // set stays live and tomorrow's run retries. Exit non-zero so the failure is
+  // visible in Railway rather than silently skipped.
+  logEvent("topics.cron.failed", {
+    durationMs: Date.now() - startedAt,
+    error: error instanceof Error ? error.message : String(error),
+  });
+  console.error("[topics-cron] derivation failed:", error);
+  process.exitCode = 1;
+}

--- a/apps/standard-reader/src/components/reader/pub-grid-list.tsx
+++ b/apps/standard-reader/src/components/reader/pub-grid-list.tsx
@@ -14,18 +14,103 @@ import { PubCard, PubDirectoryRow } from "./cards";
 import { publicationLinkParams } from "./format";
 
 /**
- * A publication section rendered as a react-aria `GridList`: the whole section
- * is a single tab stop, arrow keys move between publications, and Tab within a
- * focused item reaches its Follow button. Each item is a real, client-routed
- * link (via the react-aria `RouterProvider` bridged to TanStack Router below),
- * so cmd/ctrl-click still opens in a new tab.
+ * A section of entities rendered as a react-aria `GridList`: the whole section
+ * is a single tab stop, arrow keys move between items, and Tab within a
+ * focused item reaches its own controls (e.g. a Follow button). Each item is a
+ * real, client-routed link (via the react-aria `RouterProvider` bridged to
+ * TanStack Router below), so cmd/ctrl-click still opens in a new tab.
+ *
+ * {@link EntityGridList} is the shell — keyboard behaviour, focus scrolling,
+ * routing, and the rail/grid/list layouts. {@link PubGridList} and
+ * {@link TopicGridList} supply what differs: how an item resolves to a
+ * link, and what to render inside.
  *
  * Deliberately local to the reader (not a design-system primitive) until the
  * pattern proves out across more surfaces.
  */
 
-type Layout = "rail" | "grid" | "list";
-type Variant = "card" | "row";
+export type GridListLayout = "rail" | "grid" | "list";
+export type GridListVariant = "card" | "row";
+
+type Layout = GridListLayout;
+type Variant = GridListVariant;
+
+/** How one item identifies and links itself. */
+export interface GridListEntity {
+  /** Stable key + react-aria item id. */
+  key: string;
+  /** Accessible label used for typeahead. */
+  label: string;
+  href?: string;
+  /** Opens in a new tab (an off-site publication URL). */
+  external?: boolean;
+}
+
+export function EntityGridList<T>({
+  items,
+  describe,
+  renderItem,
+  layout,
+  variant,
+  "aria-label": ariaLabel,
+}: {
+  items: Array<T>;
+  describe: (item: T) => GridListEntity;
+  renderItem: (item: T, index: number) => React.ReactNode;
+  layout: Layout;
+  variant: Variant;
+  "aria-label": string;
+}) {
+  const navigate = useNavigate();
+
+  const routerNavigate = useCallback(
+    (to: string, options?: { replace?: boolean }) => {
+      void navigate({ to, replace: options?.replace });
+    },
+    [navigate],
+  );
+
+  return (
+    <RouterProvider navigate={routerNavigate}>
+      <div
+        {...stylex.props(styles.focusScope)}
+        onFocusCapture={scrollFocusedIntoView}
+      >
+        <GridList
+          aria-label={ariaLabel}
+          layout={layout === "list" ? "stack" : "grid"}
+          selectionMode="none"
+          {...stylex.props(
+            layout === "rail" && styles.rail,
+            layout === "grid" && styles.grid,
+            layout === "list" && styles.list,
+          )}
+        >
+          {items.map((item, index) => {
+            const entity = describe(item);
+            return (
+              <GridListItem
+                key={entity.key}
+                id={entity.key}
+                textValue={entity.label}
+                href={entity.href}
+                target={entity.external ? "_blank" : undefined}
+                rel={entity.external ? "noreferrer" : undefined}
+                {...stylex.props(
+                  styles.item,
+                  variant === "card" ? styles.itemCard : styles.itemRow,
+                  layout === "rail" && styles.railItem,
+                )}
+              >
+                {renderItem(item, index)}
+              </GridListItem>
+            );
+          })}
+        </GridList>
+      </div>
+    </RouterProvider>
+  );
+}
 
 /**
  * Keep a keyboard-focused item within view. react-aria scrolls the item into
@@ -88,64 +173,36 @@ export function PubGridList({
   showRank?: boolean;
   "aria-label": string;
 }) {
-  const navigate = useNavigate();
   const target = usePubTarget();
 
-  const routerNavigate = useCallback(
-    (to: string, options?: { replace?: boolean }) => {
-      void navigate({ to, replace: options?.replace });
-    },
-    [navigate],
-  );
-
   return (
-    <RouterProvider navigate={routerNavigate}>
-      <div
-        {...stylex.props(styles.focusScope)}
-        onFocusCapture={scrollFocusedIntoView}
-      >
-        <GridList
-          aria-label={ariaLabel}
-          layout={layout === "list" ? "stack" : "grid"}
-          selectionMode="none"
-          {...stylex.props(
-            layout === "rail" && styles.rail,
-            layout === "grid" && styles.grid,
-            layout === "list" && styles.list,
-          )}
-        >
-          {pubs.map((pub, index) => {
-            const t = target(pub);
-            return (
-              <GridListItem
-                key={pub.uri}
-                id={pub.uri}
-                textValue={pub.name}
-                href={t?.href}
-                target={t?.external ? "_blank" : undefined}
-                rel={t?.external ? "noreferrer" : undefined}
-                {...stylex.props(
-                  styles.item,
-                  variant === "card" ? styles.itemCard : styles.itemRow,
-                  layout === "rail" && styles.railItem,
-                )}
-              >
-                {variant === "card" ? (
-                  <PubCard pub={pub} rail={layout === "rail"} noLink />
-                ) : (
-                  <PubDirectoryRow
-                    pub={pub}
-                    noLink
-                    rank={showRank ? index + 1 : undefined}
-                    isLast={index === pubs.length - 1}
-                  />
-                )}
-              </GridListItem>
-            );
-          })}
-        </GridList>
-      </div>
-    </RouterProvider>
+    <EntityGridList
+      items={pubs}
+      layout={layout}
+      variant={variant}
+      aria-label={ariaLabel}
+      describe={(pub) => {
+        const t = target(pub);
+        return {
+          key: pub.uri,
+          label: pub.name,
+          href: t?.href,
+          external: t?.external,
+        };
+      }}
+      renderItem={(pub, index) =>
+        variant === "card" ? (
+          <PubCard pub={pub} rail={layout === "rail"} noLink />
+        ) : (
+          <PubDirectoryRow
+            pub={pub}
+            noLink
+            rank={showRank ? index + 1 : undefined}
+            isLast={index === pubs.length - 1}
+          />
+        )
+      }
+    />
   );
 }
 

--- a/apps/standard-reader/src/components/reader/topic-cards.tsx
+++ b/apps/standard-reader/src/components/reader/topic-cards.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import { Plural } from "@lingui/react/macro";
+import { Flex } from "@standard-reader/design-system/flex";
+import { Skeleton } from "@standard-reader/design-system/skeleton";
+import { animationDuration } from "@standard-reader/design-system/theme/animations.stylex";
+import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
+import { radius } from "@standard-reader/design-system/theme/radius.stylex";
+import { shadow } from "@standard-reader/design-system/theme/shadow.stylex";
+import { spacing } from "@standard-reader/design-system/theme/spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+  tracking,
+} from "@standard-reader/design-system/theme/typography.stylex";
+import * as stylex from "@stylexjs/stylex";
+import { useRouter } from "@tanstack/react-router";
+
+import type { TopicCard as TopicCardData } from "#/server/reader/topics";
+
+import { MetaGroup, MetaLine, MetaText, PublicationAvatar } from "./primitives";
+import { EntityGridList } from "./pub-grid-list";
+import type { GridListLayout } from "./pub-grid-list";
+
+/**
+ * Cards for auto-derived topics.
+ *
+ * Visually the publication card's sibling (same border, hover lift, serif
+ * title) so Discover reads as one system. The difference is the anchor: a
+ * publication leads with its own icon, and a topic — which has no image of
+ * its own — leads with a stack of its members'. That is the card's focal point
+ * and its most useful fact at a glance; without it the card was a wall of text
+ * sitting next to rails that all had one.
+ *
+ * Tags are a *sample*, not the set. The index carries 24 per topic so that
+ * search can match them, but rendering 24 pills buried the name and the
+ * description under a grid of chips; {@link CARD_TAGS} shows the few that
+ * characterize it and the topic page shows the rest.
+ */
+
+/** Sub-area tags shown on a card, whatever the caller loaded. */
+const CARD_TAGS = 4;
+
+function TopicAvatars({ topic }: { topic: TopicCardData }) {
+  if (topic.avatars.length === 0) return null;
+
+  return (
+    // Overlapped so it reads as a group rather than a row of unrelated icons —
+    // the same treatment the "people you follow" prompt uses on Discover.
+    <div {...stylex.props(styles.avatars)} aria-hidden>
+      {topic.avatars.map((member, index) => (
+        <PublicationAvatar
+          key={`${member.name}-${index}`}
+          pub={{
+            name: member.name,
+            iconUrl: member.iconUrl,
+            ownerAvatarUrl: member.ownerAvatarUrl,
+          }}
+          size="md"
+          style={styles.avatar}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function TopicCard({
+  topic,
+  rail = false,
+}: {
+  topic: TopicCardData;
+  rail?: boolean;
+}) {
+  const tags = topic.tags.slice(0, CARD_TAGS);
+
+  return (
+    <div {...stylex.props(styles.card, rail && styles.cardRail)}>
+      <TopicAvatars topic={topic} />
+      <span {...stylex.props(styles.name)}>{topic.name}</span>
+      {topic.description ? (
+        <p dir="auto" {...stylex.props(styles.description)}>
+          {topic.description}
+        </p>
+      ) : (
+        <div aria-hidden {...stylex.props(styles.grow)} />
+      )}
+
+      {tags.length > 0 ? (
+        <Flex gap="xs" wrap style={styles.tags}>
+          {tags.map((tag) => (
+            // Plain text, not links: the whole card is already one press
+            // target, and the topic page is where sub-areas become
+            // navigable. `dir="auto"` because tags are author-supplied.
+            <span key={tag} dir="auto" {...stylex.props(styles.tag)}>
+              {tag}
+            </span>
+          ))}
+        </Flex>
+      ) : null}
+
+      <div {...stylex.props(styles.footWrap)}>
+        <div {...stylex.props(styles.foot)}>
+          <MetaLine>
+            <MetaGroup>
+              <MetaText>
+                <Plural
+                  value={topic.publicationCount}
+                  one="# publication"
+                  other="# publications"
+                />
+              </MetaText>
+            </MetaGroup>
+            <MetaGroup>
+              <MetaText>
+                <Plural
+                  value={topic.authorCount}
+                  one="# writer"
+                  other="# writers"
+                />
+              </MetaText>
+            </MetaGroup>
+          </MetaLine>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function TopicCardSkeleton({ rail = false }: { rail?: boolean }) {
+  return (
+    <div
+      aria-hidden
+      {...stylex.props(styles.card, rail && styles.cardRail, styles.skeleton)}
+    >
+      <div {...stylex.props(styles.avatars)}>
+        {Array.from({ length: 4 }, (_, index) => (
+          <Skeleton
+            key={index}
+            variant="circle"
+            size="sm"
+            style={styles.avatar}
+          />
+        ))}
+      </div>
+      <Skeleton variant="rectangle" height={spacing["6"]} width="70%" />
+      <Skeleton variant="rectangle" height={spacing["5"]} width="100%" />
+      <Skeleton variant="rectangle" height={spacing["5"]} width="85%" />
+      <Flex gap="xs" wrap style={styles.tags}>
+        {Array.from({ length: 4 }, (_, index) => (
+          <Skeleton
+            key={index}
+            variant="rectangle"
+            height={spacing["4"]}
+            width={spacing["12"]}
+          />
+        ))}
+      </Flex>
+      <div {...stylex.props(styles.footWrap)}>
+        <div {...stylex.props(styles.foot)}>
+          <Skeleton variant="rectangle" height={spacing["4"]} width="60%" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Topics as a keyboard-navigable, client-routed rail or grid. */
+export function TopicGridList({
+  topics,
+  layout,
+  "aria-label": ariaLabel,
+}: {
+  topics: Array<TopicCardData>;
+  layout: GridListLayout;
+  "aria-label": string;
+}) {
+  const router = useRouter();
+
+  return (
+    <EntityGridList
+      items={topics}
+      layout={layout}
+      variant="card"
+      aria-label={ariaLabel}
+      describe={(topic) => ({
+        key: topic.slug,
+        label: topic.name,
+        href: router.buildLocation({
+          to: "/topics/$slug",
+          params: { slug: topic.slug },
+        }).href,
+      })}
+      renderItem={(topic) => (
+        <TopicCard topic={topic} rail={layout === "rail"} />
+      )}
+    />
+  );
+}
+
+const styles = stylex.create({
+  card: {
+    borderColor: {
+      default: uiColor.border1,
+      ":hover": uiColor.border2,
+    },
+    borderRadius: radius.md,
+    borderStyle: "solid",
+    borderWidth: 1,
+    backgroundColor: uiColor.bgSubtle,
+    boxShadow: {
+      default: null,
+      ":hover": shadow.sm,
+    },
+    boxSizing: "border-box",
+    display: "flex",
+    flexDirection: "column",
+    paddingInlineEnd: spacing["5"],
+    paddingInlineStart: spacing["5"],
+    scrollSnapAlign: "start",
+    transform: {
+      default: null,
+      ":hover": "translateY(-2px)",
+    },
+    transitionDuration: animationDuration.fast,
+    transitionProperty: {
+      default: "border-color, box-shadow, transform",
+      "@media (prefers-reduced-motion: reduce)": "none",
+    },
+    height: "100%",
+    paddingBottom: spacing["5"],
+    paddingTop: spacing["5"],
+  },
+  cardRail: {
+    alignSelf: "stretch",
+    width: {
+      default: "260px",
+      "@media (min-width: 40rem)": "300px",
+    },
+  },
+  name: {
+    color: uiColor.text2,
+    fontFamily: fontFamily.serif,
+    fontSize: fontSize.xl,
+    fontWeight: fontWeight.semibold,
+    letterSpacing: tracking.tight,
+    lineHeight: lineHeight.sm,
+    // Single-line NAME/TITLE in a UI row: isolate for ordering, but let
+    // alignment follow the surrounding UI (right under RTL).
+    unicodeBidi: "isolate",
+    marginTop: spacing["0"],
+  },
+  description: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.serif,
+    fontSize: fontSize.base,
+    lineHeight: lineHeight.sm,
+    overflow: "hidden",
+    // eslint-disable-next-line @stylexjs/valid-styles
+    WebkitBoxOrient: "vertical",
+    // eslint-disable-next-line @stylexjs/valid-styles
+    WebkitLineClamp: 2,
+    display: "-webkit-box",
+    marginBottom: spacing["0"],
+    marginTop: spacing["2"],
+  },
+  avatars: {
+    display: "flex",
+    flexShrink: 0,
+    // First avatar on top, so the stack reads left-to-right as a group. The
+    // padding cancels the first child's negative margin.
+    paddingInlineStart: spacing["2"],
+    marginBottom: spacing["3.5"],
+  },
+  avatar: {
+    borderColor: uiColor.bgSubtle,
+    borderStyle: "solid",
+    borderWidth: 2,
+    marginInlineStart: `calc(-1 * ${spacing["2"]})`,
+  },
+  grow: {
+    flexBasis: "0%",
+    flexGrow: 1,
+  },
+  tags: {
+    marginTop: spacing["3.5"],
+  },
+  tag: {
+    borderColor: uiColor.border1,
+    borderRadius: radius.full,
+    borderStyle: "solid",
+    borderWidth: 1,
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.xs,
+    lineHeight: lineHeight.sm,
+    paddingInlineEnd: spacing["2"],
+    paddingInlineStart: spacing["2"],
+    // Single-line tag chip: isolate so bidi text keeps its own ordering
+    // without dragging the chip row's alignment around.
+    unicodeBidi: "isolate",
+    paddingBottom: spacing["0.5"],
+    paddingTop: spacing["0.5"],
+  },
+  footWrap: {
+    flexShrink: 0,
+    marginTop: "auto",
+    paddingTop: spacing["4"],
+    width: "100%",
+  },
+  foot: {
+    borderTopColor: uiColor.border1,
+    borderTopStyle: "solid",
+    borderTopWidth: 1,
+    paddingTop: spacing["3"],
+    width: "100%",
+  },
+  skeleton: {
+    rowGap: spacing["2"],
+  },
+});

--- a/apps/standard-reader/src/db/schema.ts
+++ b/apps/standard-reader/src/db/schema.ts
@@ -21,6 +21,7 @@ export * from "./schema/lists.ts";
 export * from "./schema/stats.ts";
 export * from "./schema/network-stats.ts";
 export * from "./schema/discover-topics.ts";
+export * from "./schema/topics.ts";
 export * from "./schema/ingest.ts";
 export * from "./schema/labels.ts";
 export * from "./schema/mcp.ts";

--- a/apps/standard-reader/src/db/schema/discover-topics.ts
+++ b/apps/standard-reader/src/db/schema/discover-topics.ts
@@ -7,7 +7,7 @@ import { index, integer, pgTable, text } from "drizzle-orm/pg-core";
  * — via an explicit `publications.topic` OR any of the publication's document
  * tags — which is exactly how many a reader reaches by selecting the chip.
  *
- * Rebuilt each sweep by `recomputeTopics()`. Reading from this table keeps the
+ * Rebuilt each sweep by `recomputeTopicCounts()`. Reading from this table keeps the
  * Discover request path off a ~2s network-wide `unnest(tags)` aggregation; the
  * cron already scans every tag to derive per-publication dominant topics, so
  * populating this is near-free marginal work.

--- a/apps/standard-reader/src/db/schema/topics.ts
+++ b/apps/standard-reader/src/db/schema/topics.ts
@@ -1,0 +1,186 @@
+import {
+  boolean,
+  doublePrecision,
+  index,
+  integer,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core";
+
+import { publications } from "./publications.ts";
+
+/**
+ * Auto-derived topic topics (`APP_VISION.md` §5): a cluster of related tags
+ * presented as one browsable area, with its own trending publications and
+ * documents, and its member tags exposed as sub-areas.
+ *
+ * Topics exist because the raw tag vocabulary is both too large (450k+
+ * distinct tags in `discover_topic_counts`) and too skewed to be a navigation
+ * surface — ranking tags by frequency puts the network's atproto-native topics
+ * (`atproto`, `bluesky`, `atmosphere`, …) on top of a page meant to represent
+ * the whole network. Clustering rebalances that: atproto becomes one topic
+ * among many.
+ *
+ * Rebuilt each sweep by `recomputeTopics()`, which clusters the tag
+ * co-occurrence graph and names each cluster. Nothing here is hand-curated.
+ */
+export const topics = pgTable(
+  "topics",
+  {
+    /**
+     * Stable URL identity (`/topics/$slug`). Assigned once, when the
+     * topic first appears, and never changed afterwards — the sweep matches
+     * re-derived clusters back onto existing rows by tag-set overlap so a
+     * topic's URL survives the cluster drifting or being renamed.
+     */
+    slug: text("slug").primaryKey(),
+
+    /** Display name. Authored by the naming model; see `nameModel`. */
+    name: text("name").notNull(),
+    /** One-line description, also model-authored. Not a translated UI string. */
+    description: text("description"),
+
+    /**
+     * The cluster's highest-weight tags, in descending weight order. Doubles as
+     * the naming model's input and as the identity fingerprint the next sweep
+     * matches against — a large drift here is what triggers a re-name.
+     */
+    signatureTags: text("signature_tags").array().notNull(),
+
+    /** Cluster size and reach, recomputed every sweep. */
+    tagCount: integer("tag_count").notNull().default(0),
+    publicationCount: integer("publication_count").notNull().default(0),
+    /**
+     * Distinct repo DIDs behind those publications. This is the signal that
+     * separates a topic from a single-operator publication fleet: the
+     * largest tag cluster on the network by publication count is one bot
+     * network (773 publications, all from one DID), and only a distinct-author
+     * threshold excludes it.
+     */
+    authorCount: integer("author_count").notNull().default(0),
+    documentCount: integer("document_count").notNull().default(0),
+
+    /** Ranking score for the Discover rail and any listing. */
+    score: doublePrecision("score").notNull().default(0),
+
+    /**
+     * Whether the cluster cleared the quality bar in the latest sweep. Rows
+     * below the bar are kept (not deleted) so a topic that dips and
+     * recovers keeps its slug and name rather than minting a new URL.
+     */
+    published: boolean("published").notNull().default(false),
+
+    /** Model that produced `name`/`description`; null when the fallback (the
+     * cluster's dominant tag) was used because naming was unavailable. */
+    nameModel: text("name_model"),
+    namedAt: timestamp("named_at", { withTimezone: true }),
+
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    // The Discover rail and any listing read "published, best first".
+    index("topics_published_score_idx").on(table.published, table.score.desc()),
+  ],
+);
+
+/**
+ * A topic's member tags — the "sub-areas" surfaced on the topic page,
+ * each linking to the existing `/tag/$tag` view.
+ *
+ * Also the source of the tag array used to scope a topic's documents:
+ * documents are matched live via `immutable_normalized_tags(tags) && <array>`
+ * (GIN-servable) rather than materialized, since a topic spans hundreds of
+ * thousands of documents.
+ */
+export const topicTags = pgTable(
+  "topic_tags",
+  {
+    topicSlug: text("topic_slug")
+      .notNull()
+      .references(() => topics.slug, { onDelete: "cascade" }),
+    /** Normalized tag — `lower(btrim(...))`, matching `documents_tags_norm_idx`. */
+    tag: text("tag").notNull(),
+    /** Cosine centrality of the tag within its cluster; orders the sub-areas. */
+    weight: doublePrecision("weight").notNull().default(0),
+  },
+  (table) => [
+    primaryKey({ columns: [table.topicSlug, table.tag] }),
+    // Reverse lookup: which topic does this tag belong to?
+    index("topic_tags_tag_idx").on(table.tag),
+    // Sub-area chips are "top-N by weight" for one topic.
+    index("topic_tags_weight_idx").on(table.topicSlug, table.weight.desc()),
+  ],
+);
+
+/**
+ * Precomputed topic membership for publications, so the topic rail and
+ * the topic page's Publications tab are a plain indexed read instead of a
+ * per-request tag aggregation.
+ */
+export const topicPublications = pgTable(
+  "topic_publications",
+  {
+    topicSlug: text("topic_slug")
+      .notNull()
+      .references(() => topics.slug, { onDelete: "cascade" }),
+    publicationUri: text("publication_uri")
+      .notNull()
+      .references(() => publications.uri, { onDelete: "cascade" }),
+    /** How strongly the publication belongs — summed weight of its matched tags. */
+    score: doublePrecision("score").notNull().default(0),
+    /** Distinct topic tags this publication's documents carry. */
+    matchedTagCount: integer("matched_tag_count").notNull().default(0),
+  },
+  (table) => [
+    primaryKey({ columns: [table.topicSlug, table.publicationUri] }),
+    // Top-N publications within a topic.
+    index("topic_publications_rank_idx").on(
+      table.topicSlug,
+      table.score.desc(),
+    ),
+    // Reverse lookup: which topics is this publication in? Used to
+    // personalize the Discover rail from the reader's follows.
+    index("topic_publications_pub_idx").on(table.publicationUri),
+  ],
+);
+
+/**
+ * Cached sentence-embedding per tag, so the topic sweep pays the model once
+ * per tag rather than once per hour.
+ *
+ * Embeddings exist because co-occurrence alone cannot join a subject its
+ * publishers happen to split: `typescript` and `css` are the same area, but the
+ * people who tag one largely are not the people who tag the other, so no amount
+ * of counting relates them. Meaning does.
+ *
+ * Small by construction — one row per tag in the clustering vocabulary (a few
+ * thousand), not one per document — so it needs no vector extension; the sweep
+ * loads the whole table and compares in memory.
+ */
+export const tagEmbeddings = pgTable("tag_embeddings", {
+  /** Normalized tag, matching `discover_topic_counts.topic`. */
+  tag: text("tag").primaryKey(),
+  /** Unit-normalized vector, so similarity is a plain dot product. */
+  embedding: doublePrecision("embedding").array().notNull(),
+  /** Model that produced it; a change invalidates the row. */
+  model: text("model").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+export type TagEmbedding = typeof tagEmbeddings.$inferSelect;
+
+export type Topic = typeof topics.$inferSelect;
+export type NewTopic = typeof topics.$inferInsert;
+export type TopicTag = typeof topicTags.$inferSelect;
+export type NewTopicTag = typeof topicTags.$inferInsert;
+export type TopicPublication = typeof topicPublications.$inferSelect;
+export type NewTopicPublication = typeof topicPublications.$inferInsert;

--- a/apps/standard-reader/src/db/schema/topics.ts
+++ b/apps/standard-reader/src/db/schema/topics.ts
@@ -1,3 +1,4 @@
+import type { AnyPgColumn } from "drizzle-orm/pg-core";
 import {
   boolean,
   doublePrecision,
@@ -71,6 +72,27 @@ export const topics = pgTable(
      * recovers keeps its slug and name rather than minting a new URL.
      */
     published: boolean("published").notNull().default(false),
+
+    /**
+     * Where this topic's URL should send readers now that it is unpublished.
+     *
+     * A topic can stop existing honestly: its tags drift apart, or the cluster
+     * merges into a neighbour, and the next derivation simply has nothing that
+     * matches it. Its row stays (so the slug is never reused) but its tags and
+     * memberships are gone, which would make the page a 404 — and these are
+     * public links people share. So when a published topic loses its cluster,
+     * the sweep records the closest surviving topic by tag-set overlap and the
+     * route redirects there. Null means nothing resembled it closely enough,
+     * and the route falls back to the index rather than dead-ending.
+     *
+     * Self-referential, and chains are possible (A merges into B, B later
+     * merges into C), so the read path follows it transitively with a depth
+     * cap — see `topicRedirectTarget`.
+     */
+    supersededBy: text("superseded_by").references(
+      (): AnyPgColumn => topics.slug,
+      { onDelete: "set null" },
+    ),
 
     /** Model that produced `name`/`description`; null when the fallback (the
      * cluster's dominant tag) was used because naming was unavailable. */

--- a/apps/standard-reader/src/db/schema/topics.ts
+++ b/apps/standard-reader/src/db/schema/topics.ts
@@ -12,7 +12,7 @@ import {
 import { publications } from "./publications.ts";
 
 /**
- * Auto-derived topic topics (`APP_VISION.md` §5): a cluster of related tags
+ * Auto-derived topics (`APP_VISION.md` §5): a cluster of related tags
  * presented as one browsable area, with its own trending publications and
  * documents, and its member tags exposed as sub-areas.
  *

--- a/apps/standard-reader/src/integrations/tanstack-query/api-topics.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-topics.functions.ts
@@ -1,0 +1,419 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { queryOptions } from "@tanstack/react-query";
+import { createServerFn } from "@tanstack/react-start";
+import { getRequest } from "@tanstack/react-start/server";
+import { z } from "zod";
+
+import { observe } from "#/server/observability/log";
+import { attachReaderSpanContext } from "#/server/observability/span-context.ts";
+import { attachCommentCountsToArticles } from "#/server/reader/document-comments";
+import { selectArticleCardsByUris } from "#/server/reader/queries";
+import { rotationSeed } from "#/server/reader/rail-rotation";
+import {
+  attachRecommendedByToArticles,
+  attachViewerRecommendedToArticles,
+} from "#/server/reader/recommended-by";
+import {
+  effectiveFollowSets,
+  effectiveFollowUris,
+} from "#/server/reader/saved-lists";
+import type { TopicCard, TopicDirectorySort } from "#/server/reader/topics";
+import {
+  topicBySlug,
+  topicPublicationCards,
+  topicTagList,
+  countTopicPublications,
+  discoverTopics,
+  listTopics,
+  selectTopicDocumentUris,
+} from "#/server/reader/topics";
+
+import type { ArticleCard, PublicationCard } from "./api-shapes";
+import { dbMiddleware } from "./db-middleware";
+
+export type { TopicCard };
+
+/**
+ * Topic reads (`APP_VISION.md` §5). Topics are clusters of related
+ * tags derived by the recompute sweep; these serve the Discover rail and the
+ * per-topic page.
+ */
+
+const directorySort = z.enum(["belonging", "readers", "active", "az"]);
+const articleSortEnum = z.enum(["recent", "trending", "popular"]);
+
+export type TopicArticleSort = z.infer<typeof articleSortEnum>;
+
+/**
+ * Sub-area chips on the topic page. Capped by the stored signature (24
+ * tags), which is plenty for a chip row and avoids joining `topic_tags`
+ * just to render the masthead.
+ */
+const TOPIC_PAGE_TAGS = 24;
+/**
+ * Tags handed to the document query. Capped well below the chip list: the
+ * array-overlap predicate widens with every tag, and the tail of a cluster
+ * contributes almost no documents the head does not already match.
+ */
+const TOPIC_FEED_TAGS = 30;
+
+const slugInput = z.object({
+  slug: z
+    .string()
+    .trim()
+    .min(1)
+    .max(80)
+    .regex(/^[\w-]+$/, "invalid topic slug"),
+});
+
+const railInput = z.object({
+  limit: z.number().int().min(1).max(24).default(8),
+});
+
+const publicationsInput = slugInput.extend({
+  sort: directorySort.default("belonging"),
+  limit: z.number().int().min(1).max(60).default(24),
+  offset: z.number().int().min(0).default(0),
+});
+
+const articlesInput = slugInput.extend({
+  articleSort: articleSortEnum.default("recent"),
+  limit: z.number().int().min(1).max(60).default(24),
+  offset: z.number().int().min(0).default(0),
+});
+
+const topicPageInput = slugInput.extend({
+  view: z.enum(["feed", "publications"]).default("feed"),
+  sort: directorySort.default("belonging"),
+  articleSort: articleSortEnum.default("recent"),
+  limit: z.number().int().min(1).max(60).default(24),
+  offset: z.number().int().min(0).default(0),
+});
+
+export interface TopicPublicationPage {
+  items: Array<PublicationCard>;
+  nextOffset: number | null;
+}
+
+export interface TopicArticlePage {
+  items: Array<ArticleCard>;
+  nextOffset: number | null;
+}
+
+export interface TopicPageData {
+  topic: TopicCard | null;
+  publicationCount: number;
+  articles?: TopicArticlePage;
+  publications?: TopicPublicationPage;
+}
+
+/** Every published topic, for the browse-all index. */
+const getAllTopics = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware])
+  .handler(
+    observe("topics.list", async ({ context }, span) => {
+      const { db, schema } = context;
+      await attachReaderSpanContext(span, getRequest());
+      const items = await listTopics(db, schema);
+      span.set("count", items.length);
+      return items;
+    }),
+  );
+
+/** Topics for the Discover rail, personalized to the reader's follows. */
+const getDiscoverTopics = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware])
+  .validator(railInput)
+  .handler(
+    observe("topics.getDiscoverRail", async ({ data, context }, span) => {
+      const { db, schema } = context;
+      const did = await attachReaderSpanContext(span, getRequest());
+      const followUris = did ? await effectiveFollowUris(db, schema, did) : [];
+      span.set("personalized", followUris.length > 0);
+
+      const items = await discoverTopics(db, schema, {
+        limit: data.limit,
+        followUris,
+        seed: rotationSeed("topics", did ?? "anon"),
+      });
+      span.set("count", items.length);
+      return items;
+    }),
+  );
+
+async function loadTopicArticles(
+  context: {
+    db: Parameters<typeof selectArticleCardsByUris>[0];
+    schema: Parameters<typeof selectArticleCardsByUris>[1];
+    trackReadingEnabled: boolean;
+    countOldPostsAsUnreadEnabled: boolean;
+  },
+  did: string | null,
+  tags: Array<string>,
+  { slug, articleSort, limit, offset }: z.infer<typeof articlesInput>,
+): Promise<TopicArticlePage> {
+  const { db, schema } = context;
+  if (tags.length === 0) return { items: [], nextOffset: null };
+
+  const trackReading = did == null ? false : context.trackReadingEnabled;
+  const countOldPostsAsUnread =
+    did == null ? true : context.countOldPostsAsUnreadEnabled;
+
+  // Two steps rather than one query: resolving the page's URIs through the tag
+  // GIN index first is what keeps this off a 1.6s plan — see
+  // `selectTopicDocumentUris`.
+  const [uris, followSets] = await Promise.all([
+    selectTopicDocumentUris(db, {
+      slug,
+      tags,
+      sort: articleSort,
+      limit,
+      offset,
+    }),
+    did ? effectiveFollowSets(db, schema, did) : Promise.resolve(null),
+  ]);
+  const rows = await selectArticleCardsByUris(db, schema, uris, {
+    readForDid: trackReading && did ? did : undefined,
+    countOldPostsAsUnread,
+  });
+
+  const withComments = await attachCommentCountsToArticles(db, schema, rows);
+  const withRecs = await attachRecommendedByToArticles(
+    db,
+    schema,
+    followSets?.userDids ?? [],
+    withComments,
+  );
+  const items = await attachViewerRecommendedToArticles(
+    db,
+    schema,
+    did,
+    withRecs,
+  );
+
+  return { items, nextOffset: items.length === limit ? offset + limit : null };
+}
+
+const getArticles = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware])
+  .validator(articlesInput)
+  .handler(
+    observe("topics.getArticles", async ({ data, context }, span) => {
+      const { db, schema } = context;
+      const did = await attachReaderSpanContext(span, getRequest());
+      span.set("slug", data.slug);
+      span.set("offset", data.offset);
+
+      const tags = await topicTagList(db, schema, data.slug, TOPIC_FEED_TAGS);
+      const page = await loadTopicArticles(context, did, tags, data);
+      span.set("count", page.items.length);
+      return page;
+    }),
+  );
+
+const getPublications = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware])
+  .validator(publicationsInput)
+  .handler(
+    observe("topics.getPublications", async ({ data, context }, span) => {
+      const { db, schema } = context;
+      await attachReaderSpanContext(span, getRequest());
+      span.set("slug", data.slug);
+      span.set("sort", data.sort);
+      span.set("offset", data.offset);
+
+      const items = await topicPublicationCards(db, schema, {
+        slug: data.slug,
+        sort: data.sort as TopicDirectorySort,
+        limit: data.limit,
+        offset: data.offset,
+      });
+      span.set("count", items.length);
+      return {
+        items,
+        nextOffset:
+          items.length === data.limit ? data.offset + data.limit : null,
+      } satisfies TopicPublicationPage;
+    }),
+  );
+
+/**
+ * One round trip for the topic page: masthead + counts + the active tab's
+ * first page. Only the active tab is fetched — the inactive panel never mounts
+ * its query, so fetching both would double the work on every load.
+ */
+const getTopicPage = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware])
+  .validator(topicPageInput)
+  .handler(
+    observe("topics.getPage", async ({ data, context }, span) => {
+      const { db, schema } = context;
+      const did = await attachReaderSpanContext(span, getRequest());
+      span.set("slug", data.slug);
+      span.set("view", data.view);
+      span.set("offset", data.offset);
+
+      const topic = await topicBySlug(db, schema, data.slug, {
+        tagLimit: TOPIC_PAGE_TAGS,
+      });
+      if (!topic) {
+        span.set("found", false);
+        return {
+          topic: null,
+          publicationCount: 0,
+        } satisfies TopicPageData;
+      }
+
+      const [publicationCount, content] = await Promise.all([
+        countTopicPublications(db, schema, data.slug),
+        data.view === "feed"
+          ? topicTagList(db, schema, data.slug, TOPIC_FEED_TAGS).then((tags) =>
+              loadTopicArticles(context, did, tags, {
+                slug: data.slug,
+                articleSort: data.articleSort,
+                limit: data.limit,
+                offset: data.offset,
+              }),
+            )
+          : topicPublicationCards(db, schema, {
+              slug: data.slug,
+              sort: data.sort as TopicDirectorySort,
+              limit: data.limit,
+              offset: data.offset,
+            }).then(
+              (items) =>
+                ({
+                  items,
+                  nextOffset:
+                    items.length === data.limit
+                      ? data.offset + data.limit
+                      : null,
+                }) satisfies TopicPublicationPage,
+            ),
+      ]);
+
+      span.set("publicationCount", publicationCount);
+
+      return data.view === "feed"
+        ? ({
+            topic,
+            publicationCount,
+            articles: content as TopicArticlePage,
+          } satisfies TopicPageData)
+        : ({
+            topic,
+            publicationCount,
+            publications: content as TopicPublicationPage,
+          } satisfies TopicPageData);
+    }),
+  );
+
+function getAllTopicsQueryOptions() {
+  return queryOptions({
+    queryKey: ["topics", "all"] as const,
+    queryFn: async () => getAllTopics(),
+    staleTime: 60_000,
+  });
+}
+
+function getDiscoverTopicsQueryOptions({ limit = 8 }: { limit?: number } = {}) {
+  return queryOptions({
+    queryKey: ["topics", "discover", limit] as const,
+    queryFn: async () => getDiscoverTopics({ data: { limit } }),
+    staleTime: 60_000,
+  });
+}
+
+function getArticlesQueryOptions({
+  slug,
+  articleSort = "recent",
+  limit = 24,
+  offset = 0,
+}: z.input<typeof articlesInput>) {
+  return queryOptions({
+    queryKey: ["topics", "articles", slug, articleSort, limit, offset] as const,
+    queryFn: async () =>
+      getArticles({ data: { slug, articleSort, limit, offset } }),
+  });
+}
+
+function getPublicationsQueryOptions({
+  slug,
+  sort = "belonging",
+  limit = 24,
+  offset = 0,
+}: z.input<typeof publicationsInput>) {
+  return queryOptions({
+    queryKey: ["topics", "publications", slug, sort, limit, offset] as const,
+    queryFn: async () =>
+      getPublications({ data: { slug, sort, limit, offset } }),
+  });
+}
+
+function getTopicQueryOptions({ slug }: z.input<typeof slugInput>) {
+  return queryOptions({
+    queryKey: ["topics", "detail", slug] as const,
+    queryFn: async () =>
+      getTopicPage({ data: { slug, view: "publications", limit: 1 } }).then(
+        (page) => page.topic,
+      ),
+  });
+}
+
+function getPublicationCountQueryOptions({ slug }: z.input<typeof slugInput>) {
+  return queryOptions({
+    queryKey: ["topics", "publicationCount", slug] as const,
+    queryFn: async () =>
+      getTopicPage({ data: { slug, view: "publications", limit: 1 } }).then(
+        (page) => page.publicationCount,
+      ),
+  });
+}
+
+/** Seed per-query caches from a combined {@link getTopicPage} response. */
+function seedTopicPageCaches(
+  queryClient: QueryClient,
+  page: TopicPageData,
+  {
+    slug,
+    sort = "belonging",
+    articleSort = "recent",
+    limit = 24,
+    offset = 0,
+  }: z.input<typeof topicPageInput>,
+): void {
+  queryClient.setQueryData(getTopicQueryOptions({ slug }).queryKey, page.topic);
+  queryClient.setQueryData(
+    getPublicationCountQueryOptions({ slug }).queryKey,
+    page.publicationCount,
+  );
+
+  if (page.articles) {
+    queryClient.setQueryData(
+      getArticlesQueryOptions({ slug, articleSort, limit, offset }).queryKey,
+      page.articles,
+    );
+  }
+
+  if (page.publications) {
+    queryClient.setQueryData(
+      getPublicationsQueryOptions({ slug, sort, limit, offset }).queryKey,
+      page.publications,
+    );
+  }
+}
+
+export const topicsApi = {
+  getAllTopics,
+  getAllTopicsQueryOptions,
+  getDiscoverTopics,
+  getDiscoverTopicsQueryOptions,
+  getArticles,
+  getArticlesQueryOptions,
+  getPublications,
+  getPublicationsQueryOptions,
+  getTopicPage,
+  getTopicQueryOptions,
+  getPublicationCountQueryOptions,
+  seedTopicPageCaches,
+};

--- a/apps/standard-reader/src/integrations/tanstack-query/api-topics.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-topics.functions.ts
@@ -17,7 +17,11 @@ import {
   effectiveFollowSets,
   effectiveFollowUris,
 } from "#/server/reader/saved-lists";
-import type { TopicCard, TopicDirectorySort } from "#/server/reader/topics";
+import type {
+  TopicCard,
+  TopicDirectorySort,
+  TopicRedirect,
+} from "#/server/reader/topics";
 import {
   topicBySlug,
   topicPublicationCards,
@@ -26,6 +30,7 @@ import {
   discoverTopics,
   listTopics,
   selectTopicDocumentUris,
+  topicRedirectTarget,
 } from "#/server/reader/topics";
 
 import type { ArticleCard, PublicationCard } from "./api-shapes";
@@ -102,6 +107,12 @@ export interface TopicArticlePage {
 
 export interface TopicPageData {
   topic: TopicCard | null;
+  /**
+   * Set only when `topic` is null. `known: false` is a real 404; otherwise the
+   * slug once existed and the route redirects — to `slug` if a topic absorbed
+   * it, or to the index when nothing did. See `topicRedirectTarget`.
+   */
+  redirect?: TopicRedirect;
   publicationCount: number;
   articles?: TopicArticlePage;
   publications?: TopicPublicationPage;
@@ -258,8 +269,14 @@ const getTopicPage = createServerFn({ method: "GET" })
       });
       if (!topic) {
         span.set("found", false);
+        // Unpublished or unknown. Resolving costs one more query, but only on
+        // a path that was going to be an error page anyway.
+        const redirect = await topicRedirectTarget(db, data.slug);
+        span.set("redirect.known", redirect.known);
+        span.set("redirect.slug", redirect.slug ?? "");
         return {
           topic: null,
+          redirect,
           publicationCount: 0,
         } satisfies TopicPageData;
       }

--- a/apps/standard-reader/src/lib/atproto/bridged-repo.ts
+++ b/apps/standard-reader/src/lib/atproto/bridged-repo.ts
@@ -28,6 +28,16 @@ export const BRIDGE_HANDLE_SUFFIX = ".brid.gy";
 /** Handle suffix of Bridgy's web bridge — mirrored sites, the bulk of it. */
 export const WEB_BRIDGE_HANDLE_SUFFIX = ".web.brid.gy";
 
+/**
+ * SQL `ILIKE` pattern for {@link WEB_BRIDGE_HANDLE_SUFFIX}, for the read-model
+ * queries that exclude passively mirrored sites (see the topic derivation
+ * and its feed in `#/server/reader/topics`).
+ *
+ * Lives here so every such query spells the exclusion the same way — the
+ * derivation and the topic article feed drifted apart once already.
+ */
+export const WEB_BRIDGE_HANDLE_PATTERN = `%${WEB_BRIDGE_HANDLE_SUFFIX}`;
+
 function endsWithSuffix(
   handle: string | null | undefined,
   suffix: string,

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -115,6 +115,11 @@ msgstr ""
 msgid "Add an article"
 msgstr "إضافة مقال"
 
+#: src/routes/_layout.communities.index.tsx
+#: src/routes/_layout.discover.tsx
+#~ msgid "Communities"
+#~ msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/components/reader/app-shell.tsx
@@ -157,6 +162,10 @@ msgstr "إزالة الأيقونة"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "The {SITE_NAME} browser extension helps you save articles and follow publications on the standard.site network from any tab. It connects to the same account as the web app at <0>{siteHost}</0>. This policy covers the extension only; the <1>site privacy policy</1> describes data handling on the website itself."
 msgstr "يساعدك امتداد المتصفح من {SITE_NAME} على حفظ المقالات ومتابعة المنشورات على شبكة standard.site من أي تبويب. وهو يتصل بالحساب نفسه المستخدم في تطبيق الويب على <0>{siteHost}</0>. تغطي هذه السياسة الامتداد وحده؛ أما <1>سياسة خصوصية الموقع</1> فتوضّح كيفية التعامل مع البيانات على الموقع نفسه."
+
+#: src/routes/_layout.topics.index.tsx
+msgid "Topic areas the network's writing clusters into, rebuilt as it grows. Each one gathers related tags, the publications writing about them, and everything they've published."
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "find publications, people, topics, and headlines by name."
@@ -328,6 +337,10 @@ msgstr "جارٍ فتح المجموعة…"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Density"
+msgstr ""
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Best fit"
 msgstr ""
 
 #: src/components/reader/article-view.tsx
@@ -641,6 +654,7 @@ msgstr "انقر على القلب في أي مقال لتوصي به. تعيش 
 #: src/routes/_layout.index.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Trending"
 msgstr "الرائج"
 
@@ -654,6 +668,7 @@ msgstr "المنشورات المعروضة"
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "{publicationCount, plural, one {publication} other {publications}}"
 msgstr "{publicationCount, plural, zero {منشورات} one {منشورة} two {منشورتان} few {منشورات} many {منشورة} other {منشورة}}"
 
@@ -669,6 +684,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Permanently remove data stored in your account. These actions delete records from your account and cannot be undone."
 msgstr "احذف نهائيًا البيانات المخزَّنة في حسابك. تحذف هذه الإجراءات السجلات من حسابك ولا يمكن التراجع عنها."
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Sub-areas"
+#~ msgstr ""
 
 #: src/routes/_layout.friends.tsx
 msgid "Loading people"
@@ -801,6 +820,7 @@ msgstr "فشل تسجيل الدخول. حاول مجددًا."
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Loading publications"
 msgstr "جارٍ تحميل المنشورات"
 
@@ -825,6 +845,7 @@ msgstr "تعليم كغير مقروء"
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Grid view"
 msgstr "عرض شبكي"
 
@@ -871,6 +892,7 @@ msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "List view"
 msgstr "عرض قائمة"
 
@@ -946,6 +968,7 @@ msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} pu
 msgstr "{unfollowedCount, plural, zero {الاشتراك في {formattedUnfollowedCount} منشورة؟} one {الاشتراك في منشورة واحدة؟} two {الاشتراك في منشورتين؟} few {الاشتراك في {formattedUnfollowedCount} منشورات؟} many {الاشتراك في {formattedUnfollowedCount} منشورة؟} other {الاشتراك في {formattedUnfollowedCount} منشورة؟}}"
 
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Sort articles"
 msgstr ""
 
@@ -1801,6 +1824,10 @@ msgstr "لا توجد منشورات في هذه القائمة."
 msgid "{0}, dark"
 msgstr ""
 
+#: src/routes/_layout.discover.tsx
+msgid "Browse all topics"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Can read and act on your behalf"
 msgstr ""
@@ -1837,6 +1864,7 @@ msgstr "إزالة القائمة"
 #: src/routes/_layout.friends.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Loading articles"
 msgstr "جارٍ تحميل المقالات"
 
@@ -1901,6 +1929,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "More from <0>{0}</0>"
 msgstr "المزيد من <0>{0}</0>"
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Community"
+#~ msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
@@ -1999,6 +2031,7 @@ msgstr ""
 #~ msgstr "تحصل المنشورات والقوائم والمجموعات على رابط أنيق مع بطاقة معاينة غنية — إضافةً إلى زر اشتراك يمكن للمنشورة وضعه على موقعها."
 
 #: src/components/reader/discover-topic-filters.tsx
+#: src/routes/_layout.topics.index.tsx
 msgid "Search topics"
 msgstr ""
 
@@ -2069,6 +2102,10 @@ msgstr ""
 #: src/components/reader/subscriptions-table.tsx
 msgid "Sort descending"
 msgstr ""
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "No publications in this community yet."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Anonymous"
@@ -2181,6 +2218,11 @@ msgstr ""
 msgid "Something went wrong while submitting your feedback."
 msgstr "حدث خطأ أثناء إرسال ملاحظاتك."
 
+#. placeholder {0}: visible.length
+#: src/routes/_layout.topics.index.tsx
+msgid "{0, plural, one {# topic} other {# topics}}"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
 msgstr "لا تريد تطبيقًا آخر لتتفقّده؟ اشترك في بريد أسبوعي يضم أفضل ما في المنشورات التي تتابعها، مع منشورتين تستحقان الاكتشاف. رسالة واحدة، ونقرة واحدة لإلغاء الاشتراك — ويمكنك معاينة شكلها بالضبط قبل تفعيلها."
@@ -2227,6 +2269,10 @@ msgstr "على pckt"
 #: src/components/onboarding/step-settings.tsx
 msgid "Marks what you've read for unread counts. Stored publicly on your account — turn off to read privately."
 msgstr "يحدد ما قرأته لحساب عدد غير المقروء. يُخزَّن علنًا في حسابك — أوقفه للقراءة بخصوصية."
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Newest"
+msgstr ""
 
 #: src/routes/_layout.feedback.return.tsx
 msgid "Your upvote has been recorded on userinput.app. Thanks for helping surface what matters."
@@ -2428,6 +2474,7 @@ msgstr ""
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Readers"
 msgstr "القرّاء"
@@ -2491,6 +2538,7 @@ msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Active"
 msgstr "نشط"
 
@@ -2708,6 +2756,10 @@ msgstr "لا توجد مقالات رائجة عبر الشبكة الآن. عد
 msgid "Everything below is compatibility support for formats already out there in other apps' own repos — none of it is part of the site.standard spec, and none of it is something to model a new integration on."
 msgstr "كل ما يلي هو دعم توافقية لصيغ موجودة أصلًا في مستودعات تطبيقات أخرى — لا شيء منها جزء من مواصفة site.standard، ولا شيء منها يصلح نموذجًا لتكامل جديد."
 
+#: src/routes/_layout.topics.$slug.tsx
+msgid "No articles in this topic yet."
+msgstr ""
+
 #: src/components/reader/subscribe-card.tsx
 msgid "Subscribing"
 msgstr "جارٍ الاشتراك"
@@ -2768,6 +2820,10 @@ msgstr ""
 msgid "A sentence of body copy, set in your chosen fonts and colors, so you can see how it all reads together before you save."
 msgstr "جملة من نص المتن، بالخطوط والألوان التي اخترتها، لترى كيف يبدو ذلك كله معًا قبل الحفظ."
 
+#: src/routes/_layout.discover.tsx
+#~ msgid "Find your corner"
+#~ msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Open the directory"
 msgstr "افتح الدليل"
@@ -2801,6 +2857,10 @@ msgstr "إعادة ترتيب {itemTitle}"
 msgid "Back to feedback"
 msgstr "العودة إلى الملاحظات"
 
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Community views"
+#~ msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "View on {name}"
 msgstr ""
@@ -2824,6 +2884,10 @@ msgstr "الخلفية"
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Drop another screenshot"
+msgstr ""
+
+#: src/routes/_layout.discover.tsx
+msgid "See all"
 msgstr ""
 
 #: src/components/comic/comic-reader.tsx
@@ -2962,6 +3026,7 @@ msgstr ""
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "You've reached the end."
 msgstr "وصلت إلى النهاية."
@@ -3437,6 +3502,10 @@ msgstr ""
 msgid "e.g. Dispatches from the Atmosphere"
 msgstr "مثال: رسائل من Atmosphere"
 
+#: src/routes/_layout.discover.tsx
+#~ msgid "Browse all communities"
+#~ msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "{value, plural, one {# join} other {# joins}}"
 msgstr ""
@@ -3530,6 +3599,10 @@ msgstr "بقلم @{ownerHandle}"
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "A player appears just above the navigation and stays there while you move around the app, so you can keep listening while you browse. It has play and pause, a jump back fifteen seconds, a speed control, a bar you can drag to move through the article, and a close button. The word being spoken is highlighted in the text and kept on screen; if you scroll away yourself, that stops until you select <0>Follow along</0>."
+msgstr ""
+
+#: src/routes/_layout.topics.index.tsx
+msgid "No topics match your search."
 msgstr ""
 
 #. placeholder {0}: rows.length
@@ -3713,7 +3786,9 @@ msgstr "لم يُعثر على منشورات لهذا الحساب."
 
 #. placeholder {0}: following.length
 #. placeholder {0}: list.publications.length
+#. placeholder {0}: topic.publicationCount
 #: src/components/reader/subscriptions-sheet.tsx
+#: src/components/reader/topic-cards.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "{0, plural, one {# publication} other {# publications}}"
 msgstr "{0, plural, zero {لا توجد منشورات} one {منشورة واحدة} two {منشورتان} few {# منشورات} many {# منشورة} other {# منشورة}}"
@@ -3762,6 +3837,10 @@ msgstr "لا يوجد أشخاص مطابقون."
 #: src/components/reader/subscriptions-tree.tsx
 msgid "Empty list."
 msgstr "قائمة فارغة."
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "No articles in this community yet."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Show only mine"
@@ -4247,6 +4326,10 @@ msgstr "<0>{countLabel}</0> منشورة مفهرسة — والعدد في از
 #: src/routes/_layout.index.tsx
 msgid "{newCount} new"
 msgstr "{newCount} جديد"
+
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "No communities match your search."
+#~ msgstr ""
 
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Reading in {language}"
@@ -5057,6 +5140,10 @@ msgstr ""
 msgid "Collection"
 msgstr "مجموعة"
 
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Most liked"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Clear filter"
 msgstr ""
@@ -5127,6 +5214,7 @@ msgid "Everything by one author"
 msgstr "كل ما كتبه مؤلف واحد"
 
 #: src/components/reader/subscriptions-table.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Topic"
 msgstr ""
 
@@ -5174,6 +5262,10 @@ msgstr "مشاركة مراجعة على <0>ATStore</0> تساعدنا وتسا�
 #: src/components/reader/about-view.tsx
 msgid "Publish labels others can subscribe to, or consume the ones we do."
 msgstr ""
+
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Search communities"
+#~ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "The full account is on the <0>extension privacy page</0>."
@@ -5472,6 +5564,11 @@ msgstr "‏DID الخدمة هو <0>{appviewDid}</0>. تنشر الخدمة <1>�
 msgid "The Slow Web, Revisited"
 msgstr "الويب البطيء، إعادة نظر"
 
+#. placeholder {0}: visible.length
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "{0, plural, one {# community} other {# communities}}"
+#~ msgstr ""
+
 #. placeholder {0}: labelTotal - names.length
 #: src/components/labelers-settings-view.tsx
 msgid "+{0} more"
@@ -5593,6 +5690,8 @@ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/lib/guide/navigation.ts
+#: src/routes/_layout.discover.tsx
+#: src/routes/_layout.topics.index.tsx
 msgid "Topics"
 msgstr ""
 
@@ -5628,6 +5727,10 @@ msgstr "اترك لنا مراجعة على ATStore."
 #: src/routes/_layout.feedback.index.tsx
 msgid "Search feedback"
 msgstr "ابحث في الملاحظات"
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "No publications in this topic yet."
+msgstr ""
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe"
@@ -5698,6 +5801,10 @@ msgstr "حفظ القائمة"
 msgid "Some people would rather read on the publication's own site, with its own design. Turn on the open-on-the-original-site setting in your account menu and every article link opens there in a new tab instead of in the reader. Articles that have no site of their own still open here."
 msgstr ""
 
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Search by name or topic…"
+#~ msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Contents"
 msgstr "المحتويات"
@@ -5748,6 +5855,11 @@ msgstr ""
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
 msgstr "إزالة"
+
+#. placeholder {0}: topic.authorCount
+#: src/routes/_layout.topics.$slug.tsx
+msgid "{0, plural, one {writer} other {writers}}"
+msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 msgid "<0>Platform</0> components render the blocks unique to one publishing platform — a Leaflet poll or signup, a Pckt gallery or note embed, an Offprint component. These are the interactive, often data-backed embeds; the headless defaults render nothing, so you supply your own to make them live."
@@ -5910,6 +6022,7 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Articles"
 msgstr "المقالات"
 
@@ -5990,6 +6103,7 @@ msgstr ""
 #: src/components/reader/subscriptions-sheet.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "A–Z"
 msgstr "أ–ي"
 
@@ -6139,6 +6253,10 @@ msgstr ""
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "التفاصيل"
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Topic views"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "When you save or follow from the extension, {SITE_NAME} writes AT Protocol records to <0>your</0> repository through the same server paths as the web app. Those records follow the network's visibility rules and your account settings."
@@ -6673,6 +6791,10 @@ msgstr "قراءة بصوت مسموع"
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "المقالات التي حفظتها لوقت لاحق — في مستودعك، ومُزامَنة عبر أجهزتك."
 
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Every corner"
+#~ msgstr ""
+
 #: src/components/reader/format-i18n.ts
 msgid "today"
 msgstr ""
@@ -6786,6 +6908,7 @@ msgstr "لا ننشر من حسابك إلا عند قيامك بإجراء صر
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Publications"
 msgstr "المنشورات"
@@ -7019,6 +7142,10 @@ msgstr "مدعوم بـ <0>Standard Reader</0>"
 
 #: src/components/appearance-settings.tsx
 msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."
+msgstr ""
+
+#: src/routes/_layout.topics.index.tsx
+msgid "Search by name or topic — “vinyl”, “kubernetes”…"
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
@@ -7351,6 +7478,11 @@ msgstr ""
 
 #: src/components/reader/read-on-platform.tsx
 msgid "Read this on {name}"
+msgstr ""
+
+#. placeholder {0}: topic.authorCount
+#: src/components/reader/topic-cards.tsx
+msgid "{0, plural, one {# writer} other {# writers}}"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -115,6 +115,11 @@ msgstr ""
 msgid "Add an article"
 msgstr "Artikel hinzufügen"
 
+#: src/routes/_layout.communities.index.tsx
+#: src/routes/_layout.discover.tsx
+#~ msgid "Communities"
+#~ msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/components/reader/app-shell.tsx
@@ -157,6 +162,10 @@ msgstr "Symbol entfernen"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "The {SITE_NAME} browser extension helps you save articles and follow publications on the standard.site network from any tab. It connects to the same account as the web app at <0>{siteHost}</0>. This policy covers the extension only; the <1>site privacy policy</1> describes data handling on the website itself."
 msgstr "Die {SITE_NAME}-Browsererweiterung hilft Ihnen, Artikel zu speichern und Publikationen im standard.site-Netzwerk aus jedem Tab heraus zu folgen. Sie nutzt dasselbe Konto wie die Web-App unter <0>{siteHost}</0>. Diese Richtlinie gilt nur für die Erweiterung; die <1>Datenschutzerklärung der Website</1> beschreibt den Umgang mit Daten auf der Website selbst."
+
+#: src/routes/_layout.topics.index.tsx
+msgid "Topic areas the network's writing clusters into, rebuilt as it grows. Each one gathers related tags, the publications writing about them, and everything they've published."
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "find publications, people, topics, and headlines by name."
@@ -328,6 +337,10 @@ msgstr "Sammlung wird geöffnet …"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Density"
+msgstr ""
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Best fit"
 msgstr ""
 
 #: src/components/reader/article-view.tsx
@@ -641,6 +654,7 @@ msgstr "Tippen Sie bei einem Artikel auf das Herz, um ihn zu empfehlen. Ihre Emp
 #: src/routes/_layout.index.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Trending"
 msgstr "Im Trend"
 
@@ -654,6 +668,7 @@ msgstr "Gezeigte Publikationen"
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "{publicationCount, plural, one {publication} other {publications}}"
 msgstr "{publicationCount, plural, one {Publikation} other {Publikationen}}"
 
@@ -669,6 +684,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Permanently remove data stored in your account. These actions delete records from your account and cannot be undone."
 msgstr "Daten dauerhaft aus Ihrem Konto entfernen. Diese Aktionen löschen Records aus Ihrem Konto und lassen sich nicht rückgängig machen."
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Sub-areas"
+#~ msgstr ""
 
 #: src/routes/_layout.friends.tsx
 msgid "Loading people"
@@ -801,6 +820,7 @@ msgstr "Anmeldung fehlgeschlagen. Bitte erneut versuchen."
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Loading publications"
 msgstr "Publikationen werden geladen"
 
@@ -825,6 +845,7 @@ msgstr "Als ungelesen markieren"
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Grid view"
 msgstr "Rasteransicht"
 
@@ -871,6 +892,7 @@ msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "List view"
 msgstr "Listenansicht"
 
@@ -946,6 +968,7 @@ msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} pu
 msgstr "{unfollowedCount, plural, one {{formattedUnfollowedCount} Publikation abonnieren?} other {{formattedUnfollowedCount} Publikationen abonnieren?}}"
 
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Sort articles"
 msgstr ""
 
@@ -1801,6 +1824,10 @@ msgstr "Keine Publikationen in dieser Liste."
 msgid "{0}, dark"
 msgstr ""
 
+#: src/routes/_layout.discover.tsx
+msgid "Browse all topics"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Can read and act on your behalf"
 msgstr ""
@@ -1837,6 +1864,7 @@ msgstr "Liste entfernen"
 #: src/routes/_layout.friends.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Loading articles"
 msgstr "Artikel werden geladen"
 
@@ -1901,6 +1929,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "More from <0>{0}</0>"
 msgstr "Mehr von <0>{0}</0>"
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Community"
+#~ msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
@@ -1999,6 +2031,7 @@ msgstr ""
 #~ msgstr "Publikationen, Listen und Sammlungen bekommen jeweils einen sauberen Link mit einer schönen Vorschaukarte – plus einen Abo-Button, den eine Publikation auf ihrer eigenen Website einbauen kann."
 
 #: src/components/reader/discover-topic-filters.tsx
+#: src/routes/_layout.topics.index.tsx
 msgid "Search topics"
 msgstr ""
 
@@ -2069,6 +2102,10 @@ msgstr ""
 #: src/components/reader/subscriptions-table.tsx
 msgid "Sort descending"
 msgstr ""
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "No publications in this community yet."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Anonymous"
@@ -2181,6 +2218,11 @@ msgstr ""
 msgid "Something went wrong while submitting your feedback."
 msgstr "Beim Senden Ihres Feedbacks ist etwas schiefgelaufen."
 
+#. placeholder {0}: visible.length
+#: src/routes/_layout.topics.index.tsx
+msgid "{0, plural, one {# topic} other {# topics}}"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
 msgstr "Keine Lust, noch eine App zu prüfen? Abonnieren Sie eine wöchentliche E-Mail mit dem Besten aus Ihren abonnierten Publikationen und ein paar Entdeckungen dazu. Eine E-Mail, ein Klick zum Abbestellen – und Sie können vorher genau sehen, wie sie aussieht."
@@ -2227,6 +2269,10 @@ msgstr "auf pckt"
 #: src/components/onboarding/step-settings.tsx
 msgid "Marks what you've read for unread counts. Stored publicly on your account — turn off to read privately."
 msgstr "Markiert Gelesenes für die Zähler ungelesener Artikel. Wird öffentlich in Ihrem Konto gespeichert – zum privaten Lesen ausschalten."
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Newest"
+msgstr ""
 
 #: src/routes/_layout.feedback.return.tsx
 msgid "Your upvote has been recorded on userinput.app. Thanks for helping surface what matters."
@@ -2428,6 +2474,7 @@ msgstr ""
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Readers"
 msgstr "Leser"
@@ -2491,6 +2538,7 @@ msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Active"
 msgstr "Aktiv"
 
@@ -2708,6 +2756,10 @@ msgstr "Derzeit sind keine Artikel im Netzwerk im Trend. Schauen Sie bald wieder
 msgid "Everything below is compatibility support for formats already out there in other apps' own repos — none of it is part of the site.standard spec, and none of it is something to model a new integration on."
 msgstr "Alles Folgende dient der Kompatibilität mit Formaten, die es in den Repos anderer Apps bereits gibt – nichts davon ist Teil der site.standard-Spezifikation, und nichts davon eignet sich als Vorbild für eine neue Integration."
 
+#: src/routes/_layout.topics.$slug.tsx
+msgid "No articles in this topic yet."
+msgstr ""
+
 #: src/components/reader/subscribe-card.tsx
 msgid "Subscribing"
 msgstr "Wird abonniert"
@@ -2768,6 +2820,10 @@ msgstr ""
 msgid "A sentence of body copy, set in your chosen fonts and colors, so you can see how it all reads together before you save."
 msgstr "Ein Satz Fließtext, gesetzt in Ihren gewählten Schriften und Farben, damit Sie vor dem Speichern sehen, wie alles zusammen wirkt."
 
+#: src/routes/_layout.discover.tsx
+#~ msgid "Find your corner"
+#~ msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Open the directory"
 msgstr "Verzeichnis öffnen"
@@ -2801,6 +2857,10 @@ msgstr "{itemTitle} umsortieren"
 msgid "Back to feedback"
 msgstr "Zurück zum Feedback"
 
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Community views"
+#~ msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "View on {name}"
 msgstr ""
@@ -2824,6 +2884,10 @@ msgstr "Hintergrund"
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Drop another screenshot"
+msgstr ""
+
+#: src/routes/_layout.discover.tsx
+msgid "See all"
 msgstr ""
 
 #: src/components/comic/comic-reader.tsx
@@ -2962,6 +3026,7 @@ msgstr ""
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "You've reached the end."
 msgstr "Sie sind am Ende angelangt."
@@ -3437,6 +3502,10 @@ msgstr ""
 msgid "e.g. Dispatches from the Atmosphere"
 msgstr "z. B. Dispatches from the Atmosphere"
 
+#: src/routes/_layout.discover.tsx
+#~ msgid "Browse all communities"
+#~ msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "{value, plural, one {# join} other {# joins}}"
 msgstr ""
@@ -3530,6 +3599,10 @@ msgstr "von @{ownerHandle}"
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "A player appears just above the navigation and stays there while you move around the app, so you can keep listening while you browse. It has play and pause, a jump back fifteen seconds, a speed control, a bar you can drag to move through the article, and a close button. The word being spoken is highlighted in the text and kept on screen; if you scroll away yourself, that stops until you select <0>Follow along</0>."
+msgstr ""
+
+#: src/routes/_layout.topics.index.tsx
+msgid "No topics match your search."
 msgstr ""
 
 #. placeholder {0}: rows.length
@@ -3713,7 +3786,9 @@ msgstr "Für dieses Konto wurden keine Publikationen gefunden."
 
 #. placeholder {0}: following.length
 #. placeholder {0}: list.publications.length
+#. placeholder {0}: topic.publicationCount
 #: src/components/reader/subscriptions-sheet.tsx
+#: src/components/reader/topic-cards.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "{0, plural, one {# publication} other {# publications}}"
 msgstr "{0, plural, one {# Publikation} other {# Publikationen}}"
@@ -3762,6 +3837,10 @@ msgstr "Keine passenden Personen."
 #: src/components/reader/subscriptions-tree.tsx
 msgid "Empty list."
 msgstr "Leere Liste."
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "No articles in this community yet."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Show only mine"
@@ -4247,6 +4326,10 @@ msgstr "<0>{countLabel}</0> Publikationen indexiert — und es werden mehr"
 #: src/routes/_layout.index.tsx
 msgid "{newCount} new"
 msgstr "{newCount} neu"
+
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "No communities match your search."
+#~ msgstr ""
 
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Reading in {language}"
@@ -5057,6 +5140,10 @@ msgstr ""
 msgid "Collection"
 msgstr "Sammlung"
 
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Most liked"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Clear filter"
 msgstr ""
@@ -5127,6 +5214,7 @@ msgid "Everything by one author"
 msgstr "Alles von einer Person"
 
 #: src/components/reader/subscriptions-table.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Topic"
 msgstr ""
 
@@ -5174,6 +5262,10 @@ msgstr "Eine Bewertung im <0>ATStore</0> hilft uns und anderen Nutzern zu sehen,
 #: src/components/reader/about-view.tsx
 msgid "Publish labels others can subscribe to, or consume the ones we do."
 msgstr ""
+
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Search communities"
+#~ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "The full account is on the <0>extension privacy page</0>."
@@ -5472,6 +5564,11 @@ msgstr "Die Dienst-DID lautet <0>{appviewDid}</0>. Der Dienst stellt ein <1>DID-
 msgid "The Slow Web, Revisited"
 msgstr "Das langsame Web, neu betrachtet"
 
+#. placeholder {0}: visible.length
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "{0, plural, one {# community} other {# communities}}"
+#~ msgstr ""
+
 #. placeholder {0}: labelTotal - names.length
 #: src/components/labelers-settings-view.tsx
 msgid "+{0} more"
@@ -5593,6 +5690,8 @@ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/lib/guide/navigation.ts
+#: src/routes/_layout.discover.tsx
+#: src/routes/_layout.topics.index.tsx
 msgid "Topics"
 msgstr ""
 
@@ -5628,6 +5727,10 @@ msgstr "Bewerten Sie uns im ATStore."
 #: src/routes/_layout.feedback.index.tsx
 msgid "Search feedback"
 msgstr "Feedback durchsuchen"
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "No publications in this topic yet."
+msgstr ""
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe"
@@ -5698,6 +5801,10 @@ msgstr "Liste speichern"
 msgid "Some people would rather read on the publication's own site, with its own design. Turn on the open-on-the-original-site setting in your account menu and every article link opens there in a new tab instead of in the reader. Articles that have no site of their own still open here."
 msgstr ""
 
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Search by name or topic…"
+#~ msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Contents"
 msgstr "Inhalt"
@@ -5748,6 +5855,11 @@ msgstr ""
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
 msgstr "Entfernen"
+
+#. placeholder {0}: topic.authorCount
+#: src/routes/_layout.topics.$slug.tsx
+msgid "{0, plural, one {writer} other {writers}}"
+msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 msgid "<0>Platform</0> components render the blocks unique to one publishing platform — a Leaflet poll or signup, a Pckt gallery or note embed, an Offprint component. These are the interactive, often data-backed embeds; the headless defaults render nothing, so you supply your own to make them live."
@@ -5910,6 +6022,7 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Articles"
 msgstr "Artikel"
 
@@ -5990,6 +6103,7 @@ msgstr ""
 #: src/components/reader/subscriptions-sheet.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "A–Z"
 msgstr "A–Z"
 
@@ -6139,6 +6253,10 @@ msgstr ""
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "Details"
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Topic views"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "When you save or follow from the extension, {SITE_NAME} writes AT Protocol records to <0>your</0> repository through the same server paths as the web app. Those records follow the network's visibility rules and your account settings."
@@ -6673,6 +6791,10 @@ msgstr "Vorlesen"
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "Artikel, die Sie für später gespeichert haben — in Ihrem Repo, geräteübergreifend synchronisiert."
 
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Every corner"
+#~ msgstr ""
+
 #: src/components/reader/format-i18n.ts
 msgid "today"
 msgstr ""
@@ -6786,6 +6908,7 @@ msgstr "Wir posten nichts über Ihr Konto, außer Sie lösen es ausdrücklich au
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Publications"
 msgstr "Publikationen"
@@ -7019,6 +7142,10 @@ msgstr "Ermöglicht durch <0>Standard Reader</0>"
 
 #: src/components/appearance-settings.tsx
 msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."
+msgstr ""
+
+#: src/routes/_layout.topics.index.tsx
+msgid "Search by name or topic — “vinyl”, “kubernetes”…"
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
@@ -7351,6 +7478,11 @@ msgstr ""
 
 #: src/components/reader/read-on-platform.tsx
 msgid "Read this on {name}"
+msgstr ""
+
+#. placeholder {0}: topic.authorCount
+#: src/components/reader/topic-cards.tsx
+msgid "{0, plural, one {# writer} other {# writers}}"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -115,6 +115,11 @@ msgstr ""
 msgid "Add an article"
 msgstr ""
 
+#: src/routes/_layout.communities.index.tsx
+#: src/routes/_layout.discover.tsx
+#~ msgid "Communities"
+#~ msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/components/reader/app-shell.tsx
@@ -156,6 +161,10 @@ msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "The {SITE_NAME} browser extension helps you save articles and follow publications on the standard.site network from any tab. It connects to the same account as the web app at <0>{siteHost}</0>. This policy covers the extension only; the <1>site privacy policy</1> describes data handling on the website itself."
+msgstr ""
+
+#: src/routes/_layout.topics.index.tsx
+msgid "Topic areas the network's writing clusters into, rebuilt as it grows. Each one gathers related tags, the publications writing about them, and everything they've published."
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -328,6 +337,10 @@ msgstr ""
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Density"
+msgstr ""
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Best fit"
 msgstr ""
 
 #: src/components/reader/article-view.tsx
@@ -641,6 +654,7 @@ msgstr ""
 #: src/routes/_layout.index.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Trending"
 msgstr ""
 
@@ -654,6 +668,7 @@ msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "{publicationCount, plural, one {publication} other {publications}}"
 msgstr ""
 
@@ -669,6 +684,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Permanently remove data stored in your account. These actions delete records from your account and cannot be undone."
 msgstr ""
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Sub-areas"
+#~ msgstr ""
 
 #: src/routes/_layout.friends.tsx
 msgid "Loading people"
@@ -801,6 +820,7 @@ msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Loading publications"
 msgstr ""
 
@@ -825,6 +845,7 @@ msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Grid view"
 msgstr ""
 
@@ -871,6 +892,7 @@ msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "List view"
 msgstr ""
 
@@ -946,6 +968,7 @@ msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} pu
 msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Sort articles"
 msgstr ""
 
@@ -1801,6 +1824,10 @@ msgstr ""
 msgid "{0}, dark"
 msgstr ""
 
+#: src/routes/_layout.discover.tsx
+msgid "Browse all topics"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Can read and act on your behalf"
 msgstr ""
@@ -1837,6 +1864,7 @@ msgstr ""
 #: src/routes/_layout.friends.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Loading articles"
 msgstr ""
 
@@ -1901,6 +1929,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "More from <0>{0}</0>"
 msgstr ""
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Community"
+#~ msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
@@ -1999,6 +2031,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/discover-topic-filters.tsx
+#: src/routes/_layout.topics.index.tsx
 msgid "Search topics"
 msgstr ""
 
@@ -2069,6 +2102,10 @@ msgstr ""
 #: src/components/reader/subscriptions-table.tsx
 msgid "Sort descending"
 msgstr ""
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "No publications in this community yet."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Anonymous"
@@ -2181,6 +2218,11 @@ msgstr ""
 msgid "Something went wrong while submitting your feedback."
 msgstr ""
 
+#. placeholder {0}: visible.length
+#: src/routes/_layout.topics.index.tsx
+msgid "{0, plural, one {# topic} other {# topics}}"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
 msgstr ""
@@ -2226,6 +2268,10 @@ msgstr ""
 
 #: src/components/onboarding/step-settings.tsx
 msgid "Marks what you've read for unread counts. Stored publicly on your account — turn off to read privately."
+msgstr ""
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Newest"
 msgstr ""
 
 #: src/routes/_layout.feedback.return.tsx
@@ -2428,6 +2474,7 @@ msgstr ""
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Readers"
 msgstr ""
@@ -2491,6 +2538,7 @@ msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Active"
 msgstr ""
 
@@ -2708,6 +2756,10 @@ msgstr ""
 msgid "Everything below is compatibility support for formats already out there in other apps' own repos — none of it is part of the site.standard spec, and none of it is something to model a new integration on."
 msgstr ""
 
+#: src/routes/_layout.topics.$slug.tsx
+msgid "No articles in this topic yet."
+msgstr ""
+
 #: src/components/reader/subscribe-card.tsx
 msgid "Subscribing"
 msgstr ""
@@ -2768,6 +2820,10 @@ msgstr ""
 msgid "A sentence of body copy, set in your chosen fonts and colors, so you can see how it all reads together before you save."
 msgstr ""
 
+#: src/routes/_layout.discover.tsx
+#~ msgid "Find your corner"
+#~ msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Open the directory"
 msgstr ""
@@ -2801,6 +2857,10 @@ msgstr ""
 msgid "Back to feedback"
 msgstr ""
 
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Community views"
+#~ msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "View on {name}"
 msgstr ""
@@ -2824,6 +2884,10 @@ msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Drop another screenshot"
+msgstr ""
+
+#: src/routes/_layout.discover.tsx
+msgid "See all"
 msgstr ""
 
 #: src/components/comic/comic-reader.tsx
@@ -2962,6 +3026,7 @@ msgstr ""
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "You've reached the end."
 msgstr ""
@@ -3437,6 +3502,10 @@ msgstr ""
 msgid "e.g. Dispatches from the Atmosphere"
 msgstr ""
 
+#: src/routes/_layout.discover.tsx
+#~ msgid "Browse all communities"
+#~ msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "{value, plural, one {# join} other {# joins}}"
 msgstr ""
@@ -3530,6 +3599,10 @@ msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "A player appears just above the navigation and stays there while you move around the app, so you can keep listening while you browse. It has play and pause, a jump back fifteen seconds, a speed control, a bar you can drag to move through the article, and a close button. The word being spoken is highlighted in the text and kept on screen; if you scroll away yourself, that stops until you select <0>Follow along</0>."
+msgstr ""
+
+#: src/routes/_layout.topics.index.tsx
+msgid "No topics match your search."
 msgstr ""
 
 #. placeholder {0}: rows.length
@@ -3713,7 +3786,9 @@ msgstr ""
 
 #. placeholder {0}: following.length
 #. placeholder {0}: list.publications.length
+#. placeholder {0}: topic.publicationCount
 #: src/components/reader/subscriptions-sheet.tsx
+#: src/components/reader/topic-cards.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "{0, plural, one {# publication} other {# publications}}"
 msgstr ""
@@ -3762,6 +3837,10 @@ msgstr ""
 #: src/components/reader/subscriptions-tree.tsx
 msgid "Empty list."
 msgstr ""
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "No articles in this community yet."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Show only mine"
@@ -4247,6 +4326,10 @@ msgstr ""
 #: src/routes/_layout.index.tsx
 msgid "{newCount} new"
 msgstr ""
+
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "No communities match your search."
+#~ msgstr ""
 
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Reading in {language}"
@@ -5057,6 +5140,10 @@ msgstr ""
 msgid "Collection"
 msgstr ""
 
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Most liked"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Clear filter"
 msgstr ""
@@ -5127,6 +5214,7 @@ msgid "Everything by one author"
 msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Topic"
 msgstr ""
 
@@ -5174,6 +5262,10 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 msgid "Publish labels others can subscribe to, or consume the ones we do."
 msgstr ""
+
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Search communities"
+#~ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "The full account is on the <0>extension privacy page</0>."
@@ -5472,6 +5564,11 @@ msgstr ""
 msgid "The Slow Web, Revisited"
 msgstr ""
 
+#. placeholder {0}: visible.length
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "{0, plural, one {# community} other {# communities}}"
+#~ msgstr ""
+
 #. placeholder {0}: labelTotal - names.length
 #: src/components/labelers-settings-view.tsx
 msgid "+{0} more"
@@ -5593,6 +5690,8 @@ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/lib/guide/navigation.ts
+#: src/routes/_layout.discover.tsx
+#: src/routes/_layout.topics.index.tsx
 msgid "Topics"
 msgstr ""
 
@@ -5627,6 +5726,10 @@ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Search feedback"
+msgstr ""
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "No publications in this topic yet."
 msgstr ""
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
@@ -5698,6 +5801,10 @@ msgstr ""
 msgid "Some people would rather read on the publication's own site, with its own design. Turn on the open-on-the-original-site setting in your account menu and every article link opens there in a new tab instead of in the reader. Articles that have no site of their own still open here."
 msgstr ""
 
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Search by name or topic…"
+#~ msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Contents"
 msgstr ""
@@ -5747,6 +5854,11 @@ msgstr ""
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
+msgstr ""
+
+#. placeholder {0}: topic.authorCount
+#: src/routes/_layout.topics.$slug.tsx
+msgid "{0, plural, one {writer} other {writers}}"
 msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
@@ -5910,6 +6022,7 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Articles"
 msgstr ""
 
@@ -5990,6 +6103,7 @@ msgstr ""
 #: src/components/reader/subscriptions-sheet.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "A–Z"
 msgstr ""
 
@@ -6138,6 +6252,10 @@ msgstr ""
 
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
+msgstr ""
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Topic views"
 msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
@@ -6673,6 +6791,10 @@ msgstr ""
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr ""
 
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Every corner"
+#~ msgstr ""
+
 #: src/components/reader/format-i18n.ts
 msgid "today"
 msgstr ""
@@ -6786,6 +6908,7 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Publications"
 msgstr ""
@@ -7019,6 +7142,10 @@ msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."
+msgstr ""
+
+#: src/routes/_layout.topics.index.tsx
+msgid "Search by name or topic — “vinyl”, “kubernetes”…"
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
@@ -7351,6 +7478,11 @@ msgstr ""
 
 #: src/components/reader/read-on-platform.tsx
 msgid "Read this on {name}"
+msgstr ""
+
+#. placeholder {0}: topic.authorCount
+#: src/components/reader/topic-cards.tsx
+msgid "{0, plural, one {# writer} other {# writers}}"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -115,6 +115,11 @@ msgstr "{value, plural, one {# member} other {# members}}"
 msgid "Add an article"
 msgstr "Add an article"
 
+#: src/routes/_layout.communities.index.tsx
+#: src/routes/_layout.discover.tsx
+#~ msgid "Communities"
+#~ msgstr "Communities"
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/components/reader/app-shell.tsx
@@ -157,6 +162,10 @@ msgstr "Remove icon"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "The {SITE_NAME} browser extension helps you save articles and follow publications on the standard.site network from any tab. It connects to the same account as the web app at <0>{siteHost}</0>. This policy covers the extension only; the <1>site privacy policy</1> describes data handling on the website itself."
 msgstr "The {SITE_NAME} browser extension helps you save articles and follow publications on the standard.site network from any tab. It connects to the same account as the web app at <0>{siteHost}</0>. This policy covers the extension only; the <1>site privacy policy</1> describes data handling on the website itself."
+
+#: src/routes/_layout.topics.index.tsx
+msgid "Topic areas the network's writing clusters into, rebuilt as it grows. Each one gathers related tags, the publications writing about them, and everything they've published."
+msgstr "Topic areas the network's writing clusters into, rebuilt as it grows. Each one gathers related tags, the publications writing about them, and everything they've published."
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "find publications, people, topics, and headlines by name."
@@ -329,6 +338,10 @@ msgstr "Opening the collection…"
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Density"
 msgstr "Density"
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Best fit"
+msgstr "Best fit"
 
 #: src/components/reader/article-view.tsx
 msgid "Open on publication"
@@ -641,6 +654,7 @@ msgstr "Tap the heart on any article to recommend it. Your recommendations live 
 #: src/routes/_layout.index.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Trending"
 msgstr "Trending"
 
@@ -654,6 +668,7 @@ msgstr "Publications shown"
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "{publicationCount, plural, one {publication} other {publications}}"
 msgstr "{publicationCount, plural, one {publication} other {publications}}"
 
@@ -669,6 +684,10 @@ msgstr "Attachment {0} on “{title}”"
 #: src/components/user-settings-view.tsx
 msgid "Permanently remove data stored in your account. These actions delete records from your account and cannot be undone."
 msgstr "Permanently remove data stored in your account. These actions delete records from your account and cannot be undone."
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Sub-areas"
+#~ msgstr "Sub-areas"
 
 #: src/routes/_layout.friends.tsx
 msgid "Loading people"
@@ -801,6 +820,7 @@ msgstr "Sign-in failed. Try again."
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Loading publications"
 msgstr "Loading publications"
 
@@ -825,6 +845,7 @@ msgstr "Mark as unread"
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Grid view"
 msgstr "Grid view"
 
@@ -871,6 +892,7 @@ msgstr "Images and links"
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "List view"
 msgstr "List view"
 
@@ -946,6 +968,7 @@ msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} pu
 msgstr "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Sort articles"
 msgstr "Sort articles"
 
@@ -1801,6 +1824,10 @@ msgstr "No publications in this list."
 msgid "{0}, dark"
 msgstr "{0}, dark"
 
+#: src/routes/_layout.discover.tsx
+msgid "Browse all topics"
+msgstr "Browse all topics"
+
 #: src/components/user-settings-view.tsx
 msgid "Can read and act on your behalf"
 msgstr "Can read and act on your behalf"
@@ -1837,6 +1864,7 @@ msgstr "Remove list"
 #: src/routes/_layout.friends.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Loading articles"
 msgstr "Loading articles"
 
@@ -1901,6 +1929,10 @@ msgstr "Also read natively:"
 #: src/components/reader/article-below-fold.tsx
 msgid "More from <0>{0}</0>"
 msgstr "More from <0>{0}</0>"
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Community"
+#~ msgstr "Community"
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
@@ -1999,6 +2031,7 @@ msgstr "Newest first"
 #~ msgstr "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
 
 #: src/components/reader/discover-topic-filters.tsx
+#: src/routes/_layout.topics.index.tsx
 msgid "Search topics"
 msgstr "Search topics"
 
@@ -2069,6 +2102,10 @@ msgstr "Attempt to disrupt, overload, or gain unauthorized access to the service
 #: src/components/reader/subscriptions-table.tsx
 msgid "Sort descending"
 msgstr "Sort descending"
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "No publications in this community yet."
+#~ msgstr "No publications in this community yet."
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Anonymous"
@@ -2181,6 +2218,11 @@ msgstr "The site.standard link rels"
 msgid "Something went wrong while submitting your feedback."
 msgstr "Something went wrong while submitting your feedback."
 
+#. placeholder {0}: visible.length
+#: src/routes/_layout.topics.index.tsx
+msgid "{0, plural, one {# topic} other {# topics}}"
+msgstr "{0, plural, one {# topic} other {# topics}}"
+
 #: src/components/reader/about-view.tsx
 msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
 msgstr "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
@@ -2227,6 +2269,10 @@ msgstr "on pckt"
 #: src/components/onboarding/step-settings.tsx
 msgid "Marks what you've read for unread counts. Stored publicly on your account — turn off to read privately."
 msgstr "Marks what you've read for unread counts. Stored publicly on your account — turn off to read privately."
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Newest"
+msgstr "Newest"
 
 #: src/routes/_layout.feedback.return.tsx
 msgid "Your upvote has been recorded on userinput.app. Thanks for helping surface what matters."
@@ -2428,6 +2474,7 @@ msgstr "Loading more"
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Readers"
 msgstr "Readers"
@@ -2491,6 +2538,7 @@ msgstr "Sort"
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Active"
 msgstr "Active"
 
@@ -2708,6 +2756,10 @@ msgstr "No articles are trending across the network right now. Check back soon."
 msgid "Everything below is compatibility support for formats already out there in other apps' own repos — none of it is part of the site.standard spec, and none of it is something to model a new integration on."
 msgstr "Everything below is compatibility support for formats already out there in other apps' own repos — none of it is part of the site.standard spec, and none of it is something to model a new integration on."
 
+#: src/routes/_layout.topics.$slug.tsx
+msgid "No articles in this topic yet."
+msgstr "No articles in this topic yet."
+
 #: src/components/reader/subscribe-card.tsx
 msgid "Subscribing"
 msgstr "Subscribing"
@@ -2768,6 +2820,10 @@ msgstr "Under <0>Sidebar</0>, you can hide destinations you never use. Subscript
 msgid "A sentence of body copy, set in your chosen fonts and colors, so you can see how it all reads together before you save."
 msgstr "A sentence of body copy, set in your chosen fonts and colors, so you can see how it all reads together before you save."
 
+#: src/routes/_layout.discover.tsx
+#~ msgid "Find your corner"
+#~ msgstr "Find your corner"
+
 #: src/routes/_layout.index.tsx
 msgid "Open the directory"
 msgstr "Open the directory"
@@ -2801,6 +2857,10 @@ msgstr "Reorder {itemTitle}"
 msgid "Back to feedback"
 msgstr "Back to feedback"
 
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Community views"
+#~ msgstr "Community views"
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "View on {name}"
 msgstr "View on {name}"
@@ -2825,6 +2885,10 @@ msgstr "Background"
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Drop another screenshot"
 msgstr "Drop another screenshot"
+
+#: src/routes/_layout.discover.tsx
+msgid "See all"
+msgstr "See all"
 
 #: src/components/comic/comic-reader.tsx
 msgid "This comic has no pages to show."
@@ -2962,6 +3026,7 @@ msgstr "Standard Reader can be installed like an app, straight from the browser,
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "You've reached the end."
 msgstr "You've reached the end."
@@ -3437,6 +3502,10 @@ msgstr "You agree not to use {SITE_NAME} to:"
 msgid "e.g. Dispatches from the Atmosphere"
 msgstr "e.g. Dispatches from the Atmosphere"
 
+#: src/routes/_layout.discover.tsx
+#~ msgid "Browse all communities"
+#~ msgstr "Browse all communities"
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "{value, plural, one {# join} other {# joins}}"
 msgstr "{value, plural, one {# join} other {# joins}}"
@@ -3531,6 +3600,10 @@ msgstr "by @{ownerHandle}"
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "A player appears just above the navigation and stays there while you move around the app, so you can keep listening while you browse. It has play and pause, a jump back fifteen seconds, a speed control, a bar you can drag to move through the article, and a close button. The word being spoken is highlighted in the text and kept on screen; if you scroll away yourself, that stops until you select <0>Follow along</0>."
 msgstr "A player appears just above the navigation and stays there while you move around the app, so you can keep listening while you browse. It has play and pause, a jump back fifteen seconds, a speed control, a bar you can drag to move through the article, and a close button. The word being spoken is highlighted in the text and kept on screen; if you scroll away yourself, that stops until you select <0>Follow along</0>."
+
+#: src/routes/_layout.topics.index.tsx
+msgid "No topics match your search."
+msgstr "No topics match your search."
 
 #. placeholder {0}: rows.length
 #: src/components/reader/subscriptions-table.tsx
@@ -3713,7 +3786,9 @@ msgstr "No publications found for this account."
 
 #. placeholder {0}: following.length
 #. placeholder {0}: list.publications.length
+#. placeholder {0}: topic.publicationCount
 #: src/components/reader/subscriptions-sheet.tsx
+#: src/components/reader/topic-cards.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "{0, plural, one {# publication} other {# publications}}"
 msgstr "{0, plural, one {# publication} other {# publications}}"
@@ -3762,6 +3837,10 @@ msgstr "No matching people."
 #: src/components/reader/subscriptions-tree.tsx
 msgid "Empty list."
 msgstr "Empty list."
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "No articles in this community yet."
+#~ msgstr "No articles in this community yet."
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Show only mine"
@@ -4247,6 +4326,10 @@ msgstr "<0>{countLabel}</0> publications indexed — and counting"
 #: src/routes/_layout.index.tsx
 msgid "{newCount} new"
 msgstr "{newCount} new"
+
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "No communities match your search."
+#~ msgstr "No communities match your search."
 
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Reading in {language}"
@@ -5057,6 +5140,10 @@ msgstr "Either no one you follow on Bluesky publishes here yet, or you're alread
 msgid "Collection"
 msgstr "Collection"
 
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Most liked"
+msgstr "Most liked"
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Clear filter"
 msgstr "Clear filter"
@@ -5127,6 +5214,7 @@ msgid "Everything by one author"
 msgstr "Everything by one author"
 
 #: src/components/reader/subscriptions-table.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Topic"
 msgstr "Topic"
 
@@ -5174,6 +5262,10 @@ msgstr "Sharing a review on the <0>ATStore</0> will help both us and other users
 #: src/components/reader/about-view.tsx
 msgid "Publish labels others can subscribe to, or consume the ones we do."
 msgstr "Publish labels others can subscribe to, or consume the ones we do."
+
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Search communities"
+#~ msgstr "Search communities"
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "The full account is on the <0>extension privacy page</0>."
@@ -5472,6 +5564,11 @@ msgstr "Service DID is <0>{appviewDid}</0>. The service advertises a <1>DID docu
 msgid "The Slow Web, Revisited"
 msgstr "The Slow Web, Revisited"
 
+#. placeholder {0}: visible.length
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "{0, plural, one {# community} other {# communities}}"
+#~ msgstr "{0, plural, one {# community} other {# communities}}"
+
 #. placeholder {0}: labelTotal - names.length
 #: src/components/labelers-settings-view.tsx
 msgid "+{0} more"
@@ -5593,6 +5690,8 @@ msgstr "The same toolbar can start the narration from that paragraph with <0>Rea
 
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/lib/guide/navigation.ts
+#: src/routes/_layout.discover.tsx
+#: src/routes/_layout.topics.index.tsx
 msgid "Topics"
 msgstr "Topics"
 
@@ -5628,6 +5727,10 @@ msgstr "Leave us a review on ATStore."
 #: src/routes/_layout.feedback.index.tsx
 msgid "Search feedback"
 msgstr "Search feedback"
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "No publications in this topic yet."
+msgstr "No publications in this topic yet."
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe"
@@ -5698,6 +5801,10 @@ msgstr "Save list"
 msgid "Some people would rather read on the publication's own site, with its own design. Turn on the open-on-the-original-site setting in your account menu and every article link opens there in a new tab instead of in the reader. Articles that have no site of their own still open here."
 msgstr "Some people would rather read on the publication's own site, with its own design. Turn on the open-on-the-original-site setting in your account menu and every article link opens there in a new tab instead of in the reader. Articles that have no site of their own still open here."
 
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Search by name or topic…"
+#~ msgstr "Search by name or topic…"
+
 #: src/magazine/Magazine.tsx
 msgid "Contents"
 msgstr "Contents"
@@ -5748,6 +5855,11 @@ msgstr "Top on the network"
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
 msgstr "Remove"
+
+#. placeholder {0}: topic.authorCount
+#: src/routes/_layout.topics.$slug.tsx
+msgid "{0, plural, one {writer} other {writers}}"
+msgstr "{0, plural, one {writer} other {writers}}"
 
 #: src/components/docs/renderers-docs-page.tsx
 msgid "<0>Platform</0> components render the blocks unique to one publishing platform — a Leaflet poll or signup, a Pckt gallery or note embed, an Offprint component. These are the interactive, often data-backed embeds; the headless defaults render nothing, so you supply your own to make them live."
@@ -5910,6 +6022,7 @@ msgstr "Pages you have already visited stay available when your connection drops
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Articles"
 msgstr "Articles"
 
@@ -5990,6 +6103,7 @@ msgstr "Introduction"
 #: src/components/reader/subscriptions-sheet.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "A–Z"
 msgstr "A–Z"
 
@@ -6139,6 +6253,10 @@ msgstr "Reading without an account"
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "Details"
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Topic views"
+msgstr "Topic views"
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "When you save or follow from the extension, {SITE_NAME} writes AT Protocol records to <0>your</0> repository through the same server paths as the web app. Those records follow the network's visibility rules and your account settings."
@@ -6673,6 +6791,10 @@ msgstr "Read aloud"
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "Articles you've saved for later — in your repo, synced across devices."
 
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Every corner"
+#~ msgstr "Every corner"
+
 #: src/components/reader/format-i18n.ts
 msgid "today"
 msgstr "today"
@@ -6786,6 +6908,7 @@ msgstr "We do not post to your account except when you take an explicit action t
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Publications"
 msgstr "Publications"
@@ -7020,6 +7143,10 @@ msgstr "Powered by <0>Standard Reader</0>"
 #: src/components/appearance-settings.tsx
 msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."
 msgstr "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."
+
+#: src/routes/_layout.topics.index.tsx
+msgid "Search by name or topic — “vinyl”, “kubernetes”…"
+msgstr "Search by name or topic — “vinyl”, “kubernetes”…"
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -7352,6 +7479,11 @@ msgstr "MCP server"
 #: src/components/reader/read-on-platform.tsx
 msgid "Read this on {name}"
 msgstr "Read this on {name}"
+
+#. placeholder {0}: topic.authorCount
+#: src/components/reader/topic-cards.tsx
+msgid "{0, plural, one {# writer} other {# writers}}"
+msgstr "{0, plural, one {# writer} other {# writers}}"
 
 #: src/components/reader/terms-view.tsx
 msgid "Acceptable use"

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -115,6 +115,11 @@ msgstr ""
 msgid "Add an article"
 msgstr "Añadir un artículo"
 
+#: src/routes/_layout.communities.index.tsx
+#: src/routes/_layout.discover.tsx
+#~ msgid "Communities"
+#~ msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/components/reader/app-shell.tsx
@@ -157,6 +162,10 @@ msgstr "Quitar icono"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "The {SITE_NAME} browser extension helps you save articles and follow publications on the standard.site network from any tab. It connects to the same account as the web app at <0>{siteHost}</0>. This policy covers the extension only; the <1>site privacy policy</1> describes data handling on the website itself."
 msgstr "La extensión de navegador de {SITE_NAME} le ayuda a guardar artículos y seguir publicaciones de la red standard.site desde cualquier pestaña. Se conecta a la misma cuenta que la app web en <0>{siteHost}</0>. Esta política cubre solo la extensión; la <1>política de privacidad del sitio</1> describe el tratamiento de datos en el sitio web."
+
+#: src/routes/_layout.topics.index.tsx
+msgid "Topic areas the network's writing clusters into, rebuilt as it grows. Each one gathers related tags, the publications writing about them, and everything they've published."
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "find publications, people, topics, and headlines by name."
@@ -328,6 +337,10 @@ msgstr "Abriendo la colección…"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Density"
+msgstr ""
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Best fit"
 msgstr ""
 
 #: src/components/reader/article-view.tsx
@@ -641,6 +654,7 @@ msgstr "Toque el corazón en cualquier artículo para recomendarlo. Sus recomend
 #: src/routes/_layout.index.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Trending"
 msgstr "Tendencias"
 
@@ -654,6 +668,7 @@ msgstr "Publicaciones mostradas"
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "{publicationCount, plural, one {publication} other {publications}}"
 msgstr "{publicationCount, plural, one {publicación} other {publicaciones}}"
 
@@ -669,6 +684,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Permanently remove data stored in your account. These actions delete records from your account and cannot be undone."
 msgstr "Elimine de forma permanente los datos guardados en su cuenta. Estas acciones borran registros de su cuenta y no se pueden deshacer."
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Sub-areas"
+#~ msgstr ""
 
 #: src/routes/_layout.friends.tsx
 msgid "Loading people"
@@ -801,6 +820,7 @@ msgstr "Error al iniciar sesión. Inténtelo de nuevo."
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Loading publications"
 msgstr "Cargando publicaciones"
 
@@ -825,6 +845,7 @@ msgstr "Marcar como sin leer"
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Grid view"
 msgstr "Vista de cuadrícula"
 
@@ -871,6 +892,7 @@ msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "List view"
 msgstr "Vista de lista"
 
@@ -946,6 +968,7 @@ msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} pu
 msgstr "{unfollowedCount, plural, one {¿Suscribirse a {formattedUnfollowedCount} publicación?} other {¿Suscribirse a {formattedUnfollowedCount} publicaciones?}}"
 
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Sort articles"
 msgstr ""
 
@@ -1801,6 +1824,10 @@ msgstr "No hay publicaciones en esta lista."
 msgid "{0}, dark"
 msgstr ""
 
+#: src/routes/_layout.discover.tsx
+msgid "Browse all topics"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Can read and act on your behalf"
 msgstr ""
@@ -1837,6 +1864,7 @@ msgstr "Quitar lista"
 #: src/routes/_layout.friends.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Loading articles"
 msgstr "Cargando artículos"
 
@@ -1901,6 +1929,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "More from <0>{0}</0>"
 msgstr "Más de <0>{0}</0>"
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Community"
+#~ msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
@@ -1999,6 +2031,7 @@ msgstr ""
 #~ msgstr "Las publicaciones, las listas y las colecciones tienen cada una un enlace limpio con una tarjeta de vista previa enriquecida, además de un botón de suscripción que una publicación puede colocar en su propio sitio."
 
 #: src/components/reader/discover-topic-filters.tsx
+#: src/routes/_layout.topics.index.tsx
 msgid "Search topics"
 msgstr ""
 
@@ -2069,6 +2102,10 @@ msgstr ""
 #: src/components/reader/subscriptions-table.tsx
 msgid "Sort descending"
 msgstr ""
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "No publications in this community yet."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Anonymous"
@@ -2181,6 +2218,11 @@ msgstr ""
 msgid "Something went wrong while submitting your feedback."
 msgstr "Algo salió mal al enviar su comentario."
 
+#. placeholder {0}: visible.length
+#: src/routes/_layout.topics.index.tsx
+msgid "{0, plural, one {# topic} other {# topics}}"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
 msgstr "¿No quiere otra aplicación más que revisar? Suscríbase a un correo semanal con lo mejor de las publicaciones que sigue, más un par que vale la pena descubrir. Un correo, un clic para darse de baja, y puede ver exactamente cómo se ve antes de activarlo."
@@ -2227,6 +2269,10 @@ msgstr "en pckt"
 #: src/components/onboarding/step-settings.tsx
 msgid "Marks what you've read for unread counts. Stored publicly on your account — turn off to read privately."
 msgstr "Marca lo que ha leído para los recuentos de artículos sin leer. Se guarda públicamente en su cuenta; desactívelo para leer en privado."
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Newest"
+msgstr ""
 
 #: src/routes/_layout.feedback.return.tsx
 msgid "Your upvote has been recorded on userinput.app. Thanks for helping surface what matters."
@@ -2428,6 +2474,7 @@ msgstr ""
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Readers"
 msgstr "Lectores"
@@ -2491,6 +2538,7 @@ msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Active"
 msgstr "Activo"
 
@@ -2708,6 +2756,10 @@ msgstr "Ahora mismo no hay artículos en tendencia en la red. Vuelva pronto."
 msgid "Everything below is compatibility support for formats already out there in other apps' own repos — none of it is part of the site.standard spec, and none of it is something to model a new integration on."
 msgstr "Todo lo que sigue es compatibilidad con formatos que ya existen en los repositorios de otras aplicaciones: nada de esto forma parte de la especificación site.standard ni es un modelo a seguir para una nueva integración."
 
+#: src/routes/_layout.topics.$slug.tsx
+msgid "No articles in this topic yet."
+msgstr ""
+
 #: src/components/reader/subscribe-card.tsx
 msgid "Subscribing"
 msgstr "Suscribiendo"
@@ -2768,6 +2820,10 @@ msgstr ""
 msgid "A sentence of body copy, set in your chosen fonts and colors, so you can see how it all reads together before you save."
 msgstr "Una frase de texto de cuerpo, compuesta con las fuentes y los colores que eligió, para que vea cómo se lee todo junto antes de guardar."
 
+#: src/routes/_layout.discover.tsx
+#~ msgid "Find your corner"
+#~ msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Open the directory"
 msgstr "Abrir el directorio"
@@ -2801,6 +2857,10 @@ msgstr "Reordenar {itemTitle}"
 msgid "Back to feedback"
 msgstr "Volver a los comentarios"
 
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Community views"
+#~ msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "View on {name}"
 msgstr ""
@@ -2824,6 +2884,10 @@ msgstr "Fondo"
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Drop another screenshot"
+msgstr ""
+
+#: src/routes/_layout.discover.tsx
+msgid "See all"
 msgstr ""
 
 #: src/components/comic/comic-reader.tsx
@@ -2962,6 +3026,7 @@ msgstr ""
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "You've reached the end."
 msgstr "Ha llegado al final."
@@ -3437,6 +3502,10 @@ msgstr ""
 msgid "e.g. Dispatches from the Atmosphere"
 msgstr "p. ej. Crónicas desde la Atmosphere"
 
+#: src/routes/_layout.discover.tsx
+#~ msgid "Browse all communities"
+#~ msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "{value, plural, one {# join} other {# joins}}"
 msgstr ""
@@ -3530,6 +3599,10 @@ msgstr "por @{ownerHandle}"
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "A player appears just above the navigation and stays there while you move around the app, so you can keep listening while you browse. It has play and pause, a jump back fifteen seconds, a speed control, a bar you can drag to move through the article, and a close button. The word being spoken is highlighted in the text and kept on screen; if you scroll away yourself, that stops until you select <0>Follow along</0>."
+msgstr ""
+
+#: src/routes/_layout.topics.index.tsx
+msgid "No topics match your search."
 msgstr ""
 
 #. placeholder {0}: rows.length
@@ -3713,7 +3786,9 @@ msgstr "No se encontraron publicaciones para esta cuenta."
 
 #. placeholder {0}: following.length
 #. placeholder {0}: list.publications.length
+#. placeholder {0}: topic.publicationCount
 #: src/components/reader/subscriptions-sheet.tsx
+#: src/components/reader/topic-cards.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "{0, plural, one {# publication} other {# publications}}"
 msgstr "{0, plural, one {# publicación} other {# publicaciones}}"
@@ -3762,6 +3837,10 @@ msgstr "No hay personas coincidentes."
 #: src/components/reader/subscriptions-tree.tsx
 msgid "Empty list."
 msgstr "Lista vacía."
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "No articles in this community yet."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Show only mine"
@@ -4247,6 +4326,10 @@ msgstr "<0>{countLabel}</0> publicaciones indexadas, y subiendo"
 #: src/routes/_layout.index.tsx
 msgid "{newCount} new"
 msgstr "{newCount} nuevas"
+
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "No communities match your search."
+#~ msgstr ""
 
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Reading in {language}"
@@ -5057,6 +5140,10 @@ msgstr ""
 msgid "Collection"
 msgstr "Colección"
 
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Most liked"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Clear filter"
 msgstr ""
@@ -5127,6 +5214,7 @@ msgid "Everything by one author"
 msgstr "Todo de un mismo autor"
 
 #: src/components/reader/subscriptions-table.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Topic"
 msgstr ""
 
@@ -5174,6 +5262,10 @@ msgstr "Compartir una reseña en <0>ATStore</0> nos ayudará, tanto a nosotros c
 #: src/components/reader/about-view.tsx
 msgid "Publish labels others can subscribe to, or consume the ones we do."
 msgstr ""
+
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Search communities"
+#~ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "The full account is on the <0>extension privacy page</0>."
@@ -5472,6 +5564,11 @@ msgstr "El DID del servicio es <0>{appviewDid}</0>. El servicio publica un <1>do
 msgid "The Slow Web, Revisited"
 msgstr "La web lenta, revisitada"
 
+#. placeholder {0}: visible.length
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "{0, plural, one {# community} other {# communities}}"
+#~ msgstr ""
+
 #. placeholder {0}: labelTotal - names.length
 #: src/components/labelers-settings-view.tsx
 msgid "+{0} more"
@@ -5593,6 +5690,8 @@ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/lib/guide/navigation.ts
+#: src/routes/_layout.discover.tsx
+#: src/routes/_layout.topics.index.tsx
 msgid "Topics"
 msgstr ""
 
@@ -5628,6 +5727,10 @@ msgstr "Déjenos una reseña en ATStore."
 #: src/routes/_layout.feedback.index.tsx
 msgid "Search feedback"
 msgstr "Buscar comentarios"
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "No publications in this topic yet."
+msgstr ""
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe"
@@ -5698,6 +5801,10 @@ msgstr "Guardar lista"
 msgid "Some people would rather read on the publication's own site, with its own design. Turn on the open-on-the-original-site setting in your account menu and every article link opens there in a new tab instead of in the reader. Articles that have no site of their own still open here."
 msgstr ""
 
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Search by name or topic…"
+#~ msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Contents"
 msgstr "Contenido"
@@ -5748,6 +5855,11 @@ msgstr ""
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
 msgstr "Quitar"
+
+#. placeholder {0}: topic.authorCount
+#: src/routes/_layout.topics.$slug.tsx
+msgid "{0, plural, one {writer} other {writers}}"
+msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 msgid "<0>Platform</0> components render the blocks unique to one publishing platform — a Leaflet poll or signup, a Pckt gallery or note embed, an Offprint component. These are the interactive, often data-backed embeds; the headless defaults render nothing, so you supply your own to make them live."
@@ -5910,6 +6022,7 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Articles"
 msgstr "Artículos"
 
@@ -5990,6 +6103,7 @@ msgstr ""
 #: src/components/reader/subscriptions-sheet.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "A–Z"
 msgstr "A–Z"
 
@@ -6139,6 +6253,10 @@ msgstr ""
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "Detalles"
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Topic views"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "When you save or follow from the extension, {SITE_NAME} writes AT Protocol records to <0>your</0> repository through the same server paths as the web app. Those records follow the network's visibility rules and your account settings."
@@ -6673,6 +6791,10 @@ msgstr "Leer en voz alta"
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "Artículos que guardó para después: en su repositorio y sincronizados entre dispositivos."
 
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Every corner"
+#~ msgstr ""
+
 #: src/components/reader/format-i18n.ts
 msgid "today"
 msgstr ""
@@ -6786,6 +6908,7 @@ msgstr "No publicamos nada en su cuenta salvo cuando realiza una acción explíc
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Publications"
 msgstr "Publicaciones"
@@ -7019,6 +7142,10 @@ msgstr "Con la tecnología de <0>Standard Reader</0>"
 
 #: src/components/appearance-settings.tsx
 msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."
+msgstr ""
+
+#: src/routes/_layout.topics.index.tsx
+msgid "Search by name or topic — “vinyl”, “kubernetes”…"
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
@@ -7351,6 +7478,11 @@ msgstr ""
 
 #: src/components/reader/read-on-platform.tsx
 msgid "Read this on {name}"
+msgstr ""
+
+#. placeholder {0}: topic.authorCount
+#: src/components/reader/topic-cards.tsx
+msgid "{0, plural, one {# writer} other {# writers}}"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -115,6 +115,11 @@ msgstr ""
 msgid "Add an article"
 msgstr "Ajouter un article"
 
+#: src/routes/_layout.communities.index.tsx
+#: src/routes/_layout.discover.tsx
+#~ msgid "Communities"
+#~ msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/components/reader/app-shell.tsx
@@ -157,6 +162,10 @@ msgstr "Retirer l’icône"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "The {SITE_NAME} browser extension helps you save articles and follow publications on the standard.site network from any tab. It connects to the same account as the web app at <0>{siteHost}</0>. This policy covers the extension only; the <1>site privacy policy</1> describes data handling on the website itself."
 msgstr "L’extension de navigateur {SITE_NAME} vous aide à enregistrer des articles et à suivre des publications sur le réseau standard.site depuis n’importe quel onglet. Elle utilise le même compte que l’application web sur <0>{siteHost}</0>. Cette politique ne couvre que l’extension ; la <1>politique de confidentialité du site</1> décrit le traitement des données sur le site lui-même."
+
+#: src/routes/_layout.topics.index.tsx
+msgid "Topic areas the network's writing clusters into, rebuilt as it grows. Each one gathers related tags, the publications writing about them, and everything they've published."
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "find publications, people, topics, and headlines by name."
@@ -328,6 +337,10 @@ msgstr "Ouverture de la collection…"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Density"
+msgstr ""
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Best fit"
 msgstr ""
 
 #: src/components/reader/article-view.tsx
@@ -641,6 +654,7 @@ msgstr "Touchez le cœur sur un article pour le recommander. Vos recommandations
 #: src/routes/_layout.index.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Trending"
 msgstr "Tendances"
 
@@ -654,6 +668,7 @@ msgstr "Publications affichées"
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "{publicationCount, plural, one {publication} other {publications}}"
 msgstr "{publicationCount, plural, one {publication} other {publications}}"
 
@@ -669,6 +684,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Permanently remove data stored in your account. These actions delete records from your account and cannot be undone."
 msgstr "Supprimez définitivement les données stockées dans votre compte. Ces actions effacent des enregistrements de votre compte et sont irréversibles."
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Sub-areas"
+#~ msgstr ""
 
 #: src/routes/_layout.friends.tsx
 msgid "Loading people"
@@ -801,6 +820,7 @@ msgstr "Échec de la connexion. Réessayez."
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Loading publications"
 msgstr "Chargement des publications"
 
@@ -825,6 +845,7 @@ msgstr "Marquer comme non lu"
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Grid view"
 msgstr "Vue en grille"
 
@@ -871,6 +892,7 @@ msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "List view"
 msgstr "Vue en liste"
 
@@ -946,6 +968,7 @@ msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} pu
 msgstr "{unfollowedCount, plural, one {S’abonner à {formattedUnfollowedCount} publication ?} other {S’abonner à {formattedUnfollowedCount} publications ?}}"
 
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Sort articles"
 msgstr ""
 
@@ -1801,6 +1824,10 @@ msgstr "Aucune publication dans cette liste."
 msgid "{0}, dark"
 msgstr ""
 
+#: src/routes/_layout.discover.tsx
+msgid "Browse all topics"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Can read and act on your behalf"
 msgstr ""
@@ -1837,6 +1864,7 @@ msgstr "Retirer la liste"
 #: src/routes/_layout.friends.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Loading articles"
 msgstr "Chargement des articles"
 
@@ -1901,6 +1929,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "More from <0>{0}</0>"
 msgstr "Plus de <0>{0}</0>"
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Community"
+#~ msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
@@ -1999,6 +2031,7 @@ msgstr ""
 #~ msgstr "Publications, listes et collections disposent chacune d'un lien épuré avec un aperçu enrichi — ainsi que d'un bouton d'abonnement qu'une publication peut installer sur son propre site."
 
 #: src/components/reader/discover-topic-filters.tsx
+#: src/routes/_layout.topics.index.tsx
 msgid "Search topics"
 msgstr ""
 
@@ -2069,6 +2102,10 @@ msgstr ""
 #: src/components/reader/subscriptions-table.tsx
 msgid "Sort descending"
 msgstr ""
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "No publications in this community yet."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Anonymous"
@@ -2181,6 +2218,11 @@ msgstr ""
 msgid "Something went wrong while submitting your feedback."
 msgstr "Une erreur est survenue lors de l'envoi de votre retour."
 
+#. placeholder {0}: visible.length
+#: src/routes/_layout.topics.index.tsx
+msgid "{0, plural, one {# topic} other {# topics}}"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
 msgstr "Pas envie d'une application de plus à consulter ? Inscrivez-vous à un e-mail hebdomadaire réunissant le meilleur des publications auxquelles vous êtes abonné, plus quelques pépites à découvrir. Un seul e-mail, un seul clic pour se désinscrire — et vous pouvez prévisualiser exactement son rendu avant même de l'activer."
@@ -2227,6 +2269,10 @@ msgstr "sur pckt"
 #: src/components/onboarding/step-settings.tsx
 msgid "Marks what you've read for unread counts. Stored publicly on your account — turn off to read privately."
 msgstr "Enregistre ce que vous avez lu pour le décompte des non-lus. Stocké publiquement sur votre compte — désactivez cette option pour lire en privé."
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Newest"
+msgstr ""
 
 #: src/routes/_layout.feedback.return.tsx
 msgid "Your upvote has been recorded on userinput.app. Thanks for helping surface what matters."
@@ -2428,6 +2474,7 @@ msgstr ""
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Readers"
 msgstr "Lecteurs"
@@ -2491,6 +2538,7 @@ msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Active"
 msgstr "Actif"
 
@@ -2708,6 +2756,10 @@ msgstr "Aucun article ne fait l'actualité sur le réseau en ce moment. Revenez 
 msgid "Everything below is compatibility support for formats already out there in other apps' own repos — none of it is part of the site.standard spec, and none of it is something to model a new integration on."
 msgstr "Tout ce qui suit relève de la compatibilité avec des formats déjà présents dans les repos d'autres applications — rien de tout cela ne fait partie de la spécification site.standard, et rien ne doit servir de modèle à une nouvelle intégration."
 
+#: src/routes/_layout.topics.$slug.tsx
+msgid "No articles in this topic yet."
+msgstr ""
+
 #: src/components/reader/subscribe-card.tsx
 msgid "Subscribing"
 msgstr "Abonnement en cours"
@@ -2768,6 +2820,10 @@ msgstr ""
 msgid "A sentence of body copy, set in your chosen fonts and colors, so you can see how it all reads together before you save."
 msgstr "Une phrase de texte courant, composée avec les polices et les couleurs que vous avez choisies, pour voir le rendu d'ensemble avant d'enregistrer."
 
+#: src/routes/_layout.discover.tsx
+#~ msgid "Find your corner"
+#~ msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Open the directory"
 msgstr "Ouvrir l'annuaire"
@@ -2801,6 +2857,10 @@ msgstr "Réorganiser {itemTitle}"
 msgid "Back to feedback"
 msgstr "Retour aux retours"
 
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Community views"
+#~ msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "View on {name}"
 msgstr ""
@@ -2824,6 +2884,10 @@ msgstr "Arrière-plan"
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Drop another screenshot"
+msgstr ""
+
+#: src/routes/_layout.discover.tsx
+msgid "See all"
 msgstr ""
 
 #: src/components/comic/comic-reader.tsx
@@ -2962,6 +3026,7 @@ msgstr ""
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "You've reached the end."
 msgstr "Vous êtes arrivé au bout."
@@ -3437,6 +3502,10 @@ msgstr ""
 msgid "e.g. Dispatches from the Atmosphere"
 msgstr "ex. Chroniques de l’Atmosphere"
 
+#: src/routes/_layout.discover.tsx
+#~ msgid "Browse all communities"
+#~ msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "{value, plural, one {# join} other {# joins}}"
 msgstr ""
@@ -3530,6 +3599,10 @@ msgstr "par @{ownerHandle}"
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "A player appears just above the navigation and stays there while you move around the app, so you can keep listening while you browse. It has play and pause, a jump back fifteen seconds, a speed control, a bar you can drag to move through the article, and a close button. The word being spoken is highlighted in the text and kept on screen; if you scroll away yourself, that stops until you select <0>Follow along</0>."
+msgstr ""
+
+#: src/routes/_layout.topics.index.tsx
+msgid "No topics match your search."
 msgstr ""
 
 #. placeholder {0}: rows.length
@@ -3713,7 +3786,9 @@ msgstr "Aucune publication trouvée pour ce compte."
 
 #. placeholder {0}: following.length
 #. placeholder {0}: list.publications.length
+#. placeholder {0}: topic.publicationCount
 #: src/components/reader/subscriptions-sheet.tsx
+#: src/components/reader/topic-cards.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "{0, plural, one {# publication} other {# publications}}"
 msgstr "{0, plural, one {# publication} other {# publications}}"
@@ -3762,6 +3837,10 @@ msgstr "Aucune personne correspondante."
 #: src/components/reader/subscriptions-tree.tsx
 msgid "Empty list."
 msgstr "Liste vide."
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "No articles in this community yet."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Show only mine"
@@ -4247,6 +4326,10 @@ msgstr "<0>{countLabel}</0> publications indexées — et ce n’est qu’un dé
 #: src/routes/_layout.index.tsx
 msgid "{newCount} new"
 msgstr "{newCount} nouveaux"
+
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "No communities match your search."
+#~ msgstr ""
 
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Reading in {language}"
@@ -5057,6 +5140,10 @@ msgstr ""
 msgid "Collection"
 msgstr "Collection"
 
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Most liked"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Clear filter"
 msgstr ""
@@ -5127,6 +5214,7 @@ msgid "Everything by one author"
 msgstr "Tout d'un même auteur"
 
 #: src/components/reader/subscriptions-table.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Topic"
 msgstr ""
 
@@ -5174,6 +5262,10 @@ msgstr "Partager un avis sur l'<0>ATStore</0> nous aidera, ainsi que les autres 
 #: src/components/reader/about-view.tsx
 msgid "Publish labels others can subscribe to, or consume the ones we do."
 msgstr ""
+
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Search communities"
+#~ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "The full account is on the <0>extension privacy page</0>."
@@ -5472,6 +5564,11 @@ msgstr "Le DID du service est <0>{appviewDid}</0>. Le service publie un <1>docum
 msgid "The Slow Web, Revisited"
 msgstr "Le Slow Web, revisité"
 
+#. placeholder {0}: visible.length
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "{0, plural, one {# community} other {# communities}}"
+#~ msgstr ""
+
 #. placeholder {0}: labelTotal - names.length
 #: src/components/labelers-settings-view.tsx
 msgid "+{0} more"
@@ -5593,6 +5690,8 @@ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/lib/guide/navigation.ts
+#: src/routes/_layout.discover.tsx
+#: src/routes/_layout.topics.index.tsx
 msgid "Topics"
 msgstr ""
 
@@ -5628,6 +5727,10 @@ msgstr "Laissez-nous un avis sur ATStore."
 #: src/routes/_layout.feedback.index.tsx
 msgid "Search feedback"
 msgstr "Rechercher dans les retours"
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "No publications in this topic yet."
+msgstr ""
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe"
@@ -5698,6 +5801,10 @@ msgstr "Enregistrer la liste"
 msgid "Some people would rather read on the publication's own site, with its own design. Turn on the open-on-the-original-site setting in your account menu and every article link opens there in a new tab instead of in the reader. Articles that have no site of their own still open here."
 msgstr ""
 
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Search by name or topic…"
+#~ msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Contents"
 msgstr "Sommaire"
@@ -5748,6 +5855,11 @@ msgstr ""
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
 msgstr "Retirer"
+
+#. placeholder {0}: topic.authorCount
+#: src/routes/_layout.topics.$slug.tsx
+msgid "{0, plural, one {writer} other {writers}}"
+msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 msgid "<0>Platform</0> components render the blocks unique to one publishing platform — a Leaflet poll or signup, a Pckt gallery or note embed, an Offprint component. These are the interactive, often data-backed embeds; the headless defaults render nothing, so you supply your own to make them live."
@@ -5910,6 +6022,7 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Articles"
 msgstr "Articles"
 
@@ -5990,6 +6103,7 @@ msgstr ""
 #: src/components/reader/subscriptions-sheet.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "A–Z"
 msgstr "A–Z"
 
@@ -6139,6 +6253,10 @@ msgstr ""
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "Détails"
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Topic views"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "When you save or follow from the extension, {SITE_NAME} writes AT Protocol records to <0>your</0> repository through the same server paths as the web app. Those records follow the network's visibility rules and your account settings."
@@ -6673,6 +6791,10 @@ msgstr "Lire à voix haute"
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "Les articles que vous avez enregistrés pour plus tard — dans votre dépôt, synchronisés entre vos appareils."
 
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Every corner"
+#~ msgstr ""
+
 #: src/components/reader/format-i18n.ts
 msgid "today"
 msgstr ""
@@ -6786,6 +6908,7 @@ msgstr "Nous ne publions rien depuis votre compte, sauf lorsque vous effectuez u
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Publications"
 msgstr "Publications"
@@ -7019,6 +7142,10 @@ msgstr "Propulsé par <0>Standard Reader</0>"
 
 #: src/components/appearance-settings.tsx
 msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."
+msgstr ""
+
+#: src/routes/_layout.topics.index.tsx
+msgid "Search by name or topic — “vinyl”, “kubernetes”…"
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
@@ -7351,6 +7478,11 @@ msgstr ""
 
 #: src/components/reader/read-on-platform.tsx
 msgid "Read this on {name}"
+msgstr ""
+
+#. placeholder {0}: topic.authorCount
+#: src/components/reader/topic-cards.tsx
+msgid "{0, plural, one {# writer} other {# writers}}"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -115,6 +115,11 @@ msgstr ""
 msgid "Add an article"
 msgstr "記事を追加"
 
+#: src/routes/_layout.communities.index.tsx
+#: src/routes/_layout.discover.tsx
+#~ msgid "Communities"
+#~ msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/components/reader/app-shell.tsx
@@ -157,6 +162,10 @@ msgstr "アイコンを削除"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "The {SITE_NAME} browser extension helps you save articles and follow publications on the standard.site network from any tab. It connects to the same account as the web app at <0>{siteHost}</0>. This policy covers the extension only; the <1>site privacy policy</1> describes data handling on the website itself."
 msgstr "{SITE_NAME} のブラウザ拡張機能を使うと、どのタブからでも standard.site ネットワークの記事を保存したり発行物をフォローしたりできます。拡張機能は <0>{siteHost}</0> のウェブアプリと同じアカウントに接続します。このポリシーは拡張機能のみを対象としています。ウェブサイト自体のデータの取り扱いについては<1>サイトのプライバシーポリシー</1>をご覧ください。"
+
+#: src/routes/_layout.topics.index.tsx
+msgid "Topic areas the network's writing clusters into, rebuilt as it grows. Each one gathers related tags, the publications writing about them, and everything they've published."
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "find publications, people, topics, and headlines by name."
@@ -328,6 +337,10 @@ msgstr "コレクションを開いています…"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Density"
+msgstr ""
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Best fit"
 msgstr ""
 
 #: src/components/reader/article-view.tsx
@@ -641,6 +654,7 @@ msgstr "記事のハートをタップするとおすすめできます。おす
 #: src/routes/_layout.index.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Trending"
 msgstr "トレンド"
 
@@ -654,6 +668,7 @@ msgstr "表示する発行物"
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "{publicationCount, plural, one {publication} other {publications}}"
 msgstr "{publicationCount, plural, one {発行物} other {発行物}}"
 
@@ -669,6 +684,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Permanently remove data stored in your account. These actions delete records from your account and cannot be undone."
 msgstr "アカウントに保存されているデータを完全に削除します。これらの操作はアカウントからレコードを削除するもので、取り消せません。"
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Sub-areas"
+#~ msgstr ""
 
 #: src/routes/_layout.friends.tsx
 msgid "Loading people"
@@ -801,6 +820,7 @@ msgstr "サインインに失敗しました。もう一度お試しください
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Loading publications"
 msgstr "発行物を読み込み中"
 
@@ -825,6 +845,7 @@ msgstr "未読にする"
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Grid view"
 msgstr "グリッド表示"
 
@@ -871,6 +892,7 @@ msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "List view"
 msgstr "リスト表示"
 
@@ -946,6 +968,7 @@ msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} pu
 msgstr "{unfollowedCount, plural, one {{formattedUnfollowedCount} 件の発行物を購読しますか？} other {{formattedUnfollowedCount} 件の発行物を購読しますか？}}"
 
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Sort articles"
 msgstr ""
 
@@ -1801,6 +1824,10 @@ msgstr "このリストには発行物がありません。"
 msgid "{0}, dark"
 msgstr ""
 
+#: src/routes/_layout.discover.tsx
+msgid "Browse all topics"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Can read and act on your behalf"
 msgstr ""
@@ -1837,6 +1864,7 @@ msgstr "リストを削除"
 #: src/routes/_layout.friends.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Loading articles"
 msgstr "記事を読み込み中"
 
@@ -1901,6 +1929,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "More from <0>{0}</0>"
 msgstr "<0>{0}</0>の他の記事"
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Community"
+#~ msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
@@ -1999,6 +2031,7 @@ msgstr ""
 #~ msgstr "発行物・リスト・コレクションのそれぞれに、リッチなプレビューカード付きのすっきりしたリンクが用意されます。発行物が自分のサイトに設置できる購読ボタンも使えます。"
 
 #: src/components/reader/discover-topic-filters.tsx
+#: src/routes/_layout.topics.index.tsx
 msgid "Search topics"
 msgstr ""
 
@@ -2069,6 +2102,10 @@ msgstr ""
 #: src/components/reader/subscriptions-table.tsx
 msgid "Sort descending"
 msgstr ""
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "No publications in this community yet."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Anonymous"
@@ -2181,6 +2218,11 @@ msgstr ""
 msgid "Something went wrong while submitting your feedback."
 msgstr "フィードバックの送信中に問題が発生しました。"
 
+#. placeholder {0}: visible.length
+#: src/routes/_layout.topics.index.tsx
+msgid "{0, plural, one {# topic} other {# topics}}"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
 msgstr "もう一つアプリを開くのは面倒ですか？購読中の発行物のベスト記事に、見つける価値のある数本を添えた週刊メールを受け取れます。メールは週1通、解除はワンクリック。オンにする前に、どんな内容か実際にプレビューできます。"
@@ -2227,6 +2269,10 @@ msgstr "pckt で"
 #: src/components/onboarding/step-settings.tsx
 msgid "Marks what you've read for unread counts. Stored publicly on your account — turn off to read privately."
 msgstr "未読数のために既読状態を記録します。アカウント上に公開で保存されるため、非公開で読みたい場合はオフにしてください。"
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Newest"
+msgstr ""
 
 #: src/routes/_layout.feedback.return.tsx
 msgid "Your upvote has been recorded on userinput.app. Thanks for helping surface what matters."
@@ -2428,6 +2474,7 @@ msgstr ""
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Readers"
 msgstr "読者"
@@ -2491,6 +2538,7 @@ msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Active"
 msgstr "有効"
 
@@ -2708,6 +2756,10 @@ msgstr "現在、ネットワーク全体で話題になっている記事はあ
 msgid "Everything below is compatibility support for formats already out there in other apps' own repos — none of it is part of the site.standard spec, and none of it is something to model a new integration on."
 msgstr "以下はすべて、他アプリのリポジトリにすでに存在する形式との互換性のためのものです。いずれも site.standard 仕様の一部ではなく、新しい実装のお手本にすべきものでもありません。"
 
+#: src/routes/_layout.topics.$slug.tsx
+msgid "No articles in this topic yet."
+msgstr ""
+
 #: src/components/reader/subscribe-card.tsx
 msgid "Subscribing"
 msgstr "購読中"
@@ -2768,6 +2820,10 @@ msgstr ""
 msgid "A sentence of body copy, set in your chosen fonts and colors, so you can see how it all reads together before you save."
 msgstr "選んだフォントと色で組まれた本文のサンプルです。保存する前に、全体の読み心地を確認できます。"
 
+#: src/routes/_layout.discover.tsx
+#~ msgid "Find your corner"
+#~ msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Open the directory"
 msgstr "ディレクトリを開く"
@@ -2801,6 +2857,10 @@ msgstr "{itemTitle} を並べ替え"
 msgid "Back to feedback"
 msgstr "フィードバックに戻る"
 
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Community views"
+#~ msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "View on {name}"
 msgstr ""
@@ -2824,6 +2884,10 @@ msgstr "背景"
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Drop another screenshot"
+msgstr ""
+
+#: src/routes/_layout.discover.tsx
+msgid "See all"
 msgstr ""
 
 #: src/components/comic/comic-reader.tsx
@@ -2962,6 +3026,7 @@ msgstr ""
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "You've reached the end."
 msgstr "最後まで表示しました。"
@@ -3437,6 +3502,10 @@ msgstr ""
 msgid "e.g. Dispatches from the Atmosphere"
 msgstr "例: Dispatches from the Atmosphere"
 
+#: src/routes/_layout.discover.tsx
+#~ msgid "Browse all communities"
+#~ msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "{value, plural, one {# join} other {# joins}}"
 msgstr ""
@@ -3530,6 +3599,10 @@ msgstr "@{ownerHandle} による"
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "A player appears just above the navigation and stays there while you move around the app, so you can keep listening while you browse. It has play and pause, a jump back fifteen seconds, a speed control, a bar you can drag to move through the article, and a close button. The word being spoken is highlighted in the text and kept on screen; if you scroll away yourself, that stops until you select <0>Follow along</0>."
+msgstr ""
+
+#: src/routes/_layout.topics.index.tsx
+msgid "No topics match your search."
 msgstr ""
 
 #. placeholder {0}: rows.length
@@ -3713,7 +3786,9 @@ msgstr "このアカウントの発行物は見つかりませんでした。"
 
 #. placeholder {0}: following.length
 #. placeholder {0}: list.publications.length
+#. placeholder {0}: topic.publicationCount
 #: src/components/reader/subscriptions-sheet.tsx
+#: src/components/reader/topic-cards.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "{0, plural, one {# publication} other {# publications}}"
 msgstr "{0, plural, one {# 件の発行物} other {# 件の発行物}}"
@@ -3762,6 +3837,10 @@ msgstr "一致するユーザーはいません。"
 #: src/components/reader/subscriptions-tree.tsx
 msgid "Empty list."
 msgstr "リストは空です。"
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "No articles in this community yet."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Show only mine"
@@ -4247,6 +4326,10 @@ msgstr "<0>{countLabel}</0> 件の発行物をインデックス済み — さ�
 #: src/routes/_layout.index.tsx
 msgid "{newCount} new"
 msgstr "{newCount} 件の新着"
+
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "No communities match your search."
+#~ msgstr ""
 
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Reading in {language}"
@@ -5057,6 +5140,10 @@ msgstr ""
 msgid "Collection"
 msgstr "コレクション"
 
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Most liked"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Clear filter"
 msgstr ""
@@ -5127,6 +5214,7 @@ msgid "Everything by one author"
 msgstr "同じ著者のすべての記事"
 
 #: src/components/reader/subscriptions-table.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Topic"
 msgstr ""
 
@@ -5174,6 +5262,10 @@ msgstr "<0>ATStore</0> でレビューを共有していただくと、Standard 
 #: src/components/reader/about-view.tsx
 msgid "Publish labels others can subscribe to, or consume the ones we do."
 msgstr ""
+
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Search communities"
+#~ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "The full account is on the <0>extension privacy page</0>."
@@ -5472,6 +5564,11 @@ msgstr "サービスの DID は <0>{appviewDid}</0> です。スコープを調�
 msgid "The Slow Web, Revisited"
 msgstr "スロー・ウェブ再訪"
 
+#. placeholder {0}: visible.length
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "{0, plural, one {# community} other {# communities}}"
+#~ msgstr ""
+
 #. placeholder {0}: labelTotal - names.length
 #: src/components/labelers-settings-view.tsx
 msgid "+{0} more"
@@ -5593,6 +5690,8 @@ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/lib/guide/navigation.ts
+#: src/routes/_layout.discover.tsx
+#: src/routes/_layout.topics.index.tsx
 msgid "Topics"
 msgstr ""
 
@@ -5628,6 +5727,10 @@ msgstr "ATStore にレビューを投稿する。"
 #: src/routes/_layout.feedback.index.tsx
 msgid "Search feedback"
 msgstr "フィードバックを検索"
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "No publications in this topic yet."
+msgstr ""
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe"
@@ -5698,6 +5801,10 @@ msgstr "リストを保存"
 msgid "Some people would rather read on the publication's own site, with its own design. Turn on the open-on-the-original-site setting in your account menu and every article link opens there in a new tab instead of in the reader. Articles that have no site of their own still open here."
 msgstr ""
 
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Search by name or topic…"
+#~ msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Contents"
 msgstr "目次"
@@ -5748,6 +5855,11 @@ msgstr ""
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
 msgstr "削除"
+
+#. placeholder {0}: topic.authorCount
+#: src/routes/_layout.topics.$slug.tsx
+msgid "{0, plural, one {writer} other {writers}}"
+msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 msgid "<0>Platform</0> components render the blocks unique to one publishing platform — a Leaflet poll or signup, a Pckt gallery or note embed, an Offprint component. These are the interactive, often data-backed embeds; the headless defaults render nothing, so you supply your own to make them live."
@@ -5910,6 +6022,7 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Articles"
 msgstr "記事"
 
@@ -5990,6 +6103,7 @@ msgstr ""
 #: src/components/reader/subscriptions-sheet.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "A–Z"
 msgstr "A–Z"
 
@@ -6139,6 +6253,10 @@ msgstr ""
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "詳細"
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Topic views"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "When you save or follow from the extension, {SITE_NAME} writes AT Protocol records to <0>your</0> repository through the same server paths as the web app. Those records follow the network's visibility rules and your account settings."
@@ -6673,6 +6791,10 @@ msgstr "読み上げ"
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "あとで読むために保存した記事です。リポジトリに保存され、デバイス間で同期されます。"
 
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Every corner"
+#~ msgstr ""
+
 #: src/components/reader/format-i18n.ts
 msgid "today"
 msgstr ""
@@ -6786,6 +6908,7 @@ msgstr "明示的な操作（発行物のフォロー、記事への高評価や
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Publications"
 msgstr "発行物"
@@ -7019,6 +7142,10 @@ msgstr "Powered by <0>Standard Reader</0>"
 
 #: src/components/appearance-settings.tsx
 msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."
+msgstr ""
+
+#: src/routes/_layout.topics.index.tsx
+msgid "Search by name or topic — “vinyl”, “kubernetes”…"
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
@@ -7351,6 +7478,11 @@ msgstr ""
 
 #: src/components/reader/read-on-platform.tsx
 msgid "Read this on {name}"
+msgstr ""
+
+#. placeholder {0}: topic.authorCount
+#: src/components/reader/topic-cards.tsx
+msgid "{0, plural, one {# writer} other {# writers}}"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -115,6 +115,11 @@ msgstr ""
 msgid "Add an article"
 msgstr "글 추가"
 
+#: src/routes/_layout.communities.index.tsx
+#: src/routes/_layout.discover.tsx
+#~ msgid "Communities"
+#~ msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/components/reader/app-shell.tsx
@@ -157,6 +162,10 @@ msgstr "아이콘 제거"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "The {SITE_NAME} browser extension helps you save articles and follow publications on the standard.site network from any tab. It connects to the same account as the web app at <0>{siteHost}</0>. This policy covers the extension only; the <1>site privacy policy</1> describes data handling on the website itself."
 msgstr "{SITE_NAME} 브라우저 확장 프로그램을 사용하면 어느 탭에서든 standard.site 네트워크의 글을 저장하고 발행물을 팔로우할 수 있습니다. <0>{siteHost}</0>의 웹 앱과 동일한 계정으로 연결됩니다. 이 정책은 확장 프로그램에만 적용되며, 웹사이트 자체의 데이터 처리는 <1>사이트 개인정보처리방침</1>을 참고하세요."
+
+#: src/routes/_layout.topics.index.tsx
+msgid "Topic areas the network's writing clusters into, rebuilt as it grows. Each one gathers related tags, the publications writing about them, and everything they've published."
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "find publications, people, topics, and headlines by name."
@@ -328,6 +337,10 @@ msgstr "컬렉션을 여는 중…"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Density"
+msgstr ""
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Best fit"
 msgstr ""
 
 #: src/components/reader/article-view.tsx
@@ -641,6 +654,7 @@ msgstr "글의 하트를 탭해 추천하세요. 추천은 회원님의 repo에 
 #: src/routes/_layout.index.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Trending"
 msgstr "인기"
 
@@ -654,6 +668,7 @@ msgstr "표시된 발행물"
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "{publicationCount, plural, one {publication} other {publications}}"
 msgstr "{publicationCount, plural, one {발행물} other {발행물}}"
 
@@ -669,6 +684,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Permanently remove data stored in your account. These actions delete records from your account and cannot be undone."
 msgstr "계정에 저장된 데이터를 영구적으로 삭제합니다. 이 작업은 계정에서 레코드를 삭제하며 되돌릴 수 없습니다."
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Sub-areas"
+#~ msgstr ""
 
 #: src/routes/_layout.friends.tsx
 msgid "Loading people"
@@ -801,6 +820,7 @@ msgstr "로그인에 실패했습니다. 다시 시도하세요."
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Loading publications"
 msgstr "발행물 불러오는 중"
 
@@ -825,6 +845,7 @@ msgstr "읽지 않음으로 표시"
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Grid view"
 msgstr "그리드 보기"
 
@@ -871,6 +892,7 @@ msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "List view"
 msgstr "목록 보기"
 
@@ -946,6 +968,7 @@ msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} pu
 msgstr "{unfollowedCount, plural, one {발행물 {formattedUnfollowedCount}개를 구독할까요?} other {발행물 {formattedUnfollowedCount}개를 구독할까요?}}"
 
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Sort articles"
 msgstr ""
 
@@ -1801,6 +1824,10 @@ msgstr "이 목록에 발행물이 없습니다."
 msgid "{0}, dark"
 msgstr ""
 
+#: src/routes/_layout.discover.tsx
+msgid "Browse all topics"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Can read and act on your behalf"
 msgstr ""
@@ -1837,6 +1864,7 @@ msgstr "목록 제거"
 #: src/routes/_layout.friends.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Loading articles"
 msgstr "글 불러오는 중"
 
@@ -1901,6 +1929,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "More from <0>{0}</0>"
 msgstr "<0>{0}</0>의 다른 글"
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Community"
+#~ msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
@@ -1999,6 +2031,7 @@ msgstr ""
 #~ msgstr "발행물, 리스트, 컬렉션마다 리치 미리보기 카드가 달린 깔끔한 링크가 생깁니다. 발행물이 자체 사이트에 넣을 수 있는 구독 버튼도 함께 제공됩니다."
 
 #: src/components/reader/discover-topic-filters.tsx
+#: src/routes/_layout.topics.index.tsx
 msgid "Search topics"
 msgstr ""
 
@@ -2069,6 +2102,10 @@ msgstr ""
 #: src/components/reader/subscriptions-table.tsx
 msgid "Sort descending"
 msgstr ""
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "No publications in this community yet."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Anonymous"
@@ -2181,6 +2218,11 @@ msgstr ""
 msgid "Something went wrong while submitting your feedback."
 msgstr "피드백을 보내는 중 문제가 발생했습니다."
 
+#. placeholder {0}: visible.length
+#: src/routes/_layout.topics.index.tsx
+msgid "{0, plural, one {# topic} other {# topics}}"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
 msgstr "앱을 또 확인하기 번거롭나요? 구독한 발행물의 가장 좋은 글과 발견할 만한 글 몇 편을 담은 주간 이메일을 신청하세요. 이메일 한 통, 해지는 클릭 한 번. 신청 전에 어떤 모습인지 미리 볼 수도 있습니다."
@@ -2227,6 +2269,10 @@ msgstr "pckt에서"
 #: src/components/onboarding/step-settings.tsx
 msgid "Marks what you've read for unread counts. Stored publicly on your account — turn off to read privately."
 msgstr "읽지 않음 개수를 위해 읽은 글을 표시합니다. 계정에 공개로 저장되며, 비공개로 읽으려면 끄세요."
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Newest"
+msgstr ""
 
 #: src/routes/_layout.feedback.return.tsx
 msgid "Your upvote has been recorded on userinput.app. Thanks for helping surface what matters."
@@ -2428,6 +2474,7 @@ msgstr ""
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Readers"
 msgstr "독자"
@@ -2491,6 +2538,7 @@ msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Active"
 msgstr "활성"
 
@@ -2708,6 +2756,10 @@ msgstr "지금은 네트워크에서 인기 있는 아티클이 없습니다. �
 msgid "Everything below is compatibility support for formats already out there in other apps' own repos — none of it is part of the site.standard spec, and none of it is something to model a new integration on."
 msgstr "아래 내용은 다른 앱의 저장소에 이미 존재하는 형식에 대한 호환성 지원입니다. site.standard 스펙의 일부가 아니며, 새로운 연동을 만들 때 본보기로 삼을 대상도 아닙니다."
 
+#: src/routes/_layout.topics.$slug.tsx
+msgid "No articles in this topic yet."
+msgstr ""
+
 #: src/components/reader/subscribe-card.tsx
 msgid "Subscribing"
 msgstr "구독 중"
@@ -2768,6 +2820,10 @@ msgstr ""
 msgid "A sentence of body copy, set in your chosen fonts and colors, so you can see how it all reads together before you save."
 msgstr "선택한 서체와 색으로 표시된 본문 예시 문장입니다. 저장하기 전에 전체적인 느낌을 확인해 보세요."
 
+#: src/routes/_layout.discover.tsx
+#~ msgid "Find your corner"
+#~ msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Open the directory"
 msgstr "디렉터리 열기"
@@ -2801,6 +2857,10 @@ msgstr "{itemTitle} 순서 변경"
 msgid "Back to feedback"
 msgstr "피드백으로 돌아가기"
 
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Community views"
+#~ msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "View on {name}"
 msgstr ""
@@ -2824,6 +2884,10 @@ msgstr "배경"
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Drop another screenshot"
+msgstr ""
+
+#: src/routes/_layout.discover.tsx
+msgid "See all"
 msgstr ""
 
 #: src/components/comic/comic-reader.tsx
@@ -2962,6 +3026,7 @@ msgstr ""
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "You've reached the end."
 msgstr "마지막까지 다 보셨습니다."
@@ -3437,6 +3502,10 @@ msgstr ""
 msgid "e.g. Dispatches from the Atmosphere"
 msgstr "예: Dispatches from the Atmosphere"
 
+#: src/routes/_layout.discover.tsx
+#~ msgid "Browse all communities"
+#~ msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "{value, plural, one {# join} other {# joins}}"
 msgstr ""
@@ -3530,6 +3599,10 @@ msgstr "@{ownerHandle} 님"
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "A player appears just above the navigation and stays there while you move around the app, so you can keep listening while you browse. It has play and pause, a jump back fifteen seconds, a speed control, a bar you can drag to move through the article, and a close button. The word being spoken is highlighted in the text and kept on screen; if you scroll away yourself, that stops until you select <0>Follow along</0>."
+msgstr ""
+
+#: src/routes/_layout.topics.index.tsx
+msgid "No topics match your search."
 msgstr ""
 
 #. placeholder {0}: rows.length
@@ -3713,7 +3786,9 @@ msgstr "이 계정에서 발행물을 찾을 수 없습니다."
 
 #. placeholder {0}: following.length
 #. placeholder {0}: list.publications.length
+#. placeholder {0}: topic.publicationCount
 #: src/components/reader/subscriptions-sheet.tsx
+#: src/components/reader/topic-cards.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "{0, plural, one {# publication} other {# publications}}"
 msgstr "{0, plural, one {발행물 #개} other {발행물 #개}}"
@@ -3762,6 +3837,10 @@ msgstr "일치하는 사람이 없습니다."
 #: src/components/reader/subscriptions-tree.tsx
 msgid "Empty list."
 msgstr "빈 목록입니다."
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "No articles in this community yet."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Show only mine"
@@ -4247,6 +4326,10 @@ msgstr "<0>{countLabel}</0>개의 발행물이 색인됨 — 그리고 계속 �
 #: src/routes/_layout.index.tsx
 msgid "{newCount} new"
 msgstr "새 글 {newCount}개"
+
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "No communities match your search."
+#~ msgstr ""
 
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Reading in {language}"
@@ -5057,6 +5140,10 @@ msgstr ""
 msgid "Collection"
 msgstr "컬렉션"
 
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Most liked"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Clear filter"
 msgstr ""
@@ -5127,6 +5214,7 @@ msgid "Everything by one author"
 msgstr "한 저자의 모든 글"
 
 #: src/components/reader/subscriptions-table.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Topic"
 msgstr ""
 
@@ -5174,6 +5262,10 @@ msgstr "<0>ATStore</0>에 리뷰를 남겨 주시면 저희와 다른 사용자 
 #: src/components/reader/about-view.tsx
 msgid "Publish labels others can subscribe to, or consume the ones we do."
 msgstr ""
+
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Search communities"
+#~ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "The full account is on the <0>extension privacy page</0>."
@@ -5472,6 +5564,11 @@ msgstr "서비스 DID는 <0>{appviewDid}</0>입니다. 이 서비스는 스코�
 msgid "The Slow Web, Revisited"
 msgstr "느린 웹, 다시 보기"
 
+#. placeholder {0}: visible.length
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "{0, plural, one {# community} other {# communities}}"
+#~ msgstr ""
+
 #. placeholder {0}: labelTotal - names.length
 #: src/components/labelers-settings-view.tsx
 msgid "+{0} more"
@@ -5593,6 +5690,8 @@ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/lib/guide/navigation.ts
+#: src/routes/_layout.discover.tsx
+#: src/routes/_layout.topics.index.tsx
 msgid "Topics"
 msgstr ""
 
@@ -5628,6 +5727,10 @@ msgstr "ATStore에 리뷰를 남겨 주세요."
 #: src/routes/_layout.feedback.index.tsx
 msgid "Search feedback"
 msgstr "피드백 검색"
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "No publications in this topic yet."
+msgstr ""
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe"
@@ -5698,6 +5801,10 @@ msgstr "목록 저장"
 msgid "Some people would rather read on the publication's own site, with its own design. Turn on the open-on-the-original-site setting in your account menu and every article link opens there in a new tab instead of in the reader. Articles that have no site of their own still open here."
 msgstr ""
 
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Search by name or topic…"
+#~ msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Contents"
 msgstr "목차"
@@ -5748,6 +5855,11 @@ msgstr ""
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
 msgstr "제거"
+
+#. placeholder {0}: topic.authorCount
+#: src/routes/_layout.topics.$slug.tsx
+msgid "{0, plural, one {writer} other {writers}}"
+msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 msgid "<0>Platform</0> components render the blocks unique to one publishing platform — a Leaflet poll or signup, a Pckt gallery or note embed, an Offprint component. These are the interactive, often data-backed embeds; the headless defaults render nothing, so you supply your own to make them live."
@@ -5910,6 +6022,7 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Articles"
 msgstr "글"
 
@@ -5990,6 +6103,7 @@ msgstr ""
 #: src/components/reader/subscriptions-sheet.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "A–Z"
 msgstr "A–Z"
 
@@ -6139,6 +6253,10 @@ msgstr ""
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "세부 정보"
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Topic views"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "When you save or follow from the extension, {SITE_NAME} writes AT Protocol records to <0>your</0> repository through the same server paths as the web app. Those records follow the network's visibility rules and your account settings."
@@ -6673,6 +6791,10 @@ msgstr "소리내어 읽기"
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "나중에 읽으려고 저장한 글 — 내 저장소에 보관되어 기기 간에 동기화됩니다."
 
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Every corner"
+#~ msgstr ""
+
 #: src/components/reader/format-i18n.ts
 msgid "today"
 msgstr ""
@@ -6786,6 +6908,7 @@ msgstr "발행물 팔로우, 글 좋아요나 저장, 전용 구독 흐름을 �
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Publications"
 msgstr "발행물"
@@ -7019,6 +7142,10 @@ msgstr "<0>Standard Reader</0> 제공"
 
 #: src/components/appearance-settings.tsx
 msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."
+msgstr ""
+
+#: src/routes/_layout.topics.index.tsx
+msgid "Search by name or topic — “vinyl”, “kubernetes”…"
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
@@ -7351,6 +7478,11 @@ msgstr ""
 
 #: src/components/reader/read-on-platform.tsx
 msgid "Read this on {name}"
+msgstr ""
+
+#. placeholder {0}: topic.authorCount
+#: src/components/reader/topic-cards.tsx
+msgid "{0, plural, one {# writer} other {# writers}}"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -115,6 +115,11 @@ msgstr ""
 msgid "Add an article"
 msgstr "Adicionar um artigo"
 
+#: src/routes/_layout.communities.index.tsx
+#: src/routes/_layout.discover.tsx
+#~ msgid "Communities"
+#~ msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/components/reader/app-shell.tsx
@@ -157,6 +162,10 @@ msgstr "Remover ícone"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "The {SITE_NAME} browser extension helps you save articles and follow publications on the standard.site network from any tab. It connects to the same account as the web app at <0>{siteHost}</0>. This policy covers the extension only; the <1>site privacy policy</1> describes data handling on the website itself."
 msgstr "A extensão de navegador do {SITE_NAME} ajuda-o a salvar artigos e a seguir publicações na rede standard.site a partir de qualquer aba. Se conecta à mesma conta que a aplicação web em <0>{siteHost}</0>. Esta política abrange apenas a extensão; a <1>política de privacidade do site</1> descreve o tratamento de dados no próprio site."
+
+#: src/routes/_layout.topics.index.tsx
+msgid "Topic areas the network's writing clusters into, rebuilt as it grows. Each one gathers related tags, the publications writing about them, and everything they've published."
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "find publications, people, topics, and headlines by name."
@@ -328,6 +337,10 @@ msgstr "Abrindo a coleção…"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Density"
+msgstr ""
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Best fit"
 msgstr ""
 
 #: src/components/reader/article-view.tsx
@@ -641,6 +654,7 @@ msgstr "Toque no coração de qualquer artigo para o recomendar. As suas recomen
 #: src/routes/_layout.index.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Trending"
 msgstr "Em alta"
 
@@ -654,6 +668,7 @@ msgstr "Publicações mostradas"
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "{publicationCount, plural, one {publication} other {publications}}"
 msgstr "{publicationCount, plural, one {publicação} other {publicações}}"
 
@@ -669,6 +684,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Permanently remove data stored in your account. These actions delete records from your account and cannot be undone."
 msgstr "Remova permanentemente dados salvos na sua conta. Estas ações apagam registos da sua conta e não podem ser desfeitas."
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Sub-areas"
+#~ msgstr ""
 
 #: src/routes/_layout.friends.tsx
 msgid "Loading people"
@@ -801,6 +820,7 @@ msgstr "Falha ao iniciar sessão. Tente novamente."
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Loading publications"
 msgstr "Carregando publicações"
 
@@ -825,6 +845,7 @@ msgstr "Marcar como não lido"
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Grid view"
 msgstr "Vista de grelha"
 
@@ -871,6 +892,7 @@ msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "List view"
 msgstr "Vista de lista"
 
@@ -946,6 +968,7 @@ msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} pu
 msgstr "{unfollowedCount, plural, one {Se inscrever em {formattedUnfollowedCount} publicação?} other {Se inscrever em {formattedUnfollowedCount} publicações?}}"
 
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Sort articles"
 msgstr ""
 
@@ -1801,6 +1824,10 @@ msgstr "Nenhuma publicação nesta lista."
 msgid "{0}, dark"
 msgstr ""
 
+#: src/routes/_layout.discover.tsx
+msgid "Browse all topics"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Can read and act on your behalf"
 msgstr ""
@@ -1837,6 +1864,7 @@ msgstr "Remover lista"
 #: src/routes/_layout.friends.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Loading articles"
 msgstr "Carregando artigos"
 
@@ -1901,6 +1929,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "More from <0>{0}</0>"
 msgstr "Mais de <0>{0}</0>"
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Community"
+#~ msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
@@ -1999,6 +2031,7 @@ msgstr ""
 #~ msgstr "Publicações, listas e coleções, cada uma têm um link com um cartão de pré-visualização — mais um botão de inscrição que uma publicação pode colocar no seu próprio site."
 
 #: src/components/reader/discover-topic-filters.tsx
+#: src/routes/_layout.topics.index.tsx
 msgid "Search topics"
 msgstr "Pesquisar temas"
 
@@ -2069,6 +2102,10 @@ msgstr "Tentar interromper, sobrecarregar ou obter acesso não autorizado ao ser
 #: src/components/reader/subscriptions-table.tsx
 msgid "Sort descending"
 msgstr "Ordem descendente"
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "No publications in this community yet."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Anonymous"
@@ -2181,6 +2218,11 @@ msgstr ""
 msgid "Something went wrong while submitting your feedback."
 msgstr "Algo deu errado ao enviar o seu feedback."
 
+#. placeholder {0}: visible.length
+#: src/routes/_layout.topics.index.tsx
+msgid "{0, plural, one {# topic} other {# topics}}"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
 msgstr "Não quer mais um aplicativo para conferir? Opte por um e-mail semanal com o melhor das publicações em que está inscrito, e mais algumas que vale a pena descobrir. Um e-mail, um clique para sair — e pode pré-visualizar exatamente como é antes de sequer ativá-lo."
@@ -2227,6 +2269,10 @@ msgstr "no pckt"
 #: src/components/onboarding/step-settings.tsx
 msgid "Marks what you've read for unread counts. Stored publicly on your account — turn off to read privately."
 msgstr "Marca o que já leu para as contagens de não lidos. É salvo publicamente na sua conta — desligue para ler em privado."
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Newest"
+msgstr ""
 
 #: src/routes/_layout.feedback.return.tsx
 msgid "Your upvote has been recorded on userinput.app. Thanks for helping surface what matters."
@@ -2428,6 +2474,7 @@ msgstr ""
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Readers"
 msgstr "Leitores"
@@ -2491,6 +2538,7 @@ msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Active"
 msgstr "Ativo"
 
@@ -2708,6 +2756,10 @@ msgstr "Não há artigos em alta na rede neste momento. Volte em breve."
 msgid "Everything below is compatibility support for formats already out there in other apps' own repos — none of it is part of the site.standard spec, and none of it is something to model a new integration on."
 msgstr "Tudo o que se segue é suporte de compatibilidade para formatos que já existem nos repositórios de outras aplicações — nada disto faz parte da especificação site.standard, nem é algo em que basear uma nova integração."
 
+#: src/routes/_layout.topics.$slug.tsx
+msgid "No articles in this topic yet."
+msgstr ""
+
 #: src/components/reader/subscribe-card.tsx
 msgid "Subscribing"
 msgstr "Inscrevendo-se"
@@ -2768,6 +2820,10 @@ msgstr ""
 msgid "A sentence of body copy, set in your chosen fonts and colors, so you can see how it all reads together before you save."
 msgstr "Uma frase de texto corrido, composta com as fontes e as cores que escolheu, para ver como tudo se lê em conjunto antes de salvar."
 
+#: src/routes/_layout.discover.tsx
+#~ msgid "Find your corner"
+#~ msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Open the directory"
 msgstr "Abrir o diretório"
@@ -2801,6 +2857,10 @@ msgstr "Reordenar {itemTitle}"
 msgid "Back to feedback"
 msgstr "Voltar a feedback"
 
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Community views"
+#~ msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "View on {name}"
 msgstr ""
@@ -2824,6 +2884,10 @@ msgstr "Fundo"
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Drop another screenshot"
+msgstr ""
+
+#: src/routes/_layout.discover.tsx
+msgid "See all"
 msgstr ""
 
 #: src/components/comic/comic-reader.tsx
@@ -2962,6 +3026,7 @@ msgstr ""
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "You've reached the end."
 msgstr "Você chegou ao fim."
@@ -3437,6 +3502,10 @@ msgstr "Você concorda em não usar o {SITE_NAME} para:"
 msgid "e.g. Dispatches from the Atmosphere"
 msgstr "por ex. Relatos da Atmosfera"
 
+#: src/routes/_layout.discover.tsx
+#~ msgid "Browse all communities"
+#~ msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "{value, plural, one {# join} other {# joins}}"
 msgstr ""
@@ -3530,6 +3599,10 @@ msgstr "por @{ownerHandle}"
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "A player appears just above the navigation and stays there while you move around the app, so you can keep listening while you browse. It has play and pause, a jump back fifteen seconds, a speed control, a bar you can drag to move through the article, and a close button. The word being spoken is highlighted in the text and kept on screen; if you scroll away yourself, that stops until you select <0>Follow along</0>."
+msgstr ""
+
+#: src/routes/_layout.topics.index.tsx
+msgid "No topics match your search."
 msgstr ""
 
 #. placeholder {0}: rows.length
@@ -3713,7 +3786,9 @@ msgstr "Não foram encontradas publicações para esta conta."
 
 #. placeholder {0}: following.length
 #. placeholder {0}: list.publications.length
+#. placeholder {0}: topic.publicationCount
 #: src/components/reader/subscriptions-sheet.tsx
+#: src/components/reader/topic-cards.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "{0, plural, one {# publication} other {# publications}}"
 msgstr "{0, plural, one {# publicação} other {# publicações}}"
@@ -3762,6 +3837,10 @@ msgstr "Sem pessoas correspondentes."
 #: src/components/reader/subscriptions-tree.tsx
 msgid "Empty list."
 msgstr "Lista vazia."
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "No articles in this community yet."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Show only mine"
@@ -4247,6 +4326,10 @@ msgstr "<0>{countLabel}</0> publicações indexadas — e a contar"
 #: src/routes/_layout.index.tsx
 msgid "{newCount} new"
 msgstr "{newCount} novos"
+
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "No communities match your search."
+#~ msgstr ""
 
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Reading in {language}"
@@ -5057,6 +5140,10 @@ msgstr "Ou ninguém que você segue no Bluesky publica aqui ainda, ou você já 
 msgid "Collection"
 msgstr "Coleção"
 
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Most liked"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Clear filter"
 msgstr "Limpar filtro"
@@ -5127,6 +5214,7 @@ msgid "Everything by one author"
 msgstr "Tudo de um só autor"
 
 #: src/components/reader/subscriptions-table.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Topic"
 msgstr "Tema"
 
@@ -5174,6 +5262,10 @@ msgstr "Compartilhar uma avalição na <0>ATStore</0> ajuda-nos a nós e aos out
 #: src/components/reader/about-view.tsx
 msgid "Publish labels others can subscribe to, or consume the ones we do."
 msgstr ""
+
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Search communities"
+#~ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "The full account is on the <0>extension privacy page</0>."
@@ -5472,6 +5564,11 @@ msgstr "O DID do serviço é <0>{appviewDid}</0>. O serviço divulga um <1>docum
 msgid "The Slow Web, Revisited"
 msgstr "A Slow Web, Revisitada"
 
+#. placeholder {0}: visible.length
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "{0, plural, one {# community} other {# communities}}"
+#~ msgstr ""
+
 #. placeholder {0}: labelTotal - names.length
 #: src/components/labelers-settings-view.tsx
 msgid "+{0} more"
@@ -5593,6 +5690,8 @@ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/lib/guide/navigation.ts
+#: src/routes/_layout.discover.tsx
+#: src/routes/_layout.topics.index.tsx
 msgid "Topics"
 msgstr ""
 
@@ -5628,6 +5727,10 @@ msgstr "Deixe-nos uma avaliação na ATStore."
 #: src/routes/_layout.feedback.index.tsx
 msgid "Search feedback"
 msgstr "Pesquisar feedback"
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "No publications in this topic yet."
+msgstr ""
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe"
@@ -5698,6 +5801,10 @@ msgstr "Salvar lista"
 msgid "Some people would rather read on the publication's own site, with its own design. Turn on the open-on-the-original-site setting in your account menu and every article link opens there in a new tab instead of in the reader. Articles that have no site of their own still open here."
 msgstr ""
 
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Search by name or topic…"
+#~ msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Contents"
 msgstr "Índice"
@@ -5748,6 +5855,11 @@ msgstr "Os mais populares da rede"
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
 msgstr "Remover"
+
+#. placeholder {0}: topic.authorCount
+#: src/routes/_layout.topics.$slug.tsx
+msgid "{0, plural, one {writer} other {writers}}"
+msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 msgid "<0>Platform</0> components render the blocks unique to one publishing platform — a Leaflet poll or signup, a Pckt gallery or note embed, an Offprint component. These are the interactive, often data-backed embeds; the headless defaults render nothing, so you supply your own to make them live."
@@ -5910,6 +6022,7 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Articles"
 msgstr "Artigos"
 
@@ -5990,6 +6103,7 @@ msgstr "Introdução"
 #: src/components/reader/subscriptions-sheet.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "A–Z"
 msgstr "A–Z"
 
@@ -6139,6 +6253,10 @@ msgstr ""
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "Detalhes"
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Topic views"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "When you save or follow from the extension, {SITE_NAME} writes AT Protocol records to <0>your</0> repository through the same server paths as the web app. Those records follow the network's visibility rules and your account settings."
@@ -6673,6 +6791,10 @@ msgstr "Ler em voz alta"
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "Artigos que salvou para mais tarde — no seu repositório, sincronizados entre dispositivos."
 
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Every corner"
+#~ msgstr ""
+
 #: src/components/reader/format-i18n.ts
 msgid "today"
 msgstr ""
@@ -6786,6 +6908,7 @@ msgstr "Não publicamos na sua conta exceto quando realiza uma ação explícita
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Publications"
 msgstr "Publicações"
@@ -7019,6 +7142,10 @@ msgstr "Com tecnologia <0>Standard Reader</0>"
 
 #: src/components/appearance-settings.tsx
 msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."
+msgstr ""
+
+#: src/routes/_layout.topics.index.tsx
+msgid "Search by name or topic — “vinyl”, “kubernetes”…"
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
@@ -7352,6 +7479,11 @@ msgstr ""
 #: src/components/reader/read-on-platform.tsx
 msgid "Read this on {name}"
 msgstr "Leia isto em {name}"
+
+#. placeholder {0}: topic.authorCount
+#: src/components/reader/topic-cards.tsx
+msgid "{0, plural, one {# writer} other {# writers}}"
+msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Acceptable use"

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -115,6 +115,11 @@ msgstr ""
 msgid "Add an article"
 msgstr "添加文章"
 
+#: src/routes/_layout.communities.index.tsx
+#: src/routes/_layout.discover.tsx
+#~ msgid "Communities"
+#~ msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/components/reader/app-shell.tsx
@@ -157,6 +162,10 @@ msgstr "移除图标"
 #: src/components/reader/extension-privacy-view.tsx
 msgid "The {SITE_NAME} browser extension helps you save articles and follow publications on the standard.site network from any tab. It connects to the same account as the web app at <0>{siteHost}</0>. This policy covers the extension only; the <1>site privacy policy</1> describes data handling on the website itself."
 msgstr "{SITE_NAME} 浏览器扩展帮助你在任意标签页中保存文章、关注 standard.site 网络上的刊物。它与网页应用 <0>{siteHost}</0> 使用同一个账户。本政策仅适用于该扩展；<1>站点隐私政策</1>说明网站本身的数据处理方式。"
+
+#: src/routes/_layout.topics.index.tsx
+msgid "Topic areas the network's writing clusters into, rebuilt as it grows. Each one gathers related tags, the publications writing about them, and everything they've published."
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "find publications, people, topics, and headlines by name."
@@ -328,6 +337,10 @@ msgstr "正在打开合集…"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Density"
+msgstr ""
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Best fit"
 msgstr ""
 
 #: src/components/reader/article-view.tsx
@@ -641,6 +654,7 @@ msgstr "轻点任意文章上的爱心即可推荐它。你的推荐以 <0>site.
 #: src/routes/_layout.index.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Trending"
 msgstr "热门"
 
@@ -654,6 +668,7 @@ msgstr "显示的刊物"
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "{publicationCount, plural, one {publication} other {publications}}"
 msgstr "{publicationCount, plural, one {刊物} other {刊物}}"
 
@@ -669,6 +684,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Permanently remove data stored in your account. These actions delete records from your account and cannot be undone."
 msgstr "永久删除存储在你账户中的数据。这些操作会从你的账户中删除记录，且无法撤销。"
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Sub-areas"
+#~ msgstr ""
 
 #: src/routes/_layout.friends.tsx
 msgid "Loading people"
@@ -801,6 +820,7 @@ msgstr "登录失败，请重试。"
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Loading publications"
 msgstr "正在加载刊物"
 
@@ -825,6 +845,7 @@ msgstr "标记为未读"
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Grid view"
 msgstr "网格视图"
 
@@ -871,6 +892,7 @@ msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "List view"
 msgstr "列表视图"
 
@@ -946,6 +968,7 @@ msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} pu
 msgstr "{unfollowedCount, plural, one {订阅 {formattedUnfollowedCount} 个刊物？} other {订阅 {formattedUnfollowedCount} 个刊物？}}"
 
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Sort articles"
 msgstr ""
 
@@ -1801,6 +1824,10 @@ msgstr "此列表中没有刊物。"
 msgid "{0}, dark"
 msgstr ""
 
+#: src/routes/_layout.discover.tsx
+msgid "Browse all topics"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Can read and act on your behalf"
 msgstr ""
@@ -1837,6 +1864,7 @@ msgstr "移除列表"
 #: src/routes/_layout.friends.tsx
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Loading articles"
 msgstr "正在加载文章"
 
@@ -1901,6 +1929,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "More from <0>{0}</0>"
 msgstr "更多来自 <0>{0}</0>"
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Community"
+#~ msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
@@ -1999,6 +2031,7 @@ msgstr ""
 #~ msgstr "刊物、列表和合集都有简洁的链接与丰富的预览卡片——刊物还能把订阅按钮放到自己的网站上。"
 
 #: src/components/reader/discover-topic-filters.tsx
+#: src/routes/_layout.topics.index.tsx
 msgid "Search topics"
 msgstr ""
 
@@ -2069,6 +2102,10 @@ msgstr ""
 #: src/components/reader/subscriptions-table.tsx
 msgid "Sort descending"
 msgstr ""
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "No publications in this community yet."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Anonymous"
@@ -2181,6 +2218,11 @@ msgstr ""
 msgid "Something went wrong while submitting your feedback."
 msgstr "提交反馈时出错了。"
 
+#. placeholder {0}: visible.length
+#: src/routes/_layout.topics.index.tsx
+msgid "{0, plural, one {# topic} other {# topics}}"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Don’t want another app to check? Opt into a weekly email with the best of the publications you subscribe to, plus a couple worth discovering. One email, one click to leave — and you can preview exactly what it looks like before you ever turn it on."
 msgstr "不想再多装一个应用来查看？可以订阅每周邮件，收录你所订阅刊物中的精华，外加几个值得发现的新去处。一封邮件，一键退订——开启之前还能先预览它的样子。"
@@ -2227,6 +2269,10 @@ msgstr "在 pckt 上"
 #: src/components/onboarding/step-settings.tsx
 msgid "Marks what you've read for unread counts. Stored publicly on your account — turn off to read privately."
 msgstr "标记你读过的内容以统计未读数。公开存储在你的账号上——关闭后可私密阅读。"
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Newest"
+msgstr ""
 
 #: src/routes/_layout.feedback.return.tsx
 msgid "Your upvote has been recorded on userinput.app. Thanks for helping surface what matters."
@@ -2428,6 +2474,7 @@ msgstr ""
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Readers"
 msgstr "读者"
@@ -2491,6 +2538,7 @@ msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Active"
 msgstr "活跃"
 
@@ -2708,6 +2756,10 @@ msgstr "目前全网没有热门文章。请稍后再来看看。"
 msgid "Everything below is compatibility support for formats already out there in other apps' own repos — none of it is part of the site.standard spec, and none of it is something to model a new integration on."
 msgstr "下面这些都是对其他应用仓库中既有格式的兼容支持——它们都不属于 site.standard 规范，也都不适合作为新集成的参照。"
 
+#: src/routes/_layout.topics.$slug.tsx
+msgid "No articles in this topic yet."
+msgstr ""
+
 #: src/components/reader/subscribe-card.tsx
 msgid "Subscribing"
 msgstr "正在订阅"
@@ -2768,6 +2820,10 @@ msgstr ""
 msgid "A sentence of body copy, set in your chosen fonts and colors, so you can see how it all reads together before you save."
 msgstr "一句正文示例，使用你选定的字体与颜色排版，让你在保存前先看看整体阅读效果。"
 
+#: src/routes/_layout.discover.tsx
+#~ msgid "Find your corner"
+#~ msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "Open the directory"
 msgstr "打开目录"
@@ -2801,6 +2857,10 @@ msgstr "重新排序 {itemTitle}"
 msgid "Back to feedback"
 msgstr "返回反馈"
 
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "Community views"
+#~ msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "View on {name}"
 msgstr ""
@@ -2824,6 +2884,10 @@ msgstr "背景"
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Drop another screenshot"
+msgstr ""
+
+#: src/routes/_layout.discover.tsx
+msgid "See all"
 msgstr ""
 
 #: src/components/comic/comic-reader.tsx
@@ -2962,6 +3026,7 @@ msgstr ""
 #: src/routes/_layout.latest.tsx
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "You've reached the end."
 msgstr "已经到底了。"
@@ -3437,6 +3502,10 @@ msgstr ""
 msgid "e.g. Dispatches from the Atmosphere"
 msgstr "例如：来自 Atmosphere 的快讯"
 
+#: src/routes/_layout.discover.tsx
+#~ msgid "Browse all communities"
+#~ msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "{value, plural, one {# join} other {# joins}}"
 msgstr ""
@@ -3530,6 +3599,10 @@ msgstr "作者 @{ownerHandle}"
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "A player appears just above the navigation and stays there while you move around the app, so you can keep listening while you browse. It has play and pause, a jump back fifteen seconds, a speed control, a bar you can drag to move through the article, and a close button. The word being spoken is highlighted in the text and kept on screen; if you scroll away yourself, that stops until you select <0>Follow along</0>."
+msgstr ""
+
+#: src/routes/_layout.topics.index.tsx
+msgid "No topics match your search."
 msgstr ""
 
 #. placeholder {0}: rows.length
@@ -3713,7 +3786,9 @@ msgstr "未找到该账户下的刊物。"
 
 #. placeholder {0}: following.length
 #. placeholder {0}: list.publications.length
+#. placeholder {0}: topic.publicationCount
 #: src/components/reader/subscriptions-sheet.tsx
+#: src/components/reader/topic-cards.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "{0, plural, one {# publication} other {# publications}}"
 msgstr "{0, plural, one {# 个刊物} other {# 个刊物}}"
@@ -3762,6 +3837,10 @@ msgstr "没有匹配的人。"
 #: src/components/reader/subscriptions-tree.tsx
 msgid "Empty list."
 msgstr "空列表。"
+
+#: src/routes/_layout.communities.$slug.tsx
+#~ msgid "No articles in this community yet."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Show only mine"
@@ -4247,6 +4326,10 @@ msgstr "已收录 <0>{countLabel}</0> 个刊物，还在持续增加"
 #: src/routes/_layout.index.tsx
 msgid "{newCount} new"
 msgstr "{newCount} 条新内容"
+
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "No communities match your search."
+#~ msgstr ""
 
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Reading in {language}"
@@ -5057,6 +5140,10 @@ msgstr ""
 msgid "Collection"
 msgstr "合集"
 
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Most liked"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Clear filter"
 msgstr ""
@@ -5127,6 +5214,7 @@ msgid "Everything by one author"
 msgstr "同一作者的全部作品"
 
 #: src/components/reader/subscriptions-table.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Topic"
 msgstr ""
 
@@ -5174,6 +5262,10 @@ msgstr "在 <0>ATStore</0> 上分享评价，能帮助我们和其他用户了�
 #: src/components/reader/about-view.tsx
 msgid "Publish labels others can subscribe to, or consume the ones we do."
 msgstr ""
+
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Search communities"
+#~ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "The full account is on the <0>extension privacy page</0>."
@@ -5472,6 +5564,11 @@ msgstr "服务 DID 是 <0>{appviewDid}</0>。该服务为需要协商 scope 的�
 msgid "The Slow Web, Revisited"
 msgstr "重访慢速网络"
 
+#. placeholder {0}: visible.length
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "{0, plural, one {# community} other {# communities}}"
+#~ msgstr ""
+
 #. placeholder {0}: labelTotal - names.length
 #: src/components/labelers-settings-view.tsx
 msgid "+{0} more"
@@ -5593,6 +5690,8 @@ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/lib/guide/navigation.ts
+#: src/routes/_layout.discover.tsx
+#: src/routes/_layout.topics.index.tsx
 msgid "Topics"
 msgstr ""
 
@@ -5628,6 +5727,10 @@ msgstr "在 ATStore 上给我们留个评价。"
 #: src/routes/_layout.feedback.index.tsx
 msgid "Search feedback"
 msgstr "搜索反馈"
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "No publications in this topic yet."
+msgstr ""
 
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Unsubscribe"
@@ -5698,6 +5801,10 @@ msgstr "保存列表"
 msgid "Some people would rather read on the publication's own site, with its own design. Turn on the open-on-the-original-site setting in your account menu and every article link opens there in a new tab instead of in the reader. Articles that have no site of their own still open here."
 msgstr ""
 
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Search by name or topic…"
+#~ msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Contents"
 msgstr "目录"
@@ -5748,6 +5855,11 @@ msgstr ""
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
 msgstr "移除"
+
+#. placeholder {0}: topic.authorCount
+#: src/routes/_layout.topics.$slug.tsx
+msgid "{0, plural, one {writer} other {writers}}"
+msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 msgid "<0>Platform</0> components render the blocks unique to one publishing platform — a Leaflet poll or signup, a Pckt gallery or note embed, an Offprint component. These are the interactive, often data-backed embeds; the headless defaults render nothing, so you supply your own to make them live."
@@ -5910,6 +6022,7 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "Articles"
 msgstr "文章"
 
@@ -5990,6 +6103,7 @@ msgstr ""
 #: src/components/reader/subscriptions-sheet.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 msgid "A–Z"
 msgstr "A–Z"
 
@@ -6139,6 +6253,10 @@ msgstr ""
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "详情"
+
+#: src/routes/_layout.topics.$slug.tsx
+msgid "Topic views"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "When you save or follow from the extension, {SITE_NAME} writes AT Protocol records to <0>your</0> repository through the same server paths as the web app. Those records follow the network's visibility rules and your account settings."
@@ -6673,6 +6791,10 @@ msgstr "朗读"
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "你稍后再读的文章——存放在你的仓库中，跨设备同步。"
 
+#: src/routes/_layout.communities.index.tsx
+#~ msgid "Every corner"
+#~ msgstr ""
+
 #: src/components/reader/format-i18n.ts
 msgid "today"
 msgstr ""
@@ -6786,6 +6908,7 @@ msgstr "除非你主动执行需要写入的操作（例如关注刊物、点赞
 #: src/routes/_layout.l.$did.$rkey.tsx
 #: src/routes/_layout.search.tsx
 #: src/routes/_layout.tag.$tag.tsx
+#: src/routes/_layout.topics.$slug.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Publications"
 msgstr "刊物"
@@ -7019,6 +7142,10 @@ msgstr "由 <0>Standard Reader</0> 提供支持"
 
 #: src/components/appearance-settings.tsx
 msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."
+msgstr ""
+
+#: src/routes/_layout.topics.index.tsx
+msgid "Search by name or topic — “vinyl”, “kubernetes”…"
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
@@ -7351,6 +7478,11 @@ msgstr ""
 
 #: src/components/reader/read-on-platform.tsx
 msgid "Read this on {name}"
+msgstr ""
+
+#. placeholder {0}: topic.authorCount
+#: src/components/reader/topic-cards.tsx
+msgid "{0, plural, one {# writer} other {# writers}}"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx

--- a/apps/standard-reader/src/routeTree.gen.ts
+++ b/apps/standard-reader/src/routeTree.gen.ts
@@ -66,6 +66,8 @@ import { Route as LayoutLabelersDidRouteImport } from './routes/_layout.labelers
 import { Route as LayoutPrivacyExtensionRouteImport } from './routes/_layout.privacy.extension'
 import { Route as LayoutSettingsIndexRouteImport } from './routes/_layout.settings.index'
 import { Route as LayoutTagTagRouteImport } from './routes/_layout.tag.$tag'
+import { Route as LayoutTopicsIndexRouteImport } from './routes/_layout.topics.index'
+import { Route as LayoutTopicsSlugRouteImport } from './routes/_layout.topics.$slug'
 import { Route as LayoutUDidRouteImport } from './routes/_layout.u.$did'
 import { Route as ApiBskyPostRouteImport } from './routes/api/bsky/post'
 import { Route as ApiDevDigestPreviewRouteImport } from './routes/api/dev/digest-preview'
@@ -410,6 +412,16 @@ const LayoutTagTagRoute = LayoutTagTagRouteImport.update({
   path: '/tag/$tag',
   getParentRoute: () => LayoutRoute,
 } as any)
+const LayoutTopicsIndexRoute = LayoutTopicsIndexRouteImport.update({
+  id: '/topics/',
+  path: '/topics/',
+  getParentRoute: () => LayoutRoute,
+} as any)
+const LayoutTopicsSlugRoute = LayoutTopicsSlugRouteImport.update({
+  id: '/topics/$slug',
+  path: '/topics/$slug',
+  getParentRoute: () => LayoutRoute,
+} as any)
 const LayoutUDidRoute = LayoutUDidRouteImport.update({
   id: '/u/$did',
   path: '/u/$did',
@@ -696,6 +708,7 @@ export interface FileRoutesByFullPath {
   '/labelers/$did': typeof LayoutLabelersDidRoute
   '/privacy/extension': typeof LayoutPrivacyExtensionRoute
   '/tag/$tag': typeof LayoutTagTagRoute
+  '/topics/$slug': typeof LayoutTopicsSlugRoute
   '/u/$did': typeof LayoutUDidRoute
   '/api/bsky/post': typeof ApiBskyPostRoute
   '/api/dev/digest-preview': typeof ApiDevDigestPreviewRoute
@@ -731,6 +744,7 @@ export interface FileRoutesByFullPath {
   '/feedback/': typeof LayoutFeedbackIndexRoute
   '/labelers/': typeof LayoutLabelersIndexRoute
   '/settings/': typeof LayoutSettingsIndexRoute
+  '/topics/': typeof LayoutTopicsIndexRoute
   '/a/$did/$rkey': typeof LayoutADidRkeyRoute
   '/collections/edit/$rkey': typeof LayoutCollectionsEditRkeyRoute
   '/l/$did/$rkey': typeof LayoutLDidRkeyRoute
@@ -797,6 +811,7 @@ export interface FileRoutesByTo {
   '/labelers/$did': typeof LayoutLabelersDidRoute
   '/privacy/extension': typeof LayoutPrivacyExtensionRoute
   '/tag/$tag': typeof LayoutTagTagRoute
+  '/topics/$slug': typeof LayoutTopicsSlugRoute
   '/u/$did': typeof LayoutUDidRoute
   '/api/bsky/post': typeof ApiBskyPostRoute
   '/api/dev/digest-preview': typeof ApiDevDigestPreviewRoute
@@ -832,6 +847,7 @@ export interface FileRoutesByTo {
   '/feedback': typeof LayoutFeedbackIndexRoute
   '/labelers': typeof LayoutLabelersIndexRoute
   '/settings': typeof LayoutSettingsIndexRoute
+  '/topics': typeof LayoutTopicsIndexRoute
   '/a/$did/$rkey': typeof LayoutADidRkeyRoute
   '/collections/edit/$rkey': typeof LayoutCollectionsEditRkeyRoute
   '/l/$did/$rkey': typeof LayoutLDidRkeyRoute
@@ -903,6 +919,7 @@ export interface FileRoutesById {
   '/_layout/labelers/$did': typeof LayoutLabelersDidRoute
   '/_layout/privacy/extension': typeof LayoutPrivacyExtensionRoute
   '/_layout/tag/$tag': typeof LayoutTagTagRoute
+  '/_layout/topics/$slug': typeof LayoutTopicsSlugRoute
   '/_layout/u/$did': typeof LayoutUDidRoute
   '/api/bsky/post': typeof ApiBskyPostRoute
   '/api/dev/digest-preview': typeof ApiDevDigestPreviewRoute
@@ -938,6 +955,7 @@ export interface FileRoutesById {
   '/_layout/feedback/': typeof LayoutFeedbackIndexRoute
   '/_layout/labelers/': typeof LayoutLabelersIndexRoute
   '/_layout/settings/': typeof LayoutSettingsIndexRoute
+  '/_layout/topics/': typeof LayoutTopicsIndexRoute
   '/_layout/a/$did/$rkey': typeof LayoutADidRkeyRoute
   '/_layout/collections/edit/$rkey': typeof LayoutCollectionsEditRkeyRoute
   '/_layout/l/$did/$rkey': typeof LayoutLDidRkeyRoute
@@ -1007,6 +1025,7 @@ export interface FileRouteTypes {
     | '/labelers/$did'
     | '/privacy/extension'
     | '/tag/$tag'
+    | '/topics/$slug'
     | '/u/$did'
     | '/api/bsky/post'
     | '/api/dev/digest-preview'
@@ -1042,6 +1061,7 @@ export interface FileRouteTypes {
     | '/feedback/'
     | '/labelers/'
     | '/settings/'
+    | '/topics/'
     | '/a/$did/$rkey'
     | '/collections/edit/$rkey'
     | '/l/$did/$rkey'
@@ -1108,6 +1128,7 @@ export interface FileRouteTypes {
     | '/labelers/$did'
     | '/privacy/extension'
     | '/tag/$tag'
+    | '/topics/$slug'
     | '/u/$did'
     | '/api/bsky/post'
     | '/api/dev/digest-preview'
@@ -1143,6 +1164,7 @@ export interface FileRouteTypes {
     | '/feedback'
     | '/labelers'
     | '/settings'
+    | '/topics'
     | '/a/$did/$rkey'
     | '/collections/edit/$rkey'
     | '/l/$did/$rkey'
@@ -1213,6 +1235,7 @@ export interface FileRouteTypes {
     | '/_layout/labelers/$did'
     | '/_layout/privacy/extension'
     | '/_layout/tag/$tag'
+    | '/_layout/topics/$slug'
     | '/_layout/u/$did'
     | '/api/bsky/post'
     | '/api/dev/digest-preview'
@@ -1248,6 +1271,7 @@ export interface FileRouteTypes {
     | '/_layout/feedback/'
     | '/_layout/labelers/'
     | '/_layout/settings/'
+    | '/_layout/topics/'
     | '/_layout/a/$did/$rkey'
     | '/_layout/collections/edit/$rkey'
     | '/_layout/l/$did/$rkey'
@@ -1728,6 +1752,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutTagTagRouteImport
       parentRoute: typeof LayoutRoute
     }
+    '/_layout/topics/': {
+      id: '/_layout/topics/'
+      path: '/topics'
+      fullPath: '/topics/'
+      preLoaderRoute: typeof LayoutTopicsIndexRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/topics/$slug': {
+      id: '/_layout/topics/$slug'
+      path: '/topics/$slug'
+      fullPath: '/topics/$slug'
+      preLoaderRoute: typeof LayoutTopicsSlugRouteImport
+      parentRoute: typeof LayoutRoute
+    }
     '/_layout/u/$did': {
       id: '/_layout/u/$did'
       path: '/u/$did'
@@ -2151,10 +2189,12 @@ interface LayoutRouteChildren {
   LayoutFeedbackReturnRoute: typeof LayoutFeedbackReturnRoute
   LayoutLabelersDidRoute: typeof LayoutLabelersDidRoute
   LayoutTagTagRoute: typeof LayoutTagTagRoute
+  LayoutTopicsSlugRoute: typeof LayoutTopicsSlugRoute
   LayoutUDidRoute: typeof LayoutUDidRoute
   LayoutFeedbackIndexRoute: typeof LayoutFeedbackIndexRoute
   LayoutLabelersIndexRoute: typeof LayoutLabelersIndexRoute
   LayoutSettingsIndexRoute: typeof LayoutSettingsIndexRoute
+  LayoutTopicsIndexRoute: typeof LayoutTopicsIndexRoute
   LayoutADidRkeyRoute: typeof LayoutADidRkeyRoute
   LayoutLDidRkeyRoute: typeof LayoutLDidRkeyRoute
   LayoutPDidRkeyRoute: typeof LayoutPDidRkeyRoute
@@ -2178,10 +2218,12 @@ const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutFeedbackReturnRoute: LayoutFeedbackReturnRoute,
   LayoutLabelersDidRoute: LayoutLabelersDidRoute,
   LayoutTagTagRoute: LayoutTagTagRoute,
+  LayoutTopicsSlugRoute: LayoutTopicsSlugRoute,
   LayoutUDidRoute: LayoutUDidRoute,
   LayoutFeedbackIndexRoute: LayoutFeedbackIndexRoute,
   LayoutLabelersIndexRoute: LayoutLabelersIndexRoute,
   LayoutSettingsIndexRoute: LayoutSettingsIndexRoute,
+  LayoutTopicsIndexRoute: LayoutTopicsIndexRoute,
   LayoutADidRkeyRoute: LayoutADidRkeyRoute,
   LayoutLDidRkeyRoute: LayoutLDidRkeyRoute,
   LayoutPDidRkeyRoute: LayoutPDidRkeyRoute,

--- a/apps/standard-reader/src/routes/_layout.discover.tsx
+++ b/apps/standard-reader/src/routes/_layout.discover.tsx
@@ -44,6 +44,7 @@ import {
   DISCOVER_TOPICS_LIMIT,
   discoverApi,
 } from "#/integrations/tanstack-query/api-discover.functions";
+import { topicsApi } from "#/integrations/tanstack-query/api-topics.functions";
 import { user } from "#/integrations/tanstack-query/api-user.functions";
 import { getPublicUrlClient } from "#/lib/public-url";
 import { pageSocialMeta } from "#/lib/site-metadata";
@@ -64,6 +65,10 @@ import {
   SectionHead,
 } from "../components/reader/primitives";
 import { PubGridList } from "../components/reader/pub-grid-list";
+import {
+  TopicCardSkeleton,
+  TopicGridList,
+} from "../components/reader/topic-cards";
 import type { PublicationCard } from "../integrations/tanstack-query/api-shapes";
 
 const DIRECTORY_PAGE_SIZE = 24;
@@ -72,6 +77,8 @@ const DIRECTORY_SKELETON_COUNT = 8;
 const DIRECTORY_LOAD_MORE_SKELETON_COUNT = 3;
 const DEFERRED_ROOT_MARGIN = "600px 0px";
 const RAIL_LIMIT = 10;
+const TOPIC_RAIL_LIMIT = 8;
+const TOPIC_RAIL_SKELETONS = 4;
 const TRENDING_LIMIT_OPTIONS = [5, 10, 20, 50, 100] as const;
 const DEFAULT_TRENDING_LIMIT = 5;
 const SOCIAL_PROOF_MAX = 60;
@@ -106,8 +113,11 @@ export const Route = createFileRoute("/_layout/discover")({
     const trendingOptions = discoverApi.getTrendingPublicationsQueryOptions({
       limit: DEFAULT_TRENDING_LIMIT,
     });
-    const topicsOptions = discoverApi.getTopicsQueryOptions({
+    const topicChipsOptions = discoverApi.getTopicsQueryOptions({
       limit: DISCOVER_TOPICS_LIMIT,
+    });
+    const topicsOptions = topicsApi.getDiscoverTopicsQueryOptions({
+      limit: TOPIC_RAIL_LIMIT,
     });
     const directoryOptions = discoverApi.getPublicationsQueryOptions({
       topic: deps.topic ?? null,
@@ -124,9 +134,10 @@ export const Route = createFileRoute("/_layout/discover")({
       void context.queryClient.prefetchQuery(knownCountOptions);
       void context.queryClient.prefetchQuery(extrasOptions);
       void context.queryClient.prefetchQuery(trendingOptions);
-      void context.queryClient.prefetchQuery(topicsOptions);
+      void context.queryClient.prefetchQuery(topicChipsOptions);
       void context.queryClient.prefetchQuery(directoryOptions);
       void context.queryClient.prefetchQuery(friendsOptions);
+      void context.queryClient.prefetchQuery(topicsOptions);
       return;
     }
 
@@ -138,9 +149,12 @@ export const Route = createFileRoute("/_layout/discover")({
     await Promise.all([
       context.queryClient.ensureQueryData(knownCountOptions),
       context.queryClient.ensureQueryData(trendingOptions),
+      // Above the fold, and cheap (precomputed tables) — awaiting it keeps the
+      // rail from popping in under Trending after first paint.
+      context.queryClient.ensureQueryData(topicsOptions),
     ]);
     void context.queryClient.prefetchQuery(extrasOptions);
-    void context.queryClient.prefetchQuery(topicsOptions);
+    void context.queryClient.prefetchQuery(topicChipsOptions);
     void context.queryClient.prefetchQuery(directoryOptions);
 
     // Block on the friends lookup only if it can be answered from the warm
@@ -223,6 +237,11 @@ const styles = stylex.create({
   },
   railWrap: {
     marginTop: spacing["5"],
+  },
+  topicRailSkeleton: {
+    columnGap: spacing["6"],
+    display: "flex",
+    overflow: "hidden",
   },
   directorySearch: {
     flexShrink: 0,
@@ -517,6 +536,68 @@ function DiscoverFriendsPrompt() {
         <Users size={16} aria-hidden />
         <Trans>Find your friends</Trans>
       </ButtonLink>
+    </div>
+  );
+}
+
+/**
+ * Topics — clusters of related tags, derived by the recompute sweep.
+ *
+ * Sits directly under Trending because it is the page's answer to breadth: the
+ * topic chips further down rank tags by raw frequency, which buries everything
+ * that is not an atproto-native topic. Personalized server-side from the
+ * reader's follows when there are any.
+ *
+ * Renders nothing until it has topics — an empty rail would just be a
+ * hole above Recommended (same rule the other rails follow).
+ */
+function DiscoverTopicsSection() {
+  const { t } = useLingui();
+  const title = t`Topics`;
+  const { data: topics, isPending } = useQuery(
+    topicsApi.getDiscoverTopicsQueryOptions({
+      limit: TOPIC_RAIL_LIMIT,
+    }),
+  );
+
+  if (isPending) {
+    return (
+      <div {...stylex.props(styles.section)}>
+        <SectionHead title={title} />
+        {/* No `aria-busy` here: this section streams in after the critical
+            path, and the perf harness clears on `aria-busy`. */}
+        <div {...stylex.props(styles.railWrap, styles.topicRailSkeleton)}>
+          {Array.from({ length: TOPIC_RAIL_SKELETONS }, (_, index) => (
+            <TopicCardSkeleton key={index} rail />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!topics || topics.length === 0) return null;
+
+  return (
+    <div {...stylex.props(styles.section)}>
+      <SectionHead
+        title={title}
+        // The rail shows a personalized handful; browsing and searching the
+        // rest lives on its own page.
+        stackOnMobile={false}
+        action={
+          <ButtonLink
+            to="/topics"
+            variant="tertiary"
+            size="sm"
+            aria-label={t`Browse all topics`}
+          >
+            <Trans>See all</Trans>
+          </ButtonLink>
+        }
+      />
+      <div {...stylex.props(styles.railWrap)}>
+        <TopicGridList topics={topics} layout="rail" aria-label={title} />
+      </div>
     </div>
   );
 }
@@ -979,6 +1060,8 @@ function Discover() {
       {signedIn ? <DiscoverFriendsPrompt /> : null}
 
       <DiscoverTrendingSection />
+
+      <DiscoverTopicsSection />
 
       <DiscoverRecommendedSection
         signedIn={signedIn}

--- a/apps/standard-reader/src/routes/_layout.topics.$slug.tsx
+++ b/apps/standard-reader/src/routes/_layout.topics.$slug.tsx
@@ -1,0 +1,936 @@
+"use client";
+
+import { msg } from "@lingui/core/macro";
+import { Plural, Trans, useLingui } from "@lingui/react/macro";
+import { IconButton } from "@standard-reader/design-system/icon-button";
+import { Menu, MenuItem } from "@standard-reader/design-system/menu";
+import {
+  SegmentedControl,
+  SegmentedControlItem,
+} from "@standard-reader/design-system/segmented-control";
+import { Select, SelectItem } from "@standard-reader/design-system/select";
+import { Skeleton } from "@standard-reader/design-system/skeleton";
+import {
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
+} from "@standard-reader/design-system/tabs";
+import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
+import { spacing } from "@standard-reader/design-system/theme/spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+  tracking,
+} from "@standard-reader/design-system/theme/typography.stylex";
+import * as stylex from "@stylexjs/stylex";
+import {
+  keepPreviousData,
+  useQuery,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import {
+  createFileRoute,
+  Link,
+  notFound,
+  useNavigate,
+  useRouterState,
+} from "@tanstack/react-router";
+import { ArrowDownWideNarrow, LayoutGrid, List } from "lucide-react";
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { z } from "zod";
+
+import { topicsApi } from "#/integrations/tanstack-query/api-topics.functions";
+import { user } from "#/integrations/tanstack-query/api-user.functions";
+import { getPublicUrlClient } from "#/lib/public-url";
+import { SITE_NAME, siteSocialMeta } from "#/lib/site-metadata";
+import { useDelayedLoading } from "#/lib/use-delayed-loading";
+import { useFormatters } from "#/lib/use-formatters";
+import { useTrackReadingHistory } from "#/lib/use-track-reading-history";
+
+import {
+  ArticleRow,
+  PubCardSkeleton,
+  PubDirectoryRowSkeleton,
+} from "../components/reader/cards";
+import { FeedLoadMore } from "../components/reader/feed-load-more";
+import { Kicker, ReaderContent } from "../components/reader/primitives";
+import { PubGridList } from "../components/reader/pub-grid-list";
+import { isArticleUnreadForReader } from "../components/reader/read-optimistic";
+import type { ArticleCard } from "../integrations/tanstack-query/api-shapes";
+
+const PAGE_SIZE = 24;
+const SKELETON_COUNT = 8;
+const LOAD_MORE_SKELETON_COUNT = 3;
+const ARTICLE_SKELETON_ROWS = 8;
+/** Grace period before tab skeletons appear (avoids flash on fast loads). */
+const TAB_SKELETON_DELAY_MS = 150;
+/**
+ * Sub-area links under the masthead.
+ *
+ * The query returns up to 40 — enough for search and for the tabs below — but
+ * a masthead is not a tag cloud. Twelve is roughly two wrapped lines at the
+ * narrowest layout, which is a footnote; the rest stay reachable through the
+ * articles they tag.
+ */
+const SUB_AREA_LINKS = 12;
+
+const topicSearchShape = z.object({
+  view: z.enum(["feed", "publications"]).default("feed"),
+  /** Publications-tab ranking. */
+  sort: z.enum(["belonging", "readers", "active", "az"]).default("belonging"),
+  /** Articles-tab ranking — kept apart from `sort` so the tabs hold
+   * independent state in the URL. */
+  articleSort: z.enum(["recent", "trending", "popular"]).default("recent"),
+  layout: z.enum(["grid", "list"]).default("list"),
+});
+
+type TopicSearch = z.infer<typeof topicSearchShape>;
+type TopicView = TopicSearch["view"];
+type TopicSort = TopicSearch["sort"];
+type TopicArticleSort = TopicSearch["articleSort"];
+
+const ARTICLE_SORT_OPTIONS = [
+  { id: "recent", label: msg`Newest` },
+  { id: "trending", label: msg`Trending` },
+  { id: "popular", label: msg`Most liked` },
+] as const;
+
+const SORT_OPTIONS = [
+  { id: "belonging", label: msg`Best fit` },
+  { id: "readers", label: msg`Readers` },
+  { id: "active", label: msg`Active` },
+  { id: "az", label: msg`A–Z` },
+] as const;
+
+export const Route = createFileRoute("/_layout/topics/$slug")({
+  validateSearch: topicSearchShape,
+  staleTime: 60_000,
+  loaderDeps: ({ search }) => ({
+    view: search.view,
+    sort: search.sort,
+    articleSort: search.articleSort,
+  }),
+  loader: async ({ context, params, deps }) => {
+    const page = await topicsApi.getTopicPage({
+      data: {
+        slug: params.slug,
+        view: deps.view,
+        sort: deps.sort,
+        articleSort: deps.articleSort,
+        limit: PAGE_SIZE,
+        offset: 0,
+      },
+    });
+    // Topics are derived, so an unknown slug is a genuine 404 rather than
+    // an empty page — including a topic that dropped below the quality bar.
+    if (!page.topic) throw notFound();
+
+    topicsApi.seedTopicPageCaches(context.queryClient, page, {
+      slug: params.slug,
+      view: deps.view,
+      sort: deps.sort,
+      articleSort: deps.articleSort,
+      limit: PAGE_SIZE,
+      offset: 0,
+    });
+    return {
+      name: page.topic.name,
+      description: page.topic.description,
+    };
+  },
+  head: ({ loaderData, params }) => {
+    const baseUrl = getPublicUrlClient();
+    const name = loaderData?.name ?? params.slug;
+    const title = `${name} · ${SITE_NAME}`;
+    return {
+      meta: siteSocialMeta({
+        title,
+        description:
+          loaderData?.description ??
+          `Publications and articles across ${name} on the Atmosphere.`,
+        url: `${baseUrl.replace(/\/$/, "")}/topics/${params.slug}`,
+      }),
+    };
+  },
+  component: TopicPage,
+});
+
+/* ── Articles tab ─────────────────────────────────────────────────────────── */
+
+function TopicArticlesSkeleton({ rows = ARTICLE_SKELETON_ROWS }) {
+  const { t } = useLingui();
+  return (
+    <div aria-busy="true" aria-label={t`Loading articles`}>
+      {Array.from({ length: rows }, (_, index) => (
+        <div key={index} {...stylex.props(styles.articleSkeletonRow)}>
+          <Skeleton variant="rectangle" height={spacing["5"]} width="62%" />
+          <Skeleton variant="rectangle" height={spacing["4"]} width="38%" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TopicArticlesPanel({
+  slug,
+  articleSort,
+}: {
+  slug: string;
+  articleSort: TopicArticleSort;
+}) {
+  const { t } = useLingui();
+  const queryClient = useQueryClient();
+  const { data: session } = useQuery(user.getSessionQueryOptions);
+  const signedIn = Boolean(session?.user);
+  const { enabled: trackReading } = useTrackReadingHistory();
+
+  const {
+    data: feed,
+    isPending: feedPending,
+    isFetching: feedFetching,
+  } = useQuery({
+    ...topicsApi.getArticlesQueryOptions({
+      slug,
+      articleSort,
+      limit: PAGE_SIZE,
+      offset: 0,
+    }),
+    placeholderData: (previousData, previousQuery) => {
+      // Only keep the previous page when it belongs to this topic —
+      // otherwise navigating between topics flashes the old one's rows.
+      if (previousQuery?.queryKey[2] === slug) {
+        return keepPreviousData(previousData);
+      }
+      return;
+    },
+  });
+
+  const [loadedMore, setLoadedMore] = useState<Array<ArticleCard>>([]);
+  const [loadedMoreNextOffset, setLoadedMoreNextOffset] = useState<
+    number | null
+  >(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const loadingMoreRef = useRef(false);
+
+  useEffect(() => {
+    setLoadedMore([]);
+    setLoadedMoreNextOffset(null);
+  }, [slug, articleSort]);
+
+  const items = useMemo(
+    () => [...(feed?.items ?? []), ...loadedMore],
+    [feed?.items, loadedMore],
+  );
+  const nextOffset =
+    loadedMore.length > 0 ? loadedMoreNextOffset : (feed?.nextOffset ?? null);
+
+  const isLoading = feedPending || (feedFetching && items.length === 0);
+  const showSkeleton = useDelayedLoading(isLoading, TAB_SKELETON_DELAY_MS);
+
+  const loadMore = useCallback(async () => {
+    if (nextOffset == null || loadingMoreRef.current) return;
+    loadingMoreRef.current = true;
+    setLoadingMore(true);
+    try {
+      const page = await topicsApi.getArticles({
+        data: { slug, articleSort, limit: PAGE_SIZE, offset: nextOffset },
+      });
+      setLoadedMore((prev) => [...prev, ...page.items]);
+      setLoadedMoreNextOffset(page.nextOffset);
+    } finally {
+      loadingMoreRef.current = false;
+      setLoadingMore(false);
+    }
+  }, [articleSort, nextOffset, slug]);
+
+  if (showSkeleton) return <TopicArticlesSkeleton />;
+  // Inside the grace period keep the chrome steady rather than flashing the
+  // empty state.
+  if (isLoading) {
+    return <div aria-busy="true" aria-label={t`Loading articles`} />;
+  }
+
+  if (items.length === 0) {
+    return (
+      <p {...stylex.props(styles.empty)}>
+        <Trans>No articles in this topic yet.</Trans>
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <div>
+        {items.map((article, index) => (
+          <ArticleRow
+            key={article.uri}
+            article={article}
+            isFirstInSection={index === 0}
+            unread={isArticleUnreadForReader(queryClient, article, {
+              trackReading,
+              signedIn,
+            })}
+            showSaveButton={false}
+          />
+        ))}
+      </div>
+
+      <FeedLoadMore
+        hasMore={nextOffset != null}
+        isLoading={loadingMore}
+        onLoadMore={() => void loadMore()}
+        itemCount={items.length}
+      />
+      {loadingMore ? (
+        <TopicArticlesSkeleton rows={LOAD_MORE_SKELETON_COUNT} />
+      ) : nextOffset == null ? (
+        <p {...stylex.props(styles.endNote)}>
+          <Trans>You&apos;ve reached the end.</Trans>
+        </p>
+      ) : null}
+    </>
+  );
+}
+
+/* ── Publications tab ─────────────────────────────────────────────────────── */
+
+function TopicDirectorySkeleton({
+  layout,
+  count = SKELETON_COUNT,
+}: {
+  layout: "grid" | "list";
+  count?: number;
+}) {
+  const { t } = useLingui();
+
+  if (layout === "grid") {
+    return (
+      <div
+        aria-busy="true"
+        aria-label={t`Loading publications`}
+        {...stylex.props(styles.directoryGrid)}
+      >
+        {Array.from({ length: count }, (_, index) => (
+          <PubCardSkeleton key={index} />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div aria-busy="true" aria-label={t`Loading publications`}>
+      {Array.from({ length: count }, (_, index) => (
+        <PubDirectoryRowSkeleton key={index} isLast={index === count - 1} />
+      ))}
+    </div>
+  );
+}
+
+function TopicPublicationsPanel({
+  slug,
+  sort,
+  layout,
+}: {
+  slug: string;
+  sort: TopicSort;
+  layout: "grid" | "list";
+}) {
+  const { t, i18n } = useLingui();
+  const navigate = useNavigate({ from: Route.fullPath });
+
+  const {
+    data: directory,
+    isPending,
+    isFetching,
+  } = useQuery({
+    ...topicsApi.getPublicationsQueryOptions({
+      slug,
+      sort,
+      limit: PAGE_SIZE,
+      offset: 0,
+    }),
+    placeholderData: (previousData, previousQuery) => {
+      if (previousQuery?.queryKey[2] === slug) {
+        return keepPreviousData(previousData);
+      }
+      return;
+    },
+  });
+
+  const [loadedMore, setLoadedMore] = useState<
+    Array<NonNullable<typeof directory>["items"][number]>
+  >([]);
+  const [loadedMoreNextOffset, setLoadedMoreNextOffset] = useState<
+    number | null
+  >(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const loadingMoreRef = useRef(false);
+
+  useEffect(() => {
+    setLoadedMore([]);
+    setLoadedMoreNextOffset(null);
+  }, [slug, sort]);
+
+  const items = useMemo(
+    () => [...(directory?.items ?? []), ...loadedMore],
+    [directory?.items, loadedMore],
+  );
+  const nextOffset =
+    loadedMore.length > 0
+      ? loadedMoreNextOffset
+      : (directory?.nextOffset ?? null);
+
+  const isLoading = isPending || (isFetching && items.length === 0);
+  const showSkeleton = useDelayedLoading(isLoading, TAB_SKELETON_DELAY_MS);
+
+  const loadMore = useCallback(async () => {
+    if (nextOffset == null || loadingMoreRef.current) return;
+    loadingMoreRef.current = true;
+    setLoadingMore(true);
+    try {
+      const page = await topicsApi.getPublications({
+        data: { slug, sort, limit: PAGE_SIZE, offset: nextOffset },
+      });
+      setLoadedMore((prev) => [...prev, ...page.items]);
+      setLoadedMoreNextOffset(page.nextOffset);
+    } finally {
+      loadingMoreRef.current = false;
+      setLoadingMore(false);
+    }
+  }, [nextOffset, slug, sort]);
+
+  const updateSearch = (patch: Partial<TopicSearch>) => {
+    void navigate({
+      replace: true,
+      resetScroll: false,
+      search: (prev: TopicSearch) => ({ ...prev, ...patch }),
+    });
+  };
+
+  return (
+    <>
+      {/* Toolbar stays mounted through loading — only the rows below swap for
+          a skeleton, so the controls never jump. */}
+      <div {...stylex.props(styles.directoryToolbar)}>
+        <SegmentedControl
+          selectedKeys={new Set([sort])}
+          onSelectionChange={(keys) => {
+            const next = String([...keys][0] ?? "belonging") as TopicSort;
+            updateSearch({ sort: next });
+          }}
+          size="sm"
+        >
+          {SORT_OPTIONS.map((option) => (
+            <SegmentedControlItem key={option.id} id={option.id}>
+              {i18n._(option.label)}
+            </SegmentedControlItem>
+          ))}
+        </SegmentedControl>
+
+        <SegmentedControl
+          selectedKeys={new Set([layout])}
+          onSelectionChange={(keys) => {
+            const next = String([...keys][0] ?? "list") as "grid" | "list";
+            updateSearch({ layout: next });
+          }}
+          size="sm"
+        >
+          <SegmentedControlItem id="list" aria-label={t`List view`}>
+            <List size={16} />
+          </SegmentedControlItem>
+          <SegmentedControlItem id="grid" aria-label={t`Grid view`}>
+            <LayoutGrid size={16} />
+          </SegmentedControlItem>
+        </SegmentedControl>
+      </div>
+
+      {showSkeleton ? (
+        <TopicDirectorySkeleton layout={layout} />
+      ) : isLoading ? (
+        <div aria-busy="true" aria-label={t`Loading publications`} />
+      ) : items.length === 0 ? (
+        <p {...stylex.props(styles.empty)}>
+          <Trans>No publications in this topic yet.</Trans>
+        </p>
+      ) : (
+        <PubGridList
+          pubs={items}
+          layout={layout}
+          variant={layout === "grid" ? "card" : "row"}
+          aria-label={t`Publications`}
+        />
+      )}
+
+      {items.length > 0 && !showSkeleton ? (
+        <>
+          <FeedLoadMore
+            hasMore={nextOffset != null}
+            isLoading={loadingMore}
+            onLoadMore={() => void loadMore()}
+            itemCount={items.length}
+          />
+          {loadingMore ? (
+            <TopicDirectorySkeleton
+              layout={layout}
+              count={LOAD_MORE_SKELETON_COUNT}
+            />
+          ) : nextOffset == null ? (
+            <p {...stylex.props(styles.endNote)}>
+              <Trans>You&apos;ve reached the end.</Trans>
+            </p>
+          ) : null}
+        </>
+      ) : null}
+    </>
+  );
+}
+
+/* ── Page ─────────────────────────────────────────────────────────────────── */
+
+function TopicPage() {
+  const { t, i18n } = useLingui();
+  const fmt = useFormatters();
+  const { slug } = Route.useParams();
+  const { view, sort, articleSort, layout } = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+  const routePending = useRouterState({ select: (state) => state.isLoading });
+  const queryClient = useQueryClient();
+  const [pendingViews, setPendingViews] = useState<
+    Partial<Record<string, TopicView>>
+  >({});
+
+  const { data: topic } = useSuspenseQuery(
+    topicsApi.getTopicQueryOptions({ slug }),
+  );
+  const { data: publicationCount = 0 } = useSuspenseQuery(
+    topicsApi.getPublicationCountQueryOptions({ slug }),
+  );
+
+  // Warm the tab the reader hasn't opened, once the critical path is idle.
+  useEffect(() => {
+    if (routePending) return;
+
+    const prefetchOtherTab = () => {
+      if (view === "feed") {
+        void queryClient.prefetchQuery(
+          topicsApi.getPublicationsQueryOptions({
+            slug,
+            sort,
+            limit: PAGE_SIZE,
+            offset: 0,
+          }),
+        );
+        return;
+      }
+      void queryClient.prefetchQuery(
+        topicsApi.getArticlesQueryOptions({
+          slug,
+          articleSort,
+          limit: PAGE_SIZE,
+          offset: 0,
+        }),
+      );
+    };
+
+    const scheduleIdle =
+      globalThis.requestIdleCallback ??
+      ((callback: IdleRequestCallback) =>
+        globalThis.setTimeout(
+          () => callback({ didTimeout: false, timeRemaining: () => 0 }),
+          200,
+        ));
+    const cancelIdle =
+      globalThis.cancelIdleCallback ??
+      ((id: number) => globalThis.clearTimeout(id));
+
+    const idleId = scheduleIdle(prefetchOtherTab);
+    return () => cancelIdle(idleId);
+  }, [articleSort, queryClient, routePending, slug, sort, view]);
+
+  const pendingView = pendingViews[slug] ?? null;
+  const activeView = routePending ? (pendingView ?? view) : view;
+  const isFeed = activeView === "feed";
+
+  const onViewChange = (key: React.Key) => {
+    const next = key as TopicView;
+    // Highlight the tab immediately; the loader catches up.
+    if (next !== view) {
+      setPendingViews((prev) => ({ ...prev, [slug]: next }));
+    }
+    void navigate({
+      search: (prev: TopicSearch) => ({ ...prev, view: next }),
+    });
+  };
+
+  const onArticleSortChange = (key: React.Key | null) => {
+    if (key == null) return;
+    void navigate({
+      replace: true,
+      resetScroll: false,
+      search: (prev: TopicSearch) => ({
+        ...prev,
+        articleSort: String(key) as TopicArticleSort,
+      }),
+    });
+  };
+
+  if (!topic) return null;
+
+  const subAreas = topic.tags.slice(0, SUB_AREA_LINKS);
+
+  return (
+    <div>
+      <div {...stylex.props(styles.heroInner)}>
+        <div {...stylex.props(styles.heroInfo)}>
+          <Kicker>
+            <Trans>Topic</Trans>
+          </Kicker>
+          {/* Topic names are model-authored data, not UI copy — never
+              wrapped in a macro, and `dir="auto"` since many are not English. */}
+          <h1 dir="auto" {...stylex.props(styles.heroName)}>
+            {topic.name}
+          </h1>
+          {topic.description ? (
+            <p dir="auto" {...stylex.props(styles.heroDesc)}>
+              {topic.description}
+            </p>
+          ) : null}
+
+          <div {...stylex.props(styles.stats)}>
+            <span>
+              <span {...stylex.props(styles.statValue)}>
+                {fmt.compactNumber(publicationCount)}
+              </span>
+              <Plural
+                value={publicationCount}
+                one="publication"
+                other="publications"
+              />
+            </span>
+            <span>
+              <span {...stylex.props(styles.statValue)}>
+                {fmt.compactNumber(topic.authorCount)}
+              </span>
+              <Plural value={topic.authorCount} one="writer" other="writers" />
+            </span>
+          </div>
+
+          {/* The tags this topic was clustered from. Each still has its
+              own page, so this is the way back down to a narrower view — but
+              it is a footnote to the masthead, not a second headline. Forty
+              bordered chips read as a tag cloud and pulled the eye off the
+              name; a wrapped line of plain links says the same thing quietly,
+              and {@link SUB_AREA_LINKS} keeps it to one or two lines. */}
+          {subAreas.length > 0 ? (
+            <p {...stylex.props(styles.subAreas)}>
+              {subAreas.map((tag, index) => (
+                <Fragment key={tag}>
+                  {index > 0 ? (
+                    <span aria-hidden {...stylex.props(styles.subAreaSep)}>
+                      ·
+                    </span>
+                  ) : null}
+                  <Link
+                    to="/tag/$tag"
+                    params={{ tag }}
+                    dir="auto"
+                    {...stylex.props(styles.subAreaLink)}
+                  >
+                    {tag}
+                  </Link>
+                </Fragment>
+              ))}
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      <Tabs
+        selectedKey={activeView}
+        onSelectionChange={onViewChange}
+        style={styles.tabs}
+      >
+        <div {...stylex.props(styles.tabBar)}>
+          <div {...stylex.props(styles.tabBarInner)}>
+            <TabList aria-label={t`Topic views`} style={styles.tabList}>
+              <Tab id="feed">
+                <Trans>Articles</Trans>
+              </Tab>
+              <Tab id="publications">
+                <Trans>Publications</Trans>
+              </Tab>
+            </TabList>
+
+            {isFeed ? (
+              <>
+                <div
+                  {...stylex.props(styles.tabBarSort, styles.tabBarSortCompact)}
+                >
+                  <Menu
+                    placement="bottom end"
+                    selectionMode="single"
+                    selectedKeys={new Set([articleSort])}
+                    onSelectionChange={(keys) => {
+                      if (keys === "all") return;
+                      onArticleSortChange([...keys][0] ?? null);
+                    }}
+                    trigger={
+                      <IconButton
+                        aria-label={t`Sort articles`}
+                        size="md"
+                        variant="secondary"
+                      >
+                        <ArrowDownWideNarrow size={16} />
+                      </IconButton>
+                    }
+                  >
+                    {ARTICLE_SORT_OPTIONS.map((option) => (
+                      <MenuItem key={option.id} id={option.id}>
+                        {i18n._(option.label)}
+                      </MenuItem>
+                    ))}
+                  </Menu>
+                </div>
+
+                <div
+                  {...stylex.props(styles.tabBarSort, styles.tabBarSortFull)}
+                >
+                  <Select
+                    aria-label={t`Sort articles`}
+                    size="md"
+                    variant="secondary"
+                    prefix={<ArrowDownWideNarrow size={14} aria-hidden />}
+                    selectedKey={articleSort}
+                    style={styles.tabBarSortSelect}
+                    onSelectionChange={onArticleSortChange}
+                  >
+                    {ARTICLE_SORT_OPTIONS.map((option) => (
+                      <SelectItem
+                        key={option.id}
+                        id={option.id}
+                        textValue={i18n._(option.label)}
+                      >
+                        {i18n._(option.label)}
+                      </SelectItem>
+                    ))}
+                  </Select>
+                </div>
+              </>
+            ) : null}
+          </div>
+          <div {...stylex.props(styles.tabRule)} aria-hidden />
+        </div>
+
+        <ReaderContent>
+          {/* Only the active panel renders its content — a mounted inactive
+              panel would run its query on every load. */}
+          <TabPanel id="feed" style={styles.tabPanel}>
+            {isFeed ? (
+              <TopicArticlesPanel slug={slug} articleSort={articleSort} />
+            ) : null}
+          </TabPanel>
+          <TabPanel id="publications" style={styles.tabPanel}>
+            {isFeed ? null : (
+              <TopicPublicationsPanel slug={slug} sort={sort} layout={layout} />
+            )}
+          </TabPanel>
+        </ReaderContent>
+      </Tabs>
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  heroInner: {
+    alignItems: "flex-start",
+    boxSizing: "border-box",
+    columnGap: spacing["5"],
+    display: "flex",
+    flexWrap: "wrap",
+    marginInlineEnd: "auto",
+    marginInlineStart: "auto",
+    paddingInlineEnd: {
+      default: spacing["5"],
+      "@media (min-width: 40rem)": spacing["10"],
+    },
+    paddingInlineStart: {
+      default: spacing["5"],
+      "@media (min-width: 40rem)": spacing["10"],
+    },
+    rowGap: spacing["4"],
+    maxWidth: "82.5rem",
+    paddingBottom: spacing["0"],
+    paddingTop: spacing["6"],
+    width: "100%",
+  },
+  heroInfo: {
+    flexBasis: "0%",
+    flexGrow: 1,
+    flexShrink: 1,
+    minWidth: "15rem",
+    paddingTop: spacing["0.5"],
+  },
+  heroName: {
+    color: uiColor.text2,
+    fontFamily: fontFamily.serif,
+    fontSize: { default: "1.85rem", "@media (min-width: 48rem)": "2rem" },
+    fontWeight: fontWeight.semibold,
+    letterSpacing: tracking.tight,
+    lineHeight: lineHeight.xs,
+    marginBottom: spacing["0"],
+    marginTop: spacing["2"],
+  },
+  heroDesc: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.serif,
+    fontSize: fontSize.lg,
+    lineHeight: lineHeight.sm,
+    marginBottom: spacing["0"],
+    marginTop: spacing["2"],
+    maxWidth: "60ch",
+  },
+  stats: {
+    alignItems: "baseline",
+    color: uiColor.text1,
+    columnGap: spacing["6"],
+    display: "flex",
+    flexWrap: "wrap",
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.xs,
+    rowGap: spacing["2"],
+    marginTop: spacing["4"],
+  },
+  statValue: {
+    color: uiColor.text2,
+    fontWeight: fontWeight.semibold,
+    marginInlineEnd: spacing["1.5"],
+  },
+  subAreas: {
+    lineHeight: lineHeight.base,
+    marginBottom: spacing["0"],
+    maxWidth: "72ch",
+    marginTop: spacing["5"],
+  },
+  subAreaSep: {
+    color: uiColor.text1,
+    marginInlineEnd: spacing["1.5"],
+    marginInlineStart: spacing["1.5"],
+    opacity: 0.5,
+  },
+  subAreaLink: {
+    color: {
+      default: uiColor.text1,
+      ":hover": uiColor.text2,
+    },
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.sm,
+    textDecorationColor: uiColor.border2,
+    textDecorationLine: {
+      default: "none",
+      ":hover": "underline",
+    },
+    // Single-line tag link: isolate so bidi text keeps its own ordering
+    // without dragging the surrounding line around.
+    unicodeBidi: "isolate",
+  },
+  tabs: {
+    marginTop: spacing["6"],
+  },
+  tabBar: {
+    position: "relative",
+  },
+  tabBarInner: {
+    alignItems: "center",
+    boxSizing: "border-box",
+    display: "flex",
+    marginInlineEnd: "auto",
+    marginInlineStart: "auto",
+    paddingInlineEnd: {
+      default: spacing["5"],
+      "@media (min-width: 40rem)": spacing["10"],
+    },
+    paddingInlineStart: {
+      default: spacing["5"],
+      "@media (min-width: 40rem)": spacing["10"],
+    },
+    maxWidth: "82.5rem",
+    width: "100%",
+  },
+  tabList: {
+    flexShrink: 0,
+  },
+  tabBarSort: {
+    marginInlineStart: "auto",
+  },
+  tabBarSortCompact: {
+    display: { default: "block", "@media (min-width: 40rem)": "none" },
+  },
+  tabBarSortFull: {
+    display: { default: "none", "@media (min-width: 40rem)": "block" },
+  },
+  tabBarSortSelect: {
+    width: spacing["40"],
+  },
+  tabRule: {
+    backgroundColor: uiColor.border1,
+    bottom: 0,
+    height: 1,
+    insetInlineEnd: 0,
+    insetInlineStart: 0,
+    position: "absolute",
+  },
+  tabPanel: {
+    paddingTop: spacing["6"],
+  },
+  directoryToolbar: {
+    alignItems: "center",
+    display: "flex",
+    flexWrap: "wrap",
+    justifyContent: "space-between",
+    columnGap: spacing["3"],
+    rowGap: spacing["3"],
+    marginBottom: spacing["6"],
+  },
+  directoryGrid: {
+    columnGap: spacing["6"],
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
+    rowGap: spacing["6"],
+  },
+  articleSkeletonRow: {
+    borderBottomColor: uiColor.border1,
+    borderBottomStyle: "solid",
+    borderBottomWidth: 1,
+    display: "flex",
+    flexDirection: "column",
+    rowGap: spacing["2"],
+    paddingBottom: spacing["5"],
+    paddingTop: spacing["5"],
+  },
+  empty: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.serif,
+    fontSize: fontSize.base,
+    fontStyle: "italic",
+    marginTop: spacing["4"],
+  },
+  endNote: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.serif,
+    fontSize: fontSize.sm,
+    fontStyle: "italic",
+    textAlign: "center",
+    marginTop: spacing["6"],
+  },
+});

--- a/apps/standard-reader/src/routes/_layout.topics.$slug.tsx
+++ b/apps/standard-reader/src/routes/_layout.topics.$slug.tsx
@@ -36,6 +36,7 @@ import {
   createFileRoute,
   Link,
   notFound,
+  redirect,
   useNavigate,
   useRouterState,
 } from "@tanstack/react-router";
@@ -132,9 +133,22 @@ export const Route = createFileRoute("/_layout/topics/$slug")({
         offset: 0,
       },
     });
-    // Topics are derived, so an unknown slug is a genuine 404 rather than
-    // an empty page — including a topic that dropped below the quality bar.
-    if (!page.topic) throw notFound();
+    if (!page.topic) {
+      // A slug the table has never held is a real 404. One it has — a topic
+      // that dissolved into another, or fell below the quality bar — was a
+      // public link once, so it redirects instead: to whichever topic absorbed
+      // it, or to the index when nothing did.
+      if (!page.redirect?.known) throw notFound();
+      throw redirect(
+        page.redirect.slug
+          ? {
+              to: "/topics/$slug",
+              params: { slug: page.redirect.slug },
+              statusCode: 301,
+            }
+          : { to: "/topics", statusCode: 301 },
+      );
+    }
 
     topicsApi.seedTopicPageCaches(context.queryClient, page, {
       slug: params.slug,

--- a/apps/standard-reader/src/routes/_layout.topics.index.tsx
+++ b/apps/standard-reader/src/routes/_layout.topics.index.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { Plural, Trans, useLingui } from "@lingui/react/macro";
+import { SearchField } from "@standard-reader/design-system/search-field";
+import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
+import { spacing } from "@standard-reader/design-system/theme/spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+} from "@standard-reader/design-system/theme/typography.stylex";
+import * as stylex from "@stylexjs/stylex";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { useDeferredValue, useMemo, useState } from "react";
+
+import { topicsApi } from "#/integrations/tanstack-query/api-topics.functions";
+import { getPublicUrlClient } from "#/lib/public-url";
+import { SITE_NAME, siteSocialMeta } from "#/lib/site-metadata";
+import { useFormatters } from "#/lib/use-formatters";
+
+import { Masthead, ReaderContent } from "../components/reader/primitives";
+import { TopicGridList } from "../components/reader/topic-cards";
+
+export const Route = createFileRoute("/_layout/topics/")({
+  staleTime: 60_000,
+  loader: async ({ context }) => {
+    await context.queryClient.ensureQueryData(
+      topicsApi.getAllTopicsQueryOptions(),
+    );
+  },
+  head: () => {
+    const baseUrl = getPublicUrlClient();
+    return {
+      meta: siteSocialMeta({
+        title: `Topics · ${SITE_NAME}`,
+        description:
+          "Browse the topic topics the network's writing clusters into.",
+        url: `${baseUrl.replace(/\/$/, "")}/topics`,
+      }),
+    };
+  },
+  component: TopicsIndex,
+});
+
+/**
+ * Match a topic against a search term.
+ *
+ * Searches the sub-area tags as well as the name and description, because the
+ * word a reader has in mind is usually a tag ("vinyl", "kubernetes") rather
+ * than the topic's derived name.
+ */
+function matchesQuery(
+  topic: { name: string; description: string | null; tags: Array<string> },
+  query: string,
+): boolean {
+  if (!query) return true;
+  const haystack = [topic.name, topic.description ?? "", ...topic.tags]
+    .join(" ")
+    .toLowerCase();
+  return query
+    .split(/\s+/)
+    .filter(Boolean)
+    .every((term) => haystack.includes(term));
+}
+
+function TopicsIndex() {
+  const { t } = useLingui();
+  const fmt = useFormatters();
+  const [search, setSearch] = useState("");
+  // The whole set is already client-side, so filtering is instant — defer only
+  // so a long list re-renders without blocking keystrokes.
+  const deferredSearch = useDeferredValue(search);
+
+  const { data: topics } = useSuspenseQuery(
+    topicsApi.getAllTopicsQueryOptions(),
+  );
+
+  const query = deferredSearch.trim().toLowerCase();
+  const visible = useMemo(
+    () => topics.filter((topic) => matchesQuery(topic, query)),
+    [topics, query],
+  );
+
+  return (
+    <ReaderContent>
+      <Masthead
+        title={<Trans>Topics</Trans>}
+        dek={
+          <Trans>
+            Topic areas the network&apos;s writing clusters into, rebuilt as it
+            grows. Each one gathers related tags, the publications writing about
+            them, and everything they&apos;ve published.
+          </Trans>
+        }
+        metaLabel={t`Topics`}
+        metaValue={fmt.compactNumber(topics.length)}
+      />
+
+      {/* The search is the page's primary control — there is nothing else to
+          do here — so it spans the column rather than hiding in a corner. */}
+      <div {...stylex.props(styles.toolbar)}>
+        <SearchField
+          aria-label={t`Search topics`}
+          placeholder={t`Search by name or topic — “vinyl”, “kubernetes”…`}
+          value={search}
+          onChange={setSearch}
+          size="lg"
+          style={styles.search}
+        />
+        <p aria-live="polite" {...stylex.props(styles.count)}>
+          {query ? (
+            <Plural value={visible.length} one="# topic" other="# topics" />
+          ) : null}
+        </p>
+      </div>
+
+      {visible.length === 0 ? (
+        <p {...stylex.props(styles.empty)}>
+          <Trans>No topics match your search.</Trans>
+        </p>
+      ) : (
+        <TopicGridList topics={visible} layout="grid" aria-label={t`Topics`} />
+      )}
+    </ReaderContent>
+  );
+}
+
+const styles = stylex.create({
+  toolbar: {
+    display: "flex",
+    flexDirection: "column",
+    marginBottom: spacing["6"],
+    rowGap: spacing["2"],
+  },
+  search: {
+    minWidth: 0,
+    width: "100%",
+  },
+  count: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.sm,
+    marginBottom: spacing["0"],
+    // Reserve the line so results appearing does not shift the grid.
+    minHeight: spacing["5"],
+    marginTop: spacing["0"],
+  },
+  empty: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.serif,
+    fontSize: fontSize.base,
+    fontStyle: "italic",
+    marginTop: spacing["6"],
+  },
+});

--- a/apps/standard-reader/src/routes/_layout.topics.index.tsx
+++ b/apps/standard-reader/src/routes/_layout.topics.index.tsx
@@ -34,7 +34,7 @@ export const Route = createFileRoute("/_layout/topics/")({
       meta: siteSocialMeta({
         title: `Topics · ${SITE_NAME}`,
         description:
-          "Browse the topic topics the network's writing clusters into.",
+          "Browse the topic areas the network's writing clusters into.",
         url: `${baseUrl.replace(/\/$/, "")}/topics`,
       }),
     };

--- a/apps/standard-reader/src/server/ingest/recompute-topics.ts
+++ b/apps/standard-reader/src/server/ingest/recompute-topics.ts
@@ -152,6 +152,17 @@ const RETENTION_FACTOR = 0.7;
 /** Concentration is the anti-fleet rule, so it slackens far less than the counts. */
 const RETENTION_TOP_AUTHOR_SHARE = 0.6;
 
+/**
+ * Weakest overlap that still counts as "this topic became that one".
+ *
+ * Far below {@link IDENTITY_MATCH_SIMILARITY} by definition: anything at or
+ * above that would have been matched as the *same* topic rather than a
+ * successor. This is the looser question of where a reader who followed a link
+ * to a dissolved topic should land, and a quarter of its tags surviving in one
+ * place is a better answer than the index.
+ */
+const SUPERSEDE_SIMILARITY = 0.25;
+
 /** Tag-set overlap at which a re-derived cluster is judged the same topic. */
 const IDENTITY_MATCH_SIMILARITY = 0.5;
 /** Below this overlap with its stored fingerprint, a topic is re-named. */
@@ -630,6 +641,60 @@ export async function deriveTopics(): Promise<TopicDerivation> {
 }
 
 /**
+ * Where each unpublished topic's URL should now point.
+ *
+ * Two ways a topic ends up here, and they need different fingerprints:
+ *
+ * - **It dissolved.** No cluster matched it this sweep, so there is no fresh
+ *   signature — compare its *stored* one, which is the last thing it was.
+ * - **It fell below the bar.** It still has a cluster, so compare the fresh
+ *   signature; that is what it looks like now.
+ *
+ * Either way the answer is the published topic sharing the most tags with it,
+ * and {@link SUPERSEDE_SIMILARITY} is the floor below which "closest" stops
+ * meaning "related". Returning null for those is deliberate: the route sends
+ * them to the index, which is honest, rather than to an unrelated topic.
+ */
+function findSuccessors(
+  resolved: Array<{ slug: string; published: boolean; candidate: Candidate }>,
+  existing: Array<{ slug: string; signatureTags: Array<string> }>,
+  publishedSlugs: Array<string>,
+): Map<string, string | null> {
+  const published = new Set(publishedSlugs);
+  const targets = resolved.filter((row) => row.published);
+  const successors = new Map<string, string | null>();
+  if (targets.length === 0) return successors;
+
+  const fingerprints = new Map<string, Array<string>>();
+  for (const row of existing) fingerprints.set(row.slug, row.signatureTags);
+  // A resolved row's fresh signature beats whatever it was last sweep.
+  for (const row of resolved) {
+    fingerprints.set(row.slug, row.candidate.signature);
+  }
+
+  for (const [slug, signature] of fingerprints) {
+    if (published.has(slug)) continue;
+
+    let best: string | null = null;
+    let bestScore = SUPERSEDE_SIMILARITY;
+    for (const target of targets) {
+      const score = tagSetSimilarity(signature, target.candidate.signature);
+      // Ties break on slug so a sweep that changes nothing rewrites nothing.
+      if (
+        score > bestScore ||
+        (score === bestScore && best && target.slug < best)
+      ) {
+        best = target.slug;
+        bestScore = score;
+      }
+    }
+    successors.set(slug, best);
+  }
+
+  return successors;
+}
+
+/**
  * Whether an already-published topic is still substantial enough to stay up.
  *
  * Deliberately measured against the same three signals as the entry bar rather
@@ -733,6 +798,7 @@ export async function recomputeTopics(): Promise<TopicsRecomputeSummary> {
   const publishedSlugs = resolved
     .filter((row) => row.published)
     .map((row) => row.slug);
+  const successors = findSuccessors(resolved, existing, publishedSlugs);
 
   await db.transaction(async (tx) => {
     // One statement rather than a loop: the ingest worker and the database sit
@@ -793,6 +859,17 @@ export async function recomputeTopics(): Promise<TopicsRecomputeSummary> {
               notInArray(topics.slug, publishedSlugs),
             ),
       );
+
+    // Point every unpublished topic at its closest surviving neighbour, so its
+    // URL redirects instead of 404ing. Recomputed each sweep rather than
+    // written once: the successor may itself be unpublished later, and pointing
+    // at whatever is closest *today* keeps the chain short.
+    for (const [slug, target] of successors) {
+      await tx
+        .update(topics)
+        .set({ supersededBy: target, updatedAt: new Date() })
+        .where(eq(topics.slug, slug));
+    }
 
     // Tags and memberships are stored for published topics only — the
     // read path never asks for them otherwise, and the below-bar tail is a few

--- a/apps/standard-reader/src/server/ingest/recompute-topics.ts
+++ b/apps/standard-reader/src/server/ingest/recompute-topics.ts
@@ -1,0 +1,782 @@
+import { and, eq, notInArray, sql } from "drizzle-orm";
+
+import { WEB_BRIDGE_HANDLE_PATTERN } from "#/lib/atproto/bridged-repo";
+import { chunk } from "#/lib/concurrency";
+import { EXCLUDED_PUBLICATION_URL_PATTERN } from "#/lib/publication/exclusions";
+import { logEvent } from "#/server/observability/log";
+
+import { db } from "../../db/index.ts";
+import { topics, topicPublications, topicTags } from "../../db/schema.ts";
+import {
+  clusterTags,
+  cosineWeight,
+  tagSetSimilarity,
+} from "./tag-clustering.ts";
+import { isTagEmbeddingEnabled, semanticTagEdges } from "./tag-embeddings.ts";
+import {
+  topicSlug,
+  fallbackTopicName,
+  isTopicNamingConfigured,
+  nameTopics,
+} from "./topic-naming.ts";
+
+/**
+ * Derive topic topics from the tag co-occurrence graph.
+ *
+ * See `src/db/schema/topics.ts` for what a topic is and
+ * `./tag-clustering.ts` for the clustering itself. This module owns the SQL
+ * that builds the graph, the quality bar, identity matching across sweeps, and
+ * persistence.
+ */
+
+/**
+ * Minimum publications carrying a tag for it to enter the graph. The full
+ * vocabulary is 450k+ tags, almost all of them single-use; this trims it to a
+ * few thousand that could plausibly anchor a topic.
+ */
+const MIN_TAG_PUBLICATIONS = 5;
+
+/**
+ * Placeholder words that are never a topic, only the absence of one.
+ *
+ * These reach the vocabulary honestly — `uncategorized` really is on 87
+ * publications — but they carry no meaning to cluster on, so they act as weak
+ * bridges between unrelated areas and end up as sub-area chips that tell a
+ * reader nothing. Structural junk (emails, URLs, bare numbers, single letters)
+ * is caught by pattern in {@link selectEdges} instead of listed here.
+ *
+ * Deliberately conservative: ambiguous words that could be a real subject stay
+ * in. `notes` is a section on plenty of blogs, and the core-tag rule in the
+ * feed already handles merely-generic tags.
+ */
+const JUNK_TAGS = [
+  "uncategorized",
+  "untitled",
+  "other",
+  "misc",
+  "miscellaneous",
+  "general",
+  "none",
+  "n/a",
+  "null",
+  "undefined",
+  "tbd",
+  "test",
+  "todo",
+  "draft",
+  "read more",
+  "readmore",
+  "continue reading",
+  // Named in review as meaningless artifacts rather than subjects.
+  "note",
+  "error",
+  "overkill",
+  "down",
+  "replaced",
+];
+/**
+ * Minimum *independent publishers* that must put both tags on the same article
+ * for the pair to count as an edge. See {@link selectEdges} for why the unit is
+ * publishers rather than documents.
+ */
+const MIN_EDGE_PUBLISHERS = 3;
+
+/**
+ * Bridgy Fed's passive web bridge shapes the clusters but is never shown.
+ *
+ * A `*.web.brid.gy` repo is a website Bridgy discovered and mirrored — nobody
+ * at that site asked to be here (see `#/lib/atproto/bridged-repo`), so no
+ * bridged publication or article ever appears in a topic. But the bridge is
+ * **75% of the tagged corpus** (999k of 1.33M documents), and it is the only
+ * evidence the network has that, say, `nasa` and `apollo` belong together.
+ * Excluding it from the graph as well collapses the graph from 4,498 tags to
+ * 502 and leaves **5** publishable topics; keeping it as a clustering
+ * signal gives **44**, with nothing of it visible.
+ *
+ * So: the graph learns from everything, membership and the article feed are
+ * restricted to publications and authors that opted in. Topic membership is
+ * filtered here; the feed applies the matching author-level test in
+ * `topicDocumentWhere` (`#/server/reader/topics`) — the author is the
+ * load-bearing key there, because most bridged content is *loose* documents
+ * with no publication row for a publication-level test to catch.
+ *
+ * `*.ap.brid.gy` is never excluded — those authors chose to bridge, and they
+ * are squarely the sort of writing this reader is for.
+ */
+
+/** Tags stored as a topic's identity fingerprint and shown to the namer. */
+const SIGNATURE_SIZE = 24;
+
+/**
+ * Quality bar for publishing a topic. Clusters below it keep their row
+ * (so identity survives) but are hidden.
+ */
+/**
+ * Smallest cluster worth publishing — a floor on substance, not a quota.
+ *
+ * How many topics exist is the network's answer, not a target: as the
+ * corpus grows this number should grow with it. 14 is where a cluster stops
+ * being a handful of tags and starts having real sub-areas to browse. (For
+ * scale, on the corpus at time of writing it yields ~82; raising it to 16 would
+ * give 69, to 22 would give 57 — the knob is here if the tail ever thins out.)
+ */
+const MIN_CLUSTER_TAGS = 14;
+const MIN_CLUSTER_PUBLICATIONS = 10;
+const MIN_CLUSTER_AUTHORS = 5;
+/**
+ * Largest share of a topic's publications one repo may account for.
+ *
+ * This is what separates a topic from a single operator's publication
+ * fleet. The network's three highest-count tags (`chart`, `weekly`, `song` —
+ * 700+ publications each) are one bot network auto-generating a publication per
+ * user, all from **one DID**, and it clears every count-based threshold:
+ * hundreds of publications, and — because tags that generic are also used
+ * incidentally by real publications — enough distinct DIDs to pass an
+ * author-*count* bar too (measured: 769 publications across 8 DIDs, of which
+ * one DID is 99.5%). Concentration catches it where counting does not.
+ */
+const MAX_TOP_AUTHOR_SHARE = 0.5;
+
+/** Tag-set overlap at which a re-derived cluster is judged the same topic. */
+const IDENTITY_MATCH_SIMILARITY = 0.5;
+/** Below this overlap with its stored fingerprint, a topic is re-named. */
+const RENAME_SIMILARITY = 0.8;
+
+/** Rows per insert statement when writing tags and memberships. */
+const INSERT_CHUNK = 500;
+
+export interface TopicsRecomputeSummary {
+  /** Tags that entered the graph. */
+  tags: number;
+  edges: number;
+  semanticEdges: number;
+  clusters: number;
+  published: number;
+  /** Clusters rejected by each condition, for tuning the bar from real data. */
+  droppedByTags: number;
+  droppedByPublications: number;
+  droppedByAuthors: number;
+  /** Rejected as one operator's publication fleet rather than a topic. */
+  droppedByConcentration: number;
+  /** Clusters sent to the naming model this sweep. */
+  named: number;
+}
+
+/** Read rows off a drizzle `db.execute` result (array or `{ rows }`). */
+function executeRows<T>(result: unknown): Array<T> {
+  if (Array.isArray(result)) return result as Array<T>;
+  return ((result as { rows?: Array<T> }).rows ?? []) as Array<T>;
+}
+
+interface EdgeRow {
+  t1: string;
+  t2: string;
+  co: number;
+  n1: number;
+  n2: number;
+}
+
+interface MembershipRow {
+  cluster_key: string;
+  publication_uri: string;
+  did: string;
+  matched_tag_count: number;
+  score: number;
+  document_count: number;
+}
+
+interface Candidate {
+  key: string;
+  tags: Array<{ tag: string; weight: number }>;
+  signature: Array<string>;
+  publications: Array<{ uri: string; score: number; matchedTagCount: number }>;
+  authorCount: number;
+  /** Share of the cluster's publications owned by its single largest repo. */
+  topAuthorShare: number;
+  documentCount: number;
+  published: boolean;
+}
+
+/**
+ * Build the co-occurrence graph.
+ *
+ * Two tags are related when they appear on the same *article* — not merely
+ * somewhere in the same publication, which would make every pair of topics a
+ * wide-ranging publication covers look related.
+ *
+ * But the pair is counted **once per publisher, not once per article**, and
+ * that distinction is what makes the clusters trustworthy. Counting articles
+ * lets a single prolific author manufacture relatedness out of a personal
+ * tagging habit: one fediverse-hosted music blog tagging every post
+ * `fediverse` + `j-pop` produced 55 article-level co-occurrences, enough to
+ * make `fediverse` the music cluster's 14th-strongest member. Counting
+ * distinct publishers caps that blog's contribution at 1, and `fediverse`'s
+ * neighbours become what you would expect — activitypub, mastodon, peertube,
+ * pixelfed, indieweb — with `j-pop` falling from its strongest neighbour to
+ * its eleventh.
+ *
+ * Loose documents (no publication row) count as their own publisher, since
+ * each is an independent act rather than one author's repetition.
+ *
+ * Deliberately unfiltered — not by discover-eligibility and not by the bridge.
+ * Which tags are related is a property of the whole corpus; *who gets shown* is
+ * decided downstream, at membership and in the feed. Narrowing the graph to
+ * what is displayable was tried and is much worse: see the bridge note above.
+ */
+async function selectEdges(): Promise<Array<EdgeRow>> {
+  const result = await db.execute(sql`
+    WITH vocab AS (
+      SELECT topic
+      FROM discover_topic_counts
+      WHERE publication_count >= ${MIN_TAG_PUBLICATIONS}
+        AND topic <> ALL (array[${sql.join(
+          JUNK_TAGS.map((tag) => sql`${tag}`),
+          sql`, `,
+        )}])
+        -- Structural junk: scraped emails and URLs, bare numbers or
+        -- punctuation, and single ASCII letters. The character-class tests are
+        -- written so they never catch a non-Latin tag — a one-character CJK
+        -- topic is a real topic.
+        AND topic NOT LIKE '%@%'
+        AND topic !~* '^https?://'
+        AND topic !~ '^[[:digit:][:punct:][:space:]]+$'
+        AND topic !~* '^[a-z]$'
+    ),
+    doc_tag AS (
+      -- Publishers, not documents: a loose document is its own publisher, so a
+      -- bridged repo's thousands of posts cannot outvote anyone.
+      SELECT DISTINCT d.uri,
+                      coalesce(d.publication_uri, d.did) AS src,
+                      lower(btrim(t)) AS tag
+      FROM documents d
+      LEFT JOIN publications p ON p.uri = d.publication_uri
+      LEFT JOIN profiles ppr ON ppr.did = p.did
+      LEFT JOIN profiles apr ON apr.did = d.did
+      CROSS JOIN unnest(d.tags) AS t
+      WHERE d.deleted = false AND btrim(t) <> ''
+        -- Tested on the author, not just the publication: most bridged content
+        -- has no publication row, so a publication-only test misses nearly all
+        -- of it. A null handle is never treated as bridged — identity
+        -- resolution fails for ordinary reasons, and dropping a real
+        -- publisher's tags over a briefly unreachable DID document is worse.
+    ),
+    vocab_doc_tag AS (
+      SELECT dt.uri, dt.src, dt.tag
+      FROM doc_tag dt
+      JOIN vocab v ON v.topic = dt.tag
+    ),
+    tag_df AS (
+      SELECT tag, count(DISTINCT src)::int AS n FROM vocab_doc_tag GROUP BY tag
+    ),
+    pairs AS (
+      SELECT a.tag AS t1, b.tag AS t2, count(DISTINCT a.src)::int AS co
+      FROM vocab_doc_tag a
+      JOIN vocab_doc_tag b ON b.uri = a.uri AND a.tag < b.tag
+      GROUP BY 1, 2
+      HAVING count(DISTINCT a.src) >= ${MIN_EDGE_PUBLISHERS}
+    )
+    SELECT p.t1, p.t2, p.co, d1.n AS n1, d2.n AS n2
+    FROM pairs p
+    JOIN tag_df d1 ON d1.tag = p.t1
+    JOIN tag_df d2 ON d2.tag = p.t2
+  `);
+  return executeRows<EdgeRow>(result);
+}
+
+/**
+ * Resolve each cluster's publications, authors, and document count in one pass.
+ *
+ * The tag→cluster mapping is handed to Postgres as a single JSON parameter
+ * rather than a bound array: a JS array in a `sql` template binds as one scalar
+ * value, which silently breaks array operators.
+ */
+async function selectMemberships(
+  clusters: ReadonlyArray<{
+    key: string;
+    tags: Array<{ tag: string; weight: number }>;
+  }>,
+): Promise<Array<MembershipRow>> {
+  const mapping = clusters.flatMap((cluster) =>
+    cluster.tags.map((member) => ({
+      k: cluster.key,
+      t: member.tag,
+      w: member.weight,
+    })),
+  );
+  if (mapping.length === 0) return [];
+
+  const result = await db.execute(sql`
+    WITH mapping AS (
+      SELECT m->>'k' AS cluster_key,
+             m->>'t' AS tag,
+             (m->>'w')::float8 AS weight
+      FROM jsonb_array_elements(${JSON.stringify(mapping)}::jsonb) AS m
+    ),
+    doc_tag AS (
+      SELECT DISTINCT d.uri AS doc_uri,
+                      d.publication_uri,
+                      p.did,
+                      lower(btrim(t)) AS tag
+      FROM documents d
+      JOIN publications p ON p.uri = d.publication_uri
+      LEFT JOIN profiles ppr ON ppr.did = p.did
+      LEFT JOIN profiles apr ON apr.did = d.did
+      CROSS JOIN unnest(d.tags) AS t
+      WHERE d.deleted = false
+        AND p.deleted = false
+        AND p.show_in_discover = true
+        AND p.url NOT ILIKE ${EXCLUDED_PUBLICATION_URL_PATTERN}
+        AND (apr.handle IS NULL OR apr.handle NOT ILIKE ${WEB_BRIDGE_HANDLE_PATTERN})
+        AND (ppr.handle IS NULL OR ppr.handle NOT ILIKE ${WEB_BRIDGE_HANDLE_PATTERN})
+        AND btrim(t) <> ''
+    ),
+    matched AS (
+      SELECT m.cluster_key, dt.doc_uri, dt.publication_uri, dt.did, dt.tag, m.weight
+      FROM doc_tag dt
+      JOIN mapping m ON m.tag = dt.tag
+    ),
+    pub_tag AS (
+      SELECT DISTINCT cluster_key, publication_uri, did, tag, weight FROM matched
+    ),
+    pub_rows AS (
+      SELECT cluster_key, publication_uri, did,
+             count(*)::int AS matched_tag_count,
+             sum(weight) AS score
+      FROM pub_tag
+      GROUP BY cluster_key, publication_uri, did
+    ),
+    doc_counts AS (
+      SELECT cluster_key, count(DISTINCT doc_uri)::int AS document_count
+      FROM matched
+      GROUP BY cluster_key
+    )
+    SELECT pr.cluster_key, pr.publication_uri, pr.did,
+           pr.matched_tag_count, pr.score, dc.document_count
+    FROM pub_rows pr
+    JOIN doc_counts dc ON dc.cluster_key = pr.cluster_key
+  `);
+  return executeRows<MembershipRow>(result);
+}
+
+/**
+ * Match re-derived clusters onto existing topics so slugs (and therefore
+ * URLs) survive the cluster shifting between sweeps.
+ *
+ * Greedy and one-to-one, largest cluster first: each candidate claims the
+ * unclaimed topic its fingerprint overlaps most, provided the overlap
+ * clears {@link IDENTITY_MATCH_SIMILARITY}. Everything else is a new topic.
+ */
+function matchIdentities(
+  candidates: ReadonlyArray<Candidate>,
+  existing: ReadonlyArray<{ slug: string; signatureTags: Array<string> }>,
+): Map<string, string> {
+  const claimed = new Set<string>();
+  const matches = new Map<string, string>();
+
+  for (const candidate of candidates) {
+    let bestSlug: string | null = null;
+    let bestScore = 0;
+    for (const topic of existing) {
+      if (claimed.has(topic.slug)) continue;
+      const score = tagSetSimilarity(candidate.signature, topic.signatureTags);
+      if (score < IDENTITY_MATCH_SIMILARITY) continue;
+      // Ties break on slug so the outcome never depends on row order.
+      if (
+        bestSlug === null ||
+        score > bestScore ||
+        (score === bestScore && topic.slug < bestSlug)
+      ) {
+        bestScore = score;
+        bestSlug = topic.slug;
+      }
+    }
+    if (bestSlug) {
+      claimed.add(bestSlug);
+      matches.set(candidate.key, bestSlug);
+    }
+  }
+
+  return matches;
+}
+
+/**
+ * Put semantic edge weights on the co-occurrence scale.
+ *
+ * The two signals are both cosines but of completely different things, and
+ * their ranges do not overlap: a strong behavioural edge sits around 0.1–0.3,
+ * while every semantic edge is above the 0.72 similarity floor by construction.
+ * Mixed raw, the semantic edges win every top-N neighbour cut and the graph
+ * stops being behavioural at all — measured, that fragmented 56 topics
+ * into 35 by turning co-occurrence structure into noise.
+ *
+ * So similarity is mapped onto the *observed* spread of co-occurrence weights:
+ * the floor becomes a median behavioural edge, a perfect 1.0 becomes a strong
+ * (p90) one. A semantic edge can then argue as loudly as real evidence, never
+ * louder, and the mapping re-derives itself as the corpus moves.
+ */
+function rescaleToCooccurrence(
+  semantic: ReadonlyArray<{ a: string; b: string; weight: number }>,
+  cooccurrence: ReadonlyArray<{ weight: number }>,
+): Array<{ a: string; b: string; weight: number }> {
+  if (semantic.length === 0 || cooccurrence.length === 0) return [];
+
+  const weights = cooccurrence
+    .map((edge) => edge.weight)
+    .toSorted((a, b) => a - b);
+  const at = (quantile: number) =>
+    weights[
+      Math.min(weights.length - 1, Math.floor(weights.length * quantile))
+    ] ?? 0;
+  const low = at(0.5);
+  const high = at(0.9);
+
+  const minSimilarity = Math.min(...semantic.map((edge) => edge.weight));
+  const span = Math.max(1e-6, 1 - minSimilarity);
+
+  return semantic.map((edge) => ({
+    a: edge.a,
+    b: edge.b,
+    weight:
+      low + ((edge.weight - minSimilarity) / span) * Math.max(0, high - low),
+  }));
+}
+
+/** What the derivation found, before naming or persistence. */
+export interface TopicDerivation {
+  candidates: Array<Candidate>;
+  tags: number;
+  edges: number;
+  /** Extra edges contributed by embeddings; zero when the signal is off. */
+  semanticEdges: number;
+  clusters: number;
+  droppedByTags: number;
+  droppedByPublications: number;
+  droppedByAuthors: number;
+  droppedByConcentration: number;
+  /**
+   * Signatures of the clusters that never reached the membership query because
+   * they were too small. Carried purely so the inspection script can show what
+   * the tag bar is excluding — the sweep itself ignores this.
+   */
+  belowTagBar: Array<Array<string>>;
+}
+
+/**
+ * Everything up to (but not including) naming and persistence: build the graph,
+ * cluster it, resolve memberships, apply the quality bar.
+ *
+ * Split out so it can be run read-only — `scripts/derive-topics.mjs` uses
+ * it to check cluster quality and the bar against real data without writing.
+ */
+export async function deriveTopics(): Promise<TopicDerivation> {
+  const edgeRows = await selectEdges();
+  const edges: Array<{ a: string; b: string; weight: number }> = edgeRows.map(
+    (row) => ({
+      a: row.t1,
+      b: row.t2,
+      weight: cosineWeight(row.co, row.n1, row.n2),
+    }),
+  );
+
+  const tagCount = new Set(edgeRows.flatMap((row) => [row.t1, row.t2])).size;
+
+  // Additive only: semantic edges join subjects whose publishers split (see
+  // `./tag-embeddings`), and never remove or reweight a behavioural edge.
+  let semanticEdges = 0;
+  if (isTagEmbeddingEnabled()) {
+    try {
+      const vocabulary = [
+        ...new Set(edgeRows.flatMap((row) => [row.t1, row.t2])),
+      ].toSorted();
+      const semantic = await semanticTagEdges(vocabulary);
+      semanticEdges = semantic.length;
+      edges.push(...rescaleToCooccurrence(semantic, edges));
+    } catch {
+      // A model that will not load must not take the sweep with it; the graph
+      // is still complete without semantic edges, just more fragmented.
+    }
+  }
+
+  const clusters = clusterTags(edges);
+
+  // Only clusters that could clear the tag bar are worth resolving memberships
+  // for — that query is the expensive one.
+  const sized = clusters
+    .filter((cluster) => cluster.length >= MIN_CLUSTER_TAGS)
+    .map((cluster, index) => ({ key: String(index), tags: cluster }));
+  const droppedByTags = clusters.length - sized.length;
+  const belowTagBar = clusters
+    .filter((cluster) => cluster.length < MIN_CLUSTER_TAGS)
+    .map((cluster) => cluster.map((member) => member.tag));
+
+  const memberships = await selectMemberships(sized);
+
+  const byCluster = new Map<
+    string,
+    {
+      publications: Array<{
+        uri: string;
+        score: number;
+        matchedTagCount: number;
+      }>;
+      publicationsByDid: Map<string, number>;
+      documentCount: number;
+    }
+  >();
+  for (const row of memberships) {
+    let entry = byCluster.get(row.cluster_key);
+    if (!entry) {
+      entry = {
+        publications: [],
+        publicationsByDid: new Map(),
+        documentCount: row.document_count,
+      };
+      byCluster.set(row.cluster_key, entry);
+    }
+    entry.publications.push({
+      uri: row.publication_uri,
+      score: Number(row.score),
+      matchedTagCount: row.matched_tag_count,
+    });
+    entry.publicationsByDid.set(
+      row.did,
+      (entry.publicationsByDid.get(row.did) ?? 0) + 1,
+    );
+  }
+
+  let droppedByPublications = 0;
+  let droppedByAuthors = 0;
+  let droppedByConcentration = 0;
+
+  const candidates: Array<Candidate> = sized.map((cluster) => {
+    const entry = byCluster.get(cluster.key);
+    const publications = entry?.publications ?? [];
+    const publicationsByDid =
+      entry?.publicationsByDid ?? new Map<string, number>();
+    const authorCount = publicationsByDid.size;
+    const topAuthorPublications = Math.max(0, ...publicationsByDid.values());
+    const topAuthorShare =
+      publications.length === 0
+        ? 1
+        : topAuthorPublications / publications.length;
+    publications.sort(
+      (left, right) =>
+        right.score - left.score ||
+        (left.uri < right.uri ? -1 : left.uri > right.uri ? 1 : 0),
+    );
+
+    const enoughPublications = publications.length >= MIN_CLUSTER_PUBLICATIONS;
+    const enoughAuthors = authorCount >= MIN_CLUSTER_AUTHORS;
+    const spreadAcrossAuthors = topAuthorShare <= MAX_TOP_AUTHOR_SHARE;
+    if (!enoughPublications) droppedByPublications++;
+    else if (!enoughAuthors) droppedByAuthors++;
+    else if (!spreadAcrossAuthors) droppedByConcentration++;
+
+    return {
+      key: cluster.key,
+      tags: cluster.tags,
+      signature: cluster.tags
+        .slice(0, SIGNATURE_SIZE)
+        .map((member) => member.tag),
+      publications,
+      authorCount,
+      topAuthorShare,
+      documentCount: entry?.documentCount ?? 0,
+      published: enoughPublications && enoughAuthors && spreadAcrossAuthors,
+    } satisfies Candidate;
+  });
+
+  return {
+    candidates,
+    tags: tagCount,
+    edges: edges.length,
+    semanticEdges,
+    clusters: clusters.length,
+    droppedByTags,
+    droppedByPublications,
+    droppedByAuthors,
+    droppedByConcentration,
+    belowTagBar,
+  };
+}
+
+export async function recomputeTopics(): Promise<TopicsRecomputeSummary> {
+  const derivation = await deriveTopics();
+  const { candidates } = derivation;
+
+  const existing = await db
+    .select({
+      slug: topics.slug,
+      name: topics.name,
+      description: topics.description,
+      signatureTags: topics.signatureTags,
+      nameModel: topics.nameModel,
+      namedAt: topics.namedAt,
+    })
+    .from(topics);
+  const existingBySlug = new Map(existing.map((row) => [row.slug, row]));
+
+  const matches = matchIdentities(candidates, existing);
+
+  // Name only what needs it: a brand-new cluster, one whose fingerprint drifted
+  // far enough that its old name may no longer fit, or one still carrying the
+  // deterministic fallback name from a sweep that ran without naming.
+  const namingConfigured = isTopicNamingConfigured();
+  const needsNaming = candidates.filter((candidate) => {
+    const slug = matches.get(candidate.key);
+    const prior = slug ? existingBySlug.get(slug) : undefined;
+    if (!prior) return true;
+    if (namingConfigured && !prior.nameModel) return true;
+    return (
+      tagSetSimilarity(candidate.signature, prior.signatureTags) <
+      RENAME_SIMILARITY
+    );
+  });
+
+  const namings = await nameTopics(
+    needsNaming.map((candidate) => candidate.signature),
+  );
+  const namingByKey = new Map(
+    needsNaming.map((candidate, index) => [
+      candidate.key,
+      namings[index] ?? fallbackTopicName(candidate.signature),
+    ]),
+  );
+
+  // Assign slugs. Existing topics keep theirs; new ones mint from the name
+  // and must not collide with any slug already in the table.
+  const takenSlugs = new Set(existing.map((row) => row.slug));
+  const resolved = candidates.map((candidate) => {
+    const matchedSlug = matches.get(candidate.key);
+    const prior = matchedSlug ? existingBySlug.get(matchedSlug) : undefined;
+    const naming = namingByKey.get(candidate.key);
+    const name =
+      naming?.name ??
+      prior?.name ??
+      fallbackTopicName(candidate.signature).name;
+    const description = naming
+      ? naming.description
+      : (prior?.description ?? null);
+    const nameModel = naming ? naming.model : (prior?.nameModel ?? null);
+    const namedAt = naming ? new Date() : (prior?.namedAt ?? null);
+
+    const slug =
+      matchedSlug ?? topicSlug(name, candidate.signature.join(" "), takenSlugs);
+    takenSlugs.add(slug);
+
+    return { candidate, slug, name, description, nameModel, namedAt };
+  });
+
+  const publishedSlugs = resolved
+    .filter((row) => row.candidate.published)
+    .map((row) => row.slug);
+
+  await db.transaction(async (tx) => {
+    // One statement rather than a loop: the ingest worker and the database sit
+    // in different regions, so a per-topic round trip would dominate the
+    // pass's wall clock.
+    for (const batch of chunk(resolved, INSERT_CHUNK)) {
+      await tx
+        .insert(topics)
+        .values(
+          batch.map((row) => ({
+            slug: row.slug,
+            name: row.name,
+            description: row.description,
+            signatureTags: row.candidate.signature,
+            tagCount: row.candidate.tags.length,
+            publicationCount: row.candidate.publications.length,
+            authorCount: row.candidate.authorCount,
+            documentCount: row.candidate.documentCount,
+            // Distinct writers, not publications: what makes a topic worth
+            // showing is how many people are in it. The Discover rail rotates
+            // over a wider pool on top of this, so a fixed ranking here does
+            // not mean a fixed rail.
+            score: row.candidate.authorCount,
+            published: row.candidate.published,
+            nameModel: row.nameModel,
+            namedAt: row.namedAt,
+          })),
+        )
+        .onConflictDoUpdate({
+          target: topics.slug,
+          set: {
+            name: sql`excluded.name`,
+            description: sql`excluded.description`,
+            signatureTags: sql`excluded.signature_tags`,
+            tagCount: sql`excluded.tag_count`,
+            publicationCount: sql`excluded.publication_count`,
+            authorCount: sql`excluded.author_count`,
+            documentCount: sql`excluded.document_count`,
+            score: sql`excluded.score`,
+            published: sql`excluded.published`,
+            nameModel: sql`excluded.name_model`,
+            namedAt: sql`excluded.named_at`,
+            updatedAt: sql`now()`,
+          },
+        });
+    }
+
+    // Anything not published this sweep is hidden rather than deleted, so a
+    // topic that dips below the bar and comes back keeps its URL.
+    await tx
+      .update(topics)
+      .set({ published: false, updatedAt: new Date() })
+      .where(
+        publishedSlugs.length === 0
+          ? eq(topics.published, true)
+          : and(
+              eq(topics.published, true),
+              notInArray(topics.slug, publishedSlugs),
+            ),
+      );
+
+    // Tags and memberships are stored for published topics only — the
+    // read path never asks for them otherwise, and the below-bar tail is a few
+    // hundred clusters wide.
+    await tx.execute(sql`DELETE FROM topic_tags`);
+    await tx.execute(sql`DELETE FROM topic_publications`);
+
+    const tagValues = resolved
+      .filter((row) => row.candidate.published)
+      .flatMap((row) =>
+        row.candidate.tags.map((member) => ({
+          topicSlug: row.slug,
+          tag: member.tag,
+          weight: member.weight,
+        })),
+      );
+    for (const batch of chunk(tagValues, INSERT_CHUNK)) {
+      await tx.insert(topicTags).values(batch);
+    }
+
+    const publicationValues = resolved
+      .filter((row) => row.candidate.published)
+      .flatMap((row) =>
+        row.candidate.publications.map((publication) => ({
+          topicSlug: row.slug,
+          publicationUri: publication.uri,
+          score: publication.score,
+          matchedTagCount: publication.matchedTagCount,
+        })),
+      );
+    for (const batch of chunk(publicationValues, INSERT_CHUNK)) {
+      await tx.insert(topicPublications).values(batch);
+    }
+  });
+
+  const summary: TopicsRecomputeSummary = {
+    tags: derivation.tags,
+    edges: derivation.edges,
+    semanticEdges: derivation.semanticEdges,
+    clusters: derivation.clusters,
+    published: publishedSlugs.length,
+    droppedByTags: derivation.droppedByTags,
+    droppedByPublications: derivation.droppedByPublications,
+    droppedByAuthors: derivation.droppedByAuthors,
+    droppedByConcentration: derivation.droppedByConcentration,
+    named: needsNaming.length,
+  };
+  logEvent("ingest.recomputeTopics", { ...summary });
+  return summary;
+}

--- a/apps/standard-reader/src/server/ingest/recompute-topics.ts
+++ b/apps/standard-reader/src/server/ingest/recompute-topics.ts
@@ -19,6 +19,7 @@ import {
   isTopicNamingConfigured,
   nameTopics,
 } from "./topic-naming.ts";
+import { clearsRetentionBar, findSuccessors } from "./topic-succession.ts";
 
 /**
  * Derive topics from the tag co-occurrence graph.
@@ -151,6 +152,12 @@ const MAX_TOP_AUTHOR_SHARE = 0.5;
 const RETENTION_FACTOR = 0.7;
 /** Concentration is the anti-fleet rule, so it slackens far less than the counts. */
 const RETENTION_TOP_AUTHOR_SHARE = 0.6;
+const RETENTION_BAR = {
+  minTags: MIN_CLUSTER_TAGS * RETENTION_FACTOR,
+  minPublications: MIN_CLUSTER_PUBLICATIONS * RETENTION_FACTOR,
+  minAuthors: MIN_CLUSTER_AUTHORS * RETENTION_FACTOR,
+  maxTopAuthorShare: RETENTION_TOP_AUTHOR_SHARE,
+};
 
 /**
  * Weakest overlap that still counts as "this topic became that one".
@@ -640,78 +647,6 @@ export async function deriveTopics(): Promise<TopicDerivation> {
   };
 }
 
-/**
- * Where each unpublished topic's URL should now point.
- *
- * Two ways a topic ends up here, and they need different fingerprints:
- *
- * - **It dissolved.** No cluster matched it this sweep, so there is no fresh
- *   signature — compare its *stored* one, which is the last thing it was.
- * - **It fell below the bar.** It still has a cluster, so compare the fresh
- *   signature; that is what it looks like now.
- *
- * Either way the answer is the published topic sharing the most tags with it,
- * and {@link SUPERSEDE_SIMILARITY} is the floor below which "closest" stops
- * meaning "related". Returning null for those is deliberate: the route sends
- * them to the index, which is honest, rather than to an unrelated topic.
- */
-function findSuccessors(
-  resolved: Array<{ slug: string; published: boolean; candidate: Candidate }>,
-  existing: Array<{ slug: string; signatureTags: Array<string> }>,
-  publishedSlugs: Array<string>,
-): Map<string, string | null> {
-  const published = new Set(publishedSlugs);
-  const targets = resolved.filter((row) => row.published);
-  const successors = new Map<string, string | null>();
-  if (targets.length === 0) return successors;
-
-  const fingerprints = new Map<string, Array<string>>();
-  for (const row of existing) fingerprints.set(row.slug, row.signatureTags);
-  // A resolved row's fresh signature beats whatever it was last sweep.
-  for (const row of resolved) {
-    fingerprints.set(row.slug, row.candidate.signature);
-  }
-
-  for (const [slug, signature] of fingerprints) {
-    if (published.has(slug)) continue;
-
-    let best: string | null = null;
-    let bestScore = SUPERSEDE_SIMILARITY;
-    for (const target of targets) {
-      const score = tagSetSimilarity(signature, target.candidate.signature);
-      // Ties break on slug so a sweep that changes nothing rewrites nothing.
-      if (
-        score > bestScore ||
-        (score === bestScore && best && target.slug < best)
-      ) {
-        best = target.slug;
-        bestScore = score;
-      }
-    }
-    successors.set(slug, best);
-  }
-
-  return successors;
-}
-
-/**
- * Whether an already-published topic is still substantial enough to stay up.
- *
- * Deliberately measured against the same three signals as the entry bar rather
- * than a separate rule, so there is one definition of "a real topic" and only
- * its strictness changes. A topic that fails this has not dipped — it has
- * dissolved.
- */
-function clearsRetentionBar(candidate: Candidate): boolean {
-  return (
-    candidate.tags.length >= MIN_CLUSTER_TAGS * RETENTION_FACTOR &&
-    candidate.publications.length >=
-      MIN_CLUSTER_PUBLICATIONS * RETENTION_FACTOR &&
-    candidate.authorCount >= MIN_CLUSTER_AUTHORS * RETENTION_FACTOR &&
-    candidate.topAuthorShare <= RETENTION_TOP_AUTHOR_SHARE
-  );
-}
-
 export async function recomputeTopics(): Promise<TopicsRecomputeSummary> {
   const derivation = await deriveTopics();
   const { candidates } = derivation;
@@ -782,7 +717,16 @@ export async function recomputeTopics(): Promise<TopicsRecomputeSummary> {
     // take a live URL off the site. See RETENTION_FACTOR.
     const published =
       candidate.published ||
-      (prior?.published === true && clearsRetentionBar(candidate));
+      (prior?.published === true &&
+        clearsRetentionBar(
+          {
+            tagCount: candidate.tags.length,
+            publicationCount: candidate.publications.length,
+            authorCount: candidate.authorCount,
+            topAuthorShare: candidate.topAuthorShare,
+          },
+          RETENTION_BAR,
+        ));
 
     return {
       candidate,
@@ -798,7 +742,15 @@ export async function recomputeTopics(): Promise<TopicsRecomputeSummary> {
   const publishedSlugs = resolved
     .filter((row) => row.published)
     .map((row) => row.slug);
-  const successors = findSuccessors(resolved, existing, publishedSlugs);
+  const successors = findSuccessors(
+    resolved.map((row) => ({
+      slug: row.slug,
+      published: row.published,
+      signature: row.candidate.signature,
+    })),
+    existing,
+    SUPERSEDE_SIMILARITY,
+  );
 
   await db.transaction(async (tx) => {
     // One statement rather than a loop: the ingest worker and the database sit

--- a/apps/standard-reader/src/server/ingest/recompute-topics.ts
+++ b/apps/standard-reader/src/server/ingest/recompute-topics.ts
@@ -21,7 +21,7 @@ import {
 } from "./topic-naming.ts";
 
 /**
- * Derive topic topics from the tag co-occurrence graph.
+ * Derive topics from the tag co-occurrence graph.
  *
  * See `src/db/schema/topics.ts` for what a topic is and
  * `./tag-clustering.ts` for the clustering itself. This module owns the SQL
@@ -136,6 +136,21 @@ const MIN_CLUSTER_AUTHORS = 5;
  * one DID is 99.5%). Concentration catches it where counting does not.
  */
 const MAX_TOP_AUTHOR_SHARE = 0.5;
+
+/**
+ * How far a topic already published may slip before it is unlisted.
+ *
+ * The bars above are an *entry* test, and applying them unchanged every sweep
+ * makes a topic sitting near one of them flap: published today, gone tomorrow,
+ * back the day after. A URL that 404s on alternate days is worse than a topic
+ * that is a little thin, and these are public links people share. So a topic
+ * that has cleared the bar once keeps its place while it still clears this
+ * fraction of it — real growth and decay move slowly, so only a topic that has
+ * genuinely fallen apart drops out.
+ */
+const RETENTION_FACTOR = 0.7;
+/** Concentration is the anti-fleet rule, so it slackens far less than the counts. */
+const RETENTION_TOP_AUTHOR_SHARE = 0.6;
 
 /** Tag-set overlap at which a re-derived cluster is judged the same topic. */
 const IDENTITY_MATCH_SIMILARITY = 0.5;
@@ -499,12 +514,17 @@ export async function deriveTopics(): Promise<TopicDerivation> {
 
   const clusters = clusterTags(edges);
 
-  // Only clusters that could clear the tag bar are worth resolving memberships
-  // for — that query is the expensive one.
+  // Only clusters that could clear a tag bar are worth resolving memberships
+  // for — that query is the expensive one. The cut is at the *retention*
+  // floor, not the entry floor, so a published topic that has shrunk a little
+  // still reaches the hysteresis test below instead of vanishing here.
+  const resolveMinTags = Math.floor(MIN_CLUSTER_TAGS * RETENTION_FACTOR);
   const sized = clusters
-    .filter((cluster) => cluster.length >= MIN_CLUSTER_TAGS)
+    .filter((cluster) => cluster.length >= resolveMinTags)
     .map((cluster, index) => ({ key: String(index), tags: cluster }));
-  const droppedByTags = clusters.length - sized.length;
+  const droppedByTags = clusters.filter(
+    (cluster) => cluster.length < MIN_CLUSTER_TAGS,
+  ).length;
   const belowTagBar = clusters
     .filter((cluster) => cluster.length < MIN_CLUSTER_TAGS)
     .map((cluster) => cluster.map((member) => member.tag));
@@ -565,10 +585,15 @@ export async function deriveTopics(): Promise<TopicDerivation> {
         (left.uri < right.uri ? -1 : left.uri > right.uri ? 1 : 0),
     );
 
+    const enoughTags = cluster.tags.length >= MIN_CLUSTER_TAGS;
     const enoughPublications = publications.length >= MIN_CLUSTER_PUBLICATIONS;
     const enoughAuthors = authorCount >= MIN_CLUSTER_AUTHORS;
     const spreadAcrossAuthors = topAuthorShare <= MAX_TOP_AUTHOR_SHARE;
-    if (!enoughPublications) droppedByPublications++;
+    // Below the tag bar is already counted in `droppedByTags`; counting it
+    // again here would make the reasons sum to more than the rejections.
+    if (!enoughTags) {
+      // counted above
+    } else if (!enoughPublications) droppedByPublications++;
     else if (!enoughAuthors) droppedByAuthors++;
     else if (!spreadAcrossAuthors) droppedByConcentration++;
 
@@ -582,7 +607,11 @@ export async function deriveTopics(): Promise<TopicDerivation> {
       authorCount,
       topAuthorShare,
       documentCount: entry?.documentCount ?? 0,
-      published: enoughPublications && enoughAuthors && spreadAcrossAuthors,
+      published:
+        enoughTags &&
+        enoughPublications &&
+        enoughAuthors &&
+        spreadAcrossAuthors,
     } satisfies Candidate;
   });
 
@@ -600,6 +629,24 @@ export async function deriveTopics(): Promise<TopicDerivation> {
   };
 }
 
+/**
+ * Whether an already-published topic is still substantial enough to stay up.
+ *
+ * Deliberately measured against the same three signals as the entry bar rather
+ * than a separate rule, so there is one definition of "a real topic" and only
+ * its strictness changes. A topic that fails this has not dipped — it has
+ * dissolved.
+ */
+function clearsRetentionBar(candidate: Candidate): boolean {
+  return (
+    candidate.tags.length >= MIN_CLUSTER_TAGS * RETENTION_FACTOR &&
+    candidate.publications.length >=
+      MIN_CLUSTER_PUBLICATIONS * RETENTION_FACTOR &&
+    candidate.authorCount >= MIN_CLUSTER_AUTHORS * RETENTION_FACTOR &&
+    candidate.topAuthorShare <= RETENTION_TOP_AUTHOR_SHARE
+  );
+}
+
 export async function recomputeTopics(): Promise<TopicsRecomputeSummary> {
   const derivation = await deriveTopics();
   const { candidates } = derivation;
@@ -612,6 +659,7 @@ export async function recomputeTopics(): Promise<TopicsRecomputeSummary> {
       signatureTags: topics.signatureTags,
       nameModel: topics.nameModel,
       namedAt: topics.namedAt,
+      published: topics.published,
     })
     .from(topics);
   const existingBySlug = new Map(existing.map((row) => [row.slug, row]));
@@ -664,11 +712,26 @@ export async function recomputeTopics(): Promise<TopicsRecomputeSummary> {
       matchedSlug ?? topicSlug(name, candidate.signature.join(" "), takenSlugs);
     takenSlugs.add(slug);
 
-    return { candidate, slug, name, description, nameModel, namedAt };
+    // Hysteresis: a topic that has already been published keeps its place
+    // while it still clears the retention bar, so a marginal sweep does not
+    // take a live URL off the site. See RETENTION_FACTOR.
+    const published =
+      candidate.published ||
+      (prior?.published === true && clearsRetentionBar(candidate));
+
+    return {
+      candidate,
+      published,
+      slug,
+      name,
+      description,
+      nameModel,
+      namedAt,
+    };
   });
 
   const publishedSlugs = resolved
-    .filter((row) => row.candidate.published)
+    .filter((row) => row.published)
     .map((row) => row.slug);
 
   await db.transaction(async (tx) => {
@@ -693,7 +756,7 @@ export async function recomputeTopics(): Promise<TopicsRecomputeSummary> {
             // over a wider pool on top of this, so a fixed ranking here does
             // not mean a fixed rail.
             score: row.candidate.authorCount,
-            published: row.candidate.published,
+            published: row.published,
             nameModel: row.nameModel,
             namedAt: row.namedAt,
           })),
@@ -738,7 +801,7 @@ export async function recomputeTopics(): Promise<TopicsRecomputeSummary> {
     await tx.execute(sql`DELETE FROM topic_publications`);
 
     const tagValues = resolved
-      .filter((row) => row.candidate.published)
+      .filter((row) => row.published)
       .flatMap((row) =>
         row.candidate.tags.map((member) => ({
           topicSlug: row.slug,
@@ -751,7 +814,7 @@ export async function recomputeTopics(): Promise<TopicsRecomputeSummary> {
     }
 
     const publicationValues = resolved
-      .filter((row) => row.candidate.published)
+      .filter((row) => row.published)
       .flatMap((row) =>
         row.candidate.publications.map((publication) => ({
           topicSlug: row.slug,

--- a/apps/standard-reader/src/server/ingest/recompute.ts
+++ b/apps/standard-reader/src/server/ingest/recompute.ts
@@ -46,6 +46,7 @@ import {
 } from "../atproto/identity.ts";
 import { replayDeadLetters } from "./consumer.ts";
 import { reconcileDocumentDup, reconcilePublicationGroup } from "./handlers.ts";
+import { recomputeTopics } from "./recompute-topics.ts";
 
 /**
  * Recompute the derived per-publication aggregates (subscriber/document/
@@ -501,7 +502,7 @@ export async function recomputeCosubscriptions(): Promise<void> {
  * The Discover directory's topic chips can then be built from the top-N topics
  * by publication count.
  */
-export async function recomputeTopics(): Promise<void> {
+export async function recomputeTopicCounts(): Promise<void> {
   // Clear stale topics first so removed tags don't linger.
   await db.execute(
     sql`UPDATE publications SET topic = NULL WHERE topic IS NOT NULL`,
@@ -902,7 +903,14 @@ export async function recomputeDerived(): Promise<void> {
   await recomputePublicationStats();
   await recomputeCosubscriptions();
   await recomputeCorecommends();
-  await recomputeTopics();
+  await recomputeTopicCounts();
+  // After the tag counts: the vocabulary they rebuild is this pass's input.
+  try {
+    await recomputeTopics();
+  } catch {
+    // Topics are a discovery surface, not core data — the prior snapshot
+    // stays published and the next sweep retries.
+  }
   await recomputeSerialKinds();
   await recomputeDocumentTrending();
   // Last: dedup + the passes above are what change the eligible-document set,

--- a/apps/standard-reader/src/server/ingest/recompute.ts
+++ b/apps/standard-reader/src/server/ingest/recompute.ts
@@ -46,7 +46,6 @@ import {
 } from "../atproto/identity.ts";
 import { replayDeadLetters } from "./consumer.ts";
 import { reconcileDocumentDup, reconcilePublicationGroup } from "./handlers.ts";
-import { recomputeTopics } from "./recompute-topics.ts";
 
 /**
  * Recompute the derived per-publication aggregates (subscriber/document/
@@ -904,13 +903,10 @@ export async function recomputeDerived(): Promise<void> {
   await recomputeCosubscriptions();
   await recomputeCorecommends();
   await recomputeTopicCounts();
-  // After the tag counts: the vocabulary they rebuild is this pass's input.
-  try {
-    await recomputeTopics();
-  } catch {
-    // Topics are a discovery surface, not core data — the prior snapshot
-    // stays published and the next sweep retries.
-  }
+  // Topic derivation is deliberately NOT here — it clusters the whole tag
+  // graph and calls the naming model, which is minutes of work whose output
+  // barely moves hour to hour. It runs on its own daily schedule instead;
+  // see `scripts/topics-cron.ts`.
   await recomputeSerialKinds();
   await recomputeDocumentTrending();
   // Last: dedup + the passes above are what change the eligible-document set,

--- a/apps/standard-reader/src/server/ingest/tag-clustering.test.ts
+++ b/apps/standard-reader/src/server/ingest/tag-clustering.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+
+import { clusterTags, cosineWeight, tagSetSimilarity } from "./tag-clustering";
+import type { TagEdge } from "./tag-clustering";
+
+/** Fully connect a set of tags at a given weight. */
+function clique(tags: Array<string>, weight: number): Array<TagEdge> {
+  const edges: Array<TagEdge> = [];
+  for (let i = 0; i < tags.length; i++) {
+    for (let j = i + 1; j < tags.length; j++) {
+      edges.push({ a: tags[i] as string, b: tags[j] as string, weight });
+    }
+  }
+  return edges;
+}
+
+/** Connect tags in a loop — a sparse group, unlike a clique. */
+function ring(tags: Array<string>, weight: number): Array<TagEdge> {
+  return tags.map((tag, index) => ({
+    a: tag,
+    b: tags[(index + 1) % tags.length] as string,
+    weight,
+  }));
+}
+
+const GAMING = ["ps5", "xbox", "nintendo switch", "rpg", "video games"];
+const MUSIC = ["k-pop", "vinyl", "jazz", "hip hop", "album"];
+
+function tagsOf(cluster: Array<{ tag: string }>): Array<string> {
+  return cluster.map((member) => member.tag).toSorted();
+}
+
+describe("cosineWeight", () => {
+  it("normalizes co-occurrence by both tags' frequencies", () => {
+    // Same co-occurrence count, but the second pair is far more common overall,
+    // so the shared documents mean less.
+    expect(cosineWeight(10, 10, 10)).toBe(1);
+    expect(cosineWeight(10, 1000, 1000)).toBeCloseTo(0.01);
+  });
+
+  it("is zero for degenerate inputs", () => {
+    expect(cosineWeight(0, 10, 10)).toBe(0);
+    expect(cosineWeight(5, 0, 10)).toBe(0);
+  });
+});
+
+describe("clusterTags", () => {
+  it("separates two dense groups joined by one weak edge", () => {
+    const edges = [
+      ...clique(GAMING, 0.5),
+      ...clique(MUSIC, 0.5),
+      // A single incidental co-occurrence must not fuse them.
+      { a: "rpg", b: "album", weight: 0.03 },
+    ];
+
+    const clusters = clusterTags(edges);
+
+    expect(clusters).toHaveLength(2);
+    expect(clusters.map((c) => tagsOf(c)).toSorted()).toEqual(
+      [[...GAMING].toSorted(), [...MUSIC].toSorted()].toSorted(),
+    );
+  });
+
+  it("does not let a weak hub tag fuse unrelated clusters", () => {
+    // `news` touches everything faintly — exactly the shape that collapses a
+    // co-occurrence graph into one blob without sparsification.
+    const hub: Array<TagEdge> = [...GAMING, ...MUSIC].map((tag) => ({
+      a: "news",
+      b: tag,
+      weight: 0.05,
+    }));
+    const edges = [...clique(GAMING, 0.5), ...clique(MUSIC, 0.5), ...hub];
+
+    const clusters = clusterTags(edges);
+
+    const gaming = clusters.find((cluster) =>
+      cluster.some((member) => member.tag === "ps5"),
+    );
+    const music = clusters.find((cluster) =>
+      cluster.some((member) => member.tag === "jazz"),
+    );
+    expect(gaming).toBeDefined();
+    expect(music).toBeDefined();
+    expect(gaming).not.toBe(music);
+  });
+
+  it("drops edges below the weight floor", () => {
+    const clusters = clusterTags([
+      ...clique(GAMING, 0.5),
+      { a: "unrelated-a", b: "unrelated-b", weight: 0.001 },
+    ]);
+
+    expect(clusters).toHaveLength(1);
+    expect(tagsOf(clusters[0] as Array<{ tag: string }>)).toEqual(
+      [...GAMING].toSorted(),
+    );
+  });
+
+  it("orders members most-central first", () => {
+    // `ps5` is connected to everything; `indie` hangs off one edge.
+    const edges = [
+      ...clique(GAMING, 0.5),
+      { a: "ps5", b: "indie", weight: 0.4 },
+    ];
+
+    const clusters = clusterTags(edges);
+
+    expect(clusters[0]?.[0]?.tag).toBe("ps5");
+    expect(clusters[0]?.at(-1)?.tag).toBe("indie");
+  });
+
+  it("is deterministic regardless of edge input order", () => {
+    const edges = [...clique(GAMING, 0.5), ...clique(MUSIC, 0.5)];
+    const reversed = [...edges].toReversed();
+
+    expect(clusterTags(reversed).map((c) => tagsOf(c))).toEqual(
+      clusterTags(edges).map((c) => tagsOf(c)),
+    );
+  });
+
+  it("ignores self-edges and singleton tags", () => {
+    const clusters = clusterTags([
+      ...clique(GAMING, 0.5),
+      { a: "lonely", b: "lonely", weight: 1 },
+    ]);
+
+    expect(clusters.flatMap((c) => tagsOf(c))).not.toContain("lonely");
+  });
+
+  it("returns nothing for an empty graph", () => {
+    expect(clusterTags([])).toEqual([]);
+  });
+});
+
+describe("clusterTags — oversized clusters", () => {
+  /**
+   * The blob shape in miniature: two sparse groups, each held together by a few
+   * strong edges, drowned in a dense mat of individually-weak cross edges. That
+   * mat is what fuses them — exactly how a 429-tag cluster forms — and it is
+   * the first thing a higher weight floor removes.
+   */
+  function blob(): Array<TagEdge> {
+    const left = Array.from({ length: 12 }, (_, i) => `l${i}`);
+    const right = Array.from({ length: 12 }, (_, i) => `r${i}`);
+    const bridge: Array<TagEdge> = [];
+    for (const a of left) {
+      for (const b of right) bridge.push({ a, b, weight: 0.03 });
+    }
+    return [...ring(left, 0.06), ...ring(right, 0.06), ...bridge];
+  }
+
+  it("leaves clusters under the cap alone", () => {
+    const clusters = clusterTags(blob(), { maxClusterTags: 100 });
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0]).toHaveLength(24);
+  });
+
+  it("re-splits a cluster that exceeds the cap", () => {
+    const fused = clusterTags(blob(), { maxClusterTags: 100 });
+    expect(fused[0]?.length).toBe(24);
+
+    const split = clusterTags(blob(), { maxClusterTags: 20 });
+
+    expect(split.length).toBeGreaterThan(1);
+    for (const cluster of split) {
+      expect(cluster.length).toBeLessThanOrEqual(20);
+    }
+  });
+
+  it("keeps the original when a split cannot divide it", () => {
+    // A single dense clique has no weak seam to cut, so tightening the graph
+    // must not shred it into nothing.
+    const dense = clique(
+      Array.from({ length: 20 }, (_, i) => `t${i}`),
+      0.9,
+    );
+    const clusters = clusterTags(dense, { maxClusterTags: 5 });
+
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0]).toHaveLength(20);
+  });
+
+  it("is still deterministic when splitting", () => {
+    const a = clusterTags(blob(), { maxClusterTags: 20 });
+    const b = clusterTags(blob().toReversed(), { maxClusterTags: 20 });
+    expect(a.map((c) => tagsOf(c))).toEqual(b.map((c) => tagsOf(c)));
+  });
+});
+
+describe("tagSetSimilarity", () => {
+  it("is 1 for identical sets and 0 for disjoint ones", () => {
+    expect(tagSetSimilarity(GAMING, [...GAMING])).toBe(1);
+    expect(tagSetSimilarity(GAMING, MUSIC)).toBe(0);
+  });
+
+  it("scores partial overlap by Jaccard", () => {
+    // 2 shared of 4 distinct.
+    expect(tagSetSimilarity(["a", "b", "c"], ["b", "c", "d"])).toBeCloseTo(0.5);
+  });
+
+  it("is 0 when either side is empty", () => {
+    expect(tagSetSimilarity([], GAMING)).toBe(0);
+    expect(tagSetSimilarity(GAMING, [])).toBe(0);
+  });
+});

--- a/apps/standard-reader/src/server/ingest/tag-clustering.ts
+++ b/apps/standard-reader/src/server/ingest/tag-clustering.ts
@@ -1,0 +1,287 @@
+/**
+ * Tag clustering for auto-derived topics.
+ *
+ * Topics are found by clustering the tag co-occurrence graph: two tags are
+ * related when they appear on the same *document* (not merely somewhere in the
+ * same publication — a publication that covers both Spanish politics and New
+ * York does not make those two topics related, and publication-level
+ * co-occurrence produces exactly that kind of false edge).
+ *
+ * The clustering is weighted asynchronous label propagation. It is chosen over
+ * a fixed-K method because the number of real topics on the network is
+ * unknown and grows, and over naive connected components because any single
+ * threshold either fuses the whole graph into one blob or shatters it into
+ * hundreds of pairs — label propagation finds mid-scale structure on its own.
+ *
+ * Determinism is a hard requirement, not a nicety: the sweep runs hourly and a
+ * topic's identity (and therefore its URL) is matched across sweeps by tag
+ * overlap. Randomized iteration order would reshuffle clusters every hour and
+ * churn identities, so visitation is sorted and every tie is broken by label.
+ *
+ * Pure and side-effect free — see `recompute-topics.ts` for the SQL that
+ * builds the graph and the persistence around it.
+ */
+
+/** How many strongest neighbours each tag keeps after sparsification. */
+export const DEFAULT_NEIGHBOR_LIMIT = 12;
+/** Weakest edge weight worth keeping (cosine). Below this is coincidence. */
+export const DEFAULT_MIN_WEIGHT = 0.02;
+/** Safety bound on propagation passes; real graphs converge in well under this. */
+export const DEFAULT_MAX_ITERATIONS = 15;
+/**
+ * Above this many tags a cluster is treated as a blob and re-split rather than
+ * published as one topic. Nothing coherent needs this many sub-areas.
+ */
+export const DEFAULT_MAX_CLUSTER_TAGS = 150;
+/** How many times an oversized cluster may be re-split before it is accepted. */
+export const DEFAULT_SPLIT_DEPTH = 2;
+/** How much the weight floor rises when re-splitting an oversized cluster. */
+const SPLIT_WEIGHT_MULTIPLIER = 2;
+
+/** One undirected edge of the co-occurrence graph. */
+export interface TagEdge {
+  a: string;
+  b: string;
+  /** Similarity in (0, 1]; see {@link cosineWeight}. */
+  weight: number;
+}
+
+/** A tag and how central it is to the cluster it landed in. */
+export interface ClusteredTag {
+  tag: string;
+  /** Summed weight of this tag's edges to other members of its own cluster. */
+  weight: number;
+}
+
+export interface ClusterTagsOptions {
+  neighborLimit?: number;
+  minWeight?: number;
+  maxIterations?: number;
+  /** Re-split clusters larger than this. Zero or less disables splitting. */
+  maxClusterTags?: number;
+  /** Remaining re-split attempts. Zero accepts oversized clusters as they are. */
+  splitDepth?: number;
+}
+
+/**
+ * Cosine similarity of two tags from their co-occurrence counts.
+ *
+ * `co / sqrt(n1 * n2)` rather than raw `co` or Jaccard: raw counts let a single
+ * high-frequency tag dominate every edge it touches, and Jaccard over-penalizes
+ * a genuinely broad tag (`politics`) pairing with a narrow one (`marco rubio`).
+ */
+export function cosineWeight(co: number, n1: number, n2: number): number {
+  if (co <= 0 || n1 <= 0 || n2 <= 0) return 0;
+  return co / Math.sqrt(n1 * n2);
+}
+
+/**
+ * Adjacency map, sparsified to each tag's strongest `neighborLimit` neighbours
+ * above `minWeight`.
+ *
+ * Sparsification is what stops hub tags from fusing unrelated clusters: a tag
+ * like `news` has a weak edge to nearly everything, and left in place those
+ * edges carry enough summed weight to drag whole clusters together.
+ */
+function buildAdjacency(
+  edges: ReadonlyArray<TagEdge>,
+  neighborLimit: number,
+  minWeight: number,
+): Map<string, Array<[string, number]>> {
+  const adjacency = new Map<string, Array<[string, number]>>();
+  const push = (from: string, to: string, weight: number) => {
+    const existing = adjacency.get(from);
+    if (existing) existing.push([to, weight]);
+    else adjacency.set(from, [[to, weight]]);
+  };
+
+  for (const edge of edges) {
+    if (edge.a === edge.b) continue;
+    if (!(edge.weight >= minWeight)) continue;
+    push(edge.a, edge.b, edge.weight);
+    push(edge.b, edge.a, edge.weight);
+  }
+
+  for (const [tag, neighbors] of adjacency) {
+    neighbors.sort(
+      (left, right) =>
+        right[1] - left[1] ||
+        (left[0] < right[0] ? -1 : left[0] > right[0] ? 1 : 0),
+    );
+    if (neighbors.length > neighborLimit) {
+      adjacency.set(tag, neighbors.slice(0, neighborLimit));
+    }
+  }
+
+  return adjacency;
+}
+
+/**
+ * One pass of weighted label propagation.
+ *
+ * Every tag starts as its own label, then repeatedly adopts the label carrying
+ * the most edge weight among its neighbours. Returns clusters ordered largest
+ * first, each with its members ordered most-central first. Isolated tags (no
+ * surviving edges) are dropped — a cluster of one is not a topic.
+ */
+function propagate(
+  edges: ReadonlyArray<TagEdge>,
+  neighborLimit: number,
+  minWeight: number,
+  maxIterations: number,
+): Array<Array<ClusteredTag>> {
+  const adjacency = buildAdjacency(edges, neighborLimit, minWeight);
+  // Sorted visitation order — the whole algorithm's determinism rests on this.
+  const order = [...adjacency.keys()].toSorted();
+  const labels = new Map(order.map((tag) => [tag, tag]));
+
+  for (let iteration = 0; iteration < maxIterations; iteration++) {
+    let changed = 0;
+    for (const tag of order) {
+      const neighbors = adjacency.get(tag);
+      if (!neighbors || neighbors.length === 0) continue;
+
+      const scores = new Map<string, number>();
+      for (const [neighbor, weight] of neighbors) {
+        const label = labels.get(neighbor);
+        if (label === undefined) continue;
+        scores.set(label, (scores.get(label) ?? 0) + weight);
+      }
+      if (scores.size === 0) continue;
+
+      // Heaviest label wins; ties go to the lexicographically smaller label so
+      // the outcome never depends on Map insertion order.
+      let best = labels.get(tag) as string;
+      let bestScore = Number.NEGATIVE_INFINITY;
+      for (const [label, score] of scores) {
+        if (score > bestScore || (score === bestScore && label < best)) {
+          best = label;
+          bestScore = score;
+        }
+      }
+      if (best !== labels.get(tag)) {
+        labels.set(tag, best);
+        changed++;
+      }
+    }
+    if (changed === 0) break;
+  }
+
+  const members = new Map<string, Array<string>>();
+  for (const tag of order) {
+    const label = labels.get(tag) as string;
+    const existing = members.get(label);
+    if (existing) existing.push(tag);
+    else members.set(label, [tag]);
+  }
+
+  const clusters: Array<Array<ClusteredTag>> = [];
+  for (const tags of members.values()) {
+    if (tags.length < 2) continue;
+    const memberSet = new Set(tags);
+    const scored = tags.map((tag) => {
+      let weight = 0;
+      for (const [neighbor, edgeWeight] of adjacency.get(tag) ?? []) {
+        if (memberSet.has(neighbor)) weight += edgeWeight;
+      }
+      return { tag, weight };
+    });
+    scored.sort(
+      (left, right) =>
+        right.weight - left.weight ||
+        (left.tag < right.tag ? -1 : left.tag > right.tag ? 1 : 0),
+    );
+    clusters.push(scored);
+  }
+
+  return sortClusters(clusters);
+}
+
+/** Largest first, ties broken on the head tag so the order is deterministic. */
+function sortClusters(
+  clusters: Array<Array<ClusteredTag>>,
+): Array<Array<ClusteredTag>> {
+  return clusters.toSorted((left, right) => {
+    if (right.length !== left.length) return right.length - left.length;
+    // Every cluster has at least two members, so the head always exists.
+    const leftHead = left[0]?.tag ?? "";
+    const rightHead = right[0]?.tag ?? "";
+    return leftHead < rightHead ? -1 : leftHead > rightHead ? 1 : 0;
+  });
+}
+
+/**
+ * Group tags into clusters, splitting any cluster that grows into a blob.
+ *
+ * Label propagation has no size control, and on a real corpus it produces one
+ * or two enormous clusters alongside the good ones — a 429-tag "topic" that
+ * had absorbed musicians, actors and junk tags is what prompted this. Those are
+ * not topics; they are what is left when weak edges chain everything together.
+ *
+ * The fix is to re-run propagation on the oversized cluster alone, with the
+ * graph tightened (fewer neighbours kept, a higher weight floor). Within the
+ * blob the weak bridges that chained it are exactly what the tighter cut
+ * removes, so the real sub-topics fall out. Tags too weakly attached to
+ * survive the tighter cut are dropped — they were the noise holding the blob
+ * together. A split that fails to divide is discarded and the original kept, so
+ * this can only ever improve the shape.
+ */
+export function clusterTags(
+  edges: ReadonlyArray<TagEdge>,
+  options: ClusterTagsOptions = {},
+): Array<Array<ClusteredTag>> {
+  const {
+    neighborLimit = DEFAULT_NEIGHBOR_LIMIT,
+    minWeight = DEFAULT_MIN_WEIGHT,
+    maxIterations = DEFAULT_MAX_ITERATIONS,
+    maxClusterTags = DEFAULT_MAX_CLUSTER_TAGS,
+    splitDepth = DEFAULT_SPLIT_DEPTH,
+  } = options;
+
+  const clusters = propagate(edges, neighborLimit, minWeight, maxIterations);
+  if (splitDepth <= 0 || maxClusterTags <= 0) return clusters;
+
+  const out: Array<Array<ClusteredTag>> = [];
+  for (const cluster of clusters) {
+    if (cluster.length <= maxClusterTags) {
+      out.push(cluster);
+      continue;
+    }
+
+    const members = new Set(cluster.map((member) => member.tag));
+    const induced = edges.filter(
+      (edge) => members.has(edge.a) && members.has(edge.b),
+    );
+    const split = clusterTags(induced, {
+      neighborLimit: Math.max(3, Math.floor(neighborLimit / 2)),
+      minWeight: minWeight * SPLIT_WEIGHT_MULTIPLIER,
+      maxIterations,
+      maxClusterTags,
+      splitDepth: splitDepth - 1,
+    });
+
+    if (split.length > 1) out.push(...split);
+    else out.push(cluster);
+  }
+
+  return sortClusters(out);
+}
+
+/**
+ * Jaccard similarity of two tag sets — how a re-derived cluster is matched back
+ * onto an existing topic so its slug (and URL) survives.
+ */
+export function tagSetSimilarity(
+  left: Iterable<string>,
+  right: Iterable<string>,
+): number {
+  const leftSet = new Set(left);
+  const rightSet = new Set(right);
+  if (leftSet.size === 0 || rightSet.size === 0) return 0;
+  let shared = 0;
+  for (const tag of leftSet) {
+    if (rightSet.has(tag)) shared++;
+  }
+  const union = leftSet.size + rightSet.size - shared;
+  return union === 0 ? 0 : shared / union;
+}

--- a/apps/standard-reader/src/server/ingest/tag-embeddings.ts
+++ b/apps/standard-reader/src/server/ingest/tag-embeddings.ts
@@ -1,0 +1,286 @@
+import { inArray, ne, or, sql } from "drizzle-orm";
+
+import { chunk } from "#/lib/concurrency";
+import { logEvent } from "#/server/observability/log";
+
+import { db } from "../../db/index.ts";
+import { tagEmbeddings } from "../../db/schema.ts";
+import type { TagEdge } from "./tag-clustering.ts";
+
+/** Read rows off a drizzle `db.execute` result (array or `{ rows }`). */
+function executeRows<T>(result: unknown): Array<T> {
+  if (Array.isArray(result)) return result as Array<T>;
+  return ((result as { rows?: Array<T> }).rows ?? []) as Array<T>;
+}
+
+/**
+ * Semantic similarity between tags, used to join subjects that co-occurrence
+ * cannot.
+ *
+ * Co-occurrence measures behaviour: which tags the same publisher puts on the
+ * same article. That is the right primary signal — it is what keeps
+ * `política` and `politics` in separate, genuinely separate topics — but
+ * it is blind to a subject whose publishers split along tooling lines. On this
+ * corpus `typescript / javascript / node.js / npm` and `css / html / tailwind /
+ * web development` are two halves of web development that essentially never
+ * share a publisher, so counting alone leaves one of them too small to publish.
+ *
+ * Embeddings supply the missing edges and nothing else. They are additive: a
+ * semantic edge can join two tags that never co-occur, but it never removes or
+ * reweights a co-occurrence edge, so everything the behavioural signal already
+ * gets right is left alone.
+ */
+
+/**
+ * Small, symmetric sentence-embedding model. Deliberately not the larger
+ * instruction-tuned models used for document retrieval: these are bare tags,
+ * the comparison is symmetric (no query/passage asymmetry to respect), and the
+ * ingest container has to download whatever this names.
+ */
+const DEFAULT_MODEL = "Xenova/all-MiniLM-L6-v2";
+
+/**
+ * Cosine similarity a pair must clear to become an edge.
+ *
+ * Set from measurement on this corpus, not taste. With tags embedded in
+ * context, the pair this signal exists to join — `typescript` ↔ `web
+ * development`, the two halves of web development — scores **0.517**, while the
+ * pairs that must never merge score far below it: `música`/`music` 0.354,
+ * `política`/`politics` 0.187, `china`/`iran` 0.157. 0.45 sits in that gap.
+ *
+ * Embedding the bare tags instead is what makes this impossible: on bare words
+ * the order inverts completely (`música`/`music` 0.723 against
+ * `typescript`/`css` 0.116) because the model is then comparing spellings, not
+ * subjects. Hence {@link tagContexts}.
+ */
+const DEFAULT_SIMILARITY = 0.45;
+
+/** Strongest semantic neighbours kept per tag. Caps how much this can reshape. */
+const DEFAULT_NEIGHBORS = 6;
+
+/** Tags embedded per model call. */
+const EMBED_BATCH = 64;
+/** Article titles sampled per tag to describe how it is actually used. */
+const CONTEXT_TITLES = 12;
+/** Cap on a context string, so one long-titled tag cannot dominate the batch. */
+const CONTEXT_CHARS = 1200;
+
+/**
+ * What each tag is *about*, as the titles of articles carrying it.
+ *
+ * This is the whole trick. Embedding the word `typescript` compares it to the
+ * word `css` and finds nothing, while comparing `música` to `music` finds
+ * near-identity — the model is reading spelling. Embedding the headlines that
+ * carry each tag compares subject matter instead, which is the question we are
+ * actually asking.
+ *
+ * One pass over the corpus, numbering titles per tag with a window function,
+ * rather than an indexed probe per tag. The probe form reads better and is 70×
+ * slower: ~94ms per tag against a 1.6M-row table is seven minutes for this
+ * vocabulary, where the single pass does the whole thing in six seconds. Which
+ * titles they are does not matter — any sample describes the subject — so there
+ * is deliberately no ORDER BY inside the window.
+ */
+async function tagContexts(tags: Array<string>): Promise<Map<string, string>> {
+  const contexts = new Map<string, string>();
+  if (tags.length === 0) return contexts;
+
+  const list = sql.join(
+    tags.map((tag) => sql`${tag}`),
+    sql`, `,
+  );
+  const result = await db.execute(sql`
+    WITH vocabulary AS (SELECT unnest(array[${list}]) AS tag),
+    tagged AS (
+      SELECT lower(btrim(t)) AS tag, d.title,
+             row_number() OVER (PARTITION BY lower(btrim(t))) AS rn
+      FROM documents d
+      CROSS JOIN unnest(d.tags) AS t
+      WHERE d.deleted = false AND d.title <> ''
+    )
+    SELECT tg.tag, string_agg(tg.title, '. ') AS context
+    FROM tagged tg
+    JOIN vocabulary v ON v.tag = tg.tag
+    WHERE tg.rn <= ${CONTEXT_TITLES}
+    GROUP BY tg.tag
+  `);
+  for (const row of executeRows<{ tag: string; context: string }>(result)) {
+    contexts.set(
+      row.tag,
+      `${row.tag}. ${row.context ?? ""}`.slice(0, CONTEXT_CHARS),
+    );
+  }
+
+  // A tag with no usable titles still gets embedded, on its own name.
+  for (const tag of tags) {
+    if (!contexts.has(tag)) contexts.set(tag, tag);
+  }
+  return contexts;
+}
+
+export interface SemanticEdgeOptions {
+  model?: string;
+  minSimilarity?: number;
+  neighborLimit?: number;
+}
+
+/** True when semantic edges are switched on (`TOPIC_EMBEDDINGS=1`). */
+export function isTagEmbeddingEnabled(): boolean {
+  return process.env.TOPIC_EMBEDDINGS === "1";
+}
+
+type FeatureExtractor = (
+  texts: Array<string>,
+  options: { normalize: boolean; pooling: "mean" },
+) => Promise<{ tolist: () => Array<Array<number>> }>;
+
+let extractorPromise: Promise<FeatureExtractor> | null = null;
+
+/** Lazily build the pipeline once per process (mirrors `#/lib/page-reader/voice`). */
+function loadExtractor(model: string): Promise<FeatureExtractor> {
+  if (extractorPromise) return extractorPromise;
+
+  extractorPromise = (async () => {
+    const { pipeline } = await import("@huggingface/transformers");
+    const extractor = await pipeline("feature-extraction", model, {
+      dtype: "q8",
+    });
+    return extractor as unknown as FeatureExtractor;
+  })().catch((error: unknown) => {
+    extractorPromise = null;
+    throw error;
+  });
+
+  return extractorPromise;
+}
+
+/**
+ * Vectors for every tag, reading the cache and embedding only what is missing.
+ *
+ * Rows from another model are treated as missing, so changing {@link
+ * DEFAULT_MODEL} re-embeds rather than silently mixing vector spaces.
+ */
+async function vectorsForTags(
+  tags: Array<string>,
+  model: string,
+): Promise<Map<string, Float32Array>> {
+  const vectors = new Map<string, Float32Array>();
+
+  for (const batch of chunk(tags, 1000)) {
+    const cached = await db
+      .select({
+        tag: tagEmbeddings.tag,
+        embedding: tagEmbeddings.embedding,
+        model: tagEmbeddings.model,
+      })
+      .from(tagEmbeddings)
+      .where(inArray(tagEmbeddings.tag, batch));
+    for (const row of cached) {
+      if (row.model !== model) continue;
+      vectors.set(row.tag, Float32Array.from(row.embedding));
+    }
+  }
+
+  const missing = tags.filter((tag) => !vectors.has(tag));
+  if (missing.length === 0) return vectors;
+
+  const contexts = await tagContexts(missing);
+  const extractor = await loadExtractor(model);
+  for (const batch of chunk(missing, EMBED_BATCH)) {
+    const output = await extractor(
+      batch.map((tag) => contexts.get(tag) ?? tag),
+      { normalize: true, pooling: "mean" },
+    );
+    const rows = output.tolist();
+    const values = batch.map((tag, index) => ({
+      tag,
+      embedding: rows[index] ?? [],
+      model,
+    }));
+    for (const value of values) {
+      vectors.set(value.tag, Float32Array.from(value.embedding));
+    }
+    await db
+      .insert(tagEmbeddings)
+      .values(values)
+      .onConflictDoUpdate({
+        target: tagEmbeddings.tag,
+        set: {
+          embedding: sql`excluded.embedding`,
+          model: sql`excluded.model`,
+          createdAt: sql`now()`,
+        },
+      });
+  }
+
+  return vectors;
+}
+
+/**
+ * Semantic edges between tags, as extra input to the co-occurrence graph.
+ *
+ * Vectors are unit-normalized, so similarity is a dot product and the whole
+ * comparison is one dense scan. At a few thousand tags that is a second or two;
+ * it is not worth an index.
+ */
+export async function semanticTagEdges(
+  tags: Array<string>,
+  options: SemanticEdgeOptions = {},
+): Promise<Array<TagEdge>> {
+  const {
+    model = process.env.TOPIC_EMBEDDING_MODEL || DEFAULT_MODEL,
+    minSimilarity = DEFAULT_SIMILARITY,
+    neighborLimit = DEFAULT_NEIGHBORS,
+  } = options;
+  if (tags.length < 2) return [];
+
+  const vectors = await vectorsForTags(tags, model);
+  const known = tags.filter((tag) => vectors.has(tag));
+  if (known.length < 2) return [];
+
+  const dimensions = vectors.get(known[0] as string)?.length ?? 0;
+  if (dimensions === 0) return [];
+
+  // One contiguous matrix beats a Map lookup per comparison.
+  const matrix = new Float32Array(known.length * dimensions);
+  for (const [index, tag] of known.entries()) {
+    matrix.set(vectors.get(tag) as Float32Array, index * dimensions);
+  }
+
+  const edges: Array<TagEdge> = [];
+  for (let i = 0; i < known.length; i++) {
+    const base = i * dimensions;
+    const neighbours: Array<{ index: number; score: number }> = [];
+
+    for (let j = i + 1; j < known.length; j++) {
+      const other = j * dimensions;
+      let dot = 0;
+      for (let d = 0; d < dimensions; d++) {
+        dot += (matrix[base + d] as number) * (matrix[other + d] as number);
+      }
+      if (dot >= minSimilarity) neighbours.push({ index: j, score: dot });
+    }
+
+    neighbours.sort((left, right) => right.score - left.score);
+    for (const neighbour of neighbours.slice(0, neighborLimit)) {
+      edges.push({
+        a: known[i] as string,
+        b: known[neighbour.index] as string,
+        weight: neighbour.score,
+      });
+    }
+  }
+
+  logEvent("ingest.semanticTagEdges", {
+    model,
+    tags: known.length,
+    edges: edges.length,
+    minSimilarity,
+  });
+  return edges;
+}
+
+/** Drop cached vectors from any model other than the active one. */
+export async function pruneStaleTagEmbeddings(model: string): Promise<void> {
+  await db.delete(tagEmbeddings).where(or(ne(tagEmbeddings.model, model)));
+}

--- a/apps/standard-reader/src/server/ingest/topic-naming.ts
+++ b/apps/standard-reader/src/server/ingest/topic-naming.ts
@@ -1,0 +1,221 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
+import { z } from "zod";
+
+import { mapWithConcurrency } from "#/lib/concurrency";
+
+/**
+ * Names an auto-derived tag cluster.
+ *
+ * Clustering produces a bag of related tags; a topic also needs a label a
+ * reader would recognize. The obvious deterministic answer — use the cluster's
+ * most frequent tag — is right often enough to be tempting and wrong often
+ * enough to be unusable: it labels `politics`, `gaming`, `music`, and `comics`
+ * correctly, but names a cluster of `ev / volkswagen / ford / bmw / toyota /
+ * porsche` **"Opinion"** (its highest-frequency member) and a cluster of
+ * `robotics / raspberry pi / opensource / arduino / blender` **"Linux"**.
+ *
+ * So a model reads the cluster's top tags and writes a name and one-line
+ * description. That deterministic label remains the fallback for every failure
+ * path, so a missing API key, an error, or a refusal degrades the name rather
+ * than failing the sweep.
+ *
+ * Naming is *cached by cluster identity* upstream (see `recompute-topics.ts`):
+ * only new clusters and clusters whose tag set materially drifted are sent
+ * here, so a steady-state sweep makes roughly no requests.
+ */
+
+/** Default naming model. Override with `TOPIC_NAMING_MODEL`. */
+const DEFAULT_MODEL = "claude-opus-5";
+/** Tags shown to the model — enough to characterize the cluster, not its tail. */
+export const NAMING_TAG_SAMPLE = 24;
+/** Naming requests in flight at once. */
+const NAMING_CONCURRENCY = 4;
+/**
+ * Thinking is on by default on the naming model and is billed against
+ * `max_tokens` alongside the reply, so this is sized well above the couple of
+ * dozen tokens the answer itself needs.
+ */
+const NAMING_MAX_TOKENS = 2000;
+
+const TopicNameSchema = z.object({
+  name: z
+    .string()
+    .describe(
+      "One to four words. Capitalize the significant words but leave short " +
+        "joining words lowercase — 'Crypto and Web3', not 'Crypto And Web3'. " +
+        "No punctuation, quotes, or emoji.",
+    ),
+  description: z
+    .string()
+    .describe("One sentence, at most 100 characters, no trailing period."),
+});
+
+export interface TopicNaming {
+  name: string;
+  description: string | null;
+  /** Model that produced the name, or null when the fallback was used. */
+  model: string | null;
+}
+
+/** Title-case a tag for use as a display name. */
+function titleCase(value: string): string {
+  return value
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+/**
+ * Deterministic name for a cluster: its most central tag, title-cased. Used
+ * whenever the model is unavailable or declines, and as the seed for a slug
+ * before any name exists.
+ */
+export function fallbackTopicName(tags: ReadonlyArray<string>): TopicNaming {
+  return {
+    name: titleCase(tags[0] ?? "Untitled"),
+    description: null,
+    model: null,
+  };
+}
+
+function namingPrompt(tags: ReadonlyArray<string>): string {
+  return [
+    "These tags were found to co-occur on the same articles across a network of",
+    "independent publications, so they form one topic area. Name that topic area",
+    "as it would appear as a browsable section of a reading app.",
+    "",
+    `Tags, most central first: ${tags.join(", ")}`,
+    "",
+    "Name it for what the whole cluster is about, not for whichever single tag",
+    "appears most often — a cluster of car makers is 'Cars', not 'Opinion'.",
+    "",
+    "Always answer in English, even when the tags are in another language —",
+    "the tags themselves stay as they are, but the name and description are",
+    "chrome and must match the rest of the interface. When a cluster is the",
+    "coverage of one region or language, say so: 'Brazilian Politics', not",
+    "'Politics'.",
+  ].join("\n");
+}
+
+/**
+ * True when naming is configured. The sweep still runs without it (every
+ * cluster takes the deterministic fallback name), which is what makes a local
+ * run with no API key work.
+ */
+export function isTopicNamingConfigured(): boolean {
+  return Boolean(process.env.ANTHROPIC_API_KEY);
+}
+
+async function nameOne(
+  client: Anthropic,
+  model: string,
+  tags: ReadonlyArray<string>,
+): Promise<TopicNaming> {
+  const response = await client.messages.parse({
+    model,
+    max_tokens: NAMING_MAX_TOKENS,
+    output_config: {
+      // Naming a bag of tags does not need deep reasoning, and the cost of the
+      // first sweep (which names every cluster at once) scales with this.
+      effort: "low",
+      format: zodOutputFormat(TopicNameSchema),
+    },
+    messages: [{ role: "user", content: namingPrompt(tags) }],
+  });
+
+  // A refusal is a successful HTTP response with empty/partial content, so this
+  // has to be checked before reading the parsed output.
+  if (response.stop_reason === "refusal" || !response.parsed_output) {
+    return fallbackTopicName(tags);
+  }
+
+  const name = response.parsed_output.name.trim();
+  const description = response.parsed_output.description.trim();
+  if (!name) return fallbackTopicName(tags);
+
+  return {
+    name,
+    description: description || null,
+    model: response.model,
+  };
+}
+
+/**
+ * Name each cluster, preserving input order. Per-cluster failures fall back to
+ * the deterministic label instead of rejecting — a naming outage must not take
+ * the recompute sweep down with it, and the next sweep retries the name.
+ */
+export async function nameTopics(
+  clusters: ReadonlyArray<ReadonlyArray<string>>,
+): Promise<Array<TopicNaming>> {
+  if (clusters.length === 0) return [];
+  if (!isTopicNamingConfigured()) {
+    return clusters.map((tags) => fallbackTopicName(tags));
+  }
+
+  const client = new Anthropic();
+  const model = process.env.TOPIC_NAMING_MODEL || DEFAULT_MODEL;
+
+  return mapWithConcurrency(
+    clusters as Array<ReadonlyArray<string>>,
+    NAMING_CONCURRENCY,
+    async (tags) => {
+      try {
+        return await nameOne(client, model, tags.slice(0, NAMING_TAG_SAMPLE));
+      } catch {
+        return fallbackTopicName(tags);
+      }
+    },
+  );
+}
+
+/**
+ * URL slug for a topic name.
+ *
+ * Names are English, so they normally slugify directly; the tag fallback and
+ * then the hash cover a name that reduces to nothing (a cluster named only for
+ * a non-Latin term) so a slug always exists.
+ */
+export function topicSlug(
+  name: string,
+  fallbackSeed: string,
+  taken: ReadonlySet<string>,
+): string {
+  const base =
+    slugify(name) || slugify(fallbackSeed) || `topic-${hashSlug(fallbackSeed)}`;
+  if (!taken.has(base)) return base;
+  for (let suffix = 2; suffix < 1000; suffix++) {
+    const candidate = `${base}-${suffix}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+  return `${base}-${hashSlug(name + fallbackSeed)}`;
+}
+
+function slugify(value: string): string {
+  return value
+    .normalize("NFKD")
+    .toLowerCase()
+    .replaceAll(/[̀-ͯ]/g, "")
+    .replaceAll(/[^a-z0-9]+/g, "-")
+    .replaceAll(/^-+|-+$/g, "")
+    .slice(0, 60)
+    .replaceAll(/-+$/g, "");
+}
+
+/** Base-36 modular rolling hash — 36^6, so the result is at most six chars. */
+const HASH_MODULUS = 2_176_782_336;
+
+/**
+ * Stable last-resort slug fragment, for the case where a name and its tags both
+ * reduce to an empty slug. Only uniqueness matters here, not distribution —
+ * {@link topicSlug} still de-dupes whatever comes back.
+ */
+function hashSlug(value: string): string {
+  let hash = 0;
+  for (let index = 0; index < value.length; index++) {
+    hash = (hash * 31 + (value.codePointAt(index) ?? 0)) % HASH_MODULUS;
+  }
+  return hash.toString(36);
+}

--- a/apps/standard-reader/src/server/ingest/topic-succession.test.ts
+++ b/apps/standard-reader/src/server/ingest/topic-succession.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+
+import { clearsRetentionBar, findSuccessors } from "./topic-succession";
+import type {
+  ResolvedTopic,
+  RetentionThresholds,
+  StoredTopic,
+  TopicShape,
+} from "./topic-succession";
+
+/** The production bar at the time of writing: 70% of each entry threshold. */
+const BAR: RetentionThresholds = {
+  minTags: 9.8,
+  minPublications: 7,
+  minAuthors: 3.5,
+  maxTopAuthorShare: 0.6,
+};
+
+/** Comfortably above every threshold, so each test moves one axis at a time. */
+function healthy(overrides: Partial<TopicShape> = {}): TopicShape {
+  return {
+    tagCount: 20,
+    publicationCount: 40,
+    authorCount: 30,
+    topAuthorShare: 0.1,
+    ...overrides,
+  };
+}
+
+function resolved(
+  slug: string,
+  published: boolean,
+  signature: Array<string>,
+): ResolvedTopic {
+  return { slug, published, signature };
+}
+
+function stored(slug: string, signatureTags: Array<string>): StoredTopic {
+  return { slug, signatureTags };
+}
+
+const WEB = ["javascript", "react", "css", "frontend", "typescript"];
+const MUSIC = ["vinyl", "jazz", "k-pop", "hip hop", "album"];
+
+describe("clearsRetentionBar", () => {
+  it("keeps a topic that is still comfortably substantial", () => {
+    expect(clearsRetentionBar(healthy(), BAR)).toBe(true);
+  });
+
+  it("keeps a topic sitting between the entry bar and the retention bar", () => {
+    // The whole point of hysteresis: 10 tags is below the entry floor of 14 but
+    // above the retention floor, so a published topic that shrank stays up.
+    expect(
+      clearsRetentionBar(
+        healthy({ tagCount: 10, publicationCount: 8, authorCount: 4 }),
+        BAR,
+      ),
+    ).toBe(true);
+  });
+
+  it.each([
+    ["tags", { tagCount: 9 }],
+    ["publications", { publicationCount: 6 }],
+    ["authors", { authorCount: 3 }],
+  ])("drops a topic that fell below the %s floor", (_label, override) => {
+    expect(clearsRetentionBar(healthy(override), BAR)).toBe(false);
+  });
+
+  it("drops a topic that became one operator's fleet", () => {
+    // Concentration is the anti-fleet rule, so passing every count is not
+    // enough — this is the shape the quality bar exists to exclude.
+    expect(clearsRetentionBar(healthy({ topAuthorShare: 0.9 }), BAR)).toBe(
+      false,
+    );
+  });
+
+  it("treats each threshold as inclusive", () => {
+    expect(
+      clearsRetentionBar(
+        healthy({ publicationCount: 7, authorCount: 3.5, topAuthorShare: 0.6 }),
+        BAR,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("findSuccessors", () => {
+  it("points a dissolved topic at the one that absorbed it", () => {
+    // `frontend` is gone from this sweep; Web Development carries its tags.
+    const successors = findSuccessors(
+      [resolved("web-development", true, WEB), resolved("music", true, MUSIC)],
+      [stored("frontend", ["javascript", "react", "css"])],
+      0.25,
+    );
+
+    expect(successors.get("frontend")).toBe("web-development");
+  });
+
+  it("uses the stored fingerprint when a topic has no cluster left", () => {
+    // Nothing in `resolved` mentions `frontend`, so its last-known signature is
+    // the only evidence of what it was.
+    const successors = findSuccessors(
+      [resolved("music", true, MUSIC)],
+      [stored("frontend", ["javascript", "react", "css"])],
+      0.25,
+    );
+
+    expect(successors.get("frontend")).toBeNull();
+  });
+
+  it("prefers a topic's fresh fingerprint over its stored one", () => {
+    // It still has a cluster — it just missed the bar — and that cluster now
+    // looks like music, whatever it used to be.
+    const successors = findSuccessors(
+      [
+        resolved("music", true, MUSIC),
+        resolved("web-development", true, WEB),
+        resolved("drifted", false, ["vinyl", "jazz", "k-pop"]),
+      ],
+      [stored("drifted", ["javascript", "react", "css"])],
+      0.25,
+    );
+
+    expect(successors.get("drifted")).toBe("music");
+  });
+
+  it("returns null rather than an unrelated topic below the floor", () => {
+    const successors = findSuccessors(
+      [resolved("music", true, MUSIC)],
+      [stored("gone", ["kubernetes", "docker", "terraform"])],
+      0.25,
+    );
+
+    expect(successors.has("gone")).toBe(true);
+    expect(successors.get("gone")).toBeNull();
+  });
+
+  it("treats the similarity floor as inclusive", () => {
+    // Exactly 0.25 Jaccard: 2 tags shared, 8 distinct across the two sets.
+    const successors = findSuccessors(
+      [resolved("target", true, ["a", "b", "c", "d", "e", "f", "g", "h"])],
+      [stored("gone", ["a", "b"])],
+      0.25,
+    );
+
+    expect(successors.get("gone")).toBe("target");
+  });
+
+  it("never nominates an unpublished topic as a successor", () => {
+    // Redirecting to a topic that is itself gone would just move the 404.
+    const successors = findSuccessors(
+      [
+        resolved("also-gone", false, ["javascript", "react", "css"]),
+        resolved("music", true, MUSIC),
+      ],
+      [stored("frontend", ["javascript", "react", "css"])],
+      0.25,
+    );
+
+    expect(successors.get("frontend")).toBeNull();
+  });
+
+  it("picks the closest of several plausible successors", () => {
+    const successors = findSuccessors(
+      [
+        resolved("web-development", true, WEB),
+        resolved("javascript-only", true, ["javascript", "react"]),
+      ],
+      [stored("frontend", ["javascript", "react"])],
+      0.25,
+    );
+
+    expect(successors.get("frontend")).toBe("javascript-only");
+  });
+
+  it("breaks ties on slug so an unchanged sweep rewrites nothing", () => {
+    const targets = [
+      resolved("zebra", true, ["javascript", "react"]),
+      resolved("alpha", true, ["javascript", "react"]),
+    ];
+    const gone = [stored("frontend", ["javascript", "react"])];
+
+    expect(findSuccessors(targets, gone, 0.25).get("frontend")).toBe("alpha");
+    expect(
+      findSuccessors(targets.toReversed(), gone, 0.25).get("frontend"),
+    ).toBe("alpha");
+  });
+
+  it("leaves published topics out entirely", () => {
+    const successors = findSuccessors(
+      [resolved("music", true, MUSIC)],
+      [stored("music", MUSIC)],
+      0.25,
+    );
+
+    expect(successors.has("music")).toBe(false);
+  });
+
+  it("records nothing when the sweep published nothing", () => {
+    // Every topic is unpublished, so there is no target — better to leave the
+    // existing pointers alone than to blank them all.
+    expect(
+      findSuccessors(
+        [resolved("music", false, MUSIC)],
+        [stored("frontend", WEB)],
+        0.25,
+      ).size,
+    ).toBe(0);
+  });
+});

--- a/apps/standard-reader/src/server/ingest/topic-succession.ts
+++ b/apps/standard-reader/src/server/ingest/topic-succession.ts
@@ -1,0 +1,116 @@
+/**
+ * What happens to a topic that stops clearing the quality bar.
+ *
+ * Two rules, both about not breaking URLs, kept here rather than in
+ * `recompute-topics.ts` so they are testable without a database — that module
+ * opens a connection at import time. The *policy* (which numbers) stays with
+ * the quality bar it belongs to; this module owns only the logic.
+ */
+
+import { tagSetSimilarity } from "./tag-clustering.ts";
+
+/** The four measurements the quality bar is expressed in. */
+export interface TopicShape {
+  tagCount: number;
+  publicationCount: number;
+  authorCount: number;
+  /** Share of the topic's publications belonging to its largest single repo. */
+  topAuthorShare: number;
+}
+
+export interface RetentionThresholds {
+  minTags: number;
+  minPublications: number;
+  minAuthors: number;
+  maxTopAuthorShare: number;
+}
+
+/**
+ * Whether an already-published topic is still substantial enough to stay up.
+ *
+ * Deliberately the same three signals as the entry bar rather than a separate
+ * rule, so there is one definition of "a real topic" and only its strictness
+ * changes. A topic that fails this has not dipped — it has dissolved.
+ */
+export function clearsRetentionBar(
+  topic: TopicShape,
+  thresholds: RetentionThresholds,
+): boolean {
+  return (
+    topic.tagCount >= thresholds.minTags &&
+    topic.publicationCount >= thresholds.minPublications &&
+    topic.authorCount >= thresholds.minAuthors &&
+    topic.topAuthorShare <= thresholds.maxTopAuthorShare
+  );
+}
+
+/** A topic as this sweep resolved it. */
+export interface ResolvedTopic {
+  slug: string;
+  published: boolean;
+  /** The cluster's fingerprint *this* sweep. */
+  signature: Array<string>;
+}
+
+/** A topic as the previous sweep left it in the database. */
+export interface StoredTopic {
+  slug: string;
+  signatureTags: Array<string>;
+}
+
+/**
+ * Where each unpublished topic's URL should now point.
+ *
+ * Two ways a topic ends up here, and they need different fingerprints:
+ *
+ * - **It dissolved.** No cluster matched it this sweep, so there is no fresh
+ *   signature — compare its *stored* one, which is the last thing it was.
+ * - **It fell below the bar.** It still has a cluster, so compare the fresh
+ *   signature; that is what it looks like now.
+ *
+ * Either way the answer is the published topic sharing the most tags with it.
+ * `minSimilarity` is the floor below which "closest" stops meaning "related";
+ * mapping those to null is deliberate, because the route sends them to the
+ * index, which is honest, rather than to an unrelated topic.
+ *
+ * Necessarily far below the identity-match threshold: anything that similar
+ * would have been matched as the *same* topic rather than a successor.
+ */
+export function findSuccessors(
+  resolved: Array<ResolvedTopic>,
+  stored: Array<StoredTopic>,
+  minSimilarity: number,
+): Map<string, string | null> {
+  const successors = new Map<string, string | null>();
+  const targets = resolved.filter((topic) => topic.published);
+  if (targets.length === 0) return successors;
+
+  const published = new Set(targets.map((topic) => topic.slug));
+
+  const fingerprints = new Map<string, Array<string>>();
+  for (const topic of stored) fingerprints.set(topic.slug, topic.signatureTags);
+  // A resolved topic's fresh signature beats whatever it was last sweep.
+  for (const topic of resolved) fingerprints.set(topic.slug, topic.signature);
+
+  for (const [slug, signature] of fingerprints) {
+    if (published.has(slug)) continue;
+
+    let best: string | null = null;
+    let bestScore = -1;
+    for (const target of targets) {
+      const score = tagSetSimilarity(signature, target.signature);
+      if (score < minSimilarity) continue;
+      // Ties break on slug so a sweep that changes nothing rewrites nothing.
+      const better =
+        score > bestScore ||
+        (best !== null && score === bestScore && target.slug < best);
+      if (better) {
+        best = target.slug;
+        bestScore = score;
+      }
+    }
+    successors.set(slug, best);
+  }
+
+  return successors;
+}

--- a/apps/standard-reader/src/server/reader/queries.ts
+++ b/apps/standard-reader/src/server/reader/queries.ts
@@ -1982,7 +1982,7 @@ export async function countKnownPublications(db: Db): Promise<number> {
  * its document tags — so every chip is guaranteed to return results.
  *
  * Reads the precomputed `discover_topic_counts` table (rebuilt each sweep by
- * `recomputeTopics()`); aggregating the vocabulary live is a ~2s network-wide
+ * `recomputeTopicCounts()`); aggregating the vocabulary live is a ~2s network-wide
  * `unnest(tags)` scan, far too slow for this request-path, Suspense-gated
  * query. `query`, when set, filters the vocabulary by a case-insensitive
  * substring (trigram-indexed) so the popover search can reach tags past the

--- a/apps/standard-reader/src/server/reader/topics.ts
+++ b/apps/standard-reader/src/server/reader/topics.ts
@@ -1,0 +1,568 @@
+import type { SQL } from "drizzle-orm";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
+
+import type {
+  Db,
+  PublicationCard,
+  Schema,
+} from "#/integrations/tanstack-query/api-shapes";
+import {
+  publicationCardColumns,
+  toPublicationCard,
+} from "#/integrations/tanstack-query/api-shapes";
+import { WEB_BRIDGE_HANDLE_PATTERN } from "#/lib/atproto/bridged-repo";
+import { EXCLUDED_PUBLICATION_URL_PATTERN } from "#/lib/publication/exclusions";
+import { cdnImageUrl } from "#/server/atproto/blob";
+
+import type { ArticleCardSort } from "./queries.ts";
+import { rotateRail, ROTATION_POOL_MULTIPLIER } from "./rail-rotation.ts";
+
+/** Read rows off a drizzle `db.execute` result (array or `{ rows }`). */
+function executeRows<T>(result: unknown): Array<T> {
+  if (Array.isArray(result)) return result as Array<T>;
+  return ((result as { rows?: Array<T> }).rows ?? []) as Array<T>;
+}
+
+/**
+ * Read path for auto-derived topics.
+ *
+ * Everything here reads the precomputed tables the recompute sweep writes (see
+ * `#/server/ingest/recompute-topics`) — publications come straight off
+ * `topic_publications`, and only the document feed is computed live, via
+ * GIN array-overlap on the topic's tag set.
+ */
+
+/** Enough of a member publication to draw its avatar. */
+export interface TopicAvatar {
+  name: string;
+  iconUrl: string | null;
+  ownerAvatarUrl: string | null;
+}
+
+/** A topic as the Discover rail and the topic masthead need it. */
+export interface TopicCard {
+  slug: string;
+  name: string;
+  description: string | null;
+  /** Highest-weight member tags — the topic's sub-areas. */
+  tags: Array<string>;
+  /**
+   * A few member publications, for the card's avatar stack. A topic has no
+   * image of its own and inventing one would be decoration; its members' icons
+   * are both the visual anchor and the answer to "who is in here".
+   */
+  avatars: Array<TopicAvatar>;
+  publicationCount: number;
+  authorCount: number;
+  documentCount: number;
+}
+
+/** Member avatars shown on a card. Four reads as a group without crowding. */
+export const TOPIC_AVATARS = 4;
+/**
+ * Candidates fetched per topic so the page can avoid repeating a face.
+ *
+ * Big publications sit in several topics, so the top-scoring member of one
+ * card is often the top-scoring member of the next; taking the top four of each
+ * independently made one page show the same handful of icons over and over.
+ * With a deeper pool each card can skip past whoever has already appeared.
+ */
+const TOPIC_AVATAR_POOL = TOPIC_AVATARS * 5;
+
+/** Sub-area chips shown on a topic card in a rail. */
+export const TOPIC_CARD_TAGS = 5;
+/**
+ * Tags carried by each row of the browse-all index. More than a rail card
+ * shows, because the index searches over them — a reader looking for "vinyl"
+ * should find Music even though the card never displays that tag.
+ */
+export const TOPIC_INDEX_TAGS = 24;
+
+function topicCardColumns(schema: Schema) {
+  const c = schema.topics;
+  return {
+    slug: c.slug,
+    name: c.name,
+    description: c.description,
+    signatureTags: c.signatureTags,
+    publicationCount: c.publicationCount,
+    authorCount: c.authorCount,
+    documentCount: c.documentCount,
+  };
+}
+
+interface TopicRow {
+  slug: string;
+  name: string;
+  description: string | null;
+  signatureTags: Array<string>;
+  publicationCount: number;
+  authorCount: number;
+  documentCount: number;
+}
+
+function toTopicCard(row: TopicRow, tagLimit: number): TopicCard {
+  return {
+    slug: row.slug,
+    name: row.name,
+    description: row.description,
+    tags: row.signatureTags.slice(0, tagLimit),
+    avatars: [],
+    publicationCount: row.publicationCount,
+    authorCount: row.authorCount,
+    documentCount: row.documentCount,
+  };
+}
+
+interface AvatarRow {
+  slug: string;
+  name: string;
+  did: string;
+  icon_cid: string | null;
+  avatar_url: string | null;
+}
+
+/**
+ * Identity of the *picture*, not the publication.
+ *
+ * Two publications owned by one writer both fall back to that writer's profile
+ * avatar, so keying on the publication URI would still show the same face
+ * twice. The DID is the last resort, for members with no image at all: their
+ * initials circle is derived from the name, and a shared owner means a shared
+ * initial.
+ */
+function avatarIdentity(avatar: TopicAvatar, did: string): string {
+  return avatar.iconUrl ?? avatar.ownerAvatarUrl ?? did;
+}
+
+/**
+ * Fill in each card's member avatars, in place.
+ *
+ * One lateral probe per topic rather than a query per card — the card lists
+ * are short, but a round trip each would still be the most expensive thing on
+ * the page. Publications that actually have an image sort first: a stack of
+ * initials-fallback circles is worse than a smaller stack of real ones.
+ *
+ * Cards are then filled in display order, each skipping faces an earlier card
+ * already used, so the page reads as a survey of the network rather than the
+ * same four icons repeated down the column. A card that cannot fill its stack
+ * from unused candidates shows a shorter one — repeating is the thing being
+ * avoided, so falling back to it would defeat the point.
+ */
+async function attachTopicAvatars(
+  db: Db,
+  cards: Array<TopicCard>,
+): Promise<Array<TopicCard>> {
+  if (cards.length === 0) return cards;
+
+  const slugs = sql.join(
+    cards.map((card) => sql`${card.slug}`),
+    sql`, `,
+  );
+  const result = await db.execute(sql`
+    WITH wanted AS (SELECT unnest(array[${slugs}]) AS slug)
+    SELECT w.slug, m.name, m.did, m.icon_cid, m.avatar_url
+    FROM wanted w
+    CROSS JOIN LATERAL (
+      SELECT p.name, p.did, p.icon_cid, pr.avatar_url
+      FROM topic_publications cp
+      JOIN publications p ON p.uri = cp.publication_uri
+      LEFT JOIN profiles pr ON pr.did = p.did
+      WHERE cp.topic_slug = w.slug AND p.deleted = false
+      ORDER BY (p.icon_cid IS NOT NULL OR pr.avatar_url IS NOT NULL) DESC,
+               cp.score DESC, p.uri
+      LIMIT ${TOPIC_AVATAR_POOL}
+    ) AS m
+  `);
+
+  const bySlug = new Map<string, Array<{ avatar: TopicAvatar; id: string }>>();
+  for (const row of executeRows<AvatarRow>(result)) {
+    const list = bySlug.get(row.slug) ?? [];
+    const avatar: TopicAvatar = {
+      name: row.name,
+      iconUrl: row.icon_cid ? cdnImageUrl(row.did, row.icon_cid, "png") : null,
+      ownerAvatarUrl: row.avatar_url,
+    };
+    list.push({ avatar, id: avatarIdentity(avatar, row.did) });
+    bySlug.set(row.slug, list);
+  }
+
+  const used = new Set<string>();
+  for (const card of cards) {
+    const picked: Array<TopicAvatar> = [];
+    for (const candidate of bySlug.get(card.slug) ?? []) {
+      if (picked.length === TOPIC_AVATARS) break;
+      if (used.has(candidate.id)) continue;
+      used.add(candidate.id);
+      picked.push(candidate.avatar);
+    }
+    card.avatars = picked;
+  }
+  return cards;
+}
+
+/**
+ * Topics for the Discover rail.
+ *
+ * Personalized when the reader follows anything: topics are ranked by how
+ * many of the reader's publications sit inside them, so the rail leads with
+ * what they already read rather than with the network's biggest topics. Signed
+ * out — or with no overlap — it falls back to the global ranking.
+ *
+ * Either way the result is drawn from a wider pool and rotated by seed, so a
+ * fixed ranking does not mean an unchanging rail (same treatment as the
+ * publication rails; see `./rail-rotation`).
+ */
+export async function discoverTopics(
+  db: Db,
+  schema: Schema,
+  {
+    limit,
+    followUris = [],
+    seed,
+  }: { limit: number; followUris?: Array<string>; seed?: string },
+): Promise<Array<TopicCard>> {
+  const c = schema.topics;
+  const cp = schema.topicPublications;
+  const poolSize = seed ? limit * ROTATION_POOL_MULTIPLIER : limit;
+
+  if (followUris.length > 0) {
+    const overlap = sql<number>`count(${cp.publicationUri})`;
+    const rows = await db
+      .select({ ...topicCardColumns(schema), overlap })
+      .from(c)
+      .leftJoin(
+        cp,
+        and(eq(cp.topicSlug, c.slug), inArray(cp.publicationUri, followUris)),
+      )
+      .where(eq(c.published, true))
+      .groupBy(c.slug)
+      .orderBy(desc(overlap), desc(c.score), c.slug)
+      .limit(poolSize);
+
+    if (rows.some((row) => Number(row.overlap) > 0)) {
+      const cards = rows
+        .filter((row) => Number(row.overlap) > 0)
+        .map((row) => toTopicCard(row, TOPIC_CARD_TAGS));
+      const picked = seed
+        ? rotateRail(cards, limit, seed)
+        : cards.slice(0, limit);
+      return attachTopicAvatars(db, picked);
+    }
+  }
+
+  const rows = await db
+    .select(topicCardColumns(schema))
+    .from(c)
+    .where(eq(c.published, true))
+    .orderBy(desc(c.score), c.slug)
+    .limit(poolSize);
+  const cards = rows.map((row) => toTopicCard(row, TOPIC_CARD_TAGS));
+  const picked = seed ? rotateRail(cards, limit, seed) : cards.slice(0, limit);
+  return attachTopicAvatars(db, picked);
+}
+
+/**
+ * Every published topic, best first — the browse-all index.
+ *
+ * Returned whole rather than paginated: the published set is deliberately
+ * small (tens, by the quality bar), and shipping it in one response is what
+ * lets the index filter as the reader types instead of round-tripping per
+ * keystroke.
+ */
+export async function listTopics(
+  db: Db,
+  schema: Schema,
+  { limit = 250 }: { limit?: number } = {},
+): Promise<Array<TopicCard>> {
+  const c = schema.topics;
+  const rows = await db
+    .select(topicCardColumns(schema))
+    .from(c)
+    .where(eq(c.published, true))
+    .orderBy(desc(c.score), c.slug)
+    .limit(limit);
+  return attachTopicAvatars(
+    db,
+    rows.map((row) => toTopicCard(row, TOPIC_INDEX_TAGS)),
+  );
+}
+
+/** One topic, with its full sub-area list. Null when unknown or hidden. */
+export async function topicBySlug(
+  db: Db,
+  schema: Schema,
+  slug: string,
+  { tagLimit = 40 }: { tagLimit?: number } = {},
+): Promise<TopicCard | null> {
+  const c = schema.topics;
+  const rows = await db
+    .select(topicCardColumns(schema))
+    .from(c)
+    .where(and(eq(c.slug, slug), eq(c.published, true)))
+    .limit(1);
+  const row = rows[0];
+  if (!row) return null;
+  const [card] = await attachTopicAvatars(db, [toTopicCard(row, tagLimit)]);
+  return card ?? null;
+}
+
+/**
+ * A topic's member tags, most central first — the sub-area chips, and the
+ * tag set {@link topicDocumentTags} hands to the document query.
+ */
+export async function topicTagList(
+  db: Db,
+  schema: Schema,
+  slug: string,
+  limit = 60,
+): Promise<Array<string>> {
+  const ct = schema.topicTags;
+  const rows = await db
+    .select({ tag: ct.tag })
+    .from(ct)
+    .where(eq(ct.topicSlug, slug))
+    .orderBy(desc(ct.weight), ct.tag)
+    .limit(limit);
+  return rows.map((row) => row.tag);
+}
+
+/**
+ * Source and predicate for a topic's documents.
+ *
+ * Shared by the feed and its count so the two cannot drift.
+ *
+ * **A topic's articles come from a topic's publications.** This is the
+ * rule that makes the two tabs describe the same thing, and skipping it is what
+ * made the feed untrustworthy: matching the whole corpus by tag meant Wildlife
+ * and Nature — whose members are nature photographers, so `photography` is one
+ * of its central tags — served Spanish reporting on US military hardware,
+ * because that publication also tags `photography`. Nine of its first ten
+ * articles came from publications that were not in the topic at all, and
+ * scoping to members cut the match set from 3,945 to 883.
+ *
+ * The cost is loose documents: a document with no publication row cannot be a
+ * member of anything, so it never appears in a topic feed. That is the same
+ * rule the Publications tab already implies, and `/tag/$tag` remains the
+ * un-scoped view for anyone who wants the whole corpus on a subject.
+ *
+ * **Within those publications, belonging is the core tags.** A member
+ * publication still writes about more than the topic's subject, so the tag
+ * test stays: only the {@link TOPIC_CORE_TAGS} most central tags count, not
+ * the broad tail (Middle East Geopolitics legitimately contains `china`, and an
+ * article about downloadable AI models is not Middle East geopolitics).
+ *
+ * Also considered: *core tag OR any two member tags*, which recovers ~4% more.
+ * Rejected — the two-tag branch needs a per-row array intersection the GIN index
+ * cannot serve, and it took the slowest feed from ~250ms to 4.2s.
+ *
+ * The bridge test that remains is on the document's **author**: membership is
+ * already built with bridged publications excluded, but a bridged author can
+ * still post into a member publication. A null handle is never treated as
+ * bridged — identity resolution fails for ordinary reasons, and hiding a real
+ * publisher's article over a briefly unreachable DID document is worse.
+ */
+function topicDocumentFrom(slug: string): SQL {
+  return sql`
+    FROM documents d
+    JOIN topic_publications cp
+      ON cp.publication_uri = d.publication_uri
+     AND cp.topic_slug = ${slug}
+    JOIN publications p ON p.uri = d.publication_uri
+    LEFT JOIN profiles apr ON apr.did = d.did
+  `;
+}
+
+/**
+ * How many of a topic's most central tags count as *core* — a tag specific
+ * enough that an article in a member publication carrying it belongs.
+ */
+const TOPIC_CORE_TAGS = 10;
+
+function topicDocumentWhere(tags: Array<string>): SQL {
+  const coreTags = normalizedTagList(tags.slice(0, TOPIC_CORE_TAGS));
+
+  return sql`
+    d.deleted = false
+    AND (d.published_at IS NULL OR d.published_at <= now())
+    AND immutable_normalized_tags(d.tags) && array[${coreTags}]
+    AND (apr.handle IS NULL OR apr.handle NOT ILIKE ${WEB_BRIDGE_HANDLE_PATTERN})
+    AND p.deleted = false
+    AND p.show_in_discover = true
+    AND p.url NOT ILIKE ${EXCLUDED_PUBLICATION_URL_PATTERN}
+  `;
+}
+
+/** Normalized tag list for the GIN array-overlap predicate. */
+function normalizedTagList(tags: Array<string>): SQL {
+  return sql.join(
+    tags.map((tag) => sql`lower(btrim(${tag}))`),
+    sql`, `,
+  );
+}
+
+/**
+ * Ordered document URIs for a topic's feed.
+ *
+ * The obvious form — one query filtering on the tag array and ordering by
+ * `published_at DESC LIMIT n` — is a trap. Postgres estimates the array-overlap
+ * filter as unselective, walks `documents_published_idx` in date order, and
+ * discards non-matching rows until it has a page: measured at **1.65s** for a
+ * narrow topic (47,237 rows discarded to return 24). The `MATERIALIZED`
+ * CTE is what makes it fast — it forces the tag predicate to be evaluated
+ * first, as a bitmap scan on `documents_tags_norm_idx`, leaving a few thousand
+ * rows to top-N sort: the same query then runs in **18ms**.
+ *
+ * Do not "simplify" this into a single flat query, and do not drop the
+ * `MATERIALIZED` keyword — without it Postgres is free to inline the CTE and
+ * fall straight back into the slow plan.
+ */
+export async function selectTopicDocumentUris(
+  db: Db,
+  {
+    slug,
+    tags,
+    sort = "recent",
+    limit,
+    offset = 0,
+  }: {
+    slug: string;
+    tags: Array<string>;
+    sort?: ArticleCardSort;
+    limit: number;
+    offset?: number;
+  },
+): Promise<Array<string>> {
+  if (tags.length === 0) return [];
+
+  // "Most liked" means likes, so it has to rank on the recommend count the
+  // way every other article feed does (`articleCardOrderBy`) — ranking on
+  // `backlink_count` alone made the tab a no-op, since almost no document has
+  // a backlink and the ties fell back to newest-first. The count is only
+  // computed for that sort: it is a correlated subquery per matched row, and
+  // the other two orderings have no use for it.
+  const popular = sort === "popular";
+  const recommendCount = popular
+    ? sql`, coalesce((
+        SELECT count(*)::int FROM recommends r
+        WHERE r.document_uri = d.uri AND r.deleted = false
+      ), 0) AS recommend_count`
+    : sql``;
+
+  const orderBy = (() => {
+    switch (sort) {
+      case "trending": {
+        return sql`m.trending_score desc, m.published_at desc nulls last`;
+      }
+      case "popular": {
+        return sql`m.recommend_count desc, m.backlink_count desc,
+                   m.published_at desc nulls last`;
+      }
+      default: {
+        return sql`m.published_at desc nulls last`;
+      }
+    }
+  })();
+
+  const rows = await db.execute(sql`
+    WITH matched AS MATERIALIZED (
+      SELECT d.uri, d.published_at, d.trending_score,
+             coalesce(d.backlink_count, 0) AS backlink_count${recommendCount}
+      ${topicDocumentFrom(slug)}
+      WHERE ${topicDocumentWhere(tags)}
+    )
+    SELECT m.uri FROM matched m
+    ORDER BY ${orderBy}
+    LIMIT ${limit} OFFSET ${offset}
+  `);
+
+  return executeRows<{ uri: string }>(rows).map((row) => row.uri);
+}
+
+/** How many documents a topic's tag set matches, for the tab badge. */
+export async function countTopicDocuments(
+  db: Db,
+  slug: string,
+  tags: Array<string>,
+): Promise<number> {
+  if (tags.length === 0) return 0;
+  const rows = await db.execute(sql`
+    SELECT count(*)::int AS count
+    ${topicDocumentFrom(slug)}
+    WHERE ${topicDocumentWhere(tags)}
+  `);
+  return Number(executeRows<{ count: number }>(rows)[0]?.count ?? 0);
+}
+
+export type TopicDirectorySort = "belonging" | "readers" | "active" | "az";
+
+/**
+ * Publications in a topic, read straight off the precomputed membership
+ * table. `belonging` (the default) orders by how much of the topic's tag
+ * vocabulary a publication actually covers, which is a better lead than raw
+ * subscriber count for a topic page.
+ */
+export async function topicPublicationCards(
+  db: Db,
+  schema: Schema,
+  {
+    slug,
+    sort,
+    limit,
+    offset,
+  }: {
+    slug: string;
+    sort: TopicDirectorySort;
+    limit: number;
+    offset: number;
+  },
+): Promise<Array<PublicationCard>> {
+  const p = schema.publications;
+  const pr = schema.profiles;
+  const st = schema.publicationStats;
+  const cp = schema.topicPublications;
+
+  const orderBy = (() => {
+    switch (sort) {
+      case "readers": {
+        return [desc(sql`coalesce(${st.subscriberCount}, 0)`), p.uri];
+      }
+      case "active": {
+        return [sql`${st.lastDocumentAt} desc nulls last`, p.uri];
+      }
+      case "az": {
+        return [p.name, p.uri];
+      }
+      default: {
+        return [desc(cp.score), p.uri];
+      }
+    }
+  })();
+
+  const rows = await db
+    .select(publicationCardColumns(schema))
+    .from(cp)
+    .innerJoin(p, eq(p.uri, cp.publicationUri))
+    .leftJoin(st, eq(st.publicationUri, p.uri))
+    .leftJoin(pr, eq(pr.did, p.did))
+    .where(and(eq(cp.topicSlug, slug), eq(p.deleted, false)))
+    .orderBy(...orderBy)
+    .limit(limit)
+    .offset(offset);
+
+  return rows.map((row) => toPublicationCard(row));
+}
+
+/** How many publications a topic has, for the tab badge. */
+export async function countTopicPublications(
+  db: Db,
+  schema: Schema,
+  slug: string,
+): Promise<number> {
+  const cp = schema.topicPublications;
+  const rows = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(cp)
+    .where(eq(cp.topicSlug, slug));
+  return Number(rows[0]?.count ?? 0);
+}

--- a/apps/standard-reader/src/server/reader/topics.ts
+++ b/apps/standard-reader/src/server/reader/topics.ts
@@ -307,6 +307,53 @@ export async function topicBySlug(
   return card ?? null;
 }
 
+/** Longest succession chain the redirect will follow. Also the cycle guard. */
+const MAX_SUCCESSION_HOPS = 5;
+
+export interface TopicRedirect {
+  /** False when no such topic has ever existed — a genuine 404. */
+  known: boolean;
+  /** Published topic to redirect to; null means fall back to the index. */
+  slug: string | null;
+}
+
+/**
+ * Resolve an unpublished topic's slug to wherever its readers should land.
+ *
+ * A slug the table has never seen is a 404 — a typo or a guessed URL should
+ * not be answered with a redirect. A slug it *has* seen always resolves to
+ * something, because it was once a public link: either the topic that absorbed
+ * it (following `superseded_by` transitively, since merges can chain) or the
+ * index.
+ *
+ * Recursive rather than a loop of round trips: the region gap makes each query
+ * expensive enough that a three-hop chain would be felt, and this is already
+ * the slow path.
+ */
+export async function topicRedirectTarget(
+  db: Db,
+  slug: string,
+): Promise<TopicRedirect> {
+  const result = await db.execute(sql`
+    WITH RECURSIVE chain(slug, superseded_by, published, depth) AS (
+      SELECT t.slug, t.superseded_by, t.published, 0
+      FROM topics t WHERE t.slug = ${slug}
+      UNION ALL
+      SELECT t.slug, t.superseded_by, t.published, c.depth + 1
+      FROM chain c
+      JOIN topics t ON t.slug = c.superseded_by
+      WHERE c.published = false AND c.depth < ${MAX_SUCCESSION_HOPS}
+    )
+    SELECT
+      (SELECT count(*)::int FROM chain) AS seen,
+      (SELECT slug FROM chain WHERE published = true LIMIT 1) AS target
+  `);
+
+  const row = executeRows<{ seen: number; target: string | null }>(result)[0];
+  if (!row || row.seen === 0) return { known: false, slug: null };
+  return { known: true, slug: row.target };
+}
+
 /**
  * A topic's member tags, most central first — the sub-area chips, and the
  * tag set {@link topicDocumentTags} hands to the document query.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "backfill:repo-documents": "pnpm --filter standard-reader backfill:repo-documents",
     "backfill:lists": "pnpm --filter standard-reader backfill:lists",
     "backfill:serial": "pnpm --filter standard-reader backfill:serial",
+    "topics:derive": "pnpm --filter standard-reader topics:derive",
+    "topics:recompute": "pnpm --filter standard-reader topics:recompute",
     "scan:unsupported-blocks": "pnpm --filter standard-reader scan:unsupported-blocks",
     "scan:discussion-sources": "pnpm --filter standard-reader scan:discussion-sources",
     "scan:comics": "pnpm --filter standard-reader scan:comics",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "backfill:repo-documents": "pnpm --filter standard-reader backfill:repo-documents",
     "backfill:lists": "pnpm --filter standard-reader backfill:lists",
     "backfill:serial": "pnpm --filter standard-reader backfill:serial",
+    "topics:cron": "pnpm --filter standard-reader topics:cron",
     "topics:derive": "pnpm --filter standard-reader topics:derive",
     "topics:recompute": "pnpm --filter standard-reader topics:recompute",
     "scan:unsupported-blocks": "pnpm --filter standard-reader scan:unsupported-blocks",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
 
   apps/standard-reader:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.115.0
+        version: 0.115.0(zod@4.4.3)
       '@atcute/atproto':
         specifier: ^4.0.3
         version: 4.0.3(@atcute/lexicons@2.0.2)
@@ -228,7 +231,7 @@ importers:
         version: 1.167.1(@tanstack/query-core@5.101.0)(@tanstack/react-query@5.101.0(react@19.3.0-canary-ad78e251-20260616))(@tanstack/react-router@1.170.18(react-dom@19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616))(react@19.3.0-canary-ad78e251-20260616))(@tanstack/router-core@1.171.15)(react-dom@19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616))(react@19.3.0-canary-ad78e251-20260616)
       '@tanstack/react-start':
         specifier: latest
-        version: 1.168.32(crossws@0.4.5(srvx@0.11.16))(react-dom@19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616))(react@19.3.0-canary-ad78e251-20260616)(vite@8.1.0(@types/node@22.19.20)(jiti@2.7.0)(less@4.7.0)(sass@1.85.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 1.168.34(crossws@0.4.5(srvx@0.11.16))(react-dom@19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616))(react@19.3.0-canary-ad78e251-20260616)(vite@8.1.0(@types/node@22.19.20)(jiti@2.7.0)(less@4.7.0)(sass@1.85.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/router-plugin':
         specifier: ^1.132.0
         version: 1.168.23(@tanstack/react-router@1.170.18(react-dom@19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616))(react@19.3.0-canary-ad78e251-20260616))(vite@8.1.0(@types/node@22.19.20)(jiti@2.7.0)(less@4.7.0)(sass@1.85.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -451,7 +454,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: 8.1.0
-        version: 8.1.0(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.7.0)(sass@1.85.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 8.1.0(@types/node@22.19.20)(esbuild@0.27.7)(jiti@2.7.0)(less@4.7.0)(sass@1.85.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-plugin-pwa:
         specifier: ^1.3.0
         version: 1.3.0(vite@8.1.0(@types/node@22.19.20)(jiti@2.7.0)(less@4.7.0)(sass@1.85.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
@@ -863,6 +866,15 @@ packages:
     peerDependencies:
       rxjs: ^6.5.3 || ^7.4.0
       zone.js: ~0.15.0
+
+  '@anthropic-ai/sdk@0.115.0':
+    resolution: {integrity: sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@apideck/better-ajv-errors@0.3.7':
     resolution: {integrity: sha512-TajUJwGWbDwkCx/CZi7tRE8PVB7simCvKJfHUsSdvps+aTM/PDPP4gkLmKnc+x3CE//y9i/nj74GqdL/hwk7Iw==}
@@ -1702,11 +1714,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -4476,6 +4488,9 @@ packages:
       react: 19.3.0-canary-ad78e251-20260616
       react-dom: 19.3.0-canary-ad78e251-20260616
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -4576,12 +4591,12 @@ packages:
       react: 19.3.0-canary-ad78e251-20260616
       react-dom: 19.3.0-canary-ad78e251-20260616
 
-  '@tanstack/react-start-rsc@0.1.31':
-    resolution: {integrity: sha512-WxjkXYflq550vTNJpdPyMaPC+Vyh88L5wOL+SiDTjPMGne9ad7FZmoJxqfCFEv1e7HVKMH/mMoE8619TsTNVzQ==}
+  '@tanstack/react-start-rsc@0.1.33':
+    resolution: {integrity: sha512-G4e1xwi/InoQmIGgNQSozcWASw68/o3NpbTz+exosdMGRZzLBeUDbj0swEAajxHm6jDEOQ/reSeIcDkcEfhMfw==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@rspack/core': '>=2.0.0-0'
-      '@vitejs/plugin-rsc': '>=0.5.20'
+      '@vitejs/plugin-rsc': '>=0.5.30'
       react: 19.3.0-canary-ad78e251-20260616
       react-dom: 19.3.0-canary-ad78e251-20260616
       react-server-dom-rspack: '>=0.0.2'
@@ -4600,8 +4615,8 @@ packages:
       react: 19.3.0-canary-ad78e251-20260616
       react-dom: 19.3.0-canary-ad78e251-20260616
 
-  '@tanstack/react-start@1.168.32':
-    resolution: {integrity: sha512-y1WXHo+jPfHxiuuN1m+br06IcriiBQnEWryBdbKdEOS5vw2PmnOj+Cgf1/YcGOqtSougScWFeE2rL1FXWvsLLg==}
+  '@tanstack/react-start@1.168.34':
+    resolution: {integrity: sha512-W5MDbD4QlDZHtEXlqN6bJUz7SdsPv6tbNPCih1i72FZqgQlhaxN1BoeoB8H+nN8M4tXRkfJD7VW75FCdQyaQDw==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@rsbuild/core': ^2.0.0
@@ -4671,8 +4686,8 @@ packages:
     resolution: {integrity: sha512-QWfUZ3Yo923tdQn38LyKMU8rcTw69zc+T4dAvgTWV4O56SqFRsGfS0lSWIMhJRwXIx/bvdi7nTUBDdZtTHtpTQ==}
     engines: {node: '>=22.12.0'}
 
-  '@tanstack/start-plugin-core@1.171.24':
-    resolution: {integrity: sha512-l/tm+T0ntXHeIzr9kJDTJ2IDNZC0yFazjkvbEVeZsDOrJ8F+HiZmY+tXYqI5/nDYkwxY0DVQr+kGsTRVb6y2Jw==}
+  '@tanstack/start-plugin-core@1.171.25':
+    resolution: {integrity: sha512-YmMye36vohfxau/MaVpltjkpJlf+wfUBoZp3S6Ue53mpAnsHr6El3XQDmcp1wS4kicZmyX1SNcobJpVZc+2dOQ==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@rsbuild/core': ^2.0.0
@@ -6356,6 +6371,9 @@ packages:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
     engines: {node: '>=6'}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.1.3:
     resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
@@ -7214,6 +7232,10 @@ packages:
 
   json-rpc-2.0@1.7.1:
     resolution: {integrity: sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -8951,6 +8973,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -9216,6 +9241,9 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -10069,6 +10097,13 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
       zone.js: 0.15.1
+
+  '@anthropic-ai/sdk@0.115.0(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.4.3
 
   '@apideck/better-ajv-errors@0.3.7(ajv@8.20.0)':
     dependencies:
@@ -13545,6 +13580,8 @@ snapshots:
       react: 19.3.0-canary-ad78e251-20260616
       react-dom: 19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616)
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@stylexjs/babel-plugin@0.19.0':
@@ -13686,14 +13723,14 @@ snapshots:
       react: 19.3.0-canary-ad78e251-20260616
       react-dom: 19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616)
 
-  '@tanstack/react-start-rsc@0.1.31(crossws@0.4.5(srvx@0.11.16))(react-dom@19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616))(react@19.3.0-canary-ad78e251-20260616)(vite@8.1.0(@types/node@22.19.20)(jiti@2.7.0)(less@4.7.0)(sass@1.85.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/react-start-rsc@0.1.33(crossws@0.4.5(srvx@0.11.16))(react-dom@19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616))(react@19.3.0-canary-ad78e251-20260616)(vite@8.1.0(@types/node@22.19.20)(jiti@2.7.0)(less@4.7.0)(sass@1.85.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.18(react-dom@19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616))(react@19.3.0-canary-ad78e251-20260616)
       '@tanstack/router-core': 1.171.15
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-client-core': 1.170.14
       '@tanstack/start-fn-stubs': 1.162.0
-      '@tanstack/start-plugin-core': 1.171.24(@tanstack/react-router@1.170.18(react-dom@19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616))(react@19.3.0-canary-ad78e251-20260616))(crossws@0.4.5(srvx@0.11.16))(vite@8.1.0(@types/node@22.19.20)(jiti@2.7.0)(less@4.7.0)(sass@1.85.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/start-plugin-core': 1.171.25(@tanstack/react-router@1.170.18(react-dom@19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616))(react@19.3.0-canary-ad78e251-20260616))(crossws@0.4.5(srvx@0.11.16))(vite@8.1.0(@types/node@22.19.20)(jiti@2.7.0)(less@4.7.0)(sass@1.85.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.169.17(crossws@0.4.5(srvx@0.11.16))
       '@tanstack/start-storage-context': 1.167.17
       pathe: 2.0.3
@@ -13717,15 +13754,15 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.168.32(crossws@0.4.5(srvx@0.11.16))(react-dom@19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616))(react@19.3.0-canary-ad78e251-20260616)(vite@8.1.0(@types/node@22.19.20)(jiti@2.7.0)(less@4.7.0)(sass@1.85.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/react-start@1.168.34(crossws@0.4.5(srvx@0.11.16))(react-dom@19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616))(react@19.3.0-canary-ad78e251-20260616)(vite@8.1.0(@types/node@22.19.20)(jiti@2.7.0)(less@4.7.0)(sass@1.85.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.18(react-dom@19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616))(react@19.3.0-canary-ad78e251-20260616)
       '@tanstack/react-start-client': 1.168.16(react-dom@19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616))(react@19.3.0-canary-ad78e251-20260616)
-      '@tanstack/react-start-rsc': 0.1.31(crossws@0.4.5(srvx@0.11.16))(react-dom@19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616))(react@19.3.0-canary-ad78e251-20260616)(vite@8.1.0(@types/node@22.19.20)(jiti@2.7.0)(less@4.7.0)(sass@1.85.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/react-start-rsc': 0.1.33(crossws@0.4.5(srvx@0.11.16))(react-dom@19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616))(react@19.3.0-canary-ad78e251-20260616)(vite@8.1.0(@types/node@22.19.20)(jiti@2.7.0)(less@4.7.0)(sass@1.85.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/react-start-server': 1.167.22(crossws@0.4.5(srvx@0.11.16))(react-dom@19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616))(react@19.3.0-canary-ad78e251-20260616)
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-client-core': 1.170.14
-      '@tanstack/start-plugin-core': 1.171.24(@tanstack/react-router@1.170.18(react-dom@19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616))(react@19.3.0-canary-ad78e251-20260616))(crossws@0.4.5(srvx@0.11.16))(vite@8.1.0(@types/node@22.19.20)(jiti@2.7.0)(less@4.7.0)(sass@1.85.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/start-plugin-core': 1.171.25(@tanstack/react-router@1.170.18(react-dom@19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616))(react@19.3.0-canary-ad78e251-20260616))(crossws@0.4.5(srvx@0.11.16))(vite@8.1.0(@types/node@22.19.20)(jiti@2.7.0)(less@4.7.0)(sass@1.85.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.169.17(crossws@0.4.5(srvx@0.11.16))
       pathe: 2.0.3
       react: 19.3.0-canary-ad78e251-20260616
@@ -13811,7 +13848,7 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.162.0': {}
 
-  '@tanstack/start-plugin-core@1.171.24(@tanstack/react-router@1.170.18(react-dom@19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616))(react@19.3.0-canary-ad78e251-20260616))(crossws@0.4.5(srvx@0.11.16))(vite@8.1.0(@types/node@22.19.20)(jiti@2.7.0)(less@4.7.0)(sass@1.85.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/start-plugin-core@1.171.25(@tanstack/react-router@1.170.18(react-dom@19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616))(react@19.3.0-canary-ad78e251-20260616))(crossws@0.4.5(srvx@0.11.16))(vite@8.1.0(@types/node@22.19.20)(jiti@2.7.0)(less@4.7.0)(sass@1.85.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.7
@@ -15658,6 +15695,8 @@ snapshots:
 
   fast-redact@3.5.0: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.3: {}
 
   fastq@1.20.1:
@@ -16627,6 +16666,11 @@ snapshots:
   json-parse-even-better-errors@3.0.2: {}
 
   json-rpc-2.0@1.7.1: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
 
@@ -18933,6 +18977,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
 
   std-env@4.1.0: {}
@@ -19252,6 +19301,8 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:


### PR DESCRIPTION
Discover ranked a 450k-tag vocabulary by raw frequency, so the network's atproto-native tags (`atproto`, `bluesky`, `atmosphere`) sat on top of a page meant to represent the whole network. A reader who cares about film, Brazilian politics, or comics had no entry point.

**Topics** fix the granularity. Each is a cluster of related tags presented as one browsable area, with the publications and articles scoped to it. atproto becomes one topic among ~83, next to Film and Festivals, Wildlife and Nature, Pacific Northwest Local News, and Brazilian Politics.

## Derived, never curated

The hourly sweep rebuilds the whole set:

1. **Graph** — per-publisher tag co-occurrence over non-deleted documents, cosine-weighted, top-12 neighbours per tag.
2. **Semantic edges** — context embeddings (article titles per tag, not the bare tag string) add edges between tags that mean the same thing but never co-occur, rescaled onto the co-occurrence weight distribution so they don't crowd it out. This is what unified web dev (`javascript, react, css, frontend, angular, vue, typescript, vite, nextjs, node`).
3. **Clustering** — weighted asynchronous label propagation, deterministic, re-splitting any cluster over 150 tags.
4. **Quality bar** — ≥14 tags, ≥10 publications, ≥5 authors, ≤50% top-author share.
5. **Naming** — Claude names only clusters that are new or whose tag set drifted (Jaccard < 0.8), so steady state is ~zero API calls per sweep.

### Two findings the design depends on

- **Top-author share, not author count.** The largest tags network-wide (`chart`, `weekly`, `song`) are one auto-generating fleet: 773 publications across 8 DIDs. An `author_count >= 5` guard waved it through. Real topics sit at 1–4% top-author share; the fleet is at 99%.
- **Bridged repos stay in the graph but out of the product.** `*.web.brid.gy` is 75% of the corpus — excluding it from the graph collapsed the feature from 44 topics to 5. It's excluded from membership and from every feed instead. The filter is author-level (`documents.did`), not publication-level: 82% of bridged content is loose documents with no publication row, so an owner-level test let it all through.

## Surfaces

- **Discover** — a rail of topics, personalized by overlap with the reader's follows, with **See all**.
- **`/topics`** — browsable, searchable index; search covers names, descriptions, and the 24 tags carried per row.
- **`/topics/$slug`** — Articles and Publications tabs, with the topic's sub-area tags linking down to the existing `/tag/$tag` pages.

Cards lead with a stack of member-publication avatars, de-duplicated across the page so the same face doesn't repeat down the column.

## Performance

- Topic article feed: a `MATERIALIZED` CTE forces the tag predicate to evaluate first as a bitmap scan on `documents_tags_norm_idx`. Without it the planner walks `documents_published_idx` and discards 47,237 rows to return 24 — **1.65s → 18ms**.
- Tag context embeddings: one windowed pass instead of a per-tag lateral probe — **7min → 6s** over 4,639 tags.
- Feeds are scoped to member publications, which also fixed general tags like `photography` pulling non-member articles into Wildlife and Nature.

## Notes for review

- `recomputeTopics()` (the old name for what rebuilds `discover_topic_counts`) is now `recomputeTopicCounts()`, freeing the name for this feature. The flat tag vocabulary is referred to as "tag chips" in `APP_VISION.md` now.
- Three surfaces still say "topic" but mean tags — Discover's "Filter by topic" control, the guide's Topics section, and the subscriptions table's Topic column. Left alone deliberately; happy to rename in a follow-up.
- `drizzle-kit check` passes. The migration creates the tables fresh — see the deploy note below.

## Gates

`pnpm typecheck`, `pnpm test` (716), `pnpm format:check`, and `pnpm build` all pass. `pnpm lint`'s 2 errors are pre-existing in an untracked scratch file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)