### PR TITLE
Keep bulk web-bridge mirrors out of Discover's Recommended rail

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -1130,6 +1130,12 @@ hand-tuned lists:
   only — no scoring per request.
 - **Cold start (no follows yet)** — fall back to high-readership publications
   _outside_ the current trending set so Recommended stays distinct from Trending.
+- **No bulk web-bridge mirrors in Recommended** — Discover's Recommended rail (signed-in _and_
+  cold start) excludes `*.web.brid.gy` publications. Those sites were discovered and mirrored by
+  Bridgy Fed, not published here on purpose, and they are a quarter of the discover-eligible
+  corpus — recommending them reads as noise. They stay fully reachable everywhere else: the
+  directory, search, trending, follows, and their own pages. Filtered in SQL, so the rail still
+  fills to its limit.
 
 ---
 

--- a/apps/standard-reader/src/integrations/tanstack-query/api-discover.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-discover.functions.ts
@@ -101,6 +101,12 @@ const discoverExtrasInput = z.object({
   socialProofLimit: z.number().int().min(1).max(100).default(12),
 });
 
+/**
+ * Discover's "Recommended" rail. Bridgy Fed's bulk web-bridge mirrors
+ * (`*.web.brid.gy`) are excluded here: nobody at those sites asked to be
+ * published, so they read as noise in a rail that is meant to be a suggestion.
+ * They stay reachable everywhere else — directory, search, trending, follows.
+ */
 async function loadRecommendedRail(
   db: Db,
   schema: Schema,
@@ -117,9 +123,11 @@ async function loadRecommendedRail(
           limit,
           trendingExclude,
           rotationSeed("discover", "anon"),
+          { excludeWebBridge: true },
         )
       : await recommendedPublications(db, schema, did, limit, {
           excludeUris: trendingExclude,
+          excludeWebBridge: true,
           followUris,
           seed: rotationSeed("discover", did),
         });
@@ -405,6 +413,7 @@ const getRecommendedPublications = createServerFn({ method: "GET" })
             data.limit,
             trendingExclude,
             rotationSeed("discover", "anon"),
+            { excludeWebBridge: true },
           );
           span.set("count", items.length);
           return items.filter((pub) => pub.documentCount > 0);
@@ -418,6 +427,7 @@ const getRecommendedPublications = createServerFn({ method: "GET" })
           data.limit,
           {
             excludeUris: trendingExclude,
+            excludeWebBridge: true,
             followUris: await effectiveFollowUris(db, schema, session.did),
             seed: rotationSeed("discover", session.did),
           },

--- a/apps/standard-reader/src/server/reader/publication-filters.ts
+++ b/apps/standard-reader/src/server/reader/publication-filters.ts
@@ -2,6 +2,7 @@ import type { SQL } from "drizzle-orm";
 import { and, eq, ilike, isNull, not, or } from "drizzle-orm";
 
 import type { Schema } from "#/integrations/tanstack-query/api-shapes";
+import { WEB_BRIDGE_HANDLE_SUFFIX } from "#/lib/atproto/bridged-repo";
 import { EXCLUDED_PUBLICATION_URL_PATTERN } from "#/lib/publication/exclusions";
 
 /** Read-model filter for directory / search / discovery publication queries. */
@@ -34,6 +35,22 @@ export function discoverEligibleArticleWhere(p: Schema["publications"]): SQL {
       eq(p.showInDiscover, true),
       not(ilike(p.url, EXCLUDED_PUBLICATION_URL_PATTERN)),
     ),
+  ) as SQL;
+}
+
+/**
+ * Keep publications whose owner is *not* one of Bridgy Fed's bulk web-bridge
+ * mirrors (`*.web.brid.gy`). Those sites never asked to be here — they were
+ * discovered and mirrored — so recommending them reads as noise even though
+ * they are perfectly fine to browse, subscribe to, or find by search.
+ *
+ * An unresolved handle is kept, matching `isBridgedHandle`: a briefly
+ * unreachable DID document should not silently drop a real publisher.
+ */
+export function notWebBridgePublicationWhere(pr: Schema["profiles"]): SQL {
+  return or(
+    isNull(pr.handle),
+    not(ilike(pr.handle, `%${WEB_BRIDGE_HANDLE_SUFFIX}`)),
   ) as SQL;
 }
 

--- a/apps/standard-reader/src/server/reader/queries.ts
+++ b/apps/standard-reader/src/server/reader/queries.ts
@@ -53,6 +53,7 @@ import { documentPublishedNotInFuture } from "#/server/reader/document-filters";
 import {
   discoverEligibleArticleWhere,
   discoverEligiblePublicationWhere,
+  notWebBridgePublicationWhere,
 } from "#/server/reader/publication-filters";
 import {
   ROTATION_POOL_MULTIPLIER,
@@ -2415,6 +2416,12 @@ export interface PublicationRailOpts {
    * pool; defaults to a per-viewer daily seed.
    */
   seed?: string;
+  /**
+   * Drop Bridgy Fed's bulk web-bridge mirrors (`*.web.brid.gy`) from the rail —
+   * see {@link notWebBridgePublicationWhere}. Filtered in SQL (not after the
+   * fact) so the rail still fills to `limit`.
+   */
+  excludeWebBridge?: boolean;
 }
 
 function mergeExcludeUris(...groups: Array<Array<string>>): Array<string> {
@@ -2442,6 +2449,7 @@ async function publicationCardsByOrderedUris(
   db: Db,
   schema: Schema,
   uris: Array<string>,
+  { excludeWebBridge = false }: { excludeWebBridge?: boolean } = {},
 ): Promise<Array<PublicationCard>> {
   if (uris.length === 0) {
     return [];
@@ -2461,6 +2469,7 @@ async function publicationCardsByOrderedUris(
         eq(p.deleted, false),
         discoverEligiblePublicationWhere(p),
         hasIndexedDocuments(db, schema, p.uri),
+        ...(excludeWebBridge ? [notWebBridgePublicationWhere(pr)] : []),
       ),
     );
 
@@ -2609,6 +2618,7 @@ async function backfillPublicationRail(
   limit: number,
   excludeUris: Array<string>,
   seed?: string,
+  opts: { excludeWebBridge?: boolean } = {},
 ): Promise<Array<PublicationCard>> {
   if (primary.length >= limit) {
     return primary.slice(0, limit);
@@ -2624,6 +2634,7 @@ async function backfillPublicationRail(
     limit - primary.length,
     seen,
     seed,
+    opts,
   );
   return [...primary, ...backfill].slice(0, limit);
 }
@@ -2642,6 +2653,7 @@ export async function popularPublications(
   limit: number,
   excludeUris: Array<string> = [],
   seed?: string,
+  { excludeWebBridge = false }: { excludeWebBridge?: boolean } = {},
 ): Promise<Array<PublicationCard>> {
   const p = schema.publications;
   const st = schema.publicationStats;
@@ -2653,6 +2665,9 @@ export async function popularPublications(
   ];
   if (excludeUris.length > 0) {
     conds.push(notInArray(p.uri, excludeUris));
+  }
+  if (excludeWebBridge) {
+    conds.push(notWebBridgePublicationWhere(pr));
   }
 
   const poolSize = seed ? limit * ROTATION_POOL_MULTIPLIER : limit;
@@ -2686,10 +2701,11 @@ export async function recommendedPublications(
 ): Promise<Array<PublicationCard>> {
   const excludeUris = opts.excludeUris ?? [];
   const seed = opts.seed ?? rotationSeed("recommended", did);
+  const railOpts = { excludeWebBridge: opts.excludeWebBridge ?? false };
   const followUris =
     opts.followUris ?? (await selectFollowUris(db, schema, did));
   if (followUris.length === 0) {
-    return popularPublications(db, schema, limit, excludeUris, seed);
+    return popularPublications(db, schema, limit, excludeUris, seed, railOpts);
   }
 
   const mergedExclude = mergeExcludeUris(excludeUris, followUris);
@@ -2712,6 +2728,7 @@ export async function recommendedPublications(
     db,
     schema,
     ranked.slice(0, limit * ROTATION_POOL_MULTIPLIER).map((row) => row.uri),
+    railOpts,
   );
   const primary = rotateRail(pool, limit, seed);
 
@@ -2722,6 +2739,7 @@ export async function recommendedPublications(
     limit,
     mergedExclude,
     seed,
+    railOpts,
   );
 }
 


### PR DESCRIPTION
Discover's **Recommended** rail no longer surfaces `*.web.brid.gy` publications.

Those are sites [Bridgy Fed](https://fed.brid.gy) discovered and mirrored — nobody at them chose to publish here — and they are **1533 of the 5804** discover-eligible publications (26%). Recommending them reads as noise in a rail that is meant to be a suggestion.

## What changed

- `notWebBridgePublicationWhere(pr)` in `publication-filters.ts` — SQL predicate dropping profiles whose handle ends in `.web.brid.gy` (reuses `WEB_BRIDGE_HANDLE_SUFFIX`). A null/unresolved handle is kept, matching `isBridgedHandle`: a briefly unreachable DID document should not silently drop a real publisher.
- An opt-in `excludeWebBridge` flag threaded through the rail queries (`popularPublications`, `publicationCardsByOrderedUris`, `backfillPublicationRail`, `PublicationRailOpts` → `recommendedPublications`).
- Enabled at Discover's two Recommended call sites in `api-discover.functions.ts` — `loadRecommendedRail` (backs `getDiscoverExtras`, what the route renders) and the `getRecommendedPublications` server fn — on both the signed-in and cold-start/anon branches.

The filter runs **in SQL, not over the returned cards**, so the rail still fills to its limit; a post-filter on a 12-card rail could have left 3.

## Scope

Only Discover's Recommended. The directory, search, trending, "Followed by people you follow", the home rails, digest, and the XRPC/MCP `getRecommendedPublications` endpoint are untouched — bridged sites stay browsable, searchable, and subscribable everywhere else.

## Verification

- Counted against prod Neon: 1533 web-bridge / 1 ap-bridge / 0 null-handle out of 5804 discover-eligible publications, so the pattern matches real handles.
- `typecheck`, `lint`, `format:check` clean; reader + atproto unit tests pass. No existing test covers these queries (they are DB integration-only).
- `APP_VISION.md` §6 records the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)