### PR TITLE
Give a poem back its line breaks

### DIFF
--- a/apps/standard-reader/src/components/reader/content/renderers/shared/faceted-text.tsx
+++ b/apps/standard-reader/src/components/reader/content/renderers/shared/faceted-text.tsx
@@ -47,6 +47,7 @@ import { articleBodyStyles, readingDropCapStyleProps } from "../../body-styles";
 import type { FacetFeature } from "./facets";
 import { findFacetFeature, hasFacetKind } from "./facets";
 import { useFootnoteNumber } from "./footnote-context";
+import { withLineBreaks } from "./line-breaks";
 import { useInlineMentions } from "./publication-mention-context";
 
 /**
@@ -333,8 +334,9 @@ function FacetSegment({
   features: Array<FacetFeature>;
 }) {
   const { publications, documents, actors, actorLinks } = useInlineMentions();
+  const content = withLineBreaks(text);
 
-  if (features.length === 0) return <>{text}</>;
+  if (features.length === 0) return <>{content}</>;
 
   const isBold =
     hasFacetKind(features, "bold") || hasFacetKind(features, "strong");
@@ -356,7 +358,7 @@ function FacetSegment({
   const documentMention = lookupDocumentMention(features, documents);
   const actorLink = lookupActorLinkMention(features, actorLinks);
 
-  let node: React.ReactNode = text;
+  let node: React.ReactNode = content;
 
   // A rendered link already carries its own underline (`facetLink`). Track that
   // so a co-located `underline` facet doesn't wrap it in a second `<u>` — two
@@ -364,19 +366,21 @@ function FacetSegment({
   let nodeIsUnderlinedLink = false;
 
   if (isCode) {
-    node = <code {...stylex.props(articleBodyStyles.facetCode)}>{text}</code>;
+    node = (
+      <code {...stylex.props(articleBodyStyles.facetCode)}>{content}</code>
+    );
   }
 
   if (publicationMention) {
     node = (
       <PublicationMentionChip mention={publicationMention}>
-        {text}
+        {content}
       </PublicationMentionChip>
     );
   } else if (documentMention) {
     node = (
       <DocumentMentionChip mention={documentMention}>
-        {text}
+        {content}
       </DocumentMentionChip>
     );
   } else if (actorLink) {
@@ -390,7 +394,7 @@ function FacetSegment({
   } else if (link?.uri) {
     node = (
       <SmartArticleLink href={link.uri} linkStyle={articleBodyStyles.facetLink}>
-        {text}
+        {content}
       </SmartArticleLink>
     );
     nodeIsUnderlinedLink = true;

--- a/apps/standard-reader/src/components/reader/content/renderers/shared/line-breaks.test.ts
+++ b/apps/standard-reader/src/components/reader/content/renderers/shared/line-breaks.test.ts
@@ -1,0 +1,29 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { withLineBreaks } from "./line-breaks";
+
+/** The markup a run's text renders to, as it would appear in a paragraph. */
+function render(text: string): string {
+  return renderToStaticMarkup(withLineBreaks(text));
+}
+
+describe("withLineBreaks", () => {
+  it("renders a hard break as a real <br>", () => {
+    // Without this the newline is collapsed to a space by HTML and the two
+    // lines run together — the Markpub / Mochott / GreenGale break bug.
+    expect(render("Line one\nLine two")).toBe("Line one<br/>Line two");
+  });
+
+  it("keeps consecutive breaks", () => {
+    expect(render("a\n\nb")).toBe("a<br/><br/>b");
+  });
+
+  it("keeps a leading and a trailing break", () => {
+    expect(render("\na\n")).toBe("<br/>a<br/>");
+  });
+
+  it("leaves text with no newline untouched", () => {
+    expect(withLineBreaks("just text")).toBe("just text");
+  });
+});

--- a/apps/standard-reader/src/components/reader/content/renderers/shared/line-breaks.tsx
+++ b/apps/standard-reader/src/components/reader/content/renderers/shared/line-breaks.tsx
@@ -1,0 +1,21 @@
+import { Fragment } from "react";
+
+/**
+ * A run's text with its newlines rendered as real line breaks.
+ *
+ * Every parser carries a hard break — markdown's trailing backslash, two
+ * trailing spaces or `<br>`, a ProseMirror/Mochott `hardBreak`, the joins
+ * between a list item's paragraphs — as `\n` inside the run's plaintext, so
+ * byte offsets stay aligned with the record's facets. HTML collapses a bare
+ * newline into a space, so the break has to be re-materialized at render time
+ * or it disappears from the page.
+ */
+export function withLineBreaks(text: string): React.ReactNode {
+  if (!text.includes("\n")) return text;
+  return text.split("\n").map((line, index) => (
+    <Fragment key={index}>
+      {index > 0 ? <br /> : null}
+      {line}
+    </Fragment>
+  ));
+}

--- a/packages/converter/src/targets/markpub.ts
+++ b/packages/converter/src/targets/markpub.ts
@@ -82,6 +82,12 @@ function inlineToMarkdown(nodes: Array<InlineNode>, ctx: Ctx): string {
         out += escapeInline(node.value);
         break;
       }
+      case "lineBreak": {
+        // The backslash spelling, not two trailing spaces — invisible
+        // whitespace is the one hard break an editor or diff tool eats.
+        out += "\\\n";
+        break;
+      }
       case "mark": {
         const inner = inlineToMarkdown(node.children, ctx);
         switch (node.mark) {
@@ -143,6 +149,12 @@ function plainOf(nodes: Array<InlineNode>): string {
     switch (node.type) {
       case "text": {
         out += node.value;
+        break;
+      }
+      case "lineBreak": {
+        // The only caller is an inline code span, which cannot hold a newline —
+        // CommonMark reads one as a space, so write what it would read.
+        out += " ";
         break;
       }
       case "mark":

--- a/packages/renderer-angular/src/inline.component.ts
+++ b/packages/renderer-angular/src/inline.component.ts
@@ -8,6 +8,8 @@ import type { InlineNode } from "@standard-reader/renderer-core";
   template: `@for (node of nodes; track $index) {
     @if (node.type === "text") {
       {{ node.value }}
+    } @else if (node.type === "lineBreak") {
+      <br />
     } @else if (node.type === "mark") {
       @if (node.mark === "strong") {
         <strong><sr-inline [nodes]="node.children" /></strong>

--- a/packages/renderer-core/src/__tests__/gutenberg.test.ts
+++ b/packages/renderer-core/src/__tests__/gutenberg.test.ts
@@ -208,7 +208,8 @@ describe("gutenberg — inline HTML", () => {
         href: "https://example.com",
         type: "link",
       },
-      { type: "text", value: "\nnext" },
+      { type: "lineBreak" },
+      { type: "text", value: "next" },
     ]);
   });
 

--- a/packages/renderer-core/src/__tests__/markdown.test.ts
+++ b/packages/renderer-core/src/__tests__/markdown.test.ts
@@ -350,3 +350,75 @@ describe("buildRenderTree — markdown", () => {
     expect(buildRenderTree(markdownDoc("   \n\n  "))).toBeNull();
   });
 });
+
+describe("markdown — hard line breaks", () => {
+  /** The single paragraph of a one-paragraph markdown document. */
+  function paragraph(text: string) {
+    const tree = build(markdownDoc(text));
+    return tree.children[0] as Extract<BlockNode, { type: "paragraph" }>;
+  }
+
+  it.each([
+    ["two trailing spaces", "Line one  \nLine two"],
+    ["a trailing backslash", "Line one\\\nLine two"],
+    ["an HTML <br>", "Line one<br>\nLine two"],
+    ["an HTML <br />", "Line one<br />\nLine two"],
+  ])("keeps a break written with %s", (_label, source) => {
+    // All three spellings are one paragraph with a break in the middle — the
+    // newline lives in the plaintext so facet byte offsets stay aligned.
+    expect(paragraph(source).text.plaintext).toBe("Line one\nLine two");
+  });
+
+  it("lifts the break out as an inline node, not collapsible whitespace", () => {
+    // A bare `\n` renders as a space in HTML, so the break has to reach the
+    // renderer as its own node or the two lines run together on the page.
+    const inline = segmentInline(paragraph("Line one  \nLine two").text);
+    expect(inline).toEqual([
+      { type: "text", value: "Line one" },
+      { type: "lineBreak" },
+      { type: "text", value: "Line two" },
+    ]);
+  });
+
+  it("breaks inside a styled run without losing the mark", () => {
+    // Each run carries its own facet, so the emphasis wraps each piece rather
+    // than one span — what matters is that both lines stay bold and the break
+    // survives between them.
+    const inline = segmentInline(paragraph("**bold one  \nbold two**").text);
+    expect(inline.every((node) => node.type === "mark")).toBe(true);
+    expect(
+      inline.flatMap((node) => (node.type === "mark" ? node.children : [])),
+    ).toEqual([
+      { type: "text", value: "bold one" },
+      { type: "lineBreak" },
+      { type: "text", value: "bold two" },
+    ]);
+  });
+
+  it("flattens a soft wrap to a space, per CommonMark", () => {
+    // Prose hard-wrapped at 80 columns is one line to the reader. If the
+    // newline survived into the plaintext it would render as a `<br>`.
+    expect(paragraph("Line one\nLine two").text.plaintext).toBe(
+      "Line one Line two",
+    );
+    expect(
+      segmentInline(paragraph("Line one\nLine two").text).some(
+        (node) => node.type === "lineBreak",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not open a callout with the marker line's own break", () => {
+    // `> [!NOTE]  ` — trailing spaces after the marker are a hard break in
+    // markdown, but the marker line is chrome, so the body must not start with
+    // a blank line. Seen in the wild on GreenGale's kitchen-sink post.
+    const tree = build(markdownDoc("> [!DANGER]  \n> Mind the gap."));
+    const callout = tree.children[0] as Extract<BlockNode, { type: "callout" }>;
+    expect(callout.text.plaintext).toBe("Mind the gap.");
+  });
+
+  it("still drops inline HTML that is not a break", () => {
+    const inline = segmentInline(paragraph("Before <span>x</span> after").text);
+    expect(inline.some((node) => node.type === "lineBreak")).toBe(false);
+  });
+});

--- a/packages/renderer-core/src/document/structured-content/markdown.ts
+++ b/packages/renderer-core/src/document/structured-content/markdown.ts
@@ -97,6 +97,21 @@ export function markdownText(
 // Inline: mdast phrasing content → StructuredText (plaintext + byte facets)
 // ---------------------------------------------------------------------------
 
+/** A standalone `<br>` tag, in any of the spellings authors actually write. */
+const INLINE_BREAK_HTML = /^<br\s*\/?>$/i;
+
+/**
+ * A newline inside a markdown text node is a *soft* wrap — an author hard-
+ * wrapping their prose at 80 columns — which CommonMark renders as a space.
+ *
+ * It has to be flattened here, because a `\n` reaching the plaintext means
+ * "hard break" to every renderer downstream (see {@link segmentInline}); a
+ * genuine break arrives as a `break` node or a literal `<br>` instead.
+ */
+function softWrapToSpace(value: string): string {
+  return value.includes("\n") ? value.replaceAll(/\r?\n/g, " ") : value;
+}
+
 interface InlineRun {
   text: string;
   /** Facet suffix kinds (`bold`, `italic`, `code`, `strikethrough`). */
@@ -116,7 +131,16 @@ function collectRuns(
   for (const node of nodes) {
     switch (node.type) {
       case "text": {
-        out.push({ text: node.value, kinds, link });
+        const text = softWrapToSpace(node.value);
+        // A literal `<br>` leaves the newline that ended its line inside *this*
+        // node, where the flattening above turns it into a leading space.
+        // Indentation at the start of a line is not content, so drop it.
+        const afterBreak = out.at(-1)?.text.endsWith("\n") ?? false;
+        out.push({
+          kinds,
+          link,
+          text: afterBreak ? text.replace(/^[\t ]+/, "") : text,
+        });
         break;
       }
       case "strong": {
@@ -132,7 +156,11 @@ function collectRuns(
         break;
       }
       case "inlineCode": {
-        out.push({ text: node.value, kinds: [...kinds, "code"], link });
+        out.push({
+          kinds: [...kinds, "code"],
+          link,
+          text: softWrapToSpace(node.value),
+        });
         break;
       }
       case "link": {
@@ -141,6 +169,15 @@ function collectRuns(
       }
       case "break": {
         out.push({ text: "\n", kinds, link });
+        break;
+      }
+      case "html": {
+        // Inline HTML carries no text we can faithfully render — except a
+        // literal `<br>`, which is how a lot of markdown authors write a hard
+        // break. Dropping it silently joined the two lines into one.
+        if (INLINE_BREAK_HTML.test(node.value)) {
+          out.push({ text: "\n", kinds, link });
+        }
         break;
       }
       case "inlineMath": {
@@ -165,8 +202,9 @@ function collectRuns(
         break;
       }
       default: {
-        // image (inline), html, footnoteReference, etc. carry no plain body
-        // we can faithfully inline — skip rather than emit noise.
+        // Anything left (footnote definitions in a paragraph, raw MDX-ish
+        // nodes, …) carries no plain body we can faithfully inline — skip it
+        // rather than emit noise.
         break;
       }
     }
@@ -307,10 +345,17 @@ function mapCallout(node: {
   const marker = parseCalloutMarker(lead.value);
   if (!marker) return null;
 
-  // Re-emit the first paragraph without its marker line.
+  // Re-emit the first paragraph without its marker line. A break sitting right
+  // after the marker ends *that* line — an author writing `> [!NOTE]  ` — so it
+  // is dropped rather than opening the callout with a blank line.
+  const afterMarker = lead.value.slice(marker.matchLength);
+  const trailing = first.children.slice(1);
+  const bodyStart = afterMarker.trim()
+    ? 0
+    : trailing.findIndex((child) => child.type !== "break");
   const body: Array<PhrasingContent> = [
-    { type: "text", value: lead.value.slice(marker.matchLength) },
-    ...first.children.slice(1),
+    { type: "text", value: afterMarker },
+    ...(bodyStart === -1 ? [] : trailing.slice(bodyStart)),
   ];
 
   const runs = [inlineText(body)].filter((run) => run.plaintext.trim());

--- a/packages/renderer-core/src/inline.ts
+++ b/packages/renderer-core/src/inline.ts
@@ -2,8 +2,23 @@ import { findFacetFeature, hasFacetKind } from "./facets.js";
 import { segmentFacetedText } from "./leaflet/facets.js";
 import type { InlineNode, MarkKind, RichText } from "./nodes.js";
 
-function wrapMark(node: InlineNode, mark: MarkKind): InlineNode {
-  return { type: "mark", mark, children: [node] };
+function wrapMark(children: Array<InlineNode>, mark: MarkKind): InlineNode {
+  return { type: "mark", mark, children };
+}
+
+/**
+ * One segment's text as inline nodes, with its newlines lifted into explicit
+ * {@link InlineNode} line breaks — a bare `\n` is collapsed to a space by HTML,
+ * so a hard break authored in the source would otherwise vanish on the page.
+ */
+function textNodes(value: string): Array<InlineNode> {
+  if (!value.includes("\n")) return [{ type: "text", value }];
+  const out: Array<InlineNode> = [];
+  for (const [index, line] of value.split("\n").entries()) {
+    if (index > 0) out.push({ type: "lineBreak" });
+    if (line) out.push({ type: "text", value: line });
+  }
+  return out;
 }
 
 /**
@@ -25,7 +40,7 @@ export function segmentInline(
   for (const segment of segments) {
     const { text: value, features } = segment;
     if (features.length === 0) {
-      out.push({ type: "text", value });
+      out.push(...textNodes(value));
       continue;
     }
 
@@ -48,28 +63,30 @@ export function segmentInline(
       findFacetFeature(features, "mention");
     const footnote = findFacetFeature(features, "footnote");
 
-    let node: InlineNode = { type: "text", value };
+    let nodes: Array<InlineNode> = textNodes(value);
 
-    if (isCode) node = wrapMark(node, "code");
+    if (isCode) nodes = [wrapMark(nodes, "code")];
 
     if (mention && (mention.atURI || mention.did)) {
-      node = {
-        type: "mention",
-        atUri: mention.atURI,
-        did: mention.did,
-        children: [node],
-      };
+      nodes = [
+        {
+          type: "mention",
+          atUri: mention.atURI,
+          did: mention.did,
+          children: nodes,
+        },
+      ];
     } else if (link?.uri) {
-      node = { type: "link", href: link.uri, children: [node] };
+      nodes = [{ type: "link", href: link.uri, children: nodes }];
     }
 
-    if (isHighlight) node = wrapMark(node, "highlight");
-    if (isStrikethrough) node = wrapMark(node, "strikethrough");
-    if (isUnderline) node = wrapMark(node, "underline");
-    if (isItalic) node = wrapMark(node, "emphasis");
-    if (isBold) node = wrapMark(node, "strong");
+    if (isHighlight) nodes = [wrapMark(nodes, "highlight")];
+    if (isStrikethrough) nodes = [wrapMark(nodes, "strikethrough")];
+    if (isUnderline) nodes = [wrapMark(nodes, "underline")];
+    if (isItalic) nodes = [wrapMark(nodes, "emphasis")];
+    if (isBold) nodes = [wrapMark(nodes, "strong")];
 
-    out.push(node);
+    out.push(...nodes);
 
     if (footnote?.footnoteId) {
       out.push({

--- a/packages/renderer-core/src/nodes.ts
+++ b/packages/renderer-core/src/nodes.ts
@@ -33,6 +33,16 @@ export type MarkKind =
 /** The inline tree produced by {@link segmentInline}. */
 export type InlineNode =
   | { type: "text"; value: string }
+  /**
+   * A hard line break inside a run of text — markdown's trailing-backslash,
+   * two-space and `<br>` breaks, ProseMirror/Mochott `hardBreak` nodes, and the
+   * newlines that join a multi-paragraph list item or callout.
+   *
+   * Parsers carry these as `\n` in the run's plaintext (so byte offsets stay
+   * aligned with the record's facets); {@link segmentInline} lifts them out into
+   * this node, because HTML collapses a bare newline into a space.
+   */
+  | { type: "lineBreak" }
   | { type: "mark"; mark: MarkKind; children: Array<InlineNode> }
   | { type: "link"; href: string; children: Array<InlineNode> }
   | {

--- a/packages/renderer-lit/src/inline.ts
+++ b/packages/renderer-lit/src/inline.ts
@@ -1,4 +1,5 @@
 import type { InlineNode, MarkKind } from "@standard-reader/renderer-core";
+import { html } from "lit";
 
 import type { LitSharedComponents, Renderable, RenderContext } from "./types";
 
@@ -41,6 +42,9 @@ function renderInline(node: InlineNode, ctx: RenderContext): Renderable {
   switch (node.type) {
     case "text": {
       return node.value;
+    }
+    case "lineBreak": {
+      return html`<br />`;
     }
     case "mark": {
       return markRenderer(

--- a/packages/renderer-react/src/__tests__/markdown.test.tsx
+++ b/packages/renderer-react/src/__tests__/markdown.test.tsx
@@ -158,6 +158,22 @@ describe("markdown through the React renderer", () => {
     expect(container.querySelector("h2")?.textContent).toBe("From Markpub");
   });
 
+  it("renders a hard break as a <br>, and a soft wrap as a space", () => {
+    // Markpub / Mochott / GreenGale authors write breaks all three ways; each
+    // one has to survive into the DOM, while prose wrapped in the source must
+    // not sprout breaks it never asked for.
+    const { container } = renderMarkdown(
+      ["one  ", "two\\", "three<br>", "four", "", "wrapped", "prose"].join(
+        "\n",
+      ),
+    );
+    const [broken, wrapped] = [...container.querySelectorAll("p")];
+    expect(broken?.querySelectorAll("br")).toHaveLength(3);
+    expect(broken?.textContent).toBe("onetwothreefour");
+    expect(wrapped?.querySelectorAll("br")).toHaveLength(0);
+    expect(wrapped?.textContent).toBe("wrapped prose");
+  });
+
   it("renders a markdown-in-record third-party lexicon", () => {
     const { container } = render(
       <StandardDocumentRenderer

--- a/packages/renderer-react/src/render/faceted-text.tsx
+++ b/packages/renderer-react/src/render/faceted-text.tsx
@@ -37,6 +37,9 @@ function RenderInline({ node }: { node: InlineNode }) {
     case "text": {
       return <>{node.value}</>;
     }
+    case "lineBreak": {
+      return <br />;
+    }
     case "mark": {
       const Mark = markComponent(shared, node.mark);
       return (

--- a/packages/renderer-solid/src/inline.ts
+++ b/packages/renderer-solid/src/inline.ts
@@ -1,4 +1,5 @@
 import type { InlineNode, MarkKind } from "@standard-reader/renderer-core";
+import h from "solid-js/h";
 
 import type { Renderable, RenderContext, SolidSharedComponents } from "./types";
 
@@ -41,6 +42,11 @@ function renderInline(node: InlineNode, ctx: RenderContext): Renderable {
   switch (node.type) {
     case "text": {
       return node.value;
+    }
+    case "lineBreak": {
+      // `solid-js/h` returns a thunk that Solid renders fine but which its
+      // `JSX.Element` type doesn't cover — the same cast `defaults.ts` makes.
+      return h("br") as unknown as Renderable;
     }
     case "mark": {
       return markRenderer(

--- a/packages/renderer-svelte/src/Inline.svelte
+++ b/packages/renderer-svelte/src/Inline.svelte
@@ -9,7 +9,8 @@
 </script>
 
 {#each nodes as node}
-  {#if node.type === "text"}{node.value}{:else if node.type === "mark"}
+  {#if node.type === "text"}{node.value}{:else if node.type === "lineBreak"}<br
+    />{:else if node.type === "mark"}
     {#snippet markInner()}<Inline nodes={node.children} />{/snippet}
     {#if node.mark === "strong"}
       {#if s.strong}{@render s.strong({ children: markInner })}{:else}<strong

--- a/packages/renderer-vue/src/inline.ts
+++ b/packages/renderer-vue/src/inline.ts
@@ -1,4 +1,5 @@
 import type { InlineNode, MarkKind } from "@standard-reader/renderer-core";
+import { h } from "vue";
 
 import type { Renderable, RenderContext, VueSharedComponents } from "./types";
 
@@ -41,6 +42,9 @@ function renderInline(node: InlineNode, ctx: RenderContext): Renderable {
   switch (node.type) {
     case "text": {
       return node.value;
+    }
+    case "lineBreak": {
+      return h("br");
     }
     case "mark": {
       return markRenderer(


### PR DESCRIPTION
Reported on userinput.app by **youronly.one** — [Markdown single-line breaks are no longer working for Markpub, Mochott, and GreenGale](https://userinput.app/d/did:plc:bpotnohnlgcj3fbmp7ugx4en/3ms6f5r6dkv2t).

## What was broken

All three formats funnel through `renderer-core` now. Every parser carries a hard break — markdown's trailing backslash or two trailing spaces, a literal `<br>`, a Mochott/ProseMirror `hardBreak`, the joins between a list item's paragraphs — as a `\n` inside the run's plaintext, so byte offsets stay aligned with the record's facets.

Nothing downstream ever turned that newline back into a break, and HTML collapses a bare newline into a space. So every hard break silently vanished: poems, lyrics and dialogue rendered as one run-on paragraph. The `<br>` spelling fared worse — inline HTML was dropped on the floor entirely, so those two lines were joined with no space at all.

## The fix

- **`renderer-core`** — new `{ type: "lineBreak" }` inline node. `segmentInline` lifts the newlines out of each segment, including inside marks and links, so a break in the middle of a bold run keeps both halves bold.
- **`markdown.ts`** — a literal `<br>` / `<br/>` / `<br />` now emits a break instead of being dropped. Conversely, a *soft* wrap is flattened to a space per CommonMark, so prose an author hard-wrapped at 80 columns doesn't sprout breaks it never asked for. And a `> [!NOTE]  ` marker line's own break no longer opens the callout with a blank line.
- **Every framework renderer** (react, vue, svelte, solid, lit, angular) maps `lineBreak` to a `<br>`; the converter's markpub target re-emits it as the backslash spelling, not two invisible spaces.
- **The reader** overrides `FacetText` with its own `FacetedPlaintext`, so that path needed the same treatment — a `withLineBreaks` helper applied to plain runs, code spans, links and mention chips.

## Verification

Beyond the new tests, I pulled the four records from the bug report straight from their PDSes and ran them through the built render tree:

| record | before | after |
| --- | --- | --- |
| Markpub (`<br>` + backslash) | 0 breaks | 9 |
| Markpub (trailing double-space) | 0 breaks | 17 |
| Mochott native | 0 breaks | 10 |
| GreenGale kitchen sink | 0 breaks | 7 |

No stray leading, trailing or doubled breaks in any of the four.

New tests: hard-break parsing and segmentation in `renderer-core`, a DOM-level assertion through `renderer-react` (three break spellings survive, a soft wrap does not become one), and a unit test for the reader's helper. Full suite green (1258 tests), plus lint, format and typecheck — except `packages/design-system`'s missing `tsc`, which fails on a clean tree too.

Not covered: the reader's own inline path was verified by unit test and by reading the wiring, not in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)