### PR TITLE
Index-serve the two queries saturating the Neon compute

### DIFF
--- a/apps/standard-reader/src/components/reader/article-view.tsx
+++ b/apps/standard-reader/src/components/reader/article-view.tsx
@@ -58,7 +58,14 @@ import {
   Heart,
   MoreHorizontal,
 } from "lucide-react";
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  Fragment,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { flushSync } from "react-dom";
 
 import { AppLink } from "#/components/reader/app-link";
@@ -327,6 +334,18 @@ const styles = stylex.create({
     display: "flex",
     flexWrap: "wrap",
     justifyContent: "center",
+  },
+  topics: {
+    gap: gap.xs,
+    alignItems: "center",
+    display: "flex",
+    flexWrap: "wrap",
+    justifyContent: "center",
+  },
+  topicSeparator: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.xs,
   },
   title: {
     color: uiColor.text2,
@@ -604,9 +623,15 @@ const styles = stylex.create({
   },
 });
 
-function articleTopic(article: ArticleDetail): string | null {
-  if (article.tags && article.tags.length > 0) return article.tags[0] ?? null;
-  return article.publication?.topic ?? null;
+/**
+ * Every tag the author filed the article under, else the owning publication's
+ * topic. All of them render in the kicker — a piece tagged several ways
+ * shouldn't hide the rest behind whichever tag happens to come first.
+ */
+function articleTopics(article: ArticleDetail): Array<string> {
+  const tags = (article.tags ?? []).filter((tag) => tag.trim().length > 0);
+  if (tags.length > 0) return tags;
+  return article.publication?.topic ? [article.publication.topic] : [];
 }
 
 /** The author's bare @handle (lead contributor, else publication owner). */
@@ -943,7 +968,7 @@ function ArticleViewBody({
   const handle = authorHandle(article);
   const bylineDid = authorDid(article);
   const showHandle = handle != null && authorName !== `@${handle}`;
-  const topic = articleTopic(article);
+  const topics = articleTopics(article);
   const { data: labelData } = useQuery(
     labelerApi.getDocumentLabelsQueryOptions(article.uri),
   );
@@ -1314,7 +1339,7 @@ function ArticleViewBody({
             </div>
           ) : null}
 
-          {topic || labelRefs.length > 0 ? (
+          {topics.length > 0 || labelRefs.length > 0 ? (
             <div {...stylex.props(styles.kicker)}>
               {labelRefs.length > 0 ? (
                 <div {...stylex.props(styles.labelBadges)}>
@@ -1327,10 +1352,24 @@ function ArticleViewBody({
                   ))}
                 </div>
               ) : null}
-              {topic ? (
-                <Kicker>
-                  <Topic name={topic} />
-                </Kicker>
+              {topics.length > 0 ? (
+                <div {...stylex.props(styles.topics)}>
+                  {topics.map((topic, index) => (
+                    <Fragment key={topic}>
+                      {index > 0 ? (
+                        <span
+                          aria-hidden
+                          {...stylex.props(styles.topicSeparator)}
+                        >
+                          ·
+                        </span>
+                      ) : null}
+                      <Kicker>
+                        <Topic name={topic} />
+                      </Kicker>
+                    </Fragment>
+                  ))}
+                </div>
               ) : null}
             </div>
           ) : null}

--- a/apps/standard-reader/src/server/reader/queries.explain.test.ts
+++ b/apps/standard-reader/src/server/reader/queries.explain.test.ts
@@ -29,6 +29,7 @@ import * as schema from "#/db/schema";
 import { NETWORK_DOCUMENT_COUNT_KEY } from "#/db/schema/network-stats";
 import {
   buildFollowFeedCandidateSql,
+  buildTagOverlapScoresSql,
   countNetworkDocuments,
   countNetworkDocumentsLive,
   selectFollowUris,
@@ -39,12 +40,25 @@ const RUN = process.env.FEED_PERF_TEST === "1";
 const READER_DID =
   process.env.FEED_PERF_READER_DID ?? "did:plc:m2sjv3wncvsasdapla35hzwj";
 
-/** Generous — Neon cold starts + the `documents` table growing over time. */
-const EXEC_TIME_BUDGET_MS = Number(
-  process.env.FEED_PERF_EXEC_BUDGET_MS ?? 1500,
-);
+/**
+ * Generous — Neon cold starts vary — but well under the 1651ms corpus-walk this
+ * replaced. The suppressed-old path measures 26-34ms warm once both direct
+ * branches ride their per-source composite index.
+ */
+const EXEC_TIME_BUDGET_MS = Number(process.env.FEED_PERF_EXEC_BUDGET_MS ?? 500);
 const PAGE_LIMIT = 22;
 const PAGE_OFFSET = 0;
+
+/**
+ * Looser than `EXEC_TIME_BUDGET_MS`: the tag scan touches thousands of heap
+ * pages, and a cold Neon page store turns a 254ms warm run into ~4.2s (with
+ * `dirtied`/`written` counts from first-touch hint bits). The seq-scan and
+ * index-usage assertions are the real guard; this only catches gross
+ * regressions like the 16.9s original.
+ */
+const TAG_OVERLAP_BUDGET_MS = Number(
+  process.env.FEED_PERF_TAG_BUDGET_MS ?? 6000,
+);
 
 describe.skipIf(!RUN)("follow-feed candidate query — EXPLAIN", () => {
   // EXPLAIN ANALYZE runs the query for real over the prod Neon RTT (~230ms),
@@ -56,6 +70,7 @@ describe.skipIf(!RUN)("follow-feed candidate query — EXPLAIN", () => {
     });
 
     assertNoSeqScanOnDocuments(plan);
+    assertPerSourceIndexScans(plan);
     assertExecTimeUnder(plan, EXEC_TIME_BUDGET_MS);
   }, 30_000);
 
@@ -66,6 +81,7 @@ describe.skipIf(!RUN)("follow-feed candidate query — EXPLAIN", () => {
     });
 
     assertNoSeqScanOnDocuments(plan);
+    assertPerSourceIndexScans(plan);
   }, 30_000);
 });
 
@@ -102,6 +118,66 @@ describe.skipIf(!RUN)("network document count — EXPLAIN", () => {
     expect(Math.abs(cached - live) / live).toBeLessThan(0.02);
   }, 60_000);
 });
+
+/**
+ * Related-articles tag overlap, on every article page.
+ *
+ * Before the GIN rewrite this planned a `Seq Scan on documents` over ~3M rows
+ * feeding an ~11.8M-row nested loop and a disk-spilling HashAggregate: 16.9s
+ * mean, 158.9s max, and 27% of all database time — which starved every other
+ * query on the compute, including the feed loaders above.
+ */
+describe.skipIf(!RUN)("related-articles tag overlap — EXPLAIN", () => {
+  test("tag overlap is served by documents_tags_norm_idx, not a scan", async () => {
+    const anchor = await selectTagAnchorDocument();
+    const plan = await explainSql(
+      buildTagOverlapScoresSql(anchor.uri, anchor.publicationUri),
+    );
+
+    assertNoSeqScanOnDocuments(plan);
+    // Positive assertion too: "no seq scan" alone would also pass if the
+    // planner swapped in some other non-indexed shape.
+    if (!/Bitmap Index Scan on documents_tags_norm_idx/.test(plan)) {
+      expect.fail(
+        `Plan does not use documents_tags_norm_idx — the tag predicate was ` +
+          `rewritten into a form the GIN index can't match (wrapping ` +
+          `\`tags\` in anything other than \`immutable_normalized_tags\` does ` +
+          `this). Full plan:\n\n${plan}`,
+      );
+    }
+    assertExecTimeUnder(plan, TAG_OVERLAP_BUDGET_MS);
+  }, 30_000);
+});
+
+/**
+ * A published document with enough tags to make the overlap scan non-trivial.
+ * Override with `FEED_PERF_TAG_ANCHOR_URI` to pin a specific known-heavy doc.
+ */
+async function selectTagAnchorDocument(): Promise<{
+  uri: string;
+  publicationUri: string | null;
+}> {
+  const pinned = process.env.FEED_PERF_TAG_ANCHOR_URI;
+  const result = await db.execute(
+    pinned
+      ? sql`select uri, publication_uri from documents where uri = ${pinned}`
+      : sql`select uri, publication_uri from documents
+            where deleted = false and published_at <= now()
+              and cardinality(tags) >= 5
+            limit 1`,
+  );
+  const row = (result.rows as Array<Record<string, unknown>>)[0];
+  if (!row) {
+    expect.fail(
+      "No tagged document found to anchor the tag-overlap EXPLAIN. Point " +
+        "DATABASE_URL at prod-scale data, or set FEED_PERF_TAG_ANCHOR_URI.",
+    );
+  }
+  return {
+    uri: row["uri"] as string,
+    publicationUri: (row["publication_uri"] as string | null) ?? null,
+  };
+}
 
 async function explainCandidate({
   unreadForDid,
@@ -159,6 +235,31 @@ function assertNoSeqScanOnDocuments(plan: string): void {
         `per-row correlated subquery (or the recommend aggregation was inlined ` +
         `across the join). Full plan:\n\n${plan}`,
     );
+  }
+}
+
+/**
+ * The two direct branches must each ride their per-source composite index.
+ *
+ * "No seq scan" alone does not catch the regression this replaced: collapsing
+ * the branches back into `where did in (...) or publication_uri in (...)` still
+ * plans an *Index* Scan — on `documents_published_idx`, walking the corpus
+ * newest-first and discarding ~257K rows to return 214 (1651ms). The
+ * distinguishing signal is *which* index, so assert on that.
+ */
+function assertPerSourceIndexScans(plan: string): void {
+  for (const index of [
+    "documents_publication_published_idx",
+    "documents_did_published_idx",
+  ]) {
+    if (!plan.includes(index)) {
+      expect.fail(
+        `Plan does not use ${index} — a direct follow branch fell back to a ` +
+          `corpus-ordered scan (usually: the two branches were merged back ` +
+          `into one \`OR\`, or the \`unnest ... cross join lateral\` was ` +
+          `rewritten as a bare \`in (...)\`). Full plan:\n\n${plan}`,
+      );
+    }
   }
 }
 

--- a/apps/standard-reader/src/server/reader/queries.ts
+++ b/apps/standard-reader/src/server/reader/queries.ts
@@ -483,16 +483,11 @@ export function buildFollowFeedCandidateSql(
     base.push(documentNotReadWhere(schema, opts.unreadForDid));
   const baseWhere = and(...base) ?? sql`true`;
 
-  const directParts: Array<SQL> = [inArray(d.did, followedUserDids)];
-  if (publicationUris.length > 0) {
-    directParts.push(inArray(d.publicationUri, publicationUris));
-  }
-  const directOr = or(...directParts) ?? sql`false`;
-
   // Cutoff strategy: apply the cutoff AFTER the union, on a small bounded
   // candidate pool — NOT inside each union branch. The union branches rely on an
-  // indexed `ORDER BY published_at DESC LIMIT k` scan (`documents_published_idx`)
-  // to stay cheap; joining the four cutoff CTEs *inside* each branch (the
+  // indexed `ORDER BY published_at DESC LIMIT k` scan (per-source composite
+  // indexes for the two direct branches below, `documents_published_idx` for the
+  // rest) to stay cheap; joining the four cutoff CTEs *inside* each branch (the
   // `countFollowedDocuments` shape) blocks that index pushdown and regresses to
   // walking ~364K documents + joining the cutoffs per row (~1.8s, verified via
   // EXPLAIN). `countFollowedDocuments` can use the in-branch join shape because
@@ -506,6 +501,66 @@ export function buildFollowFeedCandidateSql(
   // through only one followed source still gets that source's cutoff — matching
   // `readerSourceCutoffSql`'s `min` over the union.
   const poolK = suppressOld ? k * CUTOFF_POOL_MULT : k;
+
+  /**
+   * Newest-`poolK` documents for one class of followed source (publications, or
+   * authors), as a top-k-per-source lateral merged back down to `poolK`.
+   *
+   * The obvious form — a single branch with `where did in (...) or
+   * publication_uri in (...) order by published_at desc limit k` — is a trap.
+   * Neither IN-list is index-served under the `OR`, so Postgres walks
+   * `documents_published_idx` newest-first and filters: measured **257,677 rows
+   * discarded to return 214**, 1651ms of a 1672ms query, for a reader following
+   * ~177 publications + 9 authors. That cost scales with the whole corpus, so it
+   * degrades for every reader as `documents` grows.
+   *
+   * Splitting the `OR` into two branches is necessary but not sufficient — the
+   * planner still prefers the date index for a bare `in (...)`, and the unread
+   * `NOT EXISTS` pushes it back there even on the `did` branch (4603ms, 459,153
+   * rows discarded). Driving each branch from `unnest(...) cross join lateral`
+   * forces the per-source composite index
+   * (`documents_publication_published_idx` / `documents_did_published_idx`) —
+   * one bounded top-k scan per followed source. Measured: **40.5ms** for both
+   * branches together, now scaling with the reader's follow count instead of the
+   * corpus.
+   *
+   * `order by` must stay `desc nulls last` to match those indexes (see memory
+   * `drizzle-nulls-last-index-mismatch`).
+   */
+  const followedSourceBranch = (column: SQL, values: Array<string>): SQL => {
+    const list = sql.join(
+      values.map((value) => sql`${value}`),
+      sql`, `,
+    );
+    return sql`
+        (
+          select src_doc.uri as uri, src_doc.published_at as feed_at,
+                 src_doc.published_at as published_at, 0 as src,
+                 src_doc.publication_uri as publication_uri, src_doc.did as did
+          from unnest(array[${list}]::text[]) as src_key(value)
+          cross join lateral (
+            select ${d.uri} as uri, ${d.publishedAt} as published_at,
+                   ${d.publicationUri} as publication_uri, ${d.did} as did
+            from ${d}
+            where ${column} = src_key.value and ${baseWhere}
+            order by ${d.publishedAt} desc nulls last, ${d.uri} desc
+            limit ${poolK}
+          ) src_doc
+          order by src_doc.published_at desc nulls last, src_doc.uri desc
+          limit ${poolK}
+        )`;
+  };
+
+  // Followed authors is always non-empty in union mode (`selectArticleCards`
+  // short-circuits otherwise); publications can legitimately be empty.
+  const directBranches: Array<SQL> = [
+    followedSourceBranch(sql`${d.did}`, followedUserDids),
+  ];
+  if (publicationUris.length > 0) {
+    directBranches.push(
+      followedSourceBranch(sql`${d.publicationUri}`, publicationUris),
+    );
+  }
 
   const cutoffCtes = suppressOld
     ? sql`with
@@ -562,15 +617,7 @@ export function buildFollowFeedCandidateSql(
         u.uri as uri, u.feed_at as feed_at, u.published_at as published_at,
         u.publication_uri as publication_uri, u.did as did
       from (
-        (
-          select ${d.uri} as uri, ${d.publishedAt} as feed_at,
-                 ${d.publishedAt} as published_at, 0 as src,
-                 ${d.publicationUri} as publication_uri, ${d.did} as did
-          from ${d}
-          where ${baseWhere} and (${directOr})
-          order by ${d.publishedAt} desc nulls last, ${d.uri} desc
-          limit ${poolK}
-        )
+        ${sql.join(directBranches, sql` union all `)}
         union all
         (
           select ${d.uri} as uri, ${d.publishedAt} as feed_at,
@@ -3116,39 +3163,65 @@ async function coReadScoresForDocument(
   return result.rows as Array<ScoredUri>;
 }
 
-async function tagOverlapScoresForDocument(
-  db: Db,
+/**
+ * Cross-publication tag-overlap scores for one document.
+ *
+ * The candidate scan is gated by `immutable_normalized_tags(tags) && <anchor>`
+ * so `documents_tags_norm_idx` serves it — the same lesson as
+ * `documentCarriesTagWhere` / migration 0014, which this query predated. The
+ * `unnest(d.tags) ... WHERE lower(btrim(doc_tag)) IN (...)` form it replaces
+ * wrapped the column in functions the GIN index couldn't match, so the planner
+ * seq-scanned all ~3M `documents` rows into an ~11.8M-row nested loop and a
+ * disk-spilling HashAggregate: 16.9s mean, and **27% of all database time**
+ * across the fleet, since this fires on every article page view.
+ *
+ * The anchor stays a `MATERIALIZED` CTE rather than a second query — one round
+ * trip matters more than the SQL here (see memory `railway-neon-region-mismatch`).
+ * Scoring still unnests per candidate, but only over rows the index matched.
+ * Measured on the heaviest anchor (11 tags, ~18.9K matching docs): **254ms**.
+ */
+export function buildTagOverlapScoresSql(
   documentUri: string,
   publicationUri: string | null,
-): Promise<Array<ScoredUri>> {
+): SQL {
   const samePubFilter = publicationUri
     ? sql`AND d.publication_uri IS DISTINCT FROM ${publicationUri}`
     : sql``;
 
-  const result = await db.execute(sql`
-    WITH anchor_tags AS (
-      SELECT lower(btrim(tag)) AS tag
-      FROM documents d, unnest(d.tags) AS tag
-      WHERE d.uri = ${documentUri}
-        AND btrim(tag) <> ''
+  return sql`
+    WITH anchor AS MATERIALIZED (
+      SELECT immutable_normalized_tags(tags) AS tags
+      FROM documents
+      WHERE uri = ${documentUri}
     ),
     shared AS (
       SELECT d.uri,
              count(*)::float AS score
       FROM documents d,
-           unnest(d.tags) AS doc_tag
+           unnest(immutable_normalized_tags(d.tags)) AS doc_tag
       WHERE d.deleted = false
         AND d.uri != ${documentUri}
         AND d.published_at <= now()
         ${samePubFilter}
-        AND lower(btrim(doc_tag)) IN (SELECT tag FROM anchor_tags)
+        AND immutable_normalized_tags(d.tags) && (SELECT tags FROM anchor)
+        AND doc_tag = ANY((SELECT tags FROM anchor)::text[])
       GROUP BY d.uri
     )
     SELECT uri, score
     FROM shared
     ORDER BY score DESC
     LIMIT 30
-  `);
+  `;
+}
+
+async function tagOverlapScoresForDocument(
+  db: Db,
+  documentUri: string,
+  publicationUri: string | null,
+): Promise<Array<ScoredUri>> {
+  const result = await db.execute(
+    buildTagOverlapScoresSql(documentUri, publicationUri),
+  );
 
   return result.rows as Array<ScoredUri>;
 }


### PR DESCRIPTION
## Why

`/latest` (and everything else) was taking forever on signed-in accounts. The traces said it wasn't `/latest`'s fault: in one 5-minute window **every** server fn stalled at once, including `user.getShellBootstrap` at 1.4–2.1s when its global p95 is **0.47ms**. Global p50 stayed a healthy 5ms with p95 bursting to ~100s — that's compute saturation, not a slow route.

`pg_stat_statements` over 6.7 days: **68.1 DB CPU-hours**. Two queries account for most of it, and both have an index that fits — neither could reach it.

> There's no DB-level span instrumentation, so a 25.9s `feed.getLatestFeed` trace has only two spans and attributes nothing. This was found by going to `pg_stat_statements` directly. Worth adding query spans at some point.

## 1. Related-articles tag overlap — 27.4% of all database time

`tagOverlapScoresForDocument` matched via `unnest(d.tags) ... WHERE lower(btrim(doc_tag)) IN (...)`, wrapping the column in functions `documents_tags_norm_idx` can't match:

```
Seq Scan on documents  (rows=2,958,694)      ← full 12GB scan
  → Nested Loop unnest  (rows=11,834,776)
    → HashAggregate, Planned Partitions: 128 ← spills to disk
```

16.9s mean, 158.9s max, **on every article page view**. Gating the scan on `immutable_normalized_tags(tags) && <anchor>` lets the GIN index serve it — the same fix `documentCarriesTagWhere` already carries for migration 0014, which this query predated.

**16.9s → 254ms** on the heaviest anchor (11 tags, ~18.9K matching docs).

## 2. `/latest` follow-feed candidates — 1672ms → 26–34ms

Not the cutoff CTEs — those cost ~1ms. It was the direct-source branch:

```
Index Scan using documents_published_idx  (actual time=2.228..1651.811 rows=214)
  Filter: (did = ANY(...9 dids...)) OR (publication_uri = ANY(...177 uris...))
  Rows Removed by Filter: 257,677
```

**1651ms of the 1672ms.** Under the `OR` neither IN-list is index-served, so Postgres walks the date index newest-first and discards a quarter-million rows to find 214 — scaling with the **corpus**, so it degraded for everyone as `documents` grew.

Splitting the `OR` is necessary but **not sufficient**:

| attempt | result |
|---|---|
| original combined `OR` | 1651ms, 257,677 rows discarded |
| split into two branches | 894ms — planner still picks the date index |
| split + unread `NOT EXISTS` | **4603ms** — `did` branch regresses too, 459,153 discarded |
| `unnest(...) cross join lateral` per source | **40.5ms**, both composite indexes used |

Driving each branch from a lateral forces one bounded top-k scan per followed source, so cost now scales with follow count instead of corpus size.

**No migration** — `documents_publication_published_idx` and `documents_did_published_idx` both already existed and were simply unreachable.

## Verification

This rewrites a feed people actually read, so I checked output, not just timing.

Candidate URIs dumped under old and new code across **3 readers × 8 parameter combinations** (cutoff on/off × offset 0/22 × unread on/off), including a 2-follow account and one with no publications:

```
did:plc:m2sjv3wncvsasdapla35hzwj  IDENTICAL (all 8 cases)
did:plc:i6qphls4tfpdcsb6jktkygrr  IDENTICAL (all 8 cases)
did:plc:qrmtco7xjszr76cls33gsiso  IDENTICAL (all 8 cases)
```

Same URIs, same order. Tag overlap returns the same 30 rows; 3 differ only by tie-break among rows that **all score 3** — an ambiguity both versions share, since neither has a tiebreaker after `ORDER BY score DESC`. Worth adding `, uri DESC` sometime if you want stable rails.

`typecheck`, `lint` (0 errors), `format:check` clean. Full suite **780 passed, 0 failures**. Gated EXPLAIN spec **5/5** — including the `suppressed-old` case that fails on `main`.

## Guards

The existing `no Seq Scan on documents` assertion **would not have caught** the feed regression — it plans an *Index* Scan, just on the wrong index. Both new guards assert on index name instead:

- tag overlap must use `documents_tags_norm_idx`
- both direct branches must use their per-source composite index
- exec budget tightened **1500ms → 500ms** (>10x headroom over 34ms, well under the 1651ms regression)

## Not done

- **`pnpm perf:test:signed-in`** wasn't run — needs a dev server and session token. The EXPLAIN plus byte-identical output is stronger evidence, but worth a wall-clock confirmation before deploy.
- **The hourly recompute cron** is still outstanding: 161 runs/6.7d, each ~5 min of heavy DB work (`discover_topic_counts` 119s mean, `trending_score` UPDATE 63s) against the same compute serving live traffic. That likely wants a read replica or off-peak scheduling rather than a query rewrite — a bigger call, left for a separate change.
- The 40s means in `pg_stat_statements` were partly contention from #1, so the deployed win should look larger than the isolated numbers; the two fixes compound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)