### PR TITLE
Stop the hourly recompute sweep rewriting rows that didn't change

### DIFF
--- a/apps/standard-reader/scripts/topics-cron.ts
+++ b/apps/standard-reader/scripts/topics-cron.ts
@@ -13,8 +13,13 @@
  * than that, and the sweep's own caching means a run that finds no drift makes
  * no naming calls at all.
  *
- * Reads `discover_topic_counts` for its vocabulary, which the hourly sweep
- * rebuilds — so this only needs the counts to exist, not to have just run.
+ * Refreshes `discover_topic_counts` first, then derives from it. Those counts
+ * used to be rebuilt by the hourly sweep, but their aggregation is a full
+ * `documents` × tags scan (~119s) and an hour of ingest moves 85 of their 1.05M
+ * rows — so hourly cost two minutes of contention against live traffic for
+ * 0.008% drift. Daily is the right cadence, and running it here means the
+ * vocabulary this script clusters is the freshest available rather than up to
+ * an hour stale.
  *
  * Env:
  *   ANTHROPIC_API_KEY       enables naming; without it clusters fall back to a
@@ -25,15 +30,19 @@
  */
 
 import { recomputeTopics } from "../src/server/ingest/recompute-topics.ts";
+import { recomputeDiscoverTopicCounts } from "../src/server/ingest/recompute.ts";
 import { logEvent } from "../src/server/observability/log.ts";
 
 const startedAt = Date.now();
 
 try {
+  await recomputeDiscoverTopicCounts();
+  const countsMs = Date.now() - startedAt;
+
   const summary = await recomputeTopics();
   const durationMs = Date.now() - startedAt;
 
-  logEvent("topics.cron", { durationMs, ...summary });
+  logEvent("topics.cron", { countsMs, durationMs, ...summary });
   console.info(
     `[topics-cron] ${summary.published} published from ${summary.clusters} clusters ` +
       `(${summary.tags} tags, ${summary.edges} edges, ${summary.semanticEdges} semantic), ` +

--- a/apps/standard-reader/src/db/schema/discover-topics.ts
+++ b/apps/standard-reader/src/db/schema/discover-topics.ts
@@ -7,10 +7,12 @@ import { index, integer, pgTable, text } from "drizzle-orm/pg-core";
  * — via an explicit `publications.topic` OR any of the publication's document
  * tags — which is exactly how many a reader reaches by selecting the chip.
  *
- * Rebuilt each sweep by `recomputeTopicCounts()`. Reading from this table keeps the
- * Discover request path off a ~2s network-wide `unnest(tags)` aggregation; the
- * cron already scans every tag to derive per-publication dominant topics, so
- * populating this is near-free marginal work.
+ * Refreshed daily by `recomputeDiscoverTopicCounts()` on the topic cron, which
+ * diffs against the live table rather than rebuilding it — an hour of ingest
+ * moves ~85 of these 1.05M rows, so a full `DELETE` + `INSERT` was rewriting
+ * the heap and all three indexes below to persist almost nothing. Reading from
+ * this table keeps the Discover request path off a ~2s network-wide
+ * `unnest(tags)` aggregation.
  */
 export const discoverTopicCounts = pgTable(
   "discover_topic_counts",

--- a/apps/standard-reader/src/server/ingest/recompute.ts
+++ b/apps/standard-reader/src/server/ingest/recompute.ts
@@ -269,6 +269,22 @@ export async function recomputeDocumentBacklinks(): Promise<number> {
 /**
  * Precompute per-document trending scores for the recency-gated candidate set.
  * Articles below the distinct-recommender floor get score 0.
+ *
+ * **Only rows whose score actually moved are written.** This used to open with
+ * a blanket `UPDATE ... SET trending_score = 0` over every eligible document,
+ * then immediately overwrite all of them with their real score. Measured, the
+ * two passes targeted *the same 24,602 rows* — symmetric difference zero in
+ * both directions — so every eligible document was written twice an hour, and
+ * the zeroing pass alone cost 62.9s mean / 10,063s total over 6.7 days, ~3x the
+ * scoring pass it was priming.
+ *
+ * That is expensive out of proportion to the row count because `trending_score`
+ * is indexed (`documents_trending_idx`), so each write is a non-HOT update: a
+ * new tuple version in *every* index on a 12GB table, including the tags GIN.
+ * And of the 24,602 eligible documents only ~13 carry a non-zero score — the
+ * rest were rewriting 0 over 0. The `IS DISTINCT FROM` guard on the scoring
+ * update skips those; `trending_recomputed_at` stops advancing for skipped
+ * rows, which is free because nothing reads that column.
  */
 export async function recomputeDocumentTrending(): Promise<void> {
   const maxAge = TRENDING_MAX_AGE_DAYS;
@@ -279,24 +295,6 @@ export async function recomputeDocumentTrending(): Promise<void> {
   const wBl = ARTICLE_BLEND.backlinks;
   const wBlVel = ARTICLE_BLEND.backlinkVelocity;
   const wPub = ARTICLE_BLEND.parentPublication;
-
-  await db.execute(sql`
-    UPDATE documents d
-    SET trending_score = 0,
-        distinct_recommender_count = 0,
-        trending_recomputed_at = now()
-    WHERE d.deleted = false
-      AND d.publication_uri IS NOT NULL
-      AND EXISTS (
-        SELECT 1 FROM publications p
-        WHERE p.uri = d.publication_uri
-          AND p.deleted = false
-          AND p.show_in_discover = true
-          AND p.url NOT ILIKE ${EXCLUDED_PUBLICATION_URL_PATTERN}
-          AND d.published_at > now() - (${maxAge}::text || ' days')::interval
-          AND d.published_at <= now()
-      )
-  `);
 
   await db.execute(sql`
     WITH eligible AS (
@@ -391,6 +389,38 @@ export async function recomputeDocumentTrending(): Promise<void> {
         trending_recomputed_at = now()
     FROM scored sc
     WHERE d.uri = sc.uri
+      AND (d.trending_score IS DISTINCT FROM sc.score
+           OR d.distinct_recommender_count IS DISTINCT FROM sc.distinct_cnt)
+  `);
+
+  // Clear scores left on documents that have since fallen out of the candidate
+  // set — aged past the window, unpublished, deleted, or on a publication that
+  // left Discover. The old zeroing pass never did this: its predicate selected
+  // *eligible* rows, so anything that aged out kept its last score forever (276
+  // such rows at the time of writing, against 13 legitimately current ones).
+  // Readers are unaffected either way — every trending query re-applies the
+  // same recency gate — but leaving the column lying is a trap for the next
+  // caller who trusts it without the gate.
+  //
+  // Cheap despite naming no candidate set: `documents_trending_idx` makes
+  // `trending_score <> 0` an index scan over the handful of scored rows, and
+  // the NOT EXISTS is a primary-key probe per row.
+  await db.execute(sql`
+    UPDATE documents d
+    SET trending_score = 0,
+        distinct_recommender_count = 0,
+        trending_recomputed_at = now()
+    WHERE d.trending_score <> 0
+      AND NOT EXISTS (
+        SELECT 1 FROM publications p
+        WHERE p.uri = d.publication_uri
+          AND p.deleted = false
+          AND p.show_in_discover = true
+          AND p.url NOT ILIKE ${EXCLUDED_PUBLICATION_URL_PATTERN}
+          AND d.deleted = false
+          AND d.published_at > now() - (${maxAge}::text || ' days')::interval
+          AND d.published_at <= now()
+      )
   `);
 }
 

--- a/apps/standard-reader/src/server/ingest/recompute.ts
+++ b/apps/standard-reader/src/server/ingest/recompute.ts
@@ -498,14 +498,22 @@ export async function recomputeCosubscriptions(): Promise<void> {
  * non-deleted documents, normalized (trimmed + lowercased), ties broken
  * alphabetically. Publications with no tagged documents are reset to null.
  *
- * The Discover directory's topic chips can then be built from the top-N topics
- * by publication count.
+ * The Discover directory's topic chips are built from these by
+ * {@link recomputeDiscoverTopicCounts}, which runs on a slower cadence — this
+ * pass stays in the hourly sweep because it is ~15s and a new publication
+ * should get a topic promptly.
  */
-export async function recomputeTopicCounts(): Promise<void> {
-  // Clear stale topics first so removed tags don't linger.
-  await db.execute(
-    sql`UPDATE publications SET topic = NULL WHERE topic IS NOT NULL`,
-  );
+export async function recomputePublicationTopics(): Promise<void> {
+  // One pass, and it writes only the publications whose dominant tag actually
+  // moved. The previous shape was `UPDATE ... SET topic = NULL` (every row with
+  // a topic) followed by a re-set of every ranked row — two full rewrites of
+  // `publications` per sweep, plus the `updated_at` index churn behind them,
+  // to change a handful of topics.
+  //
+  // The `LEFT JOIN top` is what lets one statement do both jobs: publications
+  // that still have a dominant tag get it, and publications whose last tagged
+  // document went away land on `t.tag IS NULL` and are reset. `IS DISTINCT
+  // FROM` skips the rest.
   await db.execute(sql`
     WITH tag_counts AS (
       SELECT d.publication_uri AS uri,
@@ -521,24 +529,53 @@ export async function recomputeTopicCounts(): Promise<void> {
       SELECT uri, tag,
              row_number() OVER (PARTITION BY uri ORDER BY n DESC, tag ASC) AS rk
       FROM tag_counts
+    ),
+    top AS (
+      SELECT uri, tag FROM ranked WHERE rk = 1
+    ),
+    changed AS (
+      SELECT p.uri, t.tag
+      FROM publications p
+      LEFT JOIN top t ON t.uri = p.uri
+      WHERE p.topic IS DISTINCT FROM t.tag
     )
     UPDATE publications p
-    SET topic = r.tag, updated_at = now()
-    FROM ranked r
-    WHERE r.uri = p.uri AND r.rk = 1
+    SET topic = c.tag, updated_at = now()
+    FROM changed c
+    WHERE c.uri = p.uri
   `);
+}
 
-  // Rebuild the network-wide topic counts that power the Discover topic filter.
-  // The chip list and its search read this table instead of running a ~2s
-  // `unnest(tags)` aggregation on the request path. A transaction keeps
-  // concurrent readers on the prior snapshot until commit, so the chips never
-  // briefly empty mid-sweep. `publication_count` is a distinct-publication count
-  // per tag (the UNION dedupes each publication's repeated tags), matching the
-  // chip click path (`topicMatch: "document"`).
+/**
+ * Rebuild the network-wide topic counts behind the Discover topic filter.
+ *
+ * The chip list and its search read this table instead of running a ~2s
+ * `unnest(tags)` aggregation on the request path. `publication_count` is a
+ * distinct-publication count per tag (the UNION dedupes each publication's
+ * repeated tags), matching the chip click path (`topicMatch: "document"`).
+ *
+ * **Diffed, not rebuilt.** This used to `DELETE FROM discover_topic_counts`
+ * and re-`INSERT` the whole table inside a transaction — 1,056,381 rows, and
+ * with them the primary key, the count btree, and the trigram GIN index, every
+ * hour. Measured against a live snapshot, an hour of ingest moves **85 rows out
+ * of 1,056,446: 20 changed, 65 new, 0 removed** (0.008%). So the sweep was
+ * rewriting a million rows and three indexes to persist eighty-five.
+ *
+ * Now the aggregation lands in a transaction-scoped temp table and only the
+ * difference is applied: `DO UPDATE ... WHERE ... IS DISTINCT FROM` skips rows
+ * whose count is unchanged, so an unchanged row costs no heap write and no
+ * index maintenance. Still one transaction, so concurrent readers see the prior
+ * snapshot until commit and the chips never briefly empty.
+ *
+ * The aggregation itself is an unavoidable full scan of `documents` × their
+ * tags — it is a global count, so no index can narrow it (unlike
+ * `documentCarriesTagWhere`, which can). That read is why this runs on the
+ * daily topic cron rather than in the hourly sweep; see `scripts/topics-cron.ts`.
+ */
+export async function recomputeDiscoverTopicCounts(): Promise<void> {
   await db.transaction(async (tx) => {
-    await tx.execute(sql`DELETE FROM discover_topic_counts`);
     await tx.execute(sql`
-      INSERT INTO discover_topic_counts (topic, publication_count)
+      CREATE TEMP TABLE fresh_topic_counts ON COMMIT DROP AS
       WITH eligible AS (
         SELECT p.uri, p.topic
         FROM publications p
@@ -561,6 +598,25 @@ export async function recomputeTopicCounts(): Promise<void> {
       FROM pub_topic
       WHERE char_length(topic) BETWEEN 1 AND 128
       GROUP BY topic
+    `);
+    // Both statements below probe this table per row across ~1M rows; without
+    // the index (and stats for it) they plan as nested-loop scans.
+    await tx.execute(sql`CREATE UNIQUE INDEX ON fresh_topic_counts (topic)`);
+    await tx.execute(sql`ANALYZE fresh_topic_counts`);
+
+    await tx.execute(sql`
+      DELETE FROM discover_topic_counts d
+      WHERE NOT EXISTS (
+        SELECT 1 FROM fresh_topic_counts f WHERE f.topic = d.topic
+      )
+    `);
+    await tx.execute(sql`
+      INSERT INTO discover_topic_counts (topic, publication_count)
+      SELECT topic, publication_count FROM fresh_topic_counts
+      ON CONFLICT (topic) DO UPDATE
+        SET publication_count = excluded.publication_count
+        WHERE discover_topic_counts.publication_count
+              IS DISTINCT FROM excluded.publication_count
     `);
   });
 }
@@ -902,11 +958,17 @@ export async function recomputeDerived(): Promise<void> {
   await recomputePublicationStats();
   await recomputeCosubscriptions();
   await recomputeCorecommends();
-  await recomputeTopicCounts();
+  await recomputePublicationTopics();
   // Topic derivation is deliberately NOT here — it clusters the whole tag
   // graph and calls the naming model, which is minutes of work whose output
   // barely moves hour to hour. It runs on its own daily schedule instead;
   // see `scripts/topics-cron.ts`.
+  //
+  // `recomputeDiscoverTopicCounts()` moved there too, for the same reason: its
+  // aggregation is a full `documents` × tags scan (~119s, the single most
+  // expensive statement in this sweep) and an hour of ingest moves 85 of its
+  // 1.05M rows. Hourly bought nothing and put two minutes of scan in front of
+  // live traffic every hour.
   await recomputeSerialKinds();
   await recomputeDocumentTrending();
   // Last: dedup + the passes above are what change the eligible-document set,

--- a/apps/standard-reader/src/server/reader/queries.ts
+++ b/apps/standard-reader/src/server/reader/queries.ts
@@ -1981,8 +1981,8 @@ export async function countKnownPublications(db: Db): Promise<number> {
  * `topicMatch: "document"` — matching a publication's effective topic OR any of
  * its document tags — so every chip is guaranteed to return results.
  *
- * Reads the precomputed `discover_topic_counts` table (rebuilt each sweep by
- * `recomputeTopicCounts()`); aggregating the vocabulary live is a ~2s network-wide
+ * Reads the precomputed `discover_topic_counts` table (refreshed daily by
+ * `recomputeDiscoverTopicCounts()`); aggregating the vocabulary live is a ~2s network-wide
  * `unnest(tags)` scan, far too slow for this request-path, Suspense-gated
  * query. `query`, when set, filters the vocabulary by a case-insensitive
  * substring (trigram-indexed) so the popover search can reach tags past the


### PR DESCRIPTION
Follow-up to #130. Independent of it — different files, branched from `main`, mergeable in either order.

Two fixes in the hourly recompute sweep, same root cause: **rewriting rows whose values didn't change.** Together they were ~29,000 of the sweep's ~47,000 seconds of DB time over 6.7 days.

---

# 1. Topic counts: diff, don't rebuild

`recomputeTopicCounts()` was the sweep's most expensive statement — **119s mean, 140s max, 19,124s total**. It ran `DELETE FROM discover_topic_counts` then a full `INSERT … SELECT`, rewriting **1,056,381 rows** plus the primary key, the count btree, and a **trigram GIN index**, every hour.

How much actually changes in an hour:

```
fresh_rows | current_rows | unchanged | changed | new | gone
   1056446 |      1056381 |   1056361 |      20 |  65 |    0
```

**85 rows out of 1,056,446. 0.008%.**

The aggregation now lands in a transaction-scoped temp table — indexed and `ANALYZE`d, since both follow-up statements probe it per row across ~1M rows — and only the difference is applied. Still one transaction, so readers stay on the prior snapshot and the chips never briefly empty.

Same treatment for `publications.topic`, which was two full rewrites per sweep (null every row with a topic, then re-set every ranked row). One statement now, with `LEFT JOIN top` so publications that lost their last tagged document still reset.

### Split the cadence

| | cost | cadence | why |
|---|---|---|---|
| `recomputePublicationTopics()` | ~15s | **stays hourly** | a new publication should get a topic promptly |
| `recomputeDiscoverTopicCounts()` | ~119s | **moves to daily** | full `documents` × tags scan; 0.008% hourly drift |

The counts aggregation is a *global* count, so unlike `documentCarriesTagWhere` no index can narrow it — the only lever is running it less. It moves next to `recomputeTopics()`, which already runs daily for exactly this reason **and consumes these counts as its vocabulary**, so it now reads them fresh instead of up to an hour stale.

---

# 2. Trending: stop writing every row twice

`recomputeDocumentTrending()` opened with a blanket `UPDATE documents SET trending_score = 0` over every eligible document, then immediately overwrote all of them with their real score. The two passes target **the same 24,602 rows** — symmetric difference zero in both directions:

```
zeroed_rows | scored_rows | zeroed_not_scored | scored_not_zeroed
      24602 |       24602 |                 0 |                 0
```

The zeroing pass cost **62.9s mean / 10,063s total — ~3x the scoring pass it was priming.** Expensive out of proportion to the row count because `trending_score` is indexed (`documents_trending_idx`), making each write a non-HOT update: a new tuple version in *every* index on a 12GB table, including the tags GIN.

Dropped it — the scoring pass already assigns 0 to sub-floor documents via its own `CASE`.

Added an `IS DISTINCT FROM` guard to the scoring update: of 24,594 eligible documents only **13** carry a non-zero score, so the rest were rewriting 0 over 0 every hour. `trending_recomputed_at` stops advancing for skipped rows, which costs nothing — nothing in the codebase reads that column.

**Per sweep: 49,188 row writes → 289.**

### A staleness bug the old pass never fixed

The zeroing pass's predicate selected *eligible* rows, so a document that aged out of the 4-day window kept its last score forever — **276 such rows against 13 legitimately current ones.** Readers were unaffected (every trending query re-applies the recency gate), but the column was lying. The replacement cleanup is index-served off `documents_trending_idx`, scanning only the handful of scored rows.

---

# Verification

Everything below ran against **prod inside a rolled-back transaction** — real data, nothing persisted.

**`discover_topic_counts`** — final state identical to a full rebuild:
```
final_rows | expected_rows | extra_or_wrong | missing | rows_actually_written
   1056467 |       1056467 |              0 |       0 |                  117
```

**`publications.topic`** — old vs new compared in one transaction (run new, restore, run old, diff):
```
old_not_in_new | new_not_in_old | old_rows_touched
             0 |              0 |             5901
```
Identical final state; old wrote 11,802 row versions, new wrote **0**.

**Trending** — same set, same counts, same order:
```
scored_rows | nonzero_run1 | nonzero_run2 | set_diff | cnt_diff | rank_changes
      24583 |           13 |           13 |        0 |        0 |            0
```

> **One thing worth knowing:** the trending scores are not bitwise reproducible. Two evaluations of the *unchanged* query in one transaction, with `now()` fixed, agree on **zero of 13 rows** (max delta 0.0042) — parallel float aggregation in the `stats` CTE. This is pre-existing, and the control experiment above is why the old-vs-new comparison shows differing floats. It is far below the resolution separating any two documents, so membership and ranking are unaffected (`rank_changes = 0`). It does mean the new guard can't skip non-zero rows even when unchanged; the win comes entirely from the ~24.5K rows sitting at exactly 0.

`typecheck`, `lint` (0 errors), `format:check` clean on changed files. Full suite **747 passed, 0 failures**.

> `APP_VISION.md` / `TODO.md` fail `format:check`, but they do on `main` too — pre-existing, deliberately not swept into this diff.

# Deploy note

`recomputeDiscoverTopicCounts()` now runs **only** on the topics cron. If that schedule isn't enabled in Railway, the counts go stale rather than merely slow — worth confirming before merge. No migration, no schema change.

# Not fixed

The recompute's `eligible` set inner-joins `publications`, so **loose documents (no publication) never get a trending score** — while the read path's `discoverEligibleArticleWhere` explicitly treats them as eligible. That inconsistency is pre-existing and changing it would alter what appears in trending, so it's left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)