### PR TITLE
Let readers hide the websites Bridgy mirrored without asking

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -1270,6 +1270,16 @@ hand-tuned lists:
   corpus — recommending them reads as noise. They stay fully reachable everywhere else: the
   directory, search, trending, follows, and their own pages. Filtered in SQL, so the rail still
   fills to its limit.
+- **"Hide mirrored websites" takes that further, per reader** — an account setting
+  (`user.exclude_web_bridge`, default off; `src/lib/exclude-web-bridge.ts`) that drops
+  `*.web.brid.gy` from _every_ network-wide surface: Latest "All" and its badge counts, the home
+  network/trending feeds, Discover's directory and rails, search, tag pages, related articles, and
+  the weekly digest's network section. It is deliberately **not** applied to anything the reader
+  chose — their subscriptions feed, a publication page they opened, a handle or URL they searched
+  for by name — and never to `*.ap.brid.gy`. The mirrors are ~86% of documents and ~35% of
+  publications, so the filtered Latest "All" badge gets its own precomputed `network_stats` scalar
+  (`network_document_count_no_web_bridge`) rather than a live count, and the tag feed switches to a
+  tag-first query shape (`selectTagArticleUris`) that the survival rate can't blow up.
 
 ### Topic derivation
 

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -1053,6 +1053,19 @@ Backend/API exists; UI or copy is missing.
 
 ## 9. Post-v1 — reader polish (Tier 2)
 
+- [x] **"Hide mirrored websites" setting** — an account-level toggle
+      (`user.exclude_web_bridge`, default off; [`exclude-web-bridge.ts`](src/lib/exclude-web-bridge.ts),
+      `drizzle/0033_*`) that drops Bridgy Fed's bulk `*.web.brid.gy` mirrors from every
+      network-wide surface: Latest "All" + badge counts, home network/trending, Discover
+      directory + rails + known-publication count, search, tag pages (feed, directory, counts,
+      "follow all"), related articles, and the digest's network section. Never applied to the
+      reader's own subscriptions, to a publication/article page they opened, or to a handle/URL
+      they searched by name; never to `*.ap.brid.gy`. Two perf shapes were load-bearing, both
+      measured against a prod-scale copy: the filtered Latest badge is a second precomputed
+      `network_stats` scalar (a live filtered count is 26.5s), and the tag feed switches to a
+      tag-first `MATERIALIZED` query (`selectTagArticleUris`) because the ordinary
+      date-index walk discards ~200k rows to fill a page on mirror-dominated tags — 3.2s–19.2s
+      before, 225ms–2.6s after. Everything else lands within ~35ms of unfiltered.
 - [x] **Reading typography preferences** — font size / measure (and optional sans body) on the
       article wrapper; cookie + optional `user` column (same pattern as [`open-links.ts`](src/lib/open-links.ts));
       menu item alongside [`OpenLinksMenuItem`](src/components/OpenLinksMenuItem.tsx)

--- a/apps/standard-reader/drizzle/0033_worried_harry_osborn.sql
+++ b/apps/standard-reader/drizzle/0033_worried_harry_osborn.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "exclude_web_bridge" boolean;

--- a/apps/standard-reader/drizzle/meta/0033_snapshot.json
+++ b/apps/standard-reader/drizzle/meta/0033_snapshot.json
@@ -1,0 +1,4758 @@
+{
+  "id": "858c9d6b-3232-4cee-8694-417ac7e2558f",
+  "prevId": "3d5ba137-4765-4e0a-957b-d9246c30d8d2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_mode": {
+          "name": "theme_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appearance": {
+          "name": "appearance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale_hint_seen": {
+          "name": "locale_hint_seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reader_voice": {
+          "name": "reader_voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_links_externally": {
+          "name": "open_links_externally",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_collections_in_magazine": {
+          "name": "open_collections_in_magazine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reading_typography": {
+          "name": "reading_typography",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_reading_history": {
+          "name": "track_reading_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count_old_posts_as_unread": {
+          "name": "count_old_posts_as_unread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclude_web_bridge": {
+          "name": "exclude_web_bridge",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_publication_theme": {
+          "name": "use_publication_theme",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hide_feed_metrics": {
+          "name": "hide_feed_metrics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feed_pagination": {
+          "name": "feed_pagination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_scope": {
+          "name": "home_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_hidden_tabs": {
+          "name": "profile_hidden_tabs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_show_likes": {
+          "name": "profile_show_likes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_authoring_enabled": {
+          "name": "collections_authoring_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userinput_feedback_enabled": {
+          "name": "userinput_feedback_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "margin_save_enabled": {
+          "name": "margin_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semble_save_enabled": {
+          "name": "semble_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "atstore_review_prompt_dismissed": {
+          "name": "atstore_review_prompt_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_enabled": {
+          "name": "weekly_digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_subscriptions": {
+          "name": "weekly_digest_section_subscriptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_network": {
+          "name": "weekly_digest_section_network",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_saved": {
+          "name": "weekly_digest_section_saved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_recommendations": {
+          "name": "weekly_digest_section_recommendations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_last_sent_at": {
+          "name": "weekly_digest_last_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_welcome_sent_at": {
+          "name": "weekly_digest_welcome_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_labelers_imported_at": {
+          "name": "bsky_labelers_imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_did_unique": {
+          "name": "user_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "did"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pds": {
+          "name": "pds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_url": {
+          "name": "banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_uri": {
+          "name": "bsky_profile_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_cid": {
+          "name": "bsky_profile_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_fetched_at": {
+          "name": "profile_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_handle_idx": {
+          "name": "profiles_handle_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_handle_trgm_idx": {
+          "name": "profiles_handle_trgm_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "profiles_display_name_trgm_idx": {
+          "name": "profiles_display_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publications": {
+      "name": "publications",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_cid": {
+          "name": "icon_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_mime": {
+          "name": "icon_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent": {
+          "name": "theme_accent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_background": {
+          "name": "theme_background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_foreground": {
+          "name": "theme_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent_foreground": {
+          "name": "theme_accent_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_json": {
+          "name": "theme_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_in_discover": {
+          "name": "show_in_discover",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "prev_next_direction": {
+          "name": "prev_next_direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_kind": {
+          "name": "serial_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_publication": {
+          "name": "collections_publication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_checked_at": {
+          "name": "verification_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(name, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(topic, '')), 'B')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publications_did_idx": {
+          "name": "publications_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_name_idx": {
+          "name": "publications_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_discover_idx": {
+          "name": "publications_discover_idx",
+          "columns": [
+            {
+              "expression": "show_in_discover",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_topic_idx": {
+          "name": "publications_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_url_idx": {
+          "name": "publications_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_serial_idx": {
+          "name": "publications_serial_idx",
+          "columns": [
+            {
+              "expression": "prev_next_direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_search_idx": {
+          "name": "publications_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_contributors": {
+      "name": "document_contributors",
+      "schema": "",
+      "columns": {
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "document_contributors_did_idx": {
+          "name": "document_contributors_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_contributors_document_uri_documents_uri_fk": {
+          "name": "document_contributors_document_uri_documents_uri_fk",
+          "tableFrom": "document_contributors",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_contributors_document_uri_did_pk": {
+          "name": "document_contributors_document_uri_did_pk",
+          "columns": [
+            "document_uri",
+            "did"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_uri": {
+          "name": "site_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_json": {
+          "name": "collection_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_renderable_body": {
+          "name": "has_renderable_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "body_image_count": {
+          "name": "body_image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_cid": {
+          "name": "cover_image_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_mime": {
+          "name": "cover_image_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backlink_count": {
+          "name": "backlink_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_count_prev": {
+          "name": "backlink_count_prev",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_synced_at": {
+          "name": "backlink_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_recomputed_at": {
+          "name": "trending_recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_recommender_count": {
+          "name": "distinct_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bsky_post_uri": {
+          "name": "bsky_post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_post_cid": {
+          "name": "bsky_post_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_updated_at": {
+          "name": "record_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(title, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(immutable_array_to_string(tags), '')), 'B') || setweight(to_tsvector('english', coalesce(text_content, '')), 'C')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documents_did_idx": {
+          "name": "documents_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_did_published_idx": {
+          "name": "documents_did_published_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"published_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_publication_published_idx": {
+          "name": "documents_publication_published_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_published_idx": {
+          "name": "documents_published_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_featured_idx": {
+          "name": "documents_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_site_idx": {
+          "name": "documents_site_idx",
+          "columns": [
+            {
+              "expression": "site_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_search_idx": {
+          "name": "documents_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "documents_trending_idx": {
+          "name": "documents_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_idx": {
+          "name": "documents_canonical_url_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_trgm_idx": {
+          "name": "documents_canonical_url_trgm_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommends": {
+      "name": "recommends",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommender_did": {
+          "name": "recommender_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recommends_document_idx": {
+          "name": "recommends_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_recommender_idx": {
+          "name": "recommends_recommender_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_edge_idx": {
+          "name": "recommends_edge_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_doc_recommender_created_idx": {
+          "name": "recommends_doc_recommender_created_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recommends\".\"deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_did": {
+          "name": "publication_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_publication_idx": {
+          "name": "subscriptions_publication_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_subscriber_idx": {
+          "name": "subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_edge_idx": {
+          "name": "subscriptions_edge_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follower_did": {
+          "name": "follower_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excluded_publications": {
+          "name": "excluded_publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_subject_idx": {
+          "name": "user_follows_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_edge_idx": {
+          "name": "user_follows_edge_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_owner_idx": {
+          "name": "bookmarks_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_document_idx": {
+          "name": "bookmarks_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_edge_idx": {
+          "name": "bookmarks_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reads": {
+      "name": "reads",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reads_owner_idx": {
+          "name": "reads_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_document_idx": {
+          "name": "reads_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_edge_idx": {
+          "name": "reads_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidebar_prefs": {
+      "name": "sidebar_prefs",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_order": {
+          "name": "list_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "tree_order": {
+          "name": "tree_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "subscription_sort": {
+          "name": "subscription_sort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customize_nav": {
+          "name": "customize_nav",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_nav": {
+          "name": "hidden_nav",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_saves": {
+      "name": "list_saves",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saver_did": {
+          "name": "saver_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_owner_did": {
+          "name": "list_owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "list_saves_saver_idx": {
+          "name": "list_saves_saver_idx",
+          "columns": [
+            {
+              "expression": "saver_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "list_saves_list_uri_idx": {
+          "name": "list_saves_list_uri_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lists": {
+      "name": "lists",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publications": {
+          "name": "publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "users": {
+          "name": "users",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lists_owner_idx": {
+          "name": "lists_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rkey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_corecommends": {
+      "name": "publication_corecommends",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_recommender_count": {
+          "name": "co_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_corecomm_rank_idx": {
+          "name": "publication_corecomm_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_corecommends_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_corecommends_related_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_corecommends_publication_uri_related_publication_uri_pk": {
+          "name": "publication_corecommends_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_cosubscriptions": {
+      "name": "publication_cosubscriptions",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_subscriber_count": {
+          "name": "co_subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_cosub_rank_idx": {
+          "name": "publication_cosub_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_cosubscriptions_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_cosubscriptions_related_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_cosubscriptions_publication_uri_related_publication_uri_pk": {
+          "name": "publication_cosubscriptions_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_stats": {
+      "name": "publication_stats",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommend_count": {
+          "name": "recommend_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_document_at": {
+          "name": "last_document_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documents_7d": {
+          "name": "documents_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_7d": {
+          "name": "subscribers_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_7d": {
+          "name": "recommends_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "documents_prev_7d": {
+          "name": "documents_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_prev_7d": {
+          "name": "subscribers_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_prev_7d": {
+          "name": "recommends_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlinks_7d": {
+          "name": "backlinks_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_velocity": {
+          "name": "trending_velocity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_window_start": {
+          "name": "trending_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_stats_subscribers_idx": {
+          "name": "publication_stats_subscribers_idx",
+          "columns": [
+            {
+              "expression": "subscriber_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_active_idx": {
+          "name": "publication_stats_active_idx",
+          "columns": [
+            {
+              "expression": "last_document_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_trending_idx": {
+          "name": "publication_stats_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_stats_publication_uri_publications_uri_fk": {
+          "name": "publication_stats_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_stats",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_stats": {
+      "name": "network_stats",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discover_topic_counts": {
+      "name": "discover_topic_counts",
+      "schema": "",
+      "columns": {
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discover_topic_counts_count_idx": {
+          "name": "discover_topic_counts_count_idx",
+          "columns": [
+            {
+              "expression": "publication_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discover_topic_counts_topic_trgm_idx": {
+          "name": "discover_topic_counts_topic_trgm_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag_embeddings": {
+      "name": "tag_embeddings",
+      "schema": "",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "double precision[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_publications": {
+      "name": "topic_publications",
+      "schema": "",
+      "columns": {
+        "topic_slug": {
+          "name": "topic_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "matched_tag_count": {
+          "name": "matched_tag_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "topic_publications_rank_idx": {
+          "name": "topic_publications_rank_idx",
+          "columns": [
+            {
+              "expression": "topic_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_publications_pub_idx": {
+          "name": "topic_publications_pub_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_publications_topic_slug_topics_slug_fk": {
+          "name": "topic_publications_topic_slug_topics_slug_fk",
+          "tableFrom": "topic_publications",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "topic_publications_publication_uri_publications_uri_fk": {
+          "name": "topic_publications_publication_uri_publications_uri_fk",
+          "tableFrom": "topic_publications",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_publications_topic_slug_publication_uri_pk": {
+          "name": "topic_publications_topic_slug_publication_uri_pk",
+          "columns": [
+            "topic_slug",
+            "publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_tags": {
+      "name": "topic_tags",
+      "schema": "",
+      "columns": {
+        "topic_slug": {
+          "name": "topic_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "topic_tags_tag_idx": {
+          "name": "topic_tags_tag_idx",
+          "columns": [
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_tags_weight_idx": {
+          "name": "topic_tags_weight_idx",
+          "columns": [
+            {
+              "expression": "topic_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weight",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_tags_topic_slug_topics_slug_fk": {
+          "name": "topic_tags_topic_slug_topics_slug_fk",
+          "tableFrom": "topic_tags",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_tags_topic_slug_tag_pk": {
+          "name": "topic_tags_topic_slug_tag_pk",
+          "columns": [
+            "topic_slug",
+            "tag"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_tags": {
+          "name": "signature_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_count": {
+          "name": "tag_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author_count": {
+          "name": "author_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_model": {
+          "name": "name_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "named_at": {
+          "name": "named_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topics_published_score_idx": {
+          "name": "topics_published_score_idx",
+          "columns": [
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topics_superseded_by_topics_slug_fk": {
+          "name": "topics_superseded_by_topics_slug_fk",
+          "tableFrom": "topics",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "superseded_by"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_dead_letter": {
+      "name": "ingest_dead_letter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retries": {
+          "name": "retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingest_dead_letter_collection_idx": {
+          "name": "ingest_dead_letter_collection_idx",
+          "columns": [
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_state": {
+      "name": "ingest_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_processed": {
+          "name": "events_processed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_repos": {
+      "name": "tracked_repos",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_to_tap_at": {
+          "name": "added_to_tap_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_state": {
+          "name": "backfill_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_seen_rev": {
+          "name": "last_seen_rev",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_fail_count": {
+          "name": "reconcile_fail_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconcile_retry_after": {
+          "name": "reconcile_retry_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tracked_repos_state_idx": {
+          "name": "tracked_repos_state_idx",
+          "columns": [
+            {
+              "expression": "backfill_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_labels": {
+      "name": "document_labels",
+      "schema": "",
+      "columns": {
+        "src": {
+          "name": "src",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "val": {
+          "name": "val",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cts": {
+          "name": "cts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_labels_uri_idx": {
+          "name": "document_labels_uri_idx",
+          "columns": [
+            {
+              "expression": "uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_labels_src_idx": {
+          "name": "document_labels_src_idx",
+          "columns": [
+            {
+              "expression": "src",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "document_labels_src_uri_val_pk": {
+          "name": "document_labels_src_uri_val_pk",
+          "columns": [
+            "src",
+            "uri",
+            "val"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_sync_state": {
+      "name": "label_sync_state",
+      "schema": "",
+      "columns": {
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_count": {
+          "name": "stored_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rejected_count": {
+          "name": "rejected_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_services": {
+      "name": "labeler_services",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_endpoint": {
+          "name": "service_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels_standard_site": {
+          "name": "labels_standard_site",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels_probed_at": {
+          "name": "labels_probed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reachable": {
+          "name": "reachable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_value_definitions": {
+          "name": "label_value_definitions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_services_labeler_idx": {
+          "name": "labeler_services_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_subscriptions": {
+      "name": "labeler_subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefs": {
+          "name": "prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_subscriptions_subscriber_idx": {
+          "name": "labeler_subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labeler_subscriptions_labeler_idx": {
+          "name": "labeler_subscriptions_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_auth_code": {
+      "name": "mcp_auth_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_auth_code_expires_at_idx": {
+          "name": "mcp_auth_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_auth_code_client_id_mcp_client_id_fk": {
+          "name": "mcp_auth_code_client_id_mcp_client_id_fk",
+          "tableFrom": "mcp_auth_code",
+          "tableTo": "mcp_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_auth_code_user_id_user_id_fk": {
+          "name": "mcp_auth_code_user_id_user_id_fk",
+          "tableFrom": "mcp_auth_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_client": {
+      "name": "mcp_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_uri": {
+          "name": "client_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_uri": {
+          "name": "logo_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_token": {
+      "name": "mcp_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_token_user_id_idx": {
+          "name": "mcp_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_expires_at_idx": {
+          "name": "mcp_token_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_client_id_mcp_client_id_fk": {
+          "name": "mcp_token_client_id_mcp_client_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "mcp_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_user_id_user_id_fk": {
+          "name": "mcp_token_user_id_user_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_token_access_token_hash_unique": {
+          "name": "mcp_token_access_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token_hash"
+          ]
+        },
+        "mcp_token_refresh_token_hash_unique": {
+          "name": "mcp_token_refresh_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_shares": {
+      "name": "quote_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_text": {
+          "name": "quote_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quote_shares_document_uri_idx": {
+          "name": "quote_shares_document_uri_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_draft": {
+      "name": "feedback_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feedback_draft_user_idx": {
+          "name": "feedback_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_draft_expires_idx": {
+          "name": "feedback_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_draft_user_id_user_id_fk": {
+          "name": "feedback_draft_user_id_user_id_fk",
+          "tableFrom": "feedback_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upvote_draft": {
+      "name": "upvote_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "upvote_draft_user_idx": {
+          "name": "upvote_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upvote_draft_expires_idx": {
+          "name": "upvote_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upvote_draft_user_id_user_id_fk": {
+          "name": "upvote_draft_user_id_user_id_fk",
+          "tableFrom": "upvote_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.save_draft": {
+      "name": "save_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_app": {
+          "name": "target_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_uri": {
+          "name": "collection_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_cid": {
+          "name": "collection_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_collection_name": {
+          "name": "new_collection_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motivation": {
+          "name": "motivation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passage": {
+          "name": "passage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "save_draft_user_idx": {
+          "name": "save_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "save_draft_expires_idx": {
+          "name": "save_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "save_draft_user_id_user_id_fk": {
+          "name": "save_draft_user_id_user_id_fk",
+          "tableFrom": "save_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/standard-reader/drizzle/meta/_journal.json
+++ b/apps/standard-reader/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1785607674037,
       "tag": "0032_topics",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1786248774435,
+      "tag": "0033_worried_harry_osborn",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/standard-reader/src/components/user-settings-view.tsx
+++ b/apps/standard-reader/src/components/user-settings-view.tsx
@@ -94,6 +94,7 @@ import { CUSTOMIZABLE_SIDEBAR_NAV } from "#/lib/sidebar-nav";
 import type { ThemeMode } from "#/lib/theme";
 import { isThemeMode } from "#/lib/theme";
 import { useCountOldPostsAsUnread } from "#/lib/use-count-old-posts-as-unread";
+import { useExcludeWebBridge } from "#/lib/use-exclude-web-bridge";
 import {
   useFeedPagination,
   useHideFeedMetrics,
@@ -461,6 +462,8 @@ export function UserSettingsView() {
     useTrackReadingHistory();
   const { enabled: countOldAsUnread, setEnabled: setCountOldAsUnread } =
     useCountOldPostsAsUnread();
+  const { enabled: excludeWebBridge, setEnabled: setExcludeWebBridge } =
+    useExcludeWebBridge();
   const { enabled: usePublicationTheme, setEnabled: setUsePublicationTheme } =
     usePublicationThemePreference();
   const { hidden: hideFeedMetrics, setHidden: setHideFeedMetrics } =
@@ -764,6 +767,17 @@ export function UserSettingsView() {
               isSelected={hideFeedMetrics}
               onChange={setHideFeedMetrics}
               aria-label={t`Hide recommend and comment counts`}
+            />
+          </SettingRow>
+          <Separator />
+          <SettingRow
+            label={t`Hide mirrored websites`}
+            description={t`Bridgy Fed mirrors tens of thousands of websites into the network without anyone there asking. When on, they are hidden from Latest, Discover, search, and tag pages. Publications you already subscribe to are never hidden, and blogs whose authors chose to bridge (ap.brid.gy) always stay.`}
+          >
+            <Switch
+              isSelected={excludeWebBridge}
+              onChange={setExcludeWebBridge}
+              aria-label={t`Hide mirrored websites`}
             />
           </SettingRow>
           <Separator />

--- a/apps/standard-reader/src/db/schema/auth.ts
+++ b/apps/standard-reader/src/db/schema/auth.ts
@@ -66,6 +66,13 @@ export const user = pgTable("user", {
    * users that existed before this preference shipped, to preserve their current
    * behaviour. */
   countOldPostsAsUnread: boolean("count_old_posts_as_unread"),
+  /** `true` hides Bridgy Fed's bulk web bridge (`*.web.brid.gy` — websites
+   * mirrored into AT Protocol without anyone there asking) from every
+   * network-wide surface: Latest "All", Discover, search, tag pages, related
+   * articles. `null`/`false` = shown (default). Never applied to the reader's
+   * own subscriptions, and never to `*.ap.brid.gy`. See
+   * `src/lib/exclude-web-bridge.ts`. */
+  excludeWebBridge: boolean("exclude_web_bridge"),
   /** `true` paints publication pages and their documents in the publication's
    * own `site.standard.theme.basic` colors; `null`/`false` = off (default), so
    * the app's editorial theme is used everywhere. Publications that carry no

--- a/apps/standard-reader/src/db/schema/network-stats.ts
+++ b/apps/standard-reader/src/db/schema/network-stats.ts
@@ -29,5 +29,19 @@ export const networkStats = pgTable("network_stats", {
 /** Discover-eligible, published, non-deleted documents across the network. */
 export const NETWORK_DOCUMENT_COUNT_KEY = "network_document_count";
 
+/**
+ * {@link NETWORK_DOCUMENT_COUNT_KEY}, minus everything authored by — or
+ * published under — one of Bridgy Fed's bulk web-bridge mirrors: the tally the
+ * Latest "All" badge needs for a reader with "Hide mirrored websites" on (see
+ * `#/lib/exclude-web-bridge`).
+ *
+ * A second precomputed scalar rather than a live count, for the same reason as
+ * the first and then some: the mirrors are ~86% of the corpus, so the filtered
+ * count cannot short-circuit anywhere and measured **26.5s** against production
+ * — two orders of magnitude worse than the unfiltered scan it replaces.
+ */
+export const NETWORK_DOCUMENT_COUNT_NO_WEB_BRIDGE_KEY =
+  "network_document_count_no_web_bridge";
+
 export type NetworkStat = typeof networkStats.$inferSelect;
 export type NewNetworkStat = typeof networkStats.$inferInsert;

--- a/apps/standard-reader/src/integrations/tanstack-query/api-discover.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-discover.functions.ts
@@ -103,9 +103,12 @@ const discoverExtrasInput = z.object({
 
 /**
  * Discover's "Recommended" rail. Bridgy Fed's bulk web-bridge mirrors
- * (`*.web.brid.gy`) are excluded here: nobody at those sites asked to be
- * published, so they read as noise in a rail that is meant to be a suggestion.
- * They stay reachable everywhere else — directory, search, trending, follows.
+ * (`*.web.brid.gy`) are excluded here unconditionally: nobody at those sites
+ * asked to be published, so they read as noise in a rail that is meant to be a
+ * suggestion. Everywhere else they stay reachable — directory, search,
+ * trending, follows — unless the reader turned on "Hide mirrored websites"
+ * (`#/lib/exclude-web-bridge`), which is the `excludeWebBridge` threaded
+ * through the rest of this file.
  */
 async function loadRecommendedRail(
   db: Db,
@@ -140,6 +143,7 @@ async function loadDiscoverExtras(
   did: string | null | undefined,
   { recommendedLimit, socialProofLimit }: z.infer<typeof discoverExtrasInput>,
   span: Span,
+  excludeWebBridge = false,
 ): Promise<DiscoverExtras> {
   const trendingLimit = Math.max(recommendedLimit, socialProofLimit);
   span.set("personalized", did != null);
@@ -149,8 +153,8 @@ async function loadDiscoverExtras(
 
   const [knownPublicationCount, trendingExclude, followUris] =
     await Promise.all([
-      countKnownPublications(db),
-      trendingPublicationUris(db, schema, trendingLimit),
+      countKnownPublications(db, { excludeWebBridge }),
+      trendingPublicationUris(db, schema, trendingLimit, { excludeWebBridge }),
       did ? effectiveFollowUris(db, schema, did) : Promise.resolve([]),
     ]);
 
@@ -168,6 +172,7 @@ async function loadDiscoverExtras(
     did
       ? followedByPeopleYouFollow(db, schema, did, socialProofLimit, {
           excludeUris: trendingExclude,
+          excludeWebBridge,
           followUris,
           seed: rotationSeed("discover-followed-by", did),
         })
@@ -206,7 +211,9 @@ const getKnownPublicationCount = createServerFn({ method: "GET" })
   .handler(
     observe("discover.getKnownPublicationCount", async ({ context }, span) => {
       await attachReaderSpanContext(span, getRequest());
-      const count = await countKnownPublications(context.db);
+      const count = await countKnownPublications(context.db, {
+        excludeWebBridge: context.excludeWebBridgeEnabled,
+      });
       span.set("count", count);
       return count;
     }),
@@ -337,7 +344,14 @@ const getDiscoverExtras = createServerFn({ method: "GET" })
     observe("discover.getDiscoverExtras", async ({ data, context }, span) => {
       const { db, schema } = context;
       const did = await attachReaderSpanContext(span, getRequest());
-      return loadDiscoverExtras(db, schema, did, data, span);
+      return loadDiscoverExtras(
+        db,
+        schema,
+        did,
+        data,
+        span,
+        context.excludeWebBridgeEnabled,
+      );
     }),
   );
 
@@ -363,6 +377,7 @@ const getPublications = createServerFn({ method: "GET" })
         limit: data.limit,
         offset: data.offset,
         query: data.q ?? null,
+        excludeWebBridge: context.excludeWebBridgeEnabled,
       });
 
       span.set("count", items.length);
@@ -382,7 +397,9 @@ const getTrendingPublications = createServerFn({ method: "GET" })
       "discover.getTrendingPublications",
       async ({ data, context }, span) => {
         const { db, schema } = context;
-        const items = await trendingPublications(db, schema, data.limit);
+        const items = await trendingPublications(db, schema, data.limit, {
+          excludeWebBridge: context.excludeWebBridgeEnabled,
+        });
         span.set("count", items.length);
         return items;
       },
@@ -396,11 +413,12 @@ const getRecommendedPublications = createServerFn({ method: "GET" })
     observe(
       "discover.getRecommendedPublications",
       async ({ data, context }, span) => {
-        const { db, schema } = context;
+        const { db, schema, excludeWebBridgeEnabled } = context;
         const trendingExclude = await trendingPublicationUris(
           db,
           schema,
           data.limit,
+          { excludeWebBridge: excludeWebBridgeEnabled },
         );
         span.set("trendingExclude", trendingExclude.length);
 
@@ -523,7 +541,11 @@ const getOnboardingSuggestions = createServerFn({ method: "GET" })
     observe(
       "discover.getOnboardingSuggestions",
       async ({ data, context }, span): Promise<OnboardingSuggestions> => {
-        const { db, schema } = context;
+        const {
+          db,
+          schema,
+          excludeWebBridgeEnabled: excludeWebBridge,
+        } = context;
         const session = await getAtprotoSessionForRequest(getRequest());
         const did = session?.did ?? null;
         if (did) span.set("did", did);
@@ -545,7 +567,7 @@ const getOnboardingSuggestions = createServerFn({ method: "GET" })
           : [];
 
         const [trending, topicGroups] = await Promise.all([
-          trendingPublications(db, schema, 6),
+          trendingPublications(db, schema, 6, { excludeWebBridge }),
           Promise.all(
             topics.map(async (topic) => ({
               topic,
@@ -554,6 +576,7 @@ const getOnboardingSuggestions = createServerFn({ method: "GET" })
                 sort: "readers",
                 limit: 8,
                 offset: 0,
+                excludeWebBridge,
               }),
             })),
           ),
@@ -566,6 +589,7 @@ const getOnboardingSuggestions = createServerFn({ method: "GET" })
           data.limit,
           [...new Set([...followUris, ...trendingUris])],
           rotationSeed("onboarding", did ?? "anon"),
+          { excludeWebBridge },
         );
 
         const sections = buildOnboardingSections({
@@ -614,7 +638,7 @@ const getFollowedByPeopleYouFollow = createServerFn({ method: "GET" })
     observe(
       "discover.getFollowedByPeopleYouFollow",
       async ({ data, context }, span) => {
-        const { db, schema } = context;
+        const { db, schema, excludeWebBridgeEnabled } = context;
         const session = await getAtprotoSessionForRequest(getRequest());
         if (!session) {
           span.set("count", 0);
@@ -625,6 +649,7 @@ const getFollowedByPeopleYouFollow = createServerFn({ method: "GET" })
           db,
           schema,
           data.limit,
+          { excludeWebBridge: excludeWebBridgeEnabled },
         );
         span.set("trendingExclude", trendingExclude.length);
         const items = await followedByPeopleYouFollow(
@@ -634,6 +659,7 @@ const getFollowedByPeopleYouFollow = createServerFn({ method: "GET" })
           data.limit,
           {
             excludeUris: trendingExclude,
+            excludeWebBridge: excludeWebBridgeEnabled,
             followUris: await effectiveFollowUris(db, schema, session.did),
             seed: rotationSeed("discover-followed-by", session.did),
           },

--- a/apps/standard-reader/src/integrations/tanstack-query/api-feed.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-feed.functions.ts
@@ -264,10 +264,12 @@ async function resolveHomeFeedContext(
     trackReading: trackReadingOverride,
     trackReadingEnabled,
     countOldPostsAsUnreadEnabled,
+    excludeWebBridgeEnabled,
   }: {
     trackReading?: boolean;
     trackReadingEnabled?: boolean;
     countOldPostsAsUnreadEnabled?: boolean;
+    excludeWebBridgeEnabled?: boolean;
   } = {},
 ) {
   const trackReading =
@@ -275,6 +277,7 @@ async function resolveHomeFeedContext(
   const countOldPostsAsUnread = did
     ? (countOldPostsAsUnreadEnabled ?? true)
     : true;
+  const excludeWebBridge = did ? (excludeWebBridgeEnabled ?? false) : false;
 
   const { publicationUris: followUris, userDids: followedUserDids } = did
     ? await effectiveFollowSets(db, schema, did)
@@ -294,7 +297,7 @@ async function resolveHomeFeedContext(
         countOldPostsAsUnread,
         ...(trackReading && did ? { readForDid: did, unreadForDid: did } : {}),
       }
-    : { discoverOnly: true };
+    : { discoverOnly: true, excludeWebBridge };
 
   return {
     did,
@@ -304,6 +307,7 @@ async function resolveHomeFeedContext(
     hasFollows,
     isTrending,
     personalized,
+    excludeWebBridge,
     rowQuery,
   };
 }
@@ -324,9 +328,12 @@ async function buildHomeFeedCritical(
   // critical payload.
   if (isTrending) {
     const [trendingPubs, trendingRaw] = await Promise.all([
-      trendingPublications(db, schema, HOME_RAIL_LIMIT),
+      trendingPublications(db, schema, HOME_RAIL_LIMIT, {
+        excludeWebBridge: ctx.excludeWebBridge,
+      }),
       trendingArticles(db, schema, HOME_TRENDING_ROW_LIMIT + 1, {
         readForDid: trackReading && ctx.did ? ctx.did : undefined,
+        excludeWebBridge: ctx.excludeWebBridge,
       }),
     ]);
     span.set("trendingPublications", trendingPubs.length);
@@ -374,7 +381,9 @@ async function buildHomeFeedCritical(
   // Trending publications rail (sidebar). Cheap indexed top-N, fetched
   // alongside the main rows so it's part of the critical payload.
   const [trendingPubs, featuredLead, rows] = await Promise.all([
-    trendingPublications(db, schema, HOME_RAIL_LIMIT),
+    trendingPublications(db, schema, HOME_RAIL_LIMIT, {
+      excludeWebBridge: ctx.excludeWebBridge,
+    }),
     selectArticleCards(db, schema, {
       ...rowQuery,
       featuredOnly: true,
@@ -470,18 +479,20 @@ async function buildHomeFeedExtras(
   ctx: HomeFeedContext,
   span: Span,
 ): Promise<HomeFeedExtras> {
-  const { personalized, did, followUris } = ctx;
+  const { personalized, did, followUris, excludeWebBridge } = ctx;
 
   const trendingPubUris = await trendingPublicationUris(
     db,
     schema,
     HOME_RAIL_LIMIT,
+    { excludeWebBridge },
   );
 
   const youMightFollow =
     personalized && did
       ? await recommendedPublications(db, schema, did, HOME_RAIL_LIMIT, {
           excludeUris: trendingPubUris,
+          excludeWebBridge,
           followUris,
           seed: rotationSeed("home", did),
         })
@@ -491,6 +502,7 @@ async function buildHomeFeedExtras(
           HOME_RAIL_LIMIT,
           trendingPubUris,
           rotationSeed("home", did ?? "anon"),
+          { excludeWebBridge },
         );
 
   span.set("youMightFollow", youMightFollow.length);
@@ -511,6 +523,7 @@ async function loadHomeFeedCritical(
     trackReading?: boolean;
     trackReadingEnabled?: boolean;
     countOldPostsAsUnreadEnabled?: boolean;
+    excludeWebBridgeEnabled?: boolean;
   } = {},
 ): Promise<HomeFeed> {
   const ctx = await resolveHomeFeedContext(
@@ -534,6 +547,7 @@ async function loadHomeFeedExtras(
     trackReading?: boolean;
     trackReadingEnabled?: boolean;
     countOldPostsAsUnreadEnabled?: boolean;
+    excludeWebBridgeEnabled?: boolean;
   } = {},
 ): Promise<HomeFeedExtras> {
   const ctx = await resolveHomeFeedContext(
@@ -552,12 +566,18 @@ const getHomeFeed = createServerFn({ method: "GET" })
   .validator(homeInput)
   .handler(
     observe("feed.getHomeFeed", async ({ data, context }, span) => {
-      const { db, schema, trackReadingEnabled, countOldPostsAsUnreadEnabled } =
-        context;
+      const {
+        db,
+        schema,
+        trackReadingEnabled,
+        countOldPostsAsUnreadEnabled,
+        excludeWebBridgeEnabled,
+      } = context;
       const did = await attachReaderSpanContext(span, getRequest());
       return loadHomeFeedCritical(db, schema, did, data.scope, span, {
         trackReadingEnabled,
         countOldPostsAsUnreadEnabled,
+        excludeWebBridgeEnabled,
       });
     }),
   );
@@ -573,7 +593,12 @@ const getHomePage = createServerFn({ method: "GET" })
   .validator(homePageInput)
   .handler(
     observe("feed.getHomePage", async ({ data, context }, span) => {
-      const { db, schema, countOldPostsAsUnreadEnabled } = context;
+      const {
+        db,
+        schema,
+        countOldPostsAsUnreadEnabled,
+        excludeWebBridgeEnabled,
+      } = context;
       const did = await attachReaderSpanContext(span, getRequest());
       const reader = did
         ? await getReaderContextForRequest(getRequest())
@@ -600,6 +625,7 @@ const getHomePage = createServerFn({ method: "GET" })
 
       const feed = await loadHomeFeedCritical(db, schema, did, scope, span, {
         countOldPostsAsUnreadEnabled,
+        excludeWebBridgeEnabled,
         ...(trackReading === undefined ? {} : { trackReading }),
       });
       return {
@@ -616,13 +642,19 @@ const getHomeExtras = createServerFn({ method: "GET" })
   .validator(homeExtrasInput)
   .handler(
     observe("feed.getHomeExtras", async ({ data, context }, span) => {
-      const { db, schema, trackReadingEnabled, countOldPostsAsUnreadEnabled } =
-        context;
+      const {
+        db,
+        schema,
+        trackReadingEnabled,
+        countOldPostsAsUnreadEnabled,
+        excludeWebBridgeEnabled,
+      } = context;
       const did = await attachReaderSpanContext(span, getRequest());
 
       return loadHomeFeedExtras(db, schema, did, data.scope, span, {
         trackReadingEnabled,
         countOldPostsAsUnreadEnabled,
+        excludeWebBridgeEnabled,
       });
     }),
   );
@@ -635,6 +667,7 @@ async function loadLatestFeedCritical(
   span: Span,
   trackReadingEnabled: boolean,
   countOldPostsAsUnreadEnabled = true,
+  excludeWebBridgeEnabled = false,
 ): Promise<LatestFeed> {
   span.set("filter", data.filter);
   span.set("offset", data.offset);
@@ -647,6 +680,7 @@ async function loadLatestFeedCritical(
   const trackReading = did == null ? false : trackReadingEnabled;
   const countOldPostsAsUnread =
     did == null ? true : countOldPostsAsUnreadEnabled;
+  const excludeWebBridge = did == null ? false : excludeWebBridgeEnabled;
 
   const trendingLimit =
     data.filter === "trending"
@@ -660,11 +694,12 @@ async function loadLatestFeedCritical(
             offset: data.offset,
             readForDid: trackReading && did ? did : undefined,
             scope: "page",
+            excludeWebBridge,
           })
         : []
       : await selectArticleCards(db, schema, {
           ...(!did || data.filter === "all"
-            ? { discoverOnly: true }
+            ? { discoverOnly: true, excludeWebBridge }
             : {
                 publicationUris: followUris,
                 followedUserDids,
@@ -734,6 +769,7 @@ async function loadLatestFeedCounts(
   span: Span,
   trackReadingEnabled: boolean,
   countOldPostsAsUnreadEnabled = true,
+  excludeWebBridgeEnabled = false,
 ): Promise<LatestFeedCounts> {
   const { publicationUris: followUris, userDids: followedUserDids } = did
     ? await effectiveFollowSets(db, schema, did)
@@ -743,6 +779,7 @@ async function loadLatestFeedCounts(
   const trackReading = did == null ? false : trackReadingEnabled;
   const countOldPostsAsUnread =
     did == null ? true : countOldPostsAsUnreadEnabled;
+  const excludeWebBridge = did == null ? false : excludeWebBridgeEnabled;
 
   const [followCounts, networkCount, trendingCount] = await Promise.all([
     did
@@ -750,8 +787,10 @@ async function loadLatestFeedCounts(
           countOldPostsAsUnread,
         })
       : Promise.resolve({ all: 0, unread: 0 }),
-    countNetworkDocuments(db, schema),
-    did ? countTrendingDocuments(db, schema, "page") : Promise.resolve(0),
+    countNetworkDocuments(db, schema, { excludeWebBridge }),
+    did
+      ? countTrendingDocuments(db, schema, "page", { excludeWebBridge })
+      : Promise.resolve(0),
   ]);
 
   return {
@@ -767,8 +806,13 @@ const getLatestFeed = createServerFn({ method: "GET" })
   .validator(latestInput)
   .handler(
     observe("feed.getLatestFeed", async ({ data, context }, span) => {
-      const { db, schema, trackReadingEnabled, countOldPostsAsUnreadEnabled } =
-        context;
+      const {
+        db,
+        schema,
+        trackReadingEnabled,
+        countOldPostsAsUnreadEnabled,
+        excludeWebBridgeEnabled,
+      } = context;
       const did = await attachReaderSpanContext(span, getRequest());
       return loadLatestFeedCritical(
         db,
@@ -778,6 +822,7 @@ const getLatestFeed = createServerFn({ method: "GET" })
         span,
         trackReadingEnabled,
         countOldPostsAsUnreadEnabled,
+        excludeWebBridgeEnabled,
       );
     }),
   );
@@ -787,8 +832,13 @@ const getLatestFeedCounts = createServerFn({ method: "GET" })
   .middleware([dbMiddleware])
   .handler(
     observe("feed.getLatestFeedCounts", async ({ context }, span) => {
-      const { db, schema, trackReadingEnabled, countOldPostsAsUnreadEnabled } =
-        context;
+      const {
+        db,
+        schema,
+        trackReadingEnabled,
+        countOldPostsAsUnreadEnabled,
+        excludeWebBridgeEnabled,
+      } = context;
       const did = await attachReaderSpanContext(span, getRequest());
       return loadLatestFeedCounts(
         db,
@@ -797,6 +847,7 @@ const getLatestFeedCounts = createServerFn({ method: "GET" })
         span,
         trackReadingEnabled,
         countOldPostsAsUnreadEnabled,
+        excludeWebBridgeEnabled,
       );
     }),
   );

--- a/apps/standard-reader/src/integrations/tanstack-query/api-publication.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-publication.functions.ts
@@ -801,7 +801,7 @@ const getArticleExtras = createServerFn({ method: "GET" })
     observe(
       "publication.getArticleExtras",
       async ({ data, context }, span): Promise<ArticleExtras> => {
-        const { db, schema } = context;
+        const { db, schema, excludeWebBridgeEnabled } = context;
         const d = schema.documents;
         span.set("documentUri", data.documentUri);
         await attachReaderSpanContext(span, getRequest());
@@ -855,6 +855,7 @@ const getArticleExtras = createServerFn({ method: "GET" })
             documentUri: row.uri,
             publicationUri: row.publicationUri,
             limit: data.relatedLimit,
+            excludeWebBridge: excludeWebBridgeEnabled,
           }),
           articleRecommendedPublications(db, schema, {
             publicationUri: row.publicationUri,

--- a/apps/standard-reader/src/integrations/tanstack-query/api-search.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-search.functions.ts
@@ -22,6 +22,8 @@ import { attachCommentCountsToArticles } from "#/server/reader/document-comments
 import {
   discoverEligiblePublicationWhere,
   notExcludedPublicationArticleWhere,
+  notWebBridgeArticleWhere,
+  notWebBridgePublicationOwnerWhere,
 } from "#/server/reader/publication-filters";
 import { attachViewerRecommendedToArticles } from "#/server/reader/recommended-by";
 import {
@@ -95,17 +97,21 @@ const searchPublications = createServerFn({ method: "GET" })
   .validator(searchPageInput)
   .handler(
     observe("search.publications", async ({ data, context }, span) => {
-      const { db, schema } = context;
+      const { db, schema, excludeWebBridgeEnabled } = context;
       span.set("q", data.q);
       span.set("offset", data.offset);
       await attachReaderSpanContext(span, getRequest());
 
+      // Only the ranked search is filtered. The URL / handle fallbacks below are
+      // a reader naming one specific account — answering "not found" because it
+      // happens to be a mirror would be wrong.
       const page = await searchIndexedPublications(
         db,
         schema,
         data.q,
         data.limit,
         data.offset,
+        { excludeWebBridge: excludeWebBridgeEnabled },
       );
 
       let items = page.items;
@@ -148,7 +154,7 @@ const searchArticles = createServerFn({ method: "GET" })
   .validator(searchPageInput)
   .handler(
     observe("search.articles", async ({ data, context }, span) => {
-      const { db, schema } = context;
+      const { db, schema, excludeWebBridgeEnabled } = context;
       const d = schema.documents;
       const p = schema.publications;
       const pr = schema.profiles;
@@ -174,6 +180,7 @@ const searchArticles = createServerFn({ method: "GET" })
         eq(d.deleted, false),
         matchClause,
         notExcludedPublicationArticleWhere(p),
+        ...(excludeWebBridgeEnabled ? [notWebBridgeArticleWhere(schema)] : []),
       );
 
       // Page the bare document URIs (newest first) in an inner subquery, then
@@ -252,6 +259,7 @@ async function searchIndexedPublications(
   q: string,
   limit: number,
   offset: number,
+  { excludeWebBridge = false }: { excludeWebBridge?: boolean } = {},
 ): Promise<{ items: Array<PublicationCard>; total: number }> {
   const p = schema.publications;
   const st = schema.publicationStats;
@@ -261,6 +269,7 @@ async function searchIndexedPublications(
   const pubWhere = and(
     discoverEligiblePublicationWhere(p),
     publicationMatchSql(p, pr, tsq, hints),
+    ...(excludeWebBridge ? [notWebBridgePublicationOwnerWhere(schema)] : []),
   );
 
   const [countRow, publicationQueryRows] = await Promise.all([

--- a/apps/standard-reader/src/integrations/tanstack-query/api-tag.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-tag.functions.ts
@@ -80,6 +80,7 @@ const getPublicationCount = createServerFn({ method: "GET" })
         context.db,
         context.schema,
         data.tag,
+        { excludeWebBridge: context.excludeWebBridgeEnabled },
       );
       span.set("count", count);
       return count;
@@ -97,6 +98,7 @@ const getArticleCount = createServerFn({ method: "GET" })
         context.db,
         context.schema,
         data.tag,
+        { excludeWebBridge: context.excludeWebBridgeEnabled },
       );
       span.set("count", count);
       return count;
@@ -108,8 +110,13 @@ const getArticles = createServerFn({ method: "GET" })
   .validator(articlesPageInput)
   .handler(
     observe("tag.getArticles", async ({ data, context }, span) => {
-      const { db, schema, trackReadingEnabled, countOldPostsAsUnreadEnabled } =
-        context;
+      const {
+        db,
+        schema,
+        trackReadingEnabled,
+        countOldPostsAsUnreadEnabled,
+        excludeWebBridgeEnabled,
+      } = context;
       const did = await attachReaderSpanContext(span, getRequest());
       span.set("tag", data.tag);
       span.set("articleSort", data.articleSort);
@@ -118,6 +125,7 @@ const getArticles = createServerFn({ method: "GET" })
       const trackReading = did == null ? false : trackReadingEnabled;
       const countOldPostsAsUnread =
         did == null ? true : countOldPostsAsUnreadEnabled;
+      const excludeWebBridge = did == null ? false : excludeWebBridgeEnabled;
 
       // The tag rows and the reader's follow set are independent reads (the
       // follow set only needs `did`), so resolve them in one wave.
@@ -125,6 +133,7 @@ const getArticles = createServerFn({ method: "GET" })
         selectArticleCards(db, schema, {
           tag: data.tag,
           discoverOnly: true,
+          excludeWebBridge,
           sort: data.articleSort,
           limit: data.limit,
           offset: data.offset,
@@ -169,7 +178,7 @@ const getPublications = createServerFn({ method: "GET" })
   .validator(directoryInput)
   .handler(
     observe("tag.getPublications", async ({ data, context }, span) => {
-      const { db, schema } = context;
+      const { db, schema, excludeWebBridgeEnabled } = context;
       await attachReaderSpanContext(span, getRequest());
       span.set("tag", data.tag);
       span.set("sort", data.sort);
@@ -180,6 +189,7 @@ const getPublications = createServerFn({ method: "GET" })
         sort: data.sort,
         limit: data.limit,
         offset: data.offset,
+        excludeWebBridge: excludeWebBridgeEnabled,
       });
 
       span.set("count", items.length);
@@ -223,8 +233,13 @@ const getTagPage = createServerFn({ method: "GET" })
   .validator(tagPageInput)
   .handler(
     observe("tag.getPage", async ({ data, context }, span) => {
-      const { db, schema, trackReadingEnabled, countOldPostsAsUnreadEnabled } =
-        context;
+      const {
+        db,
+        schema,
+        trackReadingEnabled,
+        countOldPostsAsUnreadEnabled,
+        excludeWebBridgeEnabled,
+      } = context;
       const did = await attachReaderSpanContext(span, getRequest());
       span.set("tag", data.tag);
       span.set("view", data.view);
@@ -238,15 +253,17 @@ const getTagPage = createServerFn({ method: "GET" })
       const trackReading = did == null ? false : trackReadingEnabled;
       const countOldPostsAsUnread =
         did == null ? true : countOldPostsAsUnreadEnabled;
+      const excludeWebBridge = did == null ? false : excludeWebBridgeEnabled;
 
       const [articleCount, publicationCount, content, followSets] =
         await Promise.all([
-          countTagArticles(db, schema, data.tag),
-          countTagPublications(db, schema, data.tag),
+          countTagArticles(db, schema, data.tag, { excludeWebBridge }),
+          countTagPublications(db, schema, data.tag, { excludeWebBridge }),
           data.view === "feed"
             ? selectArticleCards(db, schema, {
                 tag: data.tag,
                 discoverOnly: true,
+                excludeWebBridge,
                 sort: data.articleSort,
                 limit: data.limit,
                 offset: data.offset,
@@ -258,6 +275,7 @@ const getTagPage = createServerFn({ method: "GET" })
                 sort: data.sort,
                 limit: data.limit,
                 offset: data.offset,
+                excludeWebBridge,
               }),
           data.view === "feed" && did
             ? effectiveFollowSets(db, schema, did)
@@ -313,7 +331,7 @@ const getTagFollowSummary = createServerFn({ method: "GET" })
   .validator(tagInput)
   .handler(
     observe("tag.getFollowSummary", async ({ data, context }, span) => {
-      const { db, schema } = context;
+      const { db, schema, excludeWebBridgeEnabled } = context;
       const did = await attachReaderSpanContext(span, getRequest());
       span.set("tag", data.tag);
 
@@ -321,6 +339,7 @@ const getTagFollowSummary = createServerFn({ method: "GET" })
         db,
         schema,
         data.tag,
+        { excludeWebBridge: excludeWebBridgeEnabled },
       );
       span.set("publicationCount", publicationUris.length);
 
@@ -350,7 +369,7 @@ const followTagPublications = createServerFn({ method: "POST" })
   .validator(tagInput)
   .handler(
     observe("tag.followPublications", async ({ data, context }, span) => {
-      const { db, schema } = context;
+      const { db, schema, excludeWebBridgeEnabled } = context;
       span.set("tag", data.tag);
 
       const session = await getAtprotoSessionForRequest(getRequest());
@@ -359,10 +378,14 @@ const followTagPublications = createServerFn({ method: "POST" })
       }
       span.set("did", session.did);
 
+      // Subscribes to exactly what the tag page listed for this reader — a
+      // "follow all" that quietly signed them up to publications the page was
+      // hiding would be a nasty surprise.
       const publicationUris = await selectTagPublicationUris(
         db,
         schema,
         data.tag,
+        { excludeWebBridge: excludeWebBridgeEnabled },
       );
       const followUris = await selectFollowUris(db, schema, session.did);
       const followedSet = new Set(followUris);

--- a/apps/standard-reader/src/integrations/tanstack-query/api-user.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-user.functions.ts
@@ -33,6 +33,11 @@ import {
   dbValueToCountOldPostsAsUnread,
   parseCountOldPostsAsUnreadCookie,
 } from "#/lib/count-old-posts-as-unread";
+import {
+  DEFAULT_EXCLUDE_WEB_BRIDGE,
+  dbValueToExcludeWebBridge,
+  excludeWebBridgeToDbValue,
+} from "#/lib/exclude-web-bridge";
 import type { FeedPagination } from "#/lib/feed-preferences";
 import {
   DEFAULT_FEED_PAGINATION,
@@ -1213,6 +1218,43 @@ const setUsePublicationThemePreference = createServerFn({ method: "POST" })
     return { enabled: data.enabled };
   });
 
+// Signed-in only, like the publication theme above. Guests get the default,
+// which is also what every network-wide query falls back to.
+const getExcludeWebBridgePreference = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware, maybeAuthMiddleware])
+  .handler(async ({ context }): Promise<{ enabled: boolean }> => {
+    const session = context?.session;
+    if (!session?.user) return { enabled: DEFAULT_EXCLUDE_WEB_BRIDGE };
+
+    const row = await context.db.query.user.findFirst({
+      where: eq(context.schema.user.id, session.user.id),
+      columns: { excludeWebBridge: true },
+    });
+    return {
+      enabled: dbValueToExcludeWebBridge(row?.excludeWebBridge ?? null),
+    };
+  });
+
+const getExcludeWebBridgePreferenceQueryOptions = queryOptions({
+  queryKey: ["excludeWebBridgePreference"] as const,
+  queryFn: () => getExcludeWebBridgePreference(),
+  staleTime: Number.POSITIVE_INFINITY,
+});
+
+const setExcludeWebBridgePreference = createServerFn({ method: "POST" })
+  .middleware([dbMiddleware, maybeAuthMiddleware])
+  .validator(z.object({ enabled: z.boolean() }))
+  .handler(async ({ data, context }): Promise<{ enabled: boolean }> => {
+    if (!context?.session?.user) return { enabled: DEFAULT_EXCLUDE_WEB_BRIDGE };
+
+    await context.db
+      .update(context.schema.user)
+      .set({ excludeWebBridge: excludeWebBridgeToDbValue(data.enabled) })
+      .where(eq(context.schema.user.id, context.session.user.id));
+
+    return { enabled: data.enabled };
+  });
+
 // Feed presentation preferences — signed-in only, like the publication theme
 // above (the settings page is behind auth), so no cookie mirror for guests.
 const getHideFeedMetricsPreference = createServerFn({ method: "GET" })
@@ -1586,6 +1628,9 @@ export const user = {
   getUsePublicationThemePreference,
   getUsePublicationThemePreferenceQueryOptions,
   setUsePublicationThemePreference,
+  getExcludeWebBridgePreference,
+  getExcludeWebBridgePreferenceQueryOptions,
+  setExcludeWebBridgePreference,
   getHideFeedMetricsPreference,
   getHideFeedMetricsPreferenceQueryOptions,
   setHideFeedMetricsPreference,

--- a/apps/standard-reader/src/integrations/tanstack-query/db-middleware.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/db-middleware.ts
@@ -9,8 +9,11 @@ export const dbMiddleware = createMiddleware({ type: "function" }).server(
         import("#/server/reader/session-preferences.server"),
       ]);
 
-    const { trackReadingEnabled, countOldPostsAsUnreadEnabled } =
-      await resolveReaderSessionPreferences(db, schema);
+    const {
+      trackReadingEnabled,
+      countOldPostsAsUnreadEnabled,
+      excludeWebBridgeEnabled,
+    } = await resolveReaderSessionPreferences(db, schema);
 
     return next({
       context: {
@@ -18,6 +21,7 @@ export const dbMiddleware = createMiddleware({ type: "function" }).server(
         schema,
         trackReadingEnabled,
         countOldPostsAsUnreadEnabled,
+        excludeWebBridgeEnabled,
       },
     });
   },

--- a/apps/standard-reader/src/lib/exclude-web-bridge.ts
+++ b/apps/standard-reader/src/lib/exclude-web-bridge.ts
@@ -1,0 +1,35 @@
+/**
+ * "Hide mirrored websites" preference — drops Bridgy Fed's bulk web bridge
+ * (`*.web.brid.gy`) from every network-wide surface for one reader.
+ *
+ * Those repos are sites Bridgy discovered and mirrored; nobody at them asked to
+ * be here (see `#/lib/atproto/bridged-repo`). They are also the overwhelming
+ * majority of the corpus — at time of writing 2.57M of 2.99M documents and
+ * 5,227 of 14,869 publications — so a reader who does not want them wants them
+ * gone from Latest "All", Discover, search and tag pages, not filtered a page at
+ * a time.
+ *
+ * Deliberately **not** applied to anything the reader chose: their
+ * subscriptions feed, a publication page they opened, an article they clicked.
+ * Subscribing to a mirrored site is an explicit "yes, this one", and a setting
+ * about discovery should not quietly retract it.
+ *
+ * `*.ap.brid.gy` is never touched — those authors opted into the bridge, and
+ * they are squarely what this reader is for.
+ *
+ * Persisted on `user.exclude_web_bridge` (`null`/`false` = show, the default —
+ * today's behaviour for everyone). Account-level only: there is no cookie
+ * mirror, so guests and signed-out sessions always get the default.
+ */
+
+export const DEFAULT_EXCLUDE_WEB_BRIDGE = false;
+
+export function excludeWebBridgeToDbValue(enabled: boolean): boolean {
+  return enabled;
+}
+
+export function dbValueToExcludeWebBridge(
+  value: boolean | null | undefined,
+): boolean {
+  return value === true;
+}

--- a/apps/standard-reader/src/lib/use-exclude-web-bridge.ts
+++ b/apps/standard-reader/src/lib/use-exclude-web-bridge.ts
@@ -1,0 +1,84 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+
+import { user } from "#/integrations/tanstack-query/api-user.functions";
+
+import { DEFAULT_EXCLUDE_WEB_BRIDGE } from "./exclude-web-bridge";
+
+export interface ExcludeWebBridgeContextValue {
+  enabled: boolean;
+  setEnabled: (next: boolean) => void;
+  isPending: boolean;
+}
+
+/** "Hide mirrored websites" preference — see `#/lib/exclude-web-bridge`. */
+export function useExcludeWebBridge(): ExcludeWebBridgeContextValue {
+  const queryClient = useQueryClient();
+
+  const { data } = useQuery({
+    ...user.getExcludeWebBridgePreferenceQueryOptions,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+  });
+  const enabled = data?.enabled ?? DEFAULT_EXCLUDE_WEB_BRIDGE;
+
+  const setMutation = useMutation({
+    mutationFn: async (next: boolean) => {
+      return await user.setExcludeWebBridgePreference({
+        data: { enabled: next },
+      });
+    },
+    onMutate: async (next) => {
+      await queryClient.cancelQueries({
+        queryKey: user.getExcludeWebBridgePreferenceQueryOptions.queryKey,
+      });
+      const previous = queryClient.getQueryData(
+        user.getExcludeWebBridgePreferenceQueryOptions.queryKey,
+      );
+      queryClient.setQueryData(
+        user.getExcludeWebBridgePreferenceQueryOptions.queryKey,
+        { enabled: next },
+      );
+      return { previous };
+    },
+    onError: (_error, _next, ctx) => {
+      if (ctx?.previous) {
+        queryClient.setQueryData(
+          user.getExcludeWebBridgePreferenceQueryOptions.queryKey,
+          ctx.previous,
+        );
+      }
+    },
+    onSuccess: (result) => {
+      queryClient.setQueryData(
+        user.getExcludeWebBridgePreferenceQueryOptions.queryKey,
+        result,
+      );
+      // Every network-wide surface is filtered server-side, so each of their
+      // caches is now stale — the rows themselves changed, not just a count.
+      for (const key of [
+        ["feed"],
+        ["discover"],
+        ["tag"],
+        ["search"],
+        ["publication"],
+      ]) {
+        void queryClient.invalidateQueries({ queryKey: key });
+      }
+    },
+  });
+
+  const setEnabled = useCallback(
+    (next: boolean) => {
+      if (next === enabled) return;
+      setMutation.mutate(next);
+    },
+    [enabled, setMutation],
+  );
+
+  return {
+    enabled,
+    setEnabled,
+    isPending: setMutation.isPending,
+  };
+}

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -3734,6 +3734,10 @@ msgstr ""
 msgid "Once you subscribe to more than a handful of publications, one long list stops helping. Lists group them, and the sidebar can be arranged around how you actually read."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Bridgy Fed mirrors tens of thousands of websites into the network without anyone there asking. When on, they are hidden from Latest, Discover, search, and tag pages. Publications you already subscribe to are never hidden, and blogs whose authors chose to bridge (ap.brid.gy) always stay."
+msgstr ""
+
 #: src/components/reader/comments/add-comment-dialog.tsx
 #~ msgid "Discussion here is assembled from posts that live in your own repo, so comments are written wherever you already post. Pick where to write yours — it joins this article's discussion once the network indexes it."
 #~ msgstr ""
@@ -6537,6 +6541,10 @@ msgstr ""
 
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "Selecting the <0>Subscriptions</0> heading in the sidebar opens one table of everything you follow — publications and people together. Each row shows unread count, when it last published, how many articles and readers it has, its topic, and which of your lists it belongs to."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Hide mirrored websites"
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -3734,6 +3734,10 @@ msgstr ""
 msgid "Once you subscribe to more than a handful of publications, one long list stops helping. Lists group them, and the sidebar can be arranged around how you actually read."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Bridgy Fed mirrors tens of thousands of websites into the network without anyone there asking. When on, they are hidden from Latest, Discover, search, and tag pages. Publications you already subscribe to are never hidden, and blogs whose authors chose to bridge (ap.brid.gy) always stay."
+msgstr ""
+
 #: src/components/reader/comments/add-comment-dialog.tsx
 #~ msgid "Discussion here is assembled from posts that live in your own repo, so comments are written wherever you already post. Pick where to write yours — it joins this article's discussion once the network indexes it."
 #~ msgstr ""
@@ -6537,6 +6541,10 @@ msgstr ""
 
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "Selecting the <0>Subscriptions</0> heading in the sidebar opens one table of everything you follow — publications and people together. Each row shows unread count, when it last published, how many articles and readers it has, its topic, and which of your lists it belongs to."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Hide mirrored websites"
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -3734,6 +3734,10 @@ msgstr ""
 msgid "Once you subscribe to more than a handful of publications, one long list stops helping. Lists group them, and the sidebar can be arranged around how you actually read."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Bridgy Fed mirrors tens of thousands of websites into the network without anyone there asking. When on, they are hidden from Latest, Discover, search, and tag pages. Publications you already subscribe to are never hidden, and blogs whose authors chose to bridge (ap.brid.gy) always stay."
+msgstr ""
+
 #: src/components/reader/comments/add-comment-dialog.tsx
 #~ msgid "Discussion here is assembled from posts that live in your own repo, so comments are written wherever you already post. Pick where to write yours — it joins this article's discussion once the network indexes it."
 #~ msgstr ""
@@ -6537,6 +6541,10 @@ msgstr ""
 
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "Selecting the <0>Subscriptions</0> heading in the sidebar opens one table of everything you follow — publications and people together. Each row shows unread count, when it last published, how many articles and readers it has, its topic, and which of your lists it belongs to."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Hide mirrored websites"
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -3734,6 +3734,10 @@ msgstr "Some labels skipped"
 msgid "Once you subscribe to more than a handful of publications, one long list stops helping. Lists group them, and the sidebar can be arranged around how you actually read."
 msgstr "Once you subscribe to more than a handful of publications, one long list stops helping. Lists group them, and the sidebar can be arranged around how you actually read."
 
+#: src/components/user-settings-view.tsx
+msgid "Bridgy Fed mirrors tens of thousands of websites into the network without anyone there asking. When on, they are hidden from Latest, Discover, search, and tag pages. Publications you already subscribe to are never hidden, and blogs whose authors chose to bridge (ap.brid.gy) always stay."
+msgstr "Bridgy Fed mirrors tens of thousands of websites into the network without anyone there asking. When on, they are hidden from Latest, Discover, search, and tag pages. Publications you already subscribe to are never hidden, and blogs whose authors chose to bridge (ap.brid.gy) always stay."
+
 #: src/components/reader/comments/add-comment-dialog.tsx
 #~ msgid "Discussion here is assembled from posts that live in your own repo, so comments are written wherever you already post. Pick where to write yours — it joins this article's discussion once the network indexes it."
 #~ msgstr "Discussion here is assembled from posts that live in your own repo, so comments are written wherever you already post. Pick where to write yours — it joins this article's discussion once the network indexes it."
@@ -6538,6 +6542,10 @@ msgstr "editorial, plain sans-serif, or any family from Google Fonts."
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "Selecting the <0>Subscriptions</0> heading in the sidebar opens one table of everything you follow — publications and people together. Each row shows unread count, when it last published, how many articles and readers it has, its topic, and which of your lists it belongs to."
 msgstr "Selecting the <0>Subscriptions</0> heading in the sidebar opens one table of everything you follow — publications and people together. Each row shows unread count, when it last published, how many articles and readers it has, its topic, and which of your lists it belongs to."
+
+#: src/components/user-settings-view.tsx
+msgid "Hide mirrored websites"
+msgstr "Hide mirrored websites"
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 #~ msgid "Open publication"

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -3734,6 +3734,10 @@ msgstr ""
 msgid "Once you subscribe to more than a handful of publications, one long list stops helping. Lists group them, and the sidebar can be arranged around how you actually read."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Bridgy Fed mirrors tens of thousands of websites into the network without anyone there asking. When on, they are hidden from Latest, Discover, search, and tag pages. Publications you already subscribe to are never hidden, and blogs whose authors chose to bridge (ap.brid.gy) always stay."
+msgstr ""
+
 #: src/components/reader/comments/add-comment-dialog.tsx
 #~ msgid "Discussion here is assembled from posts that live in your own repo, so comments are written wherever you already post. Pick where to write yours — it joins this article's discussion once the network indexes it."
 #~ msgstr ""
@@ -6537,6 +6541,10 @@ msgstr ""
 
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "Selecting the <0>Subscriptions</0> heading in the sidebar opens one table of everything you follow — publications and people together. Each row shows unread count, when it last published, how many articles and readers it has, its topic, and which of your lists it belongs to."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Hide mirrored websites"
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -3734,6 +3734,10 @@ msgstr ""
 msgid "Once you subscribe to more than a handful of publications, one long list stops helping. Lists group them, and the sidebar can be arranged around how you actually read."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Bridgy Fed mirrors tens of thousands of websites into the network without anyone there asking. When on, they are hidden from Latest, Discover, search, and tag pages. Publications you already subscribe to are never hidden, and blogs whose authors chose to bridge (ap.brid.gy) always stay."
+msgstr ""
+
 #: src/components/reader/comments/add-comment-dialog.tsx
 #~ msgid "Discussion here is assembled from posts that live in your own repo, so comments are written wherever you already post. Pick where to write yours — it joins this article's discussion once the network indexes it."
 #~ msgstr ""
@@ -6537,6 +6541,10 @@ msgstr ""
 
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "Selecting the <0>Subscriptions</0> heading in the sidebar opens one table of everything you follow — publications and people together. Each row shows unread count, when it last published, how many articles and readers it has, its topic, and which of your lists it belongs to."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Hide mirrored websites"
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -3734,6 +3734,10 @@ msgstr ""
 msgid "Once you subscribe to more than a handful of publications, one long list stops helping. Lists group them, and the sidebar can be arranged around how you actually read."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Bridgy Fed mirrors tens of thousands of websites into the network without anyone there asking. When on, they are hidden from Latest, Discover, search, and tag pages. Publications you already subscribe to are never hidden, and blogs whose authors chose to bridge (ap.brid.gy) always stay."
+msgstr ""
+
 #: src/components/reader/comments/add-comment-dialog.tsx
 #~ msgid "Discussion here is assembled from posts that live in your own repo, so comments are written wherever you already post. Pick where to write yours — it joins this article's discussion once the network indexes it."
 #~ msgstr ""
@@ -6537,6 +6541,10 @@ msgstr ""
 
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "Selecting the <0>Subscriptions</0> heading in the sidebar opens one table of everything you follow — publications and people together. Each row shows unread count, when it last published, how many articles and readers it has, its topic, and which of your lists it belongs to."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Hide mirrored websites"
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -3734,6 +3734,10 @@ msgstr ""
 msgid "Once you subscribe to more than a handful of publications, one long list stops helping. Lists group them, and the sidebar can be arranged around how you actually read."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Bridgy Fed mirrors tens of thousands of websites into the network without anyone there asking. When on, they are hidden from Latest, Discover, search, and tag pages. Publications you already subscribe to are never hidden, and blogs whose authors chose to bridge (ap.brid.gy) always stay."
+msgstr ""
+
 #: src/components/reader/comments/add-comment-dialog.tsx
 #~ msgid "Discussion here is assembled from posts that live in your own repo, so comments are written wherever you already post. Pick where to write yours — it joins this article's discussion once the network indexes it."
 #~ msgstr ""
@@ -6537,6 +6541,10 @@ msgstr ""
 
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "Selecting the <0>Subscriptions</0> heading in the sidebar opens one table of everything you follow — publications and people together. Each row shows unread count, when it last published, how many articles and readers it has, its topic, and which of your lists it belongs to."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Hide mirrored websites"
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -3734,6 +3734,10 @@ msgstr ""
 msgid "Once you subscribe to more than a handful of publications, one long list stops helping. Lists group them, and the sidebar can be arranged around how you actually read."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Bridgy Fed mirrors tens of thousands of websites into the network without anyone there asking. When on, they are hidden from Latest, Discover, search, and tag pages. Publications you already subscribe to are never hidden, and blogs whose authors chose to bridge (ap.brid.gy) always stay."
+msgstr ""
+
 #: src/components/reader/comments/add-comment-dialog.tsx
 #~ msgid "Discussion here is assembled from posts that live in your own repo, so comments are written wherever you already post. Pick where to write yours — it joins this article's discussion once the network indexes it."
 #~ msgstr ""
@@ -6537,6 +6541,10 @@ msgstr ""
 
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "Selecting the <0>Subscriptions</0> heading in the sidebar opens one table of everything you follow — publications and people together. Each row shows unread count, when it last published, how many articles and readers it has, its topic, and which of your lists it belongs to."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Hide mirrored websites"
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -3734,6 +3734,10 @@ msgstr ""
 msgid "Once you subscribe to more than a handful of publications, one long list stops helping. Lists group them, and the sidebar can be arranged around how you actually read."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Bridgy Fed mirrors tens of thousands of websites into the network without anyone there asking. When on, they are hidden from Latest, Discover, search, and tag pages. Publications you already subscribe to are never hidden, and blogs whose authors chose to bridge (ap.brid.gy) always stay."
+msgstr ""
+
 #: src/components/reader/comments/add-comment-dialog.tsx
 #~ msgid "Discussion here is assembled from posts that live in your own repo, so comments are written wherever you already post. Pick where to write yours — it joins this article's discussion once the network indexes it."
 #~ msgstr ""
@@ -6537,6 +6541,10 @@ msgstr ""
 
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "Selecting the <0>Subscriptions</0> heading in the sidebar opens one table of everything you follow — publications and people together. Each row shows unread count, when it last published, how many articles and readers it has, its topic, and which of your lists it belongs to."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Hide mirrored websites"
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx

--- a/apps/standard-reader/src/routes/api/digest/preview.tsx
+++ b/apps/standard-reader/src/routes/api/digest/preview.tsx
@@ -43,12 +43,14 @@ export const Route = createFileRoute("/api/digest/preview")({
             weeklyDigestSectionNetwork: true,
             weeklyDigestSectionSaved: true,
             weeklyDigestSectionRecommendations: true,
+            excludeWebBridge: true,
           },
         });
 
         const digest = await buildDigestForUser(db, schema, {
           did: reader.did,
           sections: digestSectionsFromUser(prefsRow ?? {}),
+          excludeWebBridge: prefsRow?.excludeWebBridge === true,
         });
         const rendered = await renderDigestEmail(digest, {
           baseUrl: getPublicUrl(),

--- a/apps/standard-reader/src/routes/api/extension/discussion.tsx
+++ b/apps/standard-reader/src/routes/api/extension/discussion.tsx
@@ -13,12 +13,18 @@ export const Route = createFileRoute("/api/extension/discussion")({
           return badRequestResponse("documentUri query param required");
         }
 
-        const [{ db }, schema] = await Promise.all([
-          import("#/db/index.server"),
-          import("#/db/schema"),
-        ]);
+        const [{ db }, schema, { resolveReaderSessionPreferences }] =
+          await Promise.all([
+            import("#/db/index.server"),
+            import("#/db/schema"),
+            import("#/server/reader/session-preferences.server"),
+          ]);
 
-        const discussion = await resolveDiscussion(db, schema, documentUri);
+        const { excludeWebBridgeEnabled } =
+          await resolveReaderSessionPreferences(db, schema);
+        const discussion = await resolveDiscussion(db, schema, documentUri, {
+          excludeWebBridge: excludeWebBridgeEnabled,
+        });
         return Response.json(discussion);
       },
     },

--- a/apps/standard-reader/src/server/api-docs/run-example.server.ts
+++ b/apps/standard-reader/src/server/api-docs/run-example.server.ts
@@ -153,8 +153,13 @@ async function runWithSessionAuth(
         });
 
   try {
-    const { db, schema, trackReadingEnabled, countOldPostsAsUnreadEnabled } =
-      await getXrpcDbContext();
+    const {
+      db,
+      schema,
+      trackReadingEnabled,
+      countOldPostsAsUnreadEnabled,
+      excludeWebBridgeEnabled,
+    } = await getXrpcDbContext();
     const auth: XrpcAuthContext = {
       did: session.did as Did,
       client: session.client,
@@ -168,6 +173,7 @@ async function runWithSessionAuth(
       schema,
       trackReadingEnabled,
       countOldPostsAsUnreadEnabled,
+      excludeWebBridgeEnabled,
       params,
       body: body ?? null,
     });

--- a/apps/standard-reader/src/server/digest/builder.ts
+++ b/apps/standard-reader/src/server/digest/builder.ts
@@ -104,7 +104,17 @@ export async function buildDigestForUser(
   {
     did,
     sections = ALL_DIGEST_SECTIONS,
-  }: { did: string; sections?: DigestSections },
+    excludeWebBridge = false,
+  }: {
+    did: string;
+    sections?: DigestSections;
+    /**
+     * The reader's "Hide mirrored websites" setting (`#/lib/exclude-web-bridge`).
+     * Only the network section is network-wide, so only it is filtered — the
+     * subscriptions and saved sections are made of sources the reader chose.
+     */
+    excludeWebBridge?: boolean;
+  },
 ): Promise<DigestData> {
   // Needed by the subscriptions section directly, and by the recommendations
   // section to exclude publications the reader already follows.
@@ -132,6 +142,7 @@ export async function buildDigestForUser(
           limit: DIGEST_NETWORK_ARTICLE_LIMIT,
           excludeUris: articleUris,
           excludeReadForDid: did,
+          excludeWebBridge,
         })
       : Promise.resolve([]),
     sections.saved
@@ -143,6 +154,7 @@ export async function buildDigestForUser(
       : Promise.resolve([]),
     sections.recommendations
       ? recommendedPublications(db, schema, did, DIGEST_RECOMMENDATION_LIMIT, {
+          excludeWebBridge,
           followUris,
           seed: rotationSeed("digest", did),
         })

--- a/apps/standard-reader/src/server/digest/run.ts
+++ b/apps/standard-reader/src/server/digest/run.ts
@@ -13,6 +13,7 @@
 
 import { and, eq, isNotNull, isNull, lt, or, sql } from "drizzle-orm";
 
+import { dbValueToExcludeWebBridge } from "#/lib/exclude-web-bridge";
 import { getPublicUrl } from "#/lib/public-url";
 
 import { db } from "../../db/index.ts";
@@ -64,6 +65,7 @@ export async function runWeeklyDigest(): Promise<DigestRunSummary> {
       weeklyDigestSectionNetwork: true,
       weeklyDigestSectionSaved: true,
       weeklyDigestSectionRecommendations: true,
+      excludeWebBridge: true,
     },
     limit: maxPerRun,
   });
@@ -84,6 +86,7 @@ export async function runWeeklyDigest(): Promise<DigestRunSummary> {
     const digest = await buildDigestForUser(db, schema, {
       did: reader.did,
       sections,
+      excludeWebBridge: dbValueToExcludeWebBridge(reader.excludeWebBridge),
     });
     // Skip when there's no real reading content to send. Recommendations alone
     // (which cold-start to popular publications) aren't enough to justify a

--- a/apps/standard-reader/src/server/extension/discussion.server.ts
+++ b/apps/standard-reader/src/server/extension/discussion.server.ts
@@ -88,6 +88,7 @@ export async function resolveDiscussion(
   dbClient: typeof db,
   schemaModule: typeof schema,
   documentUri: string,
+  { excludeWebBridge = false }: { excludeWebBridge?: boolean } = {},
 ): Promise<ExtensionDiscussionResponse> {
   const d = schemaModule.documents;
   const p = schemaModule.publications;
@@ -143,6 +144,7 @@ export async function resolveDiscussion(
       documentUri: row.uri,
       publicationUri: row.publicationUri,
       limit: 8,
+      excludeWebBridge,
     }),
     linkUrls.length > 0
       ? fetchCitedInArticles(dbClient, schemaModule, {

--- a/apps/standard-reader/src/server/ingest/recompute.ts
+++ b/apps/standard-reader/src/server/ingest/recompute.ts
@@ -10,6 +10,7 @@ import {
   sql,
 } from "drizzle-orm";
 
+import { WEB_BRIDGE_HANDLE_PATTERN } from "#/lib/atproto/bridged-repo";
 import { mapWithConcurrency } from "#/lib/concurrency";
 import { hasRenderableArticleBody } from "#/lib/document/renderable";
 import {
@@ -35,6 +36,7 @@ import * as schema from "../../db/schema.ts";
 import {
   documents,
   NETWORK_DOCUMENT_COUNT_KEY,
+  NETWORK_DOCUMENT_COUNT_NO_WEB_BRIDGE_KEY,
   profiles,
   publications,
 } from "../../db/schema.ts";
@@ -654,33 +656,79 @@ export async function recomputeDiscoverTopicCounts(): Promise<void> {
 /**
  * Rebuild the network-wide scalars in `network_stats`.
  *
- * Currently just the Latest "All" tab badge. Computing it on the request path
- * is an unbounded `count(*)` over every document joined to publications — no
- * index can serve it, so it lands as a parallel seq scan (~1.08s over ~1.4M
- * rows / 2.2GB at time of writing) on `/latest`'s blocking loader, and re-reads
- * the whole heap from storage on each call. Here it is one more sweep-time
- * scan; readers get a single-row primary-key lookup.
+ * Both entries are the Latest "All" tab badge: the plain corpus tally, and the
+ * same tally with Bridgy Fed's bulk web-bridge mirrors removed, which is what a
+ * reader with "Hide mirrored websites" on is looking at (see
+ * `#/lib/exclude-web-bridge`). Computing either on the request path is an
+ * unbounded `count(*)` over every document joined to publications — no index can
+ * serve it, so it lands as a seq scan (~1.08s over ~1.4M rows / 2.2GB at time of
+ * writing; **26.5s** for the filtered variant when its exclusions are written as
+ * per-row anti-joins) on `/latest`'s blocking loader, and re-reads the whole heap
+ * from storage on each call. Here it is sweep-time work; readers get a
+ * single-row primary-key lookup.
+ *
+ * Measured on a prod-scale copy (3.0M documents), this statement runs **~4.8s**
+ * against **~3.8s** for the single-count version it replaces — the second tally
+ * costs about a second per sweep. Two shapes that cost considerably more, both
+ * rejected:
+ *
+ * - **Aggregating after the `UNION ALL`** — a row-level CTE of eligibility flags
+ *   with a `count(*)` branch and a `count(*) FILTER` branch over it. It reads as
+ *   one pass and is not one: Postgres walks `documents` once per branch (5.7s).
+ *   Hence the aggregation below happens *first*, and the `UNION ALL` only
+ *   unpivots the resulting single row — which is also what guarantees the two
+ *   scalars describe the same instant.
+ * - **The `NOT EXISTS` spelling the read path uses**
+ *   ({@link notWebBridgeArticleWhere}). Equivalent, but the read path's sits in a
+ *   `WHERE`, where the planner turns it into an anti-join. As a projected boolean
+ *   there is no anti-join to reach for, so it becomes a SubPlan run once per row:
+ *   2.97M index searches, 8.9M buffer hits.
+ *
+ * The `LEFT JOIN` against an inline subquery below hashes the ~5.6k bridged repos
+ * once and probes. Note the inline subquery rather than a CTE: a CTE scan is
+ * parallel-restricted, which costs nothing *here* (`ON CONFLICT` already makes
+ * the insert parallel-unsafe) but doubles the runtime of the same aggregate run
+ * on its own — 4.9s against 2.6s — so the parallel-safe spelling is the one to
+ * keep. `profiles.did` is the primary key, so neither join can duplicate a row.
  *
  * The predicate must stay in lockstep with `discoverEligibleArticleWhere` +
- * `documentPublishedNotInFuture` in `#/server/reader/queries` — those still
- * define what the "All" tab actually lists, and this is only its cardinality.
+ * `documentPublishedNotInFuture` (and, for the filtered variant,
+ * `notWebBridgeArticleWhere`) in `#/server/reader/queries` — those still define
+ * what the "All" tab actually lists, and this is only its cardinality.
  */
 export async function recomputeNetworkStats(): Promise<void> {
   await db.execute(sql`
     INSERT INTO network_stats (key, value, recomputed_at)
-    SELECT ${NETWORK_DOCUMENT_COUNT_KEY}, count(*), now()
-    FROM documents d
-    LEFT JOIN publications p ON p.uri = d.publication_uri
-    WHERE d.deleted = false
-      AND (d.published_at IS NULL OR d.published_at <= now())
-      AND (
-        p.uri IS NULL
-        OR (
-          p.deleted = false
-          AND p.show_in_discover = true
-          AND p.url NOT ILIKE ${EXCLUDED_PUBLICATION_URL_PATTERN}
+    SELECT stat.key, stat.value, now()
+    FROM (
+      SELECT
+        count(*) AS all_documents,
+        count(*) FILTER (
+          WHERE wba.did IS NULL AND wbp.did IS NULL
+        ) AS documents_without_web_bridge
+      FROM documents d
+      LEFT JOIN publications p ON p.uri = d.publication_uri
+      LEFT JOIN (
+        SELECT did FROM profiles WHERE handle ILIKE ${WEB_BRIDGE_HANDLE_PATTERN}
+      ) wba ON wba.did = d.did
+      LEFT JOIN (
+        SELECT did FROM profiles WHERE handle ILIKE ${WEB_BRIDGE_HANDLE_PATTERN}
+      ) wbp ON wbp.did = p.did
+      WHERE d.deleted = false
+        AND (d.published_at IS NULL OR d.published_at <= now())
+        AND (
+          p.uri IS NULL
+          OR (
+            p.deleted = false
+            AND p.show_in_discover = true
+            AND p.url NOT ILIKE ${EXCLUDED_PUBLICATION_URL_PATTERN}
+          )
         )
-      )
+    ) totals
+    CROSS JOIN LATERAL (VALUES
+      (${NETWORK_DOCUMENT_COUNT_KEY}, totals.all_documents),
+      (${NETWORK_DOCUMENT_COUNT_NO_WEB_BRIDGE_KEY}, totals.documents_without_web_bridge)
+    ) AS stat(key, value)
     ON CONFLICT (key) DO UPDATE
       SET value = excluded.value, recomputed_at = excluded.recomputed_at
   `);

--- a/apps/standard-reader/src/server/mcp/xrpc.ts
+++ b/apps/standard-reader/src/server/mcp/xrpc.ts
@@ -87,6 +87,7 @@ export async function invokeXrpc(
     schema: db.schema,
     trackReadingEnabled: db.trackReadingEnabled,
     countOldPostsAsUnreadEnabled: db.countOldPostsAsUnreadEnabled,
+    excludeWebBridgeEnabled: db.excludeWebBridgeEnabled,
     params,
     body: input.body ?? null,
   };

--- a/apps/standard-reader/src/server/reader/publication-filters.ts
+++ b/apps/standard-reader/src/server/reader/publication-filters.ts
@@ -1,8 +1,12 @@
 import type { SQL } from "drizzle-orm";
-import { and, eq, ilike, isNull, not, or } from "drizzle-orm";
+import { and, eq, ilike, isNull, not, or, sql } from "drizzle-orm";
+import type { PgColumn } from "drizzle-orm/pg-core";
 
 import type { Schema } from "#/integrations/tanstack-query/api-shapes";
-import { WEB_BRIDGE_HANDLE_SUFFIX } from "#/lib/atproto/bridged-repo";
+import {
+  WEB_BRIDGE_HANDLE_PATTERN,
+  WEB_BRIDGE_HANDLE_SUFFIX,
+} from "#/lib/atproto/bridged-repo";
 import { EXCLUDED_PUBLICATION_URL_PATTERN } from "#/lib/publication/exclusions";
 
 /** Read-model filter for directory / search / discovery publication queries. */
@@ -57,4 +61,63 @@ export function notWebBridgePublicationWhere(pr: Schema["profiles"]): SQL {
 /** Keep articles with no publication row, or whose publication is not excluded. */
 export function notExcludedPublicationArticleWhere(p: Schema["publications"]) {
   return or(isNull(p.uri), not(ilike(p.url, EXCLUDED_PUBLICATION_URL_PATTERN)));
+}
+
+/**
+ * `did` does not belong to one of Bridgy Fed's bulk web-bridge mirrors.
+ *
+ * The anti-join form, correlating on whatever DID column is passed, so a caller
+ * needs no `profiles` join or alias — the read-model queries that want this are
+ * spread across `documents`-only counts, `publications`-only counts, and card
+ * queries that already join `profiles` twice, and one spelling for all of them
+ * is what keeps them from drifting (`topics.ts` and its derivation drifted
+ * apart once already, which is why {@link WEB_BRIDGE_HANDLE_PATTERN} exists).
+ *
+ * Costs about what the equivalent join filter costs — measured on the `/latest`
+ * "All" page against production, both forms land at ~2.4ms warm vs ~0.4ms
+ * unfiltered, because `profiles.did` is the primary key and the probe is one
+ * index search per candidate row.
+ *
+ * A DID with no profile row, or an unresolved handle, is kept — matching
+ * `isBridgedHandle`: a briefly unreachable DID document should not silently
+ * drop a real publisher.
+ */
+function notWebBridgeDidWhere(
+  pr: Schema["profiles"],
+  didColumn: PgColumn,
+): SQL {
+  return sql`not exists (
+    select 1 from ${pr} wb
+    where wb.did = ${didColumn}
+      and wb.handle ilike ${WEB_BRIDGE_HANDLE_PATTERN}
+  )`;
+}
+
+/**
+ * Drop a document whose **author** is a web-bridge mirror. Pair with
+ * {@link notWebBridgePublicationOwnerWhere} on any query that also reaches
+ * `publications`: a bridged author can post into a non-bridged publication and
+ * vice versa, so neither test implies the other.
+ */
+export function notWebBridgeAuthorWhere(schema: Schema): SQL {
+  return notWebBridgeDidWhere(schema.profiles, schema.documents.did);
+}
+
+/** Drop a publication whose **owner** is a web-bridge mirror. */
+export function notWebBridgePublicationOwnerWhere(schema: Schema): SQL {
+  return notWebBridgeDidWhere(schema.profiles, schema.publications.did);
+}
+
+/**
+ * Both web-bridge tests for an article query — author and publication owner.
+ *
+ * `p` must be `leftJoin`ed (loose documents have no publication row); the owner
+ * test passes trivially for them since `publications.did` is NULL and the
+ * anti-join finds nothing.
+ */
+export function notWebBridgeArticleWhere(schema: Schema): SQL {
+  return and(
+    notWebBridgeAuthorWhere(schema),
+    notWebBridgePublicationOwnerWhere(schema),
+  ) as SQL;
 }

--- a/apps/standard-reader/src/server/reader/queries.ts
+++ b/apps/standard-reader/src/server/reader/queries.ts
@@ -30,7 +30,10 @@ import {
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
-import { NETWORK_DOCUMENT_COUNT_KEY } from "#/db/schema/network-stats";
+import {
+  NETWORK_DOCUMENT_COUNT_KEY,
+  NETWORK_DOCUMENT_COUNT_NO_WEB_BRIDGE_KEY,
+} from "#/db/schema/network-stats";
 import type {
   ArticleCard,
   Db,
@@ -48,11 +51,17 @@ import {
   toArticleCard,
   toPublicationCard,
 } from "#/integrations/tanstack-query/api-shapes";
+import {
+  isWebBridgeHandle,
+  WEB_BRIDGE_HANDLE_PATTERN,
+} from "#/lib/atproto/bridged-repo";
 import { EXCLUDED_PUBLICATION_URL_PATTERN } from "#/lib/publication/exclusions";
 import { documentPublishedNotInFuture } from "#/server/reader/document-filters";
 import {
   discoverEligibleArticleWhere,
   discoverEligiblePublicationWhere,
+  notWebBridgeArticleWhere,
+  notWebBridgePublicationOwnerWhere,
   notWebBridgePublicationWhere,
 } from "#/server/reader/publication-filters";
 import {
@@ -124,6 +133,14 @@ export interface ArticleCardQuery {
   featuredOnly?: boolean;
   /** Only documents that belong to a discover-eligible publication. */
   discoverOnly?: boolean;
+  /**
+   * Drop documents authored by — or published under — one of Bridgy Fed's bulk
+   * web-bridge mirrors (`*.web.brid.gy`), for a reader who turned "Hide
+   * mirrored websites" on (see `#/lib/exclude-web-bridge`). Network-wide
+   * surfaces only: callers pass it alongside `discoverOnly` / `tag`, never on
+   * the follow feed, where every source is one the reader chose.
+   */
+  excludeWebBridge?: boolean;
   /** Match documents whose `tags` array includes this label (case-insensitive). */
   tag?: string;
   /**
@@ -718,6 +735,22 @@ export async function selectArticleCards(
     });
   }
 
+  // Tag feed with the mirrors hidden: resolve the page's URIs through the
+  // tag-first query below, which is the only shape that survives a tag whose
+  // matches are almost all `*.web.brid.gy`. See `selectTagArticleUris`.
+  if (opts.tag && opts.excludeWebBridge && !opts.unreadForDid) {
+    const pageUris = await selectTagArticleUris(db, schema, {
+      tag: opts.tag,
+      sort: opts.sort,
+      limit: opts.limit,
+      offset: opts.offset ?? 0,
+    });
+    return selectArticleCardsByUris(db, schema, pageUris, {
+      readForDid: opts.readForDid,
+      countOldPostsAsUnread: opts.countOldPostsAsUnread,
+    });
+  }
+
   const d = schema.documents;
   const p = schema.publications;
   const pr = schema.profiles;
@@ -738,6 +771,9 @@ export async function selectArticleCards(
     // eligible publication. `p` is leftJoin'd below, so loose docs surface as
     // `p.uri IS NULL` and pass the `or(isNull(p.uri), …)` clause.
     conds.push(discoverEligibleArticleWhere(p));
+  }
+  if (opts.excludeWebBridge) {
+    conds.push(notWebBridgeArticleWhere(schema));
   }
   if (opts.tag) {
     conds.push(documentCarriesTagWhere(d, opts.tag));
@@ -1326,19 +1362,31 @@ export async function countFollowedDocuments(
  *
  * {@link countNetworkDocumentsLive} is the fallback for the window before the
  * first sweep populates the row.
+ *
+ * `excludeWebBridge` reads the parallel scalar the same sweep maintains for
+ * readers hiding the web-bridge mirrors — never a filtered live count, which
+ * measured **26.5s** against production because the anti-joins discard ~86% of
+ * the corpus row by row.
  */
 export async function countNetworkDocuments(
   db: Db,
   schema: Schema,
+  { excludeWebBridge = false }: { excludeWebBridge?: boolean } = {},
 ): Promise<number> {
+  const key = excludeWebBridge
+    ? NETWORK_DOCUMENT_COUNT_NO_WEB_BRIDGE_KEY
+    : NETWORK_DOCUMENT_COUNT_KEY;
   const [row] = await db
     .select({ value: schema.networkStats.value })
     .from(schema.networkStats)
-    .where(eq(schema.networkStats.key, NETWORK_DOCUMENT_COUNT_KEY))
+    .where(eq(schema.networkStats.key, key))
     .limit(1);
   // Only missing before the first sweep after deploy (or on a fresh DB), so the
   // expensive path runs for minutes, not indefinitely.
-  return row?.value ?? (await countNetworkDocumentsLive(db, schema));
+  return (
+    row?.value ??
+    (await countNetworkDocumentsLive(db, schema, { excludeWebBridge }))
+  );
 }
 
 /**
@@ -1349,6 +1397,7 @@ export async function countNetworkDocuments(
 export async function countNetworkDocumentsLive(
   db: Db,
   schema: Schema,
+  { excludeWebBridge = false }: { excludeWebBridge?: boolean } = {},
 ): Promise<number> {
   const d = schema.documents;
   const p = schema.publications;
@@ -1361,6 +1410,7 @@ export async function countNetworkDocumentsLive(
         eq(d.deleted, false),
         documentPublishedNotInFuture(d),
         discoverEligibleArticleWhere(p),
+        ...(excludeWebBridge ? [notWebBridgeArticleWhere(schema)] : []),
       ),
     );
   return row?.count ?? 0;
@@ -1512,12 +1562,15 @@ export interface TrendingArticlesQuery {
   offset?: number;
   readForDid?: string;
   scope?: TrendingArticlesScope;
+  /** Hide web-bridge mirrors — see {@link ArticleCardQuery.excludeWebBridge}. */
+  excludeWebBridge?: boolean;
 }
 
 function trendingArticleWhere(
   schema: Schema,
   scope: TrendingArticlesScope,
   excludeUris: Array<string> = [],
+  excludeWebBridge = false,
 ) {
   const d = schema.documents;
   const p = schema.publications;
@@ -1531,6 +1584,10 @@ function trendingArticleWhere(
     documentPublishedNotInFuture(d),
     sql`${d.publishedAt} > now() - (${TRENDING_MAX_AGE_DAYS}::text || ' days')::interval`,
   ];
+
+  if (excludeWebBridge) {
+    conds.push(notWebBridgeArticleWhere(schema));
+  }
 
   if (scope === "rail") {
     conds.push(
@@ -1563,6 +1620,7 @@ export async function trendingArticles(
   limit: number,
   {
     excludeUris = [],
+    excludeWebBridge = false,
     offset = 0,
     readForDid,
     scope = "rail",
@@ -1580,7 +1638,11 @@ export async function trendingArticles(
       .leftJoin(p, eq(p.uri, d.publicationUri))
       .leftJoin(pr, eq(pr.did, p.did))
       .leftJoin(pa, eq(pa.did, d.did))
-      .where(and(...trendingArticleWhere(schema, scope, excludeUris)))
+      .where(
+        and(
+          ...trendingArticleWhere(schema, scope, excludeUris, excludeWebBridge),
+        ),
+      )
       .orderBy(desc(d.trendingScore), desc(d.publishedAt))
       .limit(limit)
       .offset(offset);
@@ -1597,7 +1659,11 @@ export async function trendingArticles(
     .leftJoin(p, eq(p.uri, d.publicationUri))
     .leftJoin(pr, eq(pr.did, p.did))
     .leftJoin(pa, eq(pa.did, d.did))
-    .where(and(...trendingArticleWhere(schema, scope, excludeUris)))
+    .where(
+      and(
+        ...trendingArticleWhere(schema, scope, excludeUris, excludeWebBridge),
+      ),
+    )
     .orderBy(desc(d.trendingScore), desc(d.publishedAt))
     .limit(poolSize);
 
@@ -1682,12 +1748,15 @@ export async function topNetworkArticles(
     limit,
     excludeUris = [],
     excludeReadForDid,
+    excludeWebBridge = false,
   }: {
     sinceDays: number;
     limit: number;
     excludeUris?: Array<string>;
     /** Omit documents this reader has already read (weekly digest). */
     excludeReadForDid?: string;
+    /** Hide web-bridge mirrors — see {@link ArticleCardQuery.excludeWebBridge}. */
+    excludeWebBridge?: boolean;
   },
 ): Promise<Array<ArticleCard>> {
   const d = schema.documents;
@@ -1706,6 +1775,9 @@ export async function topNetworkArticles(
   }
   if (excludeReadForDid) {
     conds.push(documentUnreadWhere(schema, excludeReadForDid));
+  }
+  if (excludeWebBridge) {
+    conds.push(notWebBridgeArticleWhere(schema));
   }
 
   const rows = await db
@@ -1805,6 +1877,7 @@ export async function weekInReviewArticles(
     limit,
     excludeUris = [],
     excludeReadForDid,
+    excludeWebBridge = false,
   }: {
     sinceDays: number;
     limit: number;
@@ -1812,6 +1885,8 @@ export async function weekInReviewArticles(
     excludeUris?: Array<string>;
     /** Omit documents this reader has already read (weekly digest). */
     excludeReadForDid?: string;
+    /** Hide web-bridge mirrors — see {@link ArticleCardQuery.excludeWebBridge}. */
+    excludeWebBridge?: boolean;
   },
 ): Promise<Array<ArticleCard>> {
   const d = schema.documents;
@@ -1855,6 +1930,9 @@ export async function weekInReviewArticles(
   if (excludeReadForDid) {
     conds.push(documentUnreadWhere(schema, excludeReadForDid));
   }
+  if (excludeWebBridge) {
+    conds.push(notWebBridgeArticleWhere(schema));
+  }
 
   const rows = await db
     .select({
@@ -1879,6 +1957,7 @@ export async function countTrendingDocuments(
   db: Db,
   schema: Schema,
   scope: TrendingArticlesScope = "rail",
+  { excludeWebBridge = false }: { excludeWebBridge?: boolean } = {},
 ): Promise<number> {
   const d = schema.documents;
   const p = schema.publications;
@@ -1887,7 +1966,7 @@ export async function countTrendingDocuments(
     .select({ count: sql<number>`count(*)`.mapWith(Number) })
     .from(d)
     .leftJoin(p, eq(p.uri, d.publicationUri))
-    .where(and(...trendingArticleWhere(schema, scope)));
+    .where(and(...trendingArticleWhere(schema, scope, [], excludeWebBridge)));
   return row?.count ?? 0;
 }
 
@@ -1902,8 +1981,9 @@ export async function trendingPublications(
   db: Db,
   _schema: Schema,
   limit: number,
+  opts: { excludeWebBridge?: boolean } = {},
 ): Promise<Array<PublicationCard>> {
-  const rows = await selectTrendingPublicationRows(db, limit);
+  const rows = await selectTrendingPublicationRows(db, limit, opts);
   return rows.map((row) => toPublicationCard(row));
 }
 
@@ -1912,8 +1992,9 @@ export async function trendingPublicationUris(
   db: Db,
   _schema: Schema,
   limit: number,
+  opts: { excludeWebBridge?: boolean } = {},
 ): Promise<Array<string>> {
-  const rows = await selectTrendingPublicationRows(db, limit);
+  const rows = await selectTrendingPublicationRows(db, limit, opts);
   return rows.map((row) => row.uri);
 }
 
@@ -1922,7 +2003,13 @@ type TrendingPublicationRow = Parameters<typeof toPublicationCard>[0];
 async function selectTrendingPublicationRows(
   db: Db,
   limit: number,
+  { excludeWebBridge = false }: { excludeWebBridge?: boolean } = {},
 ): Promise<Array<TrendingPublicationRow>> {
+  // `pr` is LEFT JOINed, so the NULL branch is load-bearing: an unresolved
+  // handle keeps the publication (see `notWebBridgePublicationWhere`).
+  const webBridgeFilter = excludeWebBridge
+    ? sql`AND (pr.handle IS NULL OR pr.handle NOT ILIKE ${WEB_BRIDGE_HANDLE_PATTERN})`
+    : sql``;
   const result = await db.execute(sql`
     SELECT
       p.uri,
@@ -1946,6 +2033,7 @@ async function selectTrendingPublicationRows(
       AND p.url NOT ILIKE ${EXCLUDED_PUBLICATION_URL_PATTERN}
       AND coalesce(st.document_count, 0) > 0
       AND coalesce(st.subscriber_count, 0) > 0
+      ${webBridgeFilter}
     ORDER BY
       coalesce(st.trending_score, 0) DESC,
       coalesce(st.subscriber_count, 0) DESC,
@@ -2008,12 +2096,23 @@ function publicationTagMatchSql(
  * `show_in_discover` and topic/document gating — this is the headline "Known
  * publications" tally, a simple count of real publications.
  */
-export async function countKnownPublications(db: Db): Promise<number> {
+export async function countKnownPublications(
+  db: Db,
+  { excludeWebBridge = false }: { excludeWebBridge?: boolean } = {},
+): Promise<number> {
+  const webBridgeFilter = excludeWebBridge
+    ? sql`AND NOT EXISTS (
+        SELECT 1 FROM profiles wb
+        WHERE wb.did = publications.did
+          AND wb.handle ILIKE ${WEB_BRIDGE_HANDLE_PATTERN}
+      )`
+    : sql``;
   const result = await db.execute(sql`
     SELECT count(*)::int AS count
     FROM publications
     WHERE deleted = false
       AND url NOT ILIKE ${EXCLUDED_PUBLICATION_URL_PATTERN}
+      ${webBridgeFilter}
   `);
   const row = result.rows[0] as { count?: number } | undefined;
   return row?.count ?? 0;
@@ -2073,6 +2172,7 @@ export async function discoverDirectoryPublications(
     limit,
     offset,
     query = null,
+    excludeWebBridge = false,
   }: {
     topic?: string | null;
     /** `effective` = publication topic only; `document` = topic or any document tag. */
@@ -2081,6 +2181,8 @@ export async function discoverDirectoryPublications(
     limit: number;
     offset: number;
     query?: string | null;
+    /** Hide web-bridge mirrors — see {@link ArticleCardQuery.excludeWebBridge}. */
+    excludeWebBridge?: boolean;
   },
 ): Promise<Array<PublicationCard>> {
   const p = schema.publications;
@@ -2090,6 +2192,9 @@ export async function discoverDirectoryPublications(
   const effectiveTopic = publicationEffectiveTopicSql(p);
 
   const conds = [discoverEligiblePublicationWhere(p)];
+  if (excludeWebBridge) {
+    conds.push(notWebBridgePublicationOwnerWhere(schema));
+  }
   if (topic) {
     conds.push(
       topicMatch === "document"
@@ -2197,6 +2302,91 @@ function documentCarriesTagWhere(d: Schema["documents"], tag: string): SQL {
 }
 
 /**
+ * A tag page's document URIs with the web-bridge mirrors excluded, tag-first.
+ *
+ * Only for readers hiding the mirrors — {@link selectArticleCards} keeps its
+ * ordinary shape otherwise, and this one must not replace it. The ordinary shape
+ * lets Postgres walk `documents_published_idx` in date order and apply the tag
+ * as a filter, stopping once it has a page. That is excellent when most matches
+ * survive (the "news" tag: 86ms) and catastrophic when almost none do: the
+ * mirrors are ~99.85% of that tag, so the same walk discards ~200k index rows to
+ * find 24, at **3.2s** — and on tags whose survivors sit further down, **19s**.
+ *
+ * So the tag predicate is forced first instead, in a `MATERIALIZED` CTE that
+ * carries its own ordering columns: the GIN index yields the tag's documents,
+ * the mirror and eligibility filters run over that bounded set, and the top-N
+ * sort never returns to `documents`. Cost then tracks the tag's size rather than
+ * the survival rate — 142ms to 3.0s across the corpus's largest tags, against
+ * 3.2s to 19.2s for the ordinary shape with the same filter.
+ *
+ * Do NOT "simplify" this by joining the CTE back to `documents` to reuse the
+ * existing predicates: that hands the planner a hash join over the whole table
+ * and measured 6.5s. The CTE must carry every column the outer query needs.
+ *
+ * Same lesson, same fix as `topicDocumentUris` in `#/server/reader/topics`.
+ */
+async function selectTagArticleUris(
+  db: Db,
+  schema: Schema,
+  {
+    tag,
+    sort = "recent",
+    limit,
+    offset,
+  }: {
+    tag: string;
+    sort?: ArticleCardSort;
+    limit: number;
+    offset: number;
+  },
+): Promise<Array<string>> {
+  const orderBy =
+    sort === "trending"
+      ? sql`t.trending_score desc, t.published_at desc nulls last, t.uri desc`
+      : sort === "popular"
+        ? sql`(
+              select count(*)::int from ${schema.recommends} rec
+              where rec.document_uri = t.uri and rec.deleted = false
+            ) desc,
+            coalesce(t.backlink_count, 0) desc,
+            t.published_at desc nulls last, t.uri desc`
+        : sql`t.published_at desc nulls last, t.uri desc`;
+
+  const result = await db.execute(sql`
+    with tagged as materialized (
+      select uri, published_at, did, publication_uri, trending_score, backlink_count
+      from ${schema.documents}
+      where deleted = false
+        and (published_at is null or published_at <= now())
+        and immutable_normalized_tags(tags) @> array[${normalizedTagSql(tag)}]
+    )
+    select t.uri
+    from tagged t
+    left join ${schema.publications} p on p.uri = t.publication_uri
+    where (
+        p.uri is null
+        or (
+          p.deleted = false
+          and p.show_in_discover = true
+          and p.url not ilike ${EXCLUDED_PUBLICATION_URL_PATTERN}
+        )
+      )
+      and not exists (
+        select 1 from ${schema.profiles} wba
+        where wba.did = t.did and wba.handle ilike ${WEB_BRIDGE_HANDLE_PATTERN}
+      )
+      and not exists (
+        select 1 from ${schema.profiles} wbp
+        where wbp.did = p.did and wbp.handle ilike ${WEB_BRIDGE_HANDLE_PATTERN}
+      )
+    order by ${orderBy}
+    limit ${limit} offset ${offset}
+  `);
+
+  return executeRows<{ uri: string }>(result).map((row) => row.uri);
+}
+
+/**
  * Newest-first document ordering, spelled to match the `published_at DESC NULLS
  * LAST` indexes (`documents_published_idx`,
  * `documents_publication_published_idx`).
@@ -2258,6 +2448,7 @@ export async function countTagArticles(
   db: Db,
   schema: Schema,
   tag: string,
+  { excludeWebBridge = false }: { excludeWebBridge?: boolean } = {},
 ): Promise<number> {
   const d = schema.documents;
   const p = schema.publications;
@@ -2272,6 +2463,7 @@ export async function countTagArticles(
         documentPublishedNotInFuture(d),
         discoverEligibleArticleWhere(p),
         documentCarriesTagWhere(d, tag),
+        ...(excludeWebBridge ? [notWebBridgeArticleWhere(schema)] : []),
       ),
     );
 
@@ -2329,11 +2521,14 @@ export async function tagDirectoryPublications(
     sort,
     limit,
     offset,
+    excludeWebBridge = false,
   }: {
     tag: string;
     sort: TagDirectorySort;
     limit: number;
     offset: number;
+    /** Hide web-bridge mirrors — see {@link ArticleCardQuery.excludeWebBridge}. */
+    excludeWebBridge?: boolean;
   },
 ): Promise<Array<TagPublicationCard>> {
   const p = schema.publications;
@@ -2347,6 +2542,7 @@ export async function tagDirectoryPublications(
   const conds = [
     discoverEligiblePublicationWhere(p),
     publicationHasTaggedDocumentSql(p, d, tag),
+    ...(excludeWebBridge ? [notWebBridgePublicationOwnerWhere(schema)] : []),
   ];
 
   const sortName = publicationSortNameSql(p.name, p.url);
@@ -2408,6 +2604,7 @@ export async function countTagPublications(
   db: Db,
   schema: Schema,
   tag: string,
+  { excludeWebBridge = false }: { excludeWebBridge?: boolean } = {},
 ): Promise<number> {
   const p = schema.publications;
   const d = schema.documents;
@@ -2419,6 +2616,9 @@ export async function countTagPublications(
       and(
         discoverEligiblePublicationWhere(p),
         publicationHasTaggedDocumentSql(p, d, tag),
+        ...(excludeWebBridge
+          ? [notWebBridgePublicationOwnerWhere(schema)]
+          : []),
       ),
     );
 
@@ -2430,6 +2630,7 @@ export async function selectTagPublicationUris(
   db: Db,
   schema: Schema,
   tag: string,
+  { excludeWebBridge = false }: { excludeWebBridge?: boolean } = {},
 ): Promise<Array<string>> {
   const p = schema.publications;
   const d = schema.documents;
@@ -2441,6 +2642,9 @@ export async function selectTagPublicationUris(
       and(
         discoverEligiblePublicationWhere(p),
         publicationHasTaggedDocumentSql(p, d, tag),
+        ...(excludeWebBridge
+          ? [notWebBridgePublicationOwnerWhere(schema)]
+          : []),
       ),
     )
     .orderBy(asc(p.uri));
@@ -2856,6 +3060,7 @@ export async function followedByPeopleYouFollow(
     db,
     schema,
     ranked.slice(0, limit * ROTATION_POOL_MULTIPLIER).map((row) => row.uri),
+    { excludeWebBridge: opts.excludeWebBridge ?? false },
   );
   return rotateRail(pool, limit, seed);
 }
@@ -3237,6 +3442,8 @@ export async function relatedArticles(
     documentUri: string;
     publicationUri: string | null;
     limit: number;
+    /** Hide web-bridge mirrors — see {@link ArticleCardQuery.excludeWebBridge}. */
+    excludeWebBridge?: boolean;
   },
 ): Promise<Array<ArticleCard>> {
   const [coRead, tagOverlap] = await Promise.all([
@@ -3253,8 +3460,25 @@ export async function relatedArticles(
     return [];
   }
 
-  const uris = ranked.slice(0, opts.limit).map((row) => row.uri);
-  return selectArticleCardsByUris(db, schema, uris);
+  // Web-bridge mirrors are dropped after hydration rather than inside the two
+  // scoring queries: the tag-overlap scan is the query that once accounted for
+  // 27% of all database time (see `buildTagOverlapScoresSql`), and it is not
+  // worth another predicate. Both scorers cap at 30 URIs, so hydrating the whole
+  // merged pool and taking the first `limit` survivors still fills the rail —
+  // and the cards already carry both handles.
+  const uris = ranked
+    .slice(0, opts.excludeWebBridge ? ranked.length : opts.limit)
+    .map((row) => row.uri);
+  const cards = await selectArticleCardsByUris(db, schema, uris);
+  if (!opts.excludeWebBridge) return cards;
+
+  return cards
+    .filter(
+      (card) =>
+        !isWebBridgeHandle(card.authorHandle) &&
+        !isWebBridgeHandle(card.publicationOwnerHandle),
+    )
+    .slice(0, opts.limit);
 }
 
 export interface AuthorProfileStats {

--- a/apps/standard-reader/src/server/reader/session-preferences.server.ts
+++ b/apps/standard-reader/src/server/reader/session-preferences.server.ts
@@ -10,6 +10,10 @@ import {
   parseCountOldPostsAsUnreadCookie,
 } from "#/lib/count-old-posts-as-unread";
 import {
+  DEFAULT_EXCLUDE_WEB_BRIDGE,
+  dbValueToExcludeWebBridge,
+} from "#/lib/exclude-web-bridge";
+import {
   TRACK_READING_HISTORY_COOKIE,
   dbValueToTrackReadingHistory,
   parseTrackReadingHistoryCookie,
@@ -18,6 +22,11 @@ import {
 export interface ReaderSessionPreferences {
   trackReadingEnabled: boolean;
   countOldPostsAsUnreadEnabled: boolean;
+  /**
+   * "Hide mirrored websites" — see `#/lib/exclude-web-bridge`. Account-level
+   * only (no cookie mirror), so guests and expired sessions get the default.
+   */
+  excludeWebBridgeEnabled: boolean;
 }
 
 function readSessionTokenCookie(
@@ -44,6 +53,7 @@ function preferencesFromCookies(): ReaderSessionPreferences {
     countOldPostsAsUnreadEnabled: parseCountOldPostsAsUnreadCookie(
       getCookie(COUNT_OLD_POSTS_AS_UNREAD_COOKIE),
     ),
+    excludeWebBridgeEnabled: DEFAULT_EXCLUDE_WEB_BRIDGE,
   };
 }
 
@@ -70,6 +80,7 @@ export async function resolveReaderSessionPreferences(
     return {
       trackReadingEnabled: false,
       countOldPostsAsUnreadEnabled: DEFAULT_COUNT_OLD_POSTS_AS_UNREAD,
+      excludeWebBridgeEnabled: DEFAULT_EXCLUDE_WEB_BRIDGE,
     };
   }
 
@@ -82,6 +93,7 @@ export async function resolveReaderSessionPreferences(
           columns: {
             trackReadingHistory: true,
             countOldPostsAsUnread: true,
+            excludeWebBridge: true,
           },
         },
       },
@@ -98,6 +110,9 @@ export async function resolveReaderSessionPreferences(
         ),
         countOldPostsAsUnreadEnabled: dbValueToCountOldPostsAsUnread(
           sessionRow.user.countOldPostsAsUnread ?? null,
+        ),
+        excludeWebBridgeEnabled: dbValueToExcludeWebBridge(
+          sessionRow.user.excludeWebBridge ?? null,
         ),
       };
     }

--- a/apps/standard-reader/src/server/xrpc/db.ts
+++ b/apps/standard-reader/src/server/xrpc/db.ts
@@ -6,6 +6,7 @@ export type XrpcDbContext = {
   schema: Schema;
   trackReadingEnabled: boolean;
   countOldPostsAsUnreadEnabled: boolean;
+  excludeWebBridgeEnabled: boolean;
 };
 
 let cachedDb: Pick<XrpcDbContext, "db" | "schema"> | null = null;
@@ -18,9 +19,17 @@ export async function getXrpcDbContext(): Promise<XrpcDbContext> {
     ]);
     cachedDb = { db, schema };
   }
-  const { trackReadingEnabled, countOldPostsAsUnreadEnabled } =
-    await resolveReaderSessionPreferences(cachedDb.db, cachedDb.schema);
-  return { ...cachedDb, trackReadingEnabled, countOldPostsAsUnreadEnabled };
+  const {
+    trackReadingEnabled,
+    countOldPostsAsUnreadEnabled,
+    excludeWebBridgeEnabled,
+  } = await resolveReaderSessionPreferences(cachedDb.db, cachedDb.schema);
+  return {
+    ...cachedDb,
+    trackReadingEnabled,
+    countOldPostsAsUnreadEnabled,
+    excludeWebBridgeEnabled,
+  };
 }
 
 export function encodeCursor(offset: number): string {

--- a/apps/standard-reader/src/server/xrpc/dispatch.ts
+++ b/apps/standard-reader/src/server/xrpc/dispatch.ts
@@ -112,7 +112,13 @@ export async function dispatchXrpc(request: Request): Promise<Response> {
 
   try {
     const [
-      { db, schema, trackReadingEnabled, countOldPostsAsUnreadEnabled },
+      {
+        db,
+        schema,
+        trackReadingEnabled,
+        countOldPostsAsUnreadEnabled,
+        excludeWebBridgeEnabled,
+      },
       auth,
     ] = await Promise.all([
       getXrpcDbContext(),
@@ -156,6 +162,7 @@ export async function dispatchXrpc(request: Request): Promise<Response> {
       schema,
       trackReadingEnabled,
       countOldPostsAsUnreadEnabled,
+      excludeWebBridgeEnabled,
       params,
       body: body ?? null,
     };

--- a/apps/standard-reader/src/server/xrpc/handlers/catalog.ts
+++ b/apps/standard-reader/src/server/xrpc/handlers/catalog.ts
@@ -217,6 +217,7 @@ export async function handleGetPublications(ctx: XrpcRequestContext) {
     limit,
     offset,
     query: q ?? undefined,
+    excludeWebBridge: ctx.excludeWebBridgeEnabled,
   });
 
   const total =
@@ -431,6 +432,7 @@ export async function handleGetDocumentContext(ctx: XrpcRequestContext) {
       documentUri: row.uri,
       publicationUri: row.publicationUri,
       limit: 6,
+      excludeWebBridge: ctx.excludeWebBridgeEnabled,
     }),
     articleRecommendedPublications(ctx.db, ctx.schema, {
       publicationUri: row.publicationUri,

--- a/apps/standard-reader/src/server/xrpc/handlers/feeds.ts
+++ b/apps/standard-reader/src/server/xrpc/handlers/feeds.ts
@@ -32,6 +32,8 @@ export async function handleGetLatestFeed(ctx: XrpcRequestContext) {
   const trackReading = subjectDid == null ? false : ctx.trackReadingEnabled;
   const countOldPostsAsUnread =
     subjectDid == null ? true : ctx.countOldPostsAsUnreadEnabled;
+  const excludeWebBridge =
+    subjectDid == null ? false : ctx.excludeWebBridgeEnabled;
   const followUris = subjectDid
     ? await effectiveFollowUris(ctx.db, ctx.schema, subjectDid)
     : [];
@@ -48,11 +50,12 @@ export async function handleGetLatestFeed(ctx: XrpcRequestContext) {
             offset,
             readForDid: trackReading && subjectDid ? subjectDid : undefined,
             scope: "page",
+            excludeWebBridge,
           })
         : []
       : await selectArticleCards(ctx.db, ctx.schema, {
           ...(!subjectDid || filter === "all"
-            ? { discoverOnly: true }
+            ? { discoverOnly: true, excludeWebBridge }
             : {
                 publicationUris: followUris,
                 unreadForDid:
@@ -85,7 +88,9 @@ export async function handleGetLatestFeed(ctx: XrpcRequestContext) {
 
 export async function handleGetTrendingPublications(ctx: XrpcRequestContext) {
   const limit = intParam(ctx.params, "limit", 12, { min: 1, max: 100 });
-  const items = await trendingPublications(ctx.db, ctx.schema, limit);
+  const items = await trendingPublications(ctx.db, ctx.schema, limit, {
+    excludeWebBridge: ctx.excludeWebBridgeEnabled,
+  });
   return { items: items.map((item) => toPublicationView(item)) };
 }
 
@@ -97,6 +102,7 @@ export async function handleGetTrendingDocuments(ctx: XrpcRequestContext) {
   const items = await trendingArticles(ctx.db, ctx.schema, limit, {
     scope,
     readForDid,
+    excludeWebBridge: ctx.excludeWebBridgeEnabled,
   });
   const enriched = await enrichDocuments(ctx, items, readForDid);
   return { items: enriched.map((item) => toDocumentView(item)) };
@@ -114,6 +120,7 @@ export async function handleGetTagFeed(ctx: XrpcRequestContext) {
       sort,
       limit,
       offset,
+      excludeWebBridge: ctx.excludeWebBridgeEnabled,
     });
     return {
       view: "publications" as const,
@@ -130,6 +137,7 @@ export async function handleGetTagFeed(ctx: XrpcRequestContext) {
   const rows = await selectArticleCards(ctx.db, ctx.schema, {
     tag,
     discoverOnly: true,
+    excludeWebBridge: ctx.excludeWebBridgeEnabled,
     limit,
     offset,
     readForDid,

--- a/apps/standard-reader/src/server/xrpc/handlers/reader.ts
+++ b/apps/standard-reader/src/server/xrpc/handlers/reader.ts
@@ -46,7 +46,10 @@ export async function handleGetHomeFeed(ctx: XrpcRequestContext) {
         countOldPostsAsUnread: ctx.countOldPostsAsUnreadEnabled,
         ...(trackReading ? { readForDid: did, unreadForDid: did } : {}),
       }
-    : { discoverOnly: true as const };
+    : {
+        discoverOnly: true as const,
+        excludeWebBridge: ctx.excludeWebBridgeEnabled,
+      };
 
   const [featuredLead, rows] = await Promise.all([
     selectArticleCards(ctx.db, ctx.schema, {
@@ -102,9 +105,11 @@ export async function handleGetRecommendedPublications(
     ctx.db,
     ctx.schema,
     limit,
+    { excludeWebBridge: ctx.excludeWebBridgeEnabled },
   );
   const items = await recommendedPublications(ctx.db, ctx.schema, did, limit, {
     excludeUris: trendingExclude,
+    excludeWebBridge: ctx.excludeWebBridgeEnabled,
     followUris,
   });
   return { items: items.map((item) => toPublicationView(item)) };
@@ -124,6 +129,7 @@ export async function handleGetFollowedByPeopleYouFollow(
     ctx.db,
     ctx.schema,
     limit,
+    { excludeWebBridge: ctx.excludeWebBridgeEnabled },
   );
   const items = await followedByPeopleYouFollow(
     ctx.db,
@@ -132,6 +138,7 @@ export async function handleGetFollowedByPeopleYouFollow(
     limit,
     {
       excludeUris: trendingExclude,
+      excludeWebBridge: ctx.excludeWebBridgeEnabled,
       followUris,
     },
   );

--- a/apps/standard-reader/src/server/xrpc/test/helpers.ts
+++ b/apps/standard-reader/src/server/xrpc/test/helpers.ts
@@ -11,6 +11,7 @@ export function mockXrpcContext(
     schema: {} as XrpcRequestContext["schema"],
     trackReadingEnabled: false,
     countOldPostsAsUnreadEnabled: true,
+    excludeWebBridgeEnabled: false,
     params: {},
     body: null,
     ...partial,

--- a/apps/standard-reader/src/server/xrpc/types.ts
+++ b/apps/standard-reader/src/server/xrpc/types.ts
@@ -13,6 +13,8 @@ export type XrpcRequestContext = {
   schema: Schema;
   trackReadingEnabled: boolean;
   countOldPostsAsUnreadEnabled: boolean;
+  /** "Hide mirrored websites" — see `#/lib/exclude-web-bridge`. */
+  excludeWebBridgeEnabled: boolean;
   /** Parsed query-string parameters (queries only). */
   params: XrpcQueryParams;
   /** Parsed JSON body (procedures only). */


### PR DESCRIPTION
Adds an account-level setting — **"Hide mirrored websites"** — that drops Bridgy Fed's bulk web bridge (`*.web.brid.gy`) from every network-wide surface.

## Why

`*.web.brid.gy` is a site Bridgy discovered and mirrored; nobody there asked for a publication. It is also most of the network:

| | total | web bridge | share |
|---|---:|---:|---:|
| documents | 2,991,209 | 2,568,099 | 86% |
| publications | 14,869 | 5,227 | 35% |

Discover's Recommended rail and the topic derivation already drop them unconditionally. Everywhere else — Latest "All", the directory, search, tag pages — a reader who didn't want them had no way to say so.

## What it covers

Latest "All" + badge counts · home network/trending feeds · Discover directory, rails, and known-publication count · search · tag pages (feed, directory, both counts, and "follow all") · related articles · the weekly digest's network section. Also threaded through the XRPC handlers, the MCP server, and the extension's discussion endpoint.

**It never applies to what the reader chose**: their subscriptions feed, a publication or article page they opened, or a handle/URL they searched for by name. `*.ap.brid.gy` is never touched — those authors opted into the bridge.

Default is **off**, so nothing changes for anyone who doesn't turn it on. `user.exclude_web_bridge` is nullable with no backfill (migration `0033`).

## Performance

Measured against a prod-scale copy of the read model (3.0M documents). Two shapes were load-bearing:

**Latest "All" badge → a second precomputed `network_stats` scalar.** A live filtered count is **26.5s** — the exclusions can't short-circuit anywhere when they discard 86% of the corpus. `recomputeNetworkStats()` now produces both tallies in one pass: **~4.8s** against **~3.8s** for the single count it replaces, once per sweep. (Getting there meant aggregating *before* the `UNION ALL` rather than after — the natural spelling walks `documents` once per branch, 5.7s — and using an inline subquery rather than a CTE for the DID set, since a CTE scan is parallel-restricted.)

**Tag feed → tag-first `MATERIALIZED` query when the setting is on.** The ordinary shape walks `documents_published_idx` in date order and applies the tag as a filter. That's excellent when most matches survive and catastrophic when almost none do:

| tag (docs) | setting off | ON, ordinary shape | ON, tag-first |
|---|---:|---:|---:|
| `news` (225k) | 86ms | 3,199ms | 2,502ms |
| `read more` (19k) | 132ms | 3,286ms | 617ms |
| `pc` (12.9k) | 158ms | 18,440ms | 243ms |
| `top-of-funnel` (9.7k) | 234ms | 19,151ms | 225ms |

Cost now tracks the tag's size rather than the survival rate. The default path is untouched — the tag-first shape is slower on the largest tag when nothing is filtered, so it's only taken when the setting is on.

Everything else lands within ~35ms of unfiltered:

```
latest all (24 rows)           off    91ms   on    95ms   +3ms
latest all (page 5)            off    90ms   on    98ms   +8ms
latest counts: network         off    82ms   on    91ms   +9ms
latest counts: trending        off   514ms   on   547ms  +33ms
trending articles (page)       off   720ms   on   700ms  -21ms
trending publications          off   102ms   on    96ms   -6ms
discover directory             off   135ms   on   135ms   -0ms
discover known count           off    91ms   on   127ms  +36ms
tag "news" article count       off  2060ms   on  2187ms +127ms
tag "news" pub count           off  6233ms   on  3277ms   -3.0s
tag "news" directory           off  8387ms   on  3583ms   -4.8s
```

## Verification

- `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test` (796 passed) all clean.
- `pnpm perf:explain` passes 5/5 against a prod-scale copy.
- Every filtered query run against real data with the flag on and off, confirming the mirrors actually disappear (e.g. known publications 13,204 → 8,181; `news` articles 224,554 → 335; related-articles rail 6 mirrors → 0).

## Deploy note

Migration `0033` adds the column, and the first `recomputeNetworkStats()` sweep seeds the new scalar. Until that sweep runs, `countNetworkDocuments` falls back to the live count — the same window the existing scalar already has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
