### PR TITLE
Tell cartoonists what the comic view is reading

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -672,10 +672,16 @@ Single search field with two modes (detected from input):
 ### Reader guide (`/guide`)
 
 The **non-technical** documentation, deliberately separate from the developer docs at
-`/docs/*`. Eight task-shaped pages under `/guide` — Welcome, Getting started, Reading an
-article, Finding things to read, Keeping track, Making it yours, Beyond the app, Your account
-and data — written for someone who only wants to read, with no AT Protocol vocabulary and
-every feature named the way the UI names it.
+`/docs/*`. Task-shaped pages under `/guide` — Welcome, Getting started, Reading an article,
+Finding things to read, Keeping track, Lists and your sidebar, Collections, Making it yours,
+The browser extension, Publishing your site, Publishing a comic, Your account and data —
+written for someone who only wants to read, with no AT Protocol vocabulary and every feature
+named the way the UI names it. The last three are the exception the guide earns rather than
+assumes: they are for someone on the other side of the page, and they name record fields where
+naming them is the only honest answer (`/guide/comics` documents the comic view from the
+cartoonist's side — the one publisher setting, the classifier's two thresholds, and the title
+convention `#/lib/comic/issue-title` parses, since none of that has a lexicon field to point
+at).
 
 - **Own route tree.** `src/routes/_guide-layout.tsx` + `_guide-layout.guide.*.tsx`, with its
   own topbar (`GuideTopbar`) tagged "Reader guide". It reuses the docs shell's layout and

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -1373,6 +1373,11 @@ cookies on `/xrpc`. Live developer docs at [`/docs/api`](/docs/api).
       personalizing, beyond the app, your data) on their own route tree and topbar, structure
       declared once in `src/lib/guide/navigation.ts`. Linked from the footer, the account menu,
       About, and the developer docs topbar; every page ends at `/feedback`.
+- [x] **Comic authoring guide (`/guide/comics`)** — the comic view from the cartoonist's side:
+      the `prevNextDirection` setting, the comic/book classifier's thresholds (60% of the 40
+      newest posts, ~700 words of prose), the `Series #2, Pg. 7` title convention and its 70%
+      match share, cover selection and the 2:3 crop, page notes, alt text, per-page read state,
+      and a troubleshooting list for a comic still reading as a blog.
 - [x] **Automated guide screenshots** — `pnpm guide:shots` drives Playwright through the shot
       manifest in `src/lib/guide/screenshots.ts` and writes `public/guide/*.png`, so refreshing
       every picture after a UI change is one command. Signed-in shots reuse the perf suite's

--- a/apps/standard-reader/src/components/guide/pages/comics-guide-page.tsx
+++ b/apps/standard-reader/src/components/guide/pages/comics-guide-page.tsx
@@ -1,0 +1,352 @@
+"use client";
+
+import { Trans } from "@lingui/react/macro";
+import * as stylex from "@stylexjs/stylex";
+import { Link } from "@tanstack/react-router";
+
+import { docsStyles } from "../../docs/docs-page.stylex";
+import { guideStyles } from "../guide-page.stylex";
+import { GuideCallout, GuideSteps, UiLabel } from "../guide-primitives";
+import { GuideShell } from "../guide-shell";
+
+/**
+ * The comic view, from the author's side.
+ *
+ * Everything the comic reader does is derived from posts a cartoonist is
+ * already making — there is no comic record, no page field, no issue field. So
+ * this page is mostly about the conventions those derivations read: one
+ * publisher setting, the shape of a post, and the way titles are written.
+ *
+ * Deliberately concrete about the two thresholds (`COMIC_PAGE_SHARE`,
+ * `ISSUE_TITLE_MATCH_SHARE`): an author whose comic is not lighting up needs to
+ * know how close it is, and "mostly" is not something you can check your own
+ * archive against.
+ */
+export function ComicsGuidePage() {
+  return (
+    <GuideShell
+      area="comics"
+      title={<Trans>Publishing a comic</Trans>}
+      dek={
+        <Trans>
+          Standard Reader has a reading mode built for comics — a shelf of
+          covers instead of a list of post titles, and a full-screen theater
+          that flips through your pages. You do not author anything specially
+          for it. This page is how to make sure your comic gets it.
+        </Trans>
+      }
+    >
+      <h2
+        {...stylex.props(docsStyles.h2, docsStyles.h2First)}
+        id="what-readers-get"
+      >
+        <Trans>What readers get</Trans>
+      </h2>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          A comic publication gets two things an ordinary blog does not. Its
+          page shows a <b>shelf of covers</b> — your art, at trade-paperback
+          proportions — rather than dozens of near-identical rows reading{" "}
+          <i>Pg. 1</i>, <i>Pg. 2</i>, <i>Pg. 3</i>. And opening one drops the
+          reader into the <b>comic reader</b>: a dark, chrome-free theater
+          holding one page at a time.
+        </Trans>
+      </p>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          The theater treats the whole publication as one book. Page numbers run
+          straight through from your first page to your latest, so a reader who
+          holds down the arrow key walks the entire run without stopping at the
+          end of every issue. Arrow keys, space, Page Up and Page Down all turn
+          pages; Home and End jump to either end; on a phone the outer edges of
+          the screen turn pages, a swipe does too, and pinch-to-zoom gets a
+          reader into a dense panel. There is a full-screen toggle on the{" "}
+          <UiLabel>f</UiLabel> key. Past the last page is a back cover telling
+          them they are caught up and inviting them to subscribe.
+        </Trans>
+      </p>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          The current page lives in the address bar, so a reader can link
+          someone straight to a page, and reopening the comic puts them back
+          where they stopped.
+        </Trans>
+      </p>
+
+      <h2 {...stylex.props(docsStyles.h2)} id="turning-it-on">
+        <Trans>Turning the comic view on</Trans>
+      </h2>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          There is no “this is a comic” switch anywhere on the network, and
+          nothing to set on Standard Reader — we do not host your publication.
+          Two things have to be true instead.
+        </Trans>
+      </p>
+      <GuideSteps>
+        <Trans>
+          <b>Your publication has to say it reads forwards.</b> That is a
+          setting on the publication itself, in whatever tool you publish with —
+          the one that says the work is read from its first post rather than
+          newest-first. In the underlying record it is{" "}
+          <code {...stylex.props(docsStyles.codeInline)}>
+            preferences.prevNextDirection
+          </code>{" "}
+          set to <code {...stylex.props(docsStyles.codeInline)}>ltr</code>.
+          Leaflet writes this field; if you roll your own records, see{" "}
+          <Link to="/guide/publishing" {...stylex.props(docsStyles.proseLink)}>
+            Publishing your site
+          </Link>
+          . Without it a comic is just a blog that happens to post drawings.
+        </Trans>
+        <Trans>
+          <b>Your posts have to read as pages.</b> We look at your 40 newest
+          posts and count the ones that render at least one image and carry no
+          more than about 700 words of prose. If at least 60% of them do, the
+          publication is a comic. If they do not, it is treated as a serialized
+          book — still read front-to-back, but as articles with an{" "}
+          <UiLabel>Up next</UiLabel> link rather than as pages of art.
+        </Trans>
+      </GuideSteps>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          Both are re-checked as your archive grows, and the setting is picked
+          up the first time anyone opens your publication after you change it —
+          you do not have to tell us. Being read as a book rather than a comic
+          is never a dead end for a reader: every route into the comic reader
+          also links to the ordinary reading view, and an issue with no art
+          falls back to it outright.
+        </Trans>
+      </p>
+
+      <h2 {...stylex.props(docsStyles.h2)} id="pages">
+        <Trans>What counts as a page</Trans>
+      </h2>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          A page is an image your post&apos;s body renders, and they are flipped
+          through in the order they appear in the post. One image per post is
+          the usual shape and the one everything here is tuned for, but a post
+          carrying three images contributes three pages, in order — useful for
+          posting a whole issue at once.
+        </Trans>
+      </p>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          A post with no images contributes nothing to flip through, so it does
+          not get a cover on the shelf and cannot be paged to: an announcement,
+          a hiatus note, or a con schedule lives in the archive&apos;s read and
+          unread views rather than in the book. If a text post matters to the
+          story, give it a piece of art and it becomes a page like any other.
+        </Trans>
+      </p>
+      <GuideCallout title={<Trans>Page numbers are absolute</Trans>}>
+        <Trans>
+          The counter reads <i>Page 12 of 340</i> across the whole publication,
+          not within one issue. That means inserting or removing a page in an
+          early issue renumbers everything after it — worth knowing before you
+          go back and edit an old post that readers may have linked to.
+        </Trans>
+      </GuideCallout>
+
+      <h2 {...stylex.props(docsStyles.h2)} id="titles">
+        <Trans>Naming issues and pages</Trans>
+      </h2>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          Nothing in the format has a field for “issue 3” — the only place that
+          number exists is your post titles, so that is where we read it back
+          out of. Title your pages the way comics have always been titled and
+          consecutive pages collapse back into the issue they came from, one
+          cover per issue:
+        </Trans>
+      </p>
+      <ul {...stylex.props(docsStyles.prose)}>
+        <li {...stylex.props(guideStyles.listItem)}>
+          <Trans>
+            <b>Fray In The Veil #2, Pg. 7</b> — series, issue, page.
+          </Trans>
+        </li>
+        <li {...stylex.props(guideStyles.listItem)}>
+          <Trans>
+            <b>FITV #1 Cover</b> — the same, with a page label instead of a
+            number.
+          </Trans>
+        </li>
+      </ul>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          The one part that is required is the hash before the issue number — a
+          bare number in a title is never read as an issue, because too many
+          ordinary titles start with one. After the number you can use a comma,
+          a colon, a dash, or nothing at all; everything following it is treated
+          as the page label and is not otherwise parsed, so write it however you
+          like.
+        </Trans>
+      </p>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          Grouping is all-or-nothing per publication: at least 70% of your
+          titles have to parse before we trust the numbers enough to group by
+          them. If they do not — a webcomic naming its posts <i>Pg01</i>,{" "}
+          <i>Pg02</i> has no issues to speak of — you still get a shelf, just
+          one cover per post instead of one per issue. That is a fine way to run
+          a comic; it is not a failure state.
+        </Trans>
+      </p>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          A single post whose title breaks the pattern does not split an issue
+          in two. An interstitial in the middle of issue 3 joins issue 3, and a
+          one-off announcement will not start a phantom issue of its own.
+        </Trans>
+      </p>
+
+      <h2 {...stylex.props(docsStyles.h2)} id="covers">
+        <Trans>Cover art</Trans>
+      </h2>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          An issue is fronted by the page whose title says it is the cover —
+          anything with the word <i>cover</i> in the page label.{" "}
+          <i>Inner cover</i> is deliberately not treated as one, since it is the
+          leaf behind the cover rather than the cover itself. When no page
+          claims it, the issue&apos;s first page fronts it, which is what the
+          reader sees on opening anyway.
+        </Trans>
+      </p>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          Covers are drawn in a 2:3 frame — the standard trade-paperback shape —
+          and art is scaled to fill it, so anything much wider or squarer gets
+          cropped at the edges. If your logo or your title lettering sits near
+          the very edge of a landscape cover, expect it to be trimmed on the
+          shelf. The full page is untouched in the reader; this only affects the
+          thumbnail.
+        </Trans>
+      </p>
+
+      <h2 {...stylex.props(docsStyles.h2)} id="notes">
+        <Trans>The words beside the art</Trans>
+      </h2>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          Most cartoonists write a line or two under the page — a caption, a
+          process note, a word about next week. That writing is not lost in the
+          theater. If a page&apos;s post carries prose, the note button in the
+          top bar lights up and lays it over the art, in the theater&apos;s own
+          type, with a way through to the full post. It closes when the reader
+          turns the page, because it belongs to the page it was written about.
+        </Trans>
+      </p>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          Pages with nothing written under them leave the button disabled rather
+          than making it appear and vanish as the reader flips, so there is no
+          penalty for a silent page.
+        </Trans>
+      </p>
+      <GuideCallout title={<Trans>Keep the essay for its own post</Trans>}>
+        <Trans>
+          The prose length is also what separates a comic from an illustrated
+          blog: a post carrying more than about 700 words stops counting as a
+          page of comic, and if most of your posts are like that the publication
+          reads as a book instead. A long process essay is better as its own
+          post — which readers will find in the archive — than appended to a
+          page.
+        </Trans>
+      </GuideCallout>
+
+      <h2 {...stylex.props(docsStyles.h2)} id="alt-text">
+        <Trans>Alt text</Trans>
+      </h2>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          Alt text on a comic page is the page, for anyone who cannot see it —
+          in the theater there is no surrounding article to fall back on, so
+          whatever you wrote is the whole experience. It is also what your comic
+          is found by in search.
+        </Trans>
+      </p>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          One thing worth knowing: if a paragraph of your post body repeats a
+          page&apos;s alt text word for word, we drop it from the note rather
+          than showing the reader a description of the picture they are looking
+          at. So transcribing your dialogue into the alt and again into the body
+          does not double up.
+        </Trans>
+      </p>
+
+      <h2 {...stylex.props(docsStyles.h2)} id="read-state">
+        <Trans>How readers pick it back up</Trans>
+      </h2>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          Read state is per post, and your posts are pages, so an issue counts
+          as unread while any page in it is — a comic read halfway through is
+          not read. Its cover wears the same unread dot an unread article does,
+          and clicking it opens on the first page that reader has not seen, not
+          back at the cover. Walking pages in the theater marks them off behind
+          them.
+        </Trans>
+      </p>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          In practice this means a reader who subscribes mid-run can come back
+          after a month and land exactly where they stopped, which is the single
+          biggest thing that keeps people reading a serial. Readers who have
+          turned reading history off see no dots — nothing is tracked for them —
+          and readers who are not signed in see the shelf as a stranger would.
+        </Trans>
+      </p>
+
+      <h2 {...stylex.props(docsStyles.h2)} id="troubleshooting">
+        <Trans>When it still reads as a blog</Trans>
+      </h2>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          If your publication page shows a list of titles instead of a shelf,
+          walk these in order:
+        </Trans>
+      </p>
+      <ul {...stylex.props(docsStyles.prose)}>
+        <li {...stylex.props(guideStyles.listItem)}>
+          <Trans>
+            <b>Is the forwards-reading setting saved?</b> This is the one that
+            is almost always the answer. Check it in your publishing tool, and
+            note that it lives on the publication, not on individual posts.
+          </Trans>
+        </li>
+        <li {...stylex.props(guideStyles.listItem)}>
+          <Trans>
+            <b>Do your recent posts render their art in the body?</b> A post
+            that only links to the page on your site, or that carries the
+            drawing as a cover image with an empty body, has no pages to flip.
+          </Trans>
+        </li>
+        <li {...stylex.props(guideStyles.listItem)}>
+          <Trans>
+            <b>Are your last 40 posts mostly art?</b> A run of text posts —
+            Kickstarter updates, con reports — can tip a comic under the line
+            until the art resumes.
+          </Trans>
+        </li>
+        <li {...stylex.props(guideStyles.listItem)}>
+          <Trans>
+            <b>Getting a shelf but not issues?</b> Then the setting is right and
+            it is the titles: check that at least 7 in 10 carry a hash and an
+            issue number.
+          </Trans>
+        </li>
+      </ul>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          If all of that is true and your comic still reads as a blog, tell us
+          on the feedback board with a link to the publication — that is a bug
+          on our side, and worth hearing about.
+        </Trans>
+      </p>
+    </GuideShell>
+  );
+}

--- a/apps/standard-reader/src/lib/guide/navigation.ts
+++ b/apps/standard-reader/src/lib/guide/navigation.ts
@@ -25,6 +25,7 @@ export type GuideArea =
   | "personalizing"
   | "extension"
   | "publishing"
+  | "comics"
   | "your-data";
 
 export type GuideRoute =
@@ -38,6 +39,7 @@ export type GuideRoute =
   | "/guide/personalizing"
   | "/guide/extension"
   | "/guide/publishing"
+  | "/guide/comics"
   | "/guide/your-data";
 
 /**
@@ -135,6 +137,13 @@ export const GUIDE_AREAS: ReadonlyArray<GuideAreaMeta> = [
     to: "/guide/publishing",
     label: msg`Publishing your site`,
     blurb: msg`Wire your own site's records so Standard Reader can find and read it.`,
+  },
+  {
+    area: "comics",
+    group: "further",
+    to: "/guide/comics",
+    label: msg`Publishing a comic`,
+    blurb: msg`Get a shelf of covers and a page-flip reader out of the pages you already post.`,
   },
   {
     area: "your-data",
@@ -242,6 +251,17 @@ export const GUIDE_SECTIONS: Record<GuideArea, ReadonlyArray<GuideSection>> = {
     },
     { id: "content-formats", label: msg`Supported content formats` },
     { id: "example", label: msg`Example record` },
+  ],
+  comics: [
+    { id: "what-readers-get", label: msg`What readers get` },
+    { id: "turning-it-on", label: msg`Turning the comic view on` },
+    { id: "pages", label: msg`What counts as a page` },
+    { id: "titles", label: msg`Naming issues and pages` },
+    { id: "covers", label: msg`Cover art` },
+    { id: "notes", label: msg`The words beside the art` },
+    { id: "alt-text", label: msg`Alt text` },
+    { id: "read-state", label: msg`How readers pick it back up` },
+    { id: "troubleshooting", label: msg`When it still reads as a blog` },
   ],
   "your-data": [
     { id: "where-it-lives", label: msg`Where your reading lives` },

--- a/apps/standard-reader/src/lib/site-metadata.ts
+++ b/apps/standard-reader/src/lib/site-metadata.ts
@@ -166,6 +166,12 @@ export const PAGE_OG_CARDS = {
     title: "Publishing your site",
     tagline: "Wire a personal site's own site.standard.* records by hand.",
   },
+  guideComics: {
+    path: "/guide/comics",
+    title: "Publishing a comic",
+    tagline:
+      "Get a shelf of covers and a page-flip reader out of the pages you already post.",
+  },
   docsRenderers: {
     path: "/docs/renderers",
     title: "Renderers",

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -242,6 +242,10 @@ msgstr ""
 msgid "Your series"
 msgstr "سلاسلك"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Nothing in the format has a field for “issue 3” — the only place that number exists is your post titles, so that is where we read it back out of. Title your pages the way comics have always been titled and consecutive pages collapse back into the issue they came from, one cover per issue:"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Mark as read"
 msgstr "تعليم كمقروء"
@@ -253,6 +257,10 @@ msgstr "هذه القائمة فارغة — أضف إليها منشورات أ
 #: src/components/docs/api-docs-intro.tsx
 #~ msgid "A labeler is any DID that publishes AT Proto labels. Readers add one by DID on the <0>Labelers</0> page, and Standard Reader then shows that labeler's labels — and can warn on or hide labeled posts — as they read. Labelers are discovered the standard way; nothing about them is specific to us. To run your own:"
 #~ msgstr "المصنِّف هو أي DID ينشر تصنيفات AT Proto. يضيف القرّاء مصنِّفًا عبر الـ DID من صفحة <0>المصنِّفات</0>، فيعرض Standard Reader تصنيفات ذلك المصنِّف — ويمكنه التحذير من المنشورات المصنَّفة أو إخفاؤها — أثناء القراءة. يُكتشف المصنِّفون بالطريقة القياسية؛ ولا شيء فيهم خاص بنا. لتشغيل مصنِّف خاص بك:"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "If your publication page shows a list of titles instead of a shelf, walk these in order:"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "The most-read articles across Standard this week."
@@ -444,6 +452,10 @@ msgstr ""
 msgid "If the site publishes in the open format but has not been indexed yet, the extension reads the page's own record hints and subscribes anyway."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A page is an image your post's body renders, and they are flipped through in the order they appear in the post. One image per post is the usual shape and the one everything here is tuned for, but a post carrying three images contributes three pages, in order — useful for posting a whole issue at once."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Open"
 msgstr "فتح"
@@ -550,6 +562,10 @@ msgstr ""
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "New collection…"
 msgstr "مجموعة جديدة…"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Fray In The Veil #2, Pg. 7</0> — series, issue, page."
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "We may update this policy as the product changes. The “Last updated” date at the top will change when we do. Continued use of the site after an update means you accept the revised policy."
@@ -811,6 +827,10 @@ msgstr "هذه القائمة فارغة."
 msgid "Play voice sample"
 msgstr "تشغيل عيّنة صوتية"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Is the forwards-reading setting saved?</0> This is the one that is almost always the answer. Check it in your publishing tool, and note that it lives on the publication, not on individual posts."
+msgstr ""
+
 #: src/components/reader/subscribe-card.tsx
 msgid "You're subscribed"
 msgstr "أنت مشترك"
@@ -840,6 +860,10 @@ msgstr "قراءة {0} دقيقة"
 
 #: src/components/user-settings-view.tsx
 msgid "Infinite scroll keeps pulling the next page as you reach the end of a list. Load more waits for you to ask."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Alt text on a comic page is the page, for anyone who cannot see it — in the theater there is no surrounding article to fall back on, so whatever you wrote is the whole experience. It is also what your comic is found by in search."
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -1172,6 +1196,11 @@ msgstr ""
 msgid "the directory of every publication the network knows about."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "How readers pick it back up"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "A list is a folder for publications — <0>Work</0>, <1>Fiction</1>, <2>Read on Sunday</2>, whatever is useful. Lists appear as their own groups in the sidebar, so you can read one part of your follows without the rest."
 #~ msgstr ""
@@ -1427,6 +1456,10 @@ msgstr "المنشورات الرائجة"
 msgid "Replace cover image"
 msgstr "استبدال صورة الغلاف"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Are your last 40 posts mostly art?</0> A run of text posts — Kickstarter updates, con reports — can tip a comic under the line until the art resumes."
+msgstr ""
+
 #: src/lib/guide/navigation.ts
 #~ msgid "Sign in, follow your first publications, and find your way around."
 #~ msgstr ""
@@ -1522,6 +1555,10 @@ msgstr "محتوى مضمَّن"
 #: src/components/user-settings-view.tsx
 msgid "Account"
 msgstr "الحساب"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "There is no “this is a comic” switch anywhere on the network, and nothing to set on Standard Reader — we do not host your publication. Two things have to be true instead."
+msgstr ""
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
@@ -2014,6 +2051,10 @@ msgstr "لماذا هذا المقال هنا؟ (يدعم markdown)"
 msgid "Sign in, subscribe to a few publications, and learn where everything lives. Ten minutes, once."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The theater treats the whole publication as one book. Page numbers run straight through from your first page to your latest, so a reader who holds down the arrow key walks the entire run without stopping at the end of every issue. Arrow keys, space, Page Up and Page Down all turn pages; Home and End jump to either end; on a phone the outer edges of the screen turn pages, a swipe does too, and pinch-to-zoom gets a reader into a dense panel. There is a full-screen toggle on the <0>f</0> key. Past the last page is a back cover telling them they are caught up and inviting them to subscribe."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "{count, plural, one {# upvote} other {# upvotes}} — click to upvote"
 msgstr "{count, plural, zero {لا أصوات} one {صوت واحد} two {صوتان} few {# أصوات} many {# صوتًا} other {# صوت}} — انقر للتصويت"
@@ -2030,6 +2071,10 @@ msgstr "قراءة"
 #: src/components/reader/comments/add-comment-dialog.tsx
 #~ msgid "Discussion here is gathered from posts across the network, so you comment wherever you already post. Yours joins this article once the network indexes it."
 #~ msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A post with no images contributes nothing to flip through, so it does not get a cover on the shelf and cannot be paged to: an announcement, a hiatus note, or a con schedule lives in the archive's read and unread views rather than in the book. If a text post matters to the story, give it a piece of art and it becomes a page like any other."
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "An HttpOnly session cookie that keeps you signed in."
@@ -2108,6 +2153,11 @@ msgstr ""
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "<0><1>Markpub</1> (recommended).</0> <2>at.markpub.markdown</2> — markdown with facets for rich text. It's not part of the site.standard spec either — no markdown format is — but it's the only one that's actually spec'd in a meaningful, reusable way, rather than one app's own ad hoc shape. Use this for a hand-rolled integration unless you already produce one of the platform formats below."
 msgstr "<0><1>Markpub</1> (موصى به).</0> <2>at.markpub.markdown</2> — markdown مع facets للنص المنسّق. وهو ليس جزءًا من مواصفة site.standard أيضًا — فلا صيغة markdown كذلك — لكنه الوحيد الموصَّف فعليًا بشكل ذي معنى وقابل لإعادة الاستخدام، بدل أن يكون شكلًا ارتجاليًا خاصًا بتطبيق واحد. استخدمه للتكامل المُعدّ يدويًا ما لم تكن تنتج أصلًا إحدى صيغ المنصات أدناه."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What counts as a page"
+msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Hide read articles"
@@ -2405,6 +2455,10 @@ msgstr "تعيين العدد"
 msgid "Feed preferences"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A single post whose title breaks the pattern does not split an issue in two. An interstitial in the middle of issue 3 joins issue 3, and a one-off announcement will not start a phantom issue of its own."
+msgstr ""
+
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Set API_DOCS_FIXTURE_LIST_URI to run this example."
 msgstr "اضبط API_DOCS_FIXTURE_LIST_URI لتشغيل هذا المثال."
@@ -2598,6 +2652,11 @@ msgstr ""
 msgid "RSS feed"
 msgstr "تغذية RSS"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Naming issues and pages"
+msgstr ""
+
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
 #~ msgid "Run a labeler"
@@ -2759,6 +2818,10 @@ msgstr "بعض التفضيلات"
 
 #: src/routes/_layout.friends.tsx
 msgid "We couldn't reach Bluesky to look up who you follow. Reload in a moment, or browse the directory in the meantime."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Keep the essay for its own post"
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -3436,6 +3499,11 @@ msgstr ""
 msgid "<0>Share</0> copies a link, or posts the article to Bluesky with a proper preview card. On a phone it can hand off to whatever you normally share with."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Turning the comic view on"
+msgstr ""
+
 #: src/components/reader/article-below-fold.tsx
 msgid "Worth subscribing to"
 msgstr "يستحق الاشتراك"
@@ -3506,6 +3574,11 @@ msgstr ""
 msgid "A publication on Standard is a <0>site.standard.document</0> record in the author's AT Protocol repository — not a row in a database we own. Standard Reader indexes those records into a public read-model and renders them, but nothing about the format is proprietary: the schemas are open, the content is portable across publishing platforms, and the same renderer we ship is available to you."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "The words beside the art"
+msgstr ""
+
 #: src/components/labelers-settings-view.tsx
 #: src/routes/_layout.latest.tsx
 msgid "On the network"
@@ -3525,6 +3598,11 @@ msgstr "مكان هادئ للقراءة"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Add publications or people, then <0>Create list</0>."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "When it still reads as a blog"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -3621,6 +3699,10 @@ msgstr "إجراءات أخرى"
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Readers who would rather not get the magazine treatment can turn <0>Open collections in magazine</0> off in <1>settings</1>, and collection articles open in the ordinary reader instead."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Covers are drawn in a 2:3 frame — the standard trade-paperback shape — and art is scaled to fill it, so anything much wider or squarer gets cropped at the edges. If your logo or your title lettering sits near the very edge of a landscape cover, expect it to be trimmed on the shelf. The full page is untouched in the reader; this only affects the thumbnail."
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -3750,6 +3832,10 @@ msgstr "الرائج هذا الأسبوع"
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "The login screen links out to create one. Any account on the network works — you do not have to use Bluesky itself, and you do not have to post anything."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "If all of that is true and your comic still reads as a blog, tell us on the feedback board with a link to the publication — that is a bug on our side, and worth hearing about."
 msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
@@ -3976,6 +4062,10 @@ msgstr ""
 msgid "We couldn’t find that publication."
 msgstr "تعذّر العثور على تلك المنشورة."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Your posts have to read as pages.</0> We look at your 40 newest posts and count the ones that render at least one image and carry no more than about 700 words of prose. If at least 60% of them do, the publication is a comic. If they do not, it is treated as a serialized book — still read front-to-back, but as articles with an <1>Up next</1> link rather than as pages of art."
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Generating audio… {percent}%"
 msgstr "جارٍ إنشاء الصوت… {percent}٪"
@@ -4000,6 +4090,10 @@ msgstr "غير مقروء"
 #: src/components/guide/pages/collections-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "How readers see it"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Standard Reader has a reading mode built for comics — a shelf of covers instead of a list of post titles, and a full-screen theater that flips through your pages. You do not author anything specially for it. This page is how to make sure your comic gets it."
 msgstr ""
 
 #. placeholder {0}: filter.trim()
@@ -4185,6 +4279,10 @@ msgstr ""
 msgid "On any page you visit"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The current page lives in the address bar, so a reader can link someone straight to a page, and reopening the comic puts them back where they stopped."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Partly removed"
 msgstr ""
@@ -4193,6 +4291,10 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Delete list"
 msgstr "حذف القائمة"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The one part that is required is the hash before the issue number — a bare number in a title is never read as an issue, because too many ordinary titles start with one. After the number you can use a comma, a colon, a dash, or nothing at all; everything following it is treated as the page label and is not otherwise parsed, so write it however you like."
+msgstr ""
 
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "What the extension can see and what it does with it is written out in full on the <0>extension privacy page</0>."
@@ -4222,6 +4324,10 @@ msgstr "مقالات موصى بها"
 
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Getting a shelf but not issues?</0> Then the setting is right and it is the titles: check that at least 7 in 10 carry a hash and an issue number."
 msgstr ""
 
 #: src/components/labeler-detail-view.tsx
@@ -4359,6 +4465,10 @@ msgstr "صوت القارئ"
 msgid "Sharp"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "An issue is fronted by the page whose title says it is the cover — anything with the word <0>cover</0> in the page label. <1>Inner cover</1> is deliberately not treated as one, since it is the leaf behind the cover rather than the cover itself. When no page claims it, the issue's first page fronts it, which is what the reader sees on opening anyway."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "What you get is a reading view made for long-form: a centered column, drop caps and pull quotes, full-bleed images you can open into a gallery. The page gets out of the way so the writing can do its work."
 msgstr "ما تحصل عليه هو عرض قراءة مصمم للكتابات الطويلة: عمود متمركز، وأحرف استهلالية واقتباسات بارزة، وصور بعرض الشاشة يمكنك فتحها في معرض. تنسحب الصفحة جانبًا لتترك للكتابة أن تؤدي عملها."
@@ -4445,6 +4555,10 @@ msgstr ""
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "Make one with <0>New list</0> in the sidebar, or add a publication to a list from its <1>Add to list</1> menu. A publication can be in as many lists as you like, and being in a list does not change your feeds — it only changes how they are grouped."
 #~ msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "In practice this means a reader who subscribes mid-run can come back after a month and land exactly where they stopped, which is the single biggest thing that keeps people reading a serial. Readers who have turned reading history off see no dots — nothing is tracked for them — and readers who are not signed in see the shelf as a stranger would."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
@@ -4724,6 +4838,10 @@ msgstr "قدّم للمجموعة… (يدعم markdown)"
 msgid "Filter"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A comic publication gets two things an ordinary blog does not. Its page shows a <0>shelf of covers</0> — your art, at trade-paperback proportions — rather than dozens of near-identical rows reading <1>Pg. 1</1>, <2>Pg. 2</2>, <3>Pg. 3</3>. And opening one drops the reader into the <4>comic reader</4>: a dark, chrome-free theater holding one page at a time."
+msgstr ""
+
 #: src/components/reader/friend-publishers.tsx
 msgid "Bluesky didn't answer in time, so this list may be incomplete. Reload to try again."
 msgstr ""
@@ -4778,6 +4896,11 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "إعدادات الملف الشخصي"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Publishing a comic"
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "The first time you sign in, a short setup walks you through it: pick a few topics you care about, see which of the people you already follow on Bluesky write here, follow anything that appeals, and choose how you like your text. You can skip any step, and skip the whole thing."
@@ -5122,6 +5245,10 @@ msgstr ""
 #: src/components/docs/docs-renderers-nav.tsx
 #: src/components/docs/renderers-docs-page.tsx
 msgid "Resolving platform data"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Your publication has to say it reads forwards.</0> That is a setting on the publication itself, in whatever tool you publish with — the one that says the work is read from its first post rather than newest-first. In the underlying record it is <1>preferences.prevNextDirection</1> set to <2>ltr</2>. Leaflet writes this field; if you roll your own records, see <3>Publishing your site</3>. Without it a comic is just a blog that happens to post drawings."
 msgstr ""
 
 #: src/components/reader/comments/add-comment-dialog.tsx
@@ -5669,6 +5796,10 @@ msgstr ""
 msgid "Articles you've recommended across the network."
 msgstr "المقالات التي رشّحتها عبر الشبكة."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "One thing worth knowing: if a paragraph of your post body repeats a page's alt text word for word, we drop it from the note rather than showing the reader a description of the picture they are looking at. So transcribing your dialogue into the alt and again into the body does not double up."
+msgstr ""
+
 #: src/routes/_layout.feedback.return.tsx
 msgid "View feedback"
 msgstr "عرض الملاحظات"
@@ -5991,6 +6122,10 @@ msgstr "الوثائق"
 msgid "The core / new frameworks"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Both are re-checked as your archive grows, and the setting is picked up the first time anyone opens your publication after you change it — you do not have to tell us. Being read as a book rather than a comic is never a dead end for a reader: every route into the comic reader also links to the ordinary reading view, and an issue with no art falls back to it outright."
+msgstr ""
+
 #. placeholder {0}: index + 1
 #: src/components/comic/comic-reader.tsx
 msgid "Page {0}"
@@ -6171,6 +6306,11 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 #~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
 #~ msgstr "امتداد متصفح خفيف يتيح لك حفظ المنشورات والاشتراك فيها أثناء تصفّحك للويب — بشارات خفيفة على bsky.app وطبقة بنقرة واحدة على أي صفحة تزورها. قائمة قراءتك تملأ نفسها."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Alt text"
+msgstr ""
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -6356,6 +6496,10 @@ msgstr ""
 msgid "Reading & privacy"
 msgstr "القراءة والخصوصية"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Grouping is all-or-nothing per publication: at least 70% of your titles have to parse before we trust the numbers enough to group by them. If they do not — a webcomic naming its posts <0>Pg01</0>, <1>Pg02</1> has no issues to speak of — you still get a shelf, just one cover per post instead of one per issue. That is a fine way to run a comic; it is not a failure state."
+msgstr ""
+
 #: src/components/Header.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/site-legal-links.tsx
@@ -6471,6 +6615,11 @@ msgstr "تحريري"
 msgid "Click Run example to fetch a live response with your session."
 msgstr "انقر على «تشغيل المثال» لجلب استجابة حية باستخدام جلستك."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What readers get"
+msgstr ""
+
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "At the bottom of settings, <0>Personal data</0> deletes categories of records outright: your reading history, your saved articles, or the publication lists you made. Each asks for confirmation and explains what will change."
 msgstr ""
@@ -6559,6 +6708,10 @@ msgstr ""
 #: src/routes/_layout.p.$did.$rkey.tsx
 #~ msgid "Open publication"
 #~ msgstr "فتح المنشورة"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Do your recent posts render their art in the body?</0> A post that only links to the page on your site, or that carries the drawing as a cover image with an empty body, has no pages to flip."
+msgstr ""
 
 #: src/components/reader/link-share-menu.tsx
 msgid "Send to Disperse"
@@ -6680,6 +6833,10 @@ msgstr "{articleCount, plural, zero {مقالات} one {مقالة} two {مقا�
 msgid "{publicationName} is in your feed. You'll see new writing as it publishes."
 msgstr "{publicationName} في تغذيتك الآن. سترى الكتابات الجديدة فور نشرها."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Read state is per post, and your posts are pages, so an issue counts as unread while any page in it is — a comic read halfway through is not read. Its cover wears the same unread dot an unread article does, and clicking it opens on the first page that reader has not seen, not back at the cover. Walking pages in the theater marks them off behind them."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Upgrade permissions"
 msgstr "ترقية الأذونات"
@@ -6740,6 +6897,10 @@ msgstr "اختارت هذه المنشورة عدم الظهور في الاست
 msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, zero {لا أصوات} one {صوت واحد} two {صوتان} few {# أصوات} many {# صوتًا} other {# صوت}} — سجّل الدخول للتصويت"
 
+#: src/lib/guide/navigation.ts
+msgid "Get a shelf of covers and a page-flip reader out of the pages you already post."
+msgstr ""
+
 #: src/components/onboarding/step-friends.tsx
 #~ msgid "Select all"
 #~ msgstr ""
@@ -6748,9 +6909,17 @@ msgstr "{count, plural, zero {لا أصوات} one {صوت واحد} two {صوت
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
 msgstr "لمعرفة كيفية عمل {SITE_NAME} إجمالًا، اطّلع على <0>حول</0>. وللخصوصية على مستوى الموقع، اطّلع على <1>سياسة خصوصية الموقع</1>. وللاستفسار عن هذا النشر، تواصل مع مشغّل {siteHost}."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The counter reads <0>Page 12 of 340</0> across the whole publication, not within one issue. That means inserting or removing a page in an early issue renumbers everything after it — worth knowing before you go back and edit an old post that readers may have linked to."
+msgstr ""
+
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Your account and data"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The prose length is also what separates a comic from an illustrated blog: a post carrying more than about 700 words stops counting as a page of comic, and if most of your posts are like that the publication reads as a book instead. A long process essay is better as its own post — which readers will find in the archive — than appended to a page."
 msgstr ""
 
 #: src/routes/review.thanks.tsx
@@ -6878,6 +7047,10 @@ msgstr "أيقونة"
 msgid "Top"
 msgstr "الأعلى"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Most cartoonists write a line or two under the page — a caption, a process note, a word about next week. That writing is not lost in the theater. If a page's post carries prose, the note button in the top bar lights up and lays it over the art, in the theater's own type, with a way through to the full post. It closes when the reader turns the page, because it belongs to the page it was written about."
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Read aloud"
 msgstr "قراءة بصوت مسموع"
@@ -6911,6 +7084,10 @@ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Subscribe to the publication it came from, in the same click."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>FITV #1 Cover</0> — the same, with a page label instead of a number."
 msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
@@ -7145,6 +7322,10 @@ msgstr "متابَع"
 msgid "Opening the issue…"
 msgstr "جارٍ فتح العدد…"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Pages with nothing written under them leave the button disabled rather than making it appear and vanish as the reader flips, so there is no penalty for a silent page."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "However you like to read it"
 msgstr ""
@@ -7318,6 +7499,11 @@ msgstr "عند التفعيل، يُحتسب أرشيف المنشورة بال�
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this reply on Bluesky"
 msgstr "فتح هذا الرد على Bluesky"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Cover art"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "what your corner of Bluesky reads."
@@ -7555,6 +7741,10 @@ msgstr ""
 
 #: src/routes/mcp/authorize.tsx
 msgid "Signed in as"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Page numbers are absolute"
 msgstr ""
 
 #: src/components/guide/pages/collections-guide-page.tsx

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -242,6 +242,10 @@ msgstr ""
 msgid "Your series"
 msgstr "Ihre Reihen"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Nothing in the format has a field for “issue 3” — the only place that number exists is your post titles, so that is where we read it back out of. Title your pages the way comics have always been titled and consecutive pages collapse back into the issue they came from, one cover per issue:"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Mark as read"
 msgstr "Als gelesen markieren"
@@ -253,6 +257,10 @@ msgstr "Diese Liste ist leer – fügen Sie Publikationen oder Personen hinzu."
 #: src/components/docs/api-docs-intro.tsx
 #~ msgid "A labeler is any DID that publishes AT Proto labels. Readers add one by DID on the <0>Labelers</0> page, and Standard Reader then shows that labeler's labels — and can warn on or hide labeled posts — as they read. Labelers are discovered the standard way; nothing about them is specific to us. To run your own:"
 #~ msgstr "Ein Labeler ist eine beliebige DID, die AT-Proto-Labels veröffentlicht. Leser fügen einen Labeler per DID auf der Seite <0>Labeler</0> hinzu, und Standard Reader zeigt dann beim Lesen dessen Label an – und kann bei gelabelten Beiträgen warnen oder sie ausblenden. Labeler werden auf dem üblichen Weg gefunden; nichts daran ist spezifisch für uns. So betreiben Sie einen eigenen:"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "If your publication page shows a list of titles instead of a shelf, walk these in order:"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "The most-read articles across Standard this week."
@@ -444,6 +452,10 @@ msgstr ""
 msgid "If the site publishes in the open format but has not been indexed yet, the extension reads the page's own record hints and subscribes anyway."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A page is an image your post's body renders, and they are flipped through in the order they appear in the post. One image per post is the usual shape and the one everything here is tuned for, but a post carrying three images contributes three pages, in order — useful for posting a whole issue at once."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Open"
 msgstr "Öffnen"
@@ -550,6 +562,10 @@ msgstr ""
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "New collection…"
 msgstr "Neue Sammlung …"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Fray In The Veil #2, Pg. 7</0> — series, issue, page."
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "We may update this policy as the product changes. The “Last updated” date at the top will change when we do. Continued use of the site after an update means you accept the revised policy."
@@ -811,6 +827,10 @@ msgstr "Diese Liste ist leer."
 msgid "Play voice sample"
 msgstr "Stimmprobe abspielen"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Is the forwards-reading setting saved?</0> This is the one that is almost always the answer. Check it in your publishing tool, and note that it lives on the publication, not on individual posts."
+msgstr ""
+
 #: src/components/reader/subscribe-card.tsx
 msgid "You're subscribed"
 msgstr "Sie haben abonniert"
@@ -840,6 +860,10 @@ msgstr "{0} Min. Lesezeit"
 
 #: src/components/user-settings-view.tsx
 msgid "Infinite scroll keeps pulling the next page as you reach the end of a list. Load more waits for you to ask."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Alt text on a comic page is the page, for anyone who cannot see it — in the theater there is no surrounding article to fall back on, so whatever you wrote is the whole experience. It is also what your comic is found by in search."
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -1172,6 +1196,11 @@ msgstr ""
 msgid "the directory of every publication the network knows about."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "How readers pick it back up"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "A list is a folder for publications — <0>Work</0>, <1>Fiction</1>, <2>Read on Sunday</2>, whatever is useful. Lists appear as their own groups in the sidebar, so you can read one part of your follows without the rest."
 #~ msgstr ""
@@ -1427,6 +1456,10 @@ msgstr "Publikationen im Trend"
 msgid "Replace cover image"
 msgstr "Titelbild ersetzen"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Are your last 40 posts mostly art?</0> A run of text posts — Kickstarter updates, con reports — can tip a comic under the line until the art resumes."
+msgstr ""
+
 #: src/lib/guide/navigation.ts
 #~ msgid "Sign in, follow your first publications, and find your way around."
 #~ msgstr ""
@@ -1522,6 +1555,10 @@ msgstr "Eingebettete Inhalte"
 #: src/components/user-settings-view.tsx
 msgid "Account"
 msgstr "Konto"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "There is no “this is a comic” switch anywhere on the network, and nothing to set on Standard Reader — we do not host your publication. Two things have to be true instead."
+msgstr ""
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
@@ -2014,6 +2051,10 @@ msgstr "Warum steht dieser Text hier? (Markdown möglich)"
 msgid "Sign in, subscribe to a few publications, and learn where everything lives. Ten minutes, once."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The theater treats the whole publication as one book. Page numbers run straight through from your first page to your latest, so a reader who holds down the arrow key walks the entire run without stopping at the end of every issue. Arrow keys, space, Page Up and Page Down all turn pages; Home and End jump to either end; on a phone the outer edges of the screen turn pages, a swipe does too, and pinch-to-zoom gets a reader into a dense panel. There is a full-screen toggle on the <0>f</0> key. Past the last page is a back cover telling them they are caught up and inviting them to subscribe."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "{count, plural, one {# upvote} other {# upvotes}} — click to upvote"
 msgstr "{count, plural, one {# Upvote} other {# Upvotes}} – klicken zum Upvoten"
@@ -2030,6 +2071,10 @@ msgstr "Lesen"
 #: src/components/reader/comments/add-comment-dialog.tsx
 #~ msgid "Discussion here is gathered from posts across the network, so you comment wherever you already post. Yours joins this article once the network indexes it."
 #~ msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A post with no images contributes nothing to flip through, so it does not get a cover on the shelf and cannot be paged to: an announcement, a hiatus note, or a con schedule lives in the archive's read and unread views rather than in the book. If a text post matters to the story, give it a piece of art and it becomes a page like any other."
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "An HttpOnly session cookie that keeps you signed in."
@@ -2108,6 +2153,11 @@ msgstr ""
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "<0><1>Markpub</1> (recommended).</0> <2>at.markpub.markdown</2> — markdown with facets for rich text. It's not part of the site.standard spec either — no markdown format is — but it's the only one that's actually spec'd in a meaningful, reusable way, rather than one app's own ad hoc shape. Use this for a hand-rolled integration unless you already produce one of the platform formats below."
 msgstr "<0><1>Markpub</1> (empfohlen).</0> <2>at.markpub.markdown</2> – Markdown mit Facets für Rich Text. Es ist ebenfalls nicht Teil der site.standard-Spezifikation – kein Markdown-Format ist das –, aber es ist das einzige, das wirklich sinnvoll und wiederverwendbar spezifiziert ist, statt nur die Ad-hoc-Form einer einzelnen App zu sein. Nutzen Sie es für eine eigene Integration, sofern Sie nicht bereits eines der unten genannten Plattformformate erzeugen."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What counts as a page"
+msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Hide read articles"
@@ -2405,6 +2455,10 @@ msgstr "Ausgabe wird gesetzt"
 msgid "Feed preferences"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A single post whose title breaks the pattern does not split an issue in two. An interstitial in the middle of issue 3 joins issue 3, and a one-off announcement will not start a phantom issue of its own."
+msgstr ""
+
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Set API_DOCS_FIXTURE_LIST_URI to run this example."
 msgstr "Setzen Sie API_DOCS_FIXTURE_LIST_URI, um dieses Beispiel auszuführen."
@@ -2598,6 +2652,11 @@ msgstr ""
 msgid "RSS feed"
 msgstr "RSS-Feed"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Naming issues and pages"
+msgstr ""
+
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
 #~ msgid "Run a labeler"
@@ -2759,6 +2818,10 @@ msgstr "Ein paar Einstellungen"
 
 #: src/routes/_layout.friends.tsx
 msgid "We couldn't reach Bluesky to look up who you follow. Reload in a moment, or browse the directory in the meantime."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Keep the essay for its own post"
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -3436,6 +3499,11 @@ msgstr ""
 msgid "<0>Share</0> copies a link, or posts the article to Bluesky with a proper preview card. On a phone it can hand off to whatever you normally share with."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Turning the comic view on"
+msgstr ""
+
 #: src/components/reader/article-below-fold.tsx
 msgid "Worth subscribing to"
 msgstr "Einen Blick wert"
@@ -3506,6 +3574,11 @@ msgstr ""
 msgid "A publication on Standard is a <0>site.standard.document</0> record in the author's AT Protocol repository — not a row in a database we own. Standard Reader indexes those records into a public read-model and renders them, but nothing about the format is proprietary: the schemas are open, the content is portable across publishing platforms, and the same renderer we ship is available to you."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "The words beside the art"
+msgstr ""
+
 #: src/components/labelers-settings-view.tsx
 #: src/routes/_layout.latest.tsx
 msgid "On the network"
@@ -3525,6 +3598,11 @@ msgstr "Ein ruhiger Ort zum Lesen"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Add publications or people, then <0>Create list</0>."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "When it still reads as a blog"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -3621,6 +3699,10 @@ msgstr "Weitere Aktionen"
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Readers who would rather not get the magazine treatment can turn <0>Open collections in magazine</0> off in <1>settings</1>, and collection articles open in the ordinary reader instead."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Covers are drawn in a 2:3 frame — the standard trade-paperback shape — and art is scaled to fill it, so anything much wider or squarer gets cropped at the edges. If your logo or your title lettering sits near the very edge of a landscape cover, expect it to be trimmed on the shelf. The full page is untouched in the reader; this only affects the thumbnail."
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -3750,6 +3832,10 @@ msgstr "Trends dieser Woche"
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "The login screen links out to create one. Any account on the network works — you do not have to use Bluesky itself, and you do not have to post anything."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "If all of that is true and your comic still reads as a blog, tell us on the feedback board with a link to the publication — that is a bug on our side, and worth hearing about."
 msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
@@ -3976,6 +4062,10 @@ msgstr ""
 msgid "We couldn’t find that publication."
 msgstr "Diese Publikation konnten wir nicht finden."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Your posts have to read as pages.</0> We look at your 40 newest posts and count the ones that render at least one image and carry no more than about 700 words of prose. If at least 60% of them do, the publication is a comic. If they do not, it is treated as a serialized book — still read front-to-back, but as articles with an <1>Up next</1> link rather than as pages of art."
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Generating audio… {percent}%"
 msgstr "Audio wird erzeugt… {percent} %"
@@ -4000,6 +4090,10 @@ msgstr "Ungelesen"
 #: src/components/guide/pages/collections-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "How readers see it"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Standard Reader has a reading mode built for comics — a shelf of covers instead of a list of post titles, and a full-screen theater that flips through your pages. You do not author anything specially for it. This page is how to make sure your comic gets it."
 msgstr ""
 
 #. placeholder {0}: filter.trim()
@@ -4185,6 +4279,10 @@ msgstr ""
 msgid "On any page you visit"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The current page lives in the address bar, so a reader can link someone straight to a page, and reopening the comic puts them back where they stopped."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Partly removed"
 msgstr ""
@@ -4193,6 +4291,10 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Delete list"
 msgstr "Liste löschen"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The one part that is required is the hash before the issue number — a bare number in a title is never read as an issue, because too many ordinary titles start with one. After the number you can use a comma, a colon, a dash, or nothing at all; everything following it is treated as the page label and is not otherwise parsed, so write it however you like."
+msgstr ""
 
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "What the extension can see and what it does with it is written out in full on the <0>extension privacy page</0>."
@@ -4222,6 +4324,10 @@ msgstr "Empfohlene Artikel"
 
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Getting a shelf but not issues?</0> Then the setting is right and it is the titles: check that at least 7 in 10 carry a hash and an issue number."
 msgstr ""
 
 #: src/components/labeler-detail-view.tsx
@@ -4359,6 +4465,10 @@ msgstr "Vorlesestimme"
 msgid "Sharp"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "An issue is fronted by the page whose title says it is the cover — anything with the word <0>cover</0> in the page label. <1>Inner cover</1> is deliberately not treated as one, since it is the leaf behind the cover rather than the cover itself. When no page claims it, the issue's first page fronts it, which is what the reader sees on opening anyway."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "What you get is a reading view made for long-form: a centered column, drop caps and pull quotes, full-bleed images you can open into a gallery. The page gets out of the way so the writing can do its work."
 msgstr "Sie bekommen eine Leseansicht für Langtexte: eine zentrierte Spalte, Initialen und Zitatblöcke, randlose Bilder, die sich zur Galerie öffnen. Die Seite tritt zurück, damit der Text wirken kann."
@@ -4445,6 +4555,10 @@ msgstr ""
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "Make one with <0>New list</0> in the sidebar, or add a publication to a list from its <1>Add to list</1> menu. A publication can be in as many lists as you like, and being in a list does not change your feeds — it only changes how they are grouped."
 #~ msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "In practice this means a reader who subscribes mid-run can come back after a month and land exactly where they stopped, which is the single biggest thing that keeps people reading a serial. Readers who have turned reading history off see no dots — nothing is tracked for them — and readers who are not signed in see the shelf as a stranger would."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
@@ -4724,6 +4838,10 @@ msgstr "Sammlung vorstellen … (Markdown möglich)"
 msgid "Filter"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A comic publication gets two things an ordinary blog does not. Its page shows a <0>shelf of covers</0> — your art, at trade-paperback proportions — rather than dozens of near-identical rows reading <1>Pg. 1</1>, <2>Pg. 2</2>, <3>Pg. 3</3>. And opening one drops the reader into the <4>comic reader</4>: a dark, chrome-free theater holding one page at a time."
+msgstr ""
+
 #: src/components/reader/friend-publishers.tsx
 msgid "Bluesky didn't answer in time, so this list may be incomplete. Reload to try again."
 msgstr ""
@@ -4778,6 +4896,11 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "Profileinstellungen"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Publishing a comic"
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "The first time you sign in, a short setup walks you through it: pick a few topics you care about, see which of the people you already follow on Bluesky write here, follow anything that appeals, and choose how you like your text. You can skip any step, and skip the whole thing."
@@ -5122,6 +5245,10 @@ msgstr ""
 #: src/components/docs/docs-renderers-nav.tsx
 #: src/components/docs/renderers-docs-page.tsx
 msgid "Resolving platform data"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Your publication has to say it reads forwards.</0> That is a setting on the publication itself, in whatever tool you publish with — the one that says the work is read from its first post rather than newest-first. In the underlying record it is <1>preferences.prevNextDirection</1> set to <2>ltr</2>. Leaflet writes this field; if you roll your own records, see <3>Publishing your site</3>. Without it a comic is just a blog that happens to post drawings."
 msgstr ""
 
 #: src/components/reader/comments/add-comment-dialog.tsx
@@ -5669,6 +5796,10 @@ msgstr ""
 msgid "Articles you've recommended across the network."
 msgstr "Artikel, die Sie im Netzwerk empfohlen haben."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "One thing worth knowing: if a paragraph of your post body repeats a page's alt text word for word, we drop it from the note rather than showing the reader a description of the picture they are looking at. So transcribing your dialogue into the alt and again into the body does not double up."
+msgstr ""
+
 #: src/routes/_layout.feedback.return.tsx
 msgid "View feedback"
 msgstr "Feedback ansehen"
@@ -5991,6 +6122,10 @@ msgstr "Doku"
 msgid "The core / new frameworks"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Both are re-checked as your archive grows, and the setting is picked up the first time anyone opens your publication after you change it — you do not have to tell us. Being read as a book rather than a comic is never a dead end for a reader: every route into the comic reader also links to the ordinary reading view, and an issue with no art falls back to it outright."
+msgstr ""
+
 #. placeholder {0}: index + 1
 #: src/components/comic/comic-reader.tsx
 msgid "Page {0}"
@@ -6171,6 +6306,11 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 #~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
 #~ msgstr "Eine schlanke Browser-Erweiterung lässt Sie Publikationen speichern und abonnieren, während Sie im Web unterwegs sind – mit dezenten Badges auf bsky.app und einem Overlay mit einem Klick auf jeder Seite. Ihre Leseliste füllt sich von selbst."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Alt text"
+msgstr ""
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -6356,6 +6496,10 @@ msgstr ""
 msgid "Reading & privacy"
 msgstr "Lesen & Datenschutz"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Grouping is all-or-nothing per publication: at least 70% of your titles have to parse before we trust the numbers enough to group by them. If they do not — a webcomic naming its posts <0>Pg01</0>, <1>Pg02</1> has no issues to speak of — you still get a shelf, just one cover per post instead of one per issue. That is a fine way to run a comic; it is not a failure state."
+msgstr ""
+
 #: src/components/Header.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/site-legal-links.tsx
@@ -6471,6 +6615,11 @@ msgstr "Redaktionell"
 msgid "Click Run example to fetch a live response with your session."
 msgstr "Klicken Sie auf „Beispiel ausführen“, um mit Ihrer Sitzung eine Live-Antwort abzurufen."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What readers get"
+msgstr ""
+
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "At the bottom of settings, <0>Personal data</0> deletes categories of records outright: your reading history, your saved articles, or the publication lists you made. Each asks for confirmation and explains what will change."
 msgstr ""
@@ -6559,6 +6708,10 @@ msgstr ""
 #: src/routes/_layout.p.$did.$rkey.tsx
 #~ msgid "Open publication"
 #~ msgstr "Publikation öffnen"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Do your recent posts render their art in the body?</0> A post that only links to the page on your site, or that carries the drawing as a cover image with an empty body, has no pages to flip."
+msgstr ""
 
 #: src/components/reader/link-share-menu.tsx
 msgid "Send to Disperse"
@@ -6680,6 +6833,10 @@ msgstr "{articleCount, plural, one {Artikel} other {Artikel}}"
 msgid "{publicationName} is in your feed. You'll see new writing as it publishes."
 msgstr "{publicationName} ist in Ihrem Feed. Neue Texte erscheinen, sobald sie veröffentlicht werden."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Read state is per post, and your posts are pages, so an issue counts as unread while any page in it is — a comic read halfway through is not read. Its cover wears the same unread dot an unread article does, and clicking it opens on the first page that reader has not seen, not back at the cover. Walking pages in the theater marks them off behind them."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Upgrade permissions"
 msgstr "Berechtigungen erweitern"
@@ -6740,6 +6897,10 @@ msgstr "Diese Publikation hat sich gegen die Entdeckung entschieden und ist dahe
 msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {# Upvote} other {# Upvotes}} — zum Abstimmen anmelden"
 
+#: src/lib/guide/navigation.ts
+msgid "Get a shelf of covers and a page-flip reader out of the pages you already post."
+msgstr ""
+
 #: src/components/onboarding/step-friends.tsx
 #~ msgid "Select all"
 #~ msgstr ""
@@ -6748,9 +6909,17 @@ msgstr "{count, plural, one {# Upvote} other {# Upvotes}} — zum Abstimmen anme
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
 msgstr "Wie {SITE_NAME} insgesamt funktioniert, steht unter <0>Über</0>. Zum Datenschutz der gesamten Website siehe die <1>Datenschutzerklärung</1>. Bei Fragen zu dieser Instanz wenden Sie sich an den Betreiber von {siteHost}."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The counter reads <0>Page 12 of 340</0> across the whole publication, not within one issue. That means inserting or removing a page in an early issue renumbers everything after it — worth knowing before you go back and edit an old post that readers may have linked to."
+msgstr ""
+
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Your account and data"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The prose length is also what separates a comic from an illustrated blog: a post carrying more than about 700 words stops counting as a page of comic, and if most of your posts are like that the publication reads as a book instead. A long process essay is better as its own post — which readers will find in the archive — than appended to a page."
 msgstr ""
 
 #: src/routes/review.thanks.tsx
@@ -6878,6 +7047,10 @@ msgstr "Symbol"
 msgid "Top"
 msgstr "Top"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Most cartoonists write a line or two under the page — a caption, a process note, a word about next week. That writing is not lost in the theater. If a page's post carries prose, the note button in the top bar lights up and lays it over the art, in the theater's own type, with a way through to the full post. It closes when the reader turns the page, because it belongs to the page it was written about."
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Read aloud"
 msgstr "Vorlesen"
@@ -6911,6 +7084,10 @@ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Subscribe to the publication it came from, in the same click."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>FITV #1 Cover</0> — the same, with a page label instead of a number."
 msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
@@ -7145,6 +7322,10 @@ msgstr "Folgt"
 msgid "Opening the issue…"
 msgstr "Ausgabe wird geöffnet…"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Pages with nothing written under them leave the button disabled rather than making it appear and vanish as the reader flips, so there is no penalty for a silent page."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "However you like to read it"
 msgstr ""
@@ -7318,6 +7499,11 @@ msgstr "Wenn aktiv, gilt beim Abonnieren der gesamte Backkatalog einer Publikati
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this reply on Bluesky"
 msgstr "Diese Antwort auf Bluesky öffnen"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Cover art"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "what your corner of Bluesky reads."
@@ -7555,6 +7741,10 @@ msgstr ""
 
 #: src/routes/mcp/authorize.tsx
 msgid "Signed in as"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Page numbers are absolute"
 msgstr ""
 
 #: src/components/guide/pages/collections-guide-page.tsx

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -242,6 +242,10 @@ msgstr ""
 msgid "Your series"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Nothing in the format has a field for “issue 3” — the only place that number exists is your post titles, so that is where we read it back out of. Title your pages the way comics have always been titled and consecutive pages collapse back into the issue they came from, one cover per issue:"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Mark as read"
 msgstr ""
@@ -253,6 +257,10 @@ msgstr ""
 #: src/components/docs/api-docs-intro.tsx
 #~ msgid "A labeler is any DID that publishes AT Proto labels. Readers add one by DID on the <0>Labelers</0> page, and Standard Reader then shows that labeler's labels — and can warn on or hide labeled posts — as they read. Labelers are discovered the standard way; nothing about them is specific to us. To run your own:"
 #~ msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "If your publication page shows a list of titles instead of a shelf, walk these in order:"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "The most-read articles across Standard this week."
@@ -444,6 +452,10 @@ msgstr ""
 msgid "If the site publishes in the open format but has not been indexed yet, the extension reads the page's own record hints and subscribes anyway."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A page is an image your post's body renders, and they are flipped through in the order they appear in the post. One image per post is the usual shape and the one everything here is tuned for, but a post carrying three images contributes three pages, in order — useful for posting a whole issue at once."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Open"
 msgstr ""
@@ -549,6 +561,10 @@ msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "New collection…"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Fray In The Veil #2, Pg. 7</0> — series, issue, page."
 msgstr ""
 
 #: src/components/reader/privacy-view.tsx
@@ -811,6 +827,10 @@ msgstr ""
 msgid "Play voice sample"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Is the forwards-reading setting saved?</0> This is the one that is almost always the answer. Check it in your publishing tool, and note that it lives on the publication, not on individual posts."
+msgstr ""
+
 #: src/components/reader/subscribe-card.tsx
 msgid "You're subscribed"
 msgstr ""
@@ -840,6 +860,10 @@ msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Infinite scroll keeps pulling the next page as you reach the end of a list. Load more waits for you to ask."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Alt text on a comic page is the page, for anyone who cannot see it — in the theater there is no surrounding article to fall back on, so whatever you wrote is the whole experience. It is also what your comic is found by in search."
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -1172,6 +1196,11 @@ msgstr ""
 msgid "the directory of every publication the network knows about."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "How readers pick it back up"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "A list is a folder for publications — <0>Work</0>, <1>Fiction</1>, <2>Read on Sunday</2>, whatever is useful. Lists appear as their own groups in the sidebar, so you can read one part of your follows without the rest."
 #~ msgstr ""
@@ -1427,6 +1456,10 @@ msgstr ""
 msgid "Replace cover image"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Are your last 40 posts mostly art?</0> A run of text posts — Kickstarter updates, con reports — can tip a comic under the line until the art resumes."
+msgstr ""
+
 #: src/lib/guide/navigation.ts
 #~ msgid "Sign in, follow your first publications, and find your way around."
 #~ msgstr ""
@@ -1521,6 +1554,10 @@ msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Account"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "There is no “this is a comic” switch anywhere on the network, and nothing to set on Standard Reader — we do not host your publication. Two things have to be true instead."
 msgstr ""
 
 #: src/components/reader/app-shell.tsx
@@ -2014,6 +2051,10 @@ msgstr ""
 msgid "Sign in, subscribe to a few publications, and learn where everything lives. Ten minutes, once."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The theater treats the whole publication as one book. Page numbers run straight through from your first page to your latest, so a reader who holds down the arrow key walks the entire run without stopping at the end of every issue. Arrow keys, space, Page Up and Page Down all turn pages; Home and End jump to either end; on a phone the outer edges of the screen turn pages, a swipe does too, and pinch-to-zoom gets a reader into a dense panel. There is a full-screen toggle on the <0>f</0> key. Past the last page is a back cover telling them they are caught up and inviting them to subscribe."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "{count, plural, one {# upvote} other {# upvotes}} — click to upvote"
 msgstr ""
@@ -2030,6 +2071,10 @@ msgstr ""
 #: src/components/reader/comments/add-comment-dialog.tsx
 #~ msgid "Discussion here is gathered from posts across the network, so you comment wherever you already post. Yours joins this article once the network indexes it."
 #~ msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A post with no images contributes nothing to flip through, so it does not get a cover on the shelf and cannot be paged to: an announcement, a hiatus note, or a con schedule lives in the archive's read and unread views rather than in the book. If a text post matters to the story, give it a piece of art and it becomes a page like any other."
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "An HttpOnly session cookie that keeps you signed in."
@@ -2107,6 +2152,11 @@ msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "<0><1>Markpub</1> (recommended).</0> <2>at.markpub.markdown</2> — markdown with facets for rich text. It's not part of the site.standard spec either — no markdown format is — but it's the only one that's actually spec'd in a meaningful, reusable way, rather than one app's own ad hoc shape. Use this for a hand-rolled integration unless you already produce one of the platform formats below."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What counts as a page"
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -2405,6 +2455,10 @@ msgstr ""
 msgid "Feed preferences"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A single post whose title breaks the pattern does not split an issue in two. An interstitial in the middle of issue 3 joins issue 3, and a one-off announcement will not start a phantom issue of its own."
+msgstr ""
+
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Set API_DOCS_FIXTURE_LIST_URI to run this example."
 msgstr ""
@@ -2598,6 +2652,11 @@ msgstr ""
 msgid "RSS feed"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Naming issues and pages"
+msgstr ""
+
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
 #~ msgid "Run a labeler"
@@ -2759,6 +2818,10 @@ msgstr ""
 
 #: src/routes/_layout.friends.tsx
 msgid "We couldn't reach Bluesky to look up who you follow. Reload in a moment, or browse the directory in the meantime."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Keep the essay for its own post"
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -3436,6 +3499,11 @@ msgstr ""
 msgid "<0>Share</0> copies a link, or posts the article to Bluesky with a proper preview card. On a phone it can hand off to whatever you normally share with."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Turning the comic view on"
+msgstr ""
+
 #: src/components/reader/article-below-fold.tsx
 msgid "Worth subscribing to"
 msgstr ""
@@ -3506,6 +3574,11 @@ msgstr ""
 msgid "A publication on Standard is a <0>site.standard.document</0> record in the author's AT Protocol repository — not a row in a database we own. Standard Reader indexes those records into a public read-model and renders them, but nothing about the format is proprietary: the schemas are open, the content is portable across publishing platforms, and the same renderer we ship is available to you."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "The words beside the art"
+msgstr ""
+
 #: src/components/labelers-settings-view.tsx
 #: src/routes/_layout.latest.tsx
 msgid "On the network"
@@ -3525,6 +3598,11 @@ msgstr ""
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Add publications or people, then <0>Create list</0>."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "When it still reads as a blog"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -3621,6 +3699,10 @@ msgstr ""
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Readers who would rather not get the magazine treatment can turn <0>Open collections in magazine</0> off in <1>settings</1>, and collection articles open in the ordinary reader instead."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Covers are drawn in a 2:3 frame — the standard trade-paperback shape — and art is scaled to fill it, so anything much wider or squarer gets cropped at the edges. If your logo or your title lettering sits near the very edge of a landscape cover, expect it to be trimmed on the shelf. The full page is untouched in the reader; this only affects the thumbnail."
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -3750,6 +3832,10 @@ msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "The login screen links out to create one. Any account on the network works — you do not have to use Bluesky itself, and you do not have to post anything."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "If all of that is true and your comic still reads as a blog, tell us on the feedback board with a link to the publication — that is a bug on our side, and worth hearing about."
 msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
@@ -3976,6 +4062,10 @@ msgstr ""
 msgid "We couldn’t find that publication."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Your posts have to read as pages.</0> We look at your 40 newest posts and count the ones that render at least one image and carry no more than about 700 words of prose. If at least 60% of them do, the publication is a comic. If they do not, it is treated as a serialized book — still read front-to-back, but as articles with an <1>Up next</1> link rather than as pages of art."
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Generating audio… {percent}%"
 msgstr ""
@@ -4000,6 +4090,10 @@ msgstr ""
 #: src/components/guide/pages/collections-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "How readers see it"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Standard Reader has a reading mode built for comics — a shelf of covers instead of a list of post titles, and a full-screen theater that flips through your pages. You do not author anything specially for it. This page is how to make sure your comic gets it."
 msgstr ""
 
 #. placeholder {0}: filter.trim()
@@ -4185,6 +4279,10 @@ msgstr ""
 msgid "On any page you visit"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The current page lives in the address bar, so a reader can link someone straight to a page, and reopening the comic puts them back where they stopped."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Partly removed"
 msgstr ""
@@ -4192,6 +4290,10 @@ msgstr ""
 #: src/components/reader/list-edit-modal.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Delete list"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The one part that is required is the hash before the issue number — a bare number in a title is never read as an issue, because too many ordinary titles start with one. After the number you can use a comma, a colon, a dash, or nothing at all; everything following it is treated as the page label and is not otherwise parsed, so write it however you like."
 msgstr ""
 
 #: src/components/guide/pages/everywhere-guide-page.tsx
@@ -4222,6 +4324,10 @@ msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Getting a shelf but not issues?</0> Then the setting is right and it is the titles: check that at least 7 in 10 carry a hash and an issue number."
 msgstr ""
 
 #: src/components/labeler-detail-view.tsx
@@ -4359,6 +4465,10 @@ msgstr ""
 msgid "Sharp"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "An issue is fronted by the page whose title says it is the cover — anything with the word <0>cover</0> in the page label. <1>Inner cover</1> is deliberately not treated as one, since it is the leaf behind the cover rather than the cover itself. When no page claims it, the issue's first page fronts it, which is what the reader sees on opening anyway."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "What you get is a reading view made for long-form: a centered column, drop caps and pull quotes, full-bleed images you can open into a gallery. The page gets out of the way so the writing can do its work."
 msgstr ""
@@ -4445,6 +4555,10 @@ msgstr ""
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "Make one with <0>New list</0> in the sidebar, or add a publication to a list from its <1>Add to list</1> menu. A publication can be in as many lists as you like, and being in a list does not change your feeds — it only changes how they are grouped."
 #~ msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "In practice this means a reader who subscribes mid-run can come back after a month and land exactly where they stopped, which is the single biggest thing that keeps people reading a serial. Readers who have turned reading history off see no dots — nothing is tracked for them — and readers who are not signed in see the shelf as a stranger would."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
@@ -4724,6 +4838,10 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A comic publication gets two things an ordinary blog does not. Its page shows a <0>shelf of covers</0> — your art, at trade-paperback proportions — rather than dozens of near-identical rows reading <1>Pg. 1</1>, <2>Pg. 2</2>, <3>Pg. 3</3>. And opening one drops the reader into the <4>comic reader</4>: a dark, chrome-free theater holding one page at a time."
+msgstr ""
+
 #: src/components/reader/friend-publishers.tsx
 msgid "Bluesky didn't answer in time, so this list may be incomplete. Reload to try again."
 msgstr ""
@@ -4777,6 +4895,11 @@ msgstr ""
 #: src/components/reader/profile-tabs-settings-modal.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Publishing a comic"
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -5122,6 +5245,10 @@ msgstr ""
 #: src/components/docs/docs-renderers-nav.tsx
 #: src/components/docs/renderers-docs-page.tsx
 msgid "Resolving platform data"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Your publication has to say it reads forwards.</0> That is a setting on the publication itself, in whatever tool you publish with — the one that says the work is read from its first post rather than newest-first. In the underlying record it is <1>preferences.prevNextDirection</1> set to <2>ltr</2>. Leaflet writes this field; if you roll your own records, see <3>Publishing your site</3>. Without it a comic is just a blog that happens to post drawings."
 msgstr ""
 
 #: src/components/reader/comments/add-comment-dialog.tsx
@@ -5669,6 +5796,10 @@ msgstr ""
 msgid "Articles you've recommended across the network."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "One thing worth knowing: if a paragraph of your post body repeats a page's alt text word for word, we drop it from the note rather than showing the reader a description of the picture they are looking at. So transcribing your dialogue into the alt and again into the body does not double up."
+msgstr ""
+
 #: src/routes/_layout.feedback.return.tsx
 msgid "View feedback"
 msgstr ""
@@ -5991,6 +6122,10 @@ msgstr ""
 msgid "The core / new frameworks"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Both are re-checked as your archive grows, and the setting is picked up the first time anyone opens your publication after you change it — you do not have to tell us. Being read as a book rather than a comic is never a dead end for a reader: every route into the comic reader also links to the ordinary reading view, and an issue with no art falls back to it outright."
+msgstr ""
+
 #. placeholder {0}: index + 1
 #: src/components/comic/comic-reader.tsx
 msgid "Page {0}"
@@ -6171,6 +6306,11 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 #~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
 #~ msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Alt text"
+msgstr ""
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -6356,6 +6496,10 @@ msgstr ""
 msgid "Reading & privacy"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Grouping is all-or-nothing per publication: at least 70% of your titles have to parse before we trust the numbers enough to group by them. If they do not — a webcomic naming its posts <0>Pg01</0>, <1>Pg02</1> has no issues to speak of — you still get a shelf, just one cover per post instead of one per issue. That is a fine way to run a comic; it is not a failure state."
+msgstr ""
+
 #: src/components/Header.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/site-legal-links.tsx
@@ -6471,6 +6615,11 @@ msgstr ""
 msgid "Click Run example to fetch a live response with your session."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What readers get"
+msgstr ""
+
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "At the bottom of settings, <0>Personal data</0> deletes categories of records outright: your reading history, your saved articles, or the publication lists you made. Each asks for confirmation and explains what will change."
 msgstr ""
@@ -6559,6 +6708,10 @@ msgstr ""
 #: src/routes/_layout.p.$did.$rkey.tsx
 #~ msgid "Open publication"
 #~ msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Do your recent posts render their art in the body?</0> A post that only links to the page on your site, or that carries the drawing as a cover image with an empty body, has no pages to flip."
+msgstr ""
 
 #: src/components/reader/link-share-menu.tsx
 msgid "Send to Disperse"
@@ -6680,6 +6833,10 @@ msgstr ""
 msgid "{publicationName} is in your feed. You'll see new writing as it publishes."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Read state is per post, and your posts are pages, so an issue counts as unread while any page in it is — a comic read halfway through is not read. Its cover wears the same unread dot an unread article does, and clicking it opens on the first page that reader has not seen, not back at the cover. Walking pages in the theater marks them off behind them."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Upgrade permissions"
 msgstr ""
@@ -6740,6 +6897,10 @@ msgstr ""
 msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr ""
 
+#: src/lib/guide/navigation.ts
+msgid "Get a shelf of covers and a page-flip reader out of the pages you already post."
+msgstr ""
+
 #: src/components/onboarding/step-friends.tsx
 #~ msgid "Select all"
 #~ msgstr ""
@@ -6748,9 +6909,17 @@ msgstr ""
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The counter reads <0>Page 12 of 340</0> across the whole publication, not within one issue. That means inserting or removing a page in an early issue renumbers everything after it — worth knowing before you go back and edit an old post that readers may have linked to."
+msgstr ""
+
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Your account and data"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The prose length is also what separates a comic from an illustrated blog: a post carrying more than about 700 words stops counting as a page of comic, and if most of your posts are like that the publication reads as a book instead. A long process essay is better as its own post — which readers will find in the archive — than appended to a page."
 msgstr ""
 
 #: src/routes/review.thanks.tsx
@@ -6878,6 +7047,10 @@ msgstr ""
 msgid "Top"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Most cartoonists write a line or two under the page — a caption, a process note, a word about next week. That writing is not lost in the theater. If a page's post carries prose, the note button in the top bar lights up and lays it over the art, in the theater's own type, with a way through to the full post. It closes when the reader turns the page, because it belongs to the page it was written about."
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Read aloud"
 msgstr ""
@@ -6911,6 +7084,10 @@ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Subscribe to the publication it came from, in the same click."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>FITV #1 Cover</0> — the same, with a page label instead of a number."
 msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
@@ -7145,6 +7322,10 @@ msgstr ""
 msgid "Opening the issue…"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Pages with nothing written under them leave the button disabled rather than making it appear and vanish as the reader flips, so there is no penalty for a silent page."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "However you like to read it"
 msgstr ""
@@ -7317,6 +7498,11 @@ msgstr ""
 
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this reply on Bluesky"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Cover art"
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -7555,6 +7741,10 @@ msgstr ""
 
 #: src/routes/mcp/authorize.tsx
 msgid "Signed in as"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Page numbers are absolute"
 msgstr ""
 
 #: src/components/guide/pages/collections-guide-page.tsx

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -242,6 +242,10 @@ msgstr "Subscribe to a publication or follow a writer and they'll show up here, 
 msgid "Your series"
 msgstr "Your series"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Nothing in the format has a field for “issue 3” — the only place that number exists is your post titles, so that is where we read it back out of. Title your pages the way comics have always been titled and consecutive pages collapse back into the issue they came from, one cover per issue:"
+msgstr "Nothing in the format has a field for “issue 3” — the only place that number exists is your post titles, so that is where we read it back out of. Title your pages the way comics have always been titled and consecutive pages collapse back into the issue they came from, one cover per issue:"
+
 #: src/components/reader/article-view.tsx
 msgid "Mark as read"
 msgstr "Mark as read"
@@ -253,6 +257,10 @@ msgstr "This list is empty — add publications or people to it."
 #: src/components/docs/api-docs-intro.tsx
 #~ msgid "A labeler is any DID that publishes AT Proto labels. Readers add one by DID on the <0>Labelers</0> page, and Standard Reader then shows that labeler's labels — and can warn on or hide labeled posts — as they read. Labelers are discovered the standard way; nothing about them is specific to us. To run your own:"
 #~ msgstr "A labeler is any DID that publishes AT Proto labels. Readers add one by DID on the <0>Labelers</0> page, and Standard Reader then shows that labeler's labels — and can warn on or hide labeled posts — as they read. Labelers are discovered the standard way; nothing about them is specific to us. To run your own:"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "If your publication page shows a list of titles instead of a shelf, walk these in order:"
+msgstr "If your publication page shows a list of titles instead of a shelf, walk these in order:"
 
 #: src/components/user-settings-view.tsx
 msgid "The most-read articles across Standard this week."
@@ -444,6 +452,10 @@ msgstr "Dismiss"
 msgid "If the site publishes in the open format but has not been indexed yet, the extension reads the page's own record hints and subscribes anyway."
 msgstr "If the site publishes in the open format but has not been indexed yet, the extension reads the page's own record hints and subscribes anyway."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A page is an image your post's body renders, and they are flipped through in the order they appear in the post. One image per post is the usual shape and the one everything here is tuned for, but a post carrying three images contributes three pages, in order — useful for posting a whole issue at once."
+msgstr "A page is an image your post's body renders, and they are flipped through in the order they appear in the post. One image per post is the usual shape and the one everything here is tuned for, but a post carrying three images contributes three pages, in order — useful for posting a whole issue at once."
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Open"
 msgstr "Open"
@@ -550,6 +562,10 @@ msgstr "Wire your own site's records so Standard Reader can find and read it."
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "New collection…"
 msgstr "New collection…"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Fray In The Veil #2, Pg. 7</0> — series, issue, page."
+msgstr "<0>Fray In The Veil #2, Pg. 7</0> — series, issue, page."
 
 #: src/components/reader/privacy-view.tsx
 msgid "We may update this policy as the product changes. The “Last updated” date at the top will change when we do. Continued use of the site after an update means you accept the revised policy."
@@ -811,6 +827,10 @@ msgstr "This list is empty."
 msgid "Play voice sample"
 msgstr "Play voice sample"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Is the forwards-reading setting saved?</0> This is the one that is almost always the answer. Check it in your publishing tool, and note that it lives on the publication, not on individual posts."
+msgstr "<0>Is the forwards-reading setting saved?</0> This is the one that is almost always the answer. Check it in your publishing tool, and note that it lives on the publication, not on individual posts."
+
 #: src/components/reader/subscribe-card.tsx
 msgid "You're subscribed"
 msgstr "You're subscribed"
@@ -841,6 +861,10 @@ msgstr "{0} min read"
 #: src/components/user-settings-view.tsx
 msgid "Infinite scroll keeps pulling the next page as you reach the end of a list. Load more waits for you to ask."
 msgstr "Infinite scroll keeps pulling the next page as you reach the end of a list. Load more waits for you to ask."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Alt text on a comic page is the page, for anyone who cannot see it — in the theater there is no surrounding article to fall back on, so whatever you wrote is the whole experience. It is also what your comic is found by in search."
+msgstr "Alt text on a comic page is the page, for anyone who cannot see it — in the theater there is no surrounding article to fall back on, so whatever you wrote is the whole experience. It is also what your comic is found by in search."
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1172,6 +1196,11 @@ msgstr "{SITE_NAME} is a web reader for standard.site publications on the AT Pro
 msgid "the directory of every publication the network knows about."
 msgstr "the directory of every publication the network knows about."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "How readers pick it back up"
+msgstr "How readers pick it back up"
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "A list is a folder for publications — <0>Work</0>, <1>Fiction</1>, <2>Read on Sunday</2>, whatever is useful. Lists appear as their own groups in the sidebar, so you can read one part of your follows without the rest."
 #~ msgstr "A list is a folder for publications — <0>Work</0>, <1>Fiction</1>, <2>Read on Sunday</2>, whatever is useful. Lists appear as their own groups in the sidebar, so you can read one part of your follows without the rest."
@@ -1427,6 +1456,10 @@ msgstr "Trending publications"
 msgid "Replace cover image"
 msgstr "Replace cover image"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Are your last 40 posts mostly art?</0> A run of text posts — Kickstarter updates, con reports — can tip a comic under the line until the art resumes."
+msgstr "<0>Are your last 40 posts mostly art?</0> A run of text posts — Kickstarter updates, con reports — can tip a comic under the line until the art resumes."
+
 #: src/lib/guide/navigation.ts
 #~ msgid "Sign in, follow your first publications, and find your way around."
 #~ msgstr "Sign in, follow your first publications, and find your way around."
@@ -1522,6 +1555,10 @@ msgstr "Embedded content"
 #: src/components/user-settings-view.tsx
 msgid "Account"
 msgstr "Account"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "There is no “this is a comic” switch anywhere on the network, and nothing to set on Standard Reader — we do not host your publication. Two things have to be true instead."
+msgstr "There is no “this is a comic” switch anywhere on the network, and nothing to set on Standard Reader — we do not host your publication. Two things have to be true instead."
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
@@ -2014,6 +2051,10 @@ msgstr "Why is this piece here? (markdown supported)"
 msgid "Sign in, subscribe to a few publications, and learn where everything lives. Ten minutes, once."
 msgstr "Sign in, subscribe to a few publications, and learn where everything lives. Ten minutes, once."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The theater treats the whole publication as one book. Page numbers run straight through from your first page to your latest, so a reader who holds down the arrow key walks the entire run without stopping at the end of every issue. Arrow keys, space, Page Up and Page Down all turn pages; Home and End jump to either end; on a phone the outer edges of the screen turn pages, a swipe does too, and pinch-to-zoom gets a reader into a dense panel. There is a full-screen toggle on the <0>f</0> key. Past the last page is a back cover telling them they are caught up and inviting them to subscribe."
+msgstr "The theater treats the whole publication as one book. Page numbers run straight through from your first page to your latest, so a reader who holds down the arrow key walks the entire run without stopping at the end of every issue. Arrow keys, space, Page Up and Page Down all turn pages; Home and End jump to either end; on a phone the outer edges of the screen turn pages, a swipe does too, and pinch-to-zoom gets a reader into a dense panel. There is a full-screen toggle on the <0>f</0> key. Past the last page is a back cover telling them they are caught up and inviting them to subscribe."
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "{count, plural, one {# upvote} other {# upvotes}} — click to upvote"
 msgstr "{count, plural, one {# upvote} other {# upvotes}} — click to upvote"
@@ -2030,6 +2071,10 @@ msgstr "Read"
 #: src/components/reader/comments/add-comment-dialog.tsx
 #~ msgid "Discussion here is gathered from posts across the network, so you comment wherever you already post. Yours joins this article once the network indexes it."
 #~ msgstr "Discussion here is gathered from posts across the network, so you comment wherever you already post. Yours joins this article once the network indexes it."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A post with no images contributes nothing to flip through, so it does not get a cover on the shelf and cannot be paged to: an announcement, a hiatus note, or a con schedule lives in the archive's read and unread views rather than in the book. If a text post matters to the story, give it a piece of art and it becomes a page like any other."
+msgstr "A post with no images contributes nothing to flip through, so it does not get a cover on the shelf and cannot be paged to: an announcement, a hiatus note, or a con schedule lives in the archive's read and unread views rather than in the book. If a text post matters to the story, give it a piece of art and it becomes a page like any other."
 
 #: src/components/reader/privacy-view.tsx
 msgid "An HttpOnly session cookie that keeps you signed in."
@@ -2108,6 +2153,11 @@ msgstr "If you continue, it will be able to:"
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "<0><1>Markpub</1> (recommended).</0> <2>at.markpub.markdown</2> — markdown with facets for rich text. It's not part of the site.standard spec either — no markdown format is — but it's the only one that's actually spec'd in a meaningful, reusable way, rather than one app's own ad hoc shape. Use this for a hand-rolled integration unless you already produce one of the platform formats below."
 msgstr "<0><1>Markpub</1> (recommended).</0> <2>at.markpub.markdown</2> — markdown with facets for rich text. It's not part of the site.standard spec either — no markdown format is — but it's the only one that's actually spec'd in a meaningful, reusable way, rather than one app's own ad hoc shape. Use this for a hand-rolled integration unless you already produce one of the platform formats below."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What counts as a page"
+msgstr "What counts as a page"
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Hide read articles"
@@ -2405,6 +2455,10 @@ msgstr "Setting the issue"
 msgid "Feed preferences"
 msgstr "Feed preferences"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A single post whose title breaks the pattern does not split an issue in two. An interstitial in the middle of issue 3 joins issue 3, and a one-off announcement will not start a phantom issue of its own."
+msgstr "A single post whose title breaks the pattern does not split an issue in two. An interstitial in the middle of issue 3 joins issue 3, and a one-off announcement will not start a phantom issue of its own."
+
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Set API_DOCS_FIXTURE_LIST_URI to run this example."
 msgstr "Set API_DOCS_FIXTURE_LIST_URI to run this example."
@@ -2598,6 +2652,11 @@ msgstr "Clear selection"
 msgid "RSS feed"
 msgstr "RSS feed"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Naming issues and pages"
+msgstr "Naming issues and pages"
+
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
 #~ msgid "Run a labeler"
@@ -2760,6 +2819,10 @@ msgstr "A few preferences"
 #: src/routes/_layout.friends.tsx
 msgid "We couldn't reach Bluesky to look up who you follow. Reload in a moment, or browse the directory in the meantime."
 msgstr "We couldn't reach Bluesky to look up who you follow. Reload in a moment, or browse the directory in the meantime."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Keep the essay for its own post"
+msgstr "Keep the essay for its own post"
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Plenty of people you already follow on Bluesky write long-form somewhere. <0>People you follow</0> finds them and puts their publications, and their newest articles, in one place. It is usually the highest-yield screen in the app the first week you use it."
@@ -3436,6 +3499,11 @@ msgstr "Prefer the original? Flip one setting and article links open on the publ
 msgid "<0>Share</0> copies a link, or posts the article to Bluesky with a proper preview card. On a phone it can hand off to whatever you normally share with."
 msgstr "<0>Share</0> copies a link, or posts the article to Bluesky with a proper preview card. On a phone it can hand off to whatever you normally share with."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Turning the comic view on"
+msgstr "Turning the comic view on"
+
 #: src/components/reader/article-below-fold.tsx
 msgid "Worth subscribing to"
 msgstr "Worth subscribing to"
@@ -3506,6 +3574,11 @@ msgstr "All the format-specific work happens once, in a framework-agnostic core 
 msgid "A publication on Standard is a <0>site.standard.document</0> record in the author's AT Protocol repository — not a row in a database we own. Standard Reader indexes those records into a public read-model and renders them, but nothing about the format is proprietary: the schemas are open, the content is portable across publishing platforms, and the same renderer we ship is available to you."
 msgstr "A publication on Standard is a <0>site.standard.document</0> record in the author's AT Protocol repository — not a row in a database we own. Standard Reader indexes those records into a public read-model and renders them, but nothing about the format is proprietary: the schemas are open, the content is portable across publishing platforms, and the same renderer we ship is available to you."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "The words beside the art"
+msgstr "The words beside the art"
+
 #: src/components/labelers-settings-view.tsx
 #: src/routes/_layout.latest.tsx
 msgid "On the network"
@@ -3526,6 +3599,11 @@ msgstr "A quiet place to read"
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Add publications or people, then <0>Create list</0>."
 msgstr "Add publications or people, then <0>Create list</0>."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "When it still reads as a blog"
+msgstr "When it still reads as a blog"
 
 #: src/components/reader/terms-view.tsx
 msgid "You agree not to use {SITE_NAME} to:"
@@ -3622,6 +3700,10 @@ msgstr "More actions"
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Readers who would rather not get the magazine treatment can turn <0>Open collections in magazine</0> off in <1>settings</1>, and collection articles open in the ordinary reader instead."
 msgstr "Readers who would rather not get the magazine treatment can turn <0>Open collections in magazine</0> off in <1>settings</1>, and collection articles open in the ordinary reader instead."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Covers are drawn in a 2:3 frame — the standard trade-paperback shape — and art is scaled to fill it, so anything much wider or squarer gets cropped at the edges. If your logo or your title lettering sits near the very edge of a landscape cover, expect it to be trimmed on the shelf. The full page is untouched in the reader; this only affects the thumbnail."
+msgstr "Covers are drawn in a 2:3 frame — the standard trade-paperback shape — and art is scaled to fill it, so anything much wider or squarer gets cropped at the edges. If your logo or your title lettering sits near the very edge of a landscape cover, expect it to be trimmed on the shelf. The full page is untouched in the reader; this only affects the thumbnail."
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "by @{ownerHandle}"
@@ -3751,6 +3833,10 @@ msgstr "Trending this week"
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "The login screen links out to create one. Any account on the network works — you do not have to use Bluesky itself, and you do not have to post anything."
 msgstr "The login screen links out to create one. Any account on the network works — you do not have to use Bluesky itself, and you do not have to post anything."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "If all of that is true and your comic still reads as a blog, tell us on the feedback board with a link to the publication — that is a bug on our side, and worth hearing about."
+msgstr "If all of that is true and your comic still reads as a blog, tell us on the feedback board with a link to the publication — that is a bug on our side, and worth hearing about."
 
 #: src/routes/_layout.u.$did.tsx
 msgid "Subscriptions aren't indexed yet."
@@ -3976,6 +4062,10 @@ msgstr "Pasting a handle works even for publications the network has not indexed
 msgid "We couldn’t find that publication."
 msgstr "We couldn’t find that publication."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Your posts have to read as pages.</0> We look at your 40 newest posts and count the ones that render at least one image and carry no more than about 700 words of prose. If at least 60% of them do, the publication is a comic. If they do not, it is treated as a serialized book — still read front-to-back, but as articles with an <1>Up next</1> link rather than as pages of art."
+msgstr "<0>Your posts have to read as pages.</0> We look at your 40 newest posts and count the ones that render at least one image and carry no more than about 700 words of prose. If at least 60% of them do, the publication is a comic. If they do not, it is treated as a serialized book — still read front-to-back, but as articles with an <1>Up next</1> link rather than as pages of art."
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Generating audio… {percent}%"
 msgstr "Generating audio… {percent}%"
@@ -4001,6 +4091,10 @@ msgstr "Unread"
 #: src/lib/guide/navigation.ts
 msgid "How readers see it"
 msgstr "How readers see it"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Standard Reader has a reading mode built for comics — a shelf of covers instead of a list of post titles, and a full-screen theater that flips through your pages. You do not author anything specially for it. This page is how to make sure your comic gets it."
+msgstr "Standard Reader has a reading mode built for comics — a shelf of covers instead of a list of post titles, and a full-screen theater that flips through your pages. You do not author anything specially for it. This page is how to make sure your comic gets it."
 
 #. placeholder {0}: filter.trim()
 #: src/components/reader/subscriptions-table.tsx
@@ -4185,6 +4279,10 @@ msgstr "Collections you have made, grouped into a series."
 msgid "On any page you visit"
 msgstr "On any page you visit"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The current page lives in the address bar, so a reader can link someone straight to a page, and reopening the comic puts them back where they stopped."
+msgstr "The current page lives in the address bar, so a reader can link someone straight to a page, and reopening the comic puts them back where they stopped."
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Partly removed"
 msgstr "Partly removed"
@@ -4193,6 +4291,10 @@ msgstr "Partly removed"
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Delete list"
 msgstr "Delete list"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The one part that is required is the hash before the issue number — a bare number in a title is never read as an issue, because too many ordinary titles start with one. After the number you can use a comma, a colon, a dash, or nothing at all; everything following it is treated as the page label and is not otherwise parsed, so write it however you like."
+msgstr "The one part that is required is the hash before the issue number — a bare number in a title is never read as an issue, because too many ordinary titles start with one. After the number you can use a comma, a colon, a dash, or nothing at all; everything following it is treated as the page label and is not otherwise parsed, so write it however you like."
 
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "What the extension can see and what it does with it is written out in full on the <0>extension privacy page</0>."
@@ -4223,6 +4325,10 @@ msgstr "Recommended articles"
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
 msgstr "Light, dark, match your system — or Custom, to choose a palette of your own."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Getting a shelf but not issues?</0> Then the setting is right and it is the titles: check that at least 7 in 10 carry a hash and an issue number."
+msgstr "<0>Getting a shelf but not issues?</0> Then the setting is right and it is the titles: check that at least 7 in 10 carry a hash and an issue number."
 
 #: src/components/labeler-detail-view.tsx
 msgid "Labeler views"
@@ -4359,6 +4465,10 @@ msgstr "Reader voice"
 msgid "Sharp"
 msgstr "Sharp"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "An issue is fronted by the page whose title says it is the cover — anything with the word <0>cover</0> in the page label. <1>Inner cover</1> is deliberately not treated as one, since it is the leaf behind the cover rather than the cover itself. When no page claims it, the issue's first page fronts it, which is what the reader sees on opening anyway."
+msgstr "An issue is fronted by the page whose title says it is the cover — anything with the word <0>cover</0> in the page label. <1>Inner cover</1> is deliberately not treated as one, since it is the leaf behind the cover rather than the cover itself. When no page claims it, the issue's first page fronts it, which is what the reader sees on opening anyway."
+
 #: src/components/reader/about-view.tsx
 msgid "What you get is a reading view made for long-form: a centered column, drop caps and pull quotes, full-bleed images you can open into a gallery. The page gets out of the way so the writing can do its work."
 msgstr "What you get is a reading view made for long-form: a centered column, drop caps and pull quotes, full-bleed images you can open into a gallery. The page gets out of the way so the writing can do its work."
@@ -4445,6 +4555,10 @@ msgstr "XS"
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "Make one with <0>New list</0> in the sidebar, or add a publication to a list from its <1>Add to list</1> menu. A publication can be in as many lists as you like, and being in a list does not change your feeds — it only changes how they are grouped."
 #~ msgstr "Make one with <0>New list</0> in the sidebar, or add a publication to a list from its <1>Add to list</1> menu. A publication can be in as many lists as you like, and being in a list does not change your feeds — it only changes how they are grouped."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "In practice this means a reader who subscribes mid-run can come back after a month and land exactly where they stopped, which is the single biggest thing that keeps people reading a serial. Readers who have turned reading history off see no dots — nothing is tracked for them — and readers who are not signed in see the shelf as a stranger would."
+msgstr "In practice this means a reader who subscribes mid-run can come back after a month and land exactly where they stopped, which is the single biggest thing that keeps people reading a serial. Readers who have turned reading history off see no dots — nothing is tracked for them — and readers who are not signed in see the shelf as a stranger would."
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
@@ -4724,6 +4838,10 @@ msgstr "Introduce the collection… (markdown supported)"
 msgid "Filter"
 msgstr "Filter"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A comic publication gets two things an ordinary blog does not. Its page shows a <0>shelf of covers</0> — your art, at trade-paperback proportions — rather than dozens of near-identical rows reading <1>Pg. 1</1>, <2>Pg. 2</2>, <3>Pg. 3</3>. And opening one drops the reader into the <4>comic reader</4>: a dark, chrome-free theater holding one page at a time."
+msgstr "A comic publication gets two things an ordinary blog does not. Its page shows a <0>shelf of covers</0> — your art, at trade-paperback proportions — rather than dozens of near-identical rows reading <1>Pg. 1</1>, <2>Pg. 2</2>, <3>Pg. 3</3>. And opening one drops the reader into the <4>comic reader</4>: a dark, chrome-free theater holding one page at a time."
+
 #: src/components/reader/friend-publishers.tsx
 msgid "Bluesky didn't answer in time, so this list may be incomplete. Reload to try again."
 msgstr "Bluesky didn't answer in time, so this list may be incomplete. Reload to try again."
@@ -4778,6 +4896,11 @@ msgstr "Use the <0>at:</0> meta tags — the convention the Atmosphere settled o
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "Profile settings"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Publishing a comic"
+msgstr "Publishing a comic"
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "The first time you sign in, a short setup walks you through it: pick a few topics you care about, see which of the people you already follow on Bluesky write here, follow anything that appeals, and choose how you like your text. You can skip any step, and skip the whole thing."
@@ -5123,6 +5246,10 @@ msgstr "Where your reading lives"
 #: src/components/docs/renderers-docs-page.tsx
 msgid "Resolving platform data"
 msgstr "Resolving platform data"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Your publication has to say it reads forwards.</0> That is a setting on the publication itself, in whatever tool you publish with — the one that says the work is read from its first post rather than newest-first. In the underlying record it is <1>preferences.prevNextDirection</1> set to <2>ltr</2>. Leaflet writes this field; if you roll your own records, see <3>Publishing your site</3>. Without it a comic is just a blog that happens to post drawings."
+msgstr "<0>Your publication has to say it reads forwards.</0> That is a setting on the publication itself, in whatever tool you publish with — the one that says the work is read from its first post rather than newest-first. In the underlying record it is <1>preferences.prevNextDirection</1> set to <2>ltr</2>. Leaflet writes this field; if you roll your own records, see <3>Publishing your site</3>. Without it a comic is just a blog that happens to post drawings."
 
 #: src/components/reader/comments/add-comment-dialog.tsx
 msgid "Reply on Bluesky"
@@ -5669,6 +5796,10 @@ msgstr "the queue of articles you put aside. A badge shows how many are waiting.
 msgid "Articles you've recommended across the network."
 msgstr "Articles you've recommended across the network."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "One thing worth knowing: if a paragraph of your post body repeats a page's alt text word for word, we drop it from the note rather than showing the reader a description of the picture they are looking at. So transcribing your dialogue into the alt and again into the body does not double up."
+msgstr "One thing worth knowing: if a paragraph of your post body repeats a page's alt text word for word, we drop it from the note rather than showing the reader a description of the picture they are looking at. So transcribing your dialogue into the alt and again into the body does not double up."
+
 #: src/routes/_layout.feedback.return.tsx
 msgid "View feedback"
 msgstr "View feedback"
@@ -5991,6 +6122,10 @@ msgstr "Docs"
 msgid "The core / new frameworks"
 msgstr "The core / new frameworks"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Both are re-checked as your archive grows, and the setting is picked up the first time anyone opens your publication after you change it — you do not have to tell us. Being read as a book rather than a comic is never a dead end for a reader: every route into the comic reader also links to the ordinary reading view, and an issue with no art falls back to it outright."
+msgstr "Both are re-checked as your archive grows, and the setting is picked up the first time anyone opens your publication after you change it — you do not have to tell us. Being read as a book rather than a comic is never a dead end for a reader: every route into the comic reader also links to the ordinary reading view, and an issue with no art falls back to it outright."
+
 #. placeholder {0}: index + 1
 #: src/components/comic/comic-reader.tsx
 msgid "Page {0}"
@@ -6171,6 +6306,11 @@ msgstr "If something is confusing, broken, or missing, the <0>feedback board</0>
 #: src/components/reader/about-view.tsx
 #~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
 #~ msgstr "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Alt text"
+msgstr "Alt text"
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -6356,6 +6496,10 @@ msgstr "Sidebar"
 msgid "Reading & privacy"
 msgstr "Reading & privacy"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Grouping is all-or-nothing per publication: at least 70% of your titles have to parse before we trust the numbers enough to group by them. If they do not — a webcomic naming its posts <0>Pg01</0>, <1>Pg02</1> has no issues to speak of — you still get a shelf, just one cover per post instead of one per issue. That is a fine way to run a comic; it is not a failure state."
+msgstr "Grouping is all-or-nothing per publication: at least 70% of your titles have to parse before we trust the numbers enough to group by them. If they do not — a webcomic naming its posts <0>Pg01</0>, <1>Pg02</1> has no issues to speak of — you still get a shelf, just one cover per post instead of one per issue. That is a fine way to run a comic; it is not a failure state."
+
 #: src/components/Header.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/site-legal-links.tsx
@@ -6471,6 +6615,11 @@ msgstr "Editorial"
 msgid "Click Run example to fetch a live response with your session."
 msgstr "Click Run example to fetch a live response with your session."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What readers get"
+msgstr "What readers get"
+
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "At the bottom of settings, <0>Personal data</0> deletes categories of records outright: your reading history, your saved articles, or the publication lists you made. Each asks for confirmation and explains what will change."
 msgstr "At the bottom of settings, <0>Personal data</0> deletes categories of records outright: your reading history, your saved articles, or the publication lists you made. Each asks for confirmation and explains what will change."
@@ -6559,6 +6708,10 @@ msgstr "Hide mirrored websites"
 #: src/routes/_layout.p.$did.$rkey.tsx
 #~ msgid "Open publication"
 #~ msgstr "Open publication"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Do your recent posts render their art in the body?</0> A post that only links to the page on your site, or that carries the drawing as a cover image with an empty body, has no pages to flip."
+msgstr "<0>Do your recent posts render their art in the body?</0> A post that only links to the page on your site, or that carries the drawing as a cover image with an empty body, has no pages to flip."
 
 #: src/components/reader/link-share-menu.tsx
 msgid "Send to Disperse"
@@ -6680,6 +6833,10 @@ msgstr "{articleCount, plural, one {article} other {articles}}"
 msgid "{publicationName} is in your feed. You'll see new writing as it publishes."
 msgstr "{publicationName} is in your feed. You'll see new writing as it publishes."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Read state is per post, and your posts are pages, so an issue counts as unread while any page in it is — a comic read halfway through is not read. Its cover wears the same unread dot an unread article does, and clicking it opens on the first page that reader has not seen, not back at the cover. Walking pages in the theater marks them off behind them."
+msgstr "Read state is per post, and your posts are pages, so an issue counts as unread while any page in it is — a comic read halfway through is not read. Its cover wears the same unread dot an unread article does, and clicking it opens on the first page that reader has not seen, not back at the cover. Walking pages in the theater marks them off behind them."
+
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Upgrade permissions"
 msgstr "Upgrade permissions"
@@ -6740,6 +6897,10 @@ msgstr "This publication opted out of discovery, so it's hidden everywhere excep
 msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 
+#: src/lib/guide/navigation.ts
+msgid "Get a shelf of covers and a page-flip reader out of the pages you already post."
+msgstr "Get a shelf of covers and a page-flip reader out of the pages you already post."
+
 #: src/components/onboarding/step-friends.tsx
 #~ msgid "Select all"
 #~ msgstr "Select all"
@@ -6748,10 +6909,18 @@ msgstr "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
 msgstr "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The counter reads <0>Page 12 of 340</0> across the whole publication, not within one issue. That means inserting or removing a page in an early issue renumbers everything after it — worth knowing before you go back and edit an old post that readers may have linked to."
+msgstr "The counter reads <0>Page 12 of 340</0> across the whole publication, not within one issue. That means inserting or removing a page in an early issue renumbers everything after it — worth knowing before you go back and edit an old post that readers may have linked to."
+
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Your account and data"
 msgstr "Your account and data"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The prose length is also what separates a comic from an illustrated blog: a post carrying more than about 700 words stops counting as a page of comic, and if most of your posts are like that the publication reads as a book instead. A long process essay is better as its own post — which readers will find in the archive — than appended to a page."
+msgstr "The prose length is also what separates a comic from an illustrated blog: a post carrying more than about 700 words stops counting as a page of comic, and if most of your posts are like that the publication reads as a book instead. A long process essay is better as its own post — which readers will find in the archive — than appended to a page."
 
 #: src/routes/review.thanks.tsx
 msgid "Your review has been posted to <0>ATStore</0>. Thanks for helping more readers discover Standard Reader."
@@ -6878,6 +7047,10 @@ msgstr "Icon"
 msgid "Top"
 msgstr "Top"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Most cartoonists write a line or two under the page — a caption, a process note, a word about next week. That writing is not lost in the theater. If a page's post carries prose, the note button in the top bar lights up and lays it over the art, in the theater's own type, with a way through to the full post. It closes when the reader turns the page, because it belongs to the page it was written about."
+msgstr "Most cartoonists write a line or two under the page — a caption, a process note, a word about next week. That writing is not lost in the theater. If a page's post carries prose, the note button in the top bar lights up and lays it over the art, in the theater's own type, with a way through to the full post. It closes when the reader turns the page, because it belongs to the page it was written about."
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Read aloud"
 msgstr "Read aloud"
@@ -6912,6 +7085,10 @@ msgstr "get this publication's new writing in your feeds."
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Subscribe to the publication it came from, in the same click."
 msgstr "Subscribe to the publication it came from, in the same click."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>FITV #1 Cover</0> — the same, with a page label instead of a number."
+msgstr "<0>FITV #1 Cover</0> — the same, with a page label instead of a number."
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Followers"
@@ -7145,6 +7322,10 @@ msgstr "Following"
 msgid "Opening the issue…"
 msgstr "Opening the issue…"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Pages with nothing written under them leave the button disabled rather than making it appear and vanish as the reader flips, so there is no penalty for a silent page."
+msgstr "Pages with nothing written under them leave the button disabled rather than making it appear and vanish as the reader flips, so there is no penalty for a silent page."
+
 #: src/components/reader/about-view.tsx
 msgid "However you like to read it"
 msgstr "However you like to read it"
@@ -7318,6 +7499,11 @@ msgstr "When on, a publication's whole back catalogue counts as unread when you 
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this reply on Bluesky"
 msgstr "Open this reply on Bluesky"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Cover art"
+msgstr "Cover art"
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "what your corner of Bluesky reads."
@@ -7556,6 +7742,10 @@ msgstr "Cited by"
 #: src/routes/mcp/authorize.tsx
 msgid "Signed in as"
 msgstr "Signed in as"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Page numbers are absolute"
+msgstr "Page numbers are absolute"
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Opening a collection shows the magazine edition — cover first, then the pieces in order. Individual articles inside it can still be opened, saved, and recommended exactly as they can anywhere else."

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -242,6 +242,10 @@ msgstr ""
 msgid "Your series"
 msgstr "Sus series"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Nothing in the format has a field for “issue 3” — the only place that number exists is your post titles, so that is where we read it back out of. Title your pages the way comics have always been titled and consecutive pages collapse back into the issue they came from, one cover per issue:"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Mark as read"
 msgstr "Marcar como leído"
@@ -253,6 +257,10 @@ msgstr "Esta lista está vacía: añádale publicaciones o personas."
 #: src/components/docs/api-docs-intro.tsx
 #~ msgid "A labeler is any DID that publishes AT Proto labels. Readers add one by DID on the <0>Labelers</0> page, and Standard Reader then shows that labeler's labels — and can warn on or hide labeled posts — as they read. Labelers are discovered the standard way; nothing about them is specific to us. To run your own:"
 #~ msgstr "Un etiquetador es cualquier DID que publica etiquetas de AT Proto. Los lectores añaden uno por DID en la página <0>Etiquetadores</0> y, a partir de ahí, Standard Reader muestra las etiquetas de ese etiquetador (y puede advertir sobre los posts etiquetados u ocultarlos) mientras leen. Los etiquetadores se descubren de la forma estándar; nada en ellos es específico de nosotros. Para ejecutar el suyo:"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "If your publication page shows a list of titles instead of a shelf, walk these in order:"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "The most-read articles across Standard this week."
@@ -444,6 +452,10 @@ msgstr ""
 msgid "If the site publishes in the open format but has not been indexed yet, the extension reads the page's own record hints and subscribes anyway."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A page is an image your post's body renders, and they are flipped through in the order they appear in the post. One image per post is the usual shape and the one everything here is tuned for, but a post carrying three images contributes three pages, in order — useful for posting a whole issue at once."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Open"
 msgstr "Abrir"
@@ -550,6 +562,10 @@ msgstr ""
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "New collection…"
 msgstr "Nueva colección…"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Fray In The Veil #2, Pg. 7</0> — series, issue, page."
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "We may update this policy as the product changes. The “Last updated” date at the top will change when we do. Continued use of the site after an update means you accept the revised policy."
@@ -811,6 +827,10 @@ msgstr "Esta lista está vacía."
 msgid "Play voice sample"
 msgstr "Reproducir muestra de voz"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Is the forwards-reading setting saved?</0> This is the one that is almost always the answer. Check it in your publishing tool, and note that it lives on the publication, not on individual posts."
+msgstr ""
+
 #: src/components/reader/subscribe-card.tsx
 msgid "You're subscribed"
 msgstr "Está suscrito"
@@ -840,6 +860,10 @@ msgstr "{0} min de lectura"
 
 #: src/components/user-settings-view.tsx
 msgid "Infinite scroll keeps pulling the next page as you reach the end of a list. Load more waits for you to ask."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Alt text on a comic page is the page, for anyone who cannot see it — in the theater there is no surrounding article to fall back on, so whatever you wrote is the whole experience. It is also what your comic is found by in search."
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -1172,6 +1196,11 @@ msgstr ""
 msgid "the directory of every publication the network knows about."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "How readers pick it back up"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "A list is a folder for publications — <0>Work</0>, <1>Fiction</1>, <2>Read on Sunday</2>, whatever is useful. Lists appear as their own groups in the sidebar, so you can read one part of your follows without the rest."
 #~ msgstr ""
@@ -1427,6 +1456,10 @@ msgstr "Publicaciones en tendencia"
 msgid "Replace cover image"
 msgstr "Reemplazar la imagen de portada"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Are your last 40 posts mostly art?</0> A run of text posts — Kickstarter updates, con reports — can tip a comic under the line until the art resumes."
+msgstr ""
+
 #: src/lib/guide/navigation.ts
 #~ msgid "Sign in, follow your first publications, and find your way around."
 #~ msgstr ""
@@ -1522,6 +1555,10 @@ msgstr "Contenido incrustado"
 #: src/components/user-settings-view.tsx
 msgid "Account"
 msgstr "Cuenta"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "There is no “this is a comic” switch anywhere on the network, and nothing to set on Standard Reader — we do not host your publication. Two things have to be true instead."
+msgstr ""
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
@@ -2014,6 +2051,10 @@ msgstr "¿Por qué está aquí este texto? (admite markdown)"
 msgid "Sign in, subscribe to a few publications, and learn where everything lives. Ten minutes, once."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The theater treats the whole publication as one book. Page numbers run straight through from your first page to your latest, so a reader who holds down the arrow key walks the entire run without stopping at the end of every issue. Arrow keys, space, Page Up and Page Down all turn pages; Home and End jump to either end; on a phone the outer edges of the screen turn pages, a swipe does too, and pinch-to-zoom gets a reader into a dense panel. There is a full-screen toggle on the <0>f</0> key. Past the last page is a back cover telling them they are caught up and inviting them to subscribe."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "{count, plural, one {# upvote} other {# upvotes}} — click to upvote"
 msgstr "{count, plural, one {# voto} other {# votos}} — haga clic para votar"
@@ -2030,6 +2071,10 @@ msgstr "Leer"
 #: src/components/reader/comments/add-comment-dialog.tsx
 #~ msgid "Discussion here is gathered from posts across the network, so you comment wherever you already post. Yours joins this article once the network indexes it."
 #~ msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A post with no images contributes nothing to flip through, so it does not get a cover on the shelf and cannot be paged to: an announcement, a hiatus note, or a con schedule lives in the archive's read and unread views rather than in the book. If a text post matters to the story, give it a piece of art and it becomes a page like any other."
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "An HttpOnly session cookie that keeps you signed in."
@@ -2108,6 +2153,11 @@ msgstr ""
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "<0><1>Markpub</1> (recommended).</0> <2>at.markpub.markdown</2> — markdown with facets for rich text. It's not part of the site.standard spec either — no markdown format is — but it's the only one that's actually spec'd in a meaningful, reusable way, rather than one app's own ad hoc shape. Use this for a hand-rolled integration unless you already produce one of the platform formats below."
 msgstr "<0><1>Markpub</1> (recomendado).</0> <2>at.markpub.markdown</2>: markdown con facets para texto enriquecido. Tampoco forma parte de la especificación site.standard —ningún formato markdown lo hace—, pero es el único realmente especificado de forma significativa y reutilizable, en lugar del formato improvisado de una sola aplicación. Use este para una integración hecha a mano, salvo que ya produzca alguno de los formatos de plataforma que aparecen abajo."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What counts as a page"
+msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Hide read articles"
@@ -2405,6 +2455,10 @@ msgstr "Estableciendo el número"
 msgid "Feed preferences"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A single post whose title breaks the pattern does not split an issue in two. An interstitial in the middle of issue 3 joins issue 3, and a one-off announcement will not start a phantom issue of its own."
+msgstr ""
+
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Set API_DOCS_FIXTURE_LIST_URI to run this example."
 msgstr "Defina API_DOCS_FIXTURE_LIST_URI para ejecutar este ejemplo."
@@ -2598,6 +2652,11 @@ msgstr ""
 msgid "RSS feed"
 msgstr "Feed RSS"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Naming issues and pages"
+msgstr ""
+
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
 #~ msgid "Run a labeler"
@@ -2759,6 +2818,10 @@ msgstr "Algunas preferencias"
 
 #: src/routes/_layout.friends.tsx
 msgid "We couldn't reach Bluesky to look up who you follow. Reload in a moment, or browse the directory in the meantime."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Keep the essay for its own post"
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -3436,6 +3499,11 @@ msgstr ""
 msgid "<0>Share</0> copies a link, or posts the article to Bluesky with a proper preview card. On a phone it can hand off to whatever you normally share with."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Turning the comic view on"
+msgstr ""
+
 #: src/components/reader/article-below-fold.tsx
 msgid "Worth subscribing to"
 msgstr "Vale la pena suscribirse"
@@ -3506,6 +3574,11 @@ msgstr ""
 msgid "A publication on Standard is a <0>site.standard.document</0> record in the author's AT Protocol repository — not a row in a database we own. Standard Reader indexes those records into a public read-model and renders them, but nothing about the format is proprietary: the schemas are open, the content is portable across publishing platforms, and the same renderer we ship is available to you."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "The words beside the art"
+msgstr ""
+
 #: src/components/labelers-settings-view.tsx
 #: src/routes/_layout.latest.tsx
 msgid "On the network"
@@ -3525,6 +3598,11 @@ msgstr "Un lugar tranquilo para leer"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Add publications or people, then <0>Create list</0>."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "When it still reads as a blog"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -3621,6 +3699,10 @@ msgstr "Más acciones"
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Readers who would rather not get the magazine treatment can turn <0>Open collections in magazine</0> off in <1>settings</1>, and collection articles open in the ordinary reader instead."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Covers are drawn in a 2:3 frame — the standard trade-paperback shape — and art is scaled to fill it, so anything much wider or squarer gets cropped at the edges. If your logo or your title lettering sits near the very edge of a landscape cover, expect it to be trimmed on the shelf. The full page is untouched in the reader; this only affects the thumbnail."
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -3750,6 +3832,10 @@ msgstr "Tendencias de esta semana"
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "The login screen links out to create one. Any account on the network works — you do not have to use Bluesky itself, and you do not have to post anything."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "If all of that is true and your comic still reads as a blog, tell us on the feedback board with a link to the publication — that is a bug on our side, and worth hearing about."
 msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
@@ -3976,6 +4062,10 @@ msgstr ""
 msgid "We couldn’t find that publication."
 msgstr "No encontramos esa publicación."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Your posts have to read as pages.</0> We look at your 40 newest posts and count the ones that render at least one image and carry no more than about 700 words of prose. If at least 60% of them do, the publication is a comic. If they do not, it is treated as a serialized book — still read front-to-back, but as articles with an <1>Up next</1> link rather than as pages of art."
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Generating audio… {percent}%"
 msgstr "Generando audio… {percent} %"
@@ -4000,6 +4090,10 @@ msgstr "Sin leer"
 #: src/components/guide/pages/collections-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "How readers see it"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Standard Reader has a reading mode built for comics — a shelf of covers instead of a list of post titles, and a full-screen theater that flips through your pages. You do not author anything specially for it. This page is how to make sure your comic gets it."
 msgstr ""
 
 #. placeholder {0}: filter.trim()
@@ -4185,6 +4279,10 @@ msgstr ""
 msgid "On any page you visit"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The current page lives in the address bar, so a reader can link someone straight to a page, and reopening the comic puts them back where they stopped."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Partly removed"
 msgstr ""
@@ -4193,6 +4291,10 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Delete list"
 msgstr "Eliminar la lista"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The one part that is required is the hash before the issue number — a bare number in a title is never read as an issue, because too many ordinary titles start with one. After the number you can use a comma, a colon, a dash, or nothing at all; everything following it is treated as the page label and is not otherwise parsed, so write it however you like."
+msgstr ""
 
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "What the extension can see and what it does with it is written out in full on the <0>extension privacy page</0>."
@@ -4222,6 +4324,10 @@ msgstr "Artículos recomendados"
 
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Getting a shelf but not issues?</0> Then the setting is right and it is the titles: check that at least 7 in 10 carry a hash and an issue number."
 msgstr ""
 
 #: src/components/labeler-detail-view.tsx
@@ -4359,6 +4465,10 @@ msgstr "Voz del lector"
 msgid "Sharp"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "An issue is fronted by the page whose title says it is the cover — anything with the word <0>cover</0> in the page label. <1>Inner cover</1> is deliberately not treated as one, since it is the leaf behind the cover rather than the cover itself. When no page claims it, the issue's first page fronts it, which is what the reader sees on opening anyway."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "What you get is a reading view made for long-form: a centered column, drop caps and pull quotes, full-bleed images you can open into a gallery. The page gets out of the way so the writing can do its work."
 msgstr "Lo que obtiene es una vista de lectura hecha para textos largos: una columna centrada, capitulares y citas destacadas, imágenes a sangre completa que se pueden abrir en una galería. La página se aparta para que la escritura haga su trabajo."
@@ -4445,6 +4555,10 @@ msgstr ""
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "Make one with <0>New list</0> in the sidebar, or add a publication to a list from its <1>Add to list</1> menu. A publication can be in as many lists as you like, and being in a list does not change your feeds — it only changes how they are grouped."
 #~ msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "In practice this means a reader who subscribes mid-run can come back after a month and land exactly where they stopped, which is the single biggest thing that keeps people reading a serial. Readers who have turned reading history off see no dots — nothing is tracked for them — and readers who are not signed in see the shelf as a stranger would."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
@@ -4724,6 +4838,10 @@ msgstr "Presente la colección… (admite markdown)"
 msgid "Filter"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A comic publication gets two things an ordinary blog does not. Its page shows a <0>shelf of covers</0> — your art, at trade-paperback proportions — rather than dozens of near-identical rows reading <1>Pg. 1</1>, <2>Pg. 2</2>, <3>Pg. 3</3>. And opening one drops the reader into the <4>comic reader</4>: a dark, chrome-free theater holding one page at a time."
+msgstr ""
+
 #: src/components/reader/friend-publishers.tsx
 msgid "Bluesky didn't answer in time, so this list may be incomplete. Reload to try again."
 msgstr ""
@@ -4778,6 +4896,11 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "Ajustes del perfil"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Publishing a comic"
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "The first time you sign in, a short setup walks you through it: pick a few topics you care about, see which of the people you already follow on Bluesky write here, follow anything that appeals, and choose how you like your text. You can skip any step, and skip the whole thing."
@@ -5122,6 +5245,10 @@ msgstr ""
 #: src/components/docs/docs-renderers-nav.tsx
 #: src/components/docs/renderers-docs-page.tsx
 msgid "Resolving platform data"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Your publication has to say it reads forwards.</0> That is a setting on the publication itself, in whatever tool you publish with — the one that says the work is read from its first post rather than newest-first. In the underlying record it is <1>preferences.prevNextDirection</1> set to <2>ltr</2>. Leaflet writes this field; if you roll your own records, see <3>Publishing your site</3>. Without it a comic is just a blog that happens to post drawings."
 msgstr ""
 
 #: src/components/reader/comments/add-comment-dialog.tsx
@@ -5669,6 +5796,10 @@ msgstr ""
 msgid "Articles you've recommended across the network."
 msgstr "Artículos que ha recomendado en la red."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "One thing worth knowing: if a paragraph of your post body repeats a page's alt text word for word, we drop it from the note rather than showing the reader a description of the picture they are looking at. So transcribing your dialogue into the alt and again into the body does not double up."
+msgstr ""
+
 #: src/routes/_layout.feedback.return.tsx
 msgid "View feedback"
 msgstr "Ver comentarios"
@@ -5991,6 +6122,10 @@ msgstr "Documentación"
 msgid "The core / new frameworks"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Both are re-checked as your archive grows, and the setting is picked up the first time anyone opens your publication after you change it — you do not have to tell us. Being read as a book rather than a comic is never a dead end for a reader: every route into the comic reader also links to the ordinary reading view, and an issue with no art falls back to it outright."
+msgstr ""
+
 #. placeholder {0}: index + 1
 #: src/components/comic/comic-reader.tsx
 msgid "Page {0}"
@@ -6171,6 +6306,11 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 #~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
 #~ msgstr "Una extensión de navegador ligera le permite guardar publicaciones y suscribirse a ellas mientras navega por la web, con distintivos sutiles en bsky.app y una superposición de un clic en cualquier página que visite. Su lista de lectura se llena sola."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Alt text"
+msgstr ""
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -6356,6 +6496,10 @@ msgstr ""
 msgid "Reading & privacy"
 msgstr "Lectura y privacidad"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Grouping is all-or-nothing per publication: at least 70% of your titles have to parse before we trust the numbers enough to group by them. If they do not — a webcomic naming its posts <0>Pg01</0>, <1>Pg02</1> has no issues to speak of — you still get a shelf, just one cover per post instead of one per issue. That is a fine way to run a comic; it is not a failure state."
+msgstr ""
+
 #: src/components/Header.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/site-legal-links.tsx
@@ -6471,6 +6615,11 @@ msgstr "Editorial"
 msgid "Click Run example to fetch a live response with your session."
 msgstr "Haga clic en Ejecutar ejemplo para obtener una respuesta en vivo con su sesión."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What readers get"
+msgstr ""
+
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "At the bottom of settings, <0>Personal data</0> deletes categories of records outright: your reading history, your saved articles, or the publication lists you made. Each asks for confirmation and explains what will change."
 msgstr ""
@@ -6559,6 +6708,10 @@ msgstr ""
 #: src/routes/_layout.p.$did.$rkey.tsx
 #~ msgid "Open publication"
 #~ msgstr "Abrir publicación"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Do your recent posts render their art in the body?</0> A post that only links to the page on your site, or that carries the drawing as a cover image with an empty body, has no pages to flip."
+msgstr ""
 
 #: src/components/reader/link-share-menu.tsx
 msgid "Send to Disperse"
@@ -6680,6 +6833,10 @@ msgstr "{articleCount, plural, one {artículo} other {artículos}}"
 msgid "{publicationName} is in your feed. You'll see new writing as it publishes."
 msgstr "{publicationName} está en su feed. Verá los textos nuevos a medida que se publiquen."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Read state is per post, and your posts are pages, so an issue counts as unread while any page in it is — a comic read halfway through is not read. Its cover wears the same unread dot an unread article does, and clicking it opens on the first page that reader has not seen, not back at the cover. Walking pages in the theater marks them off behind them."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Upgrade permissions"
 msgstr "Ampliar permisos"
@@ -6740,6 +6897,10 @@ msgstr "Esta publicación optó por no aparecer en el directorio, así que está
 msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {# voto} other {# votos}}: inicie sesión para votar"
 
+#: src/lib/guide/navigation.ts
+msgid "Get a shelf of covers and a page-flip reader out of the pages you already post."
+msgstr ""
+
 #: src/components/onboarding/step-friends.tsx
 #~ msgid "Select all"
 #~ msgstr ""
@@ -6748,9 +6909,17 @@ msgstr "{count, plural, one {# voto} other {# votos}}: inicie sesión para votar
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
 msgstr "Para saber cómo funciona {SITE_NAME} en general, consulte <0>Acerca de</0>. Para la privacidad de todo el sitio, consulte la <1>política de privacidad del sitio</1>. Si tiene preguntas sobre esta instancia, contacte al operador de {siteHost}."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The counter reads <0>Page 12 of 340</0> across the whole publication, not within one issue. That means inserting or removing a page in an early issue renumbers everything after it — worth knowing before you go back and edit an old post that readers may have linked to."
+msgstr ""
+
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Your account and data"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The prose length is also what separates a comic from an illustrated blog: a post carrying more than about 700 words stops counting as a page of comic, and if most of your posts are like that the publication reads as a book instead. A long process essay is better as its own post — which readers will find in the archive — than appended to a page."
 msgstr ""
 
 #: src/routes/review.thanks.tsx
@@ -6878,6 +7047,10 @@ msgstr "Icono"
 msgid "Top"
 msgstr "Destacados"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Most cartoonists write a line or two under the page — a caption, a process note, a word about next week. That writing is not lost in the theater. If a page's post carries prose, the note button in the top bar lights up and lays it over the art, in the theater's own type, with a way through to the full post. It closes when the reader turns the page, because it belongs to the page it was written about."
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Read aloud"
 msgstr "Leer en voz alta"
@@ -6911,6 +7084,10 @@ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Subscribe to the publication it came from, in the same click."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>FITV #1 Cover</0> — the same, with a page label instead of a number."
 msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
@@ -7145,6 +7322,10 @@ msgstr "Siguiendo"
 msgid "Opening the issue…"
 msgstr "Abriendo el número…"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Pages with nothing written under them leave the button disabled rather than making it appear and vanish as the reader flips, so there is no penalty for a silent page."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "However you like to read it"
 msgstr ""
@@ -7318,6 +7499,11 @@ msgstr "Al activarlo, todo el catálogo anterior de una publicación cuenta como
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this reply on Bluesky"
 msgstr "Abrir esta respuesta en Bluesky"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Cover art"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "what your corner of Bluesky reads."
@@ -7555,6 +7741,10 @@ msgstr ""
 
 #: src/routes/mcp/authorize.tsx
 msgid "Signed in as"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Page numbers are absolute"
 msgstr ""
 
 #: src/components/guide/pages/collections-guide-page.tsx

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -242,6 +242,10 @@ msgstr ""
 msgid "Your series"
 msgstr "Vos séries"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Nothing in the format has a field for “issue 3” — the only place that number exists is your post titles, so that is where we read it back out of. Title your pages the way comics have always been titled and consecutive pages collapse back into the issue they came from, one cover per issue:"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Mark as read"
 msgstr "Marquer comme lu"
@@ -253,6 +257,10 @@ msgstr "Cette liste est vide — ajoutez-y des publications ou des personnes."
 #: src/components/docs/api-docs-intro.tsx
 #~ msgid "A labeler is any DID that publishes AT Proto labels. Readers add one by DID on the <0>Labelers</0> page, and Standard Reader then shows that labeler's labels — and can warn on or hide labeled posts — as they read. Labelers are discovered the standard way; nothing about them is specific to us. To run your own:"
 #~ msgstr "Un service d’étiquetage est un DID qui publie des étiquettes AT Proto. Les lecteurs en ajoutent un par son DID depuis la page <0>Services d’étiquetage</0>, et Standard Reader affiche alors ses étiquettes — avec avertissement ou masquage des articles étiquetés — au fil de la lecture. Ces services se découvrent de façon standard ; rien chez eux ne nous est spécifique. Pour créer le vôtre :"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "If your publication page shows a list of titles instead of a shelf, walk these in order:"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "The most-read articles across Standard this week."
@@ -444,6 +452,10 @@ msgstr ""
 msgid "If the site publishes in the open format but has not been indexed yet, the extension reads the page's own record hints and subscribes anyway."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A page is an image your post's body renders, and they are flipped through in the order they appear in the post. One image per post is the usual shape and the one everything here is tuned for, but a post carrying three images contributes three pages, in order — useful for posting a whole issue at once."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Open"
 msgstr "Ouvrir"
@@ -550,6 +562,10 @@ msgstr ""
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "New collection…"
 msgstr "Nouvelle collection…"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Fray In The Veil #2, Pg. 7</0> — series, issue, page."
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "We may update this policy as the product changes. The “Last updated” date at the top will change when we do. Continued use of the site after an update means you accept the revised policy."
@@ -811,6 +827,10 @@ msgstr "Cette liste est vide."
 msgid "Play voice sample"
 msgstr "Écouter un extrait de la voix"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Is the forwards-reading setting saved?</0> This is the one that is almost always the answer. Check it in your publishing tool, and note that it lives on the publication, not on individual posts."
+msgstr ""
+
 #: src/components/reader/subscribe-card.tsx
 msgid "You're subscribed"
 msgstr "Vous êtes abonné"
@@ -840,6 +860,10 @@ msgstr "{0} min de lecture"
 
 #: src/components/user-settings-view.tsx
 msgid "Infinite scroll keeps pulling the next page as you reach the end of a list. Load more waits for you to ask."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Alt text on a comic page is the page, for anyone who cannot see it — in the theater there is no surrounding article to fall back on, so whatever you wrote is the whole experience. It is also what your comic is found by in search."
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -1172,6 +1196,11 @@ msgstr ""
 msgid "the directory of every publication the network knows about."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "How readers pick it back up"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "A list is a folder for publications — <0>Work</0>, <1>Fiction</1>, <2>Read on Sunday</2>, whatever is useful. Lists appear as their own groups in the sidebar, so you can read one part of your follows without the rest."
 #~ msgstr ""
@@ -1427,6 +1456,10 @@ msgstr "Publications en tendance"
 msgid "Replace cover image"
 msgstr "Remplacer l’image de couverture"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Are your last 40 posts mostly art?</0> A run of text posts — Kickstarter updates, con reports — can tip a comic under the line until the art resumes."
+msgstr ""
+
 #: src/lib/guide/navigation.ts
 #~ msgid "Sign in, follow your first publications, and find your way around."
 #~ msgstr ""
@@ -1522,6 +1555,10 @@ msgstr "Contenu intégré"
 #: src/components/user-settings-view.tsx
 msgid "Account"
 msgstr "Compte"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "There is no “this is a comic” switch anywhere on the network, and nothing to set on Standard Reader — we do not host your publication. Two things have to be true instead."
+msgstr ""
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
@@ -2014,6 +2051,10 @@ msgstr "Pourquoi cet article figure-t-il ici ? (markdown pris en charge)"
 msgid "Sign in, subscribe to a few publications, and learn where everything lives. Ten minutes, once."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The theater treats the whole publication as one book. Page numbers run straight through from your first page to your latest, so a reader who holds down the arrow key walks the entire run without stopping at the end of every issue. Arrow keys, space, Page Up and Page Down all turn pages; Home and End jump to either end; on a phone the outer edges of the screen turn pages, a swipe does too, and pinch-to-zoom gets a reader into a dense panel. There is a full-screen toggle on the <0>f</0> key. Past the last page is a back cover telling them they are caught up and inviting them to subscribe."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "{count, plural, one {# upvote} other {# upvotes}} — click to upvote"
 msgstr "{count, plural, one {# vote} other {# votes}} — cliquez pour voter"
@@ -2030,6 +2071,10 @@ msgstr "Lire"
 #: src/components/reader/comments/add-comment-dialog.tsx
 #~ msgid "Discussion here is gathered from posts across the network, so you comment wherever you already post. Yours joins this article once the network indexes it."
 #~ msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A post with no images contributes nothing to flip through, so it does not get a cover on the shelf and cannot be paged to: an announcement, a hiatus note, or a con schedule lives in the archive's read and unread views rather than in the book. If a text post matters to the story, give it a piece of art and it becomes a page like any other."
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "An HttpOnly session cookie that keeps you signed in."
@@ -2108,6 +2153,11 @@ msgstr ""
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "<0><1>Markpub</1> (recommended).</0> <2>at.markpub.markdown</2> — markdown with facets for rich text. It's not part of the site.standard spec either — no markdown format is — but it's the only one that's actually spec'd in a meaningful, reusable way, rather than one app's own ad hoc shape. Use this for a hand-rolled integration unless you already produce one of the platform formats below."
 msgstr "<0><1>Markpub</1> (recommandé).</0> <2>at.markpub.markdown</2> — du markdown avec facettes pour le texte enrichi. Ce format ne fait pas non plus partie de la spécification site.standard — aucun format markdown n'en fait partie — mais c'est le seul réellement spécifié de façon sérieuse et réutilisable, plutôt qu'une structure ad hoc propre à une application. Utilisez-le pour une intégration sur mesure, sauf si vous produisez déjà l'un des formats de plateforme ci-dessous."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What counts as a page"
+msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Hide read articles"
@@ -2405,6 +2455,10 @@ msgstr "Composition du numéro"
 msgid "Feed preferences"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A single post whose title breaks the pattern does not split an issue in two. An interstitial in the middle of issue 3 joins issue 3, and a one-off announcement will not start a phantom issue of its own."
+msgstr ""
+
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Set API_DOCS_FIXTURE_LIST_URI to run this example."
 msgstr "Définissez API_DOCS_FIXTURE_LIST_URI pour exécuter cet exemple."
@@ -2598,6 +2652,11 @@ msgstr ""
 msgid "RSS feed"
 msgstr "Flux RSS"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Naming issues and pages"
+msgstr ""
+
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
 #~ msgid "Run a labeler"
@@ -2759,6 +2818,10 @@ msgstr "Quelques préférences"
 
 #: src/routes/_layout.friends.tsx
 msgid "We couldn't reach Bluesky to look up who you follow. Reload in a moment, or browse the directory in the meantime."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Keep the essay for its own post"
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -3436,6 +3499,11 @@ msgstr ""
 msgid "<0>Share</0> copies a link, or posts the article to Bluesky with a proper preview card. On a phone it can hand off to whatever you normally share with."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Turning the comic view on"
+msgstr ""
+
 #: src/components/reader/article-below-fold.tsx
 msgid "Worth subscribing to"
 msgstr "Publications à suivre"
@@ -3506,6 +3574,11 @@ msgstr ""
 msgid "A publication on Standard is a <0>site.standard.document</0> record in the author's AT Protocol repository — not a row in a database we own. Standard Reader indexes those records into a public read-model and renders them, but nothing about the format is proprietary: the schemas are open, the content is portable across publishing platforms, and the same renderer we ship is available to you."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "The words beside the art"
+msgstr ""
+
 #: src/components/labelers-settings-view.tsx
 #: src/routes/_layout.latest.tsx
 msgid "On the network"
@@ -3525,6 +3598,11 @@ msgstr "Un endroit calme pour lire"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Add publications or people, then <0>Create list</0>."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "When it still reads as a blog"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -3621,6 +3699,10 @@ msgstr "Plus d’actions"
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Readers who would rather not get the magazine treatment can turn <0>Open collections in magazine</0> off in <1>settings</1>, and collection articles open in the ordinary reader instead."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Covers are drawn in a 2:3 frame — the standard trade-paperback shape — and art is scaled to fill it, so anything much wider or squarer gets cropped at the edges. If your logo or your title lettering sits near the very edge of a landscape cover, expect it to be trimmed on the shelf. The full page is untouched in the reader; this only affects the thumbnail."
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -3750,6 +3832,10 @@ msgstr "Tendances de la semaine"
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "The login screen links out to create one. Any account on the network works — you do not have to use Bluesky itself, and you do not have to post anything."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "If all of that is true and your comic still reads as a blog, tell us on the feedback board with a link to the publication — that is a bug on our side, and worth hearing about."
 msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
@@ -3976,6 +4062,10 @@ msgstr ""
 msgid "We couldn’t find that publication."
 msgstr "Publication introuvable."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Your posts have to read as pages.</0> We look at your 40 newest posts and count the ones that render at least one image and carry no more than about 700 words of prose. If at least 60% of them do, the publication is a comic. If they do not, it is treated as a serialized book — still read front-to-back, but as articles with an <1>Up next</1> link rather than as pages of art."
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Generating audio… {percent}%"
 msgstr "Génération de l’audio… {percent} %"
@@ -4000,6 +4090,10 @@ msgstr "Non lus"
 #: src/components/guide/pages/collections-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "How readers see it"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Standard Reader has a reading mode built for comics — a shelf of covers instead of a list of post titles, and a full-screen theater that flips through your pages. You do not author anything specially for it. This page is how to make sure your comic gets it."
 msgstr ""
 
 #. placeholder {0}: filter.trim()
@@ -4185,6 +4279,10 @@ msgstr ""
 msgid "On any page you visit"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The current page lives in the address bar, so a reader can link someone straight to a page, and reopening the comic puts them back where they stopped."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Partly removed"
 msgstr ""
@@ -4193,6 +4291,10 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Delete list"
 msgstr "Supprimer la liste"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The one part that is required is the hash before the issue number — a bare number in a title is never read as an issue, because too many ordinary titles start with one. After the number you can use a comma, a colon, a dash, or nothing at all; everything following it is treated as the page label and is not otherwise parsed, so write it however you like."
+msgstr ""
 
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "What the extension can see and what it does with it is written out in full on the <0>extension privacy page</0>."
@@ -4222,6 +4324,10 @@ msgstr "Articles recommandés"
 
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Getting a shelf but not issues?</0> Then the setting is right and it is the titles: check that at least 7 in 10 carry a hash and an issue number."
 msgstr ""
 
 #: src/components/labeler-detail-view.tsx
@@ -4359,6 +4465,10 @@ msgstr "Voix du lecteur"
 msgid "Sharp"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "An issue is fronted by the page whose title says it is the cover — anything with the word <0>cover</0> in the page label. <1>Inner cover</1> is deliberately not treated as one, since it is the leaf behind the cover rather than the cover itself. When no page claims it, the issue's first page fronts it, which is what the reader sees on opening anyway."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "What you get is a reading view made for long-form: a centered column, drop caps and pull quotes, full-bleed images you can open into a gallery. The page gets out of the way so the writing can do its work."
 msgstr "Vous obtenez une vue de lecture pensée pour les textes longs : une colonne centrée, des lettrines et des exergues, des images pleine largeur que vous pouvez ouvrir en galerie. La page s’efface pour laisser le texte faire son travail."
@@ -4445,6 +4555,10 @@ msgstr ""
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "Make one with <0>New list</0> in the sidebar, or add a publication to a list from its <1>Add to list</1> menu. A publication can be in as many lists as you like, and being in a list does not change your feeds — it only changes how they are grouped."
 #~ msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "In practice this means a reader who subscribes mid-run can come back after a month and land exactly where they stopped, which is the single biggest thing that keeps people reading a serial. Readers who have turned reading history off see no dots — nothing is tracked for them — and readers who are not signed in see the shelf as a stranger would."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
@@ -4724,6 +4838,10 @@ msgstr "Présentez la collection… (markdown pris en charge)"
 msgid "Filter"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A comic publication gets two things an ordinary blog does not. Its page shows a <0>shelf of covers</0> — your art, at trade-paperback proportions — rather than dozens of near-identical rows reading <1>Pg. 1</1>, <2>Pg. 2</2>, <3>Pg. 3</3>. And opening one drops the reader into the <4>comic reader</4>: a dark, chrome-free theater holding one page at a time."
+msgstr ""
+
 #: src/components/reader/friend-publishers.tsx
 msgid "Bluesky didn't answer in time, so this list may be incomplete. Reload to try again."
 msgstr ""
@@ -4778,6 +4896,11 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "Paramètres du profil"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Publishing a comic"
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "The first time you sign in, a short setup walks you through it: pick a few topics you care about, see which of the people you already follow on Bluesky write here, follow anything that appeals, and choose how you like your text. You can skip any step, and skip the whole thing."
@@ -5122,6 +5245,10 @@ msgstr ""
 #: src/components/docs/docs-renderers-nav.tsx
 #: src/components/docs/renderers-docs-page.tsx
 msgid "Resolving platform data"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Your publication has to say it reads forwards.</0> That is a setting on the publication itself, in whatever tool you publish with — the one that says the work is read from its first post rather than newest-first. In the underlying record it is <1>preferences.prevNextDirection</1> set to <2>ltr</2>. Leaflet writes this field; if you roll your own records, see <3>Publishing your site</3>. Without it a comic is just a blog that happens to post drawings."
 msgstr ""
 
 #: src/components/reader/comments/add-comment-dialog.tsx
@@ -5669,6 +5796,10 @@ msgstr ""
 msgid "Articles you've recommended across the network."
 msgstr "Les articles que vous avez recommandés sur le réseau."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "One thing worth knowing: if a paragraph of your post body repeats a page's alt text word for word, we drop it from the note rather than showing the reader a description of the picture they are looking at. So transcribing your dialogue into the alt and again into the body does not double up."
+msgstr ""
+
 #: src/routes/_layout.feedback.return.tsx
 msgid "View feedback"
 msgstr "Voir les retours"
@@ -5991,6 +6122,10 @@ msgstr "Docs"
 msgid "The core / new frameworks"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Both are re-checked as your archive grows, and the setting is picked up the first time anyone opens your publication after you change it — you do not have to tell us. Being read as a book rather than a comic is never a dead end for a reader: every route into the comic reader also links to the ordinary reading view, and an issue with no art falls back to it outright."
+msgstr ""
+
 #. placeholder {0}: index + 1
 #: src/components/comic/comic-reader.tsx
 msgid "Page {0}"
@@ -6171,6 +6306,11 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 #~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
 #~ msgstr "Une extension de navigateur légère vous permet d'enregistrer des publications et de vous y abonner pendant votre navigation — avec de discrets badges sur bsky.app et une surcouche accessible en un clic sur n'importe quelle page. Votre liste de lecture se remplit toute seule."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Alt text"
+msgstr ""
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -6356,6 +6496,10 @@ msgstr ""
 msgid "Reading & privacy"
 msgstr "Lecture et confidentialité"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Grouping is all-or-nothing per publication: at least 70% of your titles have to parse before we trust the numbers enough to group by them. If they do not — a webcomic naming its posts <0>Pg01</0>, <1>Pg02</1> has no issues to speak of — you still get a shelf, just one cover per post instead of one per issue. That is a fine way to run a comic; it is not a failure state."
+msgstr ""
+
 #: src/components/Header.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/site-legal-links.tsx
@@ -6471,6 +6615,11 @@ msgstr "Éditorial"
 msgid "Click Run example to fetch a live response with your session."
 msgstr "Cliquez sur Exécuter l'exemple pour obtenir une réponse en direct avec votre session."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What readers get"
+msgstr ""
+
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "At the bottom of settings, <0>Personal data</0> deletes categories of records outright: your reading history, your saved articles, or the publication lists you made. Each asks for confirmation and explains what will change."
 msgstr ""
@@ -6559,6 +6708,10 @@ msgstr ""
 #: src/routes/_layout.p.$did.$rkey.tsx
 #~ msgid "Open publication"
 #~ msgstr "Ouvrir la publication"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Do your recent posts render their art in the body?</0> A post that only links to the page on your site, or that carries the drawing as a cover image with an empty body, has no pages to flip."
+msgstr ""
 
 #: src/components/reader/link-share-menu.tsx
 msgid "Send to Disperse"
@@ -6680,6 +6833,10 @@ msgstr "{articleCount, plural, one {article} other {articles}}"
 msgid "{publicationName} is in your feed. You'll see new writing as it publishes."
 msgstr "{publicationName} est dans votre flux. Vous verrez les nouveaux écrits dès leur publication."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Read state is per post, and your posts are pages, so an issue counts as unread while any page in it is — a comic read halfway through is not read. Its cover wears the same unread dot an unread article does, and clicking it opens on the first page that reader has not seen, not back at the cover. Walking pages in the theater marks them off behind them."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Upgrade permissions"
 msgstr "Étendre les autorisations"
@@ -6740,6 +6897,10 @@ msgstr "Cette publication a choisi de ne pas apparaître dans la découverte : e
 msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {# vote} other {# votes}} — connectez-vous pour voter"
 
+#: src/lib/guide/navigation.ts
+msgid "Get a shelf of covers and a page-flip reader out of the pages you already post."
+msgstr ""
+
 #: src/components/onboarding/step-friends.tsx
 #~ msgid "Select all"
 #~ msgstr ""
@@ -6748,9 +6909,17 @@ msgstr "{count, plural, one {# vote} other {# votes}} — connectez-vous pour vo
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
 msgstr "Pour comprendre le fonctionnement général de {SITE_NAME}, consultez <0>À propos</0>. Pour la confidentialité à l'échelle du site, consultez la <1>politique de confidentialité du site</1>. Pour toute question sur ce déploiement, contactez l'opérateur de {siteHost}."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The counter reads <0>Page 12 of 340</0> across the whole publication, not within one issue. That means inserting or removing a page in an early issue renumbers everything after it — worth knowing before you go back and edit an old post that readers may have linked to."
+msgstr ""
+
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Your account and data"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The prose length is also what separates a comic from an illustrated blog: a post carrying more than about 700 words stops counting as a page of comic, and if most of your posts are like that the publication reads as a book instead. A long process essay is better as its own post — which readers will find in the archive — than appended to a page."
 msgstr ""
 
 #: src/routes/review.thanks.tsx
@@ -6878,6 +7047,10 @@ msgstr "Icône"
 msgid "Top"
 msgstr "Populaires"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Most cartoonists write a line or two under the page — a caption, a process note, a word about next week. That writing is not lost in the theater. If a page's post carries prose, the note button in the top bar lights up and lays it over the art, in the theater's own type, with a way through to the full post. It closes when the reader turns the page, because it belongs to the page it was written about."
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Read aloud"
 msgstr "Lire à voix haute"
@@ -6911,6 +7084,10 @@ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Subscribe to the publication it came from, in the same click."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>FITV #1 Cover</0> — the same, with a page label instead of a number."
 msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
@@ -7145,6 +7322,10 @@ msgstr "Abonné"
 msgid "Opening the issue…"
 msgstr "Ouverture du numéro…"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Pages with nothing written under them leave the button disabled rather than making it appear and vanish as the reader flips, so there is no penalty for a silent page."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "However you like to read it"
 msgstr ""
@@ -7318,6 +7499,11 @@ msgstr "Lorsque cette option est activée, tout le catalogue antérieur d'une pu
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this reply on Bluesky"
 msgstr "Ouvrir cette réponse sur Bluesky"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Cover art"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "what your corner of Bluesky reads."
@@ -7555,6 +7741,10 @@ msgstr ""
 
 #: src/routes/mcp/authorize.tsx
 msgid "Signed in as"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Page numbers are absolute"
 msgstr ""
 
 #: src/components/guide/pages/collections-guide-page.tsx

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -242,6 +242,10 @@ msgstr ""
 msgid "Your series"
 msgstr "自分のシリーズ"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Nothing in the format has a field for “issue 3” — the only place that number exists is your post titles, so that is where we read it back out of. Title your pages the way comics have always been titled and consecutive pages collapse back into the issue they came from, one cover per issue:"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Mark as read"
 msgstr "既読にする"
@@ -253,6 +257,10 @@ msgstr "このリストは空です。発行物やユーザーを追加してく
 #: src/components/docs/api-docs-intro.tsx
 #~ msgid "A labeler is any DID that publishes AT Proto labels. Readers add one by DID on the <0>Labelers</0> page, and Standard Reader then shows that labeler's labels — and can warn on or hide labeled posts — as they read. Labelers are discovered the standard way; nothing about them is specific to us. To run your own:"
 #~ msgstr "ラベラーとは、AT Proto のラベルを公開する DID のことです。読者は<0>ラベラー</0>ページで DID を指定して追加でき、Standard Reader はそのラベラーのラベルを表示し、ラベルの付いた投稿を警告表示したり非表示にしたりできます。ラベラーは標準的な方法で検出され、独自の仕組みは一切ありません。自分で運用するには:"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "If your publication page shows a list of titles instead of a shelf, walk these in order:"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "The most-read articles across Standard this week."
@@ -444,6 +452,10 @@ msgstr ""
 msgid "If the site publishes in the open format but has not been indexed yet, the extension reads the page's own record hints and subscribes anyway."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A page is an image your post's body renders, and they are flipped through in the order they appear in the post. One image per post is the usual shape and the one everything here is tuned for, but a post carrying three images contributes three pages, in order — useful for posting a whole issue at once."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Open"
 msgstr "開く"
@@ -550,6 +562,10 @@ msgstr ""
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "New collection…"
 msgstr "新しいコレクション…"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Fray In The Veil #2, Pg. 7</0> — series, issue, page."
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "We may update this policy as the product changes. The “Last updated” date at the top will change when we do. Continued use of the site after an update means you accept the revised policy."
@@ -811,6 +827,10 @@ msgstr "このリストは空です。"
 msgid "Play voice sample"
 msgstr "音声サンプルを再生"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Is the forwards-reading setting saved?</0> This is the one that is almost always the answer. Check it in your publishing tool, and note that it lives on the publication, not on individual posts."
+msgstr ""
+
 #: src/components/reader/subscribe-card.tsx
 msgid "You're subscribed"
 msgstr "購読中です"
@@ -840,6 +860,10 @@ msgstr "{0} 分で読めます"
 
 #: src/components/user-settings-view.tsx
 msgid "Infinite scroll keeps pulling the next page as you reach the end of a list. Load more waits for you to ask."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Alt text on a comic page is the page, for anyone who cannot see it — in the theater there is no surrounding article to fall back on, so whatever you wrote is the whole experience. It is also what your comic is found by in search."
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -1172,6 +1196,11 @@ msgstr ""
 msgid "the directory of every publication the network knows about."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "How readers pick it back up"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "A list is a folder for publications — <0>Work</0>, <1>Fiction</1>, <2>Read on Sunday</2>, whatever is useful. Lists appear as their own groups in the sidebar, so you can read one part of your follows without the rest."
 #~ msgstr ""
@@ -1427,6 +1456,10 @@ msgstr "人気の発行物"
 msgid "Replace cover image"
 msgstr "カバー画像を差し替え"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Are your last 40 posts mostly art?</0> A run of text posts — Kickstarter updates, con reports — can tip a comic under the line until the art resumes."
+msgstr ""
+
 #: src/lib/guide/navigation.ts
 #~ msgid "Sign in, follow your first publications, and find your way around."
 #~ msgstr ""
@@ -1522,6 +1555,10 @@ msgstr "埋め込みコンテンツ"
 #: src/components/user-settings-view.tsx
 msgid "Account"
 msgstr "アカウント"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "There is no “this is a comic” switch anywhere on the network, and nothing to set on Standard Reader — we do not host your publication. Two things have to be true instead."
+msgstr ""
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
@@ -2014,6 +2051,10 @@ msgstr "この記事を取り上げた理由（markdown 対応）"
 msgid "Sign in, subscribe to a few publications, and learn where everything lives. Ten minutes, once."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The theater treats the whole publication as one book. Page numbers run straight through from your first page to your latest, so a reader who holds down the arrow key walks the entire run without stopping at the end of every issue. Arrow keys, space, Page Up and Page Down all turn pages; Home and End jump to either end; on a phone the outer edges of the screen turn pages, a swipe does too, and pinch-to-zoom gets a reader into a dense panel. There is a full-screen toggle on the <0>f</0> key. Past the last page is a back cover telling them they are caught up and inviting them to subscribe."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "{count, plural, one {# upvote} other {# upvotes}} — click to upvote"
 msgstr "{count, plural, one {# 件の高評価} other {# 件の高評価}} — クリックで高評価"
@@ -2030,6 +2071,10 @@ msgstr "既読"
 #: src/components/reader/comments/add-comment-dialog.tsx
 #~ msgid "Discussion here is gathered from posts across the network, so you comment wherever you already post. Yours joins this article once the network indexes it."
 #~ msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A post with no images contributes nothing to flip through, so it does not get a cover on the shelf and cannot be paged to: an announcement, a hiatus note, or a con schedule lives in the archive's read and unread views rather than in the book. If a text post matters to the story, give it a piece of art and it becomes a page like any other."
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "An HttpOnly session cookie that keeps you signed in."
@@ -2108,6 +2153,11 @@ msgstr ""
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "<0><1>Markpub</1> (recommended).</0> <2>at.markpub.markdown</2> — markdown with facets for rich text. It's not part of the site.standard spec either — no markdown format is — but it's the only one that's actually spec'd in a meaningful, reusable way, rather than one app's own ad hoc shape. Use this for a hand-rolled integration unless you already produce one of the platform formats below."
 msgstr "<0><1>Markpub</1>（推奨）。</0> <2>at.markpub.markdown</2> — リッチテキスト用の facet に対応した markdown です。これも site.standard 仕様の一部ではありません（markdown 形式はいずれも仕様外です）が、特定アプリ独自の場当たり的な形ではなく、意味のある再利用可能な形できちんと仕様化されている唯一の形式です。以下のプラットフォーム形式のいずれかをすでに出力している場合を除き、独自に実装する際はこれを使ってください。"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What counts as a page"
+msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Hide read articles"
@@ -2405,6 +2455,10 @@ msgstr "号を設定"
 msgid "Feed preferences"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A single post whose title breaks the pattern does not split an issue in two. An interstitial in the middle of issue 3 joins issue 3, and a one-off announcement will not start a phantom issue of its own."
+msgstr ""
+
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Set API_DOCS_FIXTURE_LIST_URI to run this example."
 msgstr "この例を実行するには API_DOCS_FIXTURE_LIST_URI を設定してください。"
@@ -2598,6 +2652,11 @@ msgstr ""
 msgid "RSS feed"
 msgstr "RSS フィード"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Naming issues and pages"
+msgstr ""
+
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
 #~ msgid "Run a labeler"
@@ -2759,6 +2818,10 @@ msgstr "いくつかの設定"
 
 #: src/routes/_layout.friends.tsx
 msgid "We couldn't reach Bluesky to look up who you follow. Reload in a moment, or browse the directory in the meantime."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Keep the essay for its own post"
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -3436,6 +3499,11 @@ msgstr ""
 msgid "<0>Share</0> copies a link, or posts the article to Bluesky with a proper preview card. On a phone it can hand off to whatever you normally share with."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Turning the comic view on"
+msgstr ""
+
 #: src/components/reader/article-below-fold.tsx
 msgid "Worth subscribing to"
 msgstr "購読する価値のある発行物"
@@ -3506,6 +3574,11 @@ msgstr ""
 msgid "A publication on Standard is a <0>site.standard.document</0> record in the author's AT Protocol repository — not a row in a database we own. Standard Reader indexes those records into a public read-model and renders them, but nothing about the format is proprietary: the schemas are open, the content is portable across publishing platforms, and the same renderer we ship is available to you."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "The words beside the art"
+msgstr ""
+
 #: src/components/labelers-settings-view.tsx
 #: src/routes/_layout.latest.tsx
 msgid "On the network"
@@ -3525,6 +3598,11 @@ msgstr "静かに読める場所"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Add publications or people, then <0>Create list</0>."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "When it still reads as a blog"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -3621,6 +3699,10 @@ msgstr "その他の操作"
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Readers who would rather not get the magazine treatment can turn <0>Open collections in magazine</0> off in <1>settings</1>, and collection articles open in the ordinary reader instead."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Covers are drawn in a 2:3 frame — the standard trade-paperback shape — and art is scaled to fill it, so anything much wider or squarer gets cropped at the edges. If your logo or your title lettering sits near the very edge of a landscape cover, expect it to be trimmed on the shelf. The full page is untouched in the reader; this only affects the thumbnail."
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -3750,6 +3832,10 @@ msgstr "今週の急上昇"
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "The login screen links out to create one. Any account on the network works — you do not have to use Bluesky itself, and you do not have to post anything."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "If all of that is true and your comic still reads as a blog, tell us on the feedback board with a link to the publication — that is a bug on our side, and worth hearing about."
 msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
@@ -3976,6 +4062,10 @@ msgstr ""
 msgid "We couldn’t find that publication."
 msgstr "その発行物は見つかりませんでした。"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Your posts have to read as pages.</0> We look at your 40 newest posts and count the ones that render at least one image and carry no more than about 700 words of prose. If at least 60% of them do, the publication is a comic. If they do not, it is treated as a serialized book — still read front-to-back, but as articles with an <1>Up next</1> link rather than as pages of art."
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Generating audio… {percent}%"
 msgstr "音声を生成中… {percent}%"
@@ -4000,6 +4090,10 @@ msgstr "未読"
 #: src/components/guide/pages/collections-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "How readers see it"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Standard Reader has a reading mode built for comics — a shelf of covers instead of a list of post titles, and a full-screen theater that flips through your pages. You do not author anything specially for it. This page is how to make sure your comic gets it."
 msgstr ""
 
 #. placeholder {0}: filter.trim()
@@ -4185,6 +4279,10 @@ msgstr ""
 msgid "On any page you visit"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The current page lives in the address bar, so a reader can link someone straight to a page, and reopening the comic puts them back where they stopped."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Partly removed"
 msgstr ""
@@ -4193,6 +4291,10 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Delete list"
 msgstr "リストを削除"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The one part that is required is the hash before the issue number — a bare number in a title is never read as an issue, because too many ordinary titles start with one. After the number you can use a comma, a colon, a dash, or nothing at all; everything following it is treated as the page label and is not otherwise parsed, so write it however you like."
+msgstr ""
 
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "What the extension can see and what it does with it is written out in full on the <0>extension privacy page</0>."
@@ -4222,6 +4324,10 @@ msgstr "おすすめの記事"
 
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Getting a shelf but not issues?</0> Then the setting is right and it is the titles: check that at least 7 in 10 carry a hash and an issue number."
 msgstr ""
 
 #: src/components/labeler-detail-view.tsx
@@ -4359,6 +4465,10 @@ msgstr "読み上げの声"
 msgid "Sharp"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "An issue is fronted by the page whose title says it is the cover — anything with the word <0>cover</0> in the page label. <1>Inner cover</1> is deliberately not treated as one, since it is the leaf behind the cover rather than the cover itself. When no page claims it, the issue's first page fronts it, which is what the reader sees on opening anyway."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "What you get is a reading view made for long-form: a centered column, drop caps and pull quotes, full-bleed images you can open into a gallery. The page gets out of the way so the writing can do its work."
 msgstr "用意したのは、長文のために作られた読書ビューです。中央寄せのカラム、ドロップキャップとプルクオート、ギャラリーで開ける全幅画像。ページは前に出しゃばらず、文章そのものに仕事をさせます。"
@@ -4445,6 +4555,10 @@ msgstr ""
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "Make one with <0>New list</0> in the sidebar, or add a publication to a list from its <1>Add to list</1> menu. A publication can be in as many lists as you like, and being in a list does not change your feeds — it only changes how they are grouped."
 #~ msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "In practice this means a reader who subscribes mid-run can come back after a month and land exactly where they stopped, which is the single biggest thing that keeps people reading a serial. Readers who have turned reading history off see no dots — nothing is tracked for them — and readers who are not signed in see the shelf as a stranger would."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
@@ -4724,6 +4838,10 @@ msgstr "コレクションの紹介文…（markdown 対応）"
 msgid "Filter"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A comic publication gets two things an ordinary blog does not. Its page shows a <0>shelf of covers</0> — your art, at trade-paperback proportions — rather than dozens of near-identical rows reading <1>Pg. 1</1>, <2>Pg. 2</2>, <3>Pg. 3</3>. And opening one drops the reader into the <4>comic reader</4>: a dark, chrome-free theater holding one page at a time."
+msgstr ""
+
 #: src/components/reader/friend-publishers.tsx
 msgid "Bluesky didn't answer in time, so this list may be incomplete. Reload to try again."
 msgstr ""
@@ -4778,6 +4896,11 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "プロフィール設定"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Publishing a comic"
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "The first time you sign in, a short setup walks you through it: pick a few topics you care about, see which of the people you already follow on Bluesky write here, follow anything that appeals, and choose how you like your text. You can skip any step, and skip the whole thing."
@@ -5122,6 +5245,10 @@ msgstr ""
 #: src/components/docs/docs-renderers-nav.tsx
 #: src/components/docs/renderers-docs-page.tsx
 msgid "Resolving platform data"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Your publication has to say it reads forwards.</0> That is a setting on the publication itself, in whatever tool you publish with — the one that says the work is read from its first post rather than newest-first. In the underlying record it is <1>preferences.prevNextDirection</1> set to <2>ltr</2>. Leaflet writes this field; if you roll your own records, see <3>Publishing your site</3>. Without it a comic is just a blog that happens to post drawings."
 msgstr ""
 
 #: src/components/reader/comments/add-comment-dialog.tsx
@@ -5669,6 +5796,10 @@ msgstr ""
 msgid "Articles you've recommended across the network."
 msgstr "ネットワーク上でおすすめした記事です。"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "One thing worth knowing: if a paragraph of your post body repeats a page's alt text word for word, we drop it from the note rather than showing the reader a description of the picture they are looking at. So transcribing your dialogue into the alt and again into the body does not double up."
+msgstr ""
+
 #: src/routes/_layout.feedback.return.tsx
 msgid "View feedback"
 msgstr "フィードバックを見る"
@@ -5991,6 +6122,10 @@ msgstr "ドキュメント"
 msgid "The core / new frameworks"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Both are re-checked as your archive grows, and the setting is picked up the first time anyone opens your publication after you change it — you do not have to tell us. Being read as a book rather than a comic is never a dead end for a reader: every route into the comic reader also links to the ordinary reading view, and an issue with no art falls back to it outright."
+msgstr ""
+
 #. placeholder {0}: index + 1
 #: src/components/comic/comic-reader.tsx
 msgid "Page {0}"
@@ -6171,6 +6306,11 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 #~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
 #~ msgstr "軽量なブラウザ拡張機能を使えば、ウェブを見ている最中でも発行物を保存・購読できます。bsky.app 上のさりげないバッジと、どのページでもワンクリックで開くオーバーレイ付き。読むものリストが自然に埋まっていきます。"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Alt text"
+msgstr ""
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -6356,6 +6496,10 @@ msgstr ""
 msgid "Reading & privacy"
 msgstr "読書とプライバシー"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Grouping is all-or-nothing per publication: at least 70% of your titles have to parse before we trust the numbers enough to group by them. If they do not — a webcomic naming its posts <0>Pg01</0>, <1>Pg02</1> has no issues to speak of — you still get a shelf, just one cover per post instead of one per issue. That is a fine way to run a comic; it is not a failure state."
+msgstr ""
+
 #: src/components/Header.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/site-legal-links.tsx
@@ -6471,6 +6615,11 @@ msgstr "編集部"
 msgid "Click Run example to fetch a live response with your session."
 msgstr "「例を実行」をクリックすると、セッションを使って実際のレスポンスを取得します。"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What readers get"
+msgstr ""
+
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "At the bottom of settings, <0>Personal data</0> deletes categories of records outright: your reading history, your saved articles, or the publication lists you made. Each asks for confirmation and explains what will change."
 msgstr ""
@@ -6559,6 +6708,10 @@ msgstr ""
 #: src/routes/_layout.p.$did.$rkey.tsx
 #~ msgid "Open publication"
 #~ msgstr "発行物を開く"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Do your recent posts render their art in the body?</0> A post that only links to the page on your site, or that carries the drawing as a cover image with an empty body, has no pages to flip."
+msgstr ""
 
 #: src/components/reader/link-share-menu.tsx
 msgid "Send to Disperse"
@@ -6680,6 +6833,10 @@ msgstr "{articleCount, plural, one {記事} other {記事}}"
 msgid "{publicationName} is in your feed. You'll see new writing as it publishes."
 msgstr "{publicationName} をフィードに追加しました。新しい記事が公開されると表示されます。"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Read state is per post, and your posts are pages, so an issue counts as unread while any page in it is — a comic read halfway through is not read. Its cover wears the same unread dot an unread article does, and clicking it opens on the first page that reader has not seen, not back at the cover. Walking pages in the theater marks them off behind them."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Upgrade permissions"
 msgstr "権限をアップグレード"
@@ -6740,6 +6897,10 @@ msgstr "この発行物はディスカバリーへの掲載を停止している
 msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {# 件の高評価} other {# 件の高評価}} — 高評価するにはサインイン"
 
+#: src/lib/guide/navigation.ts
+msgid "Get a shelf of covers and a page-flip reader out of the pages you already post."
+msgstr ""
+
 #: src/components/onboarding/step-friends.tsx
 #~ msgid "Select all"
 #~ msgstr ""
@@ -6748,9 +6909,17 @@ msgstr "{count, plural, one {# 件の高評価} other {# 件の高評価}} — �
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
 msgstr "{SITE_NAME} 全体の仕組みについては <0>概要</0> をご覧ください。サイト全体のプライバシーについては <1>サイトのプライバシーポリシー</1> をご覧ください。この環境に関するお問い合わせは {siteHost} の運営者までご連絡ください。"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The counter reads <0>Page 12 of 340</0> across the whole publication, not within one issue. That means inserting or removing a page in an early issue renumbers everything after it — worth knowing before you go back and edit an old post that readers may have linked to."
+msgstr ""
+
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Your account and data"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The prose length is also what separates a comic from an illustrated blog: a post carrying more than about 700 words stops counting as a page of comic, and if most of your posts are like that the publication reads as a book instead. A long process essay is better as its own post — which readers will find in the archive — than appended to a page."
 msgstr ""
 
 #: src/routes/review.thanks.tsx
@@ -6878,6 +7047,10 @@ msgstr "アイコン"
 msgid "Top"
 msgstr "人気"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Most cartoonists write a line or two under the page — a caption, a process note, a word about next week. That writing is not lost in the theater. If a page's post carries prose, the note button in the top bar lights up and lays it over the art, in the theater's own type, with a way through to the full post. It closes when the reader turns the page, because it belongs to the page it was written about."
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Read aloud"
 msgstr "読み上げ"
@@ -6911,6 +7084,10 @@ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Subscribe to the publication it came from, in the same click."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>FITV #1 Cover</0> — the same, with a page label instead of a number."
 msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
@@ -7145,6 +7322,10 @@ msgstr "フォロー中"
 msgid "Opening the issue…"
 msgstr "号を開いています…"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Pages with nothing written under them leave the button disabled rather than making it appear and vanish as the reader flips, so there is no penalty for a silent page."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "However you like to read it"
 msgstr ""
@@ -7318,6 +7499,11 @@ msgstr "オンにすると、購読時に発行物の過去記事すべてが未
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this reply on Bluesky"
 msgstr "この返信を Bluesky で開く"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Cover art"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "what your corner of Bluesky reads."
@@ -7555,6 +7741,10 @@ msgstr ""
 
 #: src/routes/mcp/authorize.tsx
 msgid "Signed in as"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Page numbers are absolute"
 msgstr ""
 
 #: src/components/guide/pages/collections-guide-page.tsx

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -242,6 +242,10 @@ msgstr ""
 msgid "Your series"
 msgstr "내 시리즈"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Nothing in the format has a field for “issue 3” — the only place that number exists is your post titles, so that is where we read it back out of. Title your pages the way comics have always been titled and consecutive pages collapse back into the issue they came from, one cover per issue:"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Mark as read"
 msgstr "읽음으로 표시"
@@ -253,6 +257,10 @@ msgstr "이 목록은 비어 있습니다 — 발행물이나 사람을 추가�
 #: src/components/docs/api-docs-intro.tsx
 #~ msgid "A labeler is any DID that publishes AT Proto labels. Readers add one by DID on the <0>Labelers</0> page, and Standard Reader then shows that labeler's labels — and can warn on or hide labeled posts — as they read. Labelers are discovered the standard way; nothing about them is specific to us. To run your own:"
 #~ msgstr "레이블러는 AT Proto 레이블을 게시하는 모든 DID를 말합니다. 독자는 <0>레이블러</0> 페이지에서 DID로 추가하며, 그러면 Standard Reader가 읽는 동안 해당 레이블러의 레이블을 표시하고 레이블이 붙은 글을 경고하거나 숨길 수 있습니다. 레이블러는 표준 방식으로 검색되며, 저희만의 특별한 요소는 없습니다. 직접 운영하려면:"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "If your publication page shows a list of titles instead of a shelf, walk these in order:"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "The most-read articles across Standard this week."
@@ -444,6 +452,10 @@ msgstr ""
 msgid "If the site publishes in the open format but has not been indexed yet, the extension reads the page's own record hints and subscribes anyway."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A page is an image your post's body renders, and they are flipped through in the order they appear in the post. One image per post is the usual shape and the one everything here is tuned for, but a post carrying three images contributes three pages, in order — useful for posting a whole issue at once."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Open"
 msgstr "열기"
@@ -550,6 +562,10 @@ msgstr ""
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "New collection…"
 msgstr "새 컬렉션…"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Fray In The Veil #2, Pg. 7</0> — series, issue, page."
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "We may update this policy as the product changes. The “Last updated” date at the top will change when we do. Continued use of the site after an update means you accept the revised policy."
@@ -811,6 +827,10 @@ msgstr "이 목록은 비어 있습니다."
 msgid "Play voice sample"
 msgstr "음성 샘플 재생"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Is the forwards-reading setting saved?</0> This is the one that is almost always the answer. Check it in your publishing tool, and note that it lives on the publication, not on individual posts."
+msgstr ""
+
 #: src/components/reader/subscribe-card.tsx
 msgid "You're subscribed"
 msgstr "구독 중입니다"
@@ -840,6 +860,10 @@ msgstr "{0}분 분량"
 
 #: src/components/user-settings-view.tsx
 msgid "Infinite scroll keeps pulling the next page as you reach the end of a list. Load more waits for you to ask."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Alt text on a comic page is the page, for anyone who cannot see it — in the theater there is no surrounding article to fall back on, so whatever you wrote is the whole experience. It is also what your comic is found by in search."
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -1172,6 +1196,11 @@ msgstr ""
 msgid "the directory of every publication the network knows about."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "How readers pick it back up"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "A list is a folder for publications — <0>Work</0>, <1>Fiction</1>, <2>Read on Sunday</2>, whatever is useful. Lists appear as their own groups in the sidebar, so you can read one part of your follows without the rest."
 #~ msgstr ""
@@ -1427,6 +1456,10 @@ msgstr "인기 발행물"
 msgid "Replace cover image"
 msgstr "커버 이미지 교체"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Are your last 40 posts mostly art?</0> A run of text posts — Kickstarter updates, con reports — can tip a comic under the line until the art resumes."
+msgstr ""
+
 #: src/lib/guide/navigation.ts
 #~ msgid "Sign in, follow your first publications, and find your way around."
 #~ msgstr ""
@@ -1522,6 +1555,10 @@ msgstr "임베드된 콘텐츠"
 #: src/components/user-settings-view.tsx
 msgid "Account"
 msgstr "계정"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "There is no “this is a comic” switch anywhere on the network, and nothing to set on Standard Reader — we do not host your publication. Two things have to be true instead."
+msgstr ""
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
@@ -2014,6 +2051,10 @@ msgstr "이 글을 고른 이유는? (마크다운 지원)"
 msgid "Sign in, subscribe to a few publications, and learn where everything lives. Ten minutes, once."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The theater treats the whole publication as one book. Page numbers run straight through from your first page to your latest, so a reader who holds down the arrow key walks the entire run without stopping at the end of every issue. Arrow keys, space, Page Up and Page Down all turn pages; Home and End jump to either end; on a phone the outer edges of the screen turn pages, a swipe does too, and pinch-to-zoom gets a reader into a dense panel. There is a full-screen toggle on the <0>f</0> key. Past the last page is a back cover telling them they are caught up and inviting them to subscribe."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "{count, plural, one {# upvote} other {# upvotes}} — click to upvote"
 msgstr "{count, plural, one {추천 #개} other {추천 #개}} — 클릭해서 추천"
@@ -2030,6 +2071,10 @@ msgstr "읽기"
 #: src/components/reader/comments/add-comment-dialog.tsx
 #~ msgid "Discussion here is gathered from posts across the network, so you comment wherever you already post. Yours joins this article once the network indexes it."
 #~ msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A post with no images contributes nothing to flip through, so it does not get a cover on the shelf and cannot be paged to: an announcement, a hiatus note, or a con schedule lives in the archive's read and unread views rather than in the book. If a text post matters to the story, give it a piece of art and it becomes a page like any other."
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "An HttpOnly session cookie that keeps you signed in."
@@ -2108,6 +2153,11 @@ msgstr ""
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "<0><1>Markpub</1> (recommended).</0> <2>at.markpub.markdown</2> — markdown with facets for rich text. It's not part of the site.standard spec either — no markdown format is — but it's the only one that's actually spec'd in a meaningful, reusable way, rather than one app's own ad hoc shape. Use this for a hand-rolled integration unless you already produce one of the platform formats below."
 msgstr "<0><1>Markpub</1> (권장).</0> <2>at.markpub.markdown</2> — 리치 텍스트를 위한 facet이 포함된 마크다운입니다. 이 역시 site.standard 스펙의 일부는 아니지만(어떤 마크다운 형식도 아닙니다), 특정 앱의 임시 형태가 아니라 의미 있고 재사용 가능한 방식으로 실제 스펙이 정의된 유일한 형식입니다. 아래 플랫폼 형식 중 하나를 이미 생성하고 있는 게 아니라면 직접 구현할 때는 이것을 사용하세요."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What counts as a page"
+msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Hide read articles"
@@ -2405,6 +2455,10 @@ msgstr "호 설정 중"
 msgid "Feed preferences"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A single post whose title breaks the pattern does not split an issue in two. An interstitial in the middle of issue 3 joins issue 3, and a one-off announcement will not start a phantom issue of its own."
+msgstr ""
+
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Set API_DOCS_FIXTURE_LIST_URI to run this example."
 msgstr "이 예제를 실행하려면 API_DOCS_FIXTURE_LIST_URI를 설정하세요."
@@ -2598,6 +2652,11 @@ msgstr ""
 msgid "RSS feed"
 msgstr "RSS 피드"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Naming issues and pages"
+msgstr ""
+
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
 #~ msgid "Run a labeler"
@@ -2759,6 +2818,10 @@ msgstr "몇 가지 설정"
 
 #: src/routes/_layout.friends.tsx
 msgid "We couldn't reach Bluesky to look up who you follow. Reload in a moment, or browse the directory in the meantime."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Keep the essay for its own post"
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -3436,6 +3499,11 @@ msgstr ""
 msgid "<0>Share</0> copies a link, or posts the article to Bluesky with a proper preview card. On a phone it can hand off to whatever you normally share with."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Turning the comic view on"
+msgstr ""
+
 #: src/components/reader/article-below-fold.tsx
 msgid "Worth subscribing to"
 msgstr "구독할 만한 곳"
@@ -3506,6 +3574,11 @@ msgstr ""
 msgid "A publication on Standard is a <0>site.standard.document</0> record in the author's AT Protocol repository — not a row in a database we own. Standard Reader indexes those records into a public read-model and renders them, but nothing about the format is proprietary: the schemas are open, the content is portable across publishing platforms, and the same renderer we ship is available to you."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "The words beside the art"
+msgstr ""
+
 #: src/components/labelers-settings-view.tsx
 #: src/routes/_layout.latest.tsx
 msgid "On the network"
@@ -3525,6 +3598,11 @@ msgstr "조용히 읽을 수 있는 곳"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Add publications or people, then <0>Create list</0>."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "When it still reads as a blog"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -3621,6 +3699,10 @@ msgstr "더 보기"
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Readers who would rather not get the magazine treatment can turn <0>Open collections in magazine</0> off in <1>settings</1>, and collection articles open in the ordinary reader instead."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Covers are drawn in a 2:3 frame — the standard trade-paperback shape — and art is scaled to fill it, so anything much wider or squarer gets cropped at the edges. If your logo or your title lettering sits near the very edge of a landscape cover, expect it to be trimmed on the shelf. The full page is untouched in the reader; this only affects the thumbnail."
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -3750,6 +3832,10 @@ msgstr "이번 주 인기"
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "The login screen links out to create one. Any account on the network works — you do not have to use Bluesky itself, and you do not have to post anything."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "If all of that is true and your comic still reads as a blog, tell us on the feedback board with a link to the publication — that is a bug on our side, and worth hearing about."
 msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
@@ -3976,6 +4062,10 @@ msgstr ""
 msgid "We couldn’t find that publication."
 msgstr "해당 발행물을 찾을 수 없습니다."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Your posts have to read as pages.</0> We look at your 40 newest posts and count the ones that render at least one image and carry no more than about 700 words of prose. If at least 60% of them do, the publication is a comic. If they do not, it is treated as a serialized book — still read front-to-back, but as articles with an <1>Up next</1> link rather than as pages of art."
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Generating audio… {percent}%"
 msgstr "오디오 생성 중… {percent}%"
@@ -4000,6 +4090,10 @@ msgstr "읽지 않음"
 #: src/components/guide/pages/collections-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "How readers see it"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Standard Reader has a reading mode built for comics — a shelf of covers instead of a list of post titles, and a full-screen theater that flips through your pages. You do not author anything specially for it. This page is how to make sure your comic gets it."
 msgstr ""
 
 #. placeholder {0}: filter.trim()
@@ -4185,6 +4279,10 @@ msgstr ""
 msgid "On any page you visit"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The current page lives in the address bar, so a reader can link someone straight to a page, and reopening the comic puts them back where they stopped."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Partly removed"
 msgstr ""
@@ -4193,6 +4291,10 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Delete list"
 msgstr "목록 삭제"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The one part that is required is the hash before the issue number — a bare number in a title is never read as an issue, because too many ordinary titles start with one. After the number you can use a comma, a colon, a dash, or nothing at all; everything following it is treated as the page label and is not otherwise parsed, so write it however you like."
+msgstr ""
 
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "What the extension can see and what it does with it is written out in full on the <0>extension privacy page</0>."
@@ -4222,6 +4324,10 @@ msgstr "추천 아티클"
 
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Getting a shelf but not issues?</0> Then the setting is right and it is the titles: check that at least 7 in 10 carry a hash and an issue number."
 msgstr ""
 
 #: src/components/labeler-detail-view.tsx
@@ -4359,6 +4465,10 @@ msgstr "리더 음성"
 msgid "Sharp"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "An issue is fronted by the page whose title says it is the cover — anything with the word <0>cover</0> in the page label. <1>Inner cover</1> is deliberately not treated as one, since it is the leaf behind the cover rather than the cover itself. When no page claims it, the issue's first page fronts it, which is what the reader sees on opening anyway."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "What you get is a reading view made for long-form: a centered column, drop caps and pull quotes, full-bleed images you can open into a gallery. The page gets out of the way so the writing can do its work."
 msgstr "긴 글을 위해 만든 읽기 화면을 만나보세요. 가운데 정렬된 단, 드롭캡과 인용구, 갤러리로 열어볼 수 있는 전체 폭 이미지까지. 글이 제 몫을 하도록 페이지는 뒤로 물러납니다."
@@ -4445,6 +4555,10 @@ msgstr ""
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "Make one with <0>New list</0> in the sidebar, or add a publication to a list from its <1>Add to list</1> menu. A publication can be in as many lists as you like, and being in a list does not change your feeds — it only changes how they are grouped."
 #~ msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "In practice this means a reader who subscribes mid-run can come back after a month and land exactly where they stopped, which is the single biggest thing that keeps people reading a serial. Readers who have turned reading history off see no dots — nothing is tracked for them — and readers who are not signed in see the shelf as a stranger would."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
@@ -4724,6 +4838,10 @@ msgstr "컬렉션을 소개해 주세요… (마크다운 지원)"
 msgid "Filter"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A comic publication gets two things an ordinary blog does not. Its page shows a <0>shelf of covers</0> — your art, at trade-paperback proportions — rather than dozens of near-identical rows reading <1>Pg. 1</1>, <2>Pg. 2</2>, <3>Pg. 3</3>. And opening one drops the reader into the <4>comic reader</4>: a dark, chrome-free theater holding one page at a time."
+msgstr ""
+
 #: src/components/reader/friend-publishers.tsx
 msgid "Bluesky didn't answer in time, so this list may be incomplete. Reload to try again."
 msgstr ""
@@ -4778,6 +4896,11 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "프로필 설정"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Publishing a comic"
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "The first time you sign in, a short setup walks you through it: pick a few topics you care about, see which of the people you already follow on Bluesky write here, follow anything that appeals, and choose how you like your text. You can skip any step, and skip the whole thing."
@@ -5122,6 +5245,10 @@ msgstr ""
 #: src/components/docs/docs-renderers-nav.tsx
 #: src/components/docs/renderers-docs-page.tsx
 msgid "Resolving platform data"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Your publication has to say it reads forwards.</0> That is a setting on the publication itself, in whatever tool you publish with — the one that says the work is read from its first post rather than newest-first. In the underlying record it is <1>preferences.prevNextDirection</1> set to <2>ltr</2>. Leaflet writes this field; if you roll your own records, see <3>Publishing your site</3>. Without it a comic is just a blog that happens to post drawings."
 msgstr ""
 
 #: src/components/reader/comments/add-comment-dialog.tsx
@@ -5669,6 +5796,10 @@ msgstr ""
 msgid "Articles you've recommended across the network."
 msgstr "네트워크에서 추천한 글입니다."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "One thing worth knowing: if a paragraph of your post body repeats a page's alt text word for word, we drop it from the note rather than showing the reader a description of the picture they are looking at. So transcribing your dialogue into the alt and again into the body does not double up."
+msgstr ""
+
 #: src/routes/_layout.feedback.return.tsx
 msgid "View feedback"
 msgstr "피드백 보기"
@@ -5991,6 +6122,10 @@ msgstr "문서"
 msgid "The core / new frameworks"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Both are re-checked as your archive grows, and the setting is picked up the first time anyone opens your publication after you change it — you do not have to tell us. Being read as a book rather than a comic is never a dead end for a reader: every route into the comic reader also links to the ordinary reading view, and an issue with no art falls back to it outright."
+msgstr ""
+
 #. placeholder {0}: index + 1
 #: src/components/comic/comic-reader.tsx
 msgid "Page {0}"
@@ -6171,6 +6306,11 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 #~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
 #~ msgstr "가벼운 브라우저 확장 프로그램으로 웹을 둘러보다가 바로 발행물을 저장하고 구독할 수 있습니다. bsky.app에는 은은한 배지가, 방문하는 어떤 페이지에서든 원클릭 오버레이가 나타납니다. 읽을 목록이 저절로 채워집니다."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Alt text"
+msgstr ""
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -6356,6 +6496,10 @@ msgstr ""
 msgid "Reading & privacy"
 msgstr "읽기와 개인정보"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Grouping is all-or-nothing per publication: at least 70% of your titles have to parse before we trust the numbers enough to group by them. If they do not — a webcomic naming its posts <0>Pg01</0>, <1>Pg02</1> has no issues to speak of — you still get a shelf, just one cover per post instead of one per issue. That is a fine way to run a comic; it is not a failure state."
+msgstr ""
+
 #: src/components/Header.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/site-legal-links.tsx
@@ -6471,6 +6615,11 @@ msgstr "에디토리얼"
 msgid "Click Run example to fetch a live response with your session."
 msgstr "예제 실행을 누르면 내 세션으로 실시간 응답을 가져옵니다."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What readers get"
+msgstr ""
+
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "At the bottom of settings, <0>Personal data</0> deletes categories of records outright: your reading history, your saved articles, or the publication lists you made. Each asks for confirmation and explains what will change."
 msgstr ""
@@ -6559,6 +6708,10 @@ msgstr ""
 #: src/routes/_layout.p.$did.$rkey.tsx
 #~ msgid "Open publication"
 #~ msgstr "발행물 열기"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Do your recent posts render their art in the body?</0> A post that only links to the page on your site, or that carries the drawing as a cover image with an empty body, has no pages to flip."
+msgstr ""
 
 #: src/components/reader/link-share-menu.tsx
 msgid "Send to Disperse"
@@ -6680,6 +6833,10 @@ msgstr "{articleCount, plural, one {글} other {글}}"
 msgid "{publicationName} is in your feed. You'll see new writing as it publishes."
 msgstr "{publicationName}이(가) 피드에 추가되었습니다. 새 글이 게시되면 바로 볼 수 있습니다."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Read state is per post, and your posts are pages, so an issue counts as unread while any page in it is — a comic read halfway through is not read. Its cover wears the same unread dot an unread article does, and clicking it opens on the first page that reader has not seen, not back at the cover. Walking pages in the theater marks them off behind them."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Upgrade permissions"
 msgstr "권한 업그레이드"
@@ -6740,6 +6897,10 @@ msgstr "이 발행물은 둘러보기 노출을 해제했기 때문에 내 프�
 msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {추천 #개} other {추천 #개}} — 추천하려면 로그인하세요"
 
+#: src/lib/guide/navigation.ts
+msgid "Get a shelf of covers and a page-flip reader out of the pages you already post."
+msgstr ""
+
 #: src/components/onboarding/step-friends.tsx
 #~ msgid "Select all"
 #~ msgstr ""
@@ -6748,9 +6909,17 @@ msgstr "{count, plural, one {추천 #개} other {추천 #개}} — 추천하려�
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
 msgstr "{SITE_NAME}의 전반적인 작동 방식은 <0>소개</0>를 참고하세요. 사이트 전체 개인정보 처리방침은 <1>사이트 개인정보 처리방침</1>을 확인하세요. 이 배포에 대한 문의는 {siteHost} 운영자에게 연락하세요."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The counter reads <0>Page 12 of 340</0> across the whole publication, not within one issue. That means inserting or removing a page in an early issue renumbers everything after it — worth knowing before you go back and edit an old post that readers may have linked to."
+msgstr ""
+
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Your account and data"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The prose length is also what separates a comic from an illustrated blog: a post carrying more than about 700 words stops counting as a page of comic, and if most of your posts are like that the publication reads as a book instead. A long process essay is better as its own post — which readers will find in the archive — than appended to a page."
 msgstr ""
 
 #: src/routes/review.thanks.tsx
@@ -6878,6 +7047,10 @@ msgstr "아이콘"
 msgid "Top"
 msgstr "인기"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Most cartoonists write a line or two under the page — a caption, a process note, a word about next week. That writing is not lost in the theater. If a page's post carries prose, the note button in the top bar lights up and lays it over the art, in the theater's own type, with a way through to the full post. It closes when the reader turns the page, because it belongs to the page it was written about."
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Read aloud"
 msgstr "소리내어 읽기"
@@ -6911,6 +7084,10 @@ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Subscribe to the publication it came from, in the same click."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>FITV #1 Cover</0> — the same, with a page label instead of a number."
 msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
@@ -7145,6 +7322,10 @@ msgstr "팔로잉"
 msgid "Opening the issue…"
 msgstr "호를 여는 중…"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Pages with nothing written under them leave the button disabled rather than making it appear and vanish as the reader flips, so there is no penalty for a silent page."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "However you like to read it"
 msgstr ""
@@ -7318,6 +7499,11 @@ msgstr "켜면 구독할 때 해당 발행물의 지난 글 전체가 읽지 않
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this reply on Bluesky"
 msgstr "이 답글을 Bluesky에서 열기"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Cover art"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "what your corner of Bluesky reads."
@@ -7555,6 +7741,10 @@ msgstr ""
 
 #: src/routes/mcp/authorize.tsx
 msgid "Signed in as"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Page numbers are absolute"
 msgstr ""
 
 #: src/components/guide/pages/collections-guide-page.tsx

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -242,6 +242,10 @@ msgstr "Inscreva-se a uma publicação ou siga um autor e eles aparecerão aqui,
 msgid "Your series"
 msgstr "As suas séries"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Nothing in the format has a field for “issue 3” — the only place that number exists is your post titles, so that is where we read it back out of. Title your pages the way comics have always been titled and consecutive pages collapse back into the issue they came from, one cover per issue:"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Mark as read"
 msgstr "Marcar como lido"
@@ -253,6 +257,10 @@ msgstr "Esta lista está vazia — adicione publicações ou pessoas."
 #: src/components/docs/api-docs-intro.tsx
 #~ msgid "A labeler is any DID that publishes AT Proto labels. Readers add one by DID on the <0>Labelers</0> page, and Standard Reader then shows that labeler's labels — and can warn on or hide labeled posts — as they read. Labelers are discovered the standard way; nothing about them is specific to us. To run your own:"
 #~ msgstr "Um rotulador é qualquer DID que publique rótulos no AT Proto. Os leitores adicionam um por DID na página <0>Rotuladores</0> e o Standard Reader passa a mostrar os rótulos desse serviço — podendo avisar sobre publicações rotuladas ou ocultá-las — durante a leitura. Os rotuladores são descobertos da forma habitual; nada neles é específico do nosso caso. Para rodar o seu:"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "If your publication page shows a list of titles instead of a shelf, walk these in order:"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "The most-read articles across Standard this week."
@@ -444,6 +452,10 @@ msgstr "Dispensar"
 msgid "If the site publishes in the open format but has not been indexed yet, the extension reads the page's own record hints and subscribes anyway."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A page is an image your post's body renders, and they are flipped through in the order they appear in the post. One image per post is the usual shape and the one everything here is tuned for, but a post carrying three images contributes three pages, in order — useful for posting a whole issue at once."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Open"
 msgstr "Abrir"
@@ -550,6 +562,10 @@ msgstr ""
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "New collection…"
 msgstr "Nova coleção…"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Fray In The Veil #2, Pg. 7</0> — series, issue, page."
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "We may update this policy as the product changes. The “Last updated” date at the top will change when we do. Continued use of the site after an update means you accept the revised policy."
@@ -811,6 +827,10 @@ msgstr "Esta lista está vazia."
 msgid "Play voice sample"
 msgstr "Reproduzir amostra de voz"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Is the forwards-reading setting saved?</0> This is the one that is almost always the answer. Check it in your publishing tool, and note that it lives on the publication, not on individual posts."
+msgstr ""
+
 #: src/components/reader/subscribe-card.tsx
 msgid "You're subscribed"
 msgstr "Você está inscrito"
@@ -840,6 +860,10 @@ msgstr "{0} min de leitura"
 
 #: src/components/user-settings-view.tsx
 msgid "Infinite scroll keeps pulling the next page as you reach the end of a list. Load more waits for you to ask."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Alt text on a comic page is the page, for anyone who cannot see it — in the theater there is no surrounding article to fall back on, so whatever you wrote is the whole experience. It is also what your comic is found by in search."
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -1172,6 +1196,11 @@ msgstr "O {SITE_NAME} é um leitor web para publicações do standard.site no AT
 msgid "the directory of every publication the network knows about."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "How readers pick it back up"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "A list is a folder for publications — <0>Work</0>, <1>Fiction</1>, <2>Read on Sunday</2>, whatever is useful. Lists appear as their own groups in the sidebar, so you can read one part of your follows without the rest."
 #~ msgstr ""
@@ -1427,6 +1456,10 @@ msgstr "Publicações em alta"
 msgid "Replace cover image"
 msgstr "Substituir imagem de capa"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Are your last 40 posts mostly art?</0> A run of text posts — Kickstarter updates, con reports — can tip a comic under the line until the art resumes."
+msgstr ""
+
 #: src/lib/guide/navigation.ts
 #~ msgid "Sign in, follow your first publications, and find your way around."
 #~ msgstr ""
@@ -1522,6 +1555,10 @@ msgstr "Conteúdo incorporado"
 #: src/components/user-settings-view.tsx
 msgid "Account"
 msgstr "Conta"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "There is no “this is a comic” switch anywhere on the network, and nothing to set on Standard Reader — we do not host your publication. Two things have to be true instead."
+msgstr ""
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
@@ -2014,6 +2051,10 @@ msgstr "Porque esta peça está aqui? (suporta markdown)"
 msgid "Sign in, subscribe to a few publications, and learn where everything lives. Ten minutes, once."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The theater treats the whole publication as one book. Page numbers run straight through from your first page to your latest, so a reader who holds down the arrow key walks the entire run without stopping at the end of every issue. Arrow keys, space, Page Up and Page Down all turn pages; Home and End jump to either end; on a phone the outer edges of the screen turn pages, a swipe does too, and pinch-to-zoom gets a reader into a dense panel. There is a full-screen toggle on the <0>f</0> key. Past the last page is a back cover telling them they are caught up and inviting them to subscribe."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "{count, plural, one {# upvote} other {# upvotes}} — click to upvote"
 msgstr "{count, plural, one {# voto} other {# votos}} — clique para votar"
@@ -2030,6 +2071,10 @@ msgstr "Lido"
 #: src/components/reader/comments/add-comment-dialog.tsx
 #~ msgid "Discussion here is gathered from posts across the network, so you comment wherever you already post. Yours joins this article once the network indexes it."
 #~ msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A post with no images contributes nothing to flip through, so it does not get a cover on the shelf and cannot be paged to: an announcement, a hiatus note, or a con schedule lives in the archive's read and unread views rather than in the book. If a text post matters to the story, give it a piece of art and it becomes a page like any other."
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "An HttpOnly session cookie that keeps you signed in."
@@ -2108,6 +2153,11 @@ msgstr ""
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "<0><1>Markpub</1> (recommended).</0> <2>at.markpub.markdown</2> — markdown with facets for rich text. It's not part of the site.standard spec either — no markdown format is — but it's the only one that's actually spec'd in a meaningful, reusable way, rather than one app's own ad hoc shape. Use this for a hand-rolled integration unless you already produce one of the platform formats below."
 msgstr "<0><1>Markpub</1> (recomendado).</0> <2>at.markpub.markdown</2> — markdown com facets para formatação de texto. Também não faz parte da especificação site.standard — nenhum formato markdown faz — mas é o único que está realmente especificado de forma significativa e reutilizável, em vez de ser o formato ad hoc de uma única aplicação. Utilize-o numa integração feita à mão, a menos que já produza um dos formatos de plataforma abaixo."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What counts as a page"
+msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Hide read articles"
@@ -2405,6 +2455,10 @@ msgstr "Configurando a edição"
 msgid "Feed preferences"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A single post whose title breaks the pattern does not split an issue in two. An interstitial in the middle of issue 3 joins issue 3, and a one-off announcement will not start a phantom issue of its own."
+msgstr ""
+
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Set API_DOCS_FIXTURE_LIST_URI to run this example."
 msgstr "Defina API_DOCS_FIXTURE_LIST_URI para executar este exemplo."
@@ -2598,6 +2652,11 @@ msgstr "Limpar a seleção"
 msgid "RSS feed"
 msgstr "Feed RSS"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Naming issues and pages"
+msgstr ""
+
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
 #~ msgid "Run a labeler"
@@ -2760,6 +2819,10 @@ msgstr "Algumas preferências"
 #: src/routes/_layout.friends.tsx
 msgid "We couldn't reach Bluesky to look up who you follow. Reload in a moment, or browse the directory in the meantime."
 msgstr "Não conseguimos conectar com Bluesky para ver quem você segue. Recarregue em um momento, ou navegue pelo diretório enquanto isso."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Keep the essay for its own post"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Plenty of people you already follow on Bluesky write long-form somewhere. <0>People you follow</0> finds them and puts their publications, and their newest articles, in one place. It is usually the highest-yield screen in the app the first week you use it."
@@ -3436,6 +3499,11 @@ msgstr ""
 msgid "<0>Share</0> copies a link, or posts the article to Bluesky with a proper preview card. On a phone it can hand off to whatever you normally share with."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Turning the comic view on"
+msgstr ""
+
 #: src/components/reader/article-below-fold.tsx
 msgid "Worth subscribing to"
 msgstr "Vale a pena se inscrever"
@@ -3506,6 +3574,11 @@ msgstr "Todo o trabalho específico de formato é realizado uma única vez, em u
 msgid "A publication on Standard is a <0>site.standard.document</0> record in the author's AT Protocol repository — not a row in a database we own. Standard Reader indexes those records into a public read-model and renders them, but nothing about the format is proprietary: the schemas are open, the content is portable across publishing platforms, and the same renderer we ship is available to you."
 msgstr "Uma publicação no Standard é um registro do tipo <0>site.standard.document</0> no repositório AT Protocol do autor — e não uma linha em um banco de dados de nossa propriedade. O Standard Reader indexa esses registros em um modelo de leitura público e os renderiza, mas nada no formato é proprietário: os esquemas são abertos, o conteúdo é portátil entre plataformas de publicação e o mesmo renderizador que disponibilizamos também está ao seu alcance."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "The words beside the art"
+msgstr ""
+
 #: src/components/labelers-settings-view.tsx
 #: src/routes/_layout.latest.tsx
 msgid "On the network"
@@ -3525,6 +3598,11 @@ msgstr "Um lugar tranquilo para ler"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Add publications or people, then <0>Create list</0>."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "When it still reads as a blog"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -3621,6 +3699,10 @@ msgstr "Mais ações"
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Readers who would rather not get the magazine treatment can turn <0>Open collections in magazine</0> off in <1>settings</1>, and collection articles open in the ordinary reader instead."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Covers are drawn in a 2:3 frame — the standard trade-paperback shape — and art is scaled to fill it, so anything much wider or squarer gets cropped at the edges. If your logo or your title lettering sits near the very edge of a landscape cover, expect it to be trimmed on the shelf. The full page is untouched in the reader; this only affects the thumbnail."
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -3750,6 +3832,10 @@ msgstr "Em alta esta semana"
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "The login screen links out to create one. Any account on the network works — you do not have to use Bluesky itself, and you do not have to post anything."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "If all of that is true and your comic still reads as a blog, tell us on the feedback board with a link to the publication — that is a bug on our side, and worth hearing about."
 msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
@@ -3976,6 +4062,10 @@ msgstr ""
 msgid "We couldn’t find that publication."
 msgstr "Não foi possível encontrar essa publicação."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Your posts have to read as pages.</0> We look at your 40 newest posts and count the ones that render at least one image and carry no more than about 700 words of prose. If at least 60% of them do, the publication is a comic. If they do not, it is treated as a serialized book — still read front-to-back, but as articles with an <1>Up next</1> link rather than as pages of art."
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Generating audio… {percent}%"
 msgstr "A gerar áudio… {percent}%"
@@ -4000,6 +4090,10 @@ msgstr "Não lido"
 #: src/components/guide/pages/collections-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "How readers see it"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Standard Reader has a reading mode built for comics — a shelf of covers instead of a list of post titles, and a full-screen theater that flips through your pages. You do not author anything specially for it. This page is how to make sure your comic gets it."
 msgstr ""
 
 #. placeholder {0}: filter.trim()
@@ -4185,6 +4279,10 @@ msgstr ""
 msgid "On any page you visit"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The current page lives in the address bar, so a reader can link someone straight to a page, and reopening the comic puts them back where they stopped."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Partly removed"
 msgstr "Removido parcialmente"
@@ -4193,6 +4291,10 @@ msgstr "Removido parcialmente"
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Delete list"
 msgstr "Apagar lista"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The one part that is required is the hash before the issue number — a bare number in a title is never read as an issue, because too many ordinary titles start with one. After the number you can use a comma, a colon, a dash, or nothing at all; everything following it is treated as the page label and is not otherwise parsed, so write it however you like."
+msgstr ""
 
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "What the extension can see and what it does with it is written out in full on the <0>extension privacy page</0>."
@@ -4222,6 +4324,10 @@ msgstr "Artigos recomendados"
 
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Getting a shelf but not issues?</0> Then the setting is right and it is the titles: check that at least 7 in 10 carry a hash and an issue number."
 msgstr ""
 
 #: src/components/labeler-detail-view.tsx
@@ -4359,6 +4465,10 @@ msgstr "Voz de leitura"
 msgid "Sharp"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "An issue is fronted by the page whose title says it is the cover — anything with the word <0>cover</0> in the page label. <1>Inner cover</1> is deliberately not treated as one, since it is the leaf behind the cover rather than the cover itself. When no page claims it, the issue's first page fronts it, which is what the reader sees on opening anyway."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "What you get is a reading view made for long-form: a centered column, drop caps and pull quotes, full-bleed images you can open into a gallery. The page gets out of the way so the writing can do its work."
 msgstr "O que obtém é uma vista de leitura feita para formato longo: uma coluna centrada, capitulares e citações em destaque, imagens de largura total que pode abrir numa galeria. A página sai do caminho para que o texto faça o seu trabalho."
@@ -4445,6 +4555,10 @@ msgstr ""
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "Make one with <0>New list</0> in the sidebar, or add a publication to a list from its <1>Add to list</1> menu. A publication can be in as many lists as you like, and being in a list does not change your feeds — it only changes how they are grouped."
 #~ msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "In practice this means a reader who subscribes mid-run can come back after a month and land exactly where they stopped, which is the single biggest thing that keeps people reading a serial. Readers who have turned reading history off see no dots — nothing is tracked for them — and readers who are not signed in see the shelf as a stranger would."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
@@ -4724,6 +4838,10 @@ msgstr "Apresente a coleção… (com suporte para markdown)"
 msgid "Filter"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A comic publication gets two things an ordinary blog does not. Its page shows a <0>shelf of covers</0> — your art, at trade-paperback proportions — rather than dozens of near-identical rows reading <1>Pg. 1</1>, <2>Pg. 2</2>, <3>Pg. 3</3>. And opening one drops the reader into the <4>comic reader</4>: a dark, chrome-free theater holding one page at a time."
+msgstr ""
+
 #: src/components/reader/friend-publishers.tsx
 msgid "Bluesky didn't answer in time, so this list may be incomplete. Reload to try again."
 msgstr "Bluesky não respondeu a tempo, então esta lista pode estar incompleta. Recarregue para tentar novamente."
@@ -4778,6 +4896,11 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "Configurações do perfil"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Publishing a comic"
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "The first time you sign in, a short setup walks you through it: pick a few topics you care about, see which of the people you already follow on Bluesky write here, follow anything that appeals, and choose how you like your text. You can skip any step, and skip the whole thing."
@@ -5123,6 +5246,10 @@ msgstr ""
 #: src/components/docs/renderers-docs-page.tsx
 msgid "Resolving platform data"
 msgstr "Resolvendo dados da plataforma"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Your publication has to say it reads forwards.</0> That is a setting on the publication itself, in whatever tool you publish with — the one that says the work is read from its first post rather than newest-first. In the underlying record it is <1>preferences.prevNextDirection</1> set to <2>ltr</2>. Leaflet writes this field; if you roll your own records, see <3>Publishing your site</3>. Without it a comic is just a blog that happens to post drawings."
+msgstr ""
 
 #: src/components/reader/comments/add-comment-dialog.tsx
 msgid "Reply on Bluesky"
@@ -5669,6 +5796,10 @@ msgstr ""
 msgid "Articles you've recommended across the network."
 msgstr "Artigos que recomendou pela rede fora."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "One thing worth knowing: if a paragraph of your post body repeats a page's alt text word for word, we drop it from the note rather than showing the reader a description of the picture they are looking at. So transcribing your dialogue into the alt and again into the body does not double up."
+msgstr ""
+
 #: src/routes/_layout.feedback.return.tsx
 msgid "View feedback"
 msgstr "Ver feedback"
@@ -5991,6 +6122,10 @@ msgstr "Documentação"
 msgid "The core / new frameworks"
 msgstr "O núcleo / novos frameworks"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Both are re-checked as your archive grows, and the setting is picked up the first time anyone opens your publication after you change it — you do not have to tell us. Being read as a book rather than a comic is never a dead end for a reader: every route into the comic reader also links to the ordinary reading view, and an issue with no art falls back to it outright."
+msgstr ""
+
 #. placeholder {0}: index + 1
 #: src/components/comic/comic-reader.tsx
 msgid "Page {0}"
@@ -6171,6 +6306,11 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 #~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
 #~ msgstr "Uma extensão de navegador leve que lhe permite salvar e se inscrever em publicações enquanto navega pela web — com discretos botões no bsky.app e uma sobreposição de um clique em qualquer página onde estiver. A sua lista de leitura enche-se sozinha."
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Alt text"
+msgstr ""
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -6356,6 +6496,10 @@ msgstr ""
 msgid "Reading & privacy"
 msgstr "Leitura e privacidade"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Grouping is all-or-nothing per publication: at least 70% of your titles have to parse before we trust the numbers enough to group by them. If they do not — a webcomic naming its posts <0>Pg01</0>, <1>Pg02</1> has no issues to speak of — you still get a shelf, just one cover per post instead of one per issue. That is a fine way to run a comic; it is not a failure state."
+msgstr ""
+
 #: src/components/Header.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/site-legal-links.tsx
@@ -6471,6 +6615,11 @@ msgstr "Editorial"
 msgid "Click Run example to fetch a live response with your session."
 msgstr "Clique em Executar exemplo para obter uma resposta ao vivo com a sua sessão."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What readers get"
+msgstr ""
+
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "At the bottom of settings, <0>Personal data</0> deletes categories of records outright: your reading history, your saved articles, or the publication lists you made. Each asks for confirmation and explains what will change."
 msgstr ""
@@ -6559,6 +6708,10 @@ msgstr ""
 #: src/routes/_layout.p.$did.$rkey.tsx
 #~ msgid "Open publication"
 #~ msgstr "Abrir publicação"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Do your recent posts render their art in the body?</0> A post that only links to the page on your site, or that carries the drawing as a cover image with an empty body, has no pages to flip."
+msgstr ""
 
 #: src/components/reader/link-share-menu.tsx
 msgid "Send to Disperse"
@@ -6680,6 +6833,10 @@ msgstr "{articleCount, plural, one {artigo} other {artigos}}"
 msgid "{publicationName} is in your feed. You'll see new writing as it publishes."
 msgstr "{publicationName} está no seu feed. Verá novos textos à medida que forem publicados."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Read state is per post, and your posts are pages, so an issue counts as unread while any page in it is — a comic read halfway through is not read. Its cover wears the same unread dot an unread article does, and clicking it opens on the first page that reader has not seen, not back at the cover. Walking pages in the theater marks them off behind them."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Upgrade permissions"
 msgstr "Atualizar permissões"
@@ -6740,6 +6897,10 @@ msgstr "Esta publicação optou por não aparecer na descoberta, pelo que está 
 msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {# voto positivo} other {# votos positivos}} — inicie sessão para votar"
 
+#: src/lib/guide/navigation.ts
+msgid "Get a shelf of covers and a page-flip reader out of the pages you already post."
+msgstr ""
+
 #: src/components/onboarding/step-friends.tsx
 #~ msgid "Select all"
 #~ msgstr "Selecionar tudo"
@@ -6748,9 +6909,17 @@ msgstr "{count, plural, one {# voto positivo} other {# votos positivos}} — ini
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
 msgstr "Para saber como o {SITE_NAME} funciona no geral, consulte <0>Sobre</0>. Para a privacidade em todo o site, consulte a <1>política de privacidade do site</1>. Para questões sobre esta instalação, contacte o operador de {siteHost}."
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The counter reads <0>Page 12 of 340</0> across the whole publication, not within one issue. That means inserting or removing a page in an early issue renumbers everything after it — worth knowing before you go back and edit an old post that readers may have linked to."
+msgstr ""
+
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Your account and data"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The prose length is also what separates a comic from an illustrated blog: a post carrying more than about 700 words stops counting as a page of comic, and if most of your posts are like that the publication reads as a book instead. A long process essay is better as its own post — which readers will find in the archive — than appended to a page."
 msgstr ""
 
 #: src/routes/review.thanks.tsx
@@ -6878,6 +7047,10 @@ msgstr "Ícone"
 msgid "Top"
 msgstr "Populares"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Most cartoonists write a line or two under the page — a caption, a process note, a word about next week. That writing is not lost in the theater. If a page's post carries prose, the note button in the top bar lights up and lays it over the art, in the theater's own type, with a way through to the full post. It closes when the reader turns the page, because it belongs to the page it was written about."
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Read aloud"
 msgstr "Ler em voz alta"
@@ -6911,6 +7084,10 @@ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Subscribe to the publication it came from, in the same click."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>FITV #1 Cover</0> — the same, with a page label instead of a number."
 msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
@@ -7145,6 +7322,10 @@ msgstr "A seguir"
 msgid "Opening the issue…"
 msgstr "A abrir a edição…"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Pages with nothing written under them leave the button disabled rather than making it appear and vanish as the reader flips, so there is no penalty for a silent page."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "However you like to read it"
 msgstr ""
@@ -7318,6 +7499,11 @@ msgstr "Quando ativo, todos os artigos anteriores de uma publicação contam com
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this reply on Bluesky"
 msgstr "Abrir esta resposta no Bluesky"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Cover art"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "what your corner of Bluesky reads."
@@ -7555,6 +7741,10 @@ msgstr ""
 
 #: src/routes/mcp/authorize.tsx
 msgid "Signed in as"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Page numbers are absolute"
 msgstr ""
 
 #: src/components/guide/pages/collections-guide-page.tsx

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -242,6 +242,10 @@ msgstr ""
 msgid "Your series"
 msgstr "你的系列"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Nothing in the format has a field for “issue 3” — the only place that number exists is your post titles, so that is where we read it back out of. Title your pages the way comics have always been titled and consecutive pages collapse back into the issue they came from, one cover per issue:"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Mark as read"
 msgstr "标记为已读"
@@ -253,6 +257,10 @@ msgstr "此列表为空——请向其中添加刊物或人。"
 #: src/components/docs/api-docs-intro.tsx
 #~ msgid "A labeler is any DID that publishes AT Proto labels. Readers add one by DID on the <0>Labelers</0> page, and Standard Reader then shows that labeler's labels — and can warn on or hide labeled posts — as they read. Labelers are discovered the standard way; nothing about them is specific to us. To run your own:"
 #~ msgstr "标注服务是指任何发布 AT Proto 标签的 DID。读者可在<0>标注服务</0>页面通过 DID 添加，随后 Standard Reader 会在阅读时显示该标注服务的标签——并可对被标记的文章发出警告或将其隐藏。标注服务以标准方式被发现，其中没有任何我们特有的东西。若要运行你自己的："
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "If your publication page shows a list of titles instead of a shelf, walk these in order:"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "The most-read articles across Standard this week."
@@ -444,6 +452,10 @@ msgstr ""
 msgid "If the site publishes in the open format but has not been indexed yet, the extension reads the page's own record hints and subscribes anyway."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A page is an image your post's body renders, and they are flipped through in the order they appear in the post. One image per post is the usual shape and the one everything here is tuned for, but a post carrying three images contributes three pages, in order — useful for posting a whole issue at once."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Open"
 msgstr "打开"
@@ -550,6 +562,10 @@ msgstr ""
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "New collection…"
 msgstr "新建合集…"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Fray In The Veil #2, Pg. 7</0> — series, issue, page."
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "We may update this policy as the product changes. The “Last updated” date at the top will change when we do. Continued use of the site after an update means you accept the revised policy."
@@ -811,6 +827,10 @@ msgstr "此列表为空。"
 msgid "Play voice sample"
 msgstr "播放语音样本"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Is the forwards-reading setting saved?</0> This is the one that is almost always the answer. Check it in your publishing tool, and note that it lives on the publication, not on individual posts."
+msgstr ""
+
 #: src/components/reader/subscribe-card.tsx
 msgid "You're subscribed"
 msgstr "你已订阅"
@@ -840,6 +860,10 @@ msgstr "{0} 分钟阅读"
 
 #: src/components/user-settings-view.tsx
 msgid "Infinite scroll keeps pulling the next page as you reach the end of a list. Load more waits for you to ask."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Alt text on a comic page is the page, for anyone who cannot see it — in the theater there is no surrounding article to fall back on, so whatever you wrote is the whole experience. It is also what your comic is found by in search."
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -1172,6 +1196,11 @@ msgstr ""
 msgid "the directory of every publication the network knows about."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "How readers pick it back up"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "A list is a folder for publications — <0>Work</0>, <1>Fiction</1>, <2>Read on Sunday</2>, whatever is useful. Lists appear as their own groups in the sidebar, so you can read one part of your follows without the rest."
 #~ msgstr ""
@@ -1427,6 +1456,10 @@ msgstr "热门刊物"
 msgid "Replace cover image"
 msgstr "替换封面图"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Are your last 40 posts mostly art?</0> A run of text posts — Kickstarter updates, con reports — can tip a comic under the line until the art resumes."
+msgstr ""
+
 #: src/lib/guide/navigation.ts
 #~ msgid "Sign in, follow your first publications, and find your way around."
 #~ msgstr ""
@@ -1522,6 +1555,10 @@ msgstr "嵌入内容"
 #: src/components/user-settings-view.tsx
 msgid "Account"
 msgstr "账户"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "There is no “this is a comic” switch anywhere on the network, and nothing to set on Standard Reader — we do not host your publication. Two things have to be true instead."
+msgstr ""
 
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
@@ -2014,6 +2051,10 @@ msgstr "为什么收录这篇？（支持 markdown）"
 msgid "Sign in, subscribe to a few publications, and learn where everything lives. Ten minutes, once."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The theater treats the whole publication as one book. Page numbers run straight through from your first page to your latest, so a reader who holds down the arrow key walks the entire run without stopping at the end of every issue. Arrow keys, space, Page Up and Page Down all turn pages; Home and End jump to either end; on a phone the outer edges of the screen turn pages, a swipe does too, and pinch-to-zoom gets a reader into a dense panel. There is a full-screen toggle on the <0>f</0> key. Past the last page is a back cover telling them they are caught up and inviting them to subscribe."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "{count, plural, one {# upvote} other {# upvotes}} — click to upvote"
 msgstr "{count, plural, one {# 次赞同} other {# 次赞同}} — 点击赞同"
@@ -2030,6 +2071,10 @@ msgstr "阅读"
 #: src/components/reader/comments/add-comment-dialog.tsx
 #~ msgid "Discussion here is gathered from posts across the network, so you comment wherever you already post. Yours joins this article once the network indexes it."
 #~ msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A post with no images contributes nothing to flip through, so it does not get a cover on the shelf and cannot be paged to: an announcement, a hiatus note, or a con schedule lives in the archive's read and unread views rather than in the book. If a text post matters to the story, give it a piece of art and it becomes a page like any other."
+msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "An HttpOnly session cookie that keeps you signed in."
@@ -2108,6 +2153,11 @@ msgstr ""
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "<0><1>Markpub</1> (recommended).</0> <2>at.markpub.markdown</2> — markdown with facets for rich text. It's not part of the site.standard spec either — no markdown format is — but it's the only one that's actually spec'd in a meaningful, reusable way, rather than one app's own ad hoc shape. Use this for a hand-rolled integration unless you already produce one of the platform formats below."
 msgstr "<0><1>Markpub</1>（推荐）。</0> <2>at.markpub.markdown</2> —— 带 facet 的 markdown，支持富文本。它同样不属于 site.standard 规范——没有任何 markdown 格式属于——但它是唯一真正以有意义、可复用的方式定义的格式，而不是某个应用自创的临时结构。除非你已经在产出下面某种平台格式，否则手工集成时请用它。"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What counts as a page"
+msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Hide read articles"
@@ -2405,6 +2455,10 @@ msgstr "正在设置该期"
 msgid "Feed preferences"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A single post whose title breaks the pattern does not split an issue in two. An interstitial in the middle of issue 3 joins issue 3, and a one-off announcement will not start a phantom issue of its own."
+msgstr ""
+
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Set API_DOCS_FIXTURE_LIST_URI to run this example."
 msgstr "设置 API_DOCS_FIXTURE_LIST_URI 后即可运行此示例。"
@@ -2598,6 +2652,11 @@ msgstr ""
 msgid "RSS feed"
 msgstr "RSS 源"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Naming issues and pages"
+msgstr ""
+
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
 #~ msgid "Run a labeler"
@@ -2759,6 +2818,10 @@ msgstr "几项偏好设置"
 
 #: src/routes/_layout.friends.tsx
 msgid "We couldn't reach Bluesky to look up who you follow. Reload in a moment, or browse the directory in the meantime."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Keep the essay for its own post"
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -3436,6 +3499,11 @@ msgstr ""
 msgid "<0>Share</0> copies a link, or posts the article to Bluesky with a proper preview card. On a phone it can hand off to whatever you normally share with."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Turning the comic view on"
+msgstr ""
+
 #: src/components/reader/article-below-fold.tsx
 msgid "Worth subscribing to"
 msgstr "值得订阅"
@@ -3506,6 +3574,11 @@ msgstr ""
 msgid "A publication on Standard is a <0>site.standard.document</0> record in the author's AT Protocol repository — not a row in a database we own. Standard Reader indexes those records into a public read-model and renders them, but nothing about the format is proprietary: the schemas are open, the content is portable across publishing platforms, and the same renderer we ship is available to you."
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "The words beside the art"
+msgstr ""
+
 #: src/components/labelers-settings-view.tsx
 #: src/routes/_layout.latest.tsx
 msgid "On the network"
@@ -3525,6 +3598,11 @@ msgstr "一处安静的阅读之地"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Add publications or people, then <0>Create list</0>."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "When it still reads as a blog"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -3621,6 +3699,10 @@ msgstr "更多操作"
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Readers who would rather not get the magazine treatment can turn <0>Open collections in magazine</0> off in <1>settings</1>, and collection articles open in the ordinary reader instead."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Covers are drawn in a 2:3 frame — the standard trade-paperback shape — and art is scaled to fill it, so anything much wider or squarer gets cropped at the edges. If your logo or your title lettering sits near the very edge of a landscape cover, expect it to be trimmed on the shelf. The full page is untouched in the reader; this only affects the thumbnail."
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -3750,6 +3832,10 @@ msgstr "本周热门"
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "The login screen links out to create one. Any account on the network works — you do not have to use Bluesky itself, and you do not have to post anything."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "If all of that is true and your comic still reads as a blog, tell us on the feedback board with a link to the publication — that is a bug on our side, and worth hearing about."
 msgstr ""
 
 #: src/routes/_layout.u.$did.tsx
@@ -3976,6 +4062,10 @@ msgstr ""
 msgid "We couldn’t find that publication."
 msgstr "找不到该刊物。"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Your posts have to read as pages.</0> We look at your 40 newest posts and count the ones that render at least one image and carry no more than about 700 words of prose. If at least 60% of them do, the publication is a comic. If they do not, it is treated as a serialized book — still read front-to-back, but as articles with an <1>Up next</1> link rather than as pages of art."
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Generating audio… {percent}%"
 msgstr "正在生成音频… {percent}%"
@@ -4000,6 +4090,10 @@ msgstr "未读"
 #: src/components/guide/pages/collections-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "How readers see it"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Standard Reader has a reading mode built for comics — a shelf of covers instead of a list of post titles, and a full-screen theater that flips through your pages. You do not author anything specially for it. This page is how to make sure your comic gets it."
 msgstr ""
 
 #. placeholder {0}: filter.trim()
@@ -4185,6 +4279,10 @@ msgstr ""
 msgid "On any page you visit"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The current page lives in the address bar, so a reader can link someone straight to a page, and reopening the comic puts them back where they stopped."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Partly removed"
 msgstr ""
@@ -4193,6 +4291,10 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Delete list"
 msgstr "删除列表"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The one part that is required is the hash before the issue number — a bare number in a title is never read as an issue, because too many ordinary titles start with one. After the number you can use a comma, a colon, a dash, or nothing at all; everything following it is treated as the page label and is not otherwise parsed, so write it however you like."
+msgstr ""
 
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "What the extension can see and what it does with it is written out in full on the <0>extension privacy page</0>."
@@ -4222,6 +4324,10 @@ msgstr "推荐文章"
 
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Getting a shelf but not issues?</0> Then the setting is right and it is the titles: check that at least 7 in 10 carry a hash and an issue number."
 msgstr ""
 
 #: src/components/labeler-detail-view.tsx
@@ -4359,6 +4465,10 @@ msgstr "朗读音色"
 msgid "Sharp"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "An issue is fronted by the page whose title says it is the cover — anything with the word <0>cover</0> in the page label. <1>Inner cover</1> is deliberately not treated as one, since it is the leaf behind the cover rather than the cover itself. When no page claims it, the issue's first page fronts it, which is what the reader sees on opening anyway."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "What you get is a reading view made for long-form: a centered column, drop caps and pull quotes, full-bleed images you can open into a gallery. The page gets out of the way so the writing can do its work."
 msgstr "你得到的是一个为长文而生的阅读视图：居中的正文栏、首字下沉与引文块、可展开为画廊的通栏大图。页面退到一旁，让文字自己发声。"
@@ -4445,6 +4555,10 @@ msgstr ""
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #~ msgid "Make one with <0>New list</0> in the sidebar, or add a publication to a list from its <1>Add to list</1> menu. A publication can be in as many lists as you like, and being in a list does not change your feeds — it only changes how they are grouped."
 #~ msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "In practice this means a reader who subscribes mid-run can come back after a month and land exactly where they stopped, which is the single biggest thing that keeps people reading a serial. Readers who have turned reading history off see no dots — nothing is tracked for them — and readers who are not signed in see the shelf as a stranger would."
+msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
@@ -4724,6 +4838,10 @@ msgstr "介绍一下这个合集……（支持 markdown）"
 msgid "Filter"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "A comic publication gets two things an ordinary blog does not. Its page shows a <0>shelf of covers</0> — your art, at trade-paperback proportions — rather than dozens of near-identical rows reading <1>Pg. 1</1>, <2>Pg. 2</2>, <3>Pg. 3</3>. And opening one drops the reader into the <4>comic reader</4>: a dark, chrome-free theater holding one page at a time."
+msgstr ""
+
 #: src/components/reader/friend-publishers.tsx
 msgid "Bluesky didn't answer in time, so this list may be incomplete. Reload to try again."
 msgstr ""
@@ -4778,6 +4896,11 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "个人资料设置"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Publishing a comic"
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "The first time you sign in, a short setup walks you through it: pick a few topics you care about, see which of the people you already follow on Bluesky write here, follow anything that appeals, and choose how you like your text. You can skip any step, and skip the whole thing."
@@ -5122,6 +5245,10 @@ msgstr ""
 #: src/components/docs/docs-renderers-nav.tsx
 #: src/components/docs/renderers-docs-page.tsx
 msgid "Resolving platform data"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Your publication has to say it reads forwards.</0> That is a setting on the publication itself, in whatever tool you publish with — the one that says the work is read from its first post rather than newest-first. In the underlying record it is <1>preferences.prevNextDirection</1> set to <2>ltr</2>. Leaflet writes this field; if you roll your own records, see <3>Publishing your site</3>. Without it a comic is just a blog that happens to post drawings."
 msgstr ""
 
 #: src/components/reader/comments/add-comment-dialog.tsx
@@ -5669,6 +5796,10 @@ msgstr ""
 msgid "Articles you've recommended across the network."
 msgstr "你在全网推荐过的文章。"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "One thing worth knowing: if a paragraph of your post body repeats a page's alt text word for word, we drop it from the note rather than showing the reader a description of the picture they are looking at. So transcribing your dialogue into the alt and again into the body does not double up."
+msgstr ""
+
 #: src/routes/_layout.feedback.return.tsx
 msgid "View feedback"
 msgstr "查看反馈"
@@ -5991,6 +6122,10 @@ msgstr "文档"
 msgid "The core / new frameworks"
 msgstr ""
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Both are re-checked as your archive grows, and the setting is picked up the first time anyone opens your publication after you change it — you do not have to tell us. Being read as a book rather than a comic is never a dead end for a reader: every route into the comic reader also links to the ordinary reading view, and an issue with no art falls back to it outright."
+msgstr ""
+
 #. placeholder {0}: index + 1
 #: src/components/comic/comic-reader.tsx
 msgid "Page {0}"
@@ -6171,6 +6306,11 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 #~ msgid "A lightweight browser extension lets you save and subscribe to publications while you’re out on the web — with subtle badges on bsky.app and a one-click overlay on any page you land on. Your reading list fills itself."
 #~ msgstr "轻量的浏览器扩展让你在网上浏览时随手保存和订阅刊物——在 bsky.app 上显示低调的徽标，在你访问的任何页面上提供一键浮层。你的阅读清单会自己充实起来。"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Alt text"
+msgstr ""
 
 #: src/components/docs/docs-nav-areas.ts
 msgid "Introduction"
@@ -6356,6 +6496,10 @@ msgstr ""
 msgid "Reading & privacy"
 msgstr "阅读与隐私"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Grouping is all-or-nothing per publication: at least 70% of your titles have to parse before we trust the numbers enough to group by them. If they do not — a webcomic naming its posts <0>Pg01</0>, <1>Pg02</1> has no issues to speak of — you still get a shelf, just one cover per post instead of one per issue. That is a fine way to run a comic; it is not a failure state."
+msgstr ""
+
 #: src/components/Header.tsx
 #: src/components/reader/app-shell.tsx
 #: src/components/site-legal-links.tsx
@@ -6471,6 +6615,11 @@ msgstr "编辑部"
 msgid "Click Run example to fetch a live response with your session."
 msgstr "点击「运行示例」，用你的会话获取实时响应。"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What readers get"
+msgstr ""
+
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "At the bottom of settings, <0>Personal data</0> deletes categories of records outright: your reading history, your saved articles, or the publication lists you made. Each asks for confirmation and explains what will change."
 msgstr ""
@@ -6559,6 +6708,10 @@ msgstr ""
 #: src/routes/_layout.p.$did.$rkey.tsx
 #~ msgid "Open publication"
 #~ msgstr "打开刊物"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>Do your recent posts render their art in the body?</0> A post that only links to the page on your site, or that carries the drawing as a cover image with an empty body, has no pages to flip."
+msgstr ""
 
 #: src/components/reader/link-share-menu.tsx
 msgid "Send to Disperse"
@@ -6680,6 +6833,10 @@ msgstr "{articleCount, plural, one {篇文章} other {篇文章}}"
 msgid "{publicationName} is in your feed. You'll see new writing as it publishes."
 msgstr "{publicationName} 已加入你的信息流。有新文章发布时你会看到。"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Read state is per post, and your posts are pages, so an issue counts as unread while any page in it is — a comic read halfway through is not read. Its cover wears the same unread dot an unread article does, and clicking it opens on the first page that reader has not seen, not back at the cover. Walking pages in the theater marks them off behind them."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Upgrade permissions"
 msgstr "升级权限"
@@ -6740,6 +6897,10 @@ msgstr "该刊物已选择不出现在发现页，因此除了你自己的主页
 msgid "{count, plural, one {# upvote} other {# upvotes}} — sign in to upvote"
 msgstr "{count, plural, one {# 个赞} other {# 个赞}}——登录后可点赞"
 
+#: src/lib/guide/navigation.ts
+msgid "Get a shelf of covers and a page-flip reader out of the pages you already post."
+msgstr ""
+
 #: src/components/onboarding/step-friends.tsx
 #~ msgid "Select all"
 #~ msgstr ""
@@ -6748,9 +6909,17 @@ msgstr "{count, plural, one {# 个赞} other {# 个赞}}——登录后可点赞
 msgid "For how {SITE_NAME} works overall, see <0>About</0>. For site-wide privacy, see the <1>site privacy policy</1>. For questions about this deployment, contact the operator of {siteHost}."
 msgstr "想了解 {SITE_NAME} 的整体运作方式，请查看<0>关于</0>。站点级隐私说明请参见<1>站点隐私政策</1>。有关本部署的问题，请联系 {siteHost} 的运营者。"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The counter reads <0>Page 12 of 340</0> across the whole publication, not within one issue. That means inserting or removing a page in an early issue renumbers everything after it — worth knowing before you go back and edit an old post that readers may have linked to."
+msgstr ""
+
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Your account and data"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "The prose length is also what separates a comic from an illustrated blog: a post carrying more than about 700 words stops counting as a page of comic, and if most of your posts are like that the publication reads as a book instead. A long process essay is better as its own post — which readers will find in the archive — than appended to a page."
 msgstr ""
 
 #: src/routes/review.thanks.tsx
@@ -6878,6 +7047,10 @@ msgstr "图标"
 msgid "Top"
 msgstr "热门"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Most cartoonists write a line or two under the page — a caption, a process note, a word about next week. That writing is not lost in the theater. If a page's post carries prose, the note button in the top bar lights up and lays it over the art, in the theater's own type, with a way through to the full post. It closes when the reader turns the page, because it belongs to the page it was written about."
+msgstr ""
+
 #: src/components/reader/page-reader-bar.tsx
 msgid "Read aloud"
 msgstr "朗读"
@@ -6911,6 +7084,10 @@ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Subscribe to the publication it came from, in the same click."
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "<0>FITV #1 Cover</0> — the same, with a page label instead of a number."
 msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
@@ -7145,6 +7322,10 @@ msgstr "已关注"
 msgid "Opening the issue…"
 msgstr "正在打开本期…"
 
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Pages with nothing written under them leave the button disabled rather than making it appear and vanish as the reader flips, so there is no penalty for a silent page."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "However you like to read it"
 msgstr ""
@@ -7318,6 +7499,11 @@ msgstr "开启后，订阅刊物时其全部历史文章都会计为未读。关
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this reply on Bluesky"
 msgstr "在 Bluesky 上打开这条回复"
+
+#: src/components/guide/pages/comics-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Cover art"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "what your corner of Bluesky reads."
@@ -7555,6 +7741,10 @@ msgstr ""
 
 #: src/routes/mcp/authorize.tsx
 msgid "Signed in as"
+msgstr ""
+
+#: src/components/guide/pages/comics-guide-page.tsx
+msgid "Page numbers are absolute"
 msgstr ""
 
 #: src/components/guide/pages/collections-guide-page.tsx

--- a/apps/standard-reader/src/routeTree.gen.ts
+++ b/apps/standard-reader/src/routeTree.gen.ts
@@ -48,6 +48,7 @@ import { Route as DocsHeaderLayoutDocsPublishingRouteImport } from './routes/_do
 import { Route as DocsHeaderLayoutDocsRenderersRouteImport } from './routes/_docs-header-layout.docs.renderers'
 import { Route as GuideLayoutGuideIndexRouteImport } from './routes/_guide-layout.guide.index'
 import { Route as GuideLayoutGuideCollectionsRouteImport } from './routes/_guide-layout.guide.collections'
+import { Route as GuideLayoutGuideComicsRouteImport } from './routes/_guide-layout.guide.comics'
 import { Route as GuideLayoutGuideExtensionRouteImport } from './routes/_guide-layout.guide.extension'
 import { Route as GuideLayoutGuideFindingRouteImport } from './routes/_guide-layout.guide.finding'
 import { Route as GuideLayoutGuideGettingStartedRouteImport } from './routes/_guide-layout.guide.getting-started'
@@ -316,6 +317,11 @@ const GuideLayoutGuideCollectionsRoute =
     path: '/guide/collections',
     getParentRoute: () => GuideLayoutRoute,
   } as any)
+const GuideLayoutGuideComicsRoute = GuideLayoutGuideComicsRouteImport.update({
+  id: '/guide/comics',
+  path: '/guide/comics',
+  getParentRoute: () => GuideLayoutRoute,
+} as any)
 const GuideLayoutGuideExtensionRoute =
   GuideLayoutGuideExtensionRouteImport.update({
     id: '/guide/extension',
@@ -694,6 +700,7 @@ export interface FileRoutesByFullPath {
   '/docs/publishing': typeof DocsHeaderLayoutDocsPublishingRoute
   '/docs/renderers': typeof DocsHeaderLayoutDocsRenderersRoute
   '/guide/collections': typeof GuideLayoutGuideCollectionsRoute
+  '/guide/comics': typeof GuideLayoutGuideComicsRoute
   '/guide/extension': typeof GuideLayoutGuideExtensionRoute
   '/guide/finding': typeof GuideLayoutGuideFindingRoute
   '/guide/getting-started': typeof GuideLayoutGuideGettingStartedRoute
@@ -797,6 +804,7 @@ export interface FileRoutesByTo {
   '/docs/publishing': typeof DocsHeaderLayoutDocsPublishingRoute
   '/docs/renderers': typeof DocsHeaderLayoutDocsRenderersRoute
   '/guide/collections': typeof GuideLayoutGuideCollectionsRoute
+  '/guide/comics': typeof GuideLayoutGuideComicsRoute
   '/guide/extension': typeof GuideLayoutGuideExtensionRoute
   '/guide/finding': typeof GuideLayoutGuideFindingRoute
   '/guide/getting-started': typeof GuideLayoutGuideGettingStartedRoute
@@ -905,6 +913,7 @@ export interface FileRoutesById {
   '/_docs-header-layout/docs/publishing': typeof DocsHeaderLayoutDocsPublishingRoute
   '/_docs-header-layout/docs/renderers': typeof DocsHeaderLayoutDocsRenderersRoute
   '/_guide-layout/guide/collections': typeof GuideLayoutGuideCollectionsRoute
+  '/_guide-layout/guide/comics': typeof GuideLayoutGuideComicsRoute
   '/_guide-layout/guide/extension': typeof GuideLayoutGuideExtensionRoute
   '/_guide-layout/guide/finding': typeof GuideLayoutGuideFindingRoute
   '/_guide-layout/guide/getting-started': typeof GuideLayoutGuideGettingStartedRoute
@@ -1011,6 +1020,7 @@ export interface FileRouteTypes {
     | '/docs/publishing'
     | '/docs/renderers'
     | '/guide/collections'
+    | '/guide/comics'
     | '/guide/extension'
     | '/guide/finding'
     | '/guide/getting-started'
@@ -1114,6 +1124,7 @@ export interface FileRouteTypes {
     | '/docs/publishing'
     | '/docs/renderers'
     | '/guide/collections'
+    | '/guide/comics'
     | '/guide/extension'
     | '/guide/finding'
     | '/guide/getting-started'
@@ -1221,6 +1232,7 @@ export interface FileRouteTypes {
     | '/_docs-header-layout/docs/publishing'
     | '/_docs-header-layout/docs/renderers'
     | '/_guide-layout/guide/collections'
+    | '/_guide-layout/guide/comics'
     | '/_guide-layout/guide/extension'
     | '/_guide-layout/guide/finding'
     | '/_guide-layout/guide/getting-started'
@@ -1624,6 +1636,13 @@ declare module '@tanstack/react-router' {
       path: '/guide/collections'
       fullPath: '/guide/collections'
       preLoaderRoute: typeof GuideLayoutGuideCollectionsRouteImport
+      parentRoute: typeof GuideLayoutRoute
+    }
+    '/_guide-layout/guide/comics': {
+      id: '/_guide-layout/guide/comics'
+      path: '/guide/comics'
+      fullPath: '/guide/comics'
+      preLoaderRoute: typeof GuideLayoutGuideComicsRouteImport
       parentRoute: typeof GuideLayoutRoute
     }
     '/_guide-layout/guide/extension': {
@@ -2114,6 +2133,7 @@ const DocsHeaderLayoutRouteWithChildren =
 
 interface GuideLayoutRouteChildren {
   GuideLayoutGuideCollectionsRoute: typeof GuideLayoutGuideCollectionsRoute
+  GuideLayoutGuideComicsRoute: typeof GuideLayoutGuideComicsRoute
   GuideLayoutGuideExtensionRoute: typeof GuideLayoutGuideExtensionRoute
   GuideLayoutGuideFindingRoute: typeof GuideLayoutGuideFindingRoute
   GuideLayoutGuideGettingStartedRoute: typeof GuideLayoutGuideGettingStartedRoute
@@ -2128,6 +2148,7 @@ interface GuideLayoutRouteChildren {
 
 const GuideLayoutRouteChildren: GuideLayoutRouteChildren = {
   GuideLayoutGuideCollectionsRoute: GuideLayoutGuideCollectionsRoute,
+  GuideLayoutGuideComicsRoute: GuideLayoutGuideComicsRoute,
   GuideLayoutGuideExtensionRoute: GuideLayoutGuideExtensionRoute,
   GuideLayoutGuideFindingRoute: GuideLayoutGuideFindingRoute,
   GuideLayoutGuideGettingStartedRoute: GuideLayoutGuideGettingStartedRoute,

--- a/apps/standard-reader/src/routes/_guide-layout.guide.comics.tsx
+++ b/apps/standard-reader/src/routes/_guide-layout.guide.comics.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { getPublicUrlClient } from "#/lib/public-url";
+import { pageSocialMeta } from "#/lib/site-metadata";
+
+import { ComicsGuidePage } from "../components/guide/pages/comics-guide-page";
+
+export const Route = createFileRoute("/_guide-layout/guide/comics")({
+  head: () => ({
+    meta: pageSocialMeta("guideComics", getPublicUrlClient()),
+  }),
+  component: ComicsGuidePage,
+});


### PR DESCRIPTION
Adds `/guide/comics` — **Publishing a comic** — a reader-guide page written for the person making the comic rather than the person reading it.

## Why

Everything the comic view does is derived, not declared. The shelf of covers, the page-flip theater and the grouping into issues all fall out of one publisher setting, the shape of a post, and a title convention — none of which has a lexicon field to point at. A cartoonist whose comic is reading as an ordinary blog currently has nothing to check their own archive against.

## What the page covers

- **What readers get** — the shelf, the theater, publication-wide page numbering, every paging input, `f` for full screen, the back cover.
- **Turning it on** — the two conditions: `preferences.prevNextDirection: "ltr"` on the publication, and the content test (`COMIC_PAGE_SHARE` / `SERIAL_SAMPLE_SIZE` / `COMIC_PAGE_MAX_TEXT_LENGTH` — 60% of the 40 newest posts rendering an image with ≤ ~700 words of prose).
- **What counts as a page** — body images in order, multi-image posts, text-only posts getting no cover, and a callout that page numbers are absolute so editing an old issue renumbers everything after it.
- **Naming issues and pages** — the `Series #2, Pg. 7` convention, the required `#`, the 70% match share (`ISSUE_TITLE_MATCH_SHARE`), and that a stray title joins its surrounding issue rather than splitting it.
- **Cover art** — `cover` in the page label wins (`inner cover` deliberately doesn't), and the 2:3 crop trimming wide art.
- **Notes and alt text** — the note overlay, why a long note reclassifies the publication as a book, and that body paragraphs duplicating a page's alt are subtracted from the note.
- **Read state** — per-page unread, covers opening on the first unseen page.
- **Troubleshooting** — a checklist in the order the answers are usually found.

The thresholds are stated as numbers on purpose: "mostly art" is not something an author can measure their own run against, and those numbers are the whole difference between a shelf of covers and a list of titles.

## Notes

- New guide area wired through `src/lib/guide/navigation.ts`, so the sidebar, the "On this page" rail, the mobile jump menu, the scroll-spy, the welcome-page card and the prev/next footer all pick it up from the one manifest.
- No screenshot: the shot manifest has no comic fixture path, and a declared-but-uncaptured shot renders nothing.
- The forwards-reading setting is described by what it means rather than by Leaflet's UI label, which I could not verify.
- `APP_VISION.md` and `TODO.md` updated in the same change.

## Testing

- `pnpm typecheck` clean, `oxlint` 0 warnings, `oxfmt --check` clean.
- `i18n:extract` adds 190 lines per catalog and nothing else; catalogs compiled.
- Rendered against a dev server: `/guide/comics` returns 200 SSR'd with the right `<title>`, every section present, and the sidebar link showing up on the neighbouring guide pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)