### PR TITLE
Give publishers back the search ranking for the writing we mirror

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -1511,6 +1511,34 @@ Where they come from and why they're not route `head.meta`:
   record we render belongs to someone else; it's the right tag for a platform serving an
   author's own site, not for a reader.
 
+### HTML `rel=canonical` — the reader gives the ranking back
+
+Not to be confused with `at:canonical` above: that one names a **record**, this one names a
+**URL for search engines**. They answer different questions and a page carries both.
+
+We render other people's writing natively, which makes an article page on the reader a
+near-duplicate of the same article on the publication's own site. Left alone, a search engine
+picks a winner between the two by itself, and it sometimes picks us. So we choose instead:
+
+| Route                  | Canonicalizes to                                | Why                                                            |
+| ---------------------- | ----------------------------------------------- | -------------------------------------------------------------- |
+| `/a/$did/$rkey`        | the article on the publication's site, if known | their writing, their ranking — we're a mirror                  |
+| `/comic/$did/$rkey`    | same, plus folds the `?page=` deep links        | the page-flip reader is our presentation of their comic        |
+| `/collection/…`        | itself (folds `?ids=`)                          | an edition is curation we assembled — we _are_ the original    |
+| `/p/…`, `/l/…`, `/u/…` | themselves (fold `?filter=` / sort / tab views) | directories over the network, with no single off-site original |
+
+- The helpers are `canonicalLink` (`src/lib/site-metadata.ts`) and `articleSourceUrl`
+  (`src/components/reader/format.ts`). A source URL that is unparseable, non-`http(s)`, or on
+  our own host is discarded and the page self-canonicalizes.
+- `articleSourceUrl` is deliberately **stricter** than `articlePublicationUrl`: it refuses to
+  fall back to the publication root. That fallback is right for "open this on the author's
+  site", but as a canonical it would claim the article duplicates a home page.
+- We do **not** use `noindex`. Canonical keeps us crawlable — so internal discovery of
+  publications and topics still works — and a search engine may still surface the reader page
+  when the original is unstable or has weaker signal, which is a win rather than a loss.
+- Everything that isn't a mirror (home, `/discover`, `/topics/…`, `/tag/…`, `/search`, docs,
+  guide) is unaffected and indexes normally. That's where "Standard Reader" gets found.
+
 ### Browser extension architecture
 
 ```

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -930,6 +930,16 @@ Build each on hip-ui components + StyleX tokens (no raw HTML/inline styles).
       do not emit `at:me` — every record we render belongs to someone else. Discovery-hint
       parsing reads the meta tags first and falls back to the rels, so peers that drop the old
       tags still resolve. See `src/lib/at-meta-tags.ts`.
+- [x] **HTML `rel=canonical`** — the reader renders other people's writing natively, so an
+      article page here is a near-duplicate of the same article on the publication's own site.
+      `/a/...` and `/comic/...` canonicalize to the publication's own page for that article when
+      one is known (`articleSourceUrl`, strict — never the publication root); `/collection/...`
+      self-canonicalizes because an edition is our own curation, and `/p/...`, `/l/...`,
+      `/u/...` self-canonicalize to fold their `?filter=` / sort / tab variants onto one URL.
+      No `noindex` anywhere: canonical hands the ranking signal back to the publisher while
+      keeping us crawlable, and the reader page can still win when the original is unstable.
+      Helper: `canonicalLink` in `src/lib/site-metadata.ts`. Requested in
+      https://userinput.app/d/did:plc:bpotnohnlgcj3fbmp7ugx4en/3ms3oynnzff2l.
 
 ## 7. Discovery engine (network-powered)
 

--- a/apps/standard-reader/src/components/reader/format.ts
+++ b/apps/standard-reader/src/components/reader/format.ts
@@ -137,6 +137,26 @@ export function articlePublicationUrl(article: {
   return `${trimmed}${withSlash}`;
 }
 
+/**
+ * The article's own page on the publication's site — strict enough to hand a
+ * search engine as `rel=canonical`.
+ *
+ * Unlike {@link articlePublicationUrl}, this never falls back to the
+ * publication's root. That fallback is right for "open this on the author's
+ * site" (a homepage is somewhere to land), but as a canonical it would claim
+ * the article duplicates the publication's front page, which is worse than
+ * claiming nothing.
+ */
+export function articleSourceUrl(article: {
+  canonicalUrl: string | null;
+  path: string | null;
+  publication: { url: string } | null;
+}): string | null {
+  if (article.canonicalUrl) return article.canonicalUrl;
+  if (!article.path || !article.publication?.url) return null;
+  return articlePublicationUrl(article);
+}
+
 /** On-site article path (`/a/$did/$rkey`) when the URI is a document record. */
 export function articleReaderPath(documentUri: string): string | null {
   const params = documentLinkParams(documentUri);

--- a/apps/standard-reader/src/lib/canonical-link.test.ts
+++ b/apps/standard-reader/src/lib/canonical-link.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { articleSourceUrl } from "#/components/reader/format";
+import { canonicalLink } from "#/lib/site-metadata";
+
+const SELF = "https://standard-reader.app/a/did:plc:example/3abc";
+
+describe("canonicalLink", () => {
+  it("points at the publication's own page for the article", () => {
+    expect(canonicalLink(SELF, "https://example.blog/posts/hello")).toEqual({
+      rel: "canonical",
+      href: "https://example.blog/posts/hello",
+    });
+  });
+
+  it("self-canonicalizes when there is no off-site original", () => {
+    for (const source of [null, undefined, "", "   "]) {
+      expect(canonicalLink(SELF, source).href).toBe(SELF);
+    }
+  });
+
+  it("ignores a source that is unparseable or not a web URL", () => {
+    expect(canonicalLink(SELF, "not a url").href).toBe(SELF);
+    expect(canonicalLink(SELF, "/posts/hello").href).toBe(SELF);
+    expect(
+      canonicalLink(SELF, "at://did:plc:example/site.standard.document/3abc")
+        .href,
+    ).toBe(SELF);
+    expect(canonicalLink(SELF, "javascript:alert(1)").href).toBe(SELF);
+  });
+
+  it("never canonicalizes a page to another page on our own host", () => {
+    expect(
+      canonicalLink(SELF, "https://standard-reader.app/a/did:plc:other/3xyz")
+        .href,
+    ).toBe(SELF);
+  });
+});
+
+describe("articleSourceUrl", () => {
+  it("prefers the indexed canonical URL", () => {
+    expect(
+      articleSourceUrl({
+        canonicalUrl: "https://example.blog/hello",
+        path: "/ignored",
+        publication: { url: "https://other.blog" },
+      }),
+    ).toBe("https://example.blog/hello");
+  });
+
+  it("derives the article's URL from the publication and its path", () => {
+    expect(
+      articleSourceUrl({
+        canonicalUrl: null,
+        path: "posts/hello",
+        publication: { url: "https://example.blog/" },
+      }),
+    ).toBe("https://example.blog/posts/hello");
+  });
+
+  it("returns nothing rather than canonicalizing to a publication root", () => {
+    // `articlePublicationUrl` would answer `https://example.blog` here, which
+    // is fine to open but would claim the article duplicates a home page.
+    expect(
+      articleSourceUrl({
+        canonicalUrl: null,
+        path: null,
+        publication: { url: "https://example.blog" },
+      }),
+    ).toBeNull();
+    expect(
+      articleSourceUrl({
+        canonicalUrl: null,
+        path: "/posts/hello",
+        publication: null,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/standard-reader/src/lib/site-metadata.ts
+++ b/apps/standard-reader/src/lib/site-metadata.ts
@@ -315,6 +315,41 @@ export function pageSocialMeta(
   });
 }
 
+/**
+ * A `<link rel="canonical">` entry for a route `head()`.
+ *
+ * `sourceUrl` wins whenever it names this page's content somewhere off-site —
+ * the reader renders other people's publications natively, so pointing the
+ * canonical back at the publication's own domain folds the duplicate's ranking
+ * signals into the original instead of competing with it. Crawling is
+ * unaffected (that's the difference from `noindex`), and pages with no off-site
+ * original — collection editions, documents published only here — canonicalize
+ * to themselves, which still collapses query-string variants (`?q=`, `?ids=`)
+ * onto the bare URL.
+ */
+export function canonicalLink(
+  selfUrl: string,
+  sourceUrl?: string | null,
+): { rel: "canonical"; href: string } {
+  return { rel: "canonical", href: offSiteUrl(sourceUrl, selfUrl) ?? selfUrl };
+}
+
+/** `candidate` as an absolute web URL, unless it's unparseable or our own. */
+function offSiteUrl(
+  candidate: string | null | undefined,
+  selfUrl: string,
+): string | null {
+  if (!candidate?.trim()) return null;
+  try {
+    const url = new URL(candidate);
+    if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+    if (url.host === new URL(selfUrl).host) return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
 type HeadMetaEntry =
   | { title: string }
   | { name: string; content: string }

--- a/apps/standard-reader/src/routes/_layout.a.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/_layout.a.$did.$rkey.tsx
@@ -15,7 +15,11 @@ import {
   decodeQuoteParam,
   truncateQuoteForDisplay,
 } from "#/lib/quote-share";
-import { articleOgImageUrl, siteSocialMeta } from "#/lib/site-metadata";
+import {
+  articleOgImageUrl,
+  canonicalLink,
+  siteSocialMeta,
+} from "#/lib/site-metadata";
 import { useOpenLinks } from "#/lib/use-open-links";
 
 import {
@@ -26,6 +30,7 @@ import { ArticleViewSkeleton } from "../components/reader/article-view-skeleton"
 import { hasRenderableArticleBody } from "../components/reader/content/extract-text";
 import {
   articlePublicationUrl,
+  articleSourceUrl,
   documentUriFromParams,
 } from "../components/reader/format";
 import type { PublicationThemeColors } from "../components/reader/publication-theme-scale";
@@ -178,9 +183,14 @@ export const Route = createFileRoute("/_layout/a/$did/$rkey")({
       };
     }
 
-    // standard.site discovery hints — the AT-URIs of the records this page
-    // renders. See https://standard.site/docs/verification/#discovery-hint
+    const baseUrl = getPublicUrlClient();
     const links = [
+      // The publication's own page for this article, when it has one — we
+      // render their writing natively, so the ranking signals belong to them
+      // and not to us. Shared-quote links (`?q=`) fold into the bare article.
+      canonicalLink(`${baseUrl}${match.pathname}`, articleSourceUrl(article)),
+      // standard.site discovery hints — the AT-URIs of the records this page
+      // renders. See https://standard.site/docs/verification/#discovery-hint
       { rel: "site.standard.document", href: article.uri },
       ...(article.publicationUri
         ? [{ rel: "site.standard.publication", href: article.publicationUri }]
@@ -188,7 +198,6 @@ export const Route = createFileRoute("/_layout/a/$did/$rkey")({
     ];
 
     if (!quote || !match.search.q) {
-      const baseUrl = getPublicUrlClient();
       return {
         meta: siteSocialMeta({
           title: pageTitle,
@@ -205,7 +214,6 @@ export const Route = createFileRoute("/_layout/a/$did/$rkey")({
       };
     }
 
-    const baseUrl = getPublicUrlClient();
     const search = `?q=${encodeURIComponent(match.search.q)}`;
     const shareUrl = `${baseUrl}${match.pathname}${search}`;
     const ogImage = buildQuoteOgImageUrl(

--- a/apps/standard-reader/src/routes/_layout.l.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/_layout.l.$did.$rkey.tsx
@@ -64,6 +64,7 @@ import { shareLinkUrl, useNativeShareAvailable } from "#/lib/native-share";
 import { getPublicUrlClient } from "#/lib/public-url";
 import { buildBlueskyComposeUrl } from "#/lib/quote-share";
 import {
+  canonicalLink,
   listFeedUrl,
   listOgImageUrl,
   siteSocialMeta,
@@ -148,6 +149,9 @@ export const Route = createFileRoute("/_layout/l/$did/$rkey")({
         ogImage: listOgImageUrl(baseUrl, params.did, params.rkey),
       }),
       links: [
+        // Self-canonical: a reader's list is their own grouping, and the sort
+        // and layout views are the same page seen differently.
+        canonicalLink(`${baseUrl}${match.pathname}`),
         {
           rel: "alternate",
           type: "application/rss+xml",

--- a/apps/standard-reader/src/routes/_layout.p.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/_layout.p.$did.$rkey.tsx
@@ -39,6 +39,7 @@ import { user } from "#/integrations/tanstack-query/api-user.functions";
 import { getPublicUrlClient } from "#/lib/public-url";
 import type { ArchiveOrder } from "#/lib/publication/archive-order";
 import {
+  canonicalLink,
   publicationFeedUrl,
   publicationOgImageUrl,
   siteSocialMeta,
@@ -203,9 +204,12 @@ export const Route = createFileRoute("/_layout/p/$did/$rkey")({
           match.params.rkey,
         ),
       }),
-      // standard.site discovery hint — the AT-URI of the rendered publication.
-      // See https://standard.site/docs/verification/#discovery-hint
       links: [
+        // Self-canonical: this is our directory of the publication, not a copy
+        // of its home page. Folds the `?filter=` / `?sort=` views onto one URL.
+        canonicalLink(`${baseUrl}${match.pathname}`),
+        // standard.site discovery hint — the AT-URI of the rendered publication.
+        // See https://standard.site/docs/verification/#discovery-hint
         {
           rel: "site.standard.publication",
           href: publicationUriFromParams(match.params.did, match.params.rkey),

--- a/apps/standard-reader/src/routes/_layout.u.$did.tsx
+++ b/apps/standard-reader/src/routes/_layout.u.$did.tsx
@@ -60,6 +60,7 @@ import type { HideableTabId, ProfileTabId } from "#/lib/profile-tabs";
 import { getPublicUrlClient } from "#/lib/public-url";
 import {
   authorFeedUrl,
+  canonicalLink,
   profileOgImageUrl,
   siteSocialMeta,
 } from "#/lib/site-metadata";
@@ -162,6 +163,9 @@ export const Route = createFileRoute("/_layout/u/$did")({
         ogImage: profileOgImageUrl(baseUrl, match.params.did),
       }),
       links: [
+        // Self-canonical: the profile is assembled from the network, so it has
+        // no single off-site original. Folds the tab views onto one URL.
+        canonicalLink(`${baseUrl}${match.pathname}`),
         {
           rel: "alternate",
           type: "application/rss+xml",

--- a/apps/standard-reader/src/routes/collection.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/collection.$did.$rkey.tsx
@@ -20,6 +20,7 @@ import { collectionReaderViewSearch } from "#/lib/open-collections-in-magazine";
 import { getPublicUrlClient } from "#/lib/public-url";
 import {
   SITE_NAME,
+  canonicalLink,
   collectionFeedUrl,
   collectionOgImageUrl,
   siteSocialMeta,
@@ -148,6 +149,10 @@ export const Route = createFileRoute("/collection/$did/$rkey")({
           : undefined,
       }),
       links: [
+        // Self-canonical, deliberately: an edition is curation we assembled,
+        // not a mirror of anyone's page, so it's the original. It also folds
+        // the `?ids=` pinned variants back onto the edition's own URL.
+        canonicalLink(`${baseUrl}${match.pathname}`),
         ...magazineThemeFontHeadLinks(theme),
         // standard.site discovery hints — a collection edition renders a
         // `site.standard.document` like any article view does, so it carries the

--- a/apps/standard-reader/src/routes/comic.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/comic.$did.$rkey.tsx
@@ -8,11 +8,18 @@ import { publicationApi } from "#/integrations/tanstack-query/api-publication.fu
 import { user } from "#/integrations/tanstack-query/api-user.functions";
 import { documentImages } from "#/lib/document/images";
 import { getPublicUrlClient } from "#/lib/public-url";
-import { articleOgImageUrl, siteSocialMeta } from "#/lib/site-metadata";
+import {
+  articleOgImageUrl,
+  canonicalLink,
+  siteSocialMeta,
+} from "#/lib/site-metadata";
 
 import { ComicNotFound } from "../components/comic/comic-not-found";
 import { ComicReader } from "../components/comic/comic-reader";
-import { documentUriFromParams } from "../components/reader/format";
+import {
+  articleSourceUrl,
+  documentUriFromParams,
+} from "../components/reader/format";
 
 const comicSearchSchema = z.object({
   /** 1-based page; one past the last page is the end-of-issue card. */
@@ -29,14 +36,24 @@ export const Route = createFileRoute("/comic/$did/$rkey")({
       void queryClient.prefetchQuery(
         publicationApi.getArticleQueryOptions(uri),
       );
-      return { title: null, publicationName: null, description: null };
+      return {
+        title: null,
+        publicationName: null,
+        description: null,
+        sourceUrl: null,
+      };
     }
 
     const article = await queryClient.ensureQueryData(
       publicationApi.getArticleQueryOptions(uri),
     );
     if (!article) {
-      return { title: null, publicationName: null, description: null };
+      return {
+        title: null,
+        publicationName: null,
+        description: null,
+        sourceUrl: null,
+      };
     }
 
     // Nothing to flip through — the reading view is the honest fallback, and
@@ -90,6 +107,7 @@ export const Route = createFileRoute("/comic/$did/$rkey")({
       publicationName: article.publication?.name ?? null,
       publicationUri: article.publicationUri,
       description: article.description,
+      sourceUrl: articleSourceUrl(article),
       // The records this page is built from — rendered by `AtRecordMeta`.
       atMeta: {
         canonical: [uri],
@@ -120,8 +138,12 @@ export const Route = createFileRoute("/comic/$did/$rkey")({
         ),
         ogType: "article",
       }),
-      // standard.site discovery hint — the AT-URI of the rendered document.
       links: [
+        // The issue's page on the publication's own site, when it has one —
+        // the page-flip reader is our presentation of their comic, not a
+        // separate work. Also collapses the `?page=` deep links onto one URL.
+        canonicalLink(`${baseUrl}${match.pathname}`, loaderData?.sourceUrl),
+        // standard.site discovery hint — the AT-URI of the rendered document.
         {
           rel: "site.standard.document",
           href: documentUriFromParams(match.params.did, match.params.rkey),


### PR DESCRIPTION
Adds `<link rel="canonical">` across the pages that mirror someone else's writing. Requested in [this UserInput thread](https://userinput.app/d/did:plc:bpotnohnlgcj3fbmp7ugx4en/3ms3oynnzff2l) by `youronly.one`.

## Why

We render other people's articles natively, so an article page here is a near-duplicate of the same article on the publication's own site. Left alone, a search engine picks a winner between the two by itself — and it sometimes picks us. This makes the choice explicit and hands the ranking signal back to the publisher.

Deliberately **not** `noindex`: canonical keeps us crawlable, so internal discovery of publications and topics still works, and the reader page can still surface when the original is unstable or has weaker domain signal.

## What canonicalizes where

| Route | Canonicalizes to |
| --- | --- |
| `/a/$did/$rkey` | the publication's own page for that article, when known — else itself |
| `/comic/$did/$rkey` | same, and folds the `?page=` deep links |
| `/collection/$did/$rkey` | itself — an edition is curation we assembled, so we're the original (also folds `?ids=`) |
| `/p/…`, `/l/…`, `/u/…` | themselves, folding the `?filter=` / sort / tab variants onto one URL |

Everything that isn't a mirror (home, `/discover`, `/topics/…`, `/tag/…`, `/search`, docs, guide) is untouched and indexes normally.

## Two implementation notes

**`articleSourceUrl` is stricter than `articlePublicationUrl`.** The existing helper falls back to the publication's root when a document has no `path` — correct for "open this on the author's site," but as a canonical it would claim the article duplicates a homepage. The new one returns `null` instead and the page self-canonicalizes.

**`canonicalLink` discards a bad source.** Unparseable, non-`http(s)` (an `at://` URI, a `javascript:` string), or on our own host → self-canonical. A malformed `canonicalUrl` row degrades safely rather than pointing somewhere wrong.

## Verification

- New `src/lib/canonical-link.test.ts` — 7 tests over both helpers, including the homepage-fallback refusal and the hostile-URL cases.
- Full suite: 819 passed / 7 skipped. Typecheck clean, oxlint 0/0, format clean.
- I did **not** boot the app to inspect served HTML — the worktree has no `.env` and standing one up would point at the prod DB. The new entries go into the same `head.links` array that already emits the `site.standard.*` discovery-hint rels on these routes, so the render path is unchanged; only the href is new, and that's unit-tested.

Living docs updated: new "HTML `rel=canonical`" section in `APP_VISION.md` (explicitly disambiguated from the `at:canonical` *record* tag, which is a different thing on the same page), and the item checked into `TODO.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)