### PR TITLE
Let readers flip the order on Saved for later

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -581,6 +581,9 @@ comic issue with no pages falls back to it outright.
 - Signed-in reader's **save queue** (`app.standard-reader.bookmark`), newest-saved first by default.
 - Sortable via `?sort=` — date saved (default), published date, publication (alphabetical), or
   title (alphabetical); Menu (compact) / Select (full) control, mirroring `/tag`'s article sort.
+- Reversible via `?dir=` — an icon button beside the sort control flips the order. Each field runs
+  its natural way until flipped (dates newest-first, names A–Z), and the direction is named for
+  what it ranks: "Newest first" / "Oldest first" for dates, "A–Z" / "Z–A" for names.
 - Route `/saved`; linked from the sidebar (with saved count badge). Requires auth (redirects to login).
 
 ### Reader profile (liked articles)

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -1280,6 +1280,11 @@ not offline body cache). Route slug **`/saved`**.
       title), mirroring `/tag`'s article-sort Menu+Select control; `savedOrderBy` in
       [`api-reader.functions.ts`](src/integrations/tanstack-query/api-reader.functions.ts), sort
       included in the infinite-query key so paging never mixes sort orders.
+- [x] **Saved queue sort direction** — `?dir=asc|desc` beside `?sort=`, flipped by an icon button
+      next to the sort control. Absent from the URL until the reader flips it, so each field keeps
+      its natural direction (dates newest-first, names A–Z) via `defaultSavedSortDirection`; an
+      explicit choice carries across a change of field. NULLS stay LAST in both directions so a
+      bookmark whose document is gone never floats to the top.
 - [x] **Reading history** — `/history` queue backed by existing
       `app.standard-reader.read` / `reads` table (no new lexicon); `readerApi.getReadingHistory` + user-menu link + empty state; infinite scroll (20 per page). Update [`APP_VISION.md`](APP_VISION.md) when landing.
 - [x] **Track reading history setting** — user-menu toggle (cookie + `user.track_reading_history`);

--- a/apps/standard-reader/src/integrations/tanstack-query/api-reader.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-reader.functions.ts
@@ -100,8 +100,23 @@ export const SAVED_SORT_VALUES = [
 ] as const;
 export type SavedSort = (typeof SAVED_SORT_VALUES)[number];
 
+/** Which way a {@link SavedSort} runs. */
+export const SAVED_SORT_DIRECTIONS = ["desc", "asc"] as const;
+export type SavedSortDirection = (typeof SAVED_SORT_DIRECTIONS)[number];
+
+/**
+ * The direction a field runs in until the reader flips it: dates read
+ * newest-first, names read A–Z. Callers resolve the direction through this so
+ * an implicit and an explicit "newest first" are the same query.
+ */
+export function defaultSavedSortDirection(sort: SavedSort): SavedSortDirection {
+  return sort === "publication" || sort === "title" ? "asc" : "desc";
+}
+
 const savedListInput = readerListInput.extend({
   sort: z.enum(SAVED_SORT_VALUES).default("added"),
+  /** Absent means "whatever this field's natural direction is". */
+  dir: z.enum(SAVED_SORT_DIRECTIONS).optional(),
 });
 
 /** One offset page of a personal reader queue (likes, saved, history). */
@@ -1017,8 +1032,9 @@ const getBookmarkStatus = createServerFn({ method: "GET" })
   );
 
 /**
- * `ORDER BY` for a {@link SavedSort}. Every ranking carries a stable tiebreak
- * (`bookmarks.uri`) so pagination never mixes or drops rows across pages.
+ * `ORDER BY` for a {@link SavedSort} run in `direction`. Every ranking carries
+ * a stable tiebreak (`bookmarks.uri`) so pagination never mixes or drops rows
+ * across pages.
  *
  * Bookmark lists are scoped to one reader (small, per-user data — not a
  * network-wide feed), so unlike the feed-scale orderings in
@@ -1027,27 +1043,37 @@ const getBookmarkStatus = createServerFn({ method: "GET" })
  * composite indexes.
  * NULLS LAST is spelled out (not Drizzle's bare `desc()`, which emits NULLS
  * FIRST) so left-joined rows for a deleted/missing document sort to the end
- * instead of the top.
+ * instead of the top. It stays LAST in *both* directions: a bookmark whose
+ * document is gone has no title or published date to rank by, so flipping the
+ * order must not float it to the top.
  */
-function savedOrderBy(schema: Schema, sort: SavedSort): Array<SQL> {
+function savedOrderBy(
+  schema: Schema,
+  sort: SavedSort,
+  direction: SavedSortDirection,
+): Array<SQL> {
   const b = schema.bookmarks;
   const d = schema.documents;
   const p = schema.publications;
+  const dir = direction === "asc" ? sql`asc` : sql`desc`;
+  const tiebreak = direction === "asc" ? asc(b.uri) : desc(b.uri);
 
   if (sort === "published") {
-    return [sql`${d.publishedAt} desc nulls last`, desc(b.uri)];
+    return [sql`${d.publishedAt} ${dir} nulls last`, tiebreak];
   }
   if (sort === "publication") {
+    // Only the grouping flips — articles stay newest-first inside each
+    // publication either way, which is what the group is read for.
     return [
-      asc(publicationSortNameSql(p.name, p.url)),
+      sql`${publicationSortNameSql(p.name, p.url)} ${dir} nulls last`,
       sql`${d.publishedAt} desc nulls last`,
-      desc(b.uri),
+      tiebreak,
     ];
   }
   if (sort === "title") {
-    return [sql`lower(${d.title}) asc nulls last`, desc(b.uri)];
+    return [sql`lower(${d.title}) ${dir} nulls last`, tiebreak];
   }
-  return [sql`${b.createdAt} desc nulls last`, desc(b.uri)];
+  return [sql`${b.createdAt} ${dir} nulls last`, tiebreak];
 }
 
 const getSaved = createServerFn({ method: "GET" })
@@ -1059,10 +1085,12 @@ const getSaved = createServerFn({ method: "GET" })
       if (!did) {
         return buildReaderListPage<SavedArticleItem>([], data.offset, 0);
       }
+      const direction = data.dir ?? defaultSavedSortDirection(data.sort);
       span.set("did", did);
       span.set("limit", data.limit);
       span.set("offset", data.offset);
       span.set("sort", data.sort);
+      span.set("dir", direction);
 
       const b = context.schema.bookmarks;
       const d = context.schema.documents;
@@ -1090,11 +1118,12 @@ const getSaved = createServerFn({ method: "GET" })
           .leftJoin(pr, eq(pr.did, p.did))
           .leftJoin(pa, eq(pa.did, d.did))
           .where(where)
-          // The "added" (default) sort matches `bookmarks_owner_idx` (owner_did,
-          // created_at DESC NULLS LAST); see getReadingHistory for why bare
-          // `desc()` is slow. Other sorts filter via that same index, then sort
-          // in memory — see savedOrderBy.
-          .orderBy(...savedOrderBy(context.schema, data.sort))
+          // The "added" sort in its default direction matches
+          // `bookmarks_owner_idx` (owner_did, created_at DESC NULLS LAST); see
+          // getReadingHistory for why bare `desc()` is slow. Every other
+          // sort/direction pair filters via that same index, then sorts in
+          // memory — see savedOrderBy.
+          .orderBy(...savedOrderBy(context.schema, data.sort, direction))
           .limit(data.limit)
           .offset(data.offset),
       ]);
@@ -1367,12 +1396,20 @@ function getLikesInfiniteQueryOptions({
 
 function getSavedInfiniteQueryOptions({
   sort = "added",
+  dir,
   limit = READER_QUEUE_PAGE_SIZE,
-}: { sort?: SavedSort; limit?: number } = {}) {
+}: {
+  sort?: SavedSort;
+  dir?: SavedSortDirection;
+  limit?: number;
+} = {}) {
+  // Resolved here, not in the key builder's caller, so `/saved?sort=added` and
+  // `/saved?sort=added&dir=desc` share one cache entry instead of refetching.
+  const direction = dir ?? defaultSavedSortDirection(sort);
   return infiniteQueryOptions({
-    queryKey: ["reader", "saved", sort, limit] as const,
+    queryKey: ["reader", "saved", sort, direction, limit] as const,
     queryFn: async ({ pageParam }) =>
-      getSaved({ data: { sort, limit, offset: pageParam } }),
+      getSaved({ data: { sort, dir: direction, limit, offset: pageParam } }),
     initialPageParam: 0,
     getNextPageParam: (lastPage) => lastPage.nextOffset ?? undefined,
   });

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -7042,6 +7042,10 @@ msgstr "تصفية حسب الموضوع"
 msgid "Uploading {0}"
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Reordering saved articles"
+msgstr ""
+
 #: src/routes/_layout.latest.tsx
 msgid "No unread articles from your follows right now."
 msgstr "لا مقالات غير مقروءة من متابَعاتك حاليًا."

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -73,6 +73,7 @@ msgstr "الانتقال إلى قسم"
 
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.feedback.index.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Sort by"
 msgstr "الترتيب حسب"
 
@@ -6362,6 +6363,7 @@ msgid "About"
 msgstr "حول"
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Order"
 msgstr ""
 

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -2047,6 +2047,7 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, zero {لا مطابقات} one {مطابقة واحدة} two {مطابقتان} few {# مطابقات} many {# مطابقة} other {# مطابقة}}"
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Newest first"
 msgstr ""
 
@@ -4320,6 +4321,10 @@ msgstr ""
 msgid "{0, plural, one {# feature} other {# features}}"
 msgstr "{0, plural, zero {لا ميزات} one {ميزة واحدة} two {ميزتان} few {# ميزات} many {# ميزةً} other {# ميزة}}"
 
+#: src/routes/_layout.saved.tsx
+msgid "Z–A"
+msgstr ""
+
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Last active"
 msgstr "آخر نشاط"
@@ -4467,6 +4472,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Oldest first"
 msgstr ""
 
@@ -6172,6 +6178,7 @@ msgstr ""
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.saved.tsx
 #: src/routes/_layout.tag.$tag.tsx
 #: src/routes/_layout.topics.$slug.tsx
 msgid "A–Z"

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -7042,6 +7042,10 @@ msgstr "Nach Thema filtern"
 msgid "Uploading {0}"
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Reordering saved articles"
+msgstr ""
+
 #: src/routes/_layout.latest.tsx
 msgid "No unread articles from your follows right now."
 msgstr "Derzeit keine ungelesenen Artikel aus Ihren Abos."

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -73,6 +73,7 @@ msgstr "Zum Abschnitt springen"
 
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.feedback.index.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Sort by"
 msgstr "Sortieren nach"
 
@@ -6362,6 +6363,7 @@ msgid "About"
 msgstr "Über"
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Order"
 msgstr ""
 

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -2047,6 +2047,7 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {# Treffer} other {# Treffer}}"
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Newest first"
 msgstr ""
 
@@ -4320,6 +4321,10 @@ msgstr ""
 msgid "{0, plural, one {# feature} other {# features}}"
 msgstr "{0, plural, one {# Funktion} other {# Funktionen}}"
 
+#: src/routes/_layout.saved.tsx
+msgid "Z–A"
+msgstr ""
+
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Last active"
 msgstr "Zuletzt aktiv"
@@ -4467,6 +4472,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Oldest first"
 msgstr ""
 
@@ -6172,6 +6178,7 @@ msgstr ""
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.saved.tsx
 #: src/routes/_layout.tag.$tag.tsx
 #: src/routes/_layout.topics.$slug.tsx
 msgid "A–Z"

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -2047,6 +2047,7 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr ""
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Newest first"
 msgstr ""
 
@@ -4320,6 +4321,10 @@ msgstr ""
 msgid "{0, plural, one {# feature} other {# features}}"
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Z–A"
+msgstr ""
+
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Last active"
 msgstr ""
@@ -4467,6 +4472,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Oldest first"
 msgstr ""
 
@@ -6172,6 +6178,7 @@ msgstr ""
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.saved.tsx
 #: src/routes/_layout.tag.$tag.tsx
 #: src/routes/_layout.topics.$slug.tsx
 msgid "A–Z"

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -73,6 +73,7 @@ msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.feedback.index.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Sort by"
 msgstr ""
 
@@ -6362,6 +6363,7 @@ msgid "About"
 msgstr ""
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Order"
 msgstr ""
 

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -7042,6 +7042,10 @@ msgstr ""
 msgid "Uploading {0}"
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Reordering saved articles"
+msgstr ""
+
 #: src/routes/_layout.latest.tsx
 msgid "No unread articles from your follows right now."
 msgstr ""

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -2047,6 +2047,7 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {# match} other {# matches}}"
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Newest first"
 msgstr "Newest first"
 
@@ -4320,6 +4321,10 @@ msgstr "how rounded corners are, from sharp to soft."
 msgid "{0, plural, one {# feature} other {# features}}"
 msgstr "{0, plural, one {# feature} other {# features}}"
 
+#: src/routes/_layout.saved.tsx
+msgid "Z–A"
+msgstr "Z–A"
+
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Last active"
 msgstr "Last active"
@@ -4467,6 +4472,7 @@ msgstr "Making a list"
 #~ msgstr "Returning you to the app…"
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Oldest first"
 msgstr "Oldest first"
 
@@ -6172,6 +6178,7 @@ msgstr "Introduction"
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.saved.tsx
 #: src/routes/_layout.tag.$tag.tsx
 #: src/routes/_layout.topics.$slug.tsx
 msgid "A–Z"

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -73,6 +73,7 @@ msgstr "Jump to section"
 
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.feedback.index.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Sort by"
 msgstr "Sort by"
 
@@ -6362,6 +6363,7 @@ msgid "About"
 msgstr "About"
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Order"
 msgstr "Order"
 

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -7042,6 +7042,10 @@ msgstr "Filter by topic"
 msgid "Uploading {0}"
 msgstr "Uploading {0}"
 
+#: src/routes/_layout.saved.tsx
+msgid "Reordering saved articles"
+msgstr "Reordering saved articles"
+
 #: src/routes/_layout.latest.tsx
 msgid "No unread articles from your follows right now."
 msgstr "No unread articles from your follows right now."

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -73,6 +73,7 @@ msgstr "Ir a la sección"
 
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.feedback.index.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Sort by"
 msgstr "Ordenar por"
 
@@ -6362,6 +6363,7 @@ msgid "About"
 msgstr "Acerca de"
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Order"
 msgstr ""
 

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -7042,6 +7042,10 @@ msgstr "Filtrar por tema"
 msgid "Uploading {0}"
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Reordering saved articles"
+msgstr ""
+
 #: src/routes/_layout.latest.tsx
 msgid "No unread articles from your follows right now."
 msgstr "Ahora mismo no hay artículos sin leer de sus seguidos."

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -2047,6 +2047,7 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {# coincidencia} other {# coincidencias}}"
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Newest first"
 msgstr ""
 
@@ -4320,6 +4321,10 @@ msgstr ""
 msgid "{0, plural, one {# feature} other {# features}}"
 msgstr "{0, plural, one {# función} other {# funciones}}"
 
+#: src/routes/_layout.saved.tsx
+msgid "Z–A"
+msgstr ""
+
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Last active"
 msgstr "Última actividad"
@@ -4467,6 +4472,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Oldest first"
 msgstr ""
 
@@ -6172,6 +6178,7 @@ msgstr ""
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.saved.tsx
 #: src/routes/_layout.tag.$tag.tsx
 #: src/routes/_layout.topics.$slug.tsx
 msgid "A–Z"

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -73,6 +73,7 @@ msgstr "Aller à la section"
 
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.feedback.index.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Sort by"
 msgstr "Trier par"
 
@@ -6362,6 +6363,7 @@ msgid "About"
 msgstr "À propos"
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Order"
 msgstr ""
 

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -2047,6 +2047,7 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {# résultat} other {# résultats}}"
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Newest first"
 msgstr ""
 
@@ -4320,6 +4321,10 @@ msgstr ""
 msgid "{0, plural, one {# feature} other {# features}}"
 msgstr "{0, plural, one {# fonctionnalité} other {# fonctionnalités}}"
 
+#: src/routes/_layout.saved.tsx
+msgid "Z–A"
+msgstr ""
+
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Last active"
 msgstr "Dernière activité"
@@ -4467,6 +4472,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Oldest first"
 msgstr ""
 
@@ -6172,6 +6178,7 @@ msgstr ""
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.saved.tsx
 #: src/routes/_layout.tag.$tag.tsx
 #: src/routes/_layout.topics.$slug.tsx
 msgid "A–Z"

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -7042,6 +7042,10 @@ msgstr "Filtrer par sujet"
 msgid "Uploading {0}"
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Reordering saved articles"
+msgstr ""
+
 #: src/routes/_layout.latest.tsx
 msgid "No unread articles from your follows right now."
 msgstr "Aucun article non lu parmi vos abonnements pour le moment."

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -7042,6 +7042,10 @@ msgstr "トピックで絞り込む"
 msgid "Uploading {0}"
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Reordering saved articles"
+msgstr ""
+
 #: src/routes/_layout.latest.tsx
 msgid "No unread articles from your follows right now."
 msgstr "フォロー中の未読記事は今のところありません。"

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -2047,6 +2047,7 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {# 件の一致} other {# 件の一致}}"
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Newest first"
 msgstr ""
 
@@ -4320,6 +4321,10 @@ msgstr ""
 msgid "{0, plural, one {# feature} other {# features}}"
 msgstr "{0, plural, one {# 件の機能} other {# 件の機能}}"
 
+#: src/routes/_layout.saved.tsx
+msgid "Z–A"
+msgstr ""
+
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Last active"
 msgstr "最終アクティブ"
@@ -4467,6 +4472,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Oldest first"
 msgstr ""
 
@@ -6172,6 +6178,7 @@ msgstr ""
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.saved.tsx
 #: src/routes/_layout.tag.$tag.tsx
 #: src/routes/_layout.topics.$slug.tsx
 msgid "A–Z"

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -73,6 +73,7 @@ msgstr "セクションへ移動"
 
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.feedback.index.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Sort by"
 msgstr "並び替え"
 
@@ -6362,6 +6363,7 @@ msgid "About"
 msgstr "概要"
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Order"
 msgstr ""
 

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -73,6 +73,7 @@ msgstr "섹션으로 이동"
 
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.feedback.index.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Sort by"
 msgstr "정렬 기준"
 
@@ -6362,6 +6363,7 @@ msgid "About"
 msgstr "소개"
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Order"
 msgstr ""
 

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -2047,6 +2047,7 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {검색 결과 #개} other {검색 결과 #개}}"
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Newest first"
 msgstr ""
 
@@ -4320,6 +4321,10 @@ msgstr ""
 msgid "{0, plural, one {# feature} other {# features}}"
 msgstr "{0, plural, one {기능 #개} other {기능 #개}}"
 
+#: src/routes/_layout.saved.tsx
+msgid "Z–A"
+msgstr ""
+
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Last active"
 msgstr "마지막 활동"
@@ -4467,6 +4472,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Oldest first"
 msgstr ""
 
@@ -6172,6 +6178,7 @@ msgstr ""
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.saved.tsx
 #: src/routes/_layout.tag.$tag.tsx
 #: src/routes/_layout.topics.$slug.tsx
 msgid "A–Z"

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -7042,6 +7042,10 @@ msgstr "주제로 필터"
 msgid "Uploading {0}"
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Reordering saved articles"
+msgstr ""
+
 #: src/routes/_layout.latest.tsx
 msgid "No unread articles from your follows right now."
 msgstr "지금은 팔로우한 곳에 읽지 않은 글이 없습니다."

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -7042,6 +7042,10 @@ msgstr "Filtrar por tópico"
 msgid "Uploading {0}"
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Reordering saved articles"
+msgstr ""
+
 #: src/routes/_layout.latest.tsx
 msgid "No unread articles from your follows right now."
 msgstr "De momento não há artigos por ler das publicações que segue."

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -73,6 +73,7 @@ msgstr "Ir para a secção"
 
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.feedback.index.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Sort by"
 msgstr "Ordenar por"
 
@@ -6362,6 +6363,7 @@ msgid "About"
 msgstr "Sobre"
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Order"
 msgstr ""
 

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -2047,6 +2047,7 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {# resultado} other {# resultados}}"
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Newest first"
 msgstr ""
 
@@ -4320,6 +4321,10 @@ msgstr ""
 msgid "{0, plural, one {# feature} other {# features}}"
 msgstr "{0, plural, one {# funcionalidade} other {# funcionalidades}}"
 
+#: src/routes/_layout.saved.tsx
+msgid "Z–A"
+msgstr ""
+
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Last active"
 msgstr "Última atividade"
@@ -4467,6 +4472,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Oldest first"
 msgstr ""
 
@@ -6172,6 +6178,7 @@ msgstr "Introdução"
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.saved.tsx
 #: src/routes/_layout.tag.$tag.tsx
 #: src/routes/_layout.topics.$slug.tsx
 msgid "A–Z"

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -73,6 +73,7 @@ msgstr "跳转到章节"
 
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.feedback.index.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Sort by"
 msgstr "排序方式"
 
@@ -6362,6 +6363,7 @@ msgid "About"
 msgstr "关于"
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Order"
 msgstr ""
 

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -7042,6 +7042,10 @@ msgstr "按话题筛选"
 msgid "Uploading {0}"
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Reordering saved articles"
+msgstr ""
+
 #: src/routes/_layout.latest.tsx
 msgid "No unread articles from your follows right now."
 msgstr "你关注的刊物暂无未读文章。"

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -2047,6 +2047,7 @@ msgid "{total, plural, one {# match} other {# matches}}"
 msgstr "{total, plural, one {# 条匹配} other {# 条匹配}}"
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Newest first"
 msgstr ""
 
@@ -4320,6 +4321,10 @@ msgstr ""
 msgid "{0, plural, one {# feature} other {# features}}"
 msgstr "{0, plural, one {# 项功能} other {# 项功能}}"
 
+#: src/routes/_layout.saved.tsx
+msgid "Z–A"
+msgstr ""
+
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "Last active"
 msgstr "最后活跃"
@@ -4467,6 +4472,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/publication-actions.tsx
+#: src/routes/_layout.saved.tsx
 msgid "Oldest first"
 msgstr ""
 
@@ -6172,6 +6178,7 @@ msgstr ""
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 #: src/routes/_layout.discover.tsx
+#: src/routes/_layout.saved.tsx
 #: src/routes/_layout.tag.$tag.tsx
 #: src/routes/_layout.topics.$slug.tsx
 msgid "A–Z"

--- a/apps/standard-reader/src/routes/_layout.saved.tsx
+++ b/apps/standard-reader/src/routes/_layout.saved.tsx
@@ -19,15 +19,20 @@ import {
 import * as stylex from "@stylexjs/stylex";
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
-import { ArrowDownWideNarrow } from "lucide-react";
+import { ArrowDown, ArrowDownWideNarrow, ArrowUp } from "lucide-react";
 import { useCallback } from "react";
 import type { Selection } from "react-aria-components";
 import { z } from "zod";
 
 import { ButtonLink } from "#/components/router-links";
-import type { SavedSort } from "#/integrations/tanstack-query/api-reader.functions";
+import type {
+  SavedSort,
+  SavedSortDirection,
+} from "#/integrations/tanstack-query/api-reader.functions";
 import {
+  defaultSavedSortDirection,
   readerApi,
+  SAVED_SORT_DIRECTIONS,
   SAVED_SORT_VALUES,
 } from "#/integrations/tanstack-query/api-reader.functions";
 import { user } from "#/integrations/tanstack-query/api-user.functions";
@@ -41,6 +46,10 @@ import { ReaderQueueRows } from "../components/reader/reader-queue-rows";
 
 const savedSearchSchema = z.object({
   sort: z.enum(SAVED_SORT_VALUES).default("added"),
+  /** Left out of the URL until the reader flips a field off its natural
+   * direction, so a chosen direction carries across a change of field but an
+   * untouched one still follows the field (dates newest-first, names A–Z). */
+  dir: z.enum(SAVED_SORT_DIRECTIONS).optional(),
 });
 
 type SavedSearch = z.infer<typeof savedSearchSchema>;
@@ -52,9 +61,23 @@ const SAVED_SORT_OPTIONS = [
   { id: "title", label: msg`Title` },
 ] as const;
 
+/** What a direction is called depends on what the field ranks — "newest first"
+ * for a date, "A–Z" for a name. */
+const SAVED_SORT_RANKS: Record<SavedSort, "date" | "text"> = {
+  added: "date",
+  published: "date",
+  publication: "text",
+  title: "text",
+};
+
+const SAVED_DIRECTION_LABELS = {
+  date: { asc: msg`Oldest first`, desc: msg`Newest first` },
+  text: { asc: msg`A–Z`, desc: msg`Z–A` },
+} as const;
+
 export const Route = createFileRoute("/_layout/saved")({
   validateSearch: savedSearchSchema,
-  loaderDeps: ({ search }) => ({ sort: search.sort }),
+  loaderDeps: ({ search }) => ({ sort: search.sort, dir: search.dir }),
   beforeLoad: async ({ context }) => {
     const session = await context.queryClient.ensureQueryData(
       user.getSessionQueryOptions,
@@ -68,7 +91,10 @@ export const Route = createFileRoute("/_layout/saved")({
   },
   loader: async ({ context, deps }) => {
     await context.queryClient.ensureInfiniteQueryData(
-      readerApi.getSavedInfiniteQueryOptions({ sort: deps.sort }),
+      readerApi.getSavedInfiniteQueryOptions({
+        sort: deps.sort,
+        dir: deps.dir,
+      }),
     );
   },
   head: () => ({
@@ -143,10 +169,13 @@ const styles = stylex.create({
 
 function ReaderSaved() {
   const { t, i18n } = useLingui();
-  const { sort } = Route.useSearch();
+  const { sort, dir } = Route.useSearch();
+  const direction = dir ?? defaultSavedSortDirection(sort);
   const navigate = useNavigate({ from: Route.fullPath });
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useSuspenseInfiniteQuery(readerApi.getSavedInfiniteQueryOptions({ sort }));
+    useSuspenseInfiniteQuery(
+      readerApi.getSavedInfiniteQueryOptions({ sort, dir: direction }),
+    );
 
   const saved = data.pages.flatMap((page) => page.items);
   const total = data.pages[0]?.total ?? 0;
@@ -181,9 +210,24 @@ function ReaderSaved() {
     onSortChange([...keys][0] ?? null);
   };
 
+  const flipDirection = () => {
+    const next: SavedSortDirection = direction === "asc" ? "desc" : "asc";
+    void navigate({
+      replace: true,
+      resetScroll: false,
+      search: (prev: SavedSearch) => ({ ...prev, dir: next }),
+    });
+  };
+
+  const directionLabels = SAVED_DIRECTION_LABELS[SAVED_SORT_RANKS[sort]];
+  /** The button names what it will do, and shows what is true now. */
+  const flipLabel = i18n._(
+    direction === "asc" ? directionLabels.desc : directionLabels.asc,
+  );
+
   const sortControl =
     total === 0 ? undefined : (
-      <>
+      <Flex direction="row" gap="sm" align="center">
         <div {...stylex.props(styles.sortSlotCompact)}>
           <Menu
             placement="bottom end"
@@ -229,7 +273,22 @@ function ReaderSaved() {
             ))}
           </Select>
         </div>
-      </>
+
+        {/* Sits outside the breakpoint slots: an icon button is already as
+            compact as it gets, so it rides along with either control. */}
+        <IconButton
+          size="md"
+          variant="secondary"
+          label={flipLabel}
+          onPress={flipDirection}
+        >
+          {direction === "asc" ? (
+            <ArrowUp size={16} />
+          ) : (
+            <ArrowDown size={16} />
+          )}
+        </IconButton>
+      </Flex>
     );
 
   return (

--- a/apps/standard-reader/src/routes/_layout.saved.tsx
+++ b/apps/standard-reader/src/routes/_layout.saved.tsx
@@ -11,6 +11,7 @@ import {
   MenuSectionHeader,
   MenuSeparator,
 } from "@standard-reader/design-system/menu";
+import { ProgressCircle } from "@standard-reader/design-system/progress-circle";
 import { Select, SelectItem } from "@standard-reader/design-system/select";
 import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
 import { breakpoints } from "@standard-reader/design-system/theme/media-queries.stylex";
@@ -30,7 +31,7 @@ import {
   ArrowUpDown,
   ArrowUpNarrowWide,
 } from "lucide-react";
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { Selection } from "react-aria-components";
 import { z } from "zod";
 
@@ -48,6 +49,7 @@ import {
 import { user } from "#/integrations/tanstack-query/api-user.functions";
 import { getPublicUrlClient } from "#/lib/public-url";
 import { pageSocialMeta } from "#/lib/site-metadata";
+import { useDelayedLoading } from "#/lib/use-delayed-loading";
 import { buildAuthRedirectPath } from "#/utils/auth-redirect";
 
 import { FeedLoadMore } from "../components/reader/feed-load-more";
@@ -84,6 +86,16 @@ const SAVED_DIRECTION_LABELS = {
   date: { asc: msg`Oldest first`, desc: msg`Newest first` },
   text: { asc: msg`A–Z`, desc: msg`Z–A` },
 } as const;
+
+/** Everything the compact menu offers, for freezing it while a reorder runs. */
+const SAVED_MENU_KEYS: Array<string> = [
+  ...SAVED_SORT_VALUES,
+  ...SAVED_SORT_DIRECTIONS,
+];
+
+/** Matches the tab-skeleton grace period on `/tag` and `/topics`: a reorder
+ * that lands inside it never flashes a loading state at all. */
+const ORDER_PENDING_DELAY_MS = 150;
 
 export const Route = createFileRoute("/_layout/saved")({
   validateSearch: savedSearchSchema,
@@ -184,6 +196,20 @@ function ReaderSaved() {
   const { sort, dir } = Route.useSearch();
   const direction = dir ?? defaultSavedSortDirection(sort);
   const navigate = useNavigate({ from: Route.fullPath });
+  /**
+   * What the reader just asked for, until the router commits it. The route
+   * loader resolves before the search params change, so the old rows stay on
+   * screen with nothing to say a new order is on the way — this drives the
+   * controls to the new choice immediately and marks the wait.
+   *
+   * Scoped to this page's own navigations rather than the router's global
+   * `isLoading`, which would also fire when the reader clicks through to an
+   * article and spin a sort control on the page they are leaving.
+   */
+  const [requested, setRequested] = useState<{
+    sort: SavedSort;
+    dir: SavedSortDirection;
+  } | null>(null);
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useSuspenseInfiniteQuery(
       readerApi.getSavedInfiniteQueryOptions({ sort, dir: direction }),
@@ -206,9 +232,25 @@ function ReaderSaved() {
     actionLabel: t`Saved`,
   }));
 
+  // Committing the requested order is what ends the wait: the loader has
+  // already resolved by the time the router hands back the new search params.
+  useEffect(() => {
+    if (requested?.sort === sort && requested.dir === direction) {
+      setRequested(null);
+    }
+  }, [direction, requested, sort]);
+
+  const shownSort = requested?.sort ?? sort;
+  const shownDirection = requested?.dir ?? direction;
+  const changingOrder = useDelayedLoading(
+    requested !== null,
+    ORDER_PENDING_DELAY_MS,
+  );
+
   const onSortChange = (key: React.Key | null) => {
     if (key == null) return;
     const next = String(key) as SavedSort;
+    setRequested({ sort: next, dir: direction });
     void navigate({
       replace: true,
       resetScroll: false,
@@ -223,6 +265,7 @@ function ReaderSaved() {
   };
 
   const setDirection = (next: SavedSortDirection) => {
+    setRequested({ sort, dir: next });
     void navigate({
       replace: true,
       resetScroll: false,
@@ -236,18 +279,32 @@ function ReaderSaved() {
     if (next === "asc" || next === "desc") setDirection(next);
   };
 
-  const directionLabels = SAVED_DIRECTION_LABELS[SAVED_SORT_RANKS[sort]];
+  const directionLabels = SAVED_DIRECTION_LABELS[SAVED_SORT_RANKS[shownSort]];
   /** The button names what it will do, and shows what is true now. */
   const flipLabel = i18n._(
-    direction === "asc" ? directionLabels.desc : directionLabels.asc,
+    shownDirection === "asc" ? directionLabels.desc : directionLabels.asc,
   );
 
   const sortControl =
     total === 0 ? undefined : (
-      <>
+      <Flex direction="row" gap="sm" align="center">
+        {/* Leading the row, so it grows leftward off the masthead's trailing
+            edge and the controls themselves never shift. */}
+        {changingOrder ? (
+          <ProgressCircle
+            isIndeterminate
+            size="sm"
+            aria-label={t`Reordering saved articles`}
+          />
+        ) : null}
+
         <div {...stylex.props(styles.sortSlotCompact)}>
           <Menu
             placement="bottom end"
+            // The trigger stays live — it only opens the sheet. What's frozen
+            // is the choices inside it, which is also the half the reader is
+            // looking at: the menu stays open across a pick.
+            disabledKeys={changingOrder ? SAVED_MENU_KEYS : undefined}
             trigger={
               <IconButton
                 aria-label={t`Sort saved articles`}
@@ -265,7 +322,7 @@ function ReaderSaved() {
               selectionMode="single"
               disallowEmptySelection
               shouldCloseOnSelect={false}
-              selectedKeys={new Set([sort])}
+              selectedKeys={new Set([shownSort])}
               onSelectionChange={onSortSelection}
             >
               <MenuSectionHeader>
@@ -282,7 +339,7 @@ function ReaderSaved() {
               selectionMode="single"
               disallowEmptySelection
               shouldCloseOnSelect={false}
-              selectedKeys={new Set([direction])}
+              selectedKeys={new Set([shownDirection])}
               onSelectionChange={onDirectionSelection}
             >
               <MenuSectionHeader>
@@ -300,7 +357,8 @@ function ReaderSaved() {
               aria-label={t`Sort saved articles`}
               size="md"
               variant="secondary"
-              selectedKey={sort}
+              isDisabled={changingOrder}
+              selectedKey={shownSort}
               style={styles.sortSelect}
               onSelectionChange={onSortChange}
             >
@@ -319,9 +377,12 @@ function ReaderSaved() {
               variant="secondary"
               label={flipLabel}
               aria-label={flipLabel}
-              onPress={() => setDirection(direction === "asc" ? "desc" : "asc")}
+              isDisabled={changingOrder}
+              onPress={() =>
+                setDirection(shownDirection === "asc" ? "desc" : "asc")
+              }
             >
-              {direction === "asc" ? (
+              {shownDirection === "asc" ? (
                 <ArrowUpNarrowWide size={16} />
               ) : (
                 <ArrowDownWideNarrow size={16} />
@@ -329,7 +390,7 @@ function ReaderSaved() {
             </IconButton>
           </Flex>
         </div>
-      </>
+      </Flex>
     );
 
   return (

--- a/apps/standard-reader/src/routes/_layout.saved.tsx
+++ b/apps/standard-reader/src/routes/_layout.saved.tsx
@@ -19,7 +19,11 @@ import {
 import * as stylex from "@stylexjs/stylex";
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
-import { ArrowDown, ArrowDownWideNarrow, ArrowUp } from "lucide-react";
+import {
+  ArrowDownWideNarrow,
+  ArrowUpDown,
+  ArrowUpNarrowWide,
+} from "lucide-react";
 import { useCallback } from "react";
 import type { Selection } from "react-aria-components";
 import { z } from "zod";
@@ -240,7 +244,9 @@ function ReaderSaved() {
                 size="md"
                 variant="secondary"
               >
-                <ArrowDownWideNarrow size={16} />
+                {/* Neutral both-ways glyph: the field control picks what to
+                    rank by, the button next to it picks which way. */}
+                <ArrowUpDown size={16} />
               </IconButton>
             }
           >
@@ -257,7 +263,6 @@ function ReaderSaved() {
             aria-label={t`Sort saved articles`}
             size="md"
             variant="secondary"
-            prefix={<ArrowDownWideNarrow size={14} aria-hidden />}
             selectedKey={sort}
             style={styles.sortSelect}
             onSelectionChange={onSortChange}
@@ -283,9 +288,9 @@ function ReaderSaved() {
           onPress={flipDirection}
         >
           {direction === "asc" ? (
-            <ArrowUp size={16} />
+            <ArrowUpNarrowWide size={16} />
           ) : (
-            <ArrowDown size={16} />
+            <ArrowDownWideNarrow size={16} />
           )}
         </IconButton>
       </Flex>

--- a/apps/standard-reader/src/routes/_layout.saved.tsx
+++ b/apps/standard-reader/src/routes/_layout.saved.tsx
@@ -4,7 +4,13 @@ import { msg } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { Flex } from "@standard-reader/design-system/flex";
 import { IconButton } from "@standard-reader/design-system/icon-button";
-import { Menu, MenuItem } from "@standard-reader/design-system/menu";
+import {
+  Menu,
+  MenuItem,
+  MenuSection,
+  MenuSectionHeader,
+  MenuSeparator,
+} from "@standard-reader/design-system/menu";
 import { Select, SelectItem } from "@standard-reader/design-system/select";
 import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
 import { breakpoints } from "@standard-reader/design-system/theme/media-queries.stylex";
@@ -155,11 +161,13 @@ const styles = stylex.create({
     marginTop: spacing["6"],
   },
   // Two controls occupy the masthead's action slot — a compact icon menu and
-  // the full select — swapped by media query rather than a JS viewport check,
-  // so SSR emits both and neither can hydrate to the wrong one (mirrors
-  // `/tag`'s article sort). The swap is at `md` to match where the masthead
-  // drops its meta figure: below that the trailing edge is tight, so the
-  // control shrinks to the icon.
+  // the full select-plus-direction pair — swapped by media query rather than a
+  // JS viewport check, so SSR emits both and neither can hydrate to the wrong
+  // one (mirrors `/tag`'s article sort). The swap is at `md` to match where the
+  // masthead drops its meta figure: below that the trailing edge is tight, so
+  // the pair collapses into the single icon menu, which carries the order as a
+  // second section rather than a second button — two arrow glyphs side by side
+  // read as one repeated idea, not as field and direction.
   sortSlotCompact: {
     display: { default: "flex", [breakpoints.md]: "none" },
   },
@@ -214,13 +222,18 @@ function ReaderSaved() {
     onSortChange([...keys][0] ?? null);
   };
 
-  const flipDirection = () => {
-    const next: SavedSortDirection = direction === "asc" ? "desc" : "asc";
+  const setDirection = (next: SavedSortDirection) => {
     void navigate({
       replace: true,
       resetScroll: false,
       search: (prev: SavedSearch) => ({ ...prev, dir: next }),
     });
+  };
+
+  const onDirectionSelection = (keys: Selection) => {
+    if (keys === "all") return;
+    const next = [...keys][0];
+    if (next === "asc" || next === "desc") setDirection(next);
   };
 
   const directionLabels = SAVED_DIRECTION_LABELS[SAVED_SORT_RANKS[sort]];
@@ -231,69 +244,92 @@ function ReaderSaved() {
 
   const sortControl =
     total === 0 ? undefined : (
-      <Flex direction="row" gap="sm" align="center">
+      <>
         <div {...stylex.props(styles.sortSlotCompact)}>
           <Menu
             placement="bottom end"
-            selectionMode="single"
-            selectedKeys={new Set([sort])}
-            onSelectionChange={onSortSelection}
             trigger={
               <IconButton
                 aria-label={t`Sort saved articles`}
                 size="md"
                 variant="secondary"
               >
-                {/* Neutral both-ways glyph: the field control picks what to
-                    rank by, the button next to it picks which way. */}
                 <ArrowUpDown size={16} />
               </IconButton>
             }
           >
-            {SAVED_SORT_OPTIONS.map((option) => (
-              <MenuItem key={option.id} id={option.id}>
-                {i18n._(option.label)}
-              </MenuItem>
-            ))}
+            {/* Selection lives on each section (see `/feedback`'s filter menu),
+                so field and order read as one sheet and the menu stays open
+                between the two choices. */}
+            <MenuSection
+              selectionMode="single"
+              disallowEmptySelection
+              shouldCloseOnSelect={false}
+              selectedKeys={new Set([sort])}
+              onSelectionChange={onSortSelection}
+            >
+              <MenuSectionHeader>
+                <Trans>Sort by</Trans>
+              </MenuSectionHeader>
+              {SAVED_SORT_OPTIONS.map((option) => (
+                <MenuItem key={option.id} id={option.id}>
+                  {i18n._(option.label)}
+                </MenuItem>
+              ))}
+            </MenuSection>
+            <MenuSeparator />
+            <MenuSection
+              selectionMode="single"
+              disallowEmptySelection
+              shouldCloseOnSelect={false}
+              selectedKeys={new Set([direction])}
+              onSelectionChange={onDirectionSelection}
+            >
+              <MenuSectionHeader>
+                <Trans>Order</Trans>
+              </MenuSectionHeader>
+              <MenuItem id="desc">{i18n._(directionLabels.desc)}</MenuItem>
+              <MenuItem id="asc">{i18n._(directionLabels.asc)}</MenuItem>
+            </MenuSection>
           </Menu>
         </div>
 
         <div {...stylex.props(styles.sortSlotFull)}>
-          <Select
-            aria-label={t`Sort saved articles`}
-            size="md"
-            variant="secondary"
-            selectedKey={sort}
-            style={styles.sortSelect}
-            onSelectionChange={onSortChange}
-          >
-            {SAVED_SORT_OPTIONS.map((option) => (
-              <SelectItem
-                key={option.id}
-                id={option.id}
-                textValue={i18n._(option.label)}
-              >
-                {i18n._(option.label)}
-              </SelectItem>
-            ))}
-          </Select>
+          <Flex direction="row" gap="sm" align="center">
+            <Select
+              aria-label={t`Sort saved articles`}
+              size="md"
+              variant="secondary"
+              selectedKey={sort}
+              style={styles.sortSelect}
+              onSelectionChange={onSortChange}
+            >
+              {SAVED_SORT_OPTIONS.map((option) => (
+                <SelectItem
+                  key={option.id}
+                  id={option.id}
+                  textValue={i18n._(option.label)}
+                >
+                  {i18n._(option.label)}
+                </SelectItem>
+              ))}
+            </Select>
+            <IconButton
+              size="md"
+              variant="secondary"
+              label={flipLabel}
+              aria-label={flipLabel}
+              onPress={() => setDirection(direction === "asc" ? "desc" : "asc")}
+            >
+              {direction === "asc" ? (
+                <ArrowUpNarrowWide size={16} />
+              ) : (
+                <ArrowDownWideNarrow size={16} />
+              )}
+            </IconButton>
+          </Flex>
         </div>
-
-        {/* Sits outside the breakpoint slots: an icon button is already as
-            compact as it gets, so it rides along with either control. */}
-        <IconButton
-          size="md"
-          variant="secondary"
-          label={flipLabel}
-          onPress={flipDirection}
-        >
-          {direction === "asc" ? (
-            <ArrowUpNarrowWide size={16} />
-          ) : (
-            <ArrowDownWideNarrow size={16} />
-          )}
-        </IconButton>
-      </Flex>
+      </>
     );
 
   return (


### PR DESCRIPTION
Every sort on `/saved` ran one fixed way — Title and Publication A to Z, Date saved and Published date newest first. A reader who wanted the oldest thing in their queue, or the bottom of the alphabet, had no way to ask for it.

A button beside the sort control now flips the order. Each field still runs its natural way until you touch it — dates newest first, names A–Z — so nothing changes for anyone who doesn't reach for it, and `?dir=` stays out of the URL until it's actually been flipped. Once you do pick a direction it carries across a change of field.

The direction is named for what the field ranks, not for `asc`/`desc`: **Newest first / Oldest first** for Date saved and Published date, **A–Z / Z–A** for Publication and Title.

Two orderings deliberately don't reverse:

- Rows whose document is gone stay at the bottom either way. `NULLS LAST` is spelled out in both directions — a bookmark with no title or published date to rank by shouldn't be promoted to the top just because you flipped the order.
- Under the Publication sort, only the grouping flips. Articles stay newest-first inside each publication, which is what the group is read for.

Requested in [Improving sorting options for "Saved for later" page](https://userinput.app/d/did:plc:fip3nyk6tjo3senpq4ei2cxw/3msjpz77kmj2s), following on from [the original sorting request](https://userinput.app/d/did:plc:fip3nyk6tjo3senpq4ei2cxw/3mrqbqf4jxsf5).

## Notes

The infinite-query key gains a direction segment, resolved before the key is built so `?sort=added` and `?sort=added&dir=desc` share one cache entry instead of refetching. It's prefix-matched by `bookmark-optimistic.ts`, so optimistic removal and the sidebar count still hit every variant.

Ascending **Date saved** is the one combination that gives up the `bookmarks_owner_idx` order match and sorts in memory. That's fine at per-reader scale — the index still narrows to the reader's own rows, and every other sort already worked this way.

## Testing

`typecheck`, `lint`, `format:check`, and the app suite (812 passed) are green, and I printed the composed SQL through Drizzle's dialect for all eight sort/direction pairs to confirm the direction inlines as SQL rather than binding as a parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)