### PR TITLE
Keep menus on screen when a publication brings its own theme

### DIFF
--- a/apps/standard-reader/src/components/reader/publication-theme-scope.tsx
+++ b/apps/standard-reader/src/components/reader/publication-theme-scope.tsx
@@ -5,9 +5,10 @@ import { radius } from "@standard-reader/design-system/theme/radius.stylex";
 import { verticalSpace } from "@standard-reader/design-system/theme/semantic-spacing.stylex";
 import * as stylex from "@stylexjs/stylex";
 import { useRouterState } from "@tanstack/react-router";
-import type { ReactNode } from "react";
-import { useCallback, useMemo, useRef } from "react";
+import type { CSSProperties, ReactNode, RefObject } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { UNSAFE_PortalProvider } from "react-aria";
+import { createPortal } from "react-dom";
 
 import { publicationFontsHref } from "#/lib/publication-fonts";
 import { usePublicationThemePreference } from "#/lib/use-publication-theme-preference";
@@ -61,9 +62,20 @@ function usePublicationThemeColors(): PublicationThemeColors | null {
  *
  * Overlays (hover cards, popovers, menus, tooltips, modals) portal to
  * `document.body` by default, which would drop them right back onto the app's
- * own tokens. `UNSAFE_PortalProvider` re-points that portal at this container
- * instead, so they inherit the publication's palette the same way inline content
- * does — no per-component theming.
+ * own tokens. `UNSAFE_PortalProvider` re-points that portal at a second copy of
+ * the same themed wrapper — `OverlayHost` below — so they inherit the
+ * publication's palette the same way inline content does, with no
+ * per-component theming.
+ *
+ * That host deliberately lives at the end of `document.body` rather than inside
+ * this container. React Aria positions an overlay against its *containing
+ * block*, and inside the page that would be the app shell's `<main>`
+ * (`position: relative`, offset by the sidebar and as tall as the whole
+ * document). Its fit-to-viewport math then mixes that block's document-space
+ * coordinates with the viewport-space body boundary, which pushes menus past
+ * the right edge of the window and collapses them to `max-height: 0` once the
+ * page is scrolled. Portaling to the body keeps the containing block the
+ * viewport, which is the geometry React Aria expects.
  */
 export function PublicationThemeScope({
   children,
@@ -79,8 +91,8 @@ export function PublicationThemeScope({
 }) {
   const { enabled } = usePublicationThemePreference();
   const colors = usePublicationThemeColors();
-  const scopeRef = useRef<HTMLDivElement | null>(null);
-  const getContainer = useCallback(() => scopeRef.current, []);
+  const overlayHostRef = useRef<HTMLDivElement | null>(null);
+  const getContainer = useCallback(() => overlayHostRef.current, []);
 
   const scaleVars = useMemo(
     () =>
@@ -131,9 +143,10 @@ export function PublicationThemeScope({
     );
   }
 
+  const themeVars = { ...scaleVars, ...fontVars };
+
   return (
     <div
-      ref={scopeRef}
       {...stylex.props(
         publicationUi,
         publicationPrimary,
@@ -142,11 +155,12 @@ export function PublicationThemeScope({
         styles.scope,
         image ? styles.scopeWithCanvasImage : styles.scopeFlat,
       )}
-      style={{ ...scaleVars, ...fontVars, ...imageVars }}
+      style={{ ...themeVars, ...imageVars }}
     >
       {fontsHref ? (
         <link rel="stylesheet" href={fontsHref} referrerPolicy="no-referrer" />
       ) : null}
+      <OverlayHost ref={overlayHostRef} themeVars={themeVars} />
       <UNSAFE_PortalProvider getContainer={getContainer}>
         {children}
         {footer && image ? (
@@ -156,6 +170,42 @@ export function PublicationThemeScope({
         )}
       </UNSAFE_PortalProvider>
     </div>
+  );
+}
+
+/**
+ * The themed container every React Aria overlay portals into. It carries the
+ * publication's tokens but none of the page's layout, and sits at the end of
+ * `document.body` so overlays resolve their containing block to the viewport —
+ * see the note on `PublicationThemeScope`.
+ *
+ * Rendered only after mount so the first client pass still matches the server
+ * HTML; nothing can open an overlay before then.
+ */
+function OverlayHost({
+  ref,
+  themeVars,
+}: {
+  ref: RefObject<HTMLDivElement | null>;
+  themeVars: CSSProperties;
+}) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  if (!mounted) return null;
+
+  return createPortal(
+    <div
+      ref={ref}
+      {...stylex.props(
+        publicationUi,
+        publicationPrimary,
+        publicationLink,
+        publicationFonts,
+        styles.overlayHost,
+      )}
+      style={themeVars}
+    />,
+    document.body,
   );
 }
 
@@ -202,5 +252,13 @@ const styles = stylex.create({
   /** Footer sits on the page colour, not the canvas image. */
   footerSurface: {
     backgroundColor: uiColor.bg,
+  },
+  /**
+   * Token carrier only — every overlay inside it is positioned, so the host
+   * itself must take no space and paint nothing at the end of `<body>`.
+   */
+  overlayHost: {
+    color: uiColor.text2,
+    display: "contents",
   },
 });


### PR DESCRIPTION
Fixes two odd behaviors on the article page when the reader has **Use publication themes** on and the publication has theme colors — e.g. [this Cosmik Labs article](http://127.0.0.1:3176/a/did:plc:b2p6rujcgpenbtcjposmjuc3/3mquobfkn7k25):

1. The menu overflows off the right edge of the page.
2. Once you've scrolled, opening a menu shows nothing at all.

## Why

`PublicationThemeScope` re-points every React Aria overlay portal (`UNSAFE_PortalProvider`) at the themed wrapper div, so menus, popovers, hover cards, tooltips and modals inherit the publication's palette without per-component theming. That wrapper lives inside the app shell's `<main>`, which is `position: relative` — so `main` becomes the **containing block** for every absolutely-positioned overlay.

React Aria's `calculatePosition` then measures that container (offset by the sidebar, as tall as the entire document, never scrolls) against a boundary that's still the body/viewport, and the two coordinate spaces don't line up:

- **`getDelta`** — the `containerOffsetWithBoundary` terms cancel out, so the keep-it-inside-the-window clamp effectively runs in `main`-relative coordinates. The right edge is allowed to reach viewport-x `main.left + viewportWidth`.
- **`getMaxHeight`** — `overlayTop` stays in document space (`main.scrollTop` is always 0, since `main` isn't a scroll container) while `boundingRect.bottom` is in viewport space. Past roughly one viewport of scroll the subtraction goes negative and clamps to zero.

Neither happens with theming off: the portal goes to `document.body`, the containing block is the viewport, and that's the geometry React Aria is written for.

## The fix

Render a second, layout-free copy of the themed wrapper (`OverlayHost`) portaled to the end of `document.body`, and point the portal provider at that instead of the in-page div. It's `display: contents` and carries only the theme classes and `--pub-*` custom properties, so overlays keep the publication's colors and fonts while resolving their containing block to the viewport.

It renders behind a mounted flag so the first client pass still matches the server HTML; nothing can open an overlay before then.

## Verification

Measured on the Cosmik Labs article at a 1512×796 viewport, with the preference forced on locally:

| | before | after |
| --- | --- | --- |
| Share menu right edge | 1517 — past the 1512px window, `document.scrollWidth` grew to 1517 | 1504 (= viewport − the 8px `containerPadding`) |
| Share menu width | 182, shrink-to-fit squeezed inside `main` | 201, its natural width |
| `max-height` at `scrollY: 1500` | `0px` — popover box 2px tall, menu absent from the a11y tree | `736px`, drawn at viewport y=52 |
| Menu background / font | publication's | still the publication's |

Also checked the Save-to-Margin modal (centered in the viewport, still themed) and the theming-off path, which early-returns before any of this and is unchanged.

`tsc --noEmit`, `oxlint` (0/0), `oxfmt --check`, and the reader component tests (7 files / 57 tests) all pass.

No living-doc updates: this changes neither product direction, data model, lexicons, nor architecture — the reasoning now lives in the doc comment on `PublicationThemeScope`.

`ComicPageNote` uses the same `UNSAFE_PortalProvider` pattern but portals a `position: fixed` modal into a caller-supplied container, so it doesn't hit this. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
