### PR TITLE
Show every comic its art, not just the issue-numbered ones

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -425,16 +425,18 @@ What changes for a serial:
   from the publication menu; the override is a per-publication cookie, resolved server-side
   inside `getPublicationDocuments`, so the client never has to know the order to ask for the
   right page and the SSR'd HTML is already in it.
-- **A comic's archive is a shelf of covers, not a list of pages.** A comic posts one page per
+- **A comic's archive is a shelf of covers, not a list of titles.** A comic posts one page per
   document, so its archive is dozens of near-identical rows — `FITV #1 Cover`, `FITV #1, Pg. 1`.
-  Titles almost always carry series, issue and page, so `selectComicShelf`
-  (`#/server/reader/comic`) parses the issue number out of them (`#/lib/comic/issue-title`),
-  collapses consecutive pages back into the issues they came from, and shows each issue's cover
-  art — the reader browses issues instead of scrolling pages. It is a naming convention, not a
-  lexicon field, so it is treated as a guess: fewer than 70% of titles parsing, or everything
-  landing in one group, leaves `grouped: false` and the ordinary archive list stands. The
-  read/unread filters keep the list too — those are per-page views, and a shelf shows whole
-  issues.
+  What a reader browses there is art, so `selectComicShelf` (`#/server/reader/comic`) always shows
+  it. How much art fits on one cover is `ComicShelf.mode`, decided by `planComicShelf`. Titles
+  usually carry series, issue and page, so when at least 70% of them parse
+  (`#/lib/comic/issue-title`) consecutive pages collapse back into the issues they came from and
+  each issue is fronted by its cover — the reader browses `#1`, `#2` instead of scrolling their
+  pages. When they don't parse — a webcomic naming its posts `Pg01`, `Pg02` — there are no issues
+  to collapse and every post keeps its own cover, a grid of page thumbnails. Grouping is the guess;
+  showing the art is not, and the fallback for a failed guess is a plainer shelf rather than a list
+  of titles that shows nothing. The read/unread filters do keep the list — those are per-page
+  views, and a shelf shows whole issues.
 - **An issue is unread while any of its pages is**, and its cover opens on the first page the
   reader hasn't seen. Read state is per document, and a comic's documents are its pages, so the
   shelf asks for the reader's unread URIs across the whole publication (`selectUnreadDocumentUris`

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -1184,13 +1184,16 @@ Backend/API exists; UI or copy is missing.
       rather than a full `upsertPublication` per row. ~40s where the per-repo shape measured
       ~46 min of PDS reads alone.
       A comic publication's page shows a **shelf of covers** instead of its archive list
-      ([`comic-shelf.tsx`](src/components/comic/comic-shelf.tsx)): `selectComicShelf` parses the
-      issue number out of each post title ([`issue-title.ts`](src/lib/comic/issue-title.ts)),
-      collapses consecutive pages into issues, and fronts each with its cover art, so a reader
-      browses issues rather than scrolling `#1 Cover`, `#1, Pg. 1`, `#1, Pg. 2`. The convention is
-      treated as a guess — under 70% of titles parsing, or a single group, leaves `grouped: false`
-      and the ordinary list stands, as do the read/unread filters. Awaited in the route loader for
-      comics so the shelf is part of first paint.
+      ([`comic-shelf.tsx`](src/components/comic/comic-shelf.tsx)) — always, because a comic's
+      archive is art and a list of `Pg01`, `Pg02` shows none of it. What one cover stands for is
+      `ComicShelf.mode`, decided by `planComicShelf`: when at least 70% of the titles carry an
+      issue number ([`issue-title.ts`](src/lib/comic/issue-title.ts)) consecutive pages collapse
+      into one cover per issue (`"issues"`, so a reader browses `#1` / `#2` rather than scrolling
+      `#1 Cover`, `#1, Pg. 1`, `#1, Pg. 2`); when they don't there is no structure to collapse and
+      every post keeps its own cover (`"pages"`, a grid of page thumbnails). One body is opened per
+      shelf entry for its art, so a page-per-card comic costs a row per post. Only over the full
+      archive — the read/unread filters stay a list, since a shelf can't express "half of issue 3".
+      Awaited in the route loader for comics so the shelf is part of first paint.
       **Unread works by the issue**: an issue is unread while any of its pages is, so the shelf is
       reader-scoped — `selectComicShelf` hands each issue the reader's unread pages
       (`selectUnreadDocumentUris`, the same query the archive filter and "mark all as read" use),

--- a/apps/standard-reader/src/components/comic/comic-shelf.tsx
+++ b/apps/standard-reader/src/components/comic/comic-shelf.tsx
@@ -156,9 +156,14 @@ function ComicShelfCard({
           ) : null}
           <span {...stylex.props(styles.label)}>{issue.label}</span>
         </Flex>
-        <span {...stylex.props(styles.meta)}>
-          <Plural value={issue.pageCount} one="# page" other="# pages" />
-        </span>
+        {/* How much reading a cover stands for. A one-page card is its own
+            answer — on a shelf of pages every card would say "1 page", which
+            tells the reader nothing they can't see. */}
+        {issue.pageCount > 1 ? (
+          <span {...stylex.props(styles.meta)}>
+            <Plural value={issue.pageCount} one="# page" other="# pages" />
+          </span>
+        ) : null}
       </Flex>
     </Link>
   );
@@ -186,15 +191,13 @@ export function ComicShelfSkeleton() {
 }
 
 /**
- * A comic publication's issues, as covers on a shelf.
+ * A comic publication's covers, on a shelf.
  *
  * A comic posts one page per document, so its archive is a long list of
  * near-identical rows — `#1 Cover`, `#1, Pg. 1`, `#1, Pg. 2` — when what a
- * reader wants to browse is issues. This collapses those pages back into the
- * issues they came from and shows the art instead of the titles.
- *
- * The caller decides whether a shelf is warranted (`ComicShelf.grouped`); this
- * only draws it.
+ * reader wants to browse is art. The server decides what one cover stands for:
+ * an issue when the titles number them, otherwise a single post
+ * (`ComicShelf.mode`). This only draws whatever it was handed.
  *
  * `issues` always arrive in publication order (#1 first) — the spine reads that
  * way so absolute page numbers mean something. `order` is the reader's view of

--- a/apps/standard-reader/src/integrations/tanstack-query/api-publication.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-publication.functions.ts
@@ -1059,9 +1059,9 @@ const setPublicationArchiveOrder = createServerFn({ method: "POST" })
   });
 
 /**
- * A comic's issues as a shelf of covers, for the publication page. Comes back
- * `grouped: false` when the titles don't follow the issue convention, and the
- * page keeps its ordinary archive list.
+ * A comic as a shelf of covers, for the publication page. One card per issue
+ * when the titles carry issue numbers (`mode: "issues"`), otherwise one per post
+ * (`mode: "pages"`); either way the page shows art rather than its archive list.
  *
  * Reader-scoped: each issue carries the pages this reader hasn't opened, which
  * is what puts the unread dot on a cover and what decides the page a cover opens
@@ -1089,7 +1089,7 @@ const getComicShelf = createServerFn({ method: "GET" })
           readForDid,
           countOldPostsAsUnread: countOldPostsAsUnreadEnabled,
         });
-        span.set("grouped", shelf.grouped);
+        span.set("shelfMode", shelf.mode);
         span.set("issues", shelf.issues.length);
         span.set(
           "unreadIssues",

--- a/apps/standard-reader/src/routes/_layout.p.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/_layout.p.$did.$rkey.tsx
@@ -743,19 +743,21 @@ function PublicationProfileContent({
   }, [filter, nextOffset, uri]);
 
   // A comic posts one page per document, so its full archive is a long list of
-  // near-identical rows. When the titles carry issue numbers, those pages are
-  // collapsed back into issues and shown as covers instead. Only over the full
-  // archive: the read/unread filters are per-page, and a shelf can't express
-  // "half of issue 3".
+  // near-identical rows. The shelf shows that art instead — collapsed into
+  // issues when the titles carry issue numbers, one card per post when they
+  // don't. Only over the full archive: the read/unread filters are per-page, and
+  // a shelf can't express "half of issue 3".
   const shelfEnabled = pub.serial?.kind === "comic" && filter === "all";
   const { data: shelf, isPending: shelfPending } = useQuery({
     ...publicationApi.getComicShelfQueryOptions(uri, { readerScope }),
     enabled: shelfEnabled,
   });
-  // Until it resolves we don't know whether the titles group at all, and
+  // Until it resolves we don't know whether there is any art to shelve, and
   // painting the page list only to swap it for a shelf is the worse flicker.
-  // The loader awaits this for comics, so it is normally already settled.
-  const showShelf = shelfEnabled && (shelfPending || Boolean(shelf?.grouped));
+  // The loader awaits this for comics, so it is normally already settled. An
+  // empty shelf means the posts carry no images at all, and the list is right.
+  const shelfIssues = shelf?.issues ?? [];
+  const showShelf = shelfEnabled && (shelfPending || shelfIssues.length > 0);
 
   const lead = documents[0];
   const rest = documents.slice(1);
@@ -836,9 +838,9 @@ function PublicationProfileContent({
           <PublicationLatestNote publicationUri={uri} />
           {showShelf ? (
             <Flex direction="column" gap="5xl">
-              {shelf?.grouped ? (
+              {shelfIssues.length > 0 ? (
                 <ComicShelf
-                  issues={shelf.issues}
+                  issues={shelfIssues}
                   order={initialPage.order}
                   trackReading={trackReading}
                   signedIn={signedIn}

--- a/apps/standard-reader/src/server/reader/comic.test.ts
+++ b/apps/standard-reader/src/server/reader/comic.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import type { ComicIssue } from "./comic";
+import { planComicShelf } from "./comic";
+
+/** A spine entry, with the offsets a real spine would have already worked out. */
+function spine(titles: Array<string>): Array<ComicIssue> {
+  return titles.map((title, index) => ({
+    uri: `at://did:plc:comic/site.standard.document/${index}`,
+    did: "did:plc:comic",
+    rkey: String(index),
+    title,
+    publishedAt: new Date(index * 1000).toISOString(),
+    pageCount: 1,
+    pageOffset: index,
+  }));
+}
+
+/** What each shelf entry ended up standing for, as titles. */
+function laidOut(issues: Array<ComicIssue>): Array<Array<string>> {
+  return planComicShelf(issues).groups.map((group) =>
+    group.pages.map((page) => page.issue.title),
+  );
+}
+
+describe("planComicShelf", () => {
+  it("collapses issue-numbered pages into one entry per issue", () => {
+    const plan = planComicShelf(
+      spine([
+        "FITV #1 Cover",
+        "FITV #1, Pg. 1",
+        "FITV #1, Pg. 2",
+        "FITV #2 Cover",
+        "FITV #2, Pg. 1",
+      ]),
+    );
+    expect(plan.mode).toBe("issues");
+    expect(plan.groups.map((group) => group.issueNumber)).toEqual([1, 2]);
+    expect(plan.groups.map((group) => group.pages.length)).toEqual([3, 2]);
+    // The page that says it's the cover is the one that fronts the issue.
+    expect(plan.groups[0]?.pages.map((page) => page.isCover)).toEqual([
+      true,
+      false,
+      false,
+    ]);
+  });
+
+  it("keeps a card per post when the titles carry no issue number", () => {
+    // A comic that names its pages `Pg01`, `Pg02` is not broken — it just has
+    // no issues to collapse, so every page keeps its own cover.
+    const plan = planComicShelf(spine(["Pg01", "Pg02"]));
+    expect(plan.mode).toBe("pages");
+    expect(laidOut(spine(["Pg01", "Pg02"]))).toEqual([["Pg01"], ["Pg02"]]);
+    expect(plan.groups.every((group) => group.issueNumber == null)).toBe(true);
+  });
+
+  it("shelves a comic whose pages all belong to one issue", () => {
+    // One entry is still a shelf: "read issue #1" beats a column of its pages.
+    const plan = planComicShelf(
+      spine(["Astarion #1 Cover", "Astarion #1, Pg. 1"]),
+    );
+    expect(plan.mode).toBe("issues");
+    expect(plan.groups).toHaveLength(1);
+    expect(plan.groups[0]?.issueNumber).toBe(1);
+  });
+
+  it("keeps a stray untitled page inside the issue it sits in", () => {
+    // One post off-convention is not enough to lose the grouping (4 of 5 parse,
+    // over `ISSUE_TITLE_MATCH_SHARE`), and the odd one joins the issue it sits
+    // inside rather than splitting it.
+    expect(
+      laidOut(
+        spine([
+          "FITV #1 Cover",
+          "FITV #1, Pg. 1",
+          "An announcement",
+          "FITV #2 Cover",
+          "FITV #2, Pg. 1",
+        ]),
+      ),
+    ).toEqual([
+      ["FITV #1 Cover", "FITV #1, Pg. 1", "An announcement"],
+      ["FITV #2 Cover", "FITV #2, Pg. 1"],
+    ]);
+  });
+
+  it("has nothing to lay out for a comic with no pages", () => {
+    const plan = planComicShelf([]);
+    expect(plan.groups).toEqual([]);
+    expect(plan.mode).toBe("pages");
+  });
+});

--- a/apps/standard-reader/src/server/reader/comic.ts
+++ b/apps/standard-reader/src/server/reader/comic.ts
@@ -358,36 +358,104 @@ export interface ComicShelfIssue {
   unreadPages: Array<ComicUnreadPage>;
 }
 
+/**
+ * How a shelf's entries were formed.
+ *
+ * `"issues"` — the titles carry issue numbers, so consecutive pages sharing one
+ * collapsed into a single cover. `"pages"` — they don't, so every post is its
+ * own cover. Both are shelves; the mode only says what one card stands for.
+ */
+export type ComicShelfMode = "issues" | "pages";
+
 export interface ComicShelf {
   publicationUri: string;
   issues: Array<ComicShelfIssue>;
   totalPages: number;
-  /**
-   * False when the publication's titles don't follow the issue convention. The
-   * caller keeps its ordinary archive list rather than showing a shelf built on
-   * guesses — a comic that names its posts some other way is not broken, it just
-   * can't be grouped this way.
-   */
-  grouped: boolean;
+  /** See {@link ComicShelfMode} — what one entry on this shelf stands for. */
+  mode: ComicShelfMode;
+}
+
+/** One shelf entry under construction, before its cover art is looked up. */
+export type ComicShelfGroup = {
+  issueNumber: number | null;
+  pages: Array<{ issue: ComicIssue; isCover: boolean }>;
+};
+
+/**
+ * Collapse a spine into shelf entries, one per issue number.
+ *
+ * A page whose title doesn't parse joins the issue it sits inside rather than
+ * splitting it — an interstitial with an odd title is still part of that issue.
+ */
+function groupSpineByIssue(issues: Array<ComicIssue>): Array<ComicShelfGroup> {
+  const groups: Array<ComicShelfGroup> = [];
+  for (const issue of issues) {
+    const parsed = parseComicIssueTitle(issue.title);
+    const last = groups.at(-1);
+    const sameIssue =
+      last != null &&
+      (parsed == null || last.issueNumber === parsed.issueNumber);
+    const entry = {
+      issue,
+      isCover: parsed != null && isCoverPageLabel(parsed.pageLabel),
+    };
+    if (sameIssue) last.pages.push(entry);
+    else
+      groups.push({ issueNumber: parsed?.issueNumber ?? null, pages: [entry] });
+  }
+  return groups;
 }
 
 /**
- * A comic's issues as a shelf of covers.
+ * Decide what one cover on this shelf stands for, and lay the entries out.
+ *
+ * Issue-numbered titles collapse into one entry per issue; anything else keeps
+ * a card per post, since there is no structure to collapse and grouping on a bad
+ * parse would invent one.
+ *
+ * Pure and separate from {@link selectComicShelf} so the decision can be checked
+ * without a database — it is the whole difference between a shelf of issues and
+ * a grid of pages.
+ */
+export function planComicShelf(issues: Array<ComicIssue>): {
+  mode: ComicShelfMode;
+  groups: Array<ComicShelfGroup>;
+} {
+  if (titlesLookLikeIssues(issues.map((issue) => issue.title))) {
+    return { mode: "issues", groups: groupSpineByIssue(issues) };
+  }
+  return {
+    mode: "pages",
+    groups: issues.map((issue) => ({
+      issueNumber: null,
+      pages: [{ issue, isCover: false }],
+    })),
+  };
+}
+
+/**
+ * A comic as a shelf of covers.
  *
  * A comic posts one page per document, so its archive is dozens of near-identical
  * rows — `FITV #1 Cover`, `FITV #1, Pg. 1`, `FITV #1, Pg. 2` — when the thing a
- * reader browses is *issues*. The issue number lives only in those titles (the
- * lexicon has no field for it), so it is parsed back out
- * (`#/lib/comic/issue-title`) and consecutive pages sharing a number collapse
- * into one shelf entry.
+ * reader browses is art. The shelf shows the art instead of the titles.
  *
- * Because it rests on a naming convention, it declines rather than guesses: a
- * publication whose titles mostly don't parse comes back `grouped: false`.
+ * How much art fits on one card depends on the titles. When they carry issue
+ * numbers — which lives only in the title, since the lexicon has no field for it
+ * — they are parsed back out (`#/lib/comic/issue-title`) and consecutive pages
+ * sharing a number collapse into one cover per issue (`mode: "issues"`). When
+ * they don't, the pages can't be collapsed and each post keeps its own cover
+ * (`mode: "pages"`): a comic that names its posts `Pg01`, `Pg02` is not broken,
+ * and a grid of its pages still reads as a comic where a list of those titles
+ * does not.
  *
- * Only one body per issue is opened — the cover's, for its art — so the cost is
- * a handful of rows however long the comic runs.
+ * Cost follows the mode, because one body is opened per shelf entry to get its
+ * art: a handful of rows for an issue-numbered comic however long it runs, and
+ * one row per post for a page-per-card one. The spine already reads every
+ * document row for both, and a comic page's body is an image ref and a short
+ * note, so this stays a single query either way.
  *
- * With `readForDid`, each issue also carries the pages that reader hasn't opened
+ * With `readForDid`, each entry also carries the pages that reader hasn't opened
  * (`unreadPages`) — the shelf is where a reader picks up a comic, and picking it
  * up means going to the next page they haven't seen, not back to the cover.
  */
@@ -420,39 +488,9 @@ export async function selectComicShelf(
       : Promise.resolve<Array<string>>([]),
   ]);
   const unread = new Set(unreadUris);
-  const empty: ComicShelf = {
-    publicationUri,
-    issues: [],
-    totalPages: spine.totalPages,
-    grouped: false,
-  };
-  if (spine.issues.length === 0) return empty;
-  if (!titlesLookLikeIssues(spine.issues.map((issue) => issue.title))) {
-    return empty;
-  }
-
-  // Walk the spine in reading order, starting a new shelf entry whenever the
-  // issue number changes. A page whose title doesn't parse joins the issue it
-  // sits inside rather than splitting it — an interstitial with an odd title is
-  // still part of that issue.
-  type Group = {
-    issueNumber: number | null;
-    pages: Array<{ issue: (typeof spine.issues)[number]; isCover: boolean }>;
-  };
-  const groups: Array<Group> = [];
-  for (const issue of spine.issues) {
-    const parsed = parseComicIssueTitle(issue.title);
-    const last = groups.at(-1);
-    const sameIssue =
-      last != null &&
-      (parsed == null || last.issueNumber === parsed.issueNumber);
-    const entry = {
-      issue,
-      isCover: parsed != null && isCoverPageLabel(parsed.pageLabel),
-    };
-    if (sameIssue) last.pages.push(entry);
-    else
-      groups.push({ issueNumber: parsed?.issueNumber ?? null, pages: [entry] });
+  const { mode, groups } = planComicShelf(spine.issues);
+  if (groups.length === 0) {
+    return { publicationUri, issues: [], totalPages: spine.totalPages, mode };
   }
 
   // The cover is the page that says it is one; failing that, the issue's first
@@ -523,12 +561,5 @@ export async function selectComicShelf(
     });
   }
 
-  return {
-    publicationUri,
-    issues,
-    totalPages: spine.totalPages,
-    // One shelf entry holding everything means the grouping found no structure
-    // worth showing — the archive list says the same thing with more detail.
-    grouped: issues.length > 1,
-  };
+  return { publicationUri, issues, totalPages: spine.totalPages, mode };
 }


### PR DESCRIPTION
A comic publication's page is supposed to replace its archive list with a shelf of covers. It declined unless the post titles carried issue numbers (`FITV #1, Pg. 1`), and then declined again unless they spanned more than one issue. So a webcomic that names its pages `Pg01`, `Pg02` got the ordinary archive list — a column of near-identical titles and none of the art, which is the one thing a reader came to browse.

Reported against [Test comic](https://standard-reader.app/p/did:plc:4zjitxlezfmcls5cxars3f6m/3msdvugqnqk2w?filter=all), whose row is correctly `serial_kind = 'comic'`; the shelf was the part that gave up.

## The change

The refusal was in the right place for the wrong reason. Grouping pages into issues rests on a naming convention, so it should stay a guess — but the fallback for a failed guess was a list that shows nothing, when a plainer shelf was available the whole time.

`ComicShelf.grouped` becomes `ComicShelf.mode`, and a comic always shelves; only what one cover stands for varies. `planComicShelf` decides:

| titles | mode | one cover is |
| --- | --- | --- |
| ≥70% parse as `Series #N, Pg. X` | `"issues"` | an issue, its pages collapsed behind it |
| anything else | `"pages"` | a single post |

A comic whose pages all belong to one issue now shelves as that one issue rather than falling back. The read/unread filters still keep the list — those are per-page views, and a shelf can't express "half of issue 3".

- `server/reader/comic.ts` — `planComicShelf` (pure, testable without a DB) and `groupSpineByIssue`, extracted from the old inline loop unchanged.
- `_layout.p.$did.$rkey.tsx` — shows the shelf whenever it has entries. An empty shelf means the posts carry no images at all, and the list is right there.
- `comic-shelf.tsx` — the "N pages" meta only renders above 1 page; on a shelf of pages every card would have said "1 page".
- `api-publication.functions.ts` — the span records `shelfMode` instead of `grouped`.

## Cost

One body is opened per shelf entry for its art, so cost follows the mode: a handful of rows for an issue-numbered comic however long it runs, one row per post for a page-per-card one. Left unbounded rather than capped — the spine already reads every document row, a comic page's body is an image ref and a short note, and the largest ungrouped comic on the network is 18 posts. A cap here would silently truncate a shelf that has no pagination to fall back on. Worth revisiting if a webcomic reaches the hundreds of pages.

## Verification

Run against prod data in dev:

- **Test comic** (`Pg01`, `Pg02`) — two page thumbnails linking into `/comic/…`. Was a title list.
- **Astarion and Veluthe's Infinite Adventure** (18 posts, `Prologue p.N`) — an 18-cover grid. Was a title list.
- **Fray In The Veil** (54 posts, `FITV #N …`) — `#2` / 24 PAGES and `#1` / 30 PAGES. Unchanged, the regression case.

New `comic.test.ts` covers both modes, the single-issue comic, a stray off-convention post staying inside its issue, and the empty spine. `pnpm typecheck`, `pnpm lint`, `pnpm format:check` clean; app suite 792 passed / 6 skipped.

Docs updated in the same change — `APP_VISION.md` and `TODO.md` both documented the old `grouped: false` → list fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
