### PR TITLE
Notify readers when a publication or author they pick publishes

### DIFF
--- a/apps/standard-reader/.env.example
+++ b/apps/standard-reader/.env.example
@@ -298,6 +298,37 @@ CLAUDE_ROUTINE_TOKEN=""
 # DIGEST_SEND_DELAY_MS="1500"  # throttle between sends
 
 # ──────────────────────────────────────────────────────────────────────────────
+# Web push notifications (VAPID)
+# ──────────────────────────────────────────────────────────────────────────────
+# "Notify me when this publication/author posts". The tap worker queues a row
+# the instant a new document is indexed; the self-contained `push-cron` Railway
+# service drains and sends it via `pnpm push:send` every five minutes.
+#
+# Which service needs what:
+#   push-cron  — all three below, PLUS DATABASE_URL and PUBLIC_URL. This is the
+#                only process that ever holds the private key.
+#   web        — VAPID_PUBLIC_KEY only, so `getPushConfig` can hand the browser
+#                the application server key to subscribe with.
+#   ingest     — nothing. Its whole involvement is one INSERT.
+#
+# With the keys unset the cron exits cleanly having done nothing, so a PR
+# preview pointed at a shared database can't send real notifications carrying
+# preview-domain links.
+#
+# Generate a pair with: pnpm --filter standard-reader exec web-push generate-vapid-keys
+# VAPID_PUBLIC_KEY=""
+# VAPID_PRIVATE_KEY=""
+# Contact URL for the push services, `mailto:` or `https:`:
+# VAPID_SUBJECT="mailto:hello@standard-reader.app"
+#
+# Optional tuning:
+# PUSH_MAX_DOCUMENTS_PER_RUN="20"  # documents drained per invocation
+# PUSH_MAX_SENDS_PER_RUN="2000"    # ceiling on individual notifications per run
+# PUSH_SEND_CONCURRENCY="8"        # endpoints pushed to in parallel
+#
+# Local run: `pnpm push:send:dev` (loads this .env).
+
+# ──────────────────────────────────────────────────────────────────────────────
 # Topic naming (recompute sweep)
 # ──────────────────────────────────────────────────────────────────────────────
 # Server-only, needed by the `ingest` service. The sweep clusters the tag

--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -1153,6 +1153,18 @@ Standard Reader speaks the standard AT Proto label protocol, so readers can subs
 - **claudeslop** is our example labeler: a standalone service (`services/claudeslop/`) that
   consumes Jetstream, scores documents for AI-written prose, signs labels, and serves
   `queryLabels` + `subscribeLabels` — a minimal reference implementation of the labeler API.
+- **Web push notifications** are the one piece of personal state that is **app-owned, not
+  repo-owned** — a deliberate exception to the rule at the top of this section. A reader turns on
+  a bell from a publication or author page and gets a notification when that source publishes.
+  Three tables carry it (`src/db/schema/push.ts`), none of them mirroring a record:
+  `push_devices` holds a browser's push endpoint and encryption keys, which are per-browser
+  secrets — anyone holding them can push to that browser — and so must never land in a public
+  repo. `push_topics` (the per-source opt-in) _could_ have been a record like `sidebarPref`, but a
+  new record collection means an expanded OAuth write scope, which would put every existing
+  session through the "reconnect your account" flow before the bell worked at all; if the opt-in
+  ever needs to be portable, a record + mirror can be layered on the same table.
+  `document_push_queue` is the send outbox. **Notifications are independent of subscribing** —
+  the bell doesn't change your feed and doesn't require a subscription.
 
 ---
 
@@ -1289,6 +1301,32 @@ hand-tuned lists:
   publications, so the filtered Latest "All" badge gets its own precomputed `network_stats` scalar
   (`network_document_count_no_web_bridge`) rather than a live count, and the tag feed switches to a
   tag-first query shape (`selectTagArticleUris`) that the survival rate can't blow up.
+
+### Web push delivery
+
+Split across two processes, and the split is the whole design:
+
+- **The tap worker only enqueues.** `handleRecord`'s document branch runs one
+  `INSERT … SELECT` into `document_push_queue` (`src/server/push/enqueue.ts`) that inserts
+  nothing for anything that doesn't qualify. No timer, no `web-push` import, no outbound HTTP —
+  the worker's job is keeping up with the firehose, and it has been knocked over before by a
+  slow handler causing tap to redeliver.
+- **A `push-cron` Railway service sends** (`railway.push.json` → `pnpm push:send` →
+  `src/server/push/run.ts`), every five minutes, in its own short-lived process — the same shape
+  as the weekly digest, for the same reason.
+
+The queue table is also the **exactly-once claim**: its primary key is what makes tap
+redelivery, dead-letter replay, and later `update` events for one document all collapse to
+`DO NOTHING`. It is deliberately _not_ a column on `documents`, because document deletes are
+hard deletes — a delete→recreate at the same rkey is a normal republish, and a claim living on
+that row would die with it and re-notify everyone.
+
+Four guards decide whether a document is genuinely new, and each covers a different failure:
+`live` (so a PDS reconcile can't replay a repo's whole history), a date on the **record itself**
+(`documents.published_at` falls back to `now()` for an undated record, so an archive import
+would otherwise pass any freshness window), `indexed_at` (set once on first insert and never
+updated — this is what survives a tap cursor rewind or a fresh tap instance re-streaming known
+repos), and a per-author hourly cap in the sender as the backstop.
 
 ### Topic derivation
 

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -32,8 +32,8 @@ Check items off as they land.
   - **Runbook gotcha:** Railway auto-detects only the root `railway.json`, so every non-web service
     in this monorepo needs its **Config File Path** set explicitly (Dashboard → service → Settings →
     Config-as-code, or `serviceInstanceUpdate{ railwayConfigFile }` via the GraphQL API) to
-    `railway.ingest.json` / `railway.cron.json` / `railway.reconcile.json`; otherwise it silently
-    falls back to the web build.
+    `railway.ingest.json` / `railway.cron.json` / `railway.reconcile.json` / `railway.push.json`;
+    otherwise it silently falls back to the web build.
     Shared `INGEST_WEBHOOK_SECRET` = `TAP_ADMIN_PASSWORD`; `PUBLIC_URL=https://standard-reader.app`;
     `ATPROTO_PRIVATE_KEY_JWK` is the ES256 private JWK. Prod DB was reset to a clean schema (drop
     `public` + `drizzle`, then `pnpm db:migrate`) before first backfill.
@@ -1075,6 +1075,28 @@ Backend/API exists; UI or copy is missing.
       on layout pages and legal links on [`/login`](src/routes/login.tsx).
 
 ## 9. Post-v1 — reader polish (Tier 2)
+
+- [x] **Web push notifications (v1)** — a bell on a publication page
+      ([`publication-actions.tsx`](src/components/reader/publication-actions.tsx)) and an author
+      page ([`_layout.u.$did.tsx`](src/routes/_layout.u.$did.tsx)) that notifies you when that
+      source publishes. Deliberately independent of subscribing: the bell doesn't touch your feed.
+      Three tables ([`push.ts`](src/db/schema/push.ts), `drizzle/0034_*`), push listeners imported
+      into the existing Workbox SW ([`push-sw.js`](public/push-sw.js) via `workbox.importScripts`),
+      the tap worker's whole involvement is one `INSERT`
+      ([`enqueue.ts`](src/server/push/enqueue.ts)), and a new `push-cron` service sends
+      ([`run.ts`](src/server/push/run.ts)). Settings gets one section: enable on this device +
+      turn off everywhere. On iOS the bell stays live and opens add-to-Home-Screen instructions
+      ([`ios-install-prompt.tsx`](src/components/reader/ios-install-prompt.tsx)), since that's the
+      one unsupported case a reader can fix.
+      **Before deploy:** create the `push-cron` Railway service with its Config File Path set to
+      `railway.push.json` (see the note in §0), generate a VAPID pair
+      (`pnpm --filter standard-reader exec web-push generate-vapid-keys`), and set
+      `VAPID_PUBLIC_KEY` on `web` plus all three VAPID vars and `PUBLIC_URL` on `push-cron`.
+      Without the keys the cron exits cleanly having done nothing.
+
+  - [ ] **Push follow-ups** — only if v1 gets used: a notifications inbox, per-source management
+        in settings, digest-style batching for readers who follow many sources, and pruning
+        `sent`/`failed` queue rows by age from the hourly recompute sweep.
 
 - [x] **"Hide mirrored websites" setting** — an account-level toggle
       (`user.exclude_web_bridge`, default off; [`exclude-web-bridge.ts`](src/lib/exclude-web-bridge.ts),

--- a/apps/standard-reader/drizzle/0034_nostalgic_hairball.sql
+++ b/apps/standard-reader/drizzle/0034_nostalgic_hairball.sql
@@ -1,0 +1,35 @@
+CREATE TABLE "document_push_queue" (
+	"document_uri" text PRIMARY KEY NOT NULL,
+	"author_did" text NOT NULL,
+	"state" text DEFAULT 'pending' NOT NULL,
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"available_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"claimed_at" timestamp with time zone,
+	"last_error" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "push_devices" (
+	"endpoint" text PRIMARY KEY NOT NULL,
+	"owner_did" text NOT NULL,
+	"p256dh" text NOT NULL,
+	"auth" text NOT NULL,
+	"user_agent" text,
+	"failure_count" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_seen_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "push_topics" (
+	"owner_did" text NOT NULL,
+	"subject_type" text NOT NULL,
+	"subject" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "push_topics_owner_did_subject_type_subject_pk" PRIMARY KEY("owner_did","subject_type","subject")
+);
+--> statement-breakpoint
+CREATE INDEX "document_push_queue_claim_idx" ON "document_push_queue" USING btree ("state","available_at","created_at");--> statement-breakpoint
+CREATE INDEX "document_push_queue_author_idx" ON "document_push_queue" USING btree ("author_did","created_at");--> statement-breakpoint
+CREATE INDEX "push_devices_owner_idx" ON "push_devices" USING btree ("owner_did");--> statement-breakpoint
+CREATE INDEX "push_topics_subject_idx" ON "push_topics" USING btree ("subject_type","subject");

--- a/apps/standard-reader/drizzle/meta/0034_snapshot.json
+++ b/apps/standard-reader/drizzle/meta/0034_snapshot.json
@@ -1,0 +1,5028 @@
+{
+  "id": "b83590f2-4647-4768-91ef-65a1e5d3d1ac",
+  "prevId": "858c9d6b-3232-4cee-8694-417ac7e2558f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_mode": {
+          "name": "theme_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appearance": {
+          "name": "appearance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale_hint_seen": {
+          "name": "locale_hint_seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reader_voice": {
+          "name": "reader_voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_links_externally": {
+          "name": "open_links_externally",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_collections_in_magazine": {
+          "name": "open_collections_in_magazine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reading_typography": {
+          "name": "reading_typography",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_reading_history": {
+          "name": "track_reading_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count_old_posts_as_unread": {
+          "name": "count_old_posts_as_unread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclude_web_bridge": {
+          "name": "exclude_web_bridge",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_publication_theme": {
+          "name": "use_publication_theme",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hide_feed_metrics": {
+          "name": "hide_feed_metrics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feed_pagination": {
+          "name": "feed_pagination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_scope": {
+          "name": "home_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_hidden_tabs": {
+          "name": "profile_hidden_tabs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_show_likes": {
+          "name": "profile_show_likes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_authoring_enabled": {
+          "name": "collections_authoring_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userinput_feedback_enabled": {
+          "name": "userinput_feedback_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "margin_save_enabled": {
+          "name": "margin_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semble_save_enabled": {
+          "name": "semble_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "atstore_review_prompt_dismissed": {
+          "name": "atstore_review_prompt_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_enabled": {
+          "name": "weekly_digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_subscriptions": {
+          "name": "weekly_digest_section_subscriptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_network": {
+          "name": "weekly_digest_section_network",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_saved": {
+          "name": "weekly_digest_section_saved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_recommendations": {
+          "name": "weekly_digest_section_recommendations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_last_sent_at": {
+          "name": "weekly_digest_last_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_welcome_sent_at": {
+          "name": "weekly_digest_welcome_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_labelers_imported_at": {
+          "name": "bsky_labelers_imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_did_unique": {
+          "name": "user_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "did"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pds": {
+          "name": "pds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_url": {
+          "name": "banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_uri": {
+          "name": "bsky_profile_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_cid": {
+          "name": "bsky_profile_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_fetched_at": {
+          "name": "profile_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_handle_idx": {
+          "name": "profiles_handle_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_handle_trgm_idx": {
+          "name": "profiles_handle_trgm_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "profiles_display_name_trgm_idx": {
+          "name": "profiles_display_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publications": {
+      "name": "publications",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_cid": {
+          "name": "icon_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_mime": {
+          "name": "icon_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent": {
+          "name": "theme_accent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_background": {
+          "name": "theme_background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_foreground": {
+          "name": "theme_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent_foreground": {
+          "name": "theme_accent_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_json": {
+          "name": "theme_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_in_discover": {
+          "name": "show_in_discover",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "prev_next_direction": {
+          "name": "prev_next_direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_kind": {
+          "name": "serial_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_publication": {
+          "name": "collections_publication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_checked_at": {
+          "name": "verification_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(name, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(topic, '')), 'B')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publications_did_idx": {
+          "name": "publications_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_name_idx": {
+          "name": "publications_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_discover_idx": {
+          "name": "publications_discover_idx",
+          "columns": [
+            {
+              "expression": "show_in_discover",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_topic_idx": {
+          "name": "publications_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_url_idx": {
+          "name": "publications_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_serial_idx": {
+          "name": "publications_serial_idx",
+          "columns": [
+            {
+              "expression": "prev_next_direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_search_idx": {
+          "name": "publications_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_contributors": {
+      "name": "document_contributors",
+      "schema": "",
+      "columns": {
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "document_contributors_did_idx": {
+          "name": "document_contributors_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_contributors_document_uri_documents_uri_fk": {
+          "name": "document_contributors_document_uri_documents_uri_fk",
+          "tableFrom": "document_contributors",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_contributors_document_uri_did_pk": {
+          "name": "document_contributors_document_uri_did_pk",
+          "columns": [
+            "document_uri",
+            "did"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_uri": {
+          "name": "site_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_json": {
+          "name": "collection_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_renderable_body": {
+          "name": "has_renderable_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "body_image_count": {
+          "name": "body_image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_cid": {
+          "name": "cover_image_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_mime": {
+          "name": "cover_image_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backlink_count": {
+          "name": "backlink_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_count_prev": {
+          "name": "backlink_count_prev",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_synced_at": {
+          "name": "backlink_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_recomputed_at": {
+          "name": "trending_recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_recommender_count": {
+          "name": "distinct_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bsky_post_uri": {
+          "name": "bsky_post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_post_cid": {
+          "name": "bsky_post_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_updated_at": {
+          "name": "record_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(title, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(immutable_array_to_string(tags), '')), 'B') || setweight(to_tsvector('english', coalesce(text_content, '')), 'C')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documents_did_idx": {
+          "name": "documents_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_did_published_idx": {
+          "name": "documents_did_published_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"published_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_publication_published_idx": {
+          "name": "documents_publication_published_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_published_idx": {
+          "name": "documents_published_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_featured_idx": {
+          "name": "documents_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_site_idx": {
+          "name": "documents_site_idx",
+          "columns": [
+            {
+              "expression": "site_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_search_idx": {
+          "name": "documents_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "documents_trending_idx": {
+          "name": "documents_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_idx": {
+          "name": "documents_canonical_url_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_trgm_idx": {
+          "name": "documents_canonical_url_trgm_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommends": {
+      "name": "recommends",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommender_did": {
+          "name": "recommender_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recommends_document_idx": {
+          "name": "recommends_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_recommender_idx": {
+          "name": "recommends_recommender_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_edge_idx": {
+          "name": "recommends_edge_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_doc_recommender_created_idx": {
+          "name": "recommends_doc_recommender_created_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recommends\".\"deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_did": {
+          "name": "publication_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_publication_idx": {
+          "name": "subscriptions_publication_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_subscriber_idx": {
+          "name": "subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_edge_idx": {
+          "name": "subscriptions_edge_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follower_did": {
+          "name": "follower_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excluded_publications": {
+          "name": "excluded_publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_subject_idx": {
+          "name": "user_follows_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_edge_idx": {
+          "name": "user_follows_edge_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_owner_idx": {
+          "name": "bookmarks_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_document_idx": {
+          "name": "bookmarks_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_edge_idx": {
+          "name": "bookmarks_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reads": {
+      "name": "reads",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reads_owner_idx": {
+          "name": "reads_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_document_idx": {
+          "name": "reads_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_edge_idx": {
+          "name": "reads_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidebar_prefs": {
+      "name": "sidebar_prefs",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_order": {
+          "name": "list_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "tree_order": {
+          "name": "tree_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "subscription_sort": {
+          "name": "subscription_sort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customize_nav": {
+          "name": "customize_nav",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_nav": {
+          "name": "hidden_nav",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_push_queue": {
+      "name": "document_push_queue",
+      "schema": "",
+      "columns": {
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_push_queue_claim_idx": {
+          "name": "document_push_queue_claim_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_push_queue_author_idx": {
+          "name": "document_push_queue_author_idx",
+          "columns": [
+            {
+              "expression": "author_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_devices": {
+      "name": "push_devices",
+      "schema": "",
+      "columns": {
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_devices_owner_idx": {
+          "name": "push_devices_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_topics": {
+      "name": "push_topics",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_topics_subject_idx": {
+          "name": "push_topics_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "push_topics_owner_did_subject_type_subject_pk": {
+          "name": "push_topics_owner_did_subject_type_subject_pk",
+          "columns": [
+            "owner_did",
+            "subject_type",
+            "subject"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_saves": {
+      "name": "list_saves",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saver_did": {
+          "name": "saver_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_owner_did": {
+          "name": "list_owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "list_saves_saver_idx": {
+          "name": "list_saves_saver_idx",
+          "columns": [
+            {
+              "expression": "saver_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "list_saves_list_uri_idx": {
+          "name": "list_saves_list_uri_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lists": {
+      "name": "lists",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publications": {
+          "name": "publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "users": {
+          "name": "users",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lists_owner_idx": {
+          "name": "lists_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rkey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_corecommends": {
+      "name": "publication_corecommends",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_recommender_count": {
+          "name": "co_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_corecomm_rank_idx": {
+          "name": "publication_corecomm_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_corecommends_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_corecommends_related_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_corecommends_publication_uri_related_publication_uri_pk": {
+          "name": "publication_corecommends_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_cosubscriptions": {
+      "name": "publication_cosubscriptions",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_subscriber_count": {
+          "name": "co_subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_cosub_rank_idx": {
+          "name": "publication_cosub_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_cosubscriptions_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_cosubscriptions_related_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_cosubscriptions_publication_uri_related_publication_uri_pk": {
+          "name": "publication_cosubscriptions_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_stats": {
+      "name": "publication_stats",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommend_count": {
+          "name": "recommend_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_document_at": {
+          "name": "last_document_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documents_7d": {
+          "name": "documents_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_7d": {
+          "name": "subscribers_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_7d": {
+          "name": "recommends_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "documents_prev_7d": {
+          "name": "documents_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_prev_7d": {
+          "name": "subscribers_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_prev_7d": {
+          "name": "recommends_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlinks_7d": {
+          "name": "backlinks_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_velocity": {
+          "name": "trending_velocity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_window_start": {
+          "name": "trending_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_stats_subscribers_idx": {
+          "name": "publication_stats_subscribers_idx",
+          "columns": [
+            {
+              "expression": "subscriber_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_active_idx": {
+          "name": "publication_stats_active_idx",
+          "columns": [
+            {
+              "expression": "last_document_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_trending_idx": {
+          "name": "publication_stats_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_stats_publication_uri_publications_uri_fk": {
+          "name": "publication_stats_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_stats",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_stats": {
+      "name": "network_stats",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discover_topic_counts": {
+      "name": "discover_topic_counts",
+      "schema": "",
+      "columns": {
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discover_topic_counts_count_idx": {
+          "name": "discover_topic_counts_count_idx",
+          "columns": [
+            {
+              "expression": "publication_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discover_topic_counts_topic_trgm_idx": {
+          "name": "discover_topic_counts_topic_trgm_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag_embeddings": {
+      "name": "tag_embeddings",
+      "schema": "",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "double precision[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_publications": {
+      "name": "topic_publications",
+      "schema": "",
+      "columns": {
+        "topic_slug": {
+          "name": "topic_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "matched_tag_count": {
+          "name": "matched_tag_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "topic_publications_rank_idx": {
+          "name": "topic_publications_rank_idx",
+          "columns": [
+            {
+              "expression": "topic_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_publications_pub_idx": {
+          "name": "topic_publications_pub_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_publications_topic_slug_topics_slug_fk": {
+          "name": "topic_publications_topic_slug_topics_slug_fk",
+          "tableFrom": "topic_publications",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "topic_publications_publication_uri_publications_uri_fk": {
+          "name": "topic_publications_publication_uri_publications_uri_fk",
+          "tableFrom": "topic_publications",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_publications_topic_slug_publication_uri_pk": {
+          "name": "topic_publications_topic_slug_publication_uri_pk",
+          "columns": [
+            "topic_slug",
+            "publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_tags": {
+      "name": "topic_tags",
+      "schema": "",
+      "columns": {
+        "topic_slug": {
+          "name": "topic_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "topic_tags_tag_idx": {
+          "name": "topic_tags_tag_idx",
+          "columns": [
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_tags_weight_idx": {
+          "name": "topic_tags_weight_idx",
+          "columns": [
+            {
+              "expression": "topic_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weight",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_tags_topic_slug_topics_slug_fk": {
+          "name": "topic_tags_topic_slug_topics_slug_fk",
+          "tableFrom": "topic_tags",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_tags_topic_slug_tag_pk": {
+          "name": "topic_tags_topic_slug_tag_pk",
+          "columns": [
+            "topic_slug",
+            "tag"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_tags": {
+          "name": "signature_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_count": {
+          "name": "tag_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author_count": {
+          "name": "author_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_model": {
+          "name": "name_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "named_at": {
+          "name": "named_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topics_published_score_idx": {
+          "name": "topics_published_score_idx",
+          "columns": [
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topics_superseded_by_topics_slug_fk": {
+          "name": "topics_superseded_by_topics_slug_fk",
+          "tableFrom": "topics",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "superseded_by"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_dead_letter": {
+      "name": "ingest_dead_letter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retries": {
+          "name": "retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingest_dead_letter_collection_idx": {
+          "name": "ingest_dead_letter_collection_idx",
+          "columns": [
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_state": {
+      "name": "ingest_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_processed": {
+          "name": "events_processed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_repos": {
+      "name": "tracked_repos",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_to_tap_at": {
+          "name": "added_to_tap_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_state": {
+          "name": "backfill_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_seen_rev": {
+          "name": "last_seen_rev",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_fail_count": {
+          "name": "reconcile_fail_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconcile_retry_after": {
+          "name": "reconcile_retry_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tracked_repos_state_idx": {
+          "name": "tracked_repos_state_idx",
+          "columns": [
+            {
+              "expression": "backfill_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_labels": {
+      "name": "document_labels",
+      "schema": "",
+      "columns": {
+        "src": {
+          "name": "src",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "val": {
+          "name": "val",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cts": {
+          "name": "cts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_labels_uri_idx": {
+          "name": "document_labels_uri_idx",
+          "columns": [
+            {
+              "expression": "uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_labels_src_idx": {
+          "name": "document_labels_src_idx",
+          "columns": [
+            {
+              "expression": "src",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "document_labels_src_uri_val_pk": {
+          "name": "document_labels_src_uri_val_pk",
+          "columns": [
+            "src",
+            "uri",
+            "val"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_sync_state": {
+      "name": "label_sync_state",
+      "schema": "",
+      "columns": {
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_count": {
+          "name": "stored_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rejected_count": {
+          "name": "rejected_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_services": {
+      "name": "labeler_services",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_endpoint": {
+          "name": "service_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels_standard_site": {
+          "name": "labels_standard_site",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels_probed_at": {
+          "name": "labels_probed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reachable": {
+          "name": "reachable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_value_definitions": {
+          "name": "label_value_definitions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_services_labeler_idx": {
+          "name": "labeler_services_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_subscriptions": {
+      "name": "labeler_subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefs": {
+          "name": "prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_subscriptions_subscriber_idx": {
+          "name": "labeler_subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labeler_subscriptions_labeler_idx": {
+          "name": "labeler_subscriptions_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_auth_code": {
+      "name": "mcp_auth_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_auth_code_expires_at_idx": {
+          "name": "mcp_auth_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_auth_code_client_id_mcp_client_id_fk": {
+          "name": "mcp_auth_code_client_id_mcp_client_id_fk",
+          "tableFrom": "mcp_auth_code",
+          "tableTo": "mcp_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_auth_code_user_id_user_id_fk": {
+          "name": "mcp_auth_code_user_id_user_id_fk",
+          "tableFrom": "mcp_auth_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_client": {
+      "name": "mcp_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_uri": {
+          "name": "client_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_uri": {
+          "name": "logo_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_token": {
+      "name": "mcp_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_token_user_id_idx": {
+          "name": "mcp_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_expires_at_idx": {
+          "name": "mcp_token_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_client_id_mcp_client_id_fk": {
+          "name": "mcp_token_client_id_mcp_client_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "mcp_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_user_id_user_id_fk": {
+          "name": "mcp_token_user_id_user_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_token_access_token_hash_unique": {
+          "name": "mcp_token_access_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token_hash"
+          ]
+        },
+        "mcp_token_refresh_token_hash_unique": {
+          "name": "mcp_token_refresh_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_shares": {
+      "name": "quote_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_text": {
+          "name": "quote_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quote_shares_document_uri_idx": {
+          "name": "quote_shares_document_uri_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_draft": {
+      "name": "feedback_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feedback_draft_user_idx": {
+          "name": "feedback_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_draft_expires_idx": {
+          "name": "feedback_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_draft_user_id_user_id_fk": {
+          "name": "feedback_draft_user_id_user_id_fk",
+          "tableFrom": "feedback_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upvote_draft": {
+      "name": "upvote_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "upvote_draft_user_idx": {
+          "name": "upvote_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upvote_draft_expires_idx": {
+          "name": "upvote_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upvote_draft_user_id_user_id_fk": {
+          "name": "upvote_draft_user_id_user_id_fk",
+          "tableFrom": "upvote_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.save_draft": {
+      "name": "save_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_app": {
+          "name": "target_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_uri": {
+          "name": "collection_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_cid": {
+          "name": "collection_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_collection_name": {
+          "name": "new_collection_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motivation": {
+          "name": "motivation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passage": {
+          "name": "passage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "save_draft_user_idx": {
+          "name": "save_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "save_draft_expires_idx": {
+          "name": "save_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "save_draft_user_id_user_id_fk": {
+          "name": "save_draft_user_id_user_id_fk",
+          "tableFrom": "save_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/standard-reader/drizzle/meta/_journal.json
+++ b/apps/standard-reader/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1786248774435,
       "tag": "0033_worried_harry_osborn",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1786303238005,
+      "tag": "0034_nostalgic_hairball",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/standard-reader/package.json
+++ b/apps/standard-reader/package.json
@@ -27,6 +27,8 @@
     "topics:cron:dev": "tsx --env-file=.env scripts/topics-cron.ts",
     "digest:send": "tsx scripts/send-weekly-digest.ts",
     "digest:send:dev": "tsx --env-file=.env scripts/send-weekly-digest.ts",
+    "push:send": "tsx scripts/send-push.ts",
+    "push:send:dev": "tsx --env-file=.env scripts/send-push.ts",
     "thread:post": "tsx scripts/post-weekly-thread.ts",
     "thread:post:dev": "tsx --env-file=.env scripts/post-weekly-thread.ts",
     "backfill:actor-handles": "pnpm exec tsx --env-file=.env scripts/backfill-actor-handles.ts",
@@ -161,6 +163,7 @@
     "unist-util-visit": "^5.1.0",
     "universal-cookie": "^8.1.2",
     "web-haptics": "^0.0.6",
+    "web-push": "^3.6.7",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -185,6 +188,7 @@
     "@types/pg": "^8.20.0",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
+    "@types/web-push": "^3.6.4",
     "@typescript-eslint/parser": "^8.60.1",
     "@vitejs/plugin-react": "^6.0.1",
     "browserslist": "^4.28.2",

--- a/apps/standard-reader/package.json
+++ b/apps/standard-reader/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "vite dev --port 3000",
-    "build": "vite build",
+    "build": "vite build && node scripts/verify-service-worker.mjs",
     "start": "node --require @opentelemetry/auto-instrumentations-node/register .output/server/index.mjs",
     "preview": "vite preview",
     "test": "vitest run",

--- a/apps/standard-reader/public/push-sw.js
+++ b/apps/standard-reader/public/push-sw.js
@@ -1,0 +1,142 @@
+/* eslint-disable */
+/**
+ * Web push listeners, pulled into the generated Workbox service worker via
+ * `workbox.importScripts` in `vite.config.ts`.
+ *
+ * Three constraints make this file look the way it does. Please keep them:
+ *
+ *   1. **It is a classic script.** No `import`, no `export`, no top-level
+ *      `await`. Workbox emits the bundled SW in AMD format, so `importScripts`
+ *      runs inside the module factory — anything that throws here takes the
+ *      whole service worker down with it, including every caching route the app
+ *      relies on for offline. Hence the defensive style throughout.
+ *   2. **Every `push` event must show a notification.** iOS revokes the push
+ *      subscription outright if a push arrives and nothing is displayed, so
+ *      there is no early return anywhere in the handler — a malformed payload
+ *      falls back to generic copy rather than being dropped.
+ *   3. **Old copies stay live for weeks.** `registerType: "prompt"` +
+ *      `skipWaiting: false` means a changed service worker doesn't activate
+ *      until the reader accepts the reload toast. Treat the payload shape as
+ *      append-only: never repurpose a field, only add optional ones.
+ *
+ * The payload sent by `src/server/push/fan-out.server.ts` is
+ * `{ title, body, url, tag }`, all optional from this side's point of view.
+ */
+
+/* global self, clients */
+
+const FALLBACK_TITLE = "Standard Reader";
+const FALLBACK_BODY = "Something new to read.";
+const ICON = "/icon-192.png";
+const BADGE = "/icon-192.png";
+
+/** Parse the payload without ever throwing. */
+function readPayload(event) {
+  try {
+    const raw = event && event.data ? event.data.json() : null;
+    if (raw && typeof raw === "object") {
+      return raw;
+    }
+  } catch {
+    // Not JSON, or no data at all. Fall through to the text form.
+  }
+  try {
+    const text = event && event.data ? event.data.text() : "";
+    if (text) {
+      return { body: text };
+    }
+  } catch {
+    // Nothing usable — the generic notification below still shows.
+  }
+  return {};
+}
+
+function asString(value, fallback) {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
+self.addEventListener("push", (event) => {
+  const payload = readPayload(event);
+  const title = asString(payload.title, FALLBACK_TITLE);
+  const url = asString(payload.url, "/");
+
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body: asString(payload.body, FALLBACK_BODY),
+      icon: ICON,
+      badge: BADGE,
+      // Collapses a burst from one source into a single notification instead of
+      // stacking. Also what keeps a retried send from showing twice.
+      tag: asString(payload.tag, url),
+      data: { url },
+    }),
+  );
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+
+  const data = event.notification.data || {};
+  const target = asString(data.url, "/");
+
+  event.waitUntil(
+    clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((windows) => {
+        // Prefer an already-open tab on the same origin — opening a second copy
+        // of the app to read one article is worse than navigating the first.
+        for (const client of windows) {
+          if (client.url === target && "focus" in client) {
+            return client.focus();
+          }
+        }
+        for (const client of windows) {
+          if ("navigate" in client && "focus" in client) {
+            return client.focus().then(() => client.navigate(target));
+          }
+        }
+        return clients.openWindow ? clients.openWindow(target) : undefined;
+      })
+      .catch(() => {
+        return clients.openWindow ? clients.openWindow(target) : undefined;
+      }),
+  );
+});
+
+/**
+ * The push service rotated our endpoint. Chrome fires this; Safari does not
+ * implement it at all, which is why the app also re-validates its endpoint on
+ * load (`syncPushDevice` in `src/pwa/push.ts`). Without both, a rotated
+ * subscription silently stops receiving anything.
+ */
+self.addEventListener("pushsubscriptionchange", (event) => {
+  const previous = event.oldSubscription || null;
+  const applicationServerKey =
+    previous && previous.options ? previous.options.applicationServerKey : null;
+
+  if (!applicationServerKey) {
+    // Nothing to re-subscribe with. The next app load repairs it.
+    return;
+  }
+
+  event.waitUntil(
+    self.registration.pushManager
+      .subscribe({ userVisibleOnly: true, applicationServerKey })
+      .then((subscription) =>
+        fetch("/api/push/resubscribe", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          // The session cookie is what authorizes the swap; the server refuses
+          // to move a device row it can't match to the signed-in reader.
+          credentials: "include",
+          body: JSON.stringify({
+            oldEndpoint: previous.endpoint,
+            subscription: subscription.toJSON(),
+          }),
+        }),
+      )
+      .catch(() => {
+        // Best effort. `syncPushDevice` retries on the next app load.
+      }),
+  );
+});

--- a/apps/standard-reader/scripts/send-push.ts
+++ b/apps/standard-reader/scripts/send-push.ts
@@ -1,0 +1,37 @@
+/**
+ * Web push send job — the entrypoint the Railway `push-cron` service runs every
+ * five minutes.
+ *
+ * Short-lived and self-contained: it opens its own DB connection, drains a batch
+ * of `document_push_queue`, sends, and exits. It deliberately does NOT run inside
+ * the long-lived `ingest` worker (whose only job is keeping up with the firehose,
+ * and which must not be holding connections open for hundreds of outbound HTTPS
+ * calls) or the user-facing `web` app.
+ *
+ * The queue is filled from the tap handler the instant a new document is
+ * indexed, so the cron interval is the delivery latency — five minutes at the
+ * moment, tunable in `railway.push.json`.
+ *
+ * Needs (Railway env on the `push-cron` service): DATABASE_URL, PUBLIC_URL,
+ * VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY, VAPID_SUBJECT. With the VAPID keys unset
+ * the run exits cleanly having done nothing, which is what keeps a PR preview
+ * pointed at a shared database from sending real notifications.
+ *
+ * Local: `pnpm push:send:dev` (loads .env).
+ */
+
+import { runPushSend } from "#/server/push/run";
+
+const startedAt = Date.now();
+try {
+  const summary = await runPushSend();
+  console.info(
+    `[push] done in ${Date.now() - startedAt}ms: ${JSON.stringify(summary)}`,
+  );
+  // eslint-disable-next-line unicorn/no-process-exit
+  process.exit(0);
+} catch (error) {
+  console.error("[push] send job failed:", error);
+  // eslint-disable-next-line unicorn/no-process-exit
+  process.exit(1);
+}

--- a/apps/standard-reader/scripts/verify-service-worker.mjs
+++ b/apps/standard-reader/scripts/verify-service-worker.mjs
@@ -1,0 +1,86 @@
+/**
+ * Post-build check that the emitted service worker is actually usable.
+ *
+ * This exists because a truncated `sw.js` shipped to production undetected. The
+ * served file was a strict prefix of a valid build, cut off mid-token:
+ *
+ *     production  1745 bytes, ends `…ugin({statuses:[0,200]})]}),"G`
+ *     preview     1774 bytes, ends `…maxEntries:300,maxAgeSeconds:2`
+ *     good build  2351 bytes, ends `…{statuses:[0,200]})]}),"GET")});`
+ *
+ * The browser's only symptom was `SyntaxError: Unexpected end of script` at
+ * registration — which nothing surfaced, so the service worker silently never
+ * registered at all. Offline support and the update prompt had been dead for as
+ * long as it had been broken, and push was simply the first feature to notice.
+ *
+ * Two tools write `.output/public`: `vite-plugin-pwa` (via its `outDir`) and
+ * Nitro, which owns that directory as its static root. The PWA plugin's hooks
+ * additionally run once per build pass — three times for a
+ * client + SSR + Nitro build — so `sw.js` is written repeatedly while another
+ * tool is assembling the same directory. That is the shape of a partial write.
+ *
+ * Rather than guess at the exact interleaving, this fails the build loudly if
+ * the artifact isn't valid. A broken deploy is worth catching here; it is not
+ * worth discovering months later from a push timeout on someone's phone.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import vm from "node:vm";
+
+const appDir = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const swPath = path.join(appDir, ".output/public/sw.js");
+
+function fail(message) {
+  console.error(`\n[verify-sw] ${message}\n`);
+  // A plain exit, not a throw: this is a build gate, and a stack trace pointing
+  // into this script would bury the message that actually explains the failure.
+  // eslint-disable-next-line unicorn/no-process-exit
+  process.exit(1);
+}
+
+if (!existsSync(swPath)) {
+  fail(
+    `no service worker at ${path.relative(appDir, swPath)} — the PWA plugin did not emit one`,
+  );
+}
+
+const source = readFileSync(swPath, "utf8");
+
+// 1. It has to parse. A truncated file is the failure this exists to catch, and
+//    it is invisible to any check that only looks at size or existence.
+try {
+  new vm.Script(source, { filename: swPath });
+} catch (error) {
+  fail(
+    `service worker is not valid JavaScript (${error.message}).\n` +
+      `  ${source.length} bytes, ends with: ${JSON.stringify(source.slice(-60))}\n` +
+      `  This is the truncated-sw.js failure: the browser rejects it with\n` +
+      `  "SyntaxError: Unexpected end of script", registration fails, and the\n` +
+      `  app silently loses offline support, the update prompt, and web push.`,
+  );
+}
+
+// 2. It has to carry a precache manifest. Some build passes emit a structurally
+//    valid worker with zero entries; shipping one of those is a different, quieter
+//    way to lose the offline fallback.
+const manifest = source.match(/precacheAndRoute\(\[(.*?)\]/s);
+const entries = manifest
+  ? [...manifest[1].matchAll(/url:\s*"([^"]+)"/g)].map((m) => m[1])
+  : [];
+
+if (entries.length === 0) {
+  fail(
+    "service worker precaches nothing — a zero-entry build pass overwrote the real one",
+  );
+}
+if (!entries.includes("offline.html")) {
+  fail(
+    `service worker does not precache offline.html (has: ${entries.join(", ")}) — the offline fallback would 404`,
+  );
+}
+
+console.log(
+  `[verify-sw] ok — ${source.length} bytes, precaches ${entries.length}: ${entries.join(", ")}`,
+);

--- a/apps/standard-reader/scripts/verify-service-worker.mjs
+++ b/apps/standard-reader/scripts/verify-service-worker.mjs
@@ -1,36 +1,49 @@
 /**
- * Post-build check that the emitted service worker is actually usable.
+ * Post-build repair + check for the emitted service worker.
  *
- * This exists because a truncated `sw.js` shipped to production undetected. The
- * served file was a strict prefix of a valid build, cut off mid-token:
+ * ## The bug this exists for
  *
- *     production  1745 bytes, ends `…ugin({statuses:[0,200]})]}),"G`
- *     preview     1774 bytes, ends `…maxEntries:300,maxAgeSeconds:2`
- *     good build  2351 bytes, ends `…{statuses:[0,200]})]}),"GET")});`
+ * `/sw.js` was served truncated and unparseable in production for months. The
+ * browser's only symptom is `SyntaxError: Unexpected end of script` at
+ * registration, so the service worker silently never registered: offline
+ * support and the update prompt were dead, and web push was simply the first
+ * feature to notice.
  *
- * The browser's only symptom was `SyntaxError: Unexpected end of script` at
- * registration — which nothing surfaced, so the service worker silently never
- * registered at all. Offline support and the update prompt had been dead for as
- * long as it had been broken, and push was simply the first feature to notice.
+ * The file on disk is fine. **Nitro serves it truncated**, because it bakes a
+ * static-asset manifest into `.output/server/index.mjs` at build time:
  *
- * Two tools write `.output/public`: `vite-plugin-pwa` (via its `outDir`) and
- * Nitro, which owns that directory as its static root. The PWA plugin's hooks
- * additionally run once per build pass — three times for a
- * client + SSR + Nitro build — so `sw.js` is written repeatedly while another
- * tool is assembling the same directory. That is the shape of a partial write.
+ *     "/sw.js": { "size": 1774, "etag": "\"6ee-…\"", "path": "../public/sw.js" }
  *
- * Rather than guess at the exact interleaving, this fails the build loudly if
- * the artifact isn't valid. A broken deploy is worth catching here; it is not
- * worth discovering months later from a push timeout on someone's phone.
+ * while the finished worker is 2351 bytes. `vite-plugin-pwa`'s hooks run once
+ * per build pass — three times for client + SSR + Nitro, emitting `0 entries`,
+ * `0 entries`, then the real `8 entries` — and Nitro snapshots the directory
+ * partway through that sequence. It then reads the *current* file at request
+ * time but caps the response at the *recorded* size, so clients get a prefix cut
+ * mid-token. That is why the truncation is deterministic, why `content-length`
+ * and the etag agree with it, and why a build-time check of the file alone
+ * passes while the served bytes are garbage.
+ *
+ * ## What this does
+ *
+ * Rewrites any manifest entry whose recorded size disagrees with the file on
+ * disk, then asserts the worker is actually usable. Etags are opaque cache
+ * validators, so a recomputed one need not match Nitro's own scheme — it only
+ * has to change with the content, which this does.
+ *
+ * Runs from `pnpm build`, so a deploy fails loudly rather than shipping a worker
+ * that cannot register.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import vm from "node:vm";
 
 const appDir = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
-const swPath = path.join(appDir, ".output/public/sw.js");
+const publicDir = path.join(appDir, ".output/public");
+const serverEntry = path.join(appDir, ".output/server/index.mjs");
+const swPath = path.join(publicDir, "sw.js");
 
 function fail(message) {
   console.error(`\n[verify-sw] ${message}\n`);
@@ -40,31 +53,75 @@ function fail(message) {
   process.exit(1);
 }
 
+/** Nitro's shape: `"<size-in-hex>-<hash>"`, quoted. */
+function etagFor(buffer) {
+  const hash = createHash("sha1")
+    .update(buffer)
+    .digest("base64")
+    .replaceAll("=", "");
+  return `"${buffer.length.toString(16)}-${hash}"`;
+}
+
+// ── 1. Re-sync the baked manifest with what is actually on disk ──────────────
+let repaired = 0;
+if (existsSync(serverEntry)) {
+  let bundle = readFileSync(serverEntry, "utf8");
+
+  // Entries look like:
+  //   "/sw.js": {\n "type": …,\n "etag": "…",\n "mtime": …,\n "size": 1774,\n "path": "../public/sw.js"\n }
+  const entry =
+    /"(\/[^"]+)":\s*\{\s*"type":\s*"[^"]*",\s*"etag":\s*"((?:[^"\\]|\\.)*)",\s*"mtime":\s*"[^"]*",\s*"size":\s*(\d+),\s*"path":\s*"([^"]+)"\s*\}/g;
+
+  bundle = bundle.replaceAll(entry, (match, url, _etag, size, relPath) => {
+    const filePath = path.resolve(path.dirname(serverEntry), relPath);
+    if (!existsSync(filePath)) return match;
+
+    const actual = statSync(filePath).size;
+    if (actual === Number(size)) return match;
+
+    const fresh = etagFor(readFileSync(filePath));
+    repaired += 1;
+    console.log(
+      `[verify-sw] repaired ${url}: recorded ${size} bytes, actually ${actual} — Nitro would have served a truncated body`,
+    );
+    return match
+      .replace(`"size": ${size}`, `"size": ${actual}`)
+      .replace(
+        /"etag":\s*"(?:[^"\\]|\\.)*"/,
+        `"etag": ${JSON.stringify(fresh)}`,
+      );
+  });
+
+  if (repaired > 0) writeFileSync(serverEntry, bundle);
+}
+
+// ── 2. The worker itself has to be usable ───────────────────────────────────
 if (!existsSync(swPath)) {
   fail(
     `no service worker at ${path.relative(appDir, swPath)} — the PWA plugin did not emit one`,
   );
 }
 
-const source = readFileSync(swPath, "utf8");
+const bytes = readFileSync(swPath);
+// Byte length, not string length: the worker contains multi-byte characters, so
+// `source.length` disagrees with what the server records and serves.
+const byteLength = bytes.length;
+const source = bytes.toString("utf8");
 
-// 1. It has to parse. A truncated file is the failure this exists to catch, and
-//    it is invisible to any check that only looks at size or existence.
 try {
   new vm.Script(source, { filename: swPath });
 } catch (error) {
   fail(
     `service worker is not valid JavaScript (${error.message}).\n` +
-      `  ${source.length} bytes, ends with: ${JSON.stringify(source.slice(-60))}\n` +
-      `  This is the truncated-sw.js failure: the browser rejects it with\n` +
-      `  "SyntaxError: Unexpected end of script", registration fails, and the\n` +
-      `  app silently loses offline support, the update prompt, and web push.`,
+      `  ${byteLength} bytes, ends with: ${JSON.stringify(source.slice(-60))}\n` +
+      `  The browser rejects this with "SyntaxError: Unexpected end of script",\n` +
+      `  registration fails, and the app silently loses offline support, the\n` +
+      `  update prompt, and web push.`,
   );
 }
 
-// 2. It has to carry a precache manifest. Some build passes emit a structurally
-//    valid worker with zero entries; shipping one of those is a different, quieter
-//    way to lose the offline fallback.
+// Some build passes emit a structurally valid worker with nothing in it;
+// shipping one of those is a quieter way to lose the offline fallback.
 const manifest = source.match(/precacheAndRoute\(\[(.*?)\]/s);
 const entries = manifest
   ? [...manifest[1].matchAll(/url:\s*"([^"]+)"/g)].map((m) => m[1])
@@ -81,6 +138,21 @@ if (!entries.includes("offline.html")) {
   );
 }
 
+// ── 3. And the server must be prepared to serve all of it ───────────────────
+if (existsSync(serverEntry)) {
+  const bundle = readFileSync(serverEntry, "utf8");
+  const recorded = bundle.match(/"\/sw\.js":\s*\{[^}]*"size":\s*(\d+)/);
+  if (recorded && Number(recorded[1]) !== byteLength) {
+    fail(
+      `Nitro would serve ${recorded[1]} of ${byteLength} bytes of sw.js — the manifest repair did not take`,
+    );
+  }
+}
+
 console.log(
-  `[verify-sw] ok — ${source.length} bytes, precaches ${entries.length}: ${entries.join(", ")}`,
+  `[verify-sw] ok — ${byteLength} bytes, precaches ${entries.length}: ${entries.join(", ")}${
+    repaired > 0
+      ? ` (repaired ${repaired} stale manifest entr${repaired === 1 ? "y" : "ies"})`
+      : ""
+  }`,
 );

--- a/apps/standard-reader/src/components/push-diagnostics.tsx
+++ b/apps/standard-reader/src/components/push-diagnostics.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { Trans } from "@lingui/react/macro";
+import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
+import {
+  gap,
+  horizontalSpace,
+  verticalSpace,
+} from "@standard-reader/design-system/theme/semantic-spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+  lineHeight,
+} from "@standard-reader/design-system/theme/typography.stylex";
+import * as stylex from "@stylexjs/stylex";
+
+import type { PushDiagnostics } from "#/pwa/push";
+
+const styles = stylex.create({
+  panel: {
+    display: "flex",
+    flexDirection: "column",
+    paddingBlock: verticalSpace.lg,
+    paddingInlineEnd: horizontalSpace["3xl"],
+    paddingInlineStart: horizontalSpace["3xl"],
+    rowGap: gap.xs,
+  },
+  intro: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.xs,
+    lineHeight: lineHeight.sm,
+    marginBottom: verticalSpace.md,
+    marginTop: verticalSpace.none,
+    maxWidth: "42ch",
+  },
+  row: {
+    columnGap: gap.md,
+    display: "flex",
+    justifyContent: "space-between",
+  },
+  key: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.xs,
+    lineHeight: lineHeight.sm,
+  },
+  value: {
+    color: uiColor.text2,
+    // Monospace so a state string or an error is read exactly as written —
+    // this gets screenshotted from a phone and read back.
+    fontFamily: fontFamily.mono,
+    fontSize: fontSize.xs,
+    lineHeight: lineHeight.sm,
+    overflowWrap: "anywhere",
+    textAlign: "end",
+  },
+});
+
+/**
+ * Browser-side push state, rendered in settings.
+ *
+ * This exists because the first real failure landed on an installed iPhone
+ * PWA — a context where "open devtools and read the console" is not a usable
+ * debugging loop. Showing the same facts in the app turns a diagnosis
+ * round-trip into a screenshot.
+ *
+ * Deliberately unglamorous and untranslated in its *values*: the labels are
+ * localized, but the states are the literal strings the code branches on, so
+ * what a reader reports back matches what the source says.
+ */
+export function PushDiagnosticsPanel({
+  diagnostics,
+}: {
+  diagnostics: PushDiagnostics | null;
+}) {
+  if (!diagnostics) {
+    return (
+      <div {...stylex.props(styles.panel)}>
+        <p {...stylex.props(styles.intro)}>
+          <Trans>Checking…</Trans>
+        </p>
+      </div>
+    );
+  }
+
+  const rows: Array<{ label: React.ReactNode; value: string }> = [
+    { label: <Trans>Support</Trans>, value: diagnostics.capability },
+    {
+      label: <Trans>Installed to Home Screen</Trans>,
+      value: diagnostics.standalone ? "yes" : "no",
+    },
+    { label: <Trans>Permission</Trans>, value: diagnostics.permission },
+    { label: <Trans>Service worker</Trans>, value: diagnostics.serviceWorker },
+    {
+      label: <Trans>Subscription</Trans>,
+      value: diagnostics.subscribed ? "yes" : "no",
+    },
+  ];
+
+  if (diagnostics.lastError) {
+    rows.push({
+      label: <Trans>Last error</Trans>,
+      value: diagnostics.lastError,
+    });
+  }
+
+  return (
+    <div {...stylex.props(styles.panel)}>
+      <p {...stylex.props(styles.intro)}>
+        <Trans>
+          If notifications aren’t working, this is what your browser reports.
+          Sharing a screenshot of it is the fastest way to get it fixed.
+        </Trans>
+      </p>
+      {rows.map((row, index) => (
+        <div key={index} {...stylex.props(styles.row)}>
+          <span {...stylex.props(styles.key)}>{row.label}</span>
+          <span {...stylex.props(styles.value)}>{row.value}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/standard-reader/src/components/reader/ios-install-prompt.tsx
+++ b/apps/standard-reader/src/components/reader/ios-install-prompt.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { Trans } from "@lingui/react/macro";
+import { Button } from "@standard-reader/design-system/button";
+import {
+  Dialog,
+  DialogBody,
+  DialogFooter,
+  DialogHeader,
+} from "@standard-reader/design-system/dialog";
+import { Flex } from "@standard-reader/design-system/flex";
+import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
+import { verticalSpace } from "@standard-reader/design-system/theme/semantic-spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+  lineHeight,
+} from "@standard-reader/design-system/theme/typography.stylex";
+import * as stylex from "@stylexjs/stylex";
+import { Share, SquarePlus } from "lucide-react";
+
+const styles = stylex.create({
+  intro: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.sm,
+    lineHeight: lineHeight.base,
+    marginBottom: verticalSpace.none,
+    marginTop: verticalSpace.none,
+  },
+  step: {
+    color: uiColor.text2,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.sm,
+    lineHeight: lineHeight.sm,
+  },
+  stepIcon: {
+    color: uiColor.text1,
+    flexShrink: 0,
+  },
+});
+
+const ICON_SIZE = 18;
+
+/**
+ * Explains how to turn notifications on when the reader is on iOS in a Safari
+ * tab.
+ *
+ * iOS only exposes web push to a PWA installed on the Home Screen — in a tab
+ * `PushManager` doesn't exist at all — and there is no programmatic install
+ * prompt to trigger, so the only thing we can do is show the steps. The bell
+ * stays visible and pressable rather than disabled: this is the one
+ * "unsupported" case the reader can actually fix, and a dead control wouldn't
+ * tell them that.
+ */
+export function IosInstallPrompt({
+  isOpen,
+  onOpenChange,
+}: {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Dialog
+      trigger={null}
+      size="sm"
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+    >
+      <DialogHeader>
+        <Trans>Add to your Home Screen</Trans>
+      </DialogHeader>
+      <DialogBody>
+        <Flex direction="column" gap="lg">
+          <p {...stylex.props(styles.intro)}>
+            <Trans>
+              On iPhone and iPad, notifications only work once Standard Reader
+              is installed. It takes two taps.
+            </Trans>
+          </p>
+          <Flex direction="column" gap="md">
+            <Flex align="center" gap="md">
+              <Share
+                size={ICON_SIZE}
+                aria-hidden
+                {...stylex.props(styles.stepIcon)}
+              />
+              <span {...stylex.props(styles.step)}>
+                <Trans>Tap Share in the Safari toolbar.</Trans>
+              </span>
+            </Flex>
+            <Flex align="center" gap="md">
+              <SquarePlus
+                size={ICON_SIZE}
+                aria-hidden
+                {...stylex.props(styles.stepIcon)}
+              />
+              <span {...stylex.props(styles.step)}>
+                <Trans>Choose “Add to Home Screen”.</Trans>
+              </span>
+            </Flex>
+          </Flex>
+          <p {...stylex.props(styles.intro)}>
+            <Trans>
+              Then open Standard Reader from your Home Screen and turn the bell
+              on there.
+            </Trans>
+          </p>
+        </Flex>
+      </DialogBody>
+      <DialogFooter>
+        <Button variant="secondary" onPress={() => onOpenChange(false)}>
+          <Trans>Got it</Trans>
+        </Button>
+      </DialogFooter>
+    </Dialog>
+  );
+}

--- a/apps/standard-reader/src/components/reader/notify-button.tsx
+++ b/apps/standard-reader/src/components/reader/notify-button.tsx
@@ -120,6 +120,13 @@ export function NotifyButton({
         });
         return;
       }
+      if (result.status === "timed-out") {
+        toasts.add({
+          description: t`Your browser didn’t finish setting up notifications. Reloading the page usually fixes it.`,
+          title: t`That took too long`,
+        });
+        return;
+      }
       if (result.status !== "ready") {
         toasts.add({
           description: t`We couldn’t set up notifications on this device. Try again?`,

--- a/apps/standard-reader/src/components/reader/notify-button.tsx
+++ b/apps/standard-reader/src/components/reader/notify-button.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useLingui } from "@lingui/react/macro";
+import { IconButton } from "@standard-reader/design-system/icon-button";
+import { toasts } from "@standard-reader/design-system/toast";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Bell, BellRing } from "lucide-react";
+import { useState } from "react";
+
+import { IconButtonLink } from "#/components/router-links";
+import { pushApi } from "#/integrations/tanstack-query/api-push.functions";
+import type { PushSubjectTypeInput } from "#/integrations/tanstack-query/api-push.functions";
+import { ensurePushDevice, pushCapability } from "#/pwa/push";
+import { useLoginSearch } from "#/utils/use-login-search";
+
+import { IosInstallPrompt } from "./ios-install-prompt";
+
+/**
+ * "Notify me when this posts" — the bell shown next to Subscribe on a
+ * publication page and next to Follow on an author page.
+ *
+ * Deliberately independent of subscribing/following: turning it on doesn't
+ * change your feed, and you don't have to subscribe to be notified.
+ *
+ * Permission is requested from this press and nowhere else. That's a hard
+ * requirement rather than a preference — Safari only honours
+ * `requestPermission()` from a user gesture, and a `denied` in Chrome blocks the
+ * origin for months, so prompting on load would be a one-way door for anyone who
+ * dismissed it without reading.
+ */
+export function NotifyButton({
+  subjectType,
+  subject,
+  signedIn,
+  size = "md",
+}: {
+  subjectType: PushSubjectTypeInput;
+  /** Publication AT-URI, or an author DID. */
+  subject: string;
+  signedIn: boolean;
+  size?: "sm" | "md" | "lg";
+}) {
+  const { t } = useLingui();
+  const queryClient = useQueryClient();
+  const loginSearch = useLoginSearch();
+  const [iosPromptOpen, setIosPromptOpen] = useState(false);
+  const [pending, setPending] = useState(false);
+
+  const statusKey = ["push", "notify", subjectType, subject] as const;
+  const { data: status } = useQuery({
+    ...pushApi.getNotifyStatusQueryOptions({ subjectType, subject }),
+    enabled: signedIn,
+  });
+  const enabled = status?.enabled ?? false;
+
+  const setTopic = useMutation(pushApi.setNotifyTopicMutationOptions());
+
+  const iconSize = size === "lg" ? 18 : size === "md" ? 17 : 15;
+
+  const toggle = async (next: boolean) => {
+    // Optimistic — the bell flips instantly and rolls back on failure.
+    const previous = queryClient.getQueryData(statusKey);
+    queryClient.setQueryData(statusKey, { enabled: next });
+    try {
+      await setTopic.mutateAsync({ subjectType, subject, enabled: next });
+      // Settings shows a running count of sources.
+      await queryClient.invalidateQueries({ queryKey: ["push", "status"] });
+    } catch {
+      queryClient.setQueryData(statusKey, previous);
+      toasts.add({
+        description: t`Your notification setting didn’t save. Try again?`,
+        title: t`Something went wrong`,
+      });
+    }
+  };
+
+  const onPress = async () => {
+    // Turning off needs neither permission nor a device — just drop the row.
+    if (enabled) {
+      await toggle(false);
+      return;
+    }
+
+    const capability = pushCapability();
+    if (capability === "needs-ios-install") {
+      setIosPromptOpen(true);
+      return;
+    }
+    if (capability === "unsupported") {
+      toasts.add({
+        description: t`This browser doesn’t support web notifications.`,
+        title: t`Notifications aren’t available here`,
+      });
+      return;
+    }
+
+    setPending(true);
+    try {
+      const result = await ensurePushDevice();
+      if (result.status === "needs-ios-install") {
+        setIosPromptOpen(true);
+        return;
+      }
+      if (result.status === "denied") {
+        toasts.add({
+          description: t`Notifications are blocked for this site. You can turn them back on in your browser settings.`,
+          title: t`Notifications are blocked`,
+        });
+        return;
+      }
+      if (result.status !== "ready") {
+        toasts.add({
+          description: t`We couldn’t set up notifications on this device. Try again?`,
+          title: t`Something went wrong`,
+        });
+        return;
+      }
+      await toggle(true);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  if (!signedIn) {
+    return (
+      <IconButtonLink
+        to="/login"
+        search={loginSearch}
+        variant="secondary"
+        size={size}
+        label={t`Notify me about new posts`}
+      >
+        <Bell size={iconSize} aria-hidden />
+      </IconButtonLink>
+    );
+  }
+
+  return (
+    <>
+      <IconButton
+        variant="secondary"
+        size={size}
+        label={
+          enabled ? t`Turn off notifications` : t`Notify me about new posts`
+        }
+        isDisabled={pending || setTopic.isPending}
+        onPress={() => {
+          void onPress();
+        }}
+      >
+        {enabled ? (
+          <BellRing size={iconSize} aria-hidden />
+        ) : (
+          <Bell size={iconSize} aria-hidden />
+        )}
+      </IconButton>
+
+      <IosInstallPrompt
+        isOpen={iosPromptOpen}
+        onOpenChange={setIosPromptOpen}
+      />
+    </>
+  );
+}

--- a/apps/standard-reader/src/components/reader/notify-button.tsx
+++ b/apps/standard-reader/src/components/reader/notify-button.tsx
@@ -33,12 +33,17 @@ export function NotifyButton({
   subject,
   signedIn,
   size = "md",
+  variant = "secondary",
 }: {
   subjectType: PushSubjectTypeInput;
   /** Publication AT-URI, or an author DID. */
   subject: string;
   signedIn: boolean;
   size?: "sm" | "md" | "lg";
+  /** Match the surrounding control group. On a publication page the group takes
+   * the publication's own accent when the reader hasn't subscribed, so leaving
+   * this at the default made the bell the one button that ignored the theme. */
+  variant?: "primary" | "secondary";
 }) {
   const { t } = useLingui();
   const queryClient = useQueryClient();
@@ -108,6 +113,13 @@ export function NotifyButton({
         });
         return;
       }
+      if (result.status === "not-configured") {
+        toasts.add({
+          description: t`Notifications aren’t switched on for this site yet.`,
+          title: t`Notifications aren’t available`,
+        });
+        return;
+      }
       if (result.status !== "ready") {
         toasts.add({
           description: t`We couldn’t set up notifications on this device. Try again?`,
@@ -126,7 +138,7 @@ export function NotifyButton({
       <IconButtonLink
         to="/login"
         search={loginSearch}
-        variant="secondary"
+        variant={variant}
         size={size}
         label={t`Notify me about new posts`}
       >
@@ -138,7 +150,7 @@ export function NotifyButton({
   return (
     <>
       <IconButton
-        variant="secondary"
+        variant={variant}
         size={size}
         label={
           enabled ? t`Turn off notifications` : t`Notify me about new posts`

--- a/apps/standard-reader/src/components/reader/publication-actions.tsx
+++ b/apps/standard-reader/src/components/reader/publication-actions.tsx
@@ -44,6 +44,7 @@ import { useLoginSearch } from "#/utils/use-login-search";
 import type { PublicationCard } from "../../integrations/tanstack-query/api-shapes";
 import { AddToListModal } from "./add-to-list-modal";
 import { FollowButton } from "./cards";
+import { NotifyButton } from "./notify-button";
 import { RssFeedDialog } from "./rss-feed-button";
 import { ShareMenuItems, useShareActions } from "./share-menu";
 
@@ -259,6 +260,12 @@ export function PublicationActions({
           style={
             variant === "primary" ? styles.subscribeAccent : styles.subscribe
           }
+        />
+        <NotifyButton
+          subjectType="publication"
+          subject={pub.uri}
+          signedIn={signedIn}
+          size="lg"
         />
         <Menu
           placement="bottom end"

--- a/apps/standard-reader/src/components/reader/publication-actions.tsx
+++ b/apps/standard-reader/src/components/reader/publication-actions.tsx
@@ -53,9 +53,9 @@ const MENU_ICON = 14;
 
 const styles = stylex.create({
   /**
-   * The bell sits beside the Subscribe split button rather than inside it: the
-   * chevron is Subscribe's own dropdown, so a third segment wedged between them
-   * would break that pairing and read as one three-part control.
+   * The bell trails the Subscribe split button rather than sitting inside it:
+   * the chevron is Subscribe's own dropdown, so a third segment wedged between
+   * them would break that pairing and read as one three-part control.
    *
    * On desktop this row sits at the end of the hero's top row; on mobile it
    * wraps onto its own full-width line under the publication name.
@@ -70,7 +70,7 @@ const styles = stylex.create({
     paddingTop: { default: null, [breakpoints.sm]: spacing["1"] },
   },
   /** The split button itself. Takes the row's slack on mobile so it fills the
-   * line; the bell stays square at its start. */
+   * line; the bell stays square at its end. */
   group: {
     flexGrow: { default: 1, [breakpoints.sm]: 0 },
     flexShrink: 0,
@@ -204,9 +204,9 @@ function OrderSubMenu({
 }
 
 /**
- * The publication hero's action cluster: a notification bell, then a split
- * button whose primary segment subscribes and whose chevron opens every other
- * action for the publication.
+ * The publication hero's action cluster: a split button whose primary segment
+ * subscribes and whose chevron opens every other action for the publication,
+ * then a notification bell.
  *
  * Two controls instead of seven keeps the hero calm and reads the same on
  * mobile, where the split button goes full-width instead of collapsing into an
@@ -268,16 +268,6 @@ export function PublicationActions({
   return (
     <>
       <div {...stylex.props(styles.row)}>
-        <NotifyButton
-          subjectType="publication"
-          subject={pub.uri}
-          signedIn={signedIn}
-          size="lg"
-          // Takes the same variant as the split button beside it, so a
-          // publication painting the page in its own theme colors gets a bell
-          // that belongs to that palette instead of the app's neutral one.
-          variant={variant}
-        />
         <ButtonGroup style={styles.group}>
           <FollowButton
             publicationUri={pub.uri}
@@ -365,6 +355,16 @@ export function PublicationActions({
             ) : null}
           </Menu>
         </ButtonGroup>
+        <NotifyButton
+          subjectType="publication"
+          subject={pub.uri}
+          signedIn={signedIn}
+          size="lg"
+          // Takes the same variant as the split button beside it, so a
+          // publication painting the page in its own theme colors gets a bell
+          // that belongs to that palette instead of the app's neutral one.
+          variant={variant}
+        />
       </div>
 
       {share.embedDialog}

--- a/apps/standard-reader/src/components/reader/publication-actions.tsx
+++ b/apps/standard-reader/src/components/reader/publication-actions.tsx
@@ -19,6 +19,7 @@ import {
 } from "@standard-reader/design-system/menu";
 import { primaryColor } from "@standard-reader/design-system/theme/color.stylex";
 import { breakpoints } from "@standard-reader/design-system/theme/media-queries.stylex";
+import { gap } from "@standard-reader/design-system/theme/semantic-spacing.stylex";
 import { spacing } from "@standard-reader/design-system/theme/spacing.stylex";
 import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
@@ -52,14 +53,27 @@ const MENU_ICON = 14;
 
 const styles = stylex.create({
   /**
-   * On desktop the group sits at the end of the hero's top row; on mobile it
+   * The bell sits beside the Subscribe split button rather than inside it: the
+   * chevron is Subscribe's own dropdown, so a third segment wedged between them
+   * would break that pairing and read as one three-part control.
+   *
+   * On desktop this row sits at the end of the hero's top row; on mobile it
    * wraps onto its own full-width line under the publication name.
    */
-  group: {
+  row: {
+    alignItems: "center",
+    columnGap: gap.sm,
+    display: "flex",
     flexBasis: { default: "100%", [breakpoints.sm]: "auto" },
     flexShrink: 0,
     marginInlineStart: { default: null, [breakpoints.sm]: "auto" },
     paddingTop: { default: null, [breakpoints.sm]: spacing["1"] },
+  },
+  /** The split button itself. Takes the row's slack on mobile so it fills the
+   * line; the bell stays square at its start. */
+  group: {
+    flexGrow: { default: 1, [breakpoints.sm]: 0 },
+    flexShrink: 0,
   },
   /**
    * The label segment takes the slack, so on mobile it fills the row and the
@@ -190,13 +204,16 @@ function OrderSubMenu({
 }
 
 /**
- * The publication hero's action cluster: a split button whose primary segment
- * subscribes and whose chevron opens every other action for the publication.
+ * The publication hero's action cluster: a notification bell, then a split
+ * button whose primary segment subscribes and whose chevron opens every other
+ * action for the publication.
  *
- * One control instead of six keeps the hero calm and reads the same on mobile,
- * where the split button goes full-width instead of collapsing into an icon row.
- * Dialogs are rendered as siblings of the menu (not menu children) so they
- * survive the menu closing on selection.
+ * Two controls instead of seven keeps the hero calm and reads the same on
+ * mobile, where the split button goes full-width instead of collapsing into an
+ * icon row. The bell stays outside the group on purpose — the chevron is
+ * Subscribe's own dropdown, and a third segment between them would read as one
+ * three-part control. Dialogs are rendered as siblings of the menu (not menu
+ * children) so they survive the menu closing on selection.
  */
 export function PublicationActions({
   pub,
@@ -250,95 +267,105 @@ export function PublicationActions({
 
   return (
     <>
-      <ButtonGroup style={styles.group}>
-        <FollowButton
-          publicationUri={pub.uri}
-          signedIn={signedIn}
-          size="lg"
-          pub={pub}
-          responsive={false}
-          style={
-            variant === "primary" ? styles.subscribeAccent : styles.subscribe
-          }
-        />
+      <div {...stylex.props(styles.row)}>
         <NotifyButton
           subjectType="publication"
           subject={pub.uri}
           signedIn={signedIn}
           size="lg"
+          // Takes the same variant as the split button beside it, so a
+          // publication painting the page in its own theme colors gets a bell
+          // that belongs to that palette instead of the app's neutral one.
+          variant={variant}
         />
-        <Menu
-          placement="bottom end"
-          trigger={
-            <IconButton variant={variant} label={t`More actions`} size="lg">
-              <ChevronDown size={16} />
-            </IconButton>
-          }
-        >
-          {signedIn ? (
-            <MenuItem
-              onPress={() => setListOpen(true)}
-              suffix={<ListPlus size={MENU_ICON} />}
-              textValue={t`Add to list`}
-            >
-              <Trans>Add to list</Trans>
-            </MenuItem>
-          ) : (
-            <MenuItemLink
-              to="/login"
-              search={loginSearch}
-              suffix={<ListPlus size={MENU_ICON} />}
-              textValue={t`Add to list`}
-            >
-              <Trans>Add to list</Trans>
-            </MenuItemLink>
-          )}
-          {markAllRead ? (
-            <MenuItem
-              onPress={() => setMarkAllReadOpen(true)}
-              suffix={<CheckCheck size={MENU_ICON} />}
-              textValue={t`Mark all as read`}
-            >
-              <Trans>Mark all as read</Trans>
-            </MenuItem>
-          ) : null}
-          {signedIn ? (
-            <FilterSubMenu
-              filter={filter}
-              trackReading={trackReading}
-              onFilterChange={onFilterChange}
-            />
-          ) : null}
-          {/* Not gated on sign-in: the override rides in a cookie, so it works
-              for a guest exactly as well as for a reader with an account. */}
-          <OrderSubMenu order={order} onOrderChange={onOrderChange} />
-
-          <MenuSeparator />
-
-          <ShareMenuItems share={share} />
-
-          <MenuSeparator />
-
-          <MenuItem
-            onPress={() => setRssOpen(true)}
-            suffix={<Rss size={MENU_ICON} />}
-            textValue={t`RSS feed`}
+        <ButtonGroup style={styles.group}>
+          <FollowButton
+            publicationUri={pub.uri}
+            signedIn={signedIn}
+            size="lg"
+            pub={pub}
+            responsive={false}
+            style={
+              variant === "primary" ? styles.subscribeAccent : styles.subscribe
+            }
+          />
+          <Menu
+            placement="bottom end"
+            trigger={
+              <IconButton variant={variant} label={t`More actions`} size="lg">
+                <ChevronDown size={16} />
+              </IconButton>
+            }
           >
-            <Trans>RSS feed</Trans>
-          </MenuItem>
-          {pub.url ? (
+            {signedIn ? (
+              <MenuItem
+                onPress={() => setListOpen(true)}
+                suffix={<ListPlus size={MENU_ICON} />}
+                textValue={t`Add to list`}
+              >
+                <Trans>Add to list</Trans>
+              </MenuItem>
+            ) : (
+              <MenuItemLink
+                to="/login"
+                search={loginSearch}
+                suffix={<ListPlus size={MENU_ICON} />}
+                textValue={t`Add to list`}
+              >
+                <Trans>Add to list</Trans>
+              </MenuItemLink>
+            )}
+            {markAllRead ? (
+              <MenuItem
+                onPress={() => setMarkAllReadOpen(true)}
+                suffix={<CheckCheck size={MENU_ICON} />}
+                textValue={t`Mark all as read`}
+              >
+                <Trans>Mark all as read</Trans>
+              </MenuItem>
+            ) : null}
+            {signedIn ? (
+              <FilterSubMenu
+                filter={filter}
+                trackReading={trackReading}
+                onFilterChange={onFilterChange}
+              />
+            ) : null}
+            {/* Not gated on sign-in: the override rides in a cookie, so it works
+              for a guest exactly as well as for a reader with an account. */}
+            <OrderSubMenu order={order} onOrderChange={onOrderChange} />
+
+            <MenuSeparator />
+
+            <ShareMenuItems share={share} />
+
+            <MenuSeparator />
+
             <MenuItem
-              onPress={() => {
-                globalThis.open(pub.url ?? "", "_blank", "noopener,noreferrer");
-              }}
-              suffix={<ExternalLink size={MENU_ICON} />}
-              textValue={t`Visit publication site`}
+              onPress={() => setRssOpen(true)}
+              suffix={<Rss size={MENU_ICON} />}
+              textValue={t`RSS feed`}
             >
-              <Trans>Visit publication site</Trans>
+              <Trans>RSS feed</Trans>
             </MenuItem>
-          ) : null}
-        </Menu>
-      </ButtonGroup>
+            {pub.url ? (
+              <MenuItem
+                onPress={() => {
+                  globalThis.open(
+                    pub.url ?? "",
+                    "_blank",
+                    "noopener,noreferrer",
+                  );
+                }}
+                suffix={<ExternalLink size={MENU_ICON} />}
+                textValue={t`Visit publication site`}
+              >
+                <Trans>Visit publication site</Trans>
+              </MenuItem>
+            ) : null}
+          </Menu>
+        </ButtonGroup>
+      </div>
 
       {share.embedDialog}
 

--- a/apps/standard-reader/src/components/user-settings-view.tsx
+++ b/apps/standard-reader/src/components/user-settings-view.tsx
@@ -104,6 +104,7 @@ import { useLocale } from "#/lib/use-locale";
 import { useOpenCollectionsInMagazine } from "#/lib/use-open-collections-in-magazine";
 import { useOpenLinks } from "#/lib/use-open-links";
 import { usePublicationThemePreference } from "#/lib/use-publication-theme-preference";
+import { usePushSettings } from "#/lib/use-push-settings";
 import { useReaderVoice } from "#/lib/use-reader-voice";
 import { useReadingTypography } from "#/lib/use-reading-typography";
 import { useTheme } from "#/lib/use-theme";
@@ -113,6 +114,7 @@ import {
   AppearanceAdvancedRows,
   AppearancePalettePanel,
 } from "./appearance-settings";
+import { IosInstallPrompt } from "./reader/ios-install-prompt";
 import { Masthead, ReaderContent } from "./reader/primitives";
 import { ReadingCustomFontPicker } from "./reading-custom-font-picker";
 import { ReadingSettingsPreview } from "./reading-settings-preview";
@@ -569,6 +571,21 @@ export function UserSettingsView() {
   const [digestPreviewOpen, setDigestPreviewOpen] = useState(false);
   const [digestPreviewLoading, setDigestPreviewLoading] = useState(true);
 
+  const push = usePushSettings();
+  const [iosPromptOpen, setIosPromptOpen] = useState(false);
+
+  // One row, five possible states. Ordered most-actionable first so the reader
+  // is told what to do about it rather than just what's wrong.
+  const pushDescription = push.blocked
+    ? t`Notifications are blocked for this site. You can turn them back on in your browser settings.`
+    : push.capability === "needs-ios-install"
+      ? t`On iPhone and iPad, notifications need Standard Reader installed on your Home Screen.`
+      : push.capability === "unsupported"
+        ? t`This browser doesn’t support web notifications.`
+        : push.deviceRegistered
+          ? t`On for this browser. You’ll hear about new posts from the ${push.topicCount} publications and authors you’ve turned the bell on for.`
+          : t`Get notified the moment a publication or author publishes something new. Turn it on here, then choose who from their page.`;
+
   const onToggleDigest = (next: boolean) => {
     // Turning on requests the `transition:email` scope (a full PDS re-auth), so
     // confirm first and explain why. Turning off just clears the flag — no
@@ -977,6 +994,66 @@ export function UserSettingsView() {
             </AlertDialogFooter>
           </AlertDialog>
         </div>
+      </section>
+
+      <section {...stylex.props(styles.section)}>
+        <h2 {...stylex.props(styles.sectionHeading)}>
+          <Trans>Notifications</Trans>
+        </h2>
+        <div {...stylex.props(styles.settingGroup)}>
+          <SettingRow
+            label={t`Notifications on this device`}
+            description={pushDescription}
+          >
+            {push.capability === "needs-ios-install" ? (
+              <Button
+                variant="secondary"
+                onPress={() => setIosPromptOpen(true)}
+              >
+                <Trans>How to enable</Trans>
+              </Button>
+            ) : (
+              <Switch
+                isSelected={push.deviceRegistered}
+                onChange={(next) => {
+                  void (next
+                    ? push.enableOnThisDevice()
+                    : push.disableOnThisDevice());
+                }}
+                isDisabled={
+                  push.isPending ||
+                  push.blocked ||
+                  push.capability === null ||
+                  push.capability === "unsupported"
+                }
+                aria-label={t`Notifications on this device`}
+              />
+            )}
+          </SettingRow>
+          {push.topicCount > 0 || push.deviceCount > 0 ? (
+            <>
+              <Separator />
+              <SettingRow
+                label={t`Turn off everywhere`}
+                description={t`Stop notifications on every device and clear all ${push.topicCount} of the publications and authors you’ve turned the bell on for.`}
+              >
+                <Button
+                  variant="secondary"
+                  isDisabled={push.isPending}
+                  onPress={() => {
+                    void push.disableEverywhere();
+                  }}
+                >
+                  <Trans>Turn off</Trans>
+                </Button>
+              </SettingRow>
+            </>
+          ) : null}
+        </div>
+        <IosInstallPrompt
+          isOpen={iosPromptOpen}
+          onOpenChange={setIosPromptOpen}
+        />
       </section>
 
       <section {...stylex.props(styles.section)}>

--- a/apps/standard-reader/src/components/user-settings-view.tsx
+++ b/apps/standard-reader/src/components/user-settings-view.tsx
@@ -114,6 +114,7 @@ import {
   AppearanceAdvancedRows,
   AppearancePalettePanel,
 } from "./appearance-settings";
+import { PushDiagnosticsPanel } from "./push-diagnostics";
 import { IosInstallPrompt } from "./reader/ios-install-prompt";
 import { Masthead, ReaderContent } from "./reader/primitives";
 import { ReadingCustomFontPicker } from "./reading-custom-font-picker";
@@ -1049,6 +1050,15 @@ export function UserSettingsView() {
               </SettingRow>
             </>
           ) : null}
+          <Separator />
+          <Disclosure>
+            <DisclosureTitle style={styles.advancedTitle}>
+              <Trans>Troubleshooting</Trans>
+            </DisclosureTitle>
+            <DisclosurePanel>
+              <PushDiagnosticsPanel diagnostics={push.diagnostics} />
+            </DisclosurePanel>
+          </Disclosure>
         </div>
         <IosInstallPrompt
           isOpen={iosPromptOpen}

--- a/apps/standard-reader/src/db/schema.ts
+++ b/apps/standard-reader/src/db/schema.ts
@@ -17,6 +17,7 @@ export * from "./schema/publications.ts";
 export * from "./schema/documents.ts";
 export * from "./schema/graph.ts";
 export * from "./schema/personal.ts";
+export * from "./schema/push.ts";
 export * from "./schema/lists.ts";
 export * from "./schema/stats.ts";
 export * from "./schema/network-stats.ts";

--- a/apps/standard-reader/src/db/schema/push.ts
+++ b/apps/standard-reader/src/db/schema/push.ts
@@ -1,0 +1,180 @@
+import {
+  index,
+  integer,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core";
+
+/**
+ * Web push notifications — "tell me when this publication / author posts".
+ *
+ * Unlike almost everything else in `./schema/`, these tables are NOT a mirror of
+ * the network. They are app-owned state with no AT Proto record behind them:
+ *
+ *   - `push_devices` holds a browser's push endpoint and its encryption keys.
+ *     Those are per-browser secrets — anyone holding them can send that browser
+ *     a notification — so they must never be written to a public repo.
+ *   - `push_topics` (the per-source opt-in) *could* have been a record, the way
+ *     `app.standard-reader.sidebarPref` is. It isn't, because a new record
+ *     collection means an expanded OAuth write scope, and every existing session
+ *     would have to go through the "reconnect your account" flow before the bell
+ *     worked at all. If the opt-in ever needs to be portable, a record + mirror
+ *     can be layered on top of this table.
+ *   - `document_push_queue` is the send outbox. See its doc comment — it is also
+ *     the exactly-once claim, and that is why it is a table and not a column.
+ */
+
+/**
+ * One row per browser/profile that granted notification permission. Keyed by
+ * `endpoint` because that IS the identity of a push subscription: the browser
+ * hands us the same endpoint on re-subscribe, and a rotated endpoint is by
+ * definition a different destination.
+ */
+export const pushDevices = pgTable(
+  "push_devices",
+  {
+    /** Push service URL the payload is delivered to. */
+    endpoint: text("endpoint").primaryKey(),
+    /** DID of the reader this browser is signed in as. */
+    ownerDid: text("owner_did").notNull(),
+
+    /** Keys from `PushSubscription.toJSON().keys`, for RFC 8291 encryption. */
+    p256dh: text("p256dh").notNull(),
+    auth: text("auth").notNull(),
+
+    /** Raw UA string, so settings can name the device ("Chrome on macOS"). */
+    userAgent: text("user_agent"),
+
+    /** Bumped on a transient send failure; reset on success. Purely
+     * diagnostic — a dead endpoint is deleted outright on 404/410. */
+    failureCount: integer("failure_count").notNull().default(0),
+
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    /** Refreshed every time the browser re-registers, so stale rows are
+     * identifiable even when the push service never returns 410. */
+    lastSeenAt: timestamp("last_seen_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [index("push_devices_owner_idx").on(table.ownerDid)],
+);
+
+/** What a reader wants to be notified about. */
+export const PUSH_SUBJECT_TYPES = ["publication", "author"] as const;
+export type PushSubjectType = (typeof PUSH_SUBJECT_TYPES)[number];
+
+/**
+ * One row per (reader → source) opt-in. Deliberately independent of
+ * `subscriptions` / `user_follows`: turning on notifications does not change
+ * your feed, and you do not have to subscribe to be notified.
+ *
+ * `subject` is a publication AT-URI (`subject_type = 'publication'`) or an
+ * author DID (`subject_type = 'author'`).
+ */
+export const pushTopics = pgTable(
+  "push_topics",
+  {
+    ownerDid: text("owner_did").notNull(),
+    subjectType: text("subject_type").notNull(),
+    subject: text("subject").notNull(),
+
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.ownerDid, table.subjectType, table.subject],
+    }),
+    // Fan-out: given a new document, who asked about this publication/author?
+    index("push_topics_subject_idx").on(table.subjectType, table.subject),
+  ],
+);
+
+/** Lifecycle of a queued document notification. */
+export const PUSH_QUEUE_STATES = [
+  "pending",
+  "sending",
+  "sent",
+  "failed",
+] as const;
+export type PushQueueState = (typeof PUSH_QUEUE_STATES)[number];
+
+/**
+ * Send outbox for new-post notifications — and the exactly-once claim.
+ *
+ * The tap handler inserts here (`ON CONFLICT DO NOTHING`) when it indexes a
+ * genuinely new document; the push cron drains it. Being a queue *and* the claim
+ * is the point: the primary key is what makes tap redelivery, dead-letter
+ * replay, and a later `update` event for the same document all no-ops.
+ *
+ * Two things about the shape are deliberate:
+ *
+ *   1. **No foreign key to `documents`.** Document deletes are hard deletes
+ *      (`deleteRecord` in `server/ingest/handlers.ts` does `db.delete(documents)`,
+ *      not a tombstone), so an FK — or the obvious alternative, a
+ *      `documents.push_notified_at` column — would let the claim die with the
+ *      row. A delete→recreate at the same rkey is a normal republish, and it
+ *      would re-notify everyone.
+ *   2. **Not a column on `documents`** for the same reason, plus a second one:
+ *      `upsertDocument` writes `onConflictDoUpdate({ set: values })` with
+ *      `values` as a literal object, so any column that must survive an update
+ *      has to be kept out of it — with nothing in the code to say so.
+ *
+ * `sent` / `failed` rows are pruned by age from the hourly recompute sweep.
+ */
+export const documentPushQueue = pgTable(
+  "document_push_queue",
+  {
+    /** AT-URI of the document to notify about. */
+    documentUri: text("document_uri").primaryKey(),
+    /** Author DID, denormalized so the drain doesn't need `documents` to
+     * apply the per-author flood cap. */
+    authorDid: text("author_did").notNull(),
+
+    /** `pending` | `sending` | `sent` | `failed` (see PUSH_QUEUE_STATES). */
+    state: text("state").notNull().default("pending"),
+    attempts: integer("attempts").notNull().default(0),
+    /** Not eligible for a claim before this — pushed forward by `Retry-After`
+     * on a 429. */
+    availableAt: timestamp("available_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    /** When the current `sending` claim was taken. A run killed mid-send leaves
+     * this stale, which is how the next run's reaper finds it. */
+    claimedAt: timestamp("claimed_at", { withTimezone: true }),
+    /** Last failure, kept for inspecting `failed` rows. */
+    lastError: text("last_error"),
+
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    // The drain's claim query: pending-and-due, oldest first.
+    index("document_push_queue_claim_idx").on(
+      table.state,
+      table.availableAt,
+      table.createdAt,
+    ),
+    // The per-author flood cap counts recent sends for one DID.
+    index("document_push_queue_author_idx").on(
+      table.authorDid,
+      table.createdAt,
+    ),
+  ],
+);
+
+export type PushDevice = typeof pushDevices.$inferSelect;
+export type NewPushDevice = typeof pushDevices.$inferInsert;
+export type PushTopic = typeof pushTopics.$inferSelect;
+export type NewPushTopic = typeof pushTopics.$inferInsert;
+export type DocumentPushQueueRow = typeof documentPushQueue.$inferSelect;
+export type NewDocumentPushQueueRow = typeof documentPushQueue.$inferInsert;

--- a/apps/standard-reader/src/integrations/tanstack-query/api-push.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-push.functions.ts
@@ -1,0 +1,304 @@
+import { mutationOptions, queryOptions } from "@tanstack/react-query";
+import { createServerFn } from "@tanstack/react-start";
+import { getRequest } from "@tanstack/react-start/server";
+import { and, count, eq, sql } from "drizzle-orm";
+import { z } from "zod";
+
+import { getReaderDidForRequest } from "#/middleware/auth-session.server";
+import { observe } from "#/server/observability/log";
+
+import { dbMiddleware } from "./db-middleware";
+
+/**
+ * Web push: device registration and per-source notification opt-ins.
+ *
+ * All of this is app-owned DB state with no AT Proto record behind it — see the
+ * doc comment on `src/db/schema/push.ts` for why. Nothing here talks to a PDS,
+ * so every handler is a plain DB read/write against the session's DID.
+ *
+ * Note that these are API endpoints reachable independently of the UI that calls
+ * them, so each handler that touches a reader's rows checks the session itself
+ * rather than relying on a route guard.
+ */
+
+/** What a reader can ask to be notified about. */
+export const PUSH_SUBJECT_TYPE = ["publication", "author"] as const;
+export type PushSubjectTypeInput = (typeof PUSH_SUBJECT_TYPE)[number];
+
+const subjectInput = z.object({
+  subjectType: z.enum(PUSH_SUBJECT_TYPE),
+  /** Publication AT-URI, or an author DID. */
+  subject: z.string().min(1).max(512),
+});
+
+const deviceInput = z.object({
+  endpoint: z.string().min(1).max(2048),
+  p256dh: z.string().min(1).max(512),
+  auth: z.string().min(1).max(512),
+  userAgent: z.string().max(512).nullish(),
+});
+
+/**
+ * The VAPID public key the browser binds its subscription to. Deliberately a
+ * server function rather than a `VITE_`-prefixed env var: those are inlined at
+ * build time, which would mean the key has to exist on every machine that
+ * builds the app, not just the ones that run it.
+ *
+ * Returns `null` when push isn't configured, so the UI can present itself as
+ * unavailable instead of erroring.
+ */
+const getPushConfig = createServerFn({ method: "GET" }).handler(
+  async (): Promise<{ publicKey: string | null }> => {
+    const { pushConfig } = await import("#/server/push/config");
+    return { publicKey: pushConfig.configured ? pushConfig.publicKey : null };
+  },
+);
+
+const getPushConfigQueryOptions = queryOptions({
+  queryKey: ["push", "config"] as const,
+  queryFn: () => getPushConfig(),
+  staleTime: Number.POSITIVE_INFINITY,
+});
+
+/**
+ * Record (or refresh) this browser's push endpoint. Keyed on `endpoint`, which
+ * is the identity of a push subscription — re-registering the same browser
+ * updates the keys and `lastSeenAt` rather than accumulating rows.
+ *
+ * The `ownerDid` is taken from the session, never from the client: otherwise
+ * anyone could point another reader's notifications at their own endpoint.
+ */
+const registerPushDevice = createServerFn({ method: "POST" })
+  .middleware([dbMiddleware])
+  .validator(deviceInput)
+  .handler(
+    observe("push.registerDevice", async ({ data, context }, span) => {
+      const did = await getReaderDidForRequest(getRequest());
+      if (!did) {
+        throw new Error("Sign in to enable notifications.");
+      }
+      span.set("did", did);
+
+      const values = {
+        endpoint: data.endpoint,
+        ownerDid: did,
+        p256dh: data.p256dh,
+        auth: data.auth,
+        userAgent: data.userAgent ?? null,
+        failureCount: 0,
+        lastSeenAt: sql`now()`,
+      };
+
+      await context.db
+        .insert(context.schema.pushDevices)
+        .values(values)
+        .onConflictDoUpdate({
+          target: context.schema.pushDevices.endpoint,
+          set: values,
+        });
+
+      return { ok: true as const };
+    }),
+  );
+
+/** Forget this browser. Topics are left alone — the reader may still be getting
+ * notifications on another device. */
+const unregisterPushDevice = createServerFn({ method: "POST" })
+  .middleware([dbMiddleware])
+  .validator(z.object({ endpoint: z.string().min(1).max(2048) }))
+  .handler(
+    observe("push.unregisterDevice", async ({ data, context }, span) => {
+      const did = await getReaderDidForRequest(getRequest());
+      if (!did) return { ok: true as const };
+      span.set("did", did);
+
+      await context.db
+        .delete(context.schema.pushDevices)
+        .where(
+          and(
+            eq(context.schema.pushDevices.endpoint, data.endpoint),
+            eq(context.schema.pushDevices.ownerDid, did),
+          ),
+        );
+
+      return { ok: true as const };
+    }),
+  );
+
+/**
+ * State for the settings section: whether *this* browser is registered, and how
+ * many sources the reader is subscribed to overall (across every device).
+ */
+const getPushStatus = createServerFn({ method: "POST" })
+  .middleware([dbMiddleware])
+  .validator(
+    z.object({ endpoint: z.string().min(1).max(2048).nullish() }).optional(),
+  )
+  .handler(
+    async ({
+      data,
+      context,
+    }): Promise<{
+      deviceRegistered: boolean;
+      deviceCount: number;
+      topicCount: number;
+    }> => {
+      const did = await getReaderDidForRequest(getRequest());
+      if (!did) {
+        return { deviceRegistered: false, deviceCount: 0, topicCount: 0 };
+      }
+
+      const [devices, topics] = await Promise.all([
+        context.db
+          .select({ endpoint: context.schema.pushDevices.endpoint })
+          .from(context.schema.pushDevices)
+          .where(eq(context.schema.pushDevices.ownerDid, did)),
+        context.db
+          .select({ n: count() })
+          .from(context.schema.pushTopics)
+          .where(eq(context.schema.pushTopics.ownerDid, did)),
+      ]);
+
+      const endpoint = data?.endpoint ?? null;
+      return {
+        deviceRegistered:
+          endpoint != null && devices.some((d) => d.endpoint === endpoint),
+        deviceCount: devices.length,
+        topicCount: topics[0]?.n ?? 0,
+      };
+    },
+  );
+
+function getPushStatusQueryOptions(endpoint: string | null) {
+  return queryOptions({
+    queryKey: ["push", "status", endpoint] as const,
+    queryFn: () => getPushStatus({ data: { endpoint } }),
+    staleTime: 30_000,
+  });
+}
+
+/** Is the bell on for this publication / author? */
+const getNotifyStatus = createServerFn({ method: "POST" })
+  .middleware([dbMiddleware])
+  .validator(subjectInput)
+  .handler(async ({ data, context }): Promise<{ enabled: boolean }> => {
+    const did = await getReaderDidForRequest(getRequest());
+    if (!did) return { enabled: false };
+
+    const rows = await context.db
+      .select({ subject: context.schema.pushTopics.subject })
+      .from(context.schema.pushTopics)
+      .where(
+        and(
+          eq(context.schema.pushTopics.ownerDid, did),
+          eq(context.schema.pushTopics.subjectType, data.subjectType),
+          eq(context.schema.pushTopics.subject, data.subject),
+        ),
+      )
+      .limit(1);
+
+    return { enabled: rows.length > 0 };
+  });
+
+function getNotifyStatusQueryOptions(input: z.input<typeof subjectInput>) {
+  return queryOptions({
+    queryKey: ["push", "notify", input.subjectType, input.subject] as const,
+    queryFn: () => getNotifyStatus({ data: input }),
+    staleTime: 60_000,
+  });
+}
+
+/** Turn the bell on or off for one source. */
+const setNotifyTopic = createServerFn({ method: "POST" })
+  .middleware([dbMiddleware])
+  .validator(subjectInput.extend({ enabled: z.boolean() }))
+  .handler(
+    observe("push.setNotifyTopic", async ({ data, context }, span) => {
+      const did = await getReaderDidForRequest(getRequest());
+      if (!did) {
+        throw new Error("Sign in to enable notifications.");
+      }
+      span.set("did", did);
+      span.set("subjectType", data.subjectType);
+      span.set("enabled", data.enabled);
+
+      if (data.enabled) {
+        await context.db
+          .insert(context.schema.pushTopics)
+          .values({
+            ownerDid: did,
+            subjectType: data.subjectType,
+            subject: data.subject,
+          })
+          .onConflictDoNothing();
+      } else {
+        await context.db
+          .delete(context.schema.pushTopics)
+          .where(
+            and(
+              eq(context.schema.pushTopics.ownerDid, did),
+              eq(context.schema.pushTopics.subjectType, data.subjectType),
+              eq(context.schema.pushTopics.subject, data.subject),
+            ),
+          );
+      }
+
+      return { enabled: data.enabled };
+    }),
+  );
+
+function setNotifyTopicMutationOptions() {
+  return mutationOptions({
+    mutationKey: ["push", "setNotifyTopic"] as const,
+    mutationFn: (input: z.input<typeof subjectInput> & { enabled: boolean }) =>
+      setNotifyTopic({ data: input }),
+  });
+}
+
+/**
+ * The global off switch: drop every device and every opt-in for this reader.
+ * Deliberately blunt — the settings surface is minimal by design, so this is the
+ * escape hatch for "stop, all of it".
+ */
+const disableAllPush = createServerFn({ method: "POST" })
+  .middleware([dbMiddleware])
+  .handler(
+    observe("push.disableAll", async ({ context }, span) => {
+      const did = await getReaderDidForRequest(getRequest());
+      if (!did) return { ok: true as const };
+      span.set("did", did);
+
+      await Promise.all([
+        context.db
+          .delete(context.schema.pushDevices)
+          .where(eq(context.schema.pushDevices.ownerDid, did)),
+        context.db
+          .delete(context.schema.pushTopics)
+          .where(eq(context.schema.pushTopics.ownerDid, did)),
+      ]);
+
+      return { ok: true as const };
+    }),
+  );
+
+function disableAllPushMutationOptions() {
+  return mutationOptions({
+    mutationKey: ["push", "disableAll"] as const,
+    mutationFn: () => disableAllPush(),
+  });
+}
+
+export const pushApi = {
+  disableAllPush,
+  disableAllPushMutationOptions,
+  getNotifyStatus,
+  getNotifyStatusQueryOptions,
+  getPushConfig,
+  getPushConfigQueryOptions,
+  getPushStatus,
+  getPushStatusQueryOptions,
+  registerPushDevice,
+  setNotifyTopic,
+  setNotifyTopicMutationOptions,
+  unregisterPushDevice,
+};

--- a/apps/standard-reader/src/integrations/tanstack-query/api-push.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-push.functions.ts
@@ -50,7 +50,7 @@ const deviceInput = z.object({
 const getPushConfig = createServerFn({ method: "GET" }).handler(
   async (): Promise<{ publicKey: string | null }> => {
     const { pushConfig } = await import("#/server/push/config");
-    return { publicKey: pushConfig.configured ? pushConfig.publicKey : null };
+    return { publicKey: pushConfig.canRegister ? pushConfig.publicKey : null };
   },
 );
 

--- a/apps/standard-reader/src/lib/use-push-settings.ts
+++ b/apps/standard-reader/src/lib/use-push-settings.ts
@@ -7,9 +7,10 @@ import {
   ensurePushDevice,
   notificationsBlocked,
   pushCapability,
+  pushDiagnostics,
   removePushDevice,
 } from "#/pwa/push";
-import type { PushCapability } from "#/pwa/push";
+import type { PushCapability, PushDiagnostics } from "#/pwa/push";
 
 /**
  * State for the Notifications section of settings: whether *this* browser is
@@ -33,6 +34,9 @@ export interface PushSettings {
   /** Registered browsers across all of the reader's devices. */
   deviceCount: number;
   isPending: boolean;
+  /** Browser-side state, for the settings troubleshooting readout. `null`
+   * until resolved on the client. */
+  diagnostics: PushDiagnostics | null;
   /** Subscribe this browser. Must be called from a user gesture. */
   enableOnThisDevice: () => Promise<void>;
   /** Unsubscribe this browser, leaving the opt-ins alone. */
@@ -47,6 +51,11 @@ export function usePushSettings(): PushSettings {
   const [blocked, setBlocked] = useState(false);
   const [endpoint, setEndpoint] = useState<string | null>(null);
   const [isPending, setIsPending] = useState(false);
+  const [diagnostics, setDiagnostics] = useState<PushDiagnostics | null>(null);
+
+  const refreshDiagnostics = useCallback(async () => {
+    setDiagnostics(await pushDiagnostics());
+  }, []);
 
   useEffect(() => {
     setCapability(pushCapability());
@@ -54,7 +63,8 @@ export function usePushSettings(): PushSettings {
     void currentPushSubscription().then((subscription) => {
       setEndpoint(subscription?.endpoint ?? null);
     });
-  }, []);
+    void refreshDiagnostics();
+  }, [refreshDiagnostics]);
 
   const { data: status } = useQuery({
     ...pushApi.getPushStatusQueryOptions(endpoint),
@@ -67,7 +77,10 @@ export function usePushSettings(): PushSettings {
 
   const refresh = useCallback(async () => {
     await queryClient.invalidateQueries({ queryKey: ["push", "status"] });
-  }, [queryClient]);
+    // Re-read browser state too — an attempt that just failed is exactly when
+    // the troubleshooting readout needs to be current.
+    await refreshDiagnostics();
+  }, [queryClient, refreshDiagnostics]);
 
   const enableOnThisDevice = useCallback(async () => {
     setIsPending(true);
@@ -105,16 +118,18 @@ export function usePushSettings(): PushSettings {
       setEndpoint(null);
       // Every bell in the app is now off.
       await queryClient.invalidateQueries({ queryKey: ["push"] });
+      await refreshDiagnostics();
     } finally {
       setIsPending(false);
     }
-  }, [disableAll, queryClient]);
+  }, [disableAll, queryClient, refreshDiagnostics]);
 
   return {
     blocked,
     capability,
     deviceCount: status?.deviceCount ?? 0,
     deviceRegistered: status?.deviceRegistered ?? false,
+    diagnostics,
     disableEverywhere,
     disableOnThisDevice,
     enableOnThisDevice,

--- a/apps/standard-reader/src/lib/use-push-settings.ts
+++ b/apps/standard-reader/src/lib/use-push-settings.ts
@@ -1,0 +1,124 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useState } from "react";
+
+import { pushApi } from "#/integrations/tanstack-query/api-push.functions";
+import {
+  currentPushSubscription,
+  ensurePushDevice,
+  notificationsBlocked,
+  pushCapability,
+  removePushDevice,
+} from "#/pwa/push";
+import type { PushCapability } from "#/pwa/push";
+
+/**
+ * State for the Notifications section of settings: whether *this* browser is
+ * registered, how many sources the reader has turned the bell on for, and the
+ * two actions (enable here / turn off everywhere).
+ *
+ * Capability and endpoint are resolved in an effect rather than during render —
+ * both are browser-only, and reading them during SSR would either throw or
+ * produce a hydration mismatch. Until the effect runs, capability is `null`,
+ * which the UI shows as "still working it out" rather than "unsupported".
+ */
+export interface PushSettings {
+  /** `null` until resolved on the client. */
+  capability: PushCapability | null;
+  /** The reader has blocked notifications at the browser level. */
+  blocked: boolean;
+  /** This browser has an active, registered subscription. */
+  deviceRegistered: boolean;
+  /** Publications + authors the reader gets notifications for. */
+  topicCount: number;
+  /** Registered browsers across all of the reader's devices. */
+  deviceCount: number;
+  isPending: boolean;
+  /** Subscribe this browser. Must be called from a user gesture. */
+  enableOnThisDevice: () => Promise<void>;
+  /** Unsubscribe this browser, leaving the opt-ins alone. */
+  disableOnThisDevice: () => Promise<void>;
+  /** Drop every device and every opt-in. */
+  disableEverywhere: () => Promise<void>;
+}
+
+export function usePushSettings(): PushSettings {
+  const queryClient = useQueryClient();
+  const [capability, setCapability] = useState<PushCapability | null>(null);
+  const [blocked, setBlocked] = useState(false);
+  const [endpoint, setEndpoint] = useState<string | null>(null);
+  const [isPending, setIsPending] = useState(false);
+
+  useEffect(() => {
+    setCapability(pushCapability());
+    setBlocked(notificationsBlocked());
+    void currentPushSubscription().then((subscription) => {
+      setEndpoint(subscription?.endpoint ?? null);
+    });
+  }, []);
+
+  const { data: status } = useQuery({
+    ...pushApi.getPushStatusQueryOptions(endpoint),
+    // Wait for the effect above; querying with a null endpoint first would just
+    // be thrown away a tick later.
+    enabled: capability !== null,
+  });
+
+  const disableAll = useMutation(pushApi.disableAllPushMutationOptions());
+
+  const refresh = useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: ["push", "status"] });
+  }, [queryClient]);
+
+  const enableOnThisDevice = useCallback(async () => {
+    setIsPending(true);
+    try {
+      const result = await ensurePushDevice();
+      if (result.status === "ready") {
+        setEndpoint(result.endpoint);
+      }
+      setBlocked(result.status === "denied");
+      await refresh();
+    } finally {
+      setIsPending(false);
+    }
+  }, [refresh]);
+
+  const disableOnThisDevice = useCallback(async () => {
+    setIsPending(true);
+    try {
+      await removePushDevice();
+      setEndpoint(null);
+      await refresh();
+    } finally {
+      setIsPending(false);
+    }
+  }, [refresh]);
+
+  const disableEverywhere = useCallback(async () => {
+    setIsPending(true);
+    try {
+      // Drop the browser-side subscription too, not just the rows — otherwise
+      // the browser still holds a live endpoint we've forgotten about, and
+      // re-enabling later would look like nothing happened.
+      await removePushDevice().catch(() => {});
+      await disableAll.mutateAsync();
+      setEndpoint(null);
+      // Every bell in the app is now off.
+      await queryClient.invalidateQueries({ queryKey: ["push"] });
+    } finally {
+      setIsPending(false);
+    }
+  }, [disableAll, queryClient]);
+
+  return {
+    blocked,
+    capability,
+    deviceCount: status?.deviceCount ?? 0,
+    deviceRegistered: status?.deviceRegistered ?? false,
+    disableEverywhere,
+    disableOnThisDevice,
+    enableOnThisDevice,
+    isPending: isPending || disableAll.isPending,
+    topicCount: status?.topicCount ?? 0,
+  };
+}

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -5516,6 +5516,10 @@ msgstr ""
 msgid "Couldn't resolve that handle."
 msgstr "تعذّر حل هذا المُعرِّف."
 
+#: src/components/reader/notify-button.tsx
+msgid "That took too long"
+msgstr ""
+
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Good to know"
 msgstr ""
@@ -7351,6 +7355,10 @@ msgstr ""
 #: src/components/reader/text-selection-toolbar.tsx
 msgid "Save to Margin…"
 msgstr "الحفظ في Margin…"
+
+#: src/components/reader/notify-button.tsx
+msgid "Your browser didn’t finish setting up notifications. Reloading the page usually fixes it."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "{minutes} min"

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -2043,6 +2043,10 @@ msgstr "قد نحدّث هذه السياسة مع تطوّر الإضافة. و
 msgid "Your choices"
 msgstr "خياراتك"
 
+#: src/components/push-diagnostics.tsx
+msgid "Installed to Home Screen"
+msgstr ""
+
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
@@ -3440,6 +3444,10 @@ msgstr ""
 msgid "Reset filters"
 msgstr ""
 
+#: src/components/push-diagnostics.tsx
+msgid "Service worker"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Hide implemented"
 msgstr "إخفاء المنفَّذ"
@@ -4118,6 +4126,10 @@ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Subscribe and it starts appearing in your feeds like any other."
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -5507,6 +5519,10 @@ msgstr "تابِع الجديد"
 msgid "Show all feedback"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Troubleshooting"
+msgstr ""
+
 #. placeholder {0}: issue.label
 #: src/components/comic/comic-shelf.tsx
 msgid "Read {0}"
@@ -5778,6 +5794,10 @@ msgstr ""
 
 #: src/components/docs/labelers-docs-page.tsx
 msgid "Labels may apply to a document's <0>at://</0> URI or to an account DID. Account labels are shown on that account's author and publication pages and on every document it published, so a label about a publisher does not need to be re-emitted per post."
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Checking…"
 msgstr ""
 
 #: src/components/guide/pages/lists-guide-page.tsx
@@ -6243,6 +6263,10 @@ msgstr ""
 #: src/components/reader/reader-queue-rows.tsx
 msgid "Article unavailable"
 msgstr "المقالة غير متاحة"
+
+#: src/components/push-diagnostics.tsx
+msgid "Permission"
+msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Create will publish your review to ATStore."
@@ -7132,8 +7156,13 @@ msgstr "ابحث في اشتراكاتك"
 msgid "Standard Reader works the other way round. You sign in with a Bluesky account, and the things you do here — what you subscribe to, follow, save, recommend, and read — are written into your own account's storage, the same place your Bluesky posts live. We keep a copy so the app is fast, but the original is yours. Another app built on the same network can read it, and if you stop using Standard Reader, none of it disappears."
 msgstr ""
 
+#: src/components/push-diagnostics.tsx
 #: src/components/reader/use-subscriptions-tree.tsx
 msgid "Subscription"
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Last error"
 msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
@@ -7387,6 +7416,10 @@ msgstr ""
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "After that, following is one button. Anywhere you see a publication — a card in a feed, the top of an article, a publication's own page — there is a <0>Follow</0> button next to its name. Select it again to stop following. Nothing else changes: the button just decides whether new writing from that publication reaches your Home and Latest."
 #~ msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Support"
+msgstr ""
 
 #: src/components/reader/rss-feed-button.tsx
 msgid "Subscribe to {name} in any RSS reader — new articles show up there as soon as they publish."

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -62,6 +62,11 @@ msgstr "تعليم المنشورات القديمة كغير مقروءة"
 msgid "Something went wrong. Nothing was connected — try again."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+#: src/components/user-settings-view.tsx
+msgid "Notifications are blocked for this site. You can turn them back on in your browser settings."
+msgstr ""
+
 #: src/routes/_layout.u.$did.tsx
 msgid "{name} hasn't started reading or publishing here."
 msgstr "لم يبدأ {name} القراءة أو النشر هنا."
@@ -599,6 +604,10 @@ msgstr ""
 msgid "Text on accent"
 msgstr "النص على لون التمييز"
 
+#: src/components/user-settings-view.tsx
+msgid "Turn off"
+msgstr ""
+
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Finish reordering"
@@ -736,6 +745,10 @@ msgstr "اقرأ المقال ←"
 msgid "Playback speed: {0}"
 msgstr "سرعة التشغيل: {0}"
 
+#: src/components/user-settings-view.tsx
+msgid "How to enable"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "No posts yet"
 msgstr ""
@@ -829,6 +842,10 @@ msgstr "تشغيل عيّنة صوتية"
 
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "<0>Is the forwards-reading setting saved?</0> This is the one that is almost always the answer. Check it in your publishing tool, and note that it lives on the publication, not on individual posts."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Turn off everywhere"
 msgstr ""
 
 #: src/components/reader/subscribe-card.tsx
@@ -1117,6 +1134,10 @@ msgstr ""
 msgid "Take any of it as RSS"
 msgstr "احصل على أي منها عبر RSS"
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Got it"
+msgstr ""
+
 #: src/components/reader/subscriptions-sheet.tsx
 #~ msgid "Reorder lists"
 #~ msgstr "إعادة ترتيب القوائم"
@@ -1276,6 +1297,11 @@ msgstr ""
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "You don't have any subscriptions to reorder yet."
 #~ msgstr ""
+
+#: src/components/reader/notify-button.tsx
+#: src/components/user-settings-view.tsx
+msgid "This browser doesn’t support web notifications."
+msgstr ""
 
 #: src/components/guide/pages/welcome-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1594,6 +1620,10 @@ msgstr ""
 msgid "A collection is a record in your own account, the same as a follow or a save. If you stop using Standard Reader it does not disappear, and another app built on the same network can read it."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "Your notification setting didn’t save. Try again?"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #~ msgid "Home is the catch-up screen. It opens with the date and how much you have not read, leads with one featured article, and then lists what is new from the publications you follow."
 #~ msgstr ""
@@ -1691,6 +1721,10 @@ msgstr "تشغيل المثال"
 
 #: src/components/appearance-settings.tsx
 msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors."
+msgstr ""
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Tap Share in the Safari toolbar."
 msgstr ""
 
 #: src/lib/guide/navigation.ts
@@ -1937,6 +1971,10 @@ msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t available here"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -2543,6 +2581,10 @@ msgstr "استعلامات وإجراءات XRPC العامة لنموذج ال�
 msgid "Save theme"
 msgstr "حفظ السمة"
 
+#: src/components/reader/notify-button.tsx
+msgid "Notifications are blocked"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "A reply"
 msgstr ""
@@ -3015,6 +3057,10 @@ msgstr ""
 #~ msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
 #~ msgstr "بدّل إعدادًا واحدًا لتُفتح روابط المقالات على موقع المنشورة نفسها. اقرأ حيثما يناسبك."
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Add to your Home Screen"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Discover is the directory of every publication the network knows about — not a curated shelf. It runs top to bottom from most personal to most complete:"
 msgstr ""
@@ -3337,6 +3383,10 @@ msgstr ""
 msgid "See all trending"
 msgstr "عرض كل الرائج"
 
+#: src/components/reader/notify-button.tsx
+msgid "Notify me about new posts"
+msgstr ""
+
 #: src/components/onboarding/step-friends.tsx
 #~ msgid "All selected"
 #~ msgstr ""
@@ -3428,6 +3478,10 @@ msgstr "محفوظ"
 #: src/components/onboarding/step-intro.tsx
 msgid "{count, plural, one {{formattedCount} publication across the Atmosphere} other {{formattedCount} publications across the Atmosphere}}"
 msgstr "{count, plural, zero {لا توجد منشورات في Atmosphere} one {منشورة واحدة في Atmosphere} two {منشورتان في Atmosphere} few {{formattedCount} منشورات في Atmosphere} many {{formattedCount} منشورة في Atmosphere} other {{formattedCount} منشورة في Atmosphere}}"
+
+#: src/components/user-settings-view.tsx
+msgid "Notifications"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "the whole network as it publishes."
@@ -3886,6 +3940,10 @@ msgstr "تصفّح كل شيء"
 
 #: src/components/appearance-settings.tsx
 msgid "Large"
+msgstr ""
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Then open Standard Reader from your Home Screen and turn the bell on there."
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -4544,6 +4602,10 @@ msgstr ""
 msgid "The extension checks the address of the page you are on to work out whether there is anything to offer, and it acts on your account only when you click something. It does not read your browsing history or the contents of pages."
 msgstr ""
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "On iPhone and iPad, notifications only work once Standard Reader is installed. It takes two taps."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "You can sign out at any time, which clears your app session cookie. You can clear site cookies in your browser to remove theme and saved-handle preferences. You can change reading-history tracking and delete personal data from Settings. To remove other AT Protocol records you created through the app, use a compatible client or your repository tools."
 msgstr "يمكنك تسجيل الخروج في أي وقت، ما يمسح ملف تعريف ارتباط جلسة التطبيق. ويمكنك مسح ملفات تعريف الارتباط للموقع من متصفحك لإزالة تفضيلات السمة والمعرّف المحفوظ. كما يمكنك تغيير تتبع سجل القراءة وحذف بياناتك الشخصية من الإعدادات. ولإزالة سجلات AT Protocol الأخرى التي أنشأتها عبر التطبيق، استخدم عميلًا متوافقًا أو أدوات المستودع لديك."
@@ -4750,6 +4812,11 @@ msgstr ""
 msgid "Loading page…"
 msgstr ""
 
+#. placeholder {0}: push.topicCount
+#: src/components/user-settings-view.tsx
+msgid "On for this browser. You’ll hear about new posts from the {0} publications and authors you’ve turned the bell on for."
+msgstr ""
+
 #: src/routes/mcp/authorize.tsx
 msgid "This request can't be completed here, so we're returning you to the app that sent you."
 msgstr ""
@@ -4775,6 +4842,7 @@ msgstr ""
 msgid "Not in the directory yet?"
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
 msgstr "حدث خطأ ما"
@@ -4896,6 +4964,11 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "إعدادات الملف الشخصي"
+
+#. placeholder {0}: push.topicCount
+#: src/components/user-settings-view.tsx
+msgid "Stop notifications on every device and clear all {0} of the publications and authors you’ve turned the bell on for."
+msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -5189,6 +5262,10 @@ msgstr "ستُحذف كل سجلات القراءة من مستودعك، وست
 msgid "You’ve read everything from this publication."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "We couldn’t set up notifications on this device. Try again?"
+msgstr ""
+
 #: src/components/appearance-settings.tsx
 msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
@@ -5479,6 +5556,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Weekly digest email"
 msgstr "بريد الملخص الأسبوعي"
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Choose “Add to Home Screen”."
+msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6793,6 +6874,10 @@ msgid "What we collect"
 msgstr "ما نجمعه"
 
 #: src/components/user-settings-view.tsx
+msgid "On iPhone and iPad, notifications need Standard Reader installed on your Home Screen."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
 msgid "When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme."
 msgstr ""
 
@@ -7219,6 +7304,10 @@ msgstr "تصفية حسب الموضوع"
 msgid "Uploading {0}"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Notifications on this device"
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Reordering saved articles"
 msgstr ""
@@ -7245,6 +7334,10 @@ msgstr "إنشاء قائمة"
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Expand all lists"
 msgstr "توسيع كل القوائم"
+
+#: src/components/user-settings-view.tsx
+msgid "Get notified the moment a publication or author publishes something new. Turn it on here, then choose who from their page."
+msgstr ""
 
 #: src/components/reader/document-share-menu.tsx
 #: src/components/reader/text-selection-toolbar.tsx
@@ -7380,6 +7473,10 @@ msgstr "ملاحظات"
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Letting publications use their own colors"
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Turn off notifications"
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -1765,6 +1765,10 @@ msgstr "بحث سريع في النص الكامل"
 #~ msgid "Saving, recommending, reading history, and managing what you follow."
 #~ msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t available"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "اسم المجموعة"
@@ -6501,6 +6505,10 @@ msgstr "صوت القراءة الجهرية"
 
 #: src/routes/_layout.index.tsx
 msgid "Nothing left unread from the publications you follow. There's more on the network than you're following yet."
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t switched on for this site yet."
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -5516,6 +5516,10 @@ msgstr ""
 msgid "Couldn't resolve that handle."
 msgstr "Dieses Handle konnte nicht aufgelöst werden."
 
+#: src/components/reader/notify-button.tsx
+msgid "That took too long"
+msgstr ""
+
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Good to know"
 msgstr ""
@@ -7351,6 +7355,10 @@ msgstr ""
 #: src/components/reader/text-selection-toolbar.tsx
 msgid "Save to Margin…"
 msgstr "In Margin speichern…"
+
+#: src/components/reader/notify-button.tsx
+msgid "Your browser didn’t finish setting up notifications. Reloading the page usually fixes it."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "{minutes} min"

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -1765,6 +1765,10 @@ msgstr "Schnelle Volltextsuche"
 #~ msgid "Saving, recommending, reading history, and managing what you follow."
 #~ msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t available"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "Name der Sammlung"
@@ -6501,6 +6505,10 @@ msgstr "Stimme zum Vorlesen"
 
 #: src/routes/_layout.index.tsx
 msgid "Nothing left unread from the publications you follow. There's more on the network than you're following yet."
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t switched on for this site yet."
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -2043,6 +2043,10 @@ msgstr "Wir können diese Richtlinie ändern, wenn sich die Erweiterung ändert.
 msgid "Your choices"
 msgstr "Ihre Wahl"
 
+#: src/components/push-diagnostics.tsx
+msgid "Installed to Home Screen"
+msgstr ""
+
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
@@ -3440,6 +3444,10 @@ msgstr ""
 msgid "Reset filters"
 msgstr ""
 
+#: src/components/push-diagnostics.tsx
+msgid "Service worker"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Hide implemented"
 msgstr "Umgesetzte ausblenden"
@@ -4118,6 +4126,10 @@ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Subscribe and it starts appearing in your feeds like any other."
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -5507,6 +5519,10 @@ msgstr "Mitlesen"
 msgid "Show all feedback"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Troubleshooting"
+msgstr ""
+
 #. placeholder {0}: issue.label
 #: src/components/comic/comic-shelf.tsx
 msgid "Read {0}"
@@ -5778,6 +5794,10 @@ msgstr ""
 
 #: src/components/docs/labelers-docs-page.tsx
 msgid "Labels may apply to a document's <0>at://</0> URI or to an account DID. Account labels are shown on that account's author and publication pages and on every document it published, so a label about a publisher does not need to be re-emitted per post."
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Checking…"
 msgstr ""
 
 #: src/components/guide/pages/lists-guide-page.tsx
@@ -6243,6 +6263,10 @@ msgstr ""
 #: src/components/reader/reader-queue-rows.tsx
 msgid "Article unavailable"
 msgstr "Artikel nicht verfügbar"
+
+#: src/components/push-diagnostics.tsx
+msgid "Permission"
+msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Create will publish your review to ATStore."
@@ -7132,8 +7156,13 @@ msgstr "Ihre Abos durchsuchen"
 msgid "Standard Reader works the other way round. You sign in with a Bluesky account, and the things you do here — what you subscribe to, follow, save, recommend, and read — are written into your own account's storage, the same place your Bluesky posts live. We keep a copy so the app is fast, but the original is yours. Another app built on the same network can read it, and if you stop using Standard Reader, none of it disappears."
 msgstr ""
 
+#: src/components/push-diagnostics.tsx
 #: src/components/reader/use-subscriptions-tree.tsx
 msgid "Subscription"
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Last error"
 msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
@@ -7387,6 +7416,10 @@ msgstr ""
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "After that, following is one button. Anywhere you see a publication — a card in a feed, the top of an article, a publication's own page — there is a <0>Follow</0> button next to its name. Select it again to stop following. Nothing else changes: the button just decides whether new writing from that publication reaches your Home and Latest."
 #~ msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Support"
+msgstr ""
 
 #: src/components/reader/rss-feed-button.tsx
 msgid "Subscribe to {name} in any RSS reader — new articles show up there as soon as they publish."

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -62,6 +62,11 @@ msgstr "Alte Beiträge als ungelesen markieren"
 msgid "Something went wrong. Nothing was connected — try again."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+#: src/components/user-settings-view.tsx
+msgid "Notifications are blocked for this site. You can turn them back on in your browser settings."
+msgstr ""
+
 #: src/routes/_layout.u.$did.tsx
 msgid "{name} hasn't started reading or publishing here."
 msgstr "{name} hat hier noch nicht angefangen zu lesen oder zu veröffentlichen."
@@ -599,6 +604,10 @@ msgstr ""
 msgid "Text on accent"
 msgstr "Text auf Akzentfarbe"
 
+#: src/components/user-settings-view.tsx
+msgid "Turn off"
+msgstr ""
+
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Finish reordering"
@@ -736,6 +745,10 @@ msgstr "Zum Text →"
 msgid "Playback speed: {0}"
 msgstr "Geschwindigkeit: {0}"
 
+#: src/components/user-settings-view.tsx
+msgid "How to enable"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "No posts yet"
 msgstr ""
@@ -829,6 +842,10 @@ msgstr "Stimmprobe abspielen"
 
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "<0>Is the forwards-reading setting saved?</0> This is the one that is almost always the answer. Check it in your publishing tool, and note that it lives on the publication, not on individual posts."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Turn off everywhere"
 msgstr ""
 
 #: src/components/reader/subscribe-card.tsx
@@ -1117,6 +1134,10 @@ msgstr ""
 msgid "Take any of it as RSS"
 msgstr "Alles davon als RSS beziehen"
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Got it"
+msgstr ""
+
 #: src/components/reader/subscriptions-sheet.tsx
 #~ msgid "Reorder lists"
 #~ msgstr "Listen neu ordnen"
@@ -1276,6 +1297,11 @@ msgstr ""
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "You don't have any subscriptions to reorder yet."
 #~ msgstr ""
+
+#: src/components/reader/notify-button.tsx
+#: src/components/user-settings-view.tsx
+msgid "This browser doesn’t support web notifications."
+msgstr ""
 
 #: src/components/guide/pages/welcome-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1594,6 +1620,10 @@ msgstr ""
 msgid "A collection is a record in your own account, the same as a follow or a save. If you stop using Standard Reader it does not disappear, and another app built on the same network can read it."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "Your notification setting didn’t save. Try again?"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #~ msgid "Home is the catch-up screen. It opens with the date and how much you have not read, leads with one featured article, and then lists what is new from the publications you follow."
 #~ msgstr ""
@@ -1691,6 +1721,10 @@ msgstr "Beispiel ausführen"
 
 #: src/components/appearance-settings.tsx
 msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors."
+msgstr ""
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Tap Share in the Safari toolbar."
 msgstr ""
 
 #: src/lib/guide/navigation.ts
@@ -1937,6 +1971,10 @@ msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t available here"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -2543,6 +2581,10 @@ msgstr "Öffentliche XRPC-Queries und -Procedures für das indexierte Lesemodell
 msgid "Save theme"
 msgstr "Theme speichern"
 
+#: src/components/reader/notify-button.tsx
+msgid "Notifications are blocked"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "A reply"
 msgstr ""
@@ -3015,6 +3057,10 @@ msgstr ""
 #~ msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
 #~ msgstr "Eine Einstellung umlegen und Artikellinks öffnen stattdessen die Website der Publikation. Lesen Sie dort, wo es sich für Sie richtig anfühlt."
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Add to your Home Screen"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Discover is the directory of every publication the network knows about — not a curated shelf. It runs top to bottom from most personal to most complete:"
 msgstr ""
@@ -3337,6 +3383,10 @@ msgstr ""
 msgid "See all trending"
 msgstr "Alle Trends ansehen"
 
+#: src/components/reader/notify-button.tsx
+msgid "Notify me about new posts"
+msgstr ""
+
 #: src/components/onboarding/step-friends.tsx
 #~ msgid "All selected"
 #~ msgstr ""
@@ -3428,6 +3478,10 @@ msgstr "Gespeichert"
 #: src/components/onboarding/step-intro.tsx
 msgid "{count, plural, one {{formattedCount} publication across the Atmosphere} other {{formattedCount} publications across the Atmosphere}}"
 msgstr "{count, plural, one {{formattedCount} Publikation in der Atmosphere} other {{formattedCount} Publikationen in der Atmosphere}}"
+
+#: src/components/user-settings-view.tsx
+msgid "Notifications"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "the whole network as it publishes."
@@ -3886,6 +3940,10 @@ msgstr "Alles durchstöbern"
 
 #: src/components/appearance-settings.tsx
 msgid "Large"
+msgstr ""
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Then open Standard Reader from your Home Screen and turn the bell on there."
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -4544,6 +4602,10 @@ msgstr ""
 msgid "The extension checks the address of the page you are on to work out whether there is anything to offer, and it acts on your account only when you click something. It does not read your browsing history or the contents of pages."
 msgstr ""
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "On iPhone and iPad, notifications only work once Standard Reader is installed. It takes two taps."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "You can sign out at any time, which clears your app session cookie. You can clear site cookies in your browser to remove theme and saved-handle preferences. You can change reading-history tracking and delete personal data from Settings. To remove other AT Protocol records you created through the app, use a compatible client or your repository tools."
 msgstr "Sie können sich jederzeit abmelden, wodurch Ihr App-Sitzungscookie gelöscht wird. Site-Cookies können Sie im Browser löschen, um Theme- und gespeicherte Handle-Einstellungen zu entfernen. Die Erfassung des Leseverlaufs ändern und persönliche Daten löschen können Sie in den Einstellungen. Um andere AT-Protocol-Datensätze zu entfernen, die Sie über die App erstellt haben, nutzen Sie einen kompatiblen Client oder Ihre Repository-Tools."
@@ -4750,6 +4812,11 @@ msgstr ""
 msgid "Loading page…"
 msgstr ""
 
+#. placeholder {0}: push.topicCount
+#: src/components/user-settings-view.tsx
+msgid "On for this browser. You’ll hear about new posts from the {0} publications and authors you’ve turned the bell on for."
+msgstr ""
+
 #: src/routes/mcp/authorize.tsx
 msgid "This request can't be completed here, so we're returning you to the app that sent you."
 msgstr ""
@@ -4775,6 +4842,7 @@ msgstr ""
 msgid "Not in the directory yet?"
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
 msgstr "Etwas ist schiefgelaufen"
@@ -4896,6 +4964,11 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "Profileinstellungen"
+
+#. placeholder {0}: push.topicCount
+#: src/components/user-settings-view.tsx
+msgid "Stop notifications on every device and clear all {0} of the publications and authors you’ve turned the bell on for."
+msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -5189,6 +5262,10 @@ msgstr "Jeder Lese-Eintrag in Ihrem Repository wird entfernt. Artikel erscheinen
 msgid "You’ve read everything from this publication."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "We couldn’t set up notifications on this device. Try again?"
+msgstr ""
+
 #: src/components/appearance-settings.tsx
 msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
@@ -5479,6 +5556,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Weekly digest email"
 msgstr "Wöchentliche Digest-E-Mail"
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Choose “Add to Home Screen”."
+msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6793,6 +6874,10 @@ msgid "What we collect"
 msgstr "Was wir erheben"
 
 #: src/components/user-settings-view.tsx
+msgid "On iPhone and iPad, notifications need Standard Reader installed on your Home Screen."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
 msgid "When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme."
 msgstr ""
 
@@ -7219,6 +7304,10 @@ msgstr "Nach Thema filtern"
 msgid "Uploading {0}"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Notifications on this device"
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Reordering saved articles"
 msgstr ""
@@ -7245,6 +7334,10 @@ msgstr "Liste erstellen"
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Expand all lists"
 msgstr "Alle Listen ausklappen"
+
+#: src/components/user-settings-view.tsx
+msgid "Get notified the moment a publication or author publishes something new. Turn it on here, then choose who from their page."
+msgstr ""
 
 #: src/components/reader/document-share-menu.tsx
 #: src/components/reader/text-selection-toolbar.tsx
@@ -7380,6 +7473,10 @@ msgstr "Feedback"
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Letting publications use their own colors"
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Turn off notifications"
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -1765,6 +1765,10 @@ msgstr ""
 #~ msgid "Saving, recommending, reading history, and managing what you follow."
 #~ msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t available"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr ""
@@ -6501,6 +6505,10 @@ msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "Nothing left unread from the publications you follow. There's more on the network than you're following yet."
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t switched on for this site yet."
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -2043,6 +2043,10 @@ msgstr ""
 msgid "Your choices"
 msgstr ""
 
+#: src/components/push-diagnostics.tsx
+msgid "Installed to Home Screen"
+msgstr ""
+
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
@@ -3440,6 +3444,10 @@ msgstr ""
 msgid "Reset filters"
 msgstr ""
 
+#: src/components/push-diagnostics.tsx
+msgid "Service worker"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Hide implemented"
 msgstr ""
@@ -4118,6 +4126,10 @@ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Subscribe and it starts appearing in your feeds like any other."
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -5507,6 +5519,10 @@ msgstr ""
 msgid "Show all feedback"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Troubleshooting"
+msgstr ""
+
 #. placeholder {0}: issue.label
 #: src/components/comic/comic-shelf.tsx
 msgid "Read {0}"
@@ -5778,6 +5794,10 @@ msgstr ""
 
 #: src/components/docs/labelers-docs-page.tsx
 msgid "Labels may apply to a document's <0>at://</0> URI or to an account DID. Account labels are shown on that account's author and publication pages and on every document it published, so a label about a publisher does not need to be re-emitted per post."
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Checking…"
 msgstr ""
 
 #: src/components/guide/pages/lists-guide-page.tsx
@@ -6242,6 +6262,10 @@ msgstr ""
 
 #: src/components/reader/reader-queue-rows.tsx
 msgid "Article unavailable"
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Permission"
 msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
@@ -7132,8 +7156,13 @@ msgstr ""
 msgid "Standard Reader works the other way round. You sign in with a Bluesky account, and the things you do here — what you subscribe to, follow, save, recommend, and read — are written into your own account's storage, the same place your Bluesky posts live. We keep a copy so the app is fast, but the original is yours. Another app built on the same network can read it, and if you stop using Standard Reader, none of it disappears."
 msgstr ""
 
+#: src/components/push-diagnostics.tsx
 #: src/components/reader/use-subscriptions-tree.tsx
 msgid "Subscription"
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Last error"
 msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
@@ -7387,6 +7416,10 @@ msgstr ""
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "After that, following is one button. Anywhere you see a publication — a card in a feed, the top of an article, a publication's own page — there is a <0>Follow</0> button next to its name. Select it again to stop following. Nothing else changes: the button just decides whether new writing from that publication reaches your Home and Latest."
 #~ msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Support"
+msgstr ""
 
 #: src/components/reader/rss-feed-button.tsx
 msgid "Subscribe to {name} in any RSS reader — new articles show up there as soon as they publish."

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -62,6 +62,11 @@ msgstr ""
 msgid "Something went wrong. Nothing was connected — try again."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+#: src/components/user-settings-view.tsx
+msgid "Notifications are blocked for this site. You can turn them back on in your browser settings."
+msgstr ""
+
 #: src/routes/_layout.u.$did.tsx
 msgid "{name} hasn't started reading or publishing here."
 msgstr ""
@@ -599,6 +604,10 @@ msgstr ""
 msgid "Text on accent"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Turn off"
+msgstr ""
+
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Finish reordering"
@@ -736,6 +745,10 @@ msgstr ""
 msgid "Playback speed: {0}"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "How to enable"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "No posts yet"
 msgstr ""
@@ -829,6 +842,10 @@ msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "<0>Is the forwards-reading setting saved?</0> This is the one that is almost always the answer. Check it in your publishing tool, and note that it lives on the publication, not on individual posts."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Turn off everywhere"
 msgstr ""
 
 #: src/components/reader/subscribe-card.tsx
@@ -1117,6 +1134,10 @@ msgstr ""
 msgid "Take any of it as RSS"
 msgstr ""
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Got it"
+msgstr ""
+
 #: src/components/reader/subscriptions-sheet.tsx
 #~ msgid "Reorder lists"
 #~ msgstr ""
@@ -1276,6 +1297,11 @@ msgstr ""
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "You don't have any subscriptions to reorder yet."
 #~ msgstr ""
+
+#: src/components/reader/notify-button.tsx
+#: src/components/user-settings-view.tsx
+msgid "This browser doesn’t support web notifications."
+msgstr ""
 
 #: src/components/guide/pages/welcome-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1594,6 +1620,10 @@ msgstr ""
 msgid "A collection is a record in your own account, the same as a follow or a save. If you stop using Standard Reader it does not disappear, and another app built on the same network can read it."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "Your notification setting didn’t save. Try again?"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #~ msgid "Home is the catch-up screen. It opens with the date and how much you have not read, leads with one featured article, and then lists what is new from the publications you follow."
 #~ msgstr ""
@@ -1691,6 +1721,10 @@ msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors."
+msgstr ""
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Tap Share in the Safari toolbar."
 msgstr ""
 
 #: src/lib/guide/navigation.ts
@@ -1937,6 +1971,10 @@ msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t available here"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -2543,6 +2581,10 @@ msgstr ""
 msgid "Save theme"
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "Notifications are blocked"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "A reply"
 msgstr ""
@@ -3015,6 +3057,10 @@ msgstr ""
 #~ msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
 #~ msgstr ""
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Add to your Home Screen"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Discover is the directory of every publication the network knows about — not a curated shelf. It runs top to bottom from most personal to most complete:"
 msgstr ""
@@ -3337,6 +3383,10 @@ msgstr ""
 msgid "See all trending"
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "Notify me about new posts"
+msgstr ""
+
 #: src/components/onboarding/step-friends.tsx
 #~ msgid "All selected"
 #~ msgstr ""
@@ -3427,6 +3477,10 @@ msgstr ""
 
 #: src/components/onboarding/step-intro.tsx
 msgid "{count, plural, one {{formattedCount} publication across the Atmosphere} other {{formattedCount} publications across the Atmosphere}}"
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Notifications"
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -3886,6 +3940,10 @@ msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Large"
+msgstr ""
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Then open Standard Reader from your Home Screen and turn the bell on there."
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -4544,6 +4602,10 @@ msgstr ""
 msgid "The extension checks the address of the page you are on to work out whether there is anything to offer, and it acts on your account only when you click something. It does not read your browsing history or the contents of pages."
 msgstr ""
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "On iPhone and iPad, notifications only work once Standard Reader is installed. It takes two taps."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "You can sign out at any time, which clears your app session cookie. You can clear site cookies in your browser to remove theme and saved-handle preferences. You can change reading-history tracking and delete personal data from Settings. To remove other AT Protocol records you created through the app, use a compatible client or your repository tools."
 msgstr ""
@@ -4750,6 +4812,11 @@ msgstr ""
 msgid "Loading page…"
 msgstr ""
 
+#. placeholder {0}: push.topicCount
+#: src/components/user-settings-view.tsx
+msgid "On for this browser. You’ll hear about new posts from the {0} publications and authors you’ve turned the bell on for."
+msgstr ""
+
 #: src/routes/mcp/authorize.tsx
 msgid "This request can't be completed here, so we're returning you to the app that sent you."
 msgstr ""
@@ -4775,6 +4842,7 @@ msgstr ""
 msgid "Not in the directory yet?"
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
 msgstr ""
@@ -4895,6 +4963,11 @@ msgstr ""
 #: src/components/reader/profile-tabs-settings-modal.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
+msgstr ""
+
+#. placeholder {0}: push.topicCount
+#: src/components/user-settings-view.tsx
+msgid "Stop notifications on every device and clear all {0} of the publications and authors you’ve turned the bell on for."
 msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx
@@ -5189,6 +5262,10 @@ msgstr ""
 msgid "You’ve read everything from this publication."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "We couldn’t set up notifications on this device. Try again?"
+msgstr ""
+
 #: src/components/appearance-settings.tsx
 msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
@@ -5478,6 +5555,10 @@ msgstr ""
 #: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Weekly digest email"
+msgstr ""
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Choose “Add to Home Screen”."
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
@@ -6793,6 +6874,10 @@ msgid "What we collect"
 msgstr ""
 
 #: src/components/user-settings-view.tsx
+msgid "On iPhone and iPad, notifications need Standard Reader installed on your Home Screen."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
 msgid "When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme."
 msgstr ""
 
@@ -7219,6 +7304,10 @@ msgstr ""
 msgid "Uploading {0}"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Notifications on this device"
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Reordering saved articles"
 msgstr ""
@@ -7244,6 +7333,10 @@ msgstr ""
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Expand all lists"
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Get notified the moment a publication or author publishes something new. Turn it on here, then choose who from their page."
 msgstr ""
 
 #: src/components/reader/document-share-menu.tsx
@@ -7380,6 +7473,10 @@ msgstr ""
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Letting publications use their own colors"
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Turn off notifications"
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -5516,6 +5516,10 @@ msgstr ""
 msgid "Couldn't resolve that handle."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "That took too long"
+msgstr ""
+
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Good to know"
 msgstr ""
@@ -7350,6 +7354,10 @@ msgstr ""
 #: src/components/reader/document-share-menu.tsx
 #: src/components/reader/text-selection-toolbar.tsx
 msgid "Save to Margin…"
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Your browser didn’t finish setting up notifications. Reloading the page usually fixes it."
 msgstr ""
 
 #: src/components/reader/article-below-fold.tsx

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -2043,6 +2043,10 @@ msgstr "We may update this policy as the extension changes. The “Last updated�
 msgid "Your choices"
 msgstr "Your choices"
 
+#: src/components/push-diagnostics.tsx
+msgid "Installed to Home Screen"
+msgstr "Installed to Home Screen"
+
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr "Pick the package for your framework; all sit on the same core."
@@ -3440,6 +3444,10 @@ msgstr "This API is also served as a <0>Model Context Protocol</0> server at <1>
 msgid "Reset filters"
 msgstr "Reset filters"
 
+#: src/components/push-diagnostics.tsx
+msgid "Service worker"
+msgstr "Service worker"
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Hide implemented"
 msgstr "Hide implemented"
@@ -4119,6 +4127,10 @@ msgstr "Your recommendations are public, the same way a like on Bluesky is. They
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Subscribe and it starts appearing in your feeds like any other."
 msgstr "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Subscribe and it starts appearing in your feeds like any other."
+
+#: src/components/push-diagnostics.tsx
+msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
+msgstr "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "We couldn’t find that publication."
@@ -5507,6 +5519,10 @@ msgstr "Follow along"
 msgid "Show all feedback"
 msgstr "Show all feedback"
 
+#: src/components/user-settings-view.tsx
+msgid "Troubleshooting"
+msgstr "Troubleshooting"
+
 #. placeholder {0}: issue.label
 #: src/components/comic/comic-shelf.tsx
 msgid "Read {0}"
@@ -5779,6 +5795,10 @@ msgstr "People you follow"
 #: src/components/docs/labelers-docs-page.tsx
 msgid "Labels may apply to a document's <0>at://</0> URI or to an account DID. Account labels are shown on that account's author and publication pages and on every document it published, so a label about a publisher does not need to be re-emitted per post."
 msgstr "Labels may apply to a document's <0>at://</0> URI or to an account DID. Account labels are shown on that account's author and publication pages and on every document it published, so a label about a publisher does not need to be re-emitted per post."
+
+#: src/components/push-diagnostics.tsx
+msgid "Checking…"
+msgstr "Checking…"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "<0>Reorder subscriptions…</0> lets you drag your lists into the order you want, so the ones you read most sit at the top. Select <1>Finish reordering</1> when you are done."
@@ -6243,6 +6263,10 @@ msgstr "Nothing new from the people you follow"
 #: src/components/reader/reader-queue-rows.tsx
 msgid "Article unavailable"
 msgstr "Article unavailable"
+
+#: src/components/push-diagnostics.tsx
+msgid "Permission"
+msgstr "Permission"
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Create will publish your review to ATStore."
@@ -7132,9 +7156,14 @@ msgstr "Search your subscriptions"
 msgid "Standard Reader works the other way round. You sign in with a Bluesky account, and the things you do here — what you subscribe to, follow, save, recommend, and read — are written into your own account's storage, the same place your Bluesky posts live. We keep a copy so the app is fast, but the original is yours. Another app built on the same network can read it, and if you stop using Standard Reader, none of it disappears."
 msgstr "Standard Reader works the other way round. You sign in with a Bluesky account, and the things you do here — what you subscribe to, follow, save, recommend, and read — are written into your own account's storage, the same place your Bluesky posts live. We keep a copy so the app is fast, but the original is yours. Another app built on the same network can read it, and if you stop using Standard Reader, none of it disappears."
 
+#: src/components/push-diagnostics.tsx
 #: src/components/reader/use-subscriptions-tree.tsx
 msgid "Subscription"
 msgstr "Subscription"
+
+#: src/components/push-diagnostics.tsx
+msgid "Last error"
+msgstr "Last error"
 
 #: src/components/reader/collection-publication-editor.tsx
 msgid "Icon"
@@ -7387,6 +7416,10 @@ msgstr "That is a real response from the endpoint this page just called — no k
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "After that, following is one button. Anywhere you see a publication — a card in a feed, the top of an article, a publication's own page — there is a <0>Follow</0> button next to its name. Select it again to stop following. Nothing else changes: the button just decides whether new writing from that publication reaches your Home and Latest."
 #~ msgstr "After that, following is one button. Anywhere you see a publication — a card in a feed, the top of an article, a publication's own page — there is a <0>Follow</0> button next to its name. Select it again to stop following. Nothing else changes: the button just decides whether new writing from that publication reaches your Home and Latest."
+
+#: src/components/push-diagnostics.tsx
+msgid "Support"
+msgstr "Support"
 
 #: src/components/reader/rss-feed-button.tsx
 msgid "Subscribe to {name} in any RSS reader — new articles show up there as soon as they publish."

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -1765,6 +1765,10 @@ msgstr "Fast full-text search"
 #~ msgid "Saving, recommending, reading history, and managing what you follow."
 #~ msgstr "Saving, recommending, reading history, and managing what you follow."
 
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t available"
+msgstr "Notifications aren’t available"
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "Collection name"
@@ -6502,6 +6506,10 @@ msgstr "Listen aloud voice"
 #: src/routes/_layout.index.tsx
 msgid "Nothing left unread from the publications you follow. There's more on the network than you're following yet."
 msgstr "Nothing left unread from the publications you follow. There's more on the network than you're following yet."
+
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t switched on for this site yet."
+msgstr "Notifications aren’t switched on for this site yet."
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Filter and sort — {activeFilters, plural, one {# filter active} other {# filters active}}"

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -62,6 +62,11 @@ msgstr "Mark old posts as unread"
 msgid "Something went wrong. Nothing was connected — try again."
 msgstr "Something went wrong. Nothing was connected — try again."
 
+#: src/components/reader/notify-button.tsx
+#: src/components/user-settings-view.tsx
+msgid "Notifications are blocked for this site. You can turn them back on in your browser settings."
+msgstr "Notifications are blocked for this site. You can turn them back on in your browser settings."
+
 #: src/routes/_layout.u.$did.tsx
 msgid "{name} hasn't started reading or publishing here."
 msgstr "{name} hasn't started reading or publishing here."
@@ -599,6 +604,10 @@ msgstr "The settings page, showing sections for Appearance, Behavior, Feed, Side
 msgid "Text on accent"
 msgstr "Text on accent"
 
+#: src/components/user-settings-view.tsx
+msgid "Turn off"
+msgstr "Turn off"
+
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Finish reordering"
@@ -736,6 +745,10 @@ msgstr "Read the piece →"
 msgid "Playback speed: {0}"
 msgstr "Playback speed: {0}"
 
+#: src/components/user-settings-view.tsx
+msgid "How to enable"
+msgstr "How to enable"
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "No posts yet"
 msgstr "No posts yet"
@@ -830,6 +843,10 @@ msgstr "Play voice sample"
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "<0>Is the forwards-reading setting saved?</0> This is the one that is almost always the answer. Check it in your publishing tool, and note that it lives on the publication, not on individual posts."
 msgstr "<0>Is the forwards-reading setting saved?</0> This is the one that is almost always the answer. Check it in your publishing tool, and note that it lives on the publication, not on individual posts."
+
+#: src/components/user-settings-view.tsx
+msgid "Turn off everywhere"
+msgstr "Turn off everywhere"
 
 #: src/components/reader/subscribe-card.tsx
 msgid "You're subscribed"
@@ -1117,6 +1134,10 @@ msgstr "The Latest screen showing a row of filter tabs — Unread, Subscriptions
 msgid "Take any of it as RSS"
 msgstr "Take any of it as RSS"
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Got it"
+msgstr "Got it"
+
 #: src/components/reader/subscriptions-sheet.tsx
 #~ msgid "Reorder lists"
 #~ msgstr "Reorder lists"
@@ -1276,6 +1297,11 @@ msgstr "Browse the directory"
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "You don't have any subscriptions to reorder yet."
 #~ msgstr "You don't have any subscriptions to reorder yet."
+
+#: src/components/reader/notify-button.tsx
+#: src/components/user-settings-view.tsx
+msgid "This browser doesn’t support web notifications."
+msgstr "This browser doesn’t support web notifications."
 
 #: src/components/guide/pages/welcome-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1594,6 +1620,10 @@ msgstr "For a single article, the top bar's menu has <0>Open on publication</0> 
 msgid "A collection is a record in your own account, the same as a follow or a save. If you stop using Standard Reader it does not disappear, and another app built on the same network can read it."
 msgstr "A collection is a record in your own account, the same as a follow or a save. If you stop using Standard Reader it does not disappear, and another app built on the same network can read it."
 
+#: src/components/reader/notify-button.tsx
+msgid "Your notification setting didn’t save. Try again?"
+msgstr "Your notification setting didn’t save. Try again?"
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #~ msgid "Home is the catch-up screen. It opens with the date and how much you have not read, leads with one featured article, and then lists what is new from the publications you follow."
 #~ msgstr "Home is the catch-up screen. It opens with the date and how much you have not read, leads with one featured article, and then lists what is new from the publications you follow."
@@ -1692,6 +1722,10 @@ msgstr "Run example"
 #: src/components/appearance-settings.tsx
 msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors."
 msgstr "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors."
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Tap Share in the Safari toolbar."
+msgstr "Tap Share in the Safari toolbar."
 
 #: src/lib/guide/navigation.ts
 msgid "The reading view, listening to an article, and joining the conversation."
@@ -1938,6 +1972,10 @@ msgstr "Connect {0} to your account?"
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 msgstr "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
+
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t available here"
+msgstr "Notifications aren’t available here"
 
 #: src/components/reader/about-view.tsx
 #~ msgid "The reading experience"
@@ -2543,6 +2581,10 @@ msgstr "Public XRPC queries and procedures for the Standard Reader indexed read-
 msgid "Save theme"
 msgstr "Save theme"
 
+#: src/components/reader/notify-button.tsx
+msgid "Notifications are blocked"
+msgstr "Notifications are blocked"
+
 #: src/components/reader/about-view.tsx
 msgid "A reply"
 msgstr "A reply"
@@ -3015,6 +3057,10 @@ msgstr "Paper"
 #~ msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
 #~ msgstr "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Add to your Home Screen"
+msgstr "Add to your Home Screen"
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Discover is the directory of every publication the network knows about — not a curated shelf. It runs top to bottom from most personal to most complete:"
 msgstr "Discover is the directory of every publication the network knows about — not a curated shelf. It runs top to bottom from most personal to most complete:"
@@ -3337,6 +3383,10 @@ msgstr "Act on your behalf"
 msgid "See all trending"
 msgstr "See all trending"
 
+#: src/components/reader/notify-button.tsx
+msgid "Notify me about new posts"
+msgstr "Notify me about new posts"
+
 #: src/components/onboarding/step-friends.tsx
 #~ msgid "All selected"
 #~ msgstr "All selected"
@@ -3428,6 +3478,10 @@ msgstr "Saved"
 #: src/components/onboarding/step-intro.tsx
 msgid "{count, plural, one {{formattedCount} publication across the Atmosphere} other {{formattedCount} publications across the Atmosphere}}"
 msgstr "{count, plural, one {{formattedCount} publication across the Atmosphere} other {{formattedCount} publications across the Atmosphere}}"
+
+#: src/components/user-settings-view.tsx
+msgid "Notifications"
+msgstr "Notifications"
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "the whole network as it publishes."
@@ -3887,6 +3941,10 @@ msgstr "Browse everything"
 #: src/components/appearance-settings.tsx
 msgid "Large"
 msgstr "Large"
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Then open Standard Reader from your Home Screen and turn the bell on there."
+msgstr "Then open Standard Reader from your Home Screen and turn the bell on there."
 
 #: src/components/reader/about-view.tsx
 msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
@@ -4544,6 +4602,10 @@ msgstr "Lists in the sidebar"
 msgid "The extension checks the address of the page you are on to work out whether there is anything to offer, and it acts on your account only when you click something. It does not read your browsing history or the contents of pages."
 msgstr "The extension checks the address of the page you are on to work out whether there is anything to offer, and it acts on your account only when you click something. It does not read your browsing history or the contents of pages."
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "On iPhone and iPad, notifications only work once Standard Reader is installed. It takes two taps."
+msgstr "On iPhone and iPad, notifications only work once Standard Reader is installed. It takes two taps."
+
 #: src/components/reader/privacy-view.tsx
 msgid "You can sign out at any time, which clears your app session cookie. You can clear site cookies in your browser to remove theme and saved-handle preferences. You can change reading-history tracking and delete personal data from Settings. To remove other AT Protocol records you created through the app, use a compatible client or your repository tools."
 msgstr "You can sign out at any time, which clears your app session cookie. You can clear site cookies in your browser to remove theme and saved-handle preferences. You can change reading-history tracking and delete personal data from Settings. To remove other AT Protocol records you created through the app, use a compatible client or your repository tools."
@@ -4750,6 +4812,11 @@ msgstr "Assemble articles into a magazine edition others can read and follow."
 msgid "Loading page…"
 msgstr "Loading page…"
 
+#. placeholder {0}: push.topicCount
+#: src/components/user-settings-view.tsx
+msgid "On for this browser. You’ll hear about new posts from the {0} publications and authors you’ve turned the bell on for."
+msgstr "On for this browser. You’ll hear about new posts from the {0} publications and authors you’ve turned the bell on for."
+
 #: src/routes/mcp/authorize.tsx
 msgid "This request can't be completed here, so we're returning you to the app that sent you."
 msgstr "This request can't be completed here, so we're returning you to the app that sent you."
@@ -4775,6 +4842,7 @@ msgstr "{totalPeople, plural, one {# person you follow writes here} other {# peo
 msgid "Not in the directory yet?"
 msgstr "Not in the directory yet?"
 
+#: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
 msgstr "Something went wrong"
@@ -4896,6 +4964,11 @@ msgstr "Use the <0>at:</0> meta tags — the convention the Atmosphere settled o
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "Profile settings"
+
+#. placeholder {0}: push.topicCount
+#: src/components/user-settings-view.tsx
+msgid "Stop notifications on every device and clear all {0} of the publications and authors you’ve turned the bell on for."
+msgstr "Stop notifications on every device and clear all {0} of the publications and authors you’ve turned the bell on for."
 
 #: src/components/guide/pages/comics-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -5189,6 +5262,10 @@ msgstr "Every read record in your repository will be removed. Articles will appe
 msgid "You’ve read everything from this publication."
 msgstr "You’ve read everything from this publication."
 
+#: src/components/reader/notify-button.tsx
+msgid "We couldn’t set up notifications on this device. Try again?"
+msgstr "We couldn’t set up notifications on this device. Try again?"
+
 #: src/components/appearance-settings.tsx
 msgid "Text, borders and every other step are derived from these two colors."
 msgstr "Text, borders and every other step are derived from these two colors."
@@ -5479,6 +5556,10 @@ msgstr "Listen from here"
 #: src/components/user-settings-view.tsx
 msgid "Weekly digest email"
 msgstr "Weekly digest email"
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Choose “Add to Home Screen”."
+msgstr "Choose “Add to Home Screen”."
 
 #: src/components/guide/pages/extension-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6793,6 +6874,10 @@ msgid "What we collect"
 msgstr "What we collect"
 
 #: src/components/user-settings-view.tsx
+msgid "On iPhone and iPad, notifications need Standard Reader installed on your Home Screen."
+msgstr "On iPhone and iPad, notifications need Standard Reader installed on your Home Screen."
+
+#: src/components/user-settings-view.tsx
 msgid "When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme."
 msgstr "When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme."
 
@@ -7219,6 +7304,10 @@ msgstr "Filter by topic"
 msgid "Uploading {0}"
 msgstr "Uploading {0}"
 
+#: src/components/user-settings-view.tsx
+msgid "Notifications on this device"
+msgstr "Notifications on this device"
+
 #: src/routes/_layout.saved.tsx
 msgid "Reordering saved articles"
 msgstr "Reordering saved articles"
@@ -7245,6 +7334,10 @@ msgstr "Create list"
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Expand all lists"
 msgstr "Expand all lists"
+
+#: src/components/user-settings-view.tsx
+msgid "Get notified the moment a publication or author publishes something new. Turn it on here, then choose who from their page."
+msgstr "Get notified the moment a publication or author publishes something new. Turn it on here, then choose who from their page."
 
 #: src/components/reader/document-share-menu.tsx
 #: src/components/reader/text-selection-toolbar.tsx
@@ -7381,6 +7474,10 @@ msgstr "Feedback"
 #: src/lib/guide/navigation.ts
 msgid "Letting publications use their own colors"
 msgstr "Letting publications use their own colors"
+
+#: src/components/reader/notify-button.tsx
+msgid "Turn off notifications"
+msgstr "Turn off notifications"
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "List views"

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -5516,6 +5516,10 @@ msgstr "Read {0}"
 msgid "Couldn't resolve that handle."
 msgstr "Couldn't resolve that handle."
 
+#: src/components/reader/notify-button.tsx
+msgid "That took too long"
+msgstr "That took too long"
+
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Good to know"
 msgstr "Good to know"
@@ -7351,6 +7355,10 @@ msgstr "Get notified the moment a publication or author publishes something new.
 #: src/components/reader/text-selection-toolbar.tsx
 msgid "Save to Margin…"
 msgstr "Save to Margin…"
+
+#: src/components/reader/notify-button.tsx
+msgid "Your browser didn’t finish setting up notifications. Reloading the page usually fixes it."
+msgstr "Your browser didn’t finish setting up notifications. Reloading the page usually fixes it."
 
 #: src/components/reader/article-below-fold.tsx
 msgid "{minutes} min"

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -2043,6 +2043,10 @@ msgstr "Podemos actualizar esta política a medida que cambie la extensión. La 
 msgid "Your choices"
 msgstr "Sus opciones"
 
+#: src/components/push-diagnostics.tsx
+msgid "Installed to Home Screen"
+msgstr ""
+
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
@@ -3440,6 +3444,10 @@ msgstr ""
 msgid "Reset filters"
 msgstr ""
 
+#: src/components/push-diagnostics.tsx
+msgid "Service worker"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Hide implemented"
 msgstr "Ocultar implementadas"
@@ -4118,6 +4126,10 @@ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Subscribe and it starts appearing in your feeds like any other."
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -5507,6 +5519,10 @@ msgstr "Seguir la lectura"
 msgid "Show all feedback"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Troubleshooting"
+msgstr ""
+
 #. placeholder {0}: issue.label
 #: src/components/comic/comic-shelf.tsx
 msgid "Read {0}"
@@ -5778,6 +5794,10 @@ msgstr ""
 
 #: src/components/docs/labelers-docs-page.tsx
 msgid "Labels may apply to a document's <0>at://</0> URI or to an account DID. Account labels are shown on that account's author and publication pages and on every document it published, so a label about a publisher does not need to be re-emitted per post."
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Checking…"
 msgstr ""
 
 #: src/components/guide/pages/lists-guide-page.tsx
@@ -6243,6 +6263,10 @@ msgstr ""
 #: src/components/reader/reader-queue-rows.tsx
 msgid "Article unavailable"
 msgstr "Artículo no disponible"
+
+#: src/components/push-diagnostics.tsx
+msgid "Permission"
+msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Create will publish your review to ATStore."
@@ -7132,8 +7156,13 @@ msgstr "Buscar en sus suscripciones"
 msgid "Standard Reader works the other way round. You sign in with a Bluesky account, and the things you do here — what you subscribe to, follow, save, recommend, and read — are written into your own account's storage, the same place your Bluesky posts live. We keep a copy so the app is fast, but the original is yours. Another app built on the same network can read it, and if you stop using Standard Reader, none of it disappears."
 msgstr ""
 
+#: src/components/push-diagnostics.tsx
 #: src/components/reader/use-subscriptions-tree.tsx
 msgid "Subscription"
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Last error"
 msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
@@ -7387,6 +7416,10 @@ msgstr ""
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "After that, following is one button. Anywhere you see a publication — a card in a feed, the top of an article, a publication's own page — there is a <0>Follow</0> button next to its name. Select it again to stop following. Nothing else changes: the button just decides whether new writing from that publication reaches your Home and Latest."
 #~ msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Support"
+msgstr ""
 
 #: src/components/reader/rss-feed-button.tsx
 msgid "Subscribe to {name} in any RSS reader — new articles show up there as soon as they publish."

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -1765,6 +1765,10 @@ msgstr "Búsqueda rápida de texto completo"
 #~ msgid "Saving, recommending, reading history, and managing what you follow."
 #~ msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t available"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "Nombre de la colección"
@@ -6501,6 +6505,10 @@ msgstr "Voz de lectura en voz alta"
 
 #: src/routes/_layout.index.tsx
 msgid "Nothing left unread from the publications you follow. There's more on the network than you're following yet."
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t switched on for this site yet."
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -5516,6 +5516,10 @@ msgstr ""
 msgid "Couldn't resolve that handle."
 msgstr "No se pudo resolver ese handle."
 
+#: src/components/reader/notify-button.tsx
+msgid "That took too long"
+msgstr ""
+
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Good to know"
 msgstr ""
@@ -7351,6 +7355,10 @@ msgstr ""
 #: src/components/reader/text-selection-toolbar.tsx
 msgid "Save to Margin…"
 msgstr "Guardar en Margin…"
+
+#: src/components/reader/notify-button.tsx
+msgid "Your browser didn’t finish setting up notifications. Reloading the page usually fixes it."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "{minutes} min"

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -62,6 +62,11 @@ msgstr "Marcar los posts antiguos como sin leer"
 msgid "Something went wrong. Nothing was connected — try again."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+#: src/components/user-settings-view.tsx
+msgid "Notifications are blocked for this site. You can turn them back on in your browser settings."
+msgstr ""
+
 #: src/routes/_layout.u.$did.tsx
 msgid "{name} hasn't started reading or publishing here."
 msgstr "{name} aún no ha empezado a leer ni a publicar aquí."
@@ -599,6 +604,10 @@ msgstr ""
 msgid "Text on accent"
 msgstr "Texto sobre el acento"
 
+#: src/components/user-settings-view.tsx
+msgid "Turn off"
+msgstr ""
+
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Finish reordering"
@@ -736,6 +745,10 @@ msgstr "Leer la pieza →"
 msgid "Playback speed: {0}"
 msgstr "Velocidad de reproducción: {0}"
 
+#: src/components/user-settings-view.tsx
+msgid "How to enable"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "No posts yet"
 msgstr ""
@@ -829,6 +842,10 @@ msgstr "Reproducir muestra de voz"
 
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "<0>Is the forwards-reading setting saved?</0> This is the one that is almost always the answer. Check it in your publishing tool, and note that it lives on the publication, not on individual posts."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Turn off everywhere"
 msgstr ""
 
 #: src/components/reader/subscribe-card.tsx
@@ -1117,6 +1134,10 @@ msgstr ""
 msgid "Take any of it as RSS"
 msgstr "Llévese cualquier parte como RSS"
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Got it"
+msgstr ""
+
 #: src/components/reader/subscriptions-sheet.tsx
 #~ msgid "Reorder lists"
 #~ msgstr "Reordenar listas"
@@ -1276,6 +1297,11 @@ msgstr ""
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "You don't have any subscriptions to reorder yet."
 #~ msgstr ""
+
+#: src/components/reader/notify-button.tsx
+#: src/components/user-settings-view.tsx
+msgid "This browser doesn’t support web notifications."
+msgstr ""
 
 #: src/components/guide/pages/welcome-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1594,6 +1620,10 @@ msgstr ""
 msgid "A collection is a record in your own account, the same as a follow or a save. If you stop using Standard Reader it does not disappear, and another app built on the same network can read it."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "Your notification setting didn’t save. Try again?"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #~ msgid "Home is the catch-up screen. It opens with the date and how much you have not read, leads with one featured article, and then lists what is new from the publications you follow."
 #~ msgstr ""
@@ -1691,6 +1721,10 @@ msgstr "Ejecutar ejemplo"
 
 #: src/components/appearance-settings.tsx
 msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors."
+msgstr ""
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Tap Share in the Safari toolbar."
 msgstr ""
 
 #: src/lib/guide/navigation.ts
@@ -1937,6 +1971,10 @@ msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t available here"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -2543,6 +2581,10 @@ msgstr "Consultas y procedimientos XRPC públicos para el modelo de lectura inde
 msgid "Save theme"
 msgstr "Guardar tema"
 
+#: src/components/reader/notify-button.tsx
+msgid "Notifications are blocked"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "A reply"
 msgstr ""
@@ -3015,6 +3057,10 @@ msgstr ""
 #~ msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
 #~ msgstr "Cambie un ajuste y los enlaces de los artículos se abrirán en el sitio propio de la publicación. Lea donde mejor le funcione."
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Add to your Home Screen"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Discover is the directory of every publication the network knows about — not a curated shelf. It runs top to bottom from most personal to most complete:"
 msgstr ""
@@ -3337,6 +3383,10 @@ msgstr ""
 msgid "See all trending"
 msgstr "Ver todas las tendencias"
 
+#: src/components/reader/notify-button.tsx
+msgid "Notify me about new posts"
+msgstr ""
+
 #: src/components/onboarding/step-friends.tsx
 #~ msgid "All selected"
 #~ msgstr ""
@@ -3428,6 +3478,10 @@ msgstr "Guardado"
 #: src/components/onboarding/step-intro.tsx
 msgid "{count, plural, one {{formattedCount} publication across the Atmosphere} other {{formattedCount} publications across the Atmosphere}}"
 msgstr "{count, plural, one {{formattedCount} publicación en la Atmosphere} other {{formattedCount} publicaciones en la Atmosphere}}"
+
+#: src/components/user-settings-view.tsx
+msgid "Notifications"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "the whole network as it publishes."
@@ -3886,6 +3940,10 @@ msgstr "Explorar todo"
 
 #: src/components/appearance-settings.tsx
 msgid "Large"
+msgstr ""
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Then open Standard Reader from your Home Screen and turn the bell on there."
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -4544,6 +4602,10 @@ msgstr ""
 msgid "The extension checks the address of the page you are on to work out whether there is anything to offer, and it acts on your account only when you click something. It does not read your browsing history or the contents of pages."
 msgstr ""
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "On iPhone and iPad, notifications only work once Standard Reader is installed. It takes two taps."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "You can sign out at any time, which clears your app session cookie. You can clear site cookies in your browser to remove theme and saved-handle preferences. You can change reading-history tracking and delete personal data from Settings. To remove other AT Protocol records you created through the app, use a compatible client or your repository tools."
 msgstr "Puede cerrar sesión en cualquier momento, lo que borra la cookie de sesión de la app. Puede borrar las cookies del sitio en su navegador para eliminar las preferencias de tema y de identificador guardado. Puede cambiar el registro del historial de lectura y eliminar sus datos personales desde Configuración. Para eliminar otros registros de AT Protocol creados a través de la app, use un cliente compatible o las herramientas de su repositorio."
@@ -4750,6 +4812,11 @@ msgstr ""
 msgid "Loading page…"
 msgstr ""
 
+#. placeholder {0}: push.topicCount
+#: src/components/user-settings-view.tsx
+msgid "On for this browser. You’ll hear about new posts from the {0} publications and authors you’ve turned the bell on for."
+msgstr ""
+
 #: src/routes/mcp/authorize.tsx
 msgid "This request can't be completed here, so we're returning you to the app that sent you."
 msgstr ""
@@ -4775,6 +4842,7 @@ msgstr ""
 msgid "Not in the directory yet?"
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
 msgstr "Algo salió mal"
@@ -4896,6 +4964,11 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "Ajustes del perfil"
+
+#. placeholder {0}: push.topicCount
+#: src/components/user-settings-view.tsx
+msgid "Stop notifications on every device and clear all {0} of the publications and authors you’ve turned the bell on for."
+msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -5189,6 +5262,10 @@ msgstr "Se eliminarán todos los registros de lectura de su repositorio. Los art
 msgid "You’ve read everything from this publication."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "We couldn’t set up notifications on this device. Try again?"
+msgstr ""
+
 #: src/components/appearance-settings.tsx
 msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
@@ -5479,6 +5556,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Weekly digest email"
 msgstr "Correo del resumen semanal"
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Choose “Add to Home Screen”."
+msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6793,6 +6874,10 @@ msgid "What we collect"
 msgstr "Qué recopilamos"
 
 #: src/components/user-settings-view.tsx
+msgid "On iPhone and iPad, notifications need Standard Reader installed on your Home Screen."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
 msgid "When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme."
 msgstr ""
 
@@ -7219,6 +7304,10 @@ msgstr "Filtrar por tema"
 msgid "Uploading {0}"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Notifications on this device"
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Reordering saved articles"
 msgstr ""
@@ -7245,6 +7334,10 @@ msgstr "Crear lista"
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Expand all lists"
 msgstr "Expandir todas las listas"
+
+#: src/components/user-settings-view.tsx
+msgid "Get notified the moment a publication or author publishes something new. Turn it on here, then choose who from their page."
+msgstr ""
 
 #: src/components/reader/document-share-menu.tsx
 #: src/components/reader/text-selection-toolbar.tsx
@@ -7380,6 +7473,10 @@ msgstr "Comentarios"
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Letting publications use their own colors"
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Turn off notifications"
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -1765,6 +1765,10 @@ msgstr "Recherche plein texte rapide"
 #~ msgid "Saving, recommending, reading history, and managing what you follow."
 #~ msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t available"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "Nom de la collection"
@@ -6501,6 +6505,10 @@ msgstr "Voix de la lecture à voix haute"
 
 #: src/routes/_layout.index.tsx
 msgid "Nothing left unread from the publications you follow. There's more on the network than you're following yet."
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t switched on for this site yet."
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -2043,6 +2043,10 @@ msgstr "Nous pouvons faire évoluer cette politique à mesure que l'extension ch
 msgid "Your choices"
 msgstr "Vos choix"
 
+#: src/components/push-diagnostics.tsx
+msgid "Installed to Home Screen"
+msgstr ""
+
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
@@ -3440,6 +3444,10 @@ msgstr ""
 msgid "Reset filters"
 msgstr ""
 
+#: src/components/push-diagnostics.tsx
+msgid "Service worker"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Hide implemented"
 msgstr "Masquer les éléments implémentés"
@@ -4118,6 +4126,10 @@ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Subscribe and it starts appearing in your feeds like any other."
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -5507,6 +5519,10 @@ msgstr "Suivre le fil"
 msgid "Show all feedback"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Troubleshooting"
+msgstr ""
+
 #. placeholder {0}: issue.label
 #: src/components/comic/comic-shelf.tsx
 msgid "Read {0}"
@@ -5778,6 +5794,10 @@ msgstr ""
 
 #: src/components/docs/labelers-docs-page.tsx
 msgid "Labels may apply to a document's <0>at://</0> URI or to an account DID. Account labels are shown on that account's author and publication pages and on every document it published, so a label about a publisher does not need to be re-emitted per post."
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Checking…"
 msgstr ""
 
 #: src/components/guide/pages/lists-guide-page.tsx
@@ -6243,6 +6263,10 @@ msgstr ""
 #: src/components/reader/reader-queue-rows.tsx
 msgid "Article unavailable"
 msgstr "Article indisponible"
+
+#: src/components/push-diagnostics.tsx
+msgid "Permission"
+msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Create will publish your review to ATStore."
@@ -7132,8 +7156,13 @@ msgstr "Rechercher dans vos abonnements"
 msgid "Standard Reader works the other way round. You sign in with a Bluesky account, and the things you do here — what you subscribe to, follow, save, recommend, and read — are written into your own account's storage, the same place your Bluesky posts live. We keep a copy so the app is fast, but the original is yours. Another app built on the same network can read it, and if you stop using Standard Reader, none of it disappears."
 msgstr ""
 
+#: src/components/push-diagnostics.tsx
 #: src/components/reader/use-subscriptions-tree.tsx
 msgid "Subscription"
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Last error"
 msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
@@ -7387,6 +7416,10 @@ msgstr ""
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "After that, following is one button. Anywhere you see a publication — a card in a feed, the top of an article, a publication's own page — there is a <0>Follow</0> button next to its name. Select it again to stop following. Nothing else changes: the button just decides whether new writing from that publication reaches your Home and Latest."
 #~ msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Support"
+msgstr ""
 
 #: src/components/reader/rss-feed-button.tsx
 msgid "Subscribe to {name} in any RSS reader — new articles show up there as soon as they publish."

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -62,6 +62,11 @@ msgstr "Marquer les anciens articles comme non lus"
 msgid "Something went wrong. Nothing was connected — try again."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+#: src/components/user-settings-view.tsx
+msgid "Notifications are blocked for this site. You can turn them back on in your browser settings."
+msgstr ""
+
 #: src/routes/_layout.u.$did.tsx
 msgid "{name} hasn't started reading or publishing here."
 msgstr "{name} n’a pas encore commencé à lire ou à publier ici."
@@ -599,6 +604,10 @@ msgstr ""
 msgid "Text on accent"
 msgstr "Texte sur la couleur d’accent"
 
+#: src/components/user-settings-view.tsx
+msgid "Turn off"
+msgstr ""
+
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Finish reordering"
@@ -736,6 +745,10 @@ msgstr "Lire le texte →"
 msgid "Playback speed: {0}"
 msgstr "Vitesse de lecture : {0}"
 
+#: src/components/user-settings-view.tsx
+msgid "How to enable"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "No posts yet"
 msgstr ""
@@ -829,6 +842,10 @@ msgstr "Écouter un extrait de la voix"
 
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "<0>Is the forwards-reading setting saved?</0> This is the one that is almost always the answer. Check it in your publishing tool, and note that it lives on the publication, not on individual posts."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Turn off everywhere"
 msgstr ""
 
 #: src/components/reader/subscribe-card.tsx
@@ -1117,6 +1134,10 @@ msgstr ""
 msgid "Take any of it as RSS"
 msgstr "Récupérez tout cela en RSS"
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Got it"
+msgstr ""
+
 #: src/components/reader/subscriptions-sheet.tsx
 #~ msgid "Reorder lists"
 #~ msgstr "Réorganiser les listes"
@@ -1276,6 +1297,11 @@ msgstr ""
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "You don't have any subscriptions to reorder yet."
 #~ msgstr ""
+
+#: src/components/reader/notify-button.tsx
+#: src/components/user-settings-view.tsx
+msgid "This browser doesn’t support web notifications."
+msgstr ""
 
 #: src/components/guide/pages/welcome-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1594,6 +1620,10 @@ msgstr ""
 msgid "A collection is a record in your own account, the same as a follow or a save. If you stop using Standard Reader it does not disappear, and another app built on the same network can read it."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "Your notification setting didn’t save. Try again?"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #~ msgid "Home is the catch-up screen. It opens with the date and how much you have not read, leads with one featured article, and then lists what is new from the publications you follow."
 #~ msgstr ""
@@ -1691,6 +1721,10 @@ msgstr "Lancer l'exemple"
 
 #: src/components/appearance-settings.tsx
 msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors."
+msgstr ""
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Tap Share in the Safari toolbar."
 msgstr ""
 
 #: src/lib/guide/navigation.ts
@@ -1937,6 +1971,10 @@ msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t available here"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -2543,6 +2581,10 @@ msgstr "Requêtes et procédures XRPC publiques du modèle de lecture indexé de
 msgid "Save theme"
 msgstr "Enregistrer le thème"
 
+#: src/components/reader/notify-button.tsx
+msgid "Notifications are blocked"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "A reply"
 msgstr ""
@@ -3015,6 +3057,10 @@ msgstr ""
 #~ msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
 #~ msgstr "Modifiez un seul réglage et les liens des articles s'ouvriront sur le site de la publication elle-même. Lisez là où vous vous sentez bien."
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Add to your Home Screen"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Discover is the directory of every publication the network knows about — not a curated shelf. It runs top to bottom from most personal to most complete:"
 msgstr ""
@@ -3337,6 +3383,10 @@ msgstr ""
 msgid "See all trending"
 msgstr "Voir toutes les tendances"
 
+#: src/components/reader/notify-button.tsx
+msgid "Notify me about new posts"
+msgstr ""
+
 #: src/components/onboarding/step-friends.tsx
 #~ msgid "All selected"
 #~ msgstr ""
@@ -3428,6 +3478,10 @@ msgstr "Enregistré"
 #: src/components/onboarding/step-intro.tsx
 msgid "{count, plural, one {{formattedCount} publication across the Atmosphere} other {{formattedCount} publications across the Atmosphere}}"
 msgstr "{count, plural, one {{formattedCount} publication dans l’Atmosphere} other {{formattedCount} publications dans l’Atmosphere}}"
+
+#: src/components/user-settings-view.tsx
+msgid "Notifications"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "the whole network as it publishes."
@@ -3886,6 +3940,10 @@ msgstr "Tout parcourir"
 
 #: src/components/appearance-settings.tsx
 msgid "Large"
+msgstr ""
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Then open Standard Reader from your Home Screen and turn the bell on there."
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -4544,6 +4602,10 @@ msgstr ""
 msgid "The extension checks the address of the page you are on to work out whether there is anything to offer, and it acts on your account only when you click something. It does not read your browsing history or the contents of pages."
 msgstr ""
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "On iPhone and iPad, notifications only work once Standard Reader is installed. It takes two taps."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "You can sign out at any time, which clears your app session cookie. You can clear site cookies in your browser to remove theme and saved-handle preferences. You can change reading-history tracking and delete personal data from Settings. To remove other AT Protocol records you created through the app, use a compatible client or your repository tools."
 msgstr "Vous pouvez vous déconnecter à tout moment, ce qui efface le cookie de session de l’application. Vous pouvez effacer les cookies du site dans votre navigateur pour supprimer les préférences de thème et l’identifiant enregistré. Vous pouvez modifier le suivi de l’historique de lecture et supprimer vos données personnelles depuis les réglages. Pour supprimer les autres enregistrements AT Protocol créés via l’application, utilisez un client compatible ou les outils de votre dépôt."
@@ -4750,6 +4812,11 @@ msgstr ""
 msgid "Loading page…"
 msgstr ""
 
+#. placeholder {0}: push.topicCount
+#: src/components/user-settings-view.tsx
+msgid "On for this browser. You’ll hear about new posts from the {0} publications and authors you’ve turned the bell on for."
+msgstr ""
+
 #: src/routes/mcp/authorize.tsx
 msgid "This request can't be completed here, so we're returning you to the app that sent you."
 msgstr ""
@@ -4775,6 +4842,7 @@ msgstr ""
 msgid "Not in the directory yet?"
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
 msgstr "Une erreur s’est produite"
@@ -4896,6 +4964,11 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "Paramètres du profil"
+
+#. placeholder {0}: push.topicCount
+#: src/components/user-settings-view.tsx
+msgid "Stop notifications on every device and clear all {0} of the publications and authors you’ve turned the bell on for."
+msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -5189,6 +5262,10 @@ msgstr "Chaque enregistrement de lecture de votre dépôt sera supprimé. Les ar
 msgid "You’ve read everything from this publication."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "We couldn’t set up notifications on this device. Try again?"
+msgstr ""
+
 #: src/components/appearance-settings.tsx
 msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
@@ -5479,6 +5556,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Weekly digest email"
 msgstr "E-mail du condensé hebdomadaire"
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Choose “Add to Home Screen”."
+msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6793,6 +6874,10 @@ msgid "What we collect"
 msgstr "Ce que nous collectons"
 
 #: src/components/user-settings-view.tsx
+msgid "On iPhone and iPad, notifications need Standard Reader installed on your Home Screen."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
 msgid "When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme."
 msgstr ""
 
@@ -7219,6 +7304,10 @@ msgstr "Filtrer par sujet"
 msgid "Uploading {0}"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Notifications on this device"
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Reordering saved articles"
 msgstr ""
@@ -7245,6 +7334,10 @@ msgstr "Créer une liste"
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Expand all lists"
 msgstr "Développer toutes les listes"
+
+#: src/components/user-settings-view.tsx
+msgid "Get notified the moment a publication or author publishes something new. Turn it on here, then choose who from their page."
+msgstr ""
 
 #: src/components/reader/document-share-menu.tsx
 #: src/components/reader/text-selection-toolbar.tsx
@@ -7380,6 +7473,10 @@ msgstr "Commentaires"
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Letting publications use their own colors"
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Turn off notifications"
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -5516,6 +5516,10 @@ msgstr ""
 msgid "Couldn't resolve that handle."
 msgstr "Impossible de résoudre cet identifiant."
 
+#: src/components/reader/notify-button.tsx
+msgid "That took too long"
+msgstr ""
+
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Good to know"
 msgstr ""
@@ -7351,6 +7355,10 @@ msgstr ""
 #: src/components/reader/text-selection-toolbar.tsx
 msgid "Save to Margin…"
 msgstr "Enregistrer dans Margin…"
+
+#: src/components/reader/notify-button.tsx
+msgid "Your browser didn’t finish setting up notifications. Reloading the page usually fixes it."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "{minutes} min"

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -1765,6 +1765,10 @@ msgstr "高速な全文検索"
 #~ msgid "Saving, recommending, reading history, and managing what you follow."
 #~ msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t available"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "コレクション名"
@@ -6501,6 +6505,10 @@ msgstr "読み上げの音声"
 
 #: src/routes/_layout.index.tsx
 msgid "Nothing left unread from the publications you follow. There's more on the network than you're following yet."
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t switched on for this site yet."
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -2043,6 +2043,10 @@ msgstr "拡張機能の変更に合わせて、このポリシーを更新する
 msgid "Your choices"
 msgstr "選択できること"
 
+#: src/components/push-diagnostics.tsx
+msgid "Installed to Home Screen"
+msgstr ""
+
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
@@ -3440,6 +3444,10 @@ msgstr ""
 msgid "Reset filters"
 msgstr ""
 
+#: src/components/push-diagnostics.tsx
+msgid "Service worker"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Hide implemented"
 msgstr "実装済みを非表示"
@@ -4118,6 +4126,10 @@ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Subscribe and it starts appearing in your feeds like any other."
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -5507,6 +5519,10 @@ msgstr "追って読む"
 msgid "Show all feedback"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Troubleshooting"
+msgstr ""
+
 #. placeholder {0}: issue.label
 #: src/components/comic/comic-shelf.tsx
 msgid "Read {0}"
@@ -5778,6 +5794,10 @@ msgstr ""
 
 #: src/components/docs/labelers-docs-page.tsx
 msgid "Labels may apply to a document's <0>at://</0> URI or to an account DID. Account labels are shown on that account's author and publication pages and on every document it published, so a label about a publisher does not need to be re-emitted per post."
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Checking…"
 msgstr ""
 
 #: src/components/guide/pages/lists-guide-page.tsx
@@ -6243,6 +6263,10 @@ msgstr ""
 #: src/components/reader/reader-queue-rows.tsx
 msgid "Article unavailable"
 msgstr "記事を表示できません"
+
+#: src/components/push-diagnostics.tsx
+msgid "Permission"
+msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Create will publish your review to ATStore."
@@ -7132,8 +7156,13 @@ msgstr "購読中から検索"
 msgid "Standard Reader works the other way round. You sign in with a Bluesky account, and the things you do here — what you subscribe to, follow, save, recommend, and read — are written into your own account's storage, the same place your Bluesky posts live. We keep a copy so the app is fast, but the original is yours. Another app built on the same network can read it, and if you stop using Standard Reader, none of it disappears."
 msgstr ""
 
+#: src/components/push-diagnostics.tsx
 #: src/components/reader/use-subscriptions-tree.tsx
 msgid "Subscription"
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Last error"
 msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
@@ -7387,6 +7416,10 @@ msgstr ""
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "After that, following is one button. Anywhere you see a publication — a card in a feed, the top of an article, a publication's own page — there is a <0>Follow</0> button next to its name. Select it again to stop following. Nothing else changes: the button just decides whether new writing from that publication reaches your Home and Latest."
 #~ msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Support"
+msgstr ""
 
 #: src/components/reader/rss-feed-button.tsx
 msgid "Subscribe to {name} in any RSS reader — new articles show up there as soon as they publish."

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -62,6 +62,11 @@ msgstr "以前の投稿を未読として扱う"
 msgid "Something went wrong. Nothing was connected — try again."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+#: src/components/user-settings-view.tsx
+msgid "Notifications are blocked for this site. You can turn them back on in your browser settings."
+msgstr ""
+
 #: src/routes/_layout.u.$did.tsx
 msgid "{name} hasn't started reading or publishing here."
 msgstr "{name} さんはまだここで読んだり書いたりしていません。"
@@ -599,6 +604,10 @@ msgstr ""
 msgid "Text on accent"
 msgstr "アクセント上の文字"
 
+#: src/components/user-settings-view.tsx
+msgid "Turn off"
+msgstr ""
+
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Finish reordering"
@@ -736,6 +745,10 @@ msgstr "記事を読む →"
 msgid "Playback speed: {0}"
 msgstr "再生速度: {0}"
 
+#: src/components/user-settings-view.tsx
+msgid "How to enable"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "No posts yet"
 msgstr ""
@@ -829,6 +842,10 @@ msgstr "音声サンプルを再生"
 
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "<0>Is the forwards-reading setting saved?</0> This is the one that is almost always the answer. Check it in your publishing tool, and note that it lives on the publication, not on individual posts."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Turn off everywhere"
 msgstr ""
 
 #: src/components/reader/subscribe-card.tsx
@@ -1117,6 +1134,10 @@ msgstr ""
 msgid "Take any of it as RSS"
 msgstr "すべて RSS でも読める"
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Got it"
+msgstr ""
+
 #: src/components/reader/subscriptions-sheet.tsx
 #~ msgid "Reorder lists"
 #~ msgstr "リストを並べ替え"
@@ -1276,6 +1297,11 @@ msgstr ""
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "You don't have any subscriptions to reorder yet."
 #~ msgstr ""
+
+#: src/components/reader/notify-button.tsx
+#: src/components/user-settings-view.tsx
+msgid "This browser doesn’t support web notifications."
+msgstr ""
 
 #: src/components/guide/pages/welcome-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1594,6 +1620,10 @@ msgstr ""
 msgid "A collection is a record in your own account, the same as a follow or a save. If you stop using Standard Reader it does not disappear, and another app built on the same network can read it."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "Your notification setting didn’t save. Try again?"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #~ msgid "Home is the catch-up screen. It opens with the date and how much you have not read, leads with one featured article, and then lists what is new from the publications you follow."
 #~ msgstr ""
@@ -1691,6 +1721,10 @@ msgstr "例を実行"
 
 #: src/components/appearance-settings.tsx
 msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors."
+msgstr ""
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Tap Share in the Safari toolbar."
 msgstr ""
 
 #: src/lib/guide/navigation.ts
@@ -1937,6 +1971,10 @@ msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t available here"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -2543,6 +2581,10 @@ msgstr "Standard Reader のインデックス済み読み取りモデル向け�
 msgid "Save theme"
 msgstr "テーマを保存"
 
+#: src/components/reader/notify-button.tsx
+msgid "Notifications are blocked"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "A reply"
 msgstr ""
@@ -3015,6 +3057,10 @@ msgstr ""
 #~ msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
 #~ msgstr "設定を一つ切り替えるだけで、記事のリンクが発行物自身のサイトで開くようになります。心地よい場所で読んでください。"
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Add to your Home Screen"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Discover is the directory of every publication the network knows about — not a curated shelf. It runs top to bottom from most personal to most complete:"
 msgstr ""
@@ -3337,6 +3383,10 @@ msgstr ""
 msgid "See all trending"
 msgstr "急上昇をすべて見る"
 
+#: src/components/reader/notify-button.tsx
+msgid "Notify me about new posts"
+msgstr ""
+
 #: src/components/onboarding/step-friends.tsx
 #~ msgid "All selected"
 #~ msgstr ""
@@ -3428,6 +3478,10 @@ msgstr "保存済み"
 #: src/components/onboarding/step-intro.tsx
 msgid "{count, plural, one {{formattedCount} publication across the Atmosphere} other {{formattedCount} publications across the Atmosphere}}"
 msgstr "{count, plural, one {Atmosphere 全体で {formattedCount} 件の発行物} other {Atmosphere 全体で {formattedCount} 件の発行物}}"
+
+#: src/components/user-settings-view.tsx
+msgid "Notifications"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "the whole network as it publishes."
@@ -3886,6 +3940,10 @@ msgstr "すべてを見る"
 
 #: src/components/appearance-settings.tsx
 msgid "Large"
+msgstr ""
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Then open Standard Reader from your Home Screen and turn the bell on there."
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -4544,6 +4602,10 @@ msgstr ""
 msgid "The extension checks the address of the page you are on to work out whether there is anything to offer, and it acts on your account only when you click something. It does not read your browsing history or the contents of pages."
 msgstr ""
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "On iPhone and iPad, notifications only work once Standard Reader is installed. It takes two taps."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "You can sign out at any time, which clears your app session cookie. You can clear site cookies in your browser to remove theme and saved-handle preferences. You can change reading-history tracking and delete personal data from Settings. To remove other AT Protocol records you created through the app, use a compatible client or your repository tools."
 msgstr "いつでもサインアウトでき、その際アプリのセッション Cookie は消去されます。テーマや保存されたハンドルの設定は、ブラウザでサイトの Cookie を削除すれば消せます。閲覧履歴の記録の変更と個人データの削除は設定から行えます。アプリを通じて作成したその他の AT Protocol レコードを削除するには、対応クライアントまたはリポジトリ用のツールをご利用ください。"
@@ -4750,6 +4812,11 @@ msgstr ""
 msgid "Loading page…"
 msgstr ""
 
+#. placeholder {0}: push.topicCount
+#: src/components/user-settings-view.tsx
+msgid "On for this browser. You’ll hear about new posts from the {0} publications and authors you’ve turned the bell on for."
+msgstr ""
+
 #: src/routes/mcp/authorize.tsx
 msgid "This request can't be completed here, so we're returning you to the app that sent you."
 msgstr ""
@@ -4775,6 +4842,7 @@ msgstr ""
 msgid "Not in the directory yet?"
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
 msgstr "問題が発生しました"
@@ -4896,6 +4964,11 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "プロフィール設定"
+
+#. placeholder {0}: push.topicCount
+#: src/components/user-settings-view.tsx
+msgid "Stop notifications on every device and clear all {0} of the publications and authors you’ve turned the bell on for."
+msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -5189,6 +5262,10 @@ msgstr "リポジトリ内のすべての既読記録が削除されます。ア
 msgid "You’ve read everything from this publication."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "We couldn’t set up notifications on this device. Try again?"
+msgstr ""
+
 #: src/components/appearance-settings.tsx
 msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
@@ -5479,6 +5556,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Weekly digest email"
 msgstr "週刊ダイジェストメール"
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Choose “Add to Home Screen”."
+msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6793,6 +6874,10 @@ msgid "What we collect"
 msgstr "収集する情報"
 
 #: src/components/user-settings-view.tsx
+msgid "On iPhone and iPad, notifications need Standard Reader installed on your Home Screen."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
 msgid "When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme."
 msgstr ""
 
@@ -7219,6 +7304,10 @@ msgstr "トピックで絞り込む"
 msgid "Uploading {0}"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Notifications on this device"
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Reordering saved articles"
 msgstr ""
@@ -7245,6 +7334,10 @@ msgstr "リストを作成"
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Expand all lists"
 msgstr "すべてのリストを展開"
+
+#: src/components/user-settings-view.tsx
+msgid "Get notified the moment a publication or author publishes something new. Turn it on here, then choose who from their page."
+msgstr ""
 
 #: src/components/reader/document-share-menu.tsx
 #: src/components/reader/text-selection-toolbar.tsx
@@ -7380,6 +7473,10 @@ msgstr "フィードバック"
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Letting publications use their own colors"
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Turn off notifications"
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -5516,6 +5516,10 @@ msgstr ""
 msgid "Couldn't resolve that handle."
 msgstr "そのハンドルを解決できませんでした。"
 
+#: src/components/reader/notify-button.tsx
+msgid "That took too long"
+msgstr ""
+
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Good to know"
 msgstr ""
@@ -7351,6 +7355,10 @@ msgstr ""
 #: src/components/reader/text-selection-toolbar.tsx
 msgid "Save to Margin…"
 msgstr "Margin に保存…"
+
+#: src/components/reader/notify-button.tsx
+msgid "Your browser didn’t finish setting up notifications. Reloading the page usually fixes it."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "{minutes} min"

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -62,6 +62,11 @@ msgstr "지난 글을 읽지 않음으로 표시"
 msgid "Something went wrong. Nothing was connected — try again."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+#: src/components/user-settings-view.tsx
+msgid "Notifications are blocked for this site. You can turn them back on in your browser settings."
+msgstr ""
+
 #: src/routes/_layout.u.$did.tsx
 msgid "{name} hasn't started reading or publishing here."
 msgstr "{name}님은 아직 여기서 읽거나 게시하지 않았습니다."
@@ -599,6 +604,10 @@ msgstr ""
 msgid "Text on accent"
 msgstr "강조색 위 텍스트"
 
+#: src/components/user-settings-view.tsx
+msgid "Turn off"
+msgstr ""
+
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Finish reordering"
@@ -736,6 +745,10 @@ msgstr "글 읽기 →"
 msgid "Playback speed: {0}"
 msgstr "재생 속도: {0}"
 
+#: src/components/user-settings-view.tsx
+msgid "How to enable"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "No posts yet"
 msgstr ""
@@ -829,6 +842,10 @@ msgstr "음성 샘플 재생"
 
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "<0>Is the forwards-reading setting saved?</0> This is the one that is almost always the answer. Check it in your publishing tool, and note that it lives on the publication, not on individual posts."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Turn off everywhere"
 msgstr ""
 
 #: src/components/reader/subscribe-card.tsx
@@ -1117,6 +1134,10 @@ msgstr ""
 msgid "Take any of it as RSS"
 msgstr "무엇이든 RSS로 받기"
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Got it"
+msgstr ""
+
 #: src/components/reader/subscriptions-sheet.tsx
 #~ msgid "Reorder lists"
 #~ msgstr "목록 순서 변경"
@@ -1276,6 +1297,11 @@ msgstr ""
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "You don't have any subscriptions to reorder yet."
 #~ msgstr ""
+
+#: src/components/reader/notify-button.tsx
+#: src/components/user-settings-view.tsx
+msgid "This browser doesn’t support web notifications."
+msgstr ""
 
 #: src/components/guide/pages/welcome-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1594,6 +1620,10 @@ msgstr ""
 msgid "A collection is a record in your own account, the same as a follow or a save. If you stop using Standard Reader it does not disappear, and another app built on the same network can read it."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "Your notification setting didn’t save. Try again?"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #~ msgid "Home is the catch-up screen. It opens with the date and how much you have not read, leads with one featured article, and then lists what is new from the publications you follow."
 #~ msgstr ""
@@ -1691,6 +1721,10 @@ msgstr "예제 실행"
 
 #: src/components/appearance-settings.tsx
 msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors."
+msgstr ""
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Tap Share in the Safari toolbar."
 msgstr ""
 
 #: src/lib/guide/navigation.ts
@@ -1937,6 +1971,10 @@ msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t available here"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -2543,6 +2581,10 @@ msgstr "Standard Reader 인덱스 읽기 모델을 위한 공개 XRPC 쿼리와 
 msgid "Save theme"
 msgstr "테마 저장"
 
+#: src/components/reader/notify-button.tsx
+msgid "Notifications are blocked"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "A reply"
 msgstr ""
@@ -3015,6 +3057,10 @@ msgstr ""
 #~ msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
 #~ msgstr "설정 하나만 바꾸면 글 링크가 해당 발행물의 사이트에서 열립니다. 편한 곳에서 읽으세요."
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Add to your Home Screen"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Discover is the directory of every publication the network knows about — not a curated shelf. It runs top to bottom from most personal to most complete:"
 msgstr ""
@@ -3337,6 +3383,10 @@ msgstr ""
 msgid "See all trending"
 msgstr "인기 글 전체 보기"
 
+#: src/components/reader/notify-button.tsx
+msgid "Notify me about new posts"
+msgstr ""
+
 #: src/components/onboarding/step-friends.tsx
 #~ msgid "All selected"
 #~ msgstr ""
@@ -3428,6 +3478,10 @@ msgstr "저장됨"
 #: src/components/onboarding/step-intro.tsx
 msgid "{count, plural, one {{formattedCount} publication across the Atmosphere} other {{formattedCount} publications across the Atmosphere}}"
 msgstr "{count, plural, one {Atmosphere 전체 발행물 {formattedCount}곳} other {Atmosphere 전체 발행물 {formattedCount}곳}}"
+
+#: src/components/user-settings-view.tsx
+msgid "Notifications"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "the whole network as it publishes."
@@ -3886,6 +3940,10 @@ msgstr "전체 둘러보기"
 
 #: src/components/appearance-settings.tsx
 msgid "Large"
+msgstr ""
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Then open Standard Reader from your Home Screen and turn the bell on there."
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -4544,6 +4602,10 @@ msgstr ""
 msgid "The extension checks the address of the page you are on to work out whether there is anything to offer, and it acts on your account only when you click something. It does not read your browsing history or the contents of pages."
 msgstr ""
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "On iPhone and iPad, notifications only work once Standard Reader is installed. It takes two taps."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "You can sign out at any time, which clears your app session cookie. You can clear site cookies in your browser to remove theme and saved-handle preferences. You can change reading-history tracking and delete personal data from Settings. To remove other AT Protocol records you created through the app, use a compatible client or your repository tools."
 msgstr "언제든지 로그아웃할 수 있으며, 그러면 앱 세션 쿠키가 삭제됩니다. 브라우저에서 사이트 쿠키를 지우면 테마와 저장된 핸들 설정을 제거할 수 있습니다. 읽기 기록 추적은 설정에서 변경할 수 있고 개인 데이터도 삭제할 수 있습니다. 앱을 통해 생성한 다른 AT Protocol 레코드를 삭제하려면 호환되는 클라이언트나 리포지토리 도구를 사용하세요."
@@ -4750,6 +4812,11 @@ msgstr ""
 msgid "Loading page…"
 msgstr ""
 
+#. placeholder {0}: push.topicCount
+#: src/components/user-settings-view.tsx
+msgid "On for this browser. You’ll hear about new posts from the {0} publications and authors you’ve turned the bell on for."
+msgstr ""
+
 #: src/routes/mcp/authorize.tsx
 msgid "This request can't be completed here, so we're returning you to the app that sent you."
 msgstr ""
@@ -4775,6 +4842,7 @@ msgstr ""
 msgid "Not in the directory yet?"
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
 msgstr "문제가 발생했습니다"
@@ -4896,6 +4964,11 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "프로필 설정"
+
+#. placeholder {0}: push.topicCount
+#: src/components/user-settings-view.tsx
+msgid "Stop notifications on every device and clear all {0} of the publications and authors you’ve turned the bell on for."
+msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -5189,6 +5262,10 @@ msgstr "저장소에 있는 모든 읽음 기록이 삭제됩니다. 앱 전체�
 msgid "You’ve read everything from this publication."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "We couldn’t set up notifications on this device. Try again?"
+msgstr ""
+
 #: src/components/appearance-settings.tsx
 msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
@@ -5479,6 +5556,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Weekly digest email"
 msgstr "주간 다이제스트 이메일"
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Choose “Add to Home Screen”."
+msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6793,6 +6874,10 @@ msgid "What we collect"
 msgstr "저희가 수집하는 정보"
 
 #: src/components/user-settings-view.tsx
+msgid "On iPhone and iPad, notifications need Standard Reader installed on your Home Screen."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
 msgid "When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme."
 msgstr ""
 
@@ -7219,6 +7304,10 @@ msgstr "주제로 필터"
 msgid "Uploading {0}"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Notifications on this device"
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Reordering saved articles"
 msgstr ""
@@ -7245,6 +7334,10 @@ msgstr "목록 만들기"
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Expand all lists"
 msgstr "모든 목록 펼치기"
+
+#: src/components/user-settings-view.tsx
+msgid "Get notified the moment a publication or author publishes something new. Turn it on here, then choose who from their page."
+msgstr ""
 
 #: src/components/reader/document-share-menu.tsx
 #: src/components/reader/text-selection-toolbar.tsx
@@ -7380,6 +7473,10 @@ msgstr "피드백"
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Letting publications use their own colors"
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Turn off notifications"
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -5516,6 +5516,10 @@ msgstr ""
 msgid "Couldn't resolve that handle."
 msgstr "해당 핸들을 확인하지 못했습니다."
 
+#: src/components/reader/notify-button.tsx
+msgid "That took too long"
+msgstr ""
+
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Good to know"
 msgstr ""
@@ -7351,6 +7355,10 @@ msgstr ""
 #: src/components/reader/text-selection-toolbar.tsx
 msgid "Save to Margin…"
 msgstr "Margin에 저장…"
+
+#: src/components/reader/notify-button.tsx
+msgid "Your browser didn’t finish setting up notifications. Reloading the page usually fixes it."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "{minutes} min"

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -1765,6 +1765,10 @@ msgstr "빠른 전문 검색"
 #~ msgid "Saving, recommending, reading history, and managing what you follow."
 #~ msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t available"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "컬렉션 이름"
@@ -6501,6 +6505,10 @@ msgstr "소리내어 읽기 음성"
 
 #: src/routes/_layout.index.tsx
 msgid "Nothing left unread from the publications you follow. There's more on the network than you're following yet."
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t switched on for this site yet."
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -2043,6 +2043,10 @@ msgstr "확장 프로그램이 변경되면 본 정책을 업데이트할 수 �
 msgid "Your choices"
 msgstr "이용자의 선택"
 
+#: src/components/push-diagnostics.tsx
+msgid "Installed to Home Screen"
+msgstr ""
+
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
@@ -3440,6 +3444,10 @@ msgstr ""
 msgid "Reset filters"
 msgstr ""
 
+#: src/components/push-diagnostics.tsx
+msgid "Service worker"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Hide implemented"
 msgstr "구현된 항목 숨기기"
@@ -4118,6 +4126,10 @@ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Subscribe and it starts appearing in your feeds like any other."
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -5507,6 +5519,10 @@ msgstr "함께 보기"
 msgid "Show all feedback"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Troubleshooting"
+msgstr ""
+
 #. placeholder {0}: issue.label
 #: src/components/comic/comic-shelf.tsx
 msgid "Read {0}"
@@ -5778,6 +5794,10 @@ msgstr ""
 
 #: src/components/docs/labelers-docs-page.tsx
 msgid "Labels may apply to a document's <0>at://</0> URI or to an account DID. Account labels are shown on that account's author and publication pages and on every document it published, so a label about a publisher does not need to be re-emitted per post."
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Checking…"
 msgstr ""
 
 #: src/components/guide/pages/lists-guide-page.tsx
@@ -6243,6 +6263,10 @@ msgstr ""
 #: src/components/reader/reader-queue-rows.tsx
 msgid "Article unavailable"
 msgstr "글을 볼 수 없음"
+
+#: src/components/push-diagnostics.tsx
+msgid "Permission"
+msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Create will publish your review to ATStore."
@@ -7132,8 +7156,13 @@ msgstr "구독 검색"
 msgid "Standard Reader works the other way round. You sign in with a Bluesky account, and the things you do here — what you subscribe to, follow, save, recommend, and read — are written into your own account's storage, the same place your Bluesky posts live. We keep a copy so the app is fast, but the original is yours. Another app built on the same network can read it, and if you stop using Standard Reader, none of it disappears."
 msgstr ""
 
+#: src/components/push-diagnostics.tsx
 #: src/components/reader/use-subscriptions-tree.tsx
 msgid "Subscription"
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Last error"
 msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
@@ -7387,6 +7416,10 @@ msgstr ""
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "After that, following is one button. Anywhere you see a publication — a card in a feed, the top of an article, a publication's own page — there is a <0>Follow</0> button next to its name. Select it again to stop following. Nothing else changes: the button just decides whether new writing from that publication reaches your Home and Latest."
 #~ msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Support"
+msgstr ""
 
 #: src/components/reader/rss-feed-button.tsx
 msgid "Subscribe to {name} in any RSS reader — new articles show up there as soon as they publish."

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -1765,6 +1765,10 @@ msgstr "Pesquisa rápida em texto integral"
 #~ msgid "Saving, recommending, reading history, and managing what you follow."
 #~ msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t available"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "Nome da coleção"
@@ -6502,6 +6506,10 @@ msgstr "Voz da leitura em voz alta"
 #: src/routes/_layout.index.tsx
 msgid "Nothing left unread from the publications you follow. There's more on the network than you're following yet."
 msgstr "Não há nada não lido das publicações que você é inscrito. Existe mais conteúdo na rede além das suas inscrições atuais."
+
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t switched on for this site yet."
+msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Filter and sort — {activeFilters, plural, one {# filter active} other {# filters active}}"

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -2043,6 +2043,10 @@ msgstr "Podemos atualizar esta política à medida que a extensão evolui. A dat
 msgid "Your choices"
 msgstr "As suas opções"
 
+#: src/components/push-diagnostics.tsx
+msgid "Installed to Home Screen"
+msgstr ""
+
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr "Escolha o pacote para o seu framework; todos se baseiam no mesmo núcleo."
@@ -3440,6 +3444,10 @@ msgstr ""
 msgid "Reset filters"
 msgstr ""
 
+#: src/components/push-diagnostics.tsx
+msgid "Service worker"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Hide implemented"
 msgstr "Ocultar implementados"
@@ -4118,6 +4126,10 @@ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Subscribe and it starts appearing in your feeds like any other."
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -5507,6 +5519,10 @@ msgstr "Acompanhar"
 msgid "Show all feedback"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Troubleshooting"
+msgstr ""
+
 #. placeholder {0}: issue.label
 #: src/components/comic/comic-shelf.tsx
 msgid "Read {0}"
@@ -5778,6 +5794,10 @@ msgstr "Pessoas que você segue"
 
 #: src/components/docs/labelers-docs-page.tsx
 msgid "Labels may apply to a document's <0>at://</0> URI or to an account DID. Account labels are shown on that account's author and publication pages and on every document it published, so a label about a publisher does not need to be re-emitted per post."
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Checking…"
 msgstr ""
 
 #: src/components/guide/pages/lists-guide-page.tsx
@@ -6243,6 +6263,10 @@ msgstr "Nada novo das pessoas que você segue"
 #: src/components/reader/reader-queue-rows.tsx
 msgid "Article unavailable"
 msgstr "Artigo indisponível"
+
+#: src/components/push-diagnostics.tsx
+msgid "Permission"
+msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Create will publish your review to ATStore."
@@ -7132,8 +7156,13 @@ msgstr "Pesquisar nas suas inscrições"
 msgid "Standard Reader works the other way round. You sign in with a Bluesky account, and the things you do here — what you subscribe to, follow, save, recommend, and read — are written into your own account's storage, the same place your Bluesky posts live. We keep a copy so the app is fast, but the original is yours. Another app built on the same network can read it, and if you stop using Standard Reader, none of it disappears."
 msgstr ""
 
+#: src/components/push-diagnostics.tsx
 #: src/components/reader/use-subscriptions-tree.tsx
 msgid "Subscription"
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Last error"
 msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
@@ -7387,6 +7416,10 @@ msgstr ""
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "After that, following is one button. Anywhere you see a publication — a card in a feed, the top of an article, a publication's own page — there is a <0>Follow</0> button next to its name. Select it again to stop following. Nothing else changes: the button just decides whether new writing from that publication reaches your Home and Latest."
 #~ msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Support"
+msgstr ""
 
 #: src/components/reader/rss-feed-button.tsx
 msgid "Subscribe to {name} in any RSS reader — new articles show up there as soon as they publish."

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -62,6 +62,11 @@ msgstr "Marcar artigos antigos como não lidos"
 msgid "Something went wrong. Nothing was connected — try again."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+#: src/components/user-settings-view.tsx
+msgid "Notifications are blocked for this site. You can turn them back on in your browser settings."
+msgstr ""
+
 #: src/routes/_layout.u.$did.tsx
 msgid "{name} hasn't started reading or publishing here."
 msgstr "{name} ainda não começou a ler nem a publicar aqui."
@@ -599,6 +604,10 @@ msgstr ""
 msgid "Text on accent"
 msgstr "Texto em destaque"
 
+#: src/components/user-settings-view.tsx
+msgid "Turn off"
+msgstr ""
+
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Finish reordering"
@@ -736,6 +745,10 @@ msgstr "Ler o texto →"
 msgid "Playback speed: {0}"
 msgstr "Velocidade de reprodução: {0}"
 
+#: src/components/user-settings-view.tsx
+msgid "How to enable"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "No posts yet"
 msgstr "Nenhum artigo ainda"
@@ -829,6 +842,10 @@ msgstr "Reproduzir amostra de voz"
 
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "<0>Is the forwards-reading setting saved?</0> This is the one that is almost always the answer. Check it in your publishing tool, and note that it lives on the publication, not on individual posts."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Turn off everywhere"
 msgstr ""
 
 #: src/components/reader/subscribe-card.tsx
@@ -1117,6 +1134,10 @@ msgstr ""
 msgid "Take any of it as RSS"
 msgstr "Leve tudo isto em RSS"
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Got it"
+msgstr ""
+
 #: src/components/reader/subscriptions-sheet.tsx
 #~ msgid "Reorder lists"
 #~ msgstr "Reordenar listas"
@@ -1276,6 +1297,11 @@ msgstr "Navegue pelo diretório"
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "You don't have any subscriptions to reorder yet."
 #~ msgstr ""
+
+#: src/components/reader/notify-button.tsx
+#: src/components/user-settings-view.tsx
+msgid "This browser doesn’t support web notifications."
+msgstr ""
 
 #: src/components/guide/pages/welcome-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1594,6 +1620,10 @@ msgstr ""
 msgid "A collection is a record in your own account, the same as a follow or a save. If you stop using Standard Reader it does not disappear, and another app built on the same network can read it."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "Your notification setting didn’t save. Try again?"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #~ msgid "Home is the catch-up screen. It opens with the date and how much you have not read, leads with one featured article, and then lists what is new from the publications you follow."
 #~ msgstr ""
@@ -1691,6 +1721,10 @@ msgstr "Executar exemplo"
 
 #: src/components/appearance-settings.tsx
 msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors."
+msgstr ""
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Tap Share in the Safari toolbar."
 msgstr ""
 
 #: src/lib/guide/navigation.ts
@@ -1937,6 +1971,10 @@ msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t available here"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -2543,6 +2581,10 @@ msgstr "Consultas e procedimentos XRPC públicos para o modelo de leitura indexa
 msgid "Save theme"
 msgstr "Salvar tema"
 
+#: src/components/reader/notify-button.tsx
+msgid "Notifications are blocked"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "A reply"
 msgstr ""
@@ -3015,6 +3057,10 @@ msgstr ""
 #~ msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
 #~ msgstr "Mude uma definição e as ligações dos artigos passam a abrir no site da própria publicação. Leia onde lhe fizer mais sentido."
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Add to your Home Screen"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Discover is the directory of every publication the network knows about — not a curated shelf. It runs top to bottom from most personal to most complete:"
 msgstr ""
@@ -3337,6 +3383,10 @@ msgstr ""
 msgid "See all trending"
 msgstr "Ver tudo em alta"
 
+#: src/components/reader/notify-button.tsx
+msgid "Notify me about new posts"
+msgstr ""
+
 #: src/components/onboarding/step-friends.tsx
 #~ msgid "All selected"
 #~ msgstr "Todos selecionados"
@@ -3428,6 +3478,10 @@ msgstr "Salvo"
 #: src/components/onboarding/step-intro.tsx
 msgid "{count, plural, one {{formattedCount} publication across the Atmosphere} other {{formattedCount} publications across the Atmosphere}}"
 msgstr "{count, plural, one {{formattedCount} publicação na Atmosfera} other {{formattedCount} publicações na Atmosfera}}"
+
+#: src/components/user-settings-view.tsx
+msgid "Notifications"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "the whole network as it publishes."
@@ -3886,6 +3940,10 @@ msgstr "Explorar tudo"
 
 #: src/components/appearance-settings.tsx
 msgid "Large"
+msgstr ""
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Then open Standard Reader from your Home Screen and turn the bell on there."
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -4544,6 +4602,10 @@ msgstr ""
 msgid "The extension checks the address of the page you are on to work out whether there is anything to offer, and it acts on your account only when you click something. It does not read your browsing history or the contents of pages."
 msgstr ""
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "On iPhone and iPad, notifications only work once Standard Reader is installed. It takes two taps."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "You can sign out at any time, which clears your app session cookie. You can clear site cookies in your browser to remove theme and saved-handle preferences. You can change reading-history tracking and delete personal data from Settings. To remove other AT Protocol records you created through the app, use a compatible client or your repository tools."
 msgstr "Pode terminar sessão a qualquer momento, o que limpa o cookie de sessão da aplicação. Pode limpar os cookies do site no seu navegador para remover as preferências de tema e de handle guardados. Pode alterar o registo do histórico de leitura e apagar dados pessoais nas Configurações. Para remover outros registos AT Protocol que criou através da aplicação, use um cliente compatível ou as ferramentas do seu repositório."
@@ -4750,6 +4812,11 @@ msgstr ""
 msgid "Loading page…"
 msgstr ""
 
+#. placeholder {0}: push.topicCount
+#: src/components/user-settings-view.tsx
+msgid "On for this browser. You’ll hear about new posts from the {0} publications and authors you’ve turned the bell on for."
+msgstr ""
+
 #: src/routes/mcp/authorize.tsx
 msgid "This request can't be completed here, so we're returning you to the app that sent you."
 msgstr ""
@@ -4775,6 +4842,7 @@ msgstr "{totalPeople, plural, one {# pessoa que você segue escreve aqui} other 
 msgid "Not in the directory yet?"
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
 msgstr "Algo deu errado"
@@ -4896,6 +4964,11 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "Configurações do perfil"
+
+#. placeholder {0}: push.topicCount
+#: src/components/user-settings-view.tsx
+msgid "Stop notifications on every device and clear all {0} of the publications and authors you’ve turned the bell on for."
+msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -5189,6 +5262,10 @@ msgstr "Todos os registos de leitura no seu repositório serão removidos. Os ar
 msgid "You’ve read everything from this publication."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "We couldn’t set up notifications on this device. Try again?"
+msgstr ""
+
 #: src/components/appearance-settings.tsx
 msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
@@ -5479,6 +5556,10 @@ msgstr "Ouça a partir daqui"
 #: src/components/user-settings-view.tsx
 msgid "Weekly digest email"
 msgstr "E-mail de resumo semanal"
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Choose “Add to Home Screen”."
+msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6793,6 +6874,10 @@ msgid "What we collect"
 msgstr "O que recolhemos"
 
 #: src/components/user-settings-view.tsx
+msgid "On iPhone and iPad, notifications need Standard Reader installed on your Home Screen."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
 msgid "When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme."
 msgstr ""
 
@@ -7219,6 +7304,10 @@ msgstr "Filtrar por tópico"
 msgid "Uploading {0}"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Notifications on this device"
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Reordering saved articles"
 msgstr ""
@@ -7245,6 +7334,10 @@ msgstr "Criar lista"
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Expand all lists"
 msgstr "Expandir todas as listas"
+
+#: src/components/user-settings-view.tsx
+msgid "Get notified the moment a publication or author publishes something new. Turn it on here, then choose who from their page."
+msgstr ""
 
 #: src/components/reader/document-share-menu.tsx
 #: src/components/reader/text-selection-toolbar.tsx
@@ -7380,6 +7473,10 @@ msgstr "Feedback"
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Letting publications use their own colors"
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Turn off notifications"
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -5516,6 +5516,10 @@ msgstr ""
 msgid "Couldn't resolve that handle."
 msgstr "Não foi possível resolver esse identificador."
 
+#: src/components/reader/notify-button.tsx
+msgid "That took too long"
+msgstr ""
+
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Good to know"
 msgstr ""
@@ -7351,6 +7355,10 @@ msgstr ""
 #: src/components/reader/text-selection-toolbar.tsx
 msgid "Save to Margin…"
 msgstr "Salvar no Margin…"
+
+#: src/components/reader/notify-button.tsx
+msgid "Your browser didn’t finish setting up notifications. Reloading the page usually fixes it."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "{minutes} min"

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -5516,6 +5516,10 @@ msgstr ""
 msgid "Couldn't resolve that handle."
 msgstr "无法解析该 handle。"
 
+#: src/components/reader/notify-button.tsx
+msgid "That took too long"
+msgstr ""
+
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Good to know"
 msgstr ""
@@ -7351,6 +7355,10 @@ msgstr ""
 #: src/components/reader/text-selection-toolbar.tsx
 msgid "Save to Margin…"
 msgstr "保存到 Margin…"
+
+#: src/components/reader/notify-button.tsx
+msgid "Your browser didn’t finish setting up notifications. Reloading the page usually fixes it."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "{minutes} min"

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -62,6 +62,11 @@ msgstr "将旧文章标记为未读"
 msgid "Something went wrong. Nothing was connected — try again."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+#: src/components/user-settings-view.tsx
+msgid "Notifications are blocked for this site. You can turn them back on in your browser settings."
+msgstr ""
+
 #: src/routes/_layout.u.$did.tsx
 msgid "{name} hasn't started reading or publishing here."
 msgstr "{name} 还没有在这里阅读或发布过内容。"
@@ -599,6 +604,10 @@ msgstr ""
 msgid "Text on accent"
 msgstr "强调色上的文字"
 
+#: src/components/user-settings-view.tsx
+msgid "Turn off"
+msgstr ""
+
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Finish reordering"
@@ -736,6 +745,10 @@ msgstr "阅读全文 →"
 msgid "Playback speed: {0}"
 msgstr "播放速度：{0}"
 
+#: src/components/user-settings-view.tsx
+msgid "How to enable"
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "No posts yet"
 msgstr ""
@@ -829,6 +842,10 @@ msgstr "播放语音样本"
 
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "<0>Is the forwards-reading setting saved?</0> This is the one that is almost always the answer. Check it in your publishing tool, and note that it lives on the publication, not on individual posts."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Turn off everywhere"
 msgstr ""
 
 #: src/components/reader/subscribe-card.tsx
@@ -1117,6 +1134,10 @@ msgstr ""
 msgid "Take any of it as RSS"
 msgstr "全部内容都可作为 RSS 获取"
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Got it"
+msgstr ""
+
 #: src/components/reader/subscriptions-sheet.tsx
 #~ msgid "Reorder lists"
 #~ msgstr "重新排序列表"
@@ -1276,6 +1297,11 @@ msgstr ""
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "You don't have any subscriptions to reorder yet."
 #~ msgstr ""
+
+#: src/components/reader/notify-button.tsx
+#: src/components/user-settings-view.tsx
+msgid "This browser doesn’t support web notifications."
+msgstr ""
 
 #: src/components/guide/pages/welcome-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1594,6 +1620,10 @@ msgstr ""
 msgid "A collection is a record in your own account, the same as a follow or a save. If you stop using Standard Reader it does not disappear, and another app built on the same network can read it."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "Your notification setting didn’t save. Try again?"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #~ msgid "Home is the catch-up screen. It opens with the date and how much you have not read, leads with one featured article, and then lists what is new from the publications you follow."
 #~ msgstr ""
@@ -1691,6 +1721,10 @@ msgstr "运行示例"
 
 #: src/components/appearance-settings.tsx
 msgid "Your paper is dark, so the app reads as a dark theme. Text, borders and every other step are derived from these two colors."
+msgstr ""
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Tap Share in the Safari toolbar."
 msgstr ""
 
 #: src/lib/guide/navigation.ts
@@ -1937,6 +1971,10 @@ msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t available here"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -2543,6 +2581,10 @@ msgstr "面向 Standard Reader 索引读模型的公开 XRPC 查询与操作。"
 msgid "Save theme"
 msgstr "保存主题"
 
+#: src/components/reader/notify-button.tsx
+msgid "Notifications are blocked"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "A reply"
 msgstr ""
@@ -3015,6 +3057,10 @@ msgstr ""
 #~ msgid "Flip one setting and article links open on the publication’s own site instead. Read wherever feels right to you."
 #~ msgstr "改一个设置，文章链接就会改为在刊物自己的网站打开。想在哪读就在哪读。"
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Add to your Home Screen"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Discover is the directory of every publication the network knows about — not a curated shelf. It runs top to bottom from most personal to most complete:"
 msgstr ""
@@ -3337,6 +3383,10 @@ msgstr ""
 msgid "See all trending"
 msgstr "查看全部热门"
 
+#: src/components/reader/notify-button.tsx
+msgid "Notify me about new posts"
+msgstr ""
+
 #: src/components/onboarding/step-friends.tsx
 #~ msgid "All selected"
 #~ msgstr ""
@@ -3428,6 +3478,10 @@ msgstr "已保存"
 #: src/components/onboarding/step-intro.tsx
 msgid "{count, plural, one {{formattedCount} publication across the Atmosphere} other {{formattedCount} publications across the Atmosphere}}"
 msgstr "{count, plural, one {Atmosphere 上的 {formattedCount} 个刊物} other {Atmosphere 上的 {formattedCount} 个刊物}}"
+
+#: src/components/user-settings-view.tsx
+msgid "Notifications"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "the whole network as it publishes."
@@ -3886,6 +3940,10 @@ msgstr "浏览全部"
 
 #: src/components/appearance-settings.tsx
 msgid "Large"
+msgstr ""
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Then open Standard Reader from your Home Screen and turn the bell on there."
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -4544,6 +4602,10 @@ msgstr ""
 msgid "The extension checks the address of the page you are on to work out whether there is anything to offer, and it acts on your account only when you click something. It does not read your browsing history or the contents of pages."
 msgstr ""
 
+#: src/components/reader/ios-install-prompt.tsx
+msgid "On iPhone and iPad, notifications only work once Standard Reader is installed. It takes two taps."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "You can sign out at any time, which clears your app session cookie. You can clear site cookies in your browser to remove theme and saved-handle preferences. You can change reading-history tracking and delete personal data from Settings. To remove other AT Protocol records you created through the app, use a compatible client or your repository tools."
 msgstr "你可以随时退出登录，这会清除应用的会话 Cookie。在浏览器中清除站点 Cookie 可移除主题和已保存的账号偏好。你可以在设置中更改阅读历史记录并删除个人数据。若要移除你通过本应用创建的其他 AT Protocol 记录，请使用兼容的客户端或你的仓库工具。"
@@ -4750,6 +4812,11 @@ msgstr ""
 msgid "Loading page…"
 msgstr ""
 
+#. placeholder {0}: push.topicCount
+#: src/components/user-settings-view.tsx
+msgid "On for this browser. You’ll hear about new posts from the {0} publications and authors you’ve turned the bell on for."
+msgstr ""
+
 #: src/routes/mcp/authorize.tsx
 msgid "This request can't be completed here, so we're returning you to the app that sent you."
 msgstr ""
@@ -4775,6 +4842,7 @@ msgstr ""
 msgid "Not in the directory yet?"
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
 msgstr "出错了"
@@ -4896,6 +4964,11 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "个人资料设置"
+
+#. placeholder {0}: push.topicCount
+#: src/components/user-settings-view.tsx
+msgid "Stop notifications on every device and clear all {0} of the publications and authors you’ve turned the bell on for."
+msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -5189,6 +5262,10 @@ msgstr "你仓库中的所有已读记录都将被移除。文章会在整个应
 msgid "You’ve read everything from this publication."
 msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "We couldn’t set up notifications on this device. Try again?"
+msgstr ""
+
 #: src/components/appearance-settings.tsx
 msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
@@ -5479,6 +5556,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Weekly digest email"
 msgstr "每周摘要邮件"
+
+#: src/components/reader/ios-install-prompt.tsx
+msgid "Choose “Add to Home Screen”."
+msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6793,6 +6874,10 @@ msgid "What we collect"
 msgstr "我们收集哪些信息"
 
 #: src/components/user-settings-view.tsx
+msgid "On iPhone and iPad, notifications need Standard Reader installed on your Home Screen."
+msgstr ""
+
+#: src/components/user-settings-view.tsx
 msgid "When on, a publication's page and its posts are shown in that publication's own colors. Publications that haven't set any colors keep the Standard Reader theme."
 msgstr ""
 
@@ -7219,6 +7304,10 @@ msgstr "按话题筛选"
 msgid "Uploading {0}"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Notifications on this device"
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Reordering saved articles"
 msgstr ""
@@ -7245,6 +7334,10 @@ msgstr "创建列表"
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Expand all lists"
 msgstr "展开全部列表"
+
+#: src/components/user-settings-view.tsx
+msgid "Get notified the moment a publication or author publishes something new. Turn it on here, then choose who from their page."
+msgstr ""
 
 #: src/components/reader/document-share-menu.tsx
 #: src/components/reader/text-selection-toolbar.tsx
@@ -7380,6 +7473,10 @@ msgstr "反馈"
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Letting publications use their own colors"
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Turn off notifications"
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -2043,6 +2043,10 @@ msgstr "我们可能会随着扩展的变化更新本政策。更新时，顶部
 msgid "Your choices"
 msgstr "你的选择"
 
+#: src/components/push-diagnostics.tsx
+msgid "Installed to Home Screen"
+msgstr ""
+
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
@@ -3440,6 +3444,10 @@ msgstr ""
 msgid "Reset filters"
 msgstr ""
 
+#: src/components/push-diagnostics.tsx
+msgid "Service worker"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Hide implemented"
 msgstr "隐藏已实现"
@@ -4118,6 +4126,10 @@ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Subscribe and it starts appearing in your feeds like any other."
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -5507,6 +5519,10 @@ msgstr "跟随阅读"
 msgid "Show all feedback"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Troubleshooting"
+msgstr ""
+
 #. placeholder {0}: issue.label
 #: src/components/comic/comic-shelf.tsx
 msgid "Read {0}"
@@ -5778,6 +5794,10 @@ msgstr ""
 
 #: src/components/docs/labelers-docs-page.tsx
 msgid "Labels may apply to a document's <0>at://</0> URI or to an account DID. Account labels are shown on that account's author and publication pages and on every document it published, so a label about a publisher does not need to be re-emitted per post."
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Checking…"
 msgstr ""
 
 #: src/components/guide/pages/lists-guide-page.tsx
@@ -6243,6 +6263,10 @@ msgstr ""
 #: src/components/reader/reader-queue-rows.tsx
 msgid "Article unavailable"
 msgstr "文章不可用"
+
+#: src/components/push-diagnostics.tsx
+msgid "Permission"
+msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Create will publish your review to ATStore."
@@ -7132,8 +7156,13 @@ msgstr "搜索你的订阅"
 msgid "Standard Reader works the other way round. You sign in with a Bluesky account, and the things you do here — what you subscribe to, follow, save, recommend, and read — are written into your own account's storage, the same place your Bluesky posts live. We keep a copy so the app is fast, but the original is yours. Another app built on the same network can read it, and if you stop using Standard Reader, none of it disappears."
 msgstr ""
 
+#: src/components/push-diagnostics.tsx
 #: src/components/reader/use-subscriptions-tree.tsx
 msgid "Subscription"
+msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Last error"
 msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
@@ -7387,6 +7416,10 @@ msgstr ""
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "After that, following is one button. Anywhere you see a publication — a card in a feed, the top of an article, a publication's own page — there is a <0>Follow</0> button next to its name. Select it again to stop following. Nothing else changes: the button just decides whether new writing from that publication reaches your Home and Latest."
 #~ msgstr ""
+
+#: src/components/push-diagnostics.tsx
+msgid "Support"
+msgstr ""
 
 #: src/components/reader/rss-feed-button.tsx
 msgid "Subscribe to {name} in any RSS reader — new articles show up there as soon as they publish."

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -1765,6 +1765,10 @@ msgstr "快速全文搜索"
 #~ msgid "Saving, recommending, reading history, and managing what you follow."
 #~ msgstr ""
 
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t available"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "合集名称"
@@ -6501,6 +6505,10 @@ msgstr "朗读语音"
 
 #: src/routes/_layout.index.tsx
 msgid "Nothing left unread from the publications you follow. There's more on the network than you're following yet."
+msgstr ""
+
+#: src/components/reader/notify-button.tsx
+msgid "Notifications aren’t switched on for this site yet."
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx

--- a/apps/standard-reader/src/pwa/push.ts
+++ b/apps/standard-reader/src/pwa/push.ts
@@ -20,11 +20,19 @@ import { pushApi } from "#/integrations/tanstack-query/api-push.functions";
  */
 export type PushCapability = "ready" | "needs-ios-install" | "unsupported";
 
-/** Outcome of trying to subscribe this browser. */
+/**
+ * Outcome of trying to subscribe this browser.
+ *
+ * `not-configured` is deliberately distinct from `unsupported`: one is the
+ * server missing a VAPID key, the other is the browser lacking the API, and
+ * collapsing them into one "something went wrong" makes a deployment mistake
+ * look identical to an old browser.
+ */
 export type EnsurePushResult =
   | { status: "ready"; endpoint: string }
   | { status: "denied" }
   | { status: "needs-ios-install" }
+  | { status: "not-configured" }
   | { status: "unsupported" }
   | { status: "error"; error: unknown };
 
@@ -131,7 +139,12 @@ export async function ensurePushDevice(): Promise<EnsurePushResult> {
     }
 
     const { publicKey } = await pushApi.getPushConfig();
-    if (!publicKey) return { status: "unsupported" };
+    if (!publicKey) {
+      console.error(
+        "[push] the server returned no VAPID public key — VAPID_PUBLIC_KEY is not set on the web service",
+      );
+      return { status: "not-configured" };
+    }
 
     // `ready` — not `getRegistration` — because the SW registers with
     // `skipWaiting: false`, so a first-time visitor has an installed but not yet
@@ -160,6 +173,9 @@ export async function ensurePushDevice(): Promise<EnsurePushResult> {
 
     return { status: "ready", endpoint: subscription.endpoint };
   } catch (error) {
+    // The UI can only show generic copy here, so make sure the real cause is
+    // reachable from devtools rather than swallowed.
+    console.error("[push] could not subscribe this browser", error);
     return { status: "error", error };
   }
 }

--- a/apps/standard-reader/src/pwa/push.ts
+++ b/apps/standard-reader/src/pwa/push.ts
@@ -1,5 +1,7 @@
 import { pushApi } from "#/integrations/tanstack-query/api-push.functions";
 
+import { serviceWorkerReport } from "./register";
+
 /**
  * Client-side web push: capability detection, subscribing this browser, and
  * keeping the stored endpoint in step with the one the browser actually has.
@@ -121,7 +123,13 @@ export async function currentPushSubscription(): Promise<PushSubscription | null
   return (await registration?.pushManager.getSubscription()) ?? null;
 }
 
-const READY_TIMEOUT_MS = 10_000;
+/**
+ * A cold install on a phone has to fetch the worker, its Workbox runtime chunk,
+ * and `push-sw.js` before it can activate. 10s was too tight for that over
+ * cellular; this is generous because the alternative is telling someone their
+ * browser failed when it was only slow.
+ */
+const ACTIVATION_TIMEOUT_MS = 45_000;
 const SUBSCRIBE_TIMEOUT_MS = 20_000;
 
 /** Resolve to `null` rather than hanging forever. */
@@ -135,25 +143,95 @@ async function withTimeout<T>(
   ]);
 }
 
+/** Where a registration is in its lifecycle, for diagnostics and for waiting. */
+export type ServiceWorkerState =
+  | "none"
+  | "installing"
+  | "waiting"
+  | "active"
+  | "unsupported";
+
+export function registrationState(
+  registration: ServiceWorkerRegistration | null | undefined,
+): ServiceWorkerState {
+  if (!registration) return "none";
+  if (registration.active) return "active";
+  if (registration.waiting) return "waiting";
+  if (registration.installing) return "installing";
+  return "none";
+}
+
+/** Resolve once this registration has an active worker, or `null` on timeout. */
+async function whenActive(
+  registration: ServiceWorkerRegistration,
+): Promise<ServiceWorkerRegistration | null> {
+  if (registration.active) return registration;
+
+  const worker = registration.installing ?? registration.waiting;
+  if (!worker) return null;
+
+  // Watch the worker's own state machine rather than racing a blind timer, so
+  // this resolves the instant it activates instead of on a fixed delay — and so
+  // a worker that dies during install (`redundant`) reports immediately instead
+  // of burning the full timeout.
+  const settled = await withTimeout(
+    new Promise<"activated" | "redundant">((resolve) => {
+      const onChange = () => {
+        if (worker.state === "activated") {
+          worker.removeEventListener("statechange", onChange);
+          resolve("activated");
+        } else if (worker.state === "redundant") {
+          worker.removeEventListener("statechange", onChange);
+          resolve("redundant");
+        }
+      };
+      worker.addEventListener("statechange", onChange);
+      onChange();
+    }),
+    ACTIVATION_TIMEOUT_MS,
+  );
+
+  if (settled === "redundant") {
+    console.error(
+      "[push] the service worker became redundant during install — it failed to install",
+    );
+    return null;
+  }
+  return settled === "activated" ? registration : null;
+}
+
 /**
  * The active service worker registration, or `null` if none activates in time.
  *
- * `navigator.serviceWorker.ready` **never settles** when no worker ever becomes
- * active — a failed install, a browser blocking service workers, a scope
- * mismatch. Awaiting it unbounded is what left the bell stuck in a disabled
- * state with no error: the promise simply never resolved, so neither the
- * `catch` nor the `finally` that re-enables the button ever ran. A hung browser
- * API has to be treated as a failure mode, not an impossibility.
+ * Two things this must not do, both learned the hard way:
  *
- * Checks for an already-active registration first, since the common case
- * doesn't need to wait at all.
+ *   1. **Never await `navigator.serviceWorker.ready` unbounded.** It never
+ *      settles when no worker becomes active — a failed install, a browser
+ *      blocking service workers, a scope mismatch. That left the bell stuck
+ *      disabled with no error, because neither the `catch` nor the `finally`
+ *      that re-enables it ever ran.
+ *   2. **Never assume something else already registered.** This used to depend
+ *      on `<ReloadPrompt />`'s effect having run and succeeded first. If that
+ *      registration failed — silently, until `onRegisterError` was wired up —
+ *      there was no worker to wait for and no way to find out. Registering here
+ *      when none exists removes the ordering dependency entirely.
  */
 async function activeRegistration(): Promise<ServiceWorkerRegistration | null> {
   const existing = await navigator.serviceWorker.getRegistration();
   if (existing?.active) return existing;
-  // Otherwise wait for one to activate — a first visit installs before it
-  // activates — but bounded.
-  return withTimeout(navigator.serviceWorker.ready, READY_TIMEOUT_MS);
+  if (existing) return whenActive(existing);
+
+  // Nothing registered yet. Do it here rather than waiting on a worker that may
+  // never have been requested.
+  try {
+    const registration = await navigator.serviceWorker.register("/sw.js", {
+      scope: "/",
+    });
+    return await whenActive(registration);
+  } catch (error) {
+    console.error("[push] service worker registration failed", error);
+    return null;
+  }
 }
 
 /**
@@ -237,6 +315,63 @@ export async function removePushDevice(): Promise<void> {
     await subscription.unsubscribe();
   } finally {
     await pushApi.unregisterPushDevice({ data: { endpoint } });
+  }
+}
+
+/**
+ * Everything needed to tell why the bell isn't working, in one object.
+ *
+ * This exists because the failure surfaced on an installed iPhone PWA, where
+ * "open devtools and read the console" is not a usable loop. Rendering this in
+ * settings turns a diagnosis round-trip into a screenshot.
+ */
+export interface PushDiagnostics {
+  capability: PushCapability;
+  standalone: boolean;
+  permission: NotificationPermission | "unavailable";
+  serviceWorker: ServiceWorkerState;
+  /** Script URL of the registered worker, when there is one. */
+  serviceWorkerScript: string | null;
+  subscribed: boolean;
+  /** Message from the last failed registration, if any. */
+  lastError: string | null;
+}
+
+export async function pushDiagnostics(): Promise<PushDiagnostics> {
+  const capability = pushCapability();
+  const swReport = serviceWorkerReport();
+
+  const base: PushDiagnostics = {
+    capability,
+    lastError: swReport.error,
+    permission:
+      isBrowser() && "Notification" in globalThis
+        ? Notification.permission
+        : "unavailable",
+    serviceWorker: "unsupported",
+    serviceWorkerScript: swReport.scriptUrl,
+    standalone: isStandalone(),
+    subscribed: false,
+  };
+
+  if (!isBrowser() || !("serviceWorker" in navigator)) return base;
+
+  try {
+    const registration = await navigator.serviceWorker.getRegistration();
+    const subscription = await registration?.pushManager.getSubscription();
+    return {
+      ...base,
+      serviceWorker: registrationState(registration),
+      subscribed: subscription != null,
+    };
+  } catch (error) {
+    return {
+      ...base,
+      lastError:
+        base.lastError ??
+        (error instanceof Error ? error.message : String(error)),
+      serviceWorker: "none",
+    };
   }
 }
 

--- a/apps/standard-reader/src/pwa/push.ts
+++ b/apps/standard-reader/src/pwa/push.ts
@@ -1,0 +1,205 @@
+import { pushApi } from "#/integrations/tanstack-query/api-push.functions";
+
+/**
+ * Client-side web push: capability detection, subscribing this browser, and
+ * keeping the stored endpoint in step with the one the browser actually has.
+ *
+ * Everything here is a no-op on the server, so it's safe to import from a
+ * component that renders during SSR — but the functions must only be *called*
+ * from an event handler or an effect.
+ */
+
+/**
+ * Why the bell can or can't work in this browser.
+ *
+ * `needs-ios-install` is the interesting one. iOS only exposes push to a PWA
+ * installed on the Home Screen — in a Safari tab `PushManager` simply doesn't
+ * exist. That's indistinguishable from an unsupported browser by feature
+ * detection alone, but it's the one case the reader can actually fix, so it gets
+ * its own state and its own prompt.
+ */
+export type PushCapability = "ready" | "needs-ios-install" | "unsupported";
+
+/** Outcome of trying to subscribe this browser. */
+export type EnsurePushResult =
+  | { status: "ready"; endpoint: string }
+  | { status: "denied" }
+  | { status: "needs-ios-install" }
+  | { status: "unsupported" }
+  | { status: "error"; error: unknown };
+
+function isBrowser(): boolean {
+  return globalThis.window !== undefined;
+}
+
+/** True when the page is running as an installed PWA rather than in a tab. */
+export function isStandalone(): boolean {
+  if (!isBrowser()) return false;
+  if (globalThis.matchMedia?.("(display-mode: standalone)").matches) {
+    return true;
+  }
+  // iOS predates `display-mode` and still reports via this non-standard flag.
+  return (
+    (navigator as Navigator & { standalone?: boolean }).standalone === true
+  );
+}
+
+function isIos(): boolean {
+  if (!isBrowser()) return false;
+  const ua = navigator.userAgent;
+  // iPadOS 13+ reports a desktop UA, so the touch-point check is what catches it.
+  return (
+    /iPad|iPhone|iPod/.test(ua) ||
+    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)
+  );
+}
+
+export function pushCapability(): PushCapability {
+  if (!isBrowser()) return "unsupported";
+
+  const supported =
+    "serviceWorker" in navigator &&
+    "PushManager" in globalThis &&
+    "Notification" in globalThis;
+
+  if (supported) return "ready";
+  // On iOS the same feature detection fails for a fixable reason.
+  return isIos() && !isStandalone() ? "needs-ios-install" : "unsupported";
+}
+
+/** Whether the reader has already blocked notifications at the browser level. */
+export function notificationsBlocked(): boolean {
+  if (!isBrowser() || !("Notification" in globalThis)) return false;
+  return Notification.permission === "denied";
+}
+
+/**
+ * base64url → the byte array `applicationServerKey` wants. Safari has
+ * historically rejected the raw string form, so always pass bytes.
+ *
+ * The return type is spelled `Uint8Array<ArrayBuffer>` rather than plain
+ * `Uint8Array`: since TS 5.7 the latter widens to `Uint8Array<ArrayBufferLike>`,
+ * which isn't assignable to `BufferSource`.
+ */
+function decodeVapidKey(base64Url: string): Uint8Array<ArrayBuffer> {
+  const padding = "=".repeat((4 - (base64Url.length % 4)) % 4);
+  const base64 = (base64Url + padding)
+    .replaceAll("-", "+")
+    .replaceAll("_", "/");
+  const raw = globalThis.atob(base64);
+  const output = new Uint8Array(new ArrayBuffer(raw.length));
+  for (let i = 0; i < raw.length; i += 1) {
+    output[i] = raw.codePointAt(i) ?? 0;
+  }
+  return output;
+}
+
+function readKeys(
+  subscription: PushSubscription,
+): { p256dh: string; auth: string } | null {
+  const json = subscription.toJSON();
+  const p256dh = json.keys?.p256dh;
+  const auth = json.keys?.auth;
+  if (!p256dh || !auth) return null;
+  return { p256dh, auth };
+}
+
+/** The push subscription this browser currently holds, if any. */
+export async function currentPushSubscription(): Promise<PushSubscription | null> {
+  if (pushCapability() !== "ready") return null;
+  const registration = await navigator.serviceWorker.getRegistration();
+  return (await registration?.pushManager.getSubscription()) ?? null;
+}
+
+/**
+ * Subscribe this browser and record the endpoint server-side. Requests
+ * permission if it hasn't been decided yet, so this MUST be called from a user
+ * gesture — Safari requires it, and a `denied` in Chrome blocks the site for
+ * months, which is why nothing calls this on page load.
+ */
+export async function ensurePushDevice(): Promise<EnsurePushResult> {
+  const capability = pushCapability();
+  if (capability !== "ready") return { status: capability };
+
+  try {
+    if (Notification.permission === "denied") {
+      return { status: "denied" };
+    }
+    if (Notification.permission === "default") {
+      const permission = await Notification.requestPermission();
+      if (permission !== "granted") return { status: "denied" };
+    }
+
+    const { publicKey } = await pushApi.getPushConfig();
+    if (!publicKey) return { status: "unsupported" };
+
+    // `ready` — not `getRegistration` — because the SW registers with
+    // `skipWaiting: false`, so a first-time visitor has an installed but not yet
+    // *active* worker for a while, and subscribing against one fails.
+    const registration = await navigator.serviceWorker.ready;
+
+    const subscription =
+      (await registration.pushManager.getSubscription()) ??
+      (await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: decodeVapidKey(publicKey),
+      }));
+
+    const keys = readKeys(subscription);
+    if (!keys)
+      return { status: "error", error: new Error("no subscription keys") };
+
+    await pushApi.registerPushDevice({
+      data: {
+        endpoint: subscription.endpoint,
+        p256dh: keys.p256dh,
+        auth: keys.auth,
+        userAgent: navigator.userAgent.slice(0, 512),
+      },
+    });
+
+    return { status: "ready", endpoint: subscription.endpoint };
+  } catch (error) {
+    return { status: "error", error };
+  }
+}
+
+/** Drop this browser's subscription, locally and server-side. */
+export async function removePushDevice(): Promise<void> {
+  const subscription = await currentPushSubscription();
+  if (!subscription) return;
+  const { endpoint } = subscription;
+  try {
+    await subscription.unsubscribe();
+  } finally {
+    await pushApi.unregisterPushDevice({ data: { endpoint } });
+  }
+}
+
+/**
+ * Re-register the current endpoint if the browser rotated it.
+ *
+ * Chrome announces rotation via `pushsubscriptionchange`, which `push-sw.js`
+ * handles. Safari never fires that event, so without this the subscription
+ * silently stops receiving anything. Cheap enough to run on load: it only writes
+ * when there's an active subscription to write.
+ */
+export async function syncPushDevice(): Promise<void> {
+  try {
+    const subscription = await currentPushSubscription();
+    if (!subscription) return;
+    const keys = readKeys(subscription);
+    if (!keys) return;
+
+    await pushApi.registerPushDevice({
+      data: {
+        endpoint: subscription.endpoint,
+        p256dh: keys.p256dh,
+        auth: keys.auth,
+        userAgent: navigator.userAgent.slice(0, 512),
+      },
+    });
+  } catch {
+    // Best effort — a failed refresh just means the next load tries again.
+  }
+}

--- a/apps/standard-reader/src/pwa/push.ts
+++ b/apps/standard-reader/src/pwa/push.ts
@@ -33,6 +33,8 @@ export type EnsurePushResult =
   | { status: "denied" }
   | { status: "needs-ios-install" }
   | { status: "not-configured" }
+  /** A browser API never settled — see {@link activeRegistration}. */
+  | { status: "timed-out" }
   | { status: "unsupported" }
   | { status: "error"; error: unknown };
 
@@ -119,6 +121,41 @@ export async function currentPushSubscription(): Promise<PushSubscription | null
   return (await registration?.pushManager.getSubscription()) ?? null;
 }
 
+const READY_TIMEOUT_MS = 10_000;
+const SUBSCRIBE_TIMEOUT_MS = 20_000;
+
+/** Resolve to `null` rather than hanging forever. */
+async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+): Promise<T | null> {
+  return Promise.race([
+    promise,
+    new Promise<null>((resolve) => setTimeout(() => resolve(null), ms)),
+  ]);
+}
+
+/**
+ * The active service worker registration, or `null` if none activates in time.
+ *
+ * `navigator.serviceWorker.ready` **never settles** when no worker ever becomes
+ * active — a failed install, a browser blocking service workers, a scope
+ * mismatch. Awaiting it unbounded is what left the bell stuck in a disabled
+ * state with no error: the promise simply never resolved, so neither the
+ * `catch` nor the `finally` that re-enables the button ever ran. A hung browser
+ * API has to be treated as a failure mode, not an impossibility.
+ *
+ * Checks for an already-active registration first, since the common case
+ * doesn't need to wait at all.
+ */
+async function activeRegistration(): Promise<ServiceWorkerRegistration | null> {
+  const existing = await navigator.serviceWorker.getRegistration();
+  if (existing?.active) return existing;
+  // Otherwise wait for one to activate — a first visit installs before it
+  // activates — but bounded.
+  return withTimeout(navigator.serviceWorker.ready, READY_TIMEOUT_MS);
+}
+
 /**
  * Subscribe this browser and record the endpoint server-side. Requests
  * permission if it hasn't been decided yet, so this MUST be called from a user
@@ -146,17 +183,28 @@ export async function ensurePushDevice(): Promise<EnsurePushResult> {
       return { status: "not-configured" };
     }
 
-    // `ready` — not `getRegistration` — because the SW registers with
-    // `skipWaiting: false`, so a first-time visitor has an installed but not yet
-    // *active* worker for a while, and subscribing against one fails.
-    const registration = await navigator.serviceWorker.ready;
+    const registration = await activeRegistration();
+    if (!registration) {
+      console.error(
+        "[push] no service worker ever became active — check the SW registered and installed cleanly",
+      );
+      return { status: "timed-out" };
+    }
 
+    const existing = await registration.pushManager.getSubscription();
     const subscription =
-      (await registration.pushManager.getSubscription()) ??
-      (await registration.pushManager.subscribe({
-        userVisibleOnly: true,
-        applicationServerKey: decodeVapidKey(publicKey),
-      }));
+      existing ??
+      (await withTimeout(
+        registration.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey: decodeVapidKey(publicKey),
+        }),
+        SUBSCRIBE_TIMEOUT_MS,
+      ));
+    if (!subscription) {
+      console.error("[push] pushManager.subscribe() never settled");
+      return { status: "timed-out" };
+    }
 
     const keys = readKeys(subscription);
     if (!keys)

--- a/apps/standard-reader/src/pwa/register.ts
+++ b/apps/standard-reader/src/pwa/register.ts
@@ -19,6 +19,37 @@ export interface RegisterCallbacks {
 /** Trigger provided by `registerSW`; activates the waiting SW and reloads. */
 export type UpdateServiceWorker = (reloadPage?: boolean) => Promise<void>;
 
+/** What the last registration attempt did, for the settings diagnostics. */
+export interface ServiceWorkerRegistrationReport {
+  /** `null` until the first attempt settles. */
+  outcome: "registered" | "failed" | null;
+  /** Message from `onRegisterError`. */
+  error: string | null;
+  /** Script URL the plugin registered, when it succeeded. */
+  scriptUrl: string | null;
+}
+
+/**
+ * Registration outcome, kept at module scope because it is the only record of
+ * a failure that is otherwise thrown away.
+ *
+ * vite-plugin-pwa's generated code ends in `.catch(e => onRegisterError?.(e))`,
+ * so a service worker that fails to install produces **no signal at all** unless
+ * that callback is supplied. That silence is what made a broken worker on an
+ * installed iOS PWA look like nothing more than a push timeout — the worker had
+ * already failed by then, and nothing said so.
+ */
+const report: ServiceWorkerRegistrationReport = {
+  error: null,
+  outcome: null,
+  scriptUrl: null,
+};
+
+/** Snapshot of the last registration attempt (see {@link report}). */
+export function serviceWorkerReport(): ServiceWorkerRegistrationReport {
+  return { ...report };
+}
+
 /**
  * Registers the service worker. No-op on the server (and returns a stub updater)
  * so it's safe to call from a component that renders during SSR.
@@ -34,5 +65,17 @@ export function registerServiceWorker(
     immediate: true,
     onNeedRefresh: callbacks.onNeedRefresh,
     onOfflineReady: callbacks.onOfflineReady,
+    onRegisterError: (error: unknown) => {
+      report.outcome = "failed";
+      report.error = error instanceof Error ? error.message : String(error);
+      // Loud on purpose: a failed install takes every caching route down with
+      // it, not just push.
+      console.error("[pwa] service worker registration failed", error);
+    },
+    onRegisteredSW: (scriptUrl: string) => {
+      report.outcome = "registered";
+      report.error = null;
+      report.scriptUrl = scriptUrl;
+    },
   });
 }

--- a/apps/standard-reader/src/pwa/reload-prompt.tsx
+++ b/apps/standard-reader/src/pwa/reload-prompt.tsx
@@ -8,6 +8,7 @@ import { spacing } from "@standard-reader/design-system/theme/spacing.stylex";
 import * as stylex from "@stylexjs/stylex";
 import { useEffect, useRef, useState } from "react";
 
+import { syncPushDevice } from "./push";
 import type { UpdateServiceWorker } from "./register";
 import { registerServiceWorker } from "./register";
 
@@ -46,6 +47,12 @@ export function ReloadPrompt() {
     updateRef.current = registerServiceWorker({
       onNeedRefresh: () => setNeedRefresh(true),
     });
+    // Repair a rotated push endpoint. Chrome announces rotation via
+    // `pushsubscriptionchange` (handled in `public/push-sw.js`), but Safari
+    // never fires that event, so without a check on load a rotated subscription
+    // silently stops receiving anything. No-ops when the reader hasn't enabled
+    // notifications.
+    void syncPushDevice();
   }, []);
 
   if (!needRefresh) return null;

--- a/apps/standard-reader/src/routeTree.gen.ts
+++ b/apps/standard-reader/src/routeTree.gen.ts
@@ -92,6 +92,7 @@ import { Route as ApiOgProfileRouteImport } from './routes/api/og/profile'
 import { Route as ApiOgPublicationRouteImport } from './routes/api/og/publication'
 import { Route as ApiOgQuoteRouteImport } from './routes/api/og/quote'
 import { Route as ApiOgSiteRouteImport } from './routes/api/og/site'
+import { Route as ApiPushResubscribeRouteImport } from './routes/api/push/resubscribe'
 import { Route as CollectionDidRkeyRouteImport } from './routes/collection.$did.$rkey'
 import { Route as ComicDidRkeyRouteImport } from './routes/comic.$did.$rkey'
 import { Route as FeedLatestDidRouteImport } from './routes/feed.latest.$did'
@@ -543,6 +544,11 @@ const ApiOgSiteRoute = ApiOgSiteRouteImport.update({
   path: '/api/og/site',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiPushResubscribeRoute = ApiPushResubscribeRouteImport.update({
+  id: '/api/push/resubscribe',
+  path: '/api/push/resubscribe',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CollectionDidRkeyRoute = CollectionDidRkeyRouteImport.update({
   id: '/collection/$did/$rkey',
   path: '/collection/$did/$rkey',
@@ -739,6 +745,7 @@ export interface FileRoutesByFullPath {
   '/api/og/publication': typeof ApiOgPublicationRoute
   '/api/og/quote': typeof ApiOgQuoteRoute
   '/api/og/site': typeof ApiOgSiteRoute
+  '/api/push/resubscribe': typeof ApiPushResubscribeRoute
   '/collection/$did/$rkey': typeof CollectionDidRkeyRoute
   '/comic/$did/$rkey': typeof ComicDidRkeyRoute
   '/feed/latest/$did': typeof FeedLatestDidRoute
@@ -843,6 +850,7 @@ export interface FileRoutesByTo {
   '/api/og/publication': typeof ApiOgPublicationRoute
   '/api/og/quote': typeof ApiOgQuoteRoute
   '/api/og/site': typeof ApiOgSiteRoute
+  '/api/push/resubscribe': typeof ApiPushResubscribeRoute
   '/collection/$did/$rkey': typeof CollectionDidRkeyRoute
   '/comic/$did/$rkey': typeof ComicDidRkeyRoute
   '/feed/latest/$did': typeof FeedLatestDidRoute
@@ -952,6 +960,7 @@ export interface FileRoutesById {
   '/api/og/publication': typeof ApiOgPublicationRoute
   '/api/og/quote': typeof ApiOgQuoteRoute
   '/api/og/site': typeof ApiOgSiteRoute
+  '/api/push/resubscribe': typeof ApiPushResubscribeRoute
   '/collection/$did/$rkey': typeof CollectionDidRkeyRoute
   '/comic/$did/$rkey': typeof ComicDidRkeyRoute
   '/feed/latest/$did': typeof FeedLatestDidRoute
@@ -1059,6 +1068,7 @@ export interface FileRouteTypes {
     | '/api/og/publication'
     | '/api/og/quote'
     | '/api/og/site'
+    | '/api/push/resubscribe'
     | '/collection/$did/$rkey'
     | '/comic/$did/$rkey'
     | '/feed/latest/$did'
@@ -1163,6 +1173,7 @@ export interface FileRouteTypes {
     | '/api/og/publication'
     | '/api/og/quote'
     | '/api/og/site'
+    | '/api/push/resubscribe'
     | '/collection/$did/$rkey'
     | '/comic/$did/$rkey'
     | '/feed/latest/$did'
@@ -1271,6 +1282,7 @@ export interface FileRouteTypes {
     | '/api/og/publication'
     | '/api/og/quote'
     | '/api/og/site'
+    | '/api/push/resubscribe'
     | '/collection/$did/$rkey'
     | '/comic/$did/$rkey'
     | '/feed/latest/$did'
@@ -1342,6 +1354,7 @@ export interface RootRouteChildren {
   ApiOgPublicationRoute: typeof ApiOgPublicationRoute
   ApiOgQuoteRoute: typeof ApiOgQuoteRoute
   ApiOgSiteRoute: typeof ApiOgSiteRoute
+  ApiPushResubscribeRoute: typeof ApiPushResubscribeRoute
   CollectionDidRkeyRoute: typeof CollectionDidRkeyRoute
   ComicDidRkeyRoute: typeof ComicDidRkeyRoute
   FeedLatestDidRoute: typeof FeedLatestDidRoute
@@ -1946,6 +1959,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiOgSiteRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/push/resubscribe': {
+      id: '/api/push/resubscribe'
+      path: '/api/push/resubscribe'
+      fullPath: '/api/push/resubscribe'
+      preLoaderRoute: typeof ApiPushResubscribeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/collection/$did/$rkey': {
       id: '/collection/$did/$rkey'
       path: '/collection/$did/$rkey'
@@ -2296,6 +2316,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiOgPublicationRoute: ApiOgPublicationRoute,
   ApiOgQuoteRoute: ApiOgQuoteRoute,
   ApiOgSiteRoute: ApiOgSiteRoute,
+  ApiPushResubscribeRoute: ApiPushResubscribeRoute,
   CollectionDidRkeyRoute: CollectionDidRkeyRoute,
   ComicDidRkeyRoute: ComicDidRkeyRoute,
   FeedLatestDidRoute: FeedLatestDidRoute,

--- a/apps/standard-reader/src/routes/_layout.u.$did.tsx
+++ b/apps/standard-reader/src/routes/_layout.u.$did.tsx
@@ -72,6 +72,7 @@ import { ArticleRow, PubDirectoryRow } from "../components/reader/cards";
 import { FeedLoadMore } from "../components/reader/feed-load-more";
 import { FollowUserButton } from "../components/reader/follow-user-button";
 import { LinkifiedText } from "../components/reader/linkified-text";
+import { NotifyButton } from "../components/reader/notify-button";
 import {
   Handle,
   Kicker,
@@ -767,6 +768,11 @@ function AuthorProfileContent({
               ) : (
                 <>
                   {session?.user?.did ? <AddToListButton did={did} /> : null}
+                  <NotifyButton
+                    subjectType="author"
+                    subject={did}
+                    signedIn={session?.user?.did != null}
+                  />
                   <FollowUserButton
                     did={did}
                     signedIn={session?.user?.did != null}
@@ -834,6 +840,11 @@ function AuthorProfileContent({
             ) : (
               <>
                 {session?.user?.did ? <AddToListButton did={did} /> : null}
+                <NotifyButton
+                  subjectType="author"
+                  subject={did}
+                  signedIn={session?.user?.did != null}
+                />
                 <FollowUserButton
                   did={did}
                   signedIn={session?.user?.did != null}

--- a/apps/standard-reader/src/routes/api/push/resubscribe.tsx
+++ b/apps/standard-reader/src/routes/api/push/resubscribe.tsx
@@ -1,0 +1,96 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { and, eq, sql } from "drizzle-orm";
+
+/**
+ * Endpoint rotation, posted by the service worker's `pushsubscriptionchange`
+ * handler (`public/push-sw.js`).
+ *
+ * This is a plain server route rather than a server function because the caller
+ * is the service worker, which needs a stable, hand-written URL.
+ *
+ * The session cookie is the authorization: the old endpoint alone is not proof
+ * of anything, and accepting it would let anyone who learned an endpoint
+ * redirect that reader's notifications to a browser of their own. So the swap
+ * only happens between rows the signed-in reader already owns.
+ *
+ * Safari never fires `pushsubscriptionchange`, so this is a fast path, not the
+ * only one — `syncPushDevice()` re-registers on app load for everyone else.
+ */
+
+interface ResubscribeBody {
+  oldEndpoint?: unknown;
+  subscription?: {
+    endpoint?: unknown;
+    keys?: { p256dh?: unknown; auth?: unknown };
+  };
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 && value.length <= 2048
+    ? value
+    : null;
+}
+
+export const Route = createFileRoute("/api/push/resubscribe")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        let body: ResubscribeBody;
+        try {
+          body = (await request.json()) as ResubscribeBody;
+        } catch {
+          return new Response(null, { status: 400 });
+        }
+
+        const oldEndpoint = asString(body.oldEndpoint);
+        const endpoint = asString(body.subscription?.endpoint);
+        const p256dh = asString(body.subscription?.keys?.p256dh);
+        const auth = asString(body.subscription?.keys?.auth);
+        if (!endpoint || !p256dh || !auth) {
+          return new Response(null, { status: 400 });
+        }
+
+        const { getReaderDidForRequest } =
+          await import("#/middleware/auth-session.server");
+        const did = await getReaderDidForRequest(request);
+        if (!did) {
+          return new Response(null, { status: 401 });
+        }
+
+        const [{ db }, schema] = await Promise.all([
+          import("#/db/index.server"),
+          import("#/db/schema"),
+        ]);
+
+        const values = {
+          endpoint,
+          ownerDid: did,
+          p256dh,
+          auth,
+          userAgent: request.headers.get("user-agent")?.slice(0, 512) ?? null,
+          failureCount: 0,
+          lastSeenAt: sql`now()`,
+        };
+
+        await db.insert(schema.pushDevices).values(values).onConflictDoUpdate({
+          target: schema.pushDevices.endpoint,
+          set: values,
+        });
+
+        // Drop the superseded row, but only if it was this reader's.
+        if (oldEndpoint && oldEndpoint !== endpoint) {
+          await db
+            .delete(schema.pushDevices)
+            .where(
+              and(
+                eq(schema.pushDevices.endpoint, oldEndpoint),
+                eq(schema.pushDevices.ownerDid, did),
+              ),
+            );
+        }
+
+        return new Response(null, { status: 204 });
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/server/ingest/consumer.ts
+++ b/apps/standard-reader/src/server/ingest/consumer.ts
@@ -25,6 +25,10 @@ import type {
 import { Collections, buildAtUri } from "../atproto/uri.ts";
 import { logEvent } from "../observability/log.ts";
 import {
+  enqueuePostNotification,
+  recordClaimsPublishDate,
+} from "../push/enqueue.ts";
+import {
   applyIdentity,
   deleteRecord,
   upsertBookmark,
@@ -70,6 +74,44 @@ function noteUnmodeledCollection(collection: string, uri: string): void {
     reason: "unmodeled-collection",
     uri,
   });
+}
+
+/**
+ * Queue a web push notification for a document we just indexed.
+ *
+ * Gated on `live` because this dispatcher is shared with the PDS reconcile
+ * replay (`repo-sync.ts` sets `live: false`) — without it, repairing a repo
+ * would notify about its whole history. The claim inside
+ * {@link enqueuePostNotification} is what covers the rest: tap redelivery,
+ * dead-letter replay, and later `update` events for the same document.
+ *
+ * Deliberately NOT restricted to `action === "create"`. `upsertDocument`
+ * resolves external bodies (Leaflet, pckt, fetched formats), and a transient
+ * failure there leaves `hasRenderableBody = false` — a create-only gate would
+ * find nothing and the post would never notify, because the later `update` that
+ * fixes the body wouldn't try again. "The first event where it became
+ * renderable" is the trigger we actually want.
+ *
+ * Failures are swallowed: a missed notification must never dead-letter an event
+ * that was applied to the read-model successfully.
+ */
+async function maybeQueuePushNotification(
+  uri: string,
+  payload: TapRecordPayload,
+  record: Record<string, unknown>,
+): Promise<void> {
+  if (!payload.live || !recordClaimsPublishDate(record)) {
+    return;
+  }
+  try {
+    await enqueuePostNotification(uri);
+  } catch (error) {
+    logEvent("push.enqueueFailed", {
+      ok: false,
+      reason: error instanceof Error ? error.message : String(error),
+      uri,
+    });
+  }
 }
 
 /**
@@ -138,6 +180,7 @@ export async function handleRecord(payload: TapRecordPayload): Promise<void> {
         cid,
         record as unknown as DocumentRecord,
       );
+      await maybeQueuePushNotification(uri, payload, record);
       return;
     }
     case Collections.subscription: {

--- a/apps/standard-reader/src/server/push/config.test.ts
+++ b/apps/standard-reader/src/server/push/config.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { pushConfig } from "./config";
+
+/**
+ * `canRegister` and `canSend` are deliberately different gates, and conflating
+ * them is not hypothetical — it shipped. The web service holds only the public
+ * key (the private key belongs to the send cron alone), so gating device
+ * registration on both made the bell report "we couldn't set up notifications on
+ * this device" on a correctly configured deployment.
+ */
+const ORIGINAL = {
+  publicKey: process.env.VAPID_PUBLIC_KEY,
+  privateKey: process.env.VAPID_PRIVATE_KEY,
+};
+
+function setKeys(publicKey?: string, privateKey?: string): void {
+  if (publicKey === undefined) delete process.env.VAPID_PUBLIC_KEY;
+  else process.env.VAPID_PUBLIC_KEY = publicKey;
+  if (privateKey === undefined) delete process.env.VAPID_PRIVATE_KEY;
+  else process.env.VAPID_PRIVATE_KEY = privateKey;
+}
+
+afterEach(() => {
+  setKeys(ORIGINAL.publicKey, ORIGINAL.privateKey);
+});
+
+describe("pushConfig gates", () => {
+  it("lets a browser subscribe with only the public key — the web service's state", () => {
+    setKeys("pub", undefined);
+    expect(pushConfig.canRegister).toBe(true);
+    expect(pushConfig.canSend).toBe(false);
+  });
+
+  it("allows sending only when both keys are present — the cron's state", () => {
+    setKeys("pub", "priv");
+    expect(pushConfig.canRegister).toBe(true);
+    expect(pushConfig.canSend).toBe(true);
+  });
+
+  it("refuses both with no keys, so a PR preview can't send", () => {
+    setKeys(undefined, undefined);
+    expect(pushConfig.canRegister).toBe(false);
+    expect(pushConfig.canSend).toBe(false);
+  });
+
+  it("refuses to send with a private key but no public key", () => {
+    setKeys(undefined, "priv");
+    expect(pushConfig.canRegister).toBe(false);
+    expect(pushConfig.canSend).toBe(false);
+  });
+});

--- a/apps/standard-reader/src/server/push/config.ts
+++ b/apps/standard-reader/src/server/push/config.ts
@@ -1,0 +1,104 @@
+/**
+ * Server-only web-push configuration, read from environment. Mirrors
+ * `src/server/digest/config.ts`.
+ *
+ * Only `VAPID_PUBLIC_KEY` is safe to hand to a browser (it's the application
+ * server key the subscription is bound to). The private key is what authorizes
+ * sending, so it lives solely in the push-send cron — the web service never
+ * needs it, and the ingest worker needs none of this.
+ */
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is not set`);
+  }
+  return value;
+}
+
+export const pushConfig = {
+  /** VAPID public key, base64url. Sent to the browser by `getPushConfig`. */
+  get publicKey(): string {
+    return required("VAPID_PUBLIC_KEY");
+  },
+
+  /** VAPID private key, base64url. Cron only — never reaches the client. */
+  get privateKey(): string {
+    return required("VAPID_PRIVATE_KEY");
+  },
+
+  /** VAPID `sub` claim; must be a `mailto:` or `https:` URL. */
+  get subject(): string {
+    return process.env.VAPID_SUBJECT ?? "mailto:hello@standard-reader.app";
+  },
+
+  /**
+   * Whether push is configured at all. The cron exits cleanly when this is
+   * false rather than throwing, which is what keeps a Railway PR preview
+   * pointed at a shared database from sending real notifications carrying
+   * preview-domain links.
+   */
+  get configured(): boolean {
+    return Boolean(
+      process.env.VAPID_PUBLIC_KEY && process.env.VAPID_PRIVATE_KEY,
+    );
+  },
+
+  /** Documents to drain per invocation. A backlog spreads across ticks
+   * instead of one run growing without bound. */
+  get maxDocumentsPerRun(): number {
+    const raw = process.env.PUSH_MAX_DOCUMENTS_PER_RUN;
+    const n = raw ? Number.parseInt(raw, 10) : 20;
+    return Number.isFinite(n) && n > 0 ? n : 20;
+  },
+
+  /** Hard ceiling on individual notifications sent in one invocation, across
+   * all documents. Guards against one very widely-followed publication
+   * monopolising a run. */
+  get maxSendsPerRun(): number {
+    const raw = process.env.PUSH_MAX_SENDS_PER_RUN;
+    const n = raw ? Number.parseInt(raw, 10) : 2000;
+    return Number.isFinite(n) && n > 0 ? n : 2000;
+  },
+
+  /** How many endpoints to push to concurrently. Push services are independent,
+   * so this can be higher than the digest's sequential email sends. */
+  get sendConcurrency(): number {
+    const raw = process.env.PUSH_SEND_CONCURRENCY;
+    const n = raw ? Number.parseInt(raw, 10) : 8;
+    return Number.isFinite(n) && n > 0 ? n : 8;
+  },
+} as const;
+
+/**
+ * Most notifications one author may generate per hour. A repo that dumps its
+ * archive with fresh timestamps is the scenario this exists for: the enqueue's
+ * freshness guards can't tell that case apart from a genuine burst of posting,
+ * so the cap is the backstop. Documents over the cap are marked `failed` rather
+ * than retried — by the time a run is under the cap again they're no longer new.
+ */
+export const PUSH_AUTHOR_HOURLY_CAP = 5;
+
+/** Attempts before a queued document is abandoned as `failed`. */
+export const PUSH_MAX_ATTEMPTS = 3;
+
+/**
+ * A `sending` row older than this is assumed to belong to a run that died
+ * mid-send, and is re-claimed. Comfortably longer than the 5-minute cron
+ * interval so a slow-but-alive run is never stolen from.
+ */
+export const PUSH_CLAIM_TIMEOUT_MINUTES = 10;
+
+/**
+ * Only documents indexed this recently are eligible to notify. This — not
+ * `publishedAt` — is the real "new to us" signal: `documents.indexed_at` is set
+ * once on first insert and survives every later update, so a tap cursor rewind
+ * or a fresh tap instance re-streaming known repos can't page every reader at
+ * once.
+ */
+export const PUSH_INDEXED_WITHIN_HOURS = 1;
+
+/** Only documents published this recently are eligible to notify. */
+export const PUSH_PUBLISHED_WITHIN_HOURS = 24;
+
+export { required as requiredEnv };

--- a/apps/standard-reader/src/server/push/config.ts
+++ b/apps/standard-reader/src/server/push/config.ts
@@ -33,12 +33,23 @@ export const pushConfig = {
   },
 
   /**
-   * Whether push is configured at all. The cron exits cleanly when this is
-   * false rather than throwing, which is what keeps a Railway PR preview
-   * pointed at a shared database from sending real notifications carrying
-   * preview-domain links.
+   * Whether a browser can subscribe. Only the **public** key is needed to hand
+   * a browser an `applicationServerKey`, and the web service deliberately holds
+   * nothing else — so this must NOT also require the private key. Gating
+   * registration on both is what made the bell report "we couldn't set up
+   * notifications on this device" while everything was configured correctly.
    */
-  get configured(): boolean {
+  get canRegister(): boolean {
+    return Boolean(process.env.VAPID_PUBLIC_KEY);
+  },
+
+  /**
+   * Whether we can actually deliver. Signing a push requires the private key,
+   * which lives only in the send cron. It exits cleanly when this is false
+   * rather than throwing — that's what stops a Railway PR preview pointed at a
+   * shared database from sending real notifications with preview-domain links.
+   */
+  get canSend(): boolean {
     return Boolean(
       process.env.VAPID_PUBLIC_KEY && process.env.VAPID_PRIVATE_KEY,
     );

--- a/apps/standard-reader/src/server/push/enqueue.test.ts
+++ b/apps/standard-reader/src/server/push/enqueue.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { recordClaimsPublishDate } from "./enqueue";
+
+/**
+ * The guard that stops an archive import from notifying about everything.
+ *
+ * `documents.published_at` can't be trusted for this: `upsertDocument` computes
+ * it as `publishedAt ?? updatedAt ?? new Date()`, so an undated record lands
+ * with `published_at = now()` and passes any freshness window. Checking the
+ * record itself is what closes that.
+ */
+describe("recordClaimsPublishDate", () => {
+  it("accepts a record with a publishedAt", () => {
+    expect(
+      recordClaimsPublishDate({ publishedAt: "2026-08-09T12:00:00.000Z" }),
+    ).toBe(true);
+  });
+
+  it("falls back to updatedAt when publishedAt is missing", () => {
+    expect(
+      recordClaimsPublishDate({ updatedAt: "2026-08-09T12:00:00.000Z" }),
+    ).toBe(true);
+  });
+
+  it("rejects a record with no dates at all", () => {
+    // This is the archive-import case: 200 undated posts would otherwise all
+    // land with published_at = now() and notify.
+    expect(recordClaimsPublishDate({})).toBe(false);
+  });
+
+  it("rejects unparseable dates", () => {
+    expect(recordClaimsPublishDate({ publishedAt: "sometime last year" })).toBe(
+      false,
+    );
+    expect(recordClaimsPublishDate({ publishedAt: "" })).toBe(false);
+  });
+
+  it("rejects non-string date fields", () => {
+    // Records come off the firehose untyped, so a number or an object here is
+    // a real possibility rather than a hypothetical.
+    expect(recordClaimsPublishDate({ publishedAt: 1_754_740_800_000 })).toBe(
+      false,
+    );
+    expect(recordClaimsPublishDate({ publishedAt: null })).toBe(false);
+    expect(recordClaimsPublishDate({ updatedAt: { at: "now" } })).toBe(false);
+  });
+
+  it("accepts when one of the two dates is usable", () => {
+    expect(
+      recordClaimsPublishDate({
+        publishedAt: "not a date",
+        updatedAt: "2026-08-09T12:00:00.000Z",
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/standard-reader/src/server/push/enqueue.ts
+++ b/apps/standard-reader/src/server/push/enqueue.ts
@@ -1,0 +1,86 @@
+import { sql } from "drizzle-orm";
+
+import { db } from "../../db/index.ts";
+import {
+  PUSH_INDEXED_WITHIN_HOURS,
+  PUSH_PUBLISHED_WITHIN_HOURS,
+} from "./config.ts";
+
+/**
+ * The ingest side of web push: queue a newly-indexed document for notification.
+ *
+ * This is the ONLY thing push adds to the tap worker. It's one statement that
+ * usually inserts nothing, which matters — the worker sees tens of thousands of
+ * document writes an hour and must not fall behind the firehose. Everything
+ * expensive (recipient resolution, encryption, the HTTPS calls to push services)
+ * happens later, in the push-send cron.
+ */
+
+/**
+ * Whether the record itself claims a publication date.
+ *
+ * This has to be checked against the *record*, not `documents.published_at`.
+ * `upsertDocument` computes that column as
+ * `publishedAt ?? updatedAt ?? new Date()`, so a document with no dates at all
+ * lands with `published_at = now()` and sails through any freshness window. A
+ * repo importing 200 undated archive posts would then notify on all 200. Real
+ * posts carry the date — the lexicon requires it — so requiring one here costs
+ * nothing and closes that hole.
+ */
+export function recordClaimsPublishDate(record: {
+  publishedAt?: unknown;
+  updatedAt?: unknown;
+}): boolean {
+  for (const value of [record.publishedAt, record.updatedAt]) {
+    if (typeof value === "string" && Number.isFinite(Date.parse(value))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Claim a document for notification, atomically.
+ *
+ * The primary key on `document_push_queue` is what makes this exactly-once: tap
+ * redelivery, dead-letter replay, and every later `update` event for the same
+ * document all collapse into `DO NOTHING`. Returns whether this call is the one
+ * that claimed it (useful for logging; nothing downstream depends on it).
+ *
+ * The guards, in order of what each one actually protects against:
+ *
+ *   - `deleted` / `has_renderable_body` — don't notify about something there's
+ *     nothing to read.
+ *   - `indexed_at` — the real "new to us" signal. It's set once on first insert
+ *     and survives every later upsert, so a tap cursor rewind or a fresh tap
+ *     instance re-streaming repos we already know can't page every reader at
+ *     once.
+ *   - `published_at` lower bound — an old post surfacing late (a repo being
+ *     re-added, a slow backfill) isn't news.
+ *   - `published_at` upper bound — a future-dated record shouldn't be able to
+ *     stay permanently eligible.
+ */
+export async function enqueuePostNotification(
+  documentUri: string,
+): Promise<boolean> {
+  const rows = await db.execute<{ document_uri: string }>(sql`
+    insert into document_push_queue (document_uri, author_did)
+    select d.uri, d.did
+      from documents d
+     where d.uri = ${documentUri}
+       and d.deleted = false
+       and d.has_renderable_body = true
+       and d.indexed_at > now() - make_interval(hours => ${PUSH_INDEXED_WITHIN_HOURS})
+       and d.published_at > now() - make_interval(hours => ${PUSH_PUBLISHED_WITHIN_HOURS})
+       and d.published_at < now() + make_interval(hours => 1)
+    on conflict (document_uri) do nothing
+    returning document_uri
+  `);
+
+  // The neon-http and node-postgres drivers disagree about whether `execute`
+  // returns the rows directly or wraps them in `{ rows }`.
+  const returned = Array.isArray(rows)
+    ? rows
+    : ((rows as { rows?: Array<unknown> }).rows ?? []);
+  return returned.length > 0;
+}

--- a/apps/standard-reader/src/server/push/fan-out.test.ts
+++ b/apps/standard-reader/src/server/push/fan-out.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPayload, notificationTag, truncate } from "./fan-out";
+
+const BASE = {
+  did: "did:plc:author",
+  title: "The quiet part of the network",
+  description: null,
+  publicationUri: "at://did:plc:pub/site.standard.publication/abc123",
+  publicationName: "The Standard Review",
+  authorDisplayName: "Alice Example",
+  authorHandle: "alice.example.com",
+};
+
+describe("truncate", () => {
+  it("leaves short strings alone, trimmed", () => {
+    expect(truncate("  Hello  ", 40)).toBe("Hello");
+  });
+
+  it("cuts at a word boundary when there is a close one", () => {
+    const result = truncate("the quick brown fox jumps over", 20);
+    expect(result).toBe("the quick brown fox…");
+    expect(result.length).toBeLessThanOrEqual(20);
+  });
+
+  it("hard-cuts when the only boundary is too far back", () => {
+    // No space near the limit, so a word-boundary cut would throw away most of
+    // the string. Better to cut mid-word than to show almost nothing.
+    const result = truncate("a supercalifragilisticexpialidocious word", 20);
+    expect(result.length).toBeLessThanOrEqual(20);
+    expect(result.endsWith("…")).toBe(true);
+    expect(result.startsWith("a supercal")).toBe(true);
+  });
+
+  it("never exceeds the limit", () => {
+    for (const max of [10, 25, 80, 160]) {
+      const result = truncate("x ".repeat(300), max);
+      expect(result.length).toBeLessThanOrEqual(max);
+    }
+  });
+});
+
+describe("notificationTag", () => {
+  it("keys on the publication when there is one", () => {
+    const tag = notificationTag(BASE.publicationUri, BASE.did);
+    expect(tag.startsWith("sr:")).toBe(true);
+    expect(tag).toContain("abc123");
+  });
+
+  it("falls back to the author for a publication-less post", () => {
+    expect(notificationTag(null, "did:plc:author")).toBe("sr:did:plc:author");
+  });
+
+  it("stays within the push services' tag budget", () => {
+    const long = `at://did:plc:${"x".repeat(200)}/site.standard.publication/${"y".repeat(200)}`;
+    expect(notificationTag(long, BASE.did).length).toBeLessThanOrEqual(35);
+  });
+
+  it("gives two posts from one publication the same tag, so they collapse", () => {
+    expect(notificationTag(BASE.publicationUri, "did:plc:a")).toBe(
+      notificationTag(BASE.publicationUri, "did:plc:b"),
+    );
+  });
+});
+
+describe("buildPayload", () => {
+  const url = "https://standard-reader.app/a/did%3Aplc%3Aauthor/xyz";
+
+  it("titles with the publication and bodies with the post", () => {
+    const payload = buildPayload(BASE, url);
+    expect(payload.title).toBe("The Standard Review");
+    expect(payload.body).toBe("The quiet part of the network");
+    expect(payload.url).toBe(url);
+  });
+
+  it("falls back to the author when the post has no publication", () => {
+    const payload = buildPayload(
+      { ...BASE, publicationName: null, publicationUri: null },
+      url,
+    );
+    expect(payload.title).toBe("Alice Example");
+  });
+
+  it("falls back to the handle when there is no display name", () => {
+    const payload = buildPayload(
+      {
+        ...BASE,
+        authorDisplayName: null,
+        publicationName: null,
+        publicationUri: null,
+      },
+      url,
+    );
+    expect(payload.title).toBe("@alice.example.com");
+  });
+
+  it("still produces something showable with no names at all", () => {
+    // The service worker must show a notification on every push — iOS revokes
+    // the subscription otherwise — so an empty payload is not an option.
+    const payload = buildPayload(
+      {
+        ...BASE,
+        authorDisplayName: null,
+        authorHandle: null,
+        publicationName: null,
+        publicationUri: null,
+      },
+      url,
+    );
+    expect(payload.title).toBe("Standard Reader");
+  });
+
+  it("uses the description when a document has no title", () => {
+    const payload = buildPayload(
+      { ...BASE, title: "", description: "A short note about nothing" },
+      url,
+    );
+    expect(payload.body).toBe("A short note about nothing");
+  });
+
+  it("keeps the payload small enough to encrypt under the 4KB cap", () => {
+    const payload = buildPayload(
+      {
+        ...BASE,
+        description: "d".repeat(5000),
+        publicationName: "p".repeat(5000),
+        title: "t".repeat(5000),
+      },
+      url,
+    );
+    expect(JSON.stringify(payload).length).toBeLessThan(1000);
+  });
+});

--- a/apps/standard-reader/src/server/push/fan-out.ts
+++ b/apps/standard-reader/src/server/push/fan-out.ts
@@ -1,0 +1,231 @@
+import { and, eq, inArray, notInArray, or } from "drizzle-orm";
+
+import { articleReaderUrl } from "#/components/reader/format";
+
+import { db } from "../../db/index.ts";
+import {
+  documentContributors,
+  documents,
+  profiles,
+  publications,
+  pushDevices,
+  pushTopics,
+} from "../../db/schema.ts";
+
+/**
+ * Turning one queued document into a list of (device, payload) sends.
+ *
+ * Split out from the run loop so the interesting part — who actually gets
+ * notified — is testable on its own, and so the loop stays about throttling and
+ * bookkeeping.
+ *
+ * Everything here goes through the Drizzle query builder rather than raw `sql`
+ * templates on purpose: a JS array interpolated into a `sql` template binds as a
+ * single scalar, so `= any(${array})` silently matches nothing. `inArray` /
+ * `notInArray` expand properly.
+ */
+
+/** A browser to deliver to. */
+export interface PushTarget {
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+  ownerDid: string;
+}
+
+/** What a queued document turns into on the wire. */
+export interface PushPayload {
+  title: string;
+  body: string;
+  url: string;
+  tag: string;
+}
+
+export interface DocumentNotification {
+  documentUri: string;
+  payload: PushPayload;
+  targets: Array<PushTarget>;
+}
+
+/**
+ * Web push caps the encrypted payload at ~4KB, and the notification itself is
+ * two lines of text on a lock screen. Truncate hard rather than risk a 413.
+ */
+const MAX_TITLE = 80;
+const MAX_BODY = 160;
+
+export function truncate(value: string, max: number): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= max) return trimmed;
+
+  // One character of the budget belongs to the ellipsis.
+  const slice = trimmed.slice(0, max - 1);
+
+  // If the cut already landed on a word boundary, keep the whole slice — backing
+  // off to the previous space would throw away a word for nothing.
+  if (/\s/.test(trimmed.charAt(max - 1))) {
+    return `${slice.trimEnd()}…`;
+  }
+
+  // Otherwise back off to the last space, unless that's so far back it would
+  // leave almost nothing — a single very long word is better cut mid-word.
+  const lastSpace = slice.lastIndexOf(" ");
+  const base = lastSpace > max * 0.6 ? slice.slice(0, lastSpace) : slice;
+  return `${base.trimEnd()}…`;
+}
+
+/**
+ * Notification `tag`, which collapses a burst from one source into a single
+ * notification on the device instead of a stack. Also what stops a retried send
+ * from showing twice. Push services cap this, so keep it short.
+ */
+export function notificationTag(
+  publicationUri: string | null,
+  authorDid: string,
+): string {
+  const source = publicationUri ?? authorDid;
+  return `sr:${source.slice(-32)}`;
+}
+
+/** Everything the payload needs, in one round trip. (Neon lives a region away
+ * from the app, so round-trip count is what's worth optimizing.) */
+async function loadDocument(documentUri: string) {
+  const rows = await db
+    .select({
+      uri: documents.uri,
+      did: documents.did,
+      title: documents.title,
+      description: documents.description,
+      publicationUri: documents.publicationUri,
+      publicationName: publications.name,
+      authorDisplayName: profiles.displayName,
+      authorHandle: profiles.handle,
+    })
+    .from(documents)
+    .leftJoin(publications, eq(publications.uri, documents.publicationUri))
+    .leftJoin(profiles, eq(profiles.did, documents.did))
+    .where(and(eq(documents.uri, documentUri), eq(documents.deleted, false)))
+    .limit(1);
+
+  return rows[0] ?? null;
+}
+
+/** Author plus every credited contributor — the people an "author" opt-in can
+ * match, and the people who must not be notified about their own post. */
+export async function documentSubjectDids(
+  documentUri: string,
+  authorDid: string,
+): Promise<Array<string>> {
+  const rows = await db
+    .select({ did: documentContributors.did })
+    .from(documentContributors)
+    .where(eq(documentContributors.documentUri, documentUri));
+
+  return [...new Set([authorDid, ...rows.map((row) => row.did)])];
+}
+
+/**
+ * Which browsers should hear about this document.
+ *
+ * `push_topics` is the permission — a row there is the only reason anyone gets
+ * a notification. Two things in here are easy to get wrong and are load-bearing:
+ *
+ *   1. `selectDistinct`. A reader with two devices should get two sends, but the
+ *      join must not multiply rows for any other reason.
+ *   2. The author and contributors are excluded. Being told about your own post
+ *      is noise.
+ *
+ * Note this does NOT consult `subscriptions` / `user_follows`: notifications are
+ * deliberately independent of following, so the opt-in row stands on its own.
+ */
+export async function resolveTargets(
+  publicationUri: string | null,
+  subjectDids: Array<string>,
+): Promise<Array<PushTarget>> {
+  if (subjectDids.length === 0) return [];
+
+  const authorMatch = and(
+    eq(pushTopics.subjectType, "author"),
+    inArray(pushTopics.subject, subjectDids),
+  );
+  const publicationMatch = publicationUri
+    ? and(
+        eq(pushTopics.subjectType, "publication"),
+        eq(pushTopics.subject, publicationUri),
+      )
+    : undefined;
+
+  const optedIn = db
+    .select({ ownerDid: pushTopics.ownerDid })
+    .from(pushTopics)
+    .where(publicationMatch ? or(authorMatch, publicationMatch) : authorMatch);
+
+  return db
+    .selectDistinct({
+      endpoint: pushDevices.endpoint,
+      p256dh: pushDevices.p256dh,
+      auth: pushDevices.auth,
+      ownerDid: pushDevices.ownerDid,
+    })
+    .from(pushDevices)
+    .where(
+      and(
+        inArray(pushDevices.ownerDid, optedIn),
+        notInArray(pushDevices.ownerDid, subjectDids),
+      ),
+    );
+}
+
+/**
+ * Build the notification for a queued document, or `null` when there is nothing
+ * to send (document gone, unlinkable, or nobody opted in).
+ */
+export async function buildNotification(
+  documentUri: string,
+  baseUrl: string,
+): Promise<DocumentNotification | null> {
+  const document = await loadDocument(documentUri);
+  if (!document) return null;
+
+  const url = articleReaderUrl(document.uri, baseUrl);
+  if (!url) return null;
+
+  const subjectDids = await documentSubjectDids(documentUri, document.did);
+  const targets = await resolveTargets(document.publicationUri, subjectDids);
+  if (targets.length === 0) return null;
+
+  return {
+    documentUri,
+    payload: buildPayload(document, url),
+    targets,
+  };
+}
+
+/** Split out from {@link buildNotification} so the copy is testable without a DB. */
+export function buildPayload(
+  document: {
+    did: string;
+    title: string;
+    description: string | null;
+    publicationUri: string | null;
+    publicationName: string | null;
+    authorDisplayName: string | null;
+    authorHandle: string | null;
+  },
+  url: string,
+): PushPayload {
+  // Whose name goes on the notification: the publication when the post has one,
+  // otherwise the author — matching how the reader chose to follow it.
+  const source =
+    document.publicationName ??
+    document.authorDisplayName ??
+    (document.authorHandle ? `@${document.authorHandle}` : null) ??
+    "Standard Reader";
+
+  return {
+    title: truncate(source, MAX_TITLE),
+    body: truncate(document.title || document.description || "", MAX_BODY),
+    url,
+    tag: notificationTag(document.publicationUri, document.did),
+  };
+}

--- a/apps/standard-reader/src/server/push/run.ts
+++ b/apps/standard-reader/src/server/push/run.ts
@@ -215,7 +215,7 @@ export async function runPushSend(): Promise<PushRunSummary> {
     pruned: 0,
   };
 
-  if (!pushConfig.configured) {
+  if (!pushConfig.canSend) {
     // No VAPID keys. Exit quietly rather than throwing — this is the state a
     // Railway PR preview is in, and it must not send real notifications
     // carrying preview-domain links.

--- a/apps/standard-reader/src/server/push/run.ts
+++ b/apps/standard-reader/src/server/push/run.ts
@@ -1,0 +1,279 @@
+/**
+ * Push send runner. Claims a batch of queued documents, resolves who opted in,
+ * and delivers the notifications — then marks each document `sent` or `failed`.
+ *
+ * Invoked by the short-lived `push-cron` entrypoint (`scripts/send-push.ts`).
+ * Like the weekly digest, it deliberately runs in its own scheduled process
+ * rather than inside the long-lived `ingest` worker: the worker's job is keeping
+ * up with the firehose, and a fan-out to hundreds of push endpoints has no
+ * business competing with that for connections or event-loop time. The ingest
+ * side of this feature is one INSERT (`./enqueue.ts`) and nothing else.
+ */
+
+import { eq, sql } from "drizzle-orm";
+import webpush from "web-push";
+
+import { getCanonicalPublicUrl } from "#/lib/public-url";
+
+import { db } from "../../db/index.ts";
+import { documentPushQueue, pushDevices } from "../../db/schema.ts";
+import {
+  PUSH_AUTHOR_HOURLY_CAP,
+  PUSH_CLAIM_TIMEOUT_MINUTES,
+  PUSH_MAX_ATTEMPTS,
+  pushConfig,
+} from "./config.ts";
+import { buildNotification } from "./fan-out.ts";
+import type { PushPayload, PushTarget } from "./fan-out.ts";
+
+export interface PushRunSummary {
+  /** Documents claimed by this run. */
+  claimed: number;
+  /** Documents that produced at least one successful send. */
+  delivered: number;
+  /** Documents with nobody opted in (or already gone). */
+  skippedEmpty: number;
+  /** Documents held back by the per-author hourly cap. */
+  suppressed: number;
+  /** Documents that errored and were released for another attempt. */
+  retried: number;
+  /** Documents that exhausted their attempts. */
+  failed: number;
+  /** Individual notifications accepted by a push service. */
+  sent: number;
+  /** Dead endpoints pruned (404/410 from the push service). */
+  pruned: number;
+}
+
+// A type alias, not an interface: `db.execute<T>` constrains `T` to
+// `Record<string, unknown>`, and only type aliases get an implicit index
+// signature.
+type ClaimedRow = {
+  document_uri: string;
+  author_did: string;
+  attempts: number;
+};
+
+/** Normalize `db.execute` across the neon-http and node-postgres drivers. */
+async function unwrap<T>(query: Promise<unknown>): Promise<Array<T>> {
+  const result = await query;
+  if (Array.isArray(result)) return result as Array<T>;
+  return ((result as { rows?: Array<T> }).rows ?? []) as Array<T>;
+}
+
+/**
+ * Take ownership of up to `limit` queued documents.
+ *
+ * `for update skip locked` is what makes this safe to run concurrently — an
+ * overrunning cron tick and the next one can never claim the same row, so a slow
+ * run can't cause a double send.
+ *
+ * The second arm of the `where` is the reaper: a row left `sending` by a process
+ * that died mid-flight would otherwise sit there forever. The timeout is
+ * comfortably longer than the cron interval so a slow-but-alive run is never
+ * stolen from.
+ */
+async function claimBatch(limit: number): Promise<Array<ClaimedRow>> {
+  return unwrap<ClaimedRow>(
+    db.execute<ClaimedRow>(sql`
+      update document_push_queue q
+         set state = 'sending',
+             attempts = q.attempts + 1,
+             claimed_at = now(),
+             updated_at = now()
+       where q.document_uri in (
+         select document_uri
+           from document_push_queue
+          where (state = 'pending' and available_at <= now())
+             or (state = 'sending'
+                 and claimed_at < now() - make_interval(mins => ${PUSH_CLAIM_TIMEOUT_MINUTES}))
+          order by created_at
+          limit ${limit}
+          for update skip locked
+       )
+      returning q.document_uri, q.author_did, q.attempts
+    `),
+  );
+}
+
+/**
+ * How many notifications this author has already generated in the last hour.
+ *
+ * The enqueue's freshness guards can't tell a genuine burst of posting from a
+ * repo dumping its archive with fresh timestamps, so this is the backstop.
+ * Documents over the cap are marked `failed` rather than retried — by the time a
+ * run is under the cap again they're no longer new, and a delayed notification
+ * about an old post is worse than none.
+ */
+async function recentSendsForAuthor(authorDid: string): Promise<number> {
+  const rows = await unwrap<{ n: number | string }>(
+    db.execute<{ n: number | string }>(sql`
+      select count(*)::int as n
+        from document_push_queue
+       where author_did = ${authorDid}
+         and state = 'sent'
+         and updated_at > now() - make_interval(hours => 1)
+    `),
+  );
+  return Number(rows[0]?.n ?? 0);
+}
+
+async function settle(
+  documentUri: string,
+  state: "sent" | "failed" | "pending",
+  lastError: string | null,
+): Promise<void> {
+  await db
+    .update(documentPushQueue)
+    .set({
+      state,
+      lastError,
+      claimedAt: null,
+      updatedAt: sql`now()`,
+    })
+    .where(eq(documentPushQueue.documentUri, documentUri));
+}
+
+/** Run `worker` over `items` with at most `limit` in flight. */
+async function pooled<T>(
+  items: Array<T>,
+  limit: number,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  let cursor = 0;
+  const runners = Array.from(
+    { length: Math.min(limit, items.length) },
+    async () => {
+      while (cursor < items.length) {
+        const index = cursor;
+        cursor += 1;
+        await worker(items[index]);
+      }
+    },
+  );
+  await Promise.all(runners);
+}
+
+interface SendOutcome {
+  sent: number;
+  pruned: number;
+}
+
+async function deliver(
+  targets: Array<PushTarget>,
+  payload: PushPayload,
+): Promise<SendOutcome> {
+  const body = JSON.stringify(payload);
+  let sent = 0;
+  let pruned = 0;
+  const dead: Array<string> = [];
+
+  await pooled(targets, pushConfig.sendConcurrency, async (target) => {
+    try {
+      await webpush.sendNotification(
+        {
+          endpoint: target.endpoint,
+          keys: { p256dh: target.p256dh, auth: target.auth },
+        },
+        body,
+        { TTL: 60 * 60 * 12 },
+      );
+      sent += 1;
+    } catch (error: unknown) {
+      const status = (error as { statusCode?: number }).statusCode;
+      if (status === 404 || status === 410) {
+        // The subscription is gone for good — the browser was uninstalled, or
+        // the reader revoked permission. Drop the row; nothing to retry.
+        dead.push(target.endpoint);
+        pruned += 1;
+        return;
+      }
+      console.warn(
+        `[push] send failed (${status ?? "no status"}) for ${target.endpoint.slice(0, 60)}…`,
+      );
+    }
+  });
+
+  if (dead.length > 0) {
+    await pooled(dead, 4, async (endpoint) => {
+      await db.delete(pushDevices).where(eq(pushDevices.endpoint, endpoint));
+    });
+  }
+
+  return { sent, pruned };
+}
+
+export async function runPushSend(): Promise<PushRunSummary> {
+  const summary: PushRunSummary = {
+    claimed: 0,
+    delivered: 0,
+    skippedEmpty: 0,
+    suppressed: 0,
+    retried: 0,
+    failed: 0,
+    sent: 0,
+    pruned: 0,
+  };
+
+  if (!pushConfig.configured) {
+    // No VAPID keys. Exit quietly rather than throwing — this is the state a
+    // Railway PR preview is in, and it must not send real notifications
+    // carrying preview-domain links.
+    console.log("[push] VAPID keys not configured; nothing to do");
+    return summary;
+  }
+
+  webpush.setVapidDetails(
+    pushConfig.subject,
+    pushConfig.publicKey,
+    pushConfig.privateKey,
+  );
+
+  const baseUrl = getCanonicalPublicUrl();
+  const batch = await claimBatch(pushConfig.maxDocumentsPerRun);
+  summary.claimed = batch.length;
+
+  for (const row of batch) {
+    if (summary.sent >= pushConfig.maxSendsPerRun) {
+      // Run budget spent. Release the rest for the next tick rather than
+      // letting one very widely-followed publication monopolise the run.
+      await settle(row.document_uri, "pending", null);
+      continue;
+    }
+
+    try {
+      if (
+        (await recentSendsForAuthor(row.author_did)) >= PUSH_AUTHOR_HOURLY_CAP
+      ) {
+        summary.suppressed += 1;
+        await settle(row.document_uri, "failed", "author hourly cap");
+        continue;
+      }
+
+      const notification = await buildNotification(row.document_uri, baseUrl);
+      if (!notification) {
+        summary.skippedEmpty += 1;
+        await settle(row.document_uri, "sent", null);
+        continue;
+      }
+
+      const outcome = await deliver(notification.targets, notification.payload);
+      summary.sent += outcome.sent;
+      summary.pruned += outcome.pruned;
+      summary.delivered += 1;
+      await settle(row.document_uri, "sent", null);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (row.attempts >= PUSH_MAX_ATTEMPTS) {
+        summary.failed += 1;
+        await settle(row.document_uri, "failed", message);
+      } else {
+        summary.retried += 1;
+        await settle(row.document_uri, "pending", message);
+      }
+      console.warn(`[push] ${row.document_uri} failed: ${message}`);
+    }
+  }
+
+  return summary;
+}

--- a/apps/standard-reader/vite.config.ts
+++ b/apps/standard-reader/vite.config.ts
@@ -150,6 +150,17 @@ const config = defineConfig({
       devOptions: { enabled: false },
       workbox: {
         globDirectory: ".output/public",
+        // Web push listeners (`public/push-sw.js`). Kept as a separate classic
+        // script rather than moving the whole SW to `injectManifest`, which
+        // would mean hand-porting all of the runtime caching below.
+        //
+        // NOTE: `push-sw.js` is ALSO listed in `globPatterns` on purpose.
+        // `importScripts` bakes a bare URL into `sw.js`, so editing the imported
+        // file changes zero bytes of `sw.js` and browsers keep running the old
+        // push handler indefinitely. Precaching it puts its revision hash in the
+        // manifest inside `sw.js`, so the SW byte-diffs and the update actually
+        // reaches people.
+        importScripts: ["/push-sw.js"],
         // Precache ONLY the small, always-needed shell: the offline fallback,
         // the manifest, and the app icons. Deliberately do NOT precache the
         // hashed JS/CSS chunks — this app ships heavy, lazily-loaded features
@@ -160,6 +171,8 @@ const config = defineConfig({
         globPatterns: [
           "offline.html",
           "manifest.json",
+          // Not for offline use — see the `importScripts` note above.
+          "push-sw.js",
           "favicon.svg",
           "apple-touch-icon.png",
           "icon-*.png",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "reconcile:repos:dev": "pnpm --filter standard-reader reconcile:repos:dev",
     "digest:send": "pnpm --filter standard-reader digest:send",
     "digest:send:dev": "pnpm --filter standard-reader digest:send:dev",
+    "push:send": "pnpm --filter standard-reader push:send",
+    "push:send:dev": "pnpm --filter standard-reader push:send:dev",
     "thread:post": "pnpm --filter standard-reader thread:post",
     "thread:post:dev": "pnpm --filter standard-reader thread:post:dev",
     "backfill:actor-handles": "pnpm --filter standard-reader backfill:actor-handles",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,6 +354,9 @@ importers:
       web-haptics:
         specifier: ^0.0.6
         version: 0.0.6(react-dom@19.3.0-canary-ad78e251-20260616(react@19.3.0-canary-ad78e251-20260616))(react@19.3.0-canary-ad78e251-20260616)(svelte@5.56.7(@typescript-eslint/types@8.60.1))(vue@3.5.40(typescript@6.0.3))
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -421,6 +424,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.0
         version: 19.2.3(@types/react@19.2.17)
+      '@types/web-push':
+        specifier: ^3.6.4
+        version: 3.6.4
       '@typescript-eslint/parser':
         specifier: ^8.60.1
         version: 8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
@@ -4891,6 +4897,9 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/web-push@3.6.4':
+    resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
+
   '@types/webextension-polyfill@0.12.5':
     resolution: {integrity: sha512-uKSAv6LgcVdINmxXMKBuVIcg/2m5JZugoZO8x20g7j2bXJkPIl/lVGQcDlbV+aXAiTyXT2RA5U5mI4IGCDMQeg==}
 
@@ -5200,6 +5209,9 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -5303,6 +5315,9 @@ packages:
 
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
+
+  bn.js@4.12.5:
+    resolution: {integrity: sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==}
 
   body-parser@1.20.5:
     resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
@@ -6798,6 +6813,10 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
+  http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -7788,6 +7807,9 @@ packages:
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -9750,6 +9772,11 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -14099,6 +14126,10 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/web-push@3.6.4':
+    dependencies:
+      '@types/node': 22.19.20
+
   '@types/webextension-polyfill@0.12.5': {}
 
   '@types/yargs-parser@21.0.3': {}
@@ -14464,6 +14495,13 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.5
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   async-function@1.0.0: {}
@@ -14569,6 +14607,8 @@ snapshots:
       readable-stream: 3.6.2
 
   bluebird@3.7.2: {}
+
+  bn.js@4.12.5: {}
 
   body-parser@1.20.5:
     dependencies:
@@ -16259,6 +16299,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  http_ece@1.2.0: {}
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -17419,6 +17461,8 @@ snapshots:
     optional: true
 
   min-indent@1.0.1: {}
+
+  minimalistic-assert@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -19822,6 +19866,16 @@ snapshots:
       vue: 3.5.40(typescript@6.0.3)
 
   web-namespaces@2.0.1: {}
+
+  web-push@3.6.7:
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6
+      jws: 4.0.1
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
 
   webidl-conversions@3.0.1: {}
 

--- a/railway.push.json
+++ b/railway.push.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "RAILPACK"
+  },
+  "deploy": {
+    "startCommand": "pnpm push:send",
+    "cronSchedule": "*/5 * * * *",
+    "restartPolicyType": "NEVER"
+  }
+}


### PR DESCRIPTION
Standard Reader had no notifications at all. The only way to learn that a source you care about had published was to open the app and look, or wait for the Monday digest. This adds a bell to publication and author pages: turn it on, and the next time that source publishes, your browser tells you.

**Notifications are deliberately independent of subscribing.** The bell doesn't change your feed and doesn't require a subscription.

> Supersedes #140, closed so this PR gets a fresh preview environment that includes the new `push-cron` service.

## The process split is the design

The tap worker's *entire* involvement is one `INSERT … SELECT` that resolves to zero rows for anything that doesn't qualify — no timer, no `web-push` import, no outbound HTTP, no extra pool pressure. A `push-cron` Railway service does the fan-out, encryption, and delivery every five minutes in its own short-lived process, the same shape as the weekly digest.

That's not fastidiousness: the worker's job is keeping up with the firehose, and a slow handler there has already knocked it over once by causing tap to redeliver.

## Exactly-once, and why it's a table

`document_push_queue` is both the outbox and the claim. Its primary key is what makes tap redelivery, dead-letter replay, and later `update` events for the same document all collapse to `DO NOTHING`.

It is deliberately **not** a column on `documents`. Document deletes are hard deletes (`db.delete(documents)`, not a tombstone), so a claim token on that row would die with it — and a delete→recreate at the same rkey is a normal republish, which would re-notify everyone.

## Four guards, four different failure modes

| Guard | What it actually prevents |
| --- | --- |
| `payload.live` | A PDS reconcile replaying a repo notifying about its whole history |
| A date on the **record** | `documents.published_at` falls back to `now()` for an undated record, so an archive import would pass any freshness window |
| `indexed_at` | Set once on first insert, never updated — survives a tap cursor rewind or a fresh tap instance re-streaming known repos |
| Per-author hourly cap | The backstop for a repo that dumps its archive with fresh timestamps |

The enqueue is **not** gated on `action === "create"`. `upsertDocument` resolves external bodies (Leaflet, pckt, fetched formats); a transient failure leaves `hasRenderableBody = false`, so a create-only gate would find nothing and the post would *never* notify, because the later `update` that fixes the body wouldn't retry.

## Service worker

Push listeners ride into the existing Workbox SW via `workbox.importScripts` rather than switching to `injectManifest`, which would mean hand-porting the tuned runtime-caching config.

`push-sw.js` is **also** precached, deliberately. `importScripts` bakes a bare URL into `sw.js`, so editing the imported file changes zero bytes of `sw.js` and browsers keep the old push handler indefinitely. Precaching puts its revision hash in the manifest so the SW byte-diffs. Verified in the build output:

```
importScripts("/push-sw.js")
precache: push-sw.js -> 807f433486
```

It's a classic script with no imports and no top-level `await`, and it never throws — Workbox emits the SW as AMD, so a throw there would take down every caching route. It shows a notification on *every* push, including an unparseable one: iOS revokes the subscription if a push arrives and nothing is displayed.

## Two bugs found by testing on the previous preview

**The bell always failed** with "we couldn't set up notifications on this device". `getPushConfig` gated on a `configured` getter requiring *both* VAPID keys — but the web service holds only the public key by design. It always returned a null key, which the client read as an unsupported browser. Now split into `canRegister` (public key — what a browser needs to subscribe) and `canSend` (both — what signing needs), with tests pinning each service's real state. The client also collapsed "server has no key" into the same toast as a genuine exception, which made a deployment mistake look like a browser problem; that's now a distinct state, and both failure paths log the real cause.

**The bell was wedged inside the Subscribe `ButtonGroup`**, which joins its children into one control — so it landed between Subscribe and Subscribe's own dropdown chevron, breaking that pairing, and took the app's neutral variant while the rest of the group took the publication's theme accent (visible on "What The Function!?"). It now sits beside the group and takes the same variant.

## iOS

The bell stays visible and pressable. iOS only exposes push to a Home-Screen-installed PWA and offers no programmatic install prompt, so pressing it opens the Share → Add to Home Screen steps — the one "unsupported" case a reader can actually fix.

## Verification

- `pnpm typecheck` · `lint` · `format:check` clean across the monorepo
- 24 push tests; full suite 767 passing
- `pnpm build` succeeds; SW wiring verified in the output
- **Confirmed in production, not just tests:** a queued document was claimed and settled `state=sent, attempts=1, last_error=null`; subsequent cron runs log clean (`[push] done in 510ms`)
- SQL parameter binding checked read-only against real Postgres — this repo has been bitten by `sql` templates that typecheck and pass tests but bind wrong. `make_interval(hours => $1)` produces the right offsets, the enqueue predicate matches real documents, and a zero-hour control matches none. Recipient resolution uses `inArray`/`notInArray` rather than raw `= any(...)` for the same reason.
- Exactly-once verified against prod: a second identical insert returns 0 rows, and an immediate re-claim returns 0 (the reaper doesn't steal a fresh claim)

## Deployment state

Production is already wired: migration applied, `VAPID_PUBLIC_KEY` on `web`, and a `push-cron` service with its **Config File Path set to `railway.push.json`** (Railway auto-detects only the root `railway.json`; the CLI can't set this field, so it goes through `serviceInstanceUpdate` on the GraphQL API). After merge, `push-cron` needs pointing from this branch to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)