### PR TITLE
Ensure every comment card links to its comment

### DIFF
--- a/apps/extension/src/components/PopupArticleDiscussion.tsx
+++ b/apps/extension/src/components/PopupArticleDiscussion.tsx
@@ -30,6 +30,7 @@ import { MessageCircle, X } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { initials } from "#/components/reader/format";
+import { commentLink } from "#/lib/comment-permalink";
 // The extension is not localized yet (its strings are a separate i18n
 // surface), so it pins the default locale to preserve prior behaviour —
 // `formatRelativeTime` used to be hardcoded to English in `format.ts`.
@@ -300,7 +301,12 @@ function DiscussionCommentCard({
       ? "on Margin"
       : comment.source === "semble"
         ? "on Semble"
-        : "on Bluesky";
+        : comment.source === "note"
+          ? "on pckt"
+          : comment.source === "leaflet"
+            ? "on Leaflet"
+            : "on Bluesky";
+  const link = commentLink(comment);
 
   return (
     <article {...stylex.props(styles.commentCard)}>
@@ -326,7 +332,7 @@ function DiscussionCommentCard({
       </Flex>
 
       <a
-        href={comment.postUrl}
+        href={link.href}
         target="_blank"
         rel="noreferrer"
         {...stylex.props(styles.commentLink)}

--- a/apps/extension/src/lib/types.ts
+++ b/apps/extension/src/lib/types.ts
@@ -78,7 +78,7 @@ export type ExtensionNarrationResponse = {
 };
 
 export type ExtensionDiscussionComment = {
-  source: "bluesky" | "margin" | "semble";
+  source: "bluesky" | "margin" | "semble" | "note" | "leaflet";
   kind: "link" | "quote";
   postUri: string;
   postUrl: string;

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -564,6 +564,17 @@ Build each on hip-ui components + StyleX tokens (no raw HTML/inline styles).
         stored `backlink_count_prev` of 0, so `bl_vel` spikes for one cycle. Flatten it with
         `UPDATE documents SET backlink_count_prev = backlink_count WHERE backlink_synced_at > now() - interval '1 hour'`
         after that lap, or accept one skewed trending cycle.
+- [x] **Article discussion — every card links to its comment** (2026-08-09). Bluesky cards had
+      always linked out to the post; Leaflet cards often rendered unlinked because
+      `leafletCommentDrawerUrl` decided "is this Leaflet?" by sniffing for a `leaflet.pub` host —
+      the exact custom-domain miss `publishing-platform.ts` documents — so every Leaflet
+      publication on its own domain lost its link. The check now runs through
+      `publishingPlatform` (content format first, host as fallback, Skyreader linkblogs still
+      vetoed), and `commentLink` (`src/lib/comment-permalink.ts`) gives any source that still
+      can't build a platform permalink a PDSLS record link, so no card renders unlinked. The
+      card's accessible name only names a platform when the link actually goes there. Same helper
+      in the extension popup, whose copy of `ExtensionDiscussionComment` had also drifted — it was
+      missing `note` / `leaflet`, labelling pckt and Leaflet comments "on Bluesky".
 - [x] **Page reader (Listen)** — on-device TTS for the reading view via `kokoro-js` (lazy-loaded on first use; `src/lib/page-reader/*`). Top-bar "Listen" button reads the whole article; selection toolbar adds "Read from here". The transport is a floating action bar (`PageReaderBar`) docked above the bottom nav on every route — same position on desktop and mobile — with status/time, title, back-15s, accent play/pause, speed menu, close, and a thin draggable seek track; the article keeps its own scroll-progress bar (`PageReaderProvider` + `PageReaderBar`).
 - [x] **Publication profile** — banner + inline header (avatar/topic/name/desc/stats/Copy DID/Follow),
       recent writing (infinite scroll via `publicationApi.getPublicationDocuments` offset

--- a/apps/standard-reader/src/components/reader/comments/comment-card.tsx
+++ b/apps/standard-reader/src/components/reader/comments/comment-card.tsx
@@ -12,6 +12,7 @@ import { AuthorProfileLink } from "#/components/reader/author-profile-link";
 import type { DocumentComment } from "#/integrations/tanstack-query/api-comments.functions";
 import type { JsonValue } from "#/integrations/tanstack-query/api-shapes";
 import { authorProfilePath } from "#/lib/author-profile";
+import { commentLink } from "#/lib/comment-permalink";
 import { segmentFacetedText, shiftFacets } from "#/lib/leaflet/facets";
 import { utf8ByteLength } from "#/lib/leaflet/utf8";
 import { useFormatters } from "#/lib/use-formatters";
@@ -190,8 +191,12 @@ export function CommentCard({ comment }: { comment: DocumentComment }) {
           : comment.source === "leaflet"
             ? t`on Leaflet`
             : t`on Bluesky`;
-  const openLabel =
-    comment.source === "margin"
+  const link = commentLink(comment);
+  // Only name the platform when the link actually goes there — the record-viewer
+  // fallback does not, and a link whose accessible name lies about its
+  // destination is worse than a plainly-labelled one.
+  const openLabel = link.native
+    ? comment.source === "margin"
       ? t`Open this note on Margin`
       : comment.source === "semble"
         ? t`Open this note on Semble`
@@ -199,8 +204,8 @@ export function CommentCard({ comment }: { comment: DocumentComment }) {
           ? t`Open this note on pckt`
           : comment.source === "leaflet"
             ? t`Open this comment on Leaflet`
-            : t`Open this reply on Bluesky`;
-  const hasLink = comment.postUrl.trim().length > 0;
+            : t`Open this reply on Bluesky`
+    : t`Open this comment record`;
 
   const body = (
     <>
@@ -234,21 +239,19 @@ export function CommentCard({ comment }: { comment: DocumentComment }) {
   );
 
   return (
-    <div
-      {...stylex.props(commentStyles.card, hasLink && commentStyles.cardLinked)}
-    >
-      {hasLink ? (
-        // Stretched overlay link — a sibling of the header and facet links,
-        // not their ancestor, so no nested <a>. Covers the whole card so the
-        // hover highlight (`cardLinked`, above) matches the click target.
-        <a
-          href={comment.postUrl}
-          target="_blank"
-          rel="noreferrer"
-          aria-label={openLabel}
-          {...stylex.props(commentStyles.cardBodyOverlay)}
-        />
-      ) : null}
+    <div {...stylex.props(commentStyles.card, commentStyles.cardLinked)}>
+      {/*
+        Stretched overlay link — a sibling of the header and facet links, not
+        their ancestor, so no nested <a>. Covers the whole card so the hover
+        highlight (`cardLinked`, above) matches the click target.
+      */}
+      <a
+        href={link.href}
+        target="_blank"
+        rel="noreferrer"
+        aria-label={openLabel}
+        {...stylex.props(commentStyles.cardBodyOverlay)}
+      />
       <div {...stylex.props(commentStyles.cardHeader)}>
         <AuthorProfileLink
           authorRef={comment.author.did}

--- a/apps/standard-reader/src/lib/comment-permalink.test.ts
+++ b/apps/standard-reader/src/lib/comment-permalink.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { commentLink } from "./comment-permalink";
+
+const POST_URI = "at://did:plc:example/pub.leaflet.comment/3mqsc4nqyj22u";
+
+describe("commentLink", () => {
+  it("uses the platform permalink when the source built one", () => {
+    expect(
+      commentLink({
+        postUri: POST_URI,
+        postUrl: "https://bsky.app/profile/did:plc:example/post/abc",
+      }),
+    ).toEqual({
+      href: "https://bsky.app/profile/did:plc:example/post/abc",
+      native: true,
+    });
+  });
+
+  it("falls back to the record viewer so no card renders unlinked", () => {
+    expect(commentLink({ postUri: POST_URI, postUrl: "" })).toEqual({
+      href: `https://pdsls.dev/${POST_URI}`,
+      native: false,
+    });
+    expect(commentLink({ postUri: POST_URI, postUrl: "   " }).native).toBe(
+      false,
+    );
+  });
+});

--- a/apps/standard-reader/src/lib/comment-permalink.ts
+++ b/apps/standard-reader/src/lib/comment-permalink.ts
@@ -1,0 +1,33 @@
+/**
+ * Where a Discussion card opens.
+ *
+ * Every comment we render is a real AT Protocol record, so every card should be
+ * a link to that comment — the way Bluesky comments have always linked to the
+ * post on bsky.app. Most sources can build a permalink on their own platform
+ * (`postUrl`), but some can't for some records: Leaflet has no per-comment URL
+ * and needs the document's own URL to open its comment drawer, so a Leaflet
+ * document we only know by AT-URI leaves `postUrl` empty. Cards in that state
+ * used to render unlinked, which is the one case this module removes.
+ *
+ * The fallback is PDSLS, the ecosystem's record viewer: not the authoring
+ * platform, but it does show the reader the actual comment. `native` says which
+ * of the two a caller got, so the link's accessible name can be honest about
+ * where it goes.
+ */
+
+import { buildPdslsRecordUrl } from "#/lib/quote-share";
+
+export interface CommentLink {
+  href: string;
+  /** True for a permalink on the comment's own platform. */
+  native: boolean;
+}
+
+export function commentLink(comment: {
+  postUri: string;
+  postUrl: string;
+}): CommentLink {
+  const platformUrl = comment.postUrl.trim();
+  if (platformUrl) return { href: platformUrl, native: true };
+  return { href: buildPdslsRecordUrl(comment.postUri), native: false };
+}

--- a/apps/standard-reader/src/lib/leaflet/comment.test.ts
+++ b/apps/standard-reader/src/lib/leaflet/comment.test.ts
@@ -278,16 +278,54 @@ describe("extractLeafletQuoteText", () => {
 describe("leafletCommentDrawerUrl", () => {
   it("builds a drawer link for leaflet.pub-hosted publications", () => {
     expect(
-      leafletCommentDrawerUrl("https://foo.leaflet.pub/3mqsc4nqyj22u"),
+      leafletCommentDrawerUrl({
+        canonicalUrl: "https://foo.leaflet.pub/3mqsc4nqyj22u",
+        contentFormat: null,
+      }),
     ).toBe("https://foo.leaflet.pub/3mqsc4nqyj22u?interactionDrawer=comments");
   });
 
-  it("returns null for publications hosted elsewhere", () => {
-    expect(leafletCommentDrawerUrl("https://example.com/post")).toBeNull();
+  it("builds a drawer link for a Leaflet publication on a custom domain", () => {
     expect(
-      leafletCommentDrawerUrl("https://notleaflet.pub.evil.com/x"),
+      leafletCommentDrawerUrl({
+        canonicalUrl: "https://blog.example/some-post",
+        contentFormat: "pub.leaflet.content",
+      }),
+    ).toBe("https://blog.example/some-post?interactionDrawer=comments");
+  });
+
+  it("returns null for publications hosted elsewhere", () => {
+    expect(
+      leafletCommentDrawerUrl({
+        canonicalUrl: "https://example.com/post",
+        contentFormat: null,
+      }),
     ).toBeNull();
-    expect(leafletCommentDrawerUrl(null)).toBeNull();
-    expect(leafletCommentDrawerUrl("not a url")).toBeNull();
+    expect(
+      leafletCommentDrawerUrl({
+        canonicalUrl: "https://notleaflet.pub.evil.com/x",
+        contentFormat: null,
+      }),
+    ).toBeNull();
+    expect(
+      leafletCommentDrawerUrl({ canonicalUrl: null, contentFormat: null }),
+    ).toBeNull();
+    expect(
+      leafletCommentDrawerUrl({
+        canonicalUrl: "not a url",
+        contentFormat: "pub.leaflet.content",
+      }),
+    ).toBeNull();
+  });
+
+  it("does not claim a Skyreader linkblog for Leaflet", () => {
+    // Linkblogs reuse `pub.leaflet.content` but never render on Leaflet, so
+    // opening Leaflet's comment drawer for one would go nowhere useful.
+    expect(
+      leafletCommentDrawerUrl({
+        canonicalUrl: "https://linkblogs.skyreader.app/post",
+        contentFormat: "pub.leaflet.content",
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/standard-reader/src/lib/leaflet/comment.ts
+++ b/apps/standard-reader/src/lib/leaflet/comment.ts
@@ -8,6 +8,8 @@
  * to a character range inside the document's `pub.leaflet.content`.
  */
 
+import { publishingPlatform } from "#/lib/publishing-platform";
+
 import { LEAFLET_CONTENT, LEAFLET_PAGE } from "./types";
 
 export const LEAFLET_COMMENT_COLLECTION = "pub.leaflet.comment";
@@ -17,26 +19,32 @@ export const LEAFLET_COMMENT_SUBJECT_PATH = ".subject";
 
 /**
  * Leaflet's comment drawer for a document, which is the closest thing to a
- * permalink — individual comments have no addressable URL. Only meaningful for
- * Leaflet-hosted publications, so callers pass the document's canonical URL and
- * we return null for anything not on leaflet.pub.
+ * permalink — individual comments have no addressable URL.
+ *
+ * Only meaningful for Leaflet-hosted publications, but "is this Leaflet?" is
+ * decided by `publishingPlatform` (content format first, host as the fallback)
+ * rather than by sniffing for `leaflet.pub`: Leaflet supports custom domains, so
+ * a host-only check left every custom-domain publication's comments with no link
+ * at all. Returns null when the document is not Leaflet's or has no URL to open.
  */
-export function leafletCommentDrawerUrl(
-  canonicalUrl: string | null,
-): string | null {
+export function leafletCommentDrawerUrl(document: {
+  canonicalUrl: string | null;
+  contentFormat: string | null;
+}): string | null {
+  const { canonicalUrl, contentFormat } = document;
   if (!canonicalUrl) return null;
+  if (publishingPlatform({ contentFormat, canonicalUrl }) !== "leaflet") {
+    return null;
+  }
+
   let parsed: URL;
   try {
     parsed = new URL(canonicalUrl);
   } catch {
     return null;
   }
-  if (
-    parsed.hostname !== "leaflet.pub" &&
-    !parsed.hostname.endsWith(".leaflet.pub")
-  ) {
-    return null;
-  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return null;
+
   parsed.searchParams.set("interactionDrawer", "comments");
   return parsed.toString();
 }

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -5281,6 +5281,10 @@ msgstr ""
 msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across all {countLabel} publications on the network, not just the handful you’ve heard of."
 msgstr ""
 
+#: src/components/reader/comments/comment-card.tsx
+msgid "Open this comment record"
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Sharing a review on the <0>ATStore</0> will help both us and other users see what you think about Standard Reader."
 msgstr "مشاركة مراجعة على <0>ATStore</0> تساعدنا وتساعد بقية المستخدمين على معرفة رأيك في Standard Reader."

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -5281,6 +5281,10 @@ msgstr ""
 msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across all {countLabel} publications on the network, not just the handful you’ve heard of."
 msgstr ""
 
+#: src/components/reader/comments/comment-card.tsx
+msgid "Open this comment record"
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Sharing a review on the <0>ATStore</0> will help both us and other users see what you think about Standard Reader."
 msgstr "Eine Bewertung im <0>ATStore</0> hilft uns und anderen Nutzern zu sehen, was Sie von Standard Reader halten."

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -5281,6 +5281,10 @@ msgstr ""
 msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across all {countLabel} publications on the network, not just the handful you’ve heard of."
 msgstr ""
 
+#: src/components/reader/comments/comment-card.tsx
+msgid "Open this comment record"
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Sharing a review on the <0>ATStore</0> will help both us and other users see what you think about Standard Reader."
 msgstr ""

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -5281,6 +5281,10 @@ msgstr "Good to know"
 msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across all {countLabel} publications on the network, not just the handful you’ve heard of."
 msgstr "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across all {countLabel} publications on the network, not just the handful you’ve heard of."
 
+#: src/components/reader/comments/comment-card.tsx
+msgid "Open this comment record"
+msgstr "Open this comment record"
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Sharing a review on the <0>ATStore</0> will help both us and other users see what you think about Standard Reader."
 msgstr "Sharing a review on the <0>ATStore</0> will help both us and other users see what you think about Standard Reader."

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -5281,6 +5281,10 @@ msgstr ""
 msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across all {countLabel} publications on the network, not just the handful you’ve heard of."
 msgstr ""
 
+#: src/components/reader/comments/comment-card.tsx
+msgid "Open this comment record"
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Sharing a review on the <0>ATStore</0> will help both us and other users see what you think about Standard Reader."
 msgstr "Compartir una reseña en <0>ATStore</0> nos ayudará, tanto a nosotros como a otros usuarios, a saber qué opina de Standard Reader."

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -5281,6 +5281,10 @@ msgstr ""
 msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across all {countLabel} publications on the network, not just the handful you’ve heard of."
 msgstr ""
 
+#: src/components/reader/comments/comment-card.tsx
+msgid "Open this comment record"
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Sharing a review on the <0>ATStore</0> will help both us and other users see what you think about Standard Reader."
 msgstr "Partager un avis sur l'<0>ATStore</0> nous aidera, ainsi que les autres utilisateurs, à savoir ce que vous pensez de Standard Reader."

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -5281,6 +5281,10 @@ msgstr ""
 msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across all {countLabel} publications on the network, not just the handful you’ve heard of."
 msgstr ""
 
+#: src/components/reader/comments/comment-card.tsx
+msgid "Open this comment record"
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Sharing a review on the <0>ATStore</0> will help both us and other users see what you think about Standard Reader."
 msgstr "<0>ATStore</0> でレビューを共有していただくと、Standard Reader についてのご意見を私たちにも他のユーザーにも届けられます。"

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -5281,6 +5281,10 @@ msgstr ""
 msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across all {countLabel} publications on the network, not just the handful you’ve heard of."
 msgstr ""
 
+#: src/components/reader/comments/comment-card.tsx
+msgid "Open this comment record"
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Sharing a review on the <0>ATStore</0> will help both us and other users see what you think about Standard Reader."
 msgstr "<0>ATStore</0>에 리뷰를 남겨 주시면 저희와 다른 사용자 모두 Standard Reader에 대한 생각을 알 수 있습니다."

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -5281,6 +5281,10 @@ msgstr ""
 msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across all {countLabel} publications on the network, not just the handful you’ve heard of."
 msgstr ""
 
+#: src/components/reader/comments/comment-card.tsx
+msgid "Open this comment record"
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Sharing a review on the <0>ATStore</0> will help both us and other users see what you think about Standard Reader."
 msgstr "Compartilhar uma avalição na <0>ATStore</0> ajuda-nos a nós e aos outros usuários a saber o que pensa do Standard Reader."

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -5281,6 +5281,10 @@ msgstr ""
 msgid "Most readers stop at what they already subscribe to. Standard Reader treats the next voice as part of the job: the piece you just finished points at who cited it, what it’s related to, and who else is worth following — across all {countLabel} publications on the network, not just the handful you’ve heard of."
 msgstr ""
 
+#: src/components/reader/comments/comment-card.tsx
+msgid "Open this comment record"
+msgstr ""
+
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Sharing a review on the <0>ATStore</0> will help both us and other users see what you think about Standard Reader."
 msgstr "在 <0>ATStore</0> 上分享评价，能帮助我们和其他用户了解你对 Standard Reader 的看法。"

--- a/apps/standard-reader/src/server/leaflet/comments.ts
+++ b/apps/standard-reader/src/server/leaflet/comments.ts
@@ -76,6 +76,11 @@ export interface LeafletCommentContext {
   content: unknown;
   /** Canonical URL, used to build the Leaflet comment-drawer link. */
   canonicalUrl: string | null;
+  /**
+   * `$type` of the document's content union, which is what identifies the
+   * document as Leaflet's when its publication sits on a custom domain.
+   */
+  contentFormat: string | null;
 }
 
 /**
@@ -124,7 +129,7 @@ function toComment(
     source: "leaflet",
     kind: quoteText ? "quote" : "link",
     postUri: comment.uri,
-    postUrl: leafletCommentDrawerUrl(context.canonicalUrl) ?? "",
+    postUrl: leafletCommentDrawerUrl(context) ?? "",
     author,
     commentary: comment.plaintext,
     commentaryFacets: comment.facets as DocumentComment["commentaryFacets"],

--- a/apps/standard-reader/src/server/reader/document-comments.ts
+++ b/apps/standard-reader/src/server/reader/document-comments.ts
@@ -455,6 +455,7 @@ async function loadDocumentCommentTargets(
       bskyPostUri: d.bskyPostUri,
       publishedAt: d.publishedAt,
       contentJson: d.contentJson,
+      contentFormat: d.contentFormat,
     })
     .from(d)
     .leftJoin(p, eq(d.publicationUri, p.uri))
@@ -493,7 +494,11 @@ async function loadDocumentCommentTargets(
     targets,
     stripUrls: linkTargets,
     bskyPostUri,
-    leaflet: { content: doc.contentJson, canonicalUrl },
+    leaflet: {
+      content: doc.contentJson,
+      canonicalUrl,
+      contentFormat: doc.contentFormat,
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

Every comment card now renders as a link, even when the source platform can't build a permalink. Leaflet comments on custom domains now link correctly by using `publishingPlatform` to identify the platform (content format first, host as fallback) instead of sniffing for `leaflet.pub`. Cards without a native platform link fall back to PDSLS (the ecosystem's record viewer), and link labels are honest about their destination.

## Key Changes

- **New `commentLink` helper** (`src/lib/comment-permalink.ts`): Returns either a native platform permalink or a PDSLS record viewer link, with a `native` flag so callers can label links honestly. Eliminates unlinked cards.

- **Fixed Leaflet custom-domain support**: `leafletCommentDrawerUrl` now accepts a document object with `canonicalUrl` and `contentFormat`, using `publishingPlatform` to identify Leaflet publications (including those on custom domains). Skyreader linkblogs (which reuse `pub.leaflet.content` but never render on Leaflet) are explicitly vetoed.

- **Updated comment card rendering**: `CommentCard` now uses `commentLink` to build the link and only names a platform in the accessible label when the link actually goes there (native links name the platform; fallback links say "Open this comment record").

- **Fixed extension popup**: `PopupArticleDiscussion` was missing `note` and `leaflet` sources in its comment type and was labeling those comments "on Bluesky". Now uses the same `commentLink` helper and correctly identifies all sources.

- **Updated Leaflet server code**: Passes `contentFormat` from the document to `leafletCommentDrawerUrl` so it can identify custom-domain Leaflet publications.

- **Test coverage**: Added comprehensive tests for `commentLink` and expanded `leafletCommentDrawerUrl` tests to cover custom domains, Skyreader linkblogs, and edge cases.

- **Localization**: Added "Open this comment record" string to all locale files for the fallback link label.

- **Documentation**: Updated `TODO.md` to mark this work complete with implementation notes.

## Implementation Details

- The `publishingPlatform` utility (already in the codebase) provides the correct platform detection logic, avoiding the custom-domain miss that `leafletCommentDrawerUrl` had when it only checked hostnames.
- `commentLink` uses `buildPdslsRecordUrl` (already available) to construct the fallback link.
- The change is backward-compatible: all existing comment sources continue to work, and sources that already build platform permalinks are unaffected.

https://claude.ai/code/session_01DuBjsSiuwBygAkBQGqLXCY