### PR TITLE
Stop the RSS and mark-all-read buttons vanishing on /latest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,9 +319,16 @@ Implementation notes:
 - Critical feed returns `counts: null`. Pagination (`offset > 0`) never re-fetches counts.
 - One shared counts query serves every tab — prefetch it once on idle alongside inactive tab feeds.
 - **Stable chrome:** tab labels and masthead `metaValue` use skeleton placeholders while counts
-  pending; do not show `Mark all as read` until counts are loaded. When the active filter’s rows are
-  empty but empty-state copy depends on `subscriptions === 0` vs “all caught up”, show a row
-  skeleton until counts resolve.
+  pending. When the active filter’s rows are empty but empty-state copy depends on
+  `subscriptions === 0` vs “all caught up”, show a row skeleton until counts resolve.
+- **The controls row never unmounts a button.** The RSS feed and `Mark all as read` buttons are
+  driven by `latestControlsVisibility` (`src/lib/latest-feed-controls.ts`): both show on the
+  reader’s own filters (`unread`, `subscriptions`) and hide only on the network-wide ones, and
+  `Mark all as read` is **disabled** — never removed — while counts are pending or once nothing is
+  unread. Do not re-gate either button on `filter === "unread"`: `/latest` normalises to
+  `?filter=unread` and a reader with reading history off is redirected to `?filter=subscriptions`
+  on the next commit, so that gate makes the buttons appear for one paint and then vanish (with the
+  URL keeping them gone across reloads).
 - Optimistic read updates must touch both latest feed item caches and the counts cache key (see
   `read-optimistic.ts`).
 - **Loader cache priming:** on navigation, `await ensureQueryData` for the critical feed and

--- a/apps/standard-reader/src/lib/latest-feed-controls.test.ts
+++ b/apps/standard-reader/src/lib/latest-feed-controls.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { latestControlsVisibility } from "./latest-feed-controls";
+import type { LatestControlsState } from "./latest-feed-controls";
+
+function state(
+  overrides: Partial<LatestControlsState> = {},
+): LatestControlsState {
+  return {
+    countsPending: false,
+    filter: "unread",
+    signedIn: true,
+    trackReading: true,
+    unreadCount: 148,
+    ...overrides,
+  };
+}
+
+describe("latestControlsVisibility", () => {
+  it("shows both controls on the unread feed", () => {
+    expect(latestControlsVisibility(state())).toEqual({
+      markAllReadDisabled: false,
+      showMarkAllRead: true,
+      showRssFeed: true,
+    });
+  });
+
+  // The bug this module exists for: `/latest` normalises to `?filter=unread`,
+  // and a reader with reading history off is redirected to `?filter=subscriptions`
+  // right after the first paint. Gating on `filter === "unread"` made the
+  // buttons flash in and disappear, and the URL kept them gone across reloads.
+  it("keeps the RSS button on the subscriptions feed", () => {
+    expect(
+      latestControlsVisibility(state({ filter: "subscriptions" })).showRssFeed,
+    ).toBe(true);
+  });
+
+  it("keeps the RSS button when the reader has reading history off", () => {
+    expect(
+      latestControlsVisibility(
+        state({ filter: "subscriptions", trackReading: false }),
+      ),
+    ).toMatchObject({ showMarkAllRead: false, showRssFeed: true });
+  });
+
+  it("hides both controls on the network-wide feeds", () => {
+    for (const filter of ["all", "trending"] as const) {
+      expect(latestControlsVisibility(state({ filter }))).toMatchObject({
+        showMarkAllRead: false,
+        showRssFeed: false,
+      });
+    }
+  });
+
+  it("hides both controls for signed-out readers", () => {
+    expect(latestControlsVisibility(state({ signedIn: false }))).toMatchObject({
+      showMarkAllRead: false,
+      showRssFeed: false,
+    });
+  });
+
+  it("disables rather than unmounts mark-all-read once nothing is unread", () => {
+    expect(latestControlsVisibility(state({ unreadCount: 0 }))).toMatchObject({
+      markAllReadDisabled: true,
+      showMarkAllRead: true,
+    });
+  });
+
+  it("disables mark-all-read while the counts are still loading", () => {
+    expect(
+      latestControlsVisibility(state({ countsPending: true, unreadCount: 0 })),
+    ).toMatchObject({ markAllReadDisabled: true, showMarkAllRead: true });
+  });
+});

--- a/apps/standard-reader/src/lib/latest-feed-controls.ts
+++ b/apps/standard-reader/src/lib/latest-feed-controls.ts
@@ -1,0 +1,60 @@
+/**
+ * Visibility rules for the two action buttons in the `/latest` controls row —
+ * the RSS feed button and "Mark all as read".
+ *
+ * Both used to be gated on `filter === "unread"`, which made them disappear on
+ * their own: `/latest` normalises to `?filter=unread`, so the server renders
+ * the buttons, and then the client redirects a reader with reading history
+ * turned off to `?filter=subscriptions` — the buttons show for one paint and
+ * vanish. Because the filter lives in the URL, reloading landed back on
+ * `?filter=subscriptions` and they stayed gone until the reader re-entered the
+ * app at a bare `/latest`.
+ *
+ * The RSS feed behind the button (`/feed/latest/$did`) is "the newest articles
+ * from the publications you subscribe to" — it is not unread-filtered, so it is
+ * the same feed on the Unread and Subscriptions tabs. Both controls belong to
+ * the reader's own feed, so they are shown on both personal filters and hidden
+ * only on the network-wide ones (All, Trending), where the feed on screen is
+ * not the reader's.
+ *
+ * "Mark all as read" is disabled rather than unmounted when there is nothing to
+ * mark: a control that greys out reads as "all caught up", where one that
+ * disappears the moment you use it reads as broken.
+ */
+
+import type { LatestFilter } from "#/integrations/tanstack-query/api-feed.functions";
+
+/** Filters that show the reader's own feed rather than the whole network. */
+const PERSONAL_FILTERS = new Set<LatestFilter>(["unread", "subscriptions"]);
+
+export interface LatestControlsState {
+  signedIn: boolean;
+  filter: LatestFilter;
+  /** "Track reading history" preference — read state is meaningless when off. */
+  trackReading: boolean;
+  /** Tab counts have not resolved yet, so the unread total is unknown. */
+  countsPending: boolean;
+  unreadCount: number;
+}
+
+export interface LatestControlsVisibility {
+  showRssFeed: boolean;
+  showMarkAllRead: boolean;
+  markAllReadDisabled: boolean;
+}
+
+export function latestControlsVisibility({
+  signedIn,
+  filter,
+  trackReading,
+  countsPending,
+  unreadCount,
+}: LatestControlsState): LatestControlsVisibility {
+  const personalFeed = signedIn && PERSONAL_FILTERS.has(filter);
+
+  return {
+    showRssFeed: personalFeed,
+    showMarkAllRead: personalFeed && trackReading,
+    markAllReadDisabled: countsPending || unreadCount === 0,
+  };
+}

--- a/apps/standard-reader/src/routes/_layout.latest.tsx
+++ b/apps/standard-reader/src/routes/_layout.latest.tsx
@@ -54,6 +54,7 @@ import {
 } from "#/integrations/tanstack-query/api-feed.functions";
 import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
 import { user } from "#/integrations/tanstack-query/api-user.functions";
+import { latestControlsVisibility } from "#/lib/latest-feed-controls";
 import { getPublicUrlClient } from "#/lib/public-url";
 import { latestFeedUrl, pageSocialMeta } from "#/lib/site-metadata";
 import { useFormatters } from "#/lib/use-formatters";
@@ -503,9 +504,12 @@ function Latest() {
   const signedIn = Boolean(session?.user);
   const loginSearch = useLoginSearch();
 
+  // With reading history off there is no Unread tab, so `?filter=unread` is a
+  // URL to normalise away, not a page the reader chose. `replace` keeps it out
+  // of history — a pushed entry makes Back bounce off this effect forever.
   useEffect(() => {
     if (trackReading || filter !== "unread") return;
-    void navigate({ search: { filter: "subscriptions" } });
+    void navigate({ replace: true, search: { filter: "subscriptions" } });
   }, [filter, navigate, trackReading]);
 
   useEffect(() => {
@@ -604,6 +608,15 @@ function Latest() {
   const isTrending = filter === "trending";
   const isNetwork = !signedIn || filter === "all" || isTrending;
 
+  const { showRssFeed, showMarkAllRead, markAllReadDisabled } =
+    latestControlsVisibility({
+      countsPending,
+      filter,
+      signedIn,
+      trackReading,
+      unreadCount: counts.unread,
+    });
+
   const trendingCount = Math.min(counts.trending, TRENDING_PAGE_LIMIT);
   const metaCount = isTrending
     ? trendingCount
@@ -686,18 +699,14 @@ function Latest() {
           </Flex>
         )}
         <Flex align="center" gap="md">
-          {signedIn && filter === "unread" ? (
+          {showRssFeed ? (
             <RssFeedButton
               name={t`Your Latest`}
               feedUrl={latestFeedUrl(getPublicUrlClient(), readerScope)}
               size="lg"
             />
           ) : null}
-          {trackReading &&
-          signedIn &&
-          filter === "unread" &&
-          !countsPending &&
-          counts.unread > 0 ? (
+          {showMarkAllRead ? (
             <AlertDialog
               isOpen={markAllReadOpen}
               onOpenChange={setMarkAllReadOpen}
@@ -705,6 +714,7 @@ function Latest() {
                 <IconButton
                   variant="secondary"
                   size="lg"
+                  isDisabled={markAllReadDisabled}
                   label={t`Mark all as read`}
                 >
                   <CheckCheck size={18} />


### PR DESCRIPTION
Both controls were gated on `filter === "unread"`, which made them
disappear on their own. `/latest` normalises to `?filter=unread`, so the
server renders the buttons; a reader with reading history turned off is
then redirected to `?filter=subscriptions` on the next commit and both
buttons drop out after a single paint. Because the filter lives in the
URL, reloading landed back on `?filter=subscriptions` and they stayed
gone until the reader re-entered the app at a bare `/latest` — matching
the report of "there once, but vanish again", only recoverable by
closing the tab.

`Mark all as read` had a second disappearing act: it also required
`!countsPending && counts.unread > 0`, so it blinked out while counts
loaded and then unmounted for good the moment it was used.

The feed behind the RSS button (`/feed/latest/$did`) is "the newest
articles from the publications you subscribe to" — not unread-filtered,
so it is the same feed on the Unread and Subscriptions tabs. Both
controls now come from `latestControlsVisibility`: shown on the reader's
own filters, hidden only on the network-wide ones, and `Mark all as
read` is disabled rather than removed when there is nothing to mark. The
`?filter=unread` normalisation also switches to `replace` so Back no
longer bounces off the redirect.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018FYuyaHj8HtUwMmeEoTvCE