### PR TITLE
Let readers pull down to refresh a feed

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -39,7 +39,9 @@ things you already subscribe to.
   way to keep discovering new voices.
 - **Platform:** responsive web — desktop (persistent left sidebar) and mobile (top bar +
   bottom tab nav). The mobile top bar scrolls away with the page and slides back in on any
-  scroll up, so reading gets the full screen without losing the way out. Same codebase,
+  scroll up, so reading gets the full screen without losing the way out. Every feed and
+  directory pulls to refresh from the top of the page — the gesture readers already expect
+  from a phone, refetching in place rather than reloading the document. Same codebase,
   same components. **Browser extension** (WXT, MV3) as a capture + bridge client for
   save/follow while browsing.
 

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -540,6 +540,24 @@ Build each on hip-ui components + StyleX tokens (no raw HTML/inline styles).
       reads it to pull itself up by its own measured height — so back/byline/actions leave
       with the app bar and the only thing left against the top of the screen is the reading
       progress track. ([Mobile Screen Real-Estate](https://userinput.app/d/did:plc:3x5npw4cb2twifyqcox7jmqj/3mrwcpbgousq2))
+- [x] **Pull to refresh** — every feed and directory refreshes with the gesture a phone
+      already taught the reader: Home, Latest, Discover, Saved, History, Search, Tag,
+      Topics (index + slug), Subscriptions, Friends, Recommended, Collections, and the
+      list / publication / profile pages. Routes opt in with `usePullToRefresh()`
+      (`components/reader/pull-to-refresh.tsx`), which registers into a store the shell's
+      `PullToRefreshLane` subscribes to — a store, not context state, so a navigation
+      doesn't re-render the whole shell to swap handlers. The default handler runs
+      `router.invalidate()` alongside `refetchQueries({ type: "active" })`, so the page
+      refetches in place and keeps scroll position and local UI state; a route can pass its
+      own. Reading views, settings and the static pages are deliberately left out.
+      Mechanics live in `lib/use-pull-gesture.ts` + `lib/pull-gesture.ts`: pull distance is
+      rubber-banded toward a 120px asymptote and written straight to the DOM per frame
+      (only the phase goes through React), a flick commits short of the 64px threshold,
+      and the gesture is handed back on a horizontal drag, a second finger, a scrolled page,
+      or a touch inside a dialog. `touchstart` is passive and bails in two comparisons; the
+      non-passive `touchmove` only goes on once a touch qualifies, so the rest of the app
+      never carries a scroll-blocking listener. `overscroll-behavior: none` (already set in
+      `styles.css`) means the browser's own pull-to-refresh isn't competing for the gesture.
 - [x] **Home** — masthead (date + unread count), featured lead, latest unread rows, right rail (Trending articles + You might follow).
 - [x] **Latest** — chronological list, segmented Unread / Subscriptions / All-network filter with counts (Unread = unread docs from subs, Subscriptions = all docs from subs, All = whole network).
 - [x] **Discover** — Trending / Topics / Recommended / Followed-by-people-you-follow / All (chips, sort, grid⇄list toggle).

--- a/apps/standard-reader/src/components/reader/app-shell.tsx
+++ b/apps/standard-reader/src/components/reader/app-shell.tsx
@@ -90,6 +90,7 @@ import { LanguageHintPrompt } from "./language-hint-prompt";
 import { ListEditModal } from "./list-edit-modal";
 import { PageReaderBar } from "./page-reader-bar";
 import { PublicationThemeScope } from "./publication-theme-scope";
+import { PullToRefreshLane } from "./pull-to-refresh";
 import {
   SelectionDockProvider,
   useSelectionDock,
@@ -1445,6 +1446,11 @@ export function AppShell({ children }: { children: React.ReactNode }) {
                 </div>
               </Flex>
             )}
+
+            {/* Sits between the bar and the content it refreshes, which is
+                where the gesture opens a gap. Zero-height, so it costs the
+                layout nothing while the page is at rest. */}
+            <PullToRefreshLane />
 
             <div {...stylex.props(styles.scroller)}>
               {/* The footer sits inside the themed region so a publication's

--- a/apps/standard-reader/src/components/reader/pull-to-refresh.tsx
+++ b/apps/standard-reader/src/components/reader/pull-to-refresh.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useLingui } from "@lingui/react/macro";
+import { animationDuration } from "@standard-reader/design-system/theme/animations.stylex";
+import {
+  primaryColor,
+  uiColor,
+} from "@standard-reader/design-system/theme/color.stylex";
+import { radius } from "@standard-reader/design-system/theme/radius.stylex";
+import { size } from "@standard-reader/design-system/theme/semantic-spacing.stylex";
+import { shadow } from "@standard-reader/design-system/theme/shadow.stylex";
+import { spacing } from "@standard-reader/design-system/theme/spacing.stylex";
+import * as stylex from "@stylexjs/stylex";
+import { useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "@tanstack/react-router";
+import { RefreshCw } from "lucide-react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+
+import { useCompactNav } from "#/lib/use-media-query";
+import { usePullGesture } from "#/lib/use-pull-gesture";
+
+/** Mirrors the `DESKTOP` breakpoint in `app-shell.tsx`. */
+const DESKTOP = "@media (min-width: 60rem)";
+
+type RefreshHandler = () => Promise<unknown>;
+
+/**
+ * One page at a time owns the pull gesture. The registry is a store rather than
+ * context state on purpose: the handler changes on every navigation, and pushing
+ * that through context would re-render the whole shell — sidebar, nav and all —
+ * a second time after each route commits. Only the indicator subscribes.
+ */
+interface PullToRefreshStore {
+  getHandler: () => RefreshHandler | null;
+  register: (handler: RefreshHandler) => () => void;
+  subscribe: (listener: () => void) => () => void;
+}
+
+function createPullToRefreshStore(): PullToRefreshStore {
+  let handler: RefreshHandler | null = null;
+  const listeners = new Set<() => void>();
+
+  const emit = () => {
+    for (const listener of listeners) listener();
+  };
+
+  return {
+    getHandler: () => handler,
+    register(next) {
+      handler = next;
+      emit();
+      return () => {
+        // A route that has already been replaced must not clear its successor's
+        // handler — during a transition both are mounted for a moment.
+        if (handler !== next) return;
+        handler = null;
+        emit();
+      };
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}
+
+const PullToRefreshContext = createContext<PullToRefreshStore | null>(null);
+
+export function PullToRefreshProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [store] = useState(createPullToRefreshStore);
+  return (
+    <PullToRefreshContext.Provider value={store}>
+      {children}
+    </PullToRefreshContext.Provider>
+  );
+}
+
+/**
+ * Refetch whatever the page is currently showing: the route's loaders plus every
+ * query mounted under it, which on this app also covers the shell's own unread
+ * counts and subscription list. Scroll position and local UI state survive,
+ * which a document reload would not.
+ */
+function useDefaultRefresh(): RefreshHandler {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  return useCallback(
+    async () =>
+      Promise.all([
+        router.invalidate(),
+        queryClient.refetchQueries({ type: "active" }),
+      ]),
+    [queryClient, router],
+  );
+}
+
+/**
+ * Opt a page into pull-to-refresh. Call it from the route component; the
+ * gesture is live for as long as that component is mounted, and only at the
+ * widths where the shell shows its compact chrome.
+ *
+ * Pass a handler to refresh something specific — otherwise the page refetches
+ * its own route data (see {@link useDefaultRefresh}).
+ */
+// eslint-disable-next-line react/only-export-components -- consumed by route components
+export function usePullToRefresh(handler?: RefreshHandler): void {
+  const store = useContext(PullToRefreshContext);
+  const fallback = useDefaultRefresh();
+  // Read through a ref so a handler that changes identity every render — most
+  // inline arrow functions do — doesn't churn the registration.
+  const latest = useRef<RefreshHandler>(handler ?? fallback);
+  latest.current = handler ?? fallback;
+
+  useEffect(() => {
+    if (!store) return;
+    return store.register(async () => latest.current());
+  }, [store]);
+}
+
+const spin = stylex.keyframes({
+  from: { transform: "rotate(0deg)" },
+  to: { transform: "rotate(360deg)" },
+});
+
+const styles = stylex.create({
+  // Zero-height and in normal flow, directly under the mobile top bar: the
+  // gesture only runs at a scroll offset of 0, so the chip is pinned to the
+  // viewport for as long as it is on screen without any of the layer promotion
+  // an actually-fixed element would cost (see the note on `dock` in app-shell).
+  lane: {
+    display: { [DESKTOP]: "none", default: "flex" },
+    height: 0,
+    justifyContent: "center",
+    // The chip is a status indicator, never a target — taps belong to the page
+    // underneath it.
+    pointerEvents: "none",
+    position: "relative",
+    zIndex: 14,
+  },
+  chip: {
+    alignItems: "center",
+    backgroundColor: uiColor.bg,
+    borderColor: uiColor.border1,
+    borderRadius: radius.full,
+    borderStyle: "solid",
+    borderWidth: 1,
+    boxShadow: shadow.lg,
+    color: uiColor.text1,
+    display: "flex",
+    height: size["4xl"],
+    // Centred by its own insets rather than the lane's `justify-content`: the
+    // static position of an absolutely positioned flex child is a corner of the
+    // spec engines have disagreed about, and this reads the same in both
+    // writing directions.
+    insetInlineEnd: 0,
+    insetInlineStart: 0,
+    justifyContent: "center",
+    marginInlineEnd: "auto",
+    marginInlineStart: "auto",
+    // Resting state. The gesture writes transform/opacity inline while it runs
+    // and strips them again when it lands.
+    opacity: 0,
+    position: "absolute",
+    top: 0,
+    width: size["4xl"],
+  },
+  // Far enough to let go: the chip picks up the accent so the change of state is
+  // visible without looking away from the page.
+  chipArmed: {
+    borderColor: primaryColor.border2,
+    color: primaryColor.text2,
+  },
+  icon: {
+    alignItems: "center",
+    display: "flex",
+    justifyContent: "center",
+  },
+  iconSpinning: {
+    animationDuration: animationDuration.indeterminateCycle,
+    animationIterationCount: "infinite",
+    animationName: spin,
+    animationTimingFunction: "linear",
+  },
+  srOnly: {
+    borderWidth: 0,
+    clipPath: "inset(50%)",
+    height: spacing.px,
+    overflow: "hidden",
+    position: "absolute",
+    whiteSpace: "nowrap",
+    width: spacing.px,
+  },
+});
+
+/** Stand-ins for when the shell isn't there at all — embeds render standalone. */
+const noopSubscribe = () => () => {};
+const noopHandler = () => null;
+
+/**
+ * The pull indicator. Mounted once by the shell, just below the mobile top bar;
+ * it does nothing at all until a page registers a refresh handler.
+ *
+ * Deliberately not marked `aria-busy` — the perf suite treats a cleared
+ * `aria-busy` as "the page is ready" (`perf/lib/measure.ts`), and a refresh the
+ * reader asked for is not part of that first-paint contract.
+ */
+export function PullToRefreshLane() {
+  const { t } = useLingui();
+  const store = useContext(PullToRefreshContext);
+  const handler = useSyncExternalStore(
+    store?.subscribe ?? noopSubscribe,
+    store?.getHandler ?? noopHandler,
+    noopHandler,
+  );
+  const compactNav = useCompactNav();
+  const { chipRef, iconRef, phase } = usePullGesture({
+    enabled: compactNav && handler !== null,
+    onRefresh: handler,
+  });
+
+  return (
+    <div {...stylex.props(styles.lane)}>
+      <div
+        ref={chipRef}
+        aria-hidden
+        data-phase={phase}
+        {...stylex.props(styles.chip, phase === "armed" && styles.chipArmed)}
+      >
+        <span
+          ref={iconRef}
+          {...stylex.props(
+            styles.icon,
+            phase === "refreshing" && styles.iconSpinning,
+          )}
+        >
+          <RefreshCw size={18} />
+        </span>
+      </div>
+      <span role="status" {...stylex.props(styles.srOnly)}>
+        {phase === "refreshing" ? t`Refreshing` : ""}
+      </span>
+    </div>
+  );
+}

--- a/apps/standard-reader/src/lib/pull-gesture.test.ts
+++ b/apps/standard-reader/src/lib/pull-gesture.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_PULL,
+  PULL_THRESHOLD,
+  dampPull,
+  isVerticalPull,
+  pullProgress,
+  shouldCommitPull,
+} from "./pull-gesture";
+
+describe("dampPull", () => {
+  it("ignores upward movement", () => {
+    expect(dampPull(-40)).toBe(0);
+    expect(dampPull(0)).toBe(0);
+  });
+
+  it("tracks the finger almost exactly at the start of the pull", () => {
+    // The first few pixels have to feel connected — damping that bites
+    // immediately reads as lag.
+    expect(dampPull(4)).toBeGreaterThan(3.8);
+  });
+
+  it("gets heavier the further it is pulled", () => {
+    const first = dampPull(20) - dampPull(10);
+    const later = dampPull(120) - dampPull(110);
+    expect(later).toBeLessThan(first);
+  });
+
+  it("never travels past the ceiling, however hard it is pulled", () => {
+    // The curve approaches MAX_PULL asymptotically; far out along it the
+    // exponent underflows and it settles exactly on the ceiling.
+    expect(dampPull(400)).toBeLessThan(MAX_PULL);
+    expect(dampPull(400)).toBeGreaterThan(MAX_PULL - 6);
+    expect(dampPull(10_000)).toBeLessThanOrEqual(MAX_PULL);
+  });
+
+  it("still leaves the threshold reachable", () => {
+    // A threshold the damping curve can't get to would make the gesture
+    // impossible; 200px of finger travel has to be more than enough.
+    expect(dampPull(200)).toBeGreaterThan(PULL_THRESHOLD);
+  });
+});
+
+describe("pullProgress", () => {
+  it("runs 0 → 1 across the threshold and clamps there", () => {
+    expect(pullProgress(0)).toBe(0);
+    expect(pullProgress(PULL_THRESHOLD / 2)).toBeCloseTo(0.5);
+    expect(pullProgress(PULL_THRESHOLD)).toBe(1);
+    expect(pullProgress(PULL_THRESHOLD * 4)).toBe(1);
+  });
+});
+
+describe("shouldCommitPull", () => {
+  it("commits once the pull crosses the threshold", () => {
+    expect(
+      shouldCommitPull({
+        dampedDistance: PULL_THRESHOLD,
+        elapsedMs: 2000,
+        rawDistance: 90,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not commit a slow, short pull", () => {
+    expect(
+      shouldCommitPull({
+        dampedDistance: 30,
+        elapsedMs: 2000,
+        rawDistance: 32,
+      }),
+    ).toBe(false);
+  });
+
+  it("commits a quick flick that never reached the threshold", () => {
+    expect(
+      shouldCommitPull({
+        dampedDistance: 40,
+        elapsedMs: 120,
+        rawDistance: 44,
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores a fast twitch that barely moved", () => {
+    expect(
+      shouldCommitPull({
+        dampedDistance: 10,
+        elapsedMs: 20,
+        rawDistance: 10,
+      }),
+    ).toBe(false);
+  });
+
+  it("treats a zero-length gesture as no gesture", () => {
+    expect(
+      shouldCommitPull({ dampedDistance: 0, elapsedMs: 0, rawDistance: 0 }),
+    ).toBe(false);
+  });
+});
+
+describe("isVerticalPull", () => {
+  it("claims a downward drag", () => {
+    expect(isVerticalPull(2, 30)).toBe(true);
+  });
+
+  it("leaves horizontal swipes to the page", () => {
+    expect(isVerticalPull(40, 12)).toBe(false);
+    expect(isVerticalPull(-40, 12)).toBe(false);
+  });
+
+  it("leaves upward drags alone", () => {
+    expect(isVerticalPull(0, -30)).toBe(false);
+  });
+});

--- a/apps/standard-reader/src/lib/pull-gesture.ts
+++ b/apps/standard-reader/src/lib/pull-gesture.ts
@@ -1,0 +1,74 @@
+/**
+ * Geometry and arming rules for the pull-to-refresh gesture, kept apart from the
+ * hook so they can be exercised without a DOM.
+ */
+
+/**
+ * The furthest the indicator will ever travel. Raw finger distance is damped
+ * toward this asymptote, so the pull never hits a wall — it just gets heavier,
+ * which is what the gesture feels like everywhere else on a phone.
+ */
+export const MAX_PULL = 120;
+
+/** Damped distance at which letting go commits to a refresh. */
+export const PULL_THRESHOLD = 64;
+
+/** Where the indicator parks while the refresh runs. */
+export const PULL_REST = 56;
+
+/**
+ * Movement shorter than this is still ambiguous — it could become a scroll, a
+ * horizontal swipe, or a tap — so the gesture stays unclaimed until it is past.
+ */
+export const PULL_SLOP = 8;
+
+/**
+ * A quick flick should refresh even if it never travelled the full threshold.
+ * px/ms at release, paired with {@link FLICK_MIN_DISTANCE} so a stray twitch
+ * can't trip it.
+ */
+export const FLICK_VELOCITY = 0.11;
+export const FLICK_MIN_DISTANCE = 24;
+
+/**
+ * Rubber-banding: every pixel of finger travel buys a little less indicator
+ * travel than the one before it, approaching {@link MAX_PULL} but never
+ * reaching it.
+ */
+export function dampPull(rawDistance: number): number {
+  if (rawDistance <= 0) return 0;
+  return MAX_PULL * (1 - Math.exp(-rawDistance / MAX_PULL));
+}
+
+/** 0 → nothing pulled, 1 → far enough to let go. Clamped at 1. */
+export function pullProgress(dampedDistance: number): number {
+  return Math.min(1, Math.max(0, dampedDistance / PULL_THRESHOLD));
+}
+
+/**
+ * Whether releasing here should refresh: either the pull crossed the threshold,
+ * or it was a fast enough flick to mean the same thing.
+ */
+export function shouldCommitPull({
+  dampedDistance,
+  rawDistance,
+  elapsedMs,
+}: {
+  dampedDistance: number;
+  rawDistance: number;
+  elapsedMs: number;
+}): boolean {
+  if (dampedDistance >= PULL_THRESHOLD) return true;
+  if (elapsedMs <= 0) return false;
+  const velocity = rawDistance / elapsedMs;
+  return velocity > FLICK_VELOCITY && dampedDistance >= FLICK_MIN_DISTANCE;
+}
+
+/**
+ * A downward drag only counts once it is clearly vertical. Horizontal-dominant
+ * movement belongs to whatever the finger is actually on — a carousel, a
+ * swipeable row, the comic reader's page turn.
+ */
+export function isVerticalPull(deltaX: number, deltaY: number): boolean {
+  return deltaY > 0 && Math.abs(deltaY) > Math.abs(deltaX);
+}

--- a/apps/standard-reader/src/lib/use-pull-gesture.test.ts
+++ b/apps/standard-reader/src/lib/use-pull-gesture.test.ts
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { usePullGesture } from "./use-pull-gesture";
+
+/**
+ * jsdom has no touch events at all, so they are built by hand. The hook reads
+ * only `touches`, `changedTouches` and `preventDefault`, which is exactly what
+ * a real `TouchEvent` would hand it.
+ */
+function touchEvent(
+  type: "touchstart" | "touchmove" | "touchend" | "touchcancel",
+  points: Array<{ id?: number; x?: number; y?: number }>,
+) {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  const touches = points.map(({ id = 1, x = 0, y = 0 }) => ({
+    clientX: x,
+    clientY: y,
+    identifier: id,
+    target: document.body,
+  }));
+  Object.defineProperty(event, "touches", { value: touches });
+  Object.defineProperty(event, "changedTouches", { value: touches });
+  return event;
+}
+
+function dispatch(...args: Parameters<typeof touchEvent>) {
+  act(() => {
+    document.dispatchEvent(touchEvent(...args));
+  });
+}
+
+/** A pull far enough past the damping curve to arm (threshold is 64 damped). */
+const PAST_THRESHOLD = 140;
+
+function setup({ enabled = true }: { enabled?: boolean } = {}) {
+  const onRefresh = vi.fn(async () => "refreshed");
+  const rendered = renderHook(() => usePullGesture({ enabled, onRefresh }));
+  // The hook writes to whatever the caller rendered; stand in for the indicator.
+  rendered.result.current.chipRef.current = document.createElement("div");
+  rendered.result.current.iconRef.current = document.createElement("span");
+  return { ...rendered, onRefresh };
+}
+
+/** The `translate3d(0, Npx, 0)` the gesture wrote, or null while at rest. */
+function writtenOffset(chip: HTMLElement | null): number | null {
+  const match = chip?.style.transform.match(/translate3d\(0, ([\d.]+)px/);
+  return match?.[1] === undefined ? null : Number(match[1]);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  // The gesture batches its DOM writes into a frame; run them inline so a test
+  // can assert on what it wrote without pumping an animation loop.
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    callback(0);
+    return 0;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => {});
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  window.scrollY = 0;
+});
+
+describe("usePullGesture", () => {
+  it("does nothing until the pull is clearly vertical and past the slop", () => {
+    const { result } = setup();
+
+    dispatch("touchstart", [{ y: 100 }]);
+    expect(result.current.phase).toBe("idle");
+
+    // Inside the slop radius: still ambiguous.
+    dispatch("touchmove", [{ y: 104 }]);
+    expect(result.current.phase).toBe("idle");
+
+    dispatch("touchmove", [{ y: 130 }]);
+    expect(result.current.phase).toBe("pulling");
+  });
+
+  it("arms once the pull crosses the threshold and refreshes on release", async () => {
+    const { onRefresh, result } = setup();
+
+    dispatch("touchstart", [{ y: 100 }]);
+    dispatch("touchmove", [{ y: 120 }]);
+    expect(result.current.phase).toBe("pulling");
+    expect(onRefresh).not.toHaveBeenCalled();
+
+    dispatch("touchmove", [{ y: 100 + PAST_THRESHOLD }]);
+    expect(result.current.phase).toBe("armed");
+    // The indicator has been moved, and by less than the finger travelled —
+    // that difference is the rubber-banding.
+    const offset = writtenOffset(result.current.chipRef.current);
+    expect(offset).not.toBeNull();
+    expect(offset).toBeGreaterThan(64);
+    expect(offset).toBeLessThan(PAST_THRESHOLD);
+
+    dispatch("touchend", [{ y: 100 + PAST_THRESHOLD }]);
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(result.current.phase).toBe("refreshing");
+
+    // The spinner is held past the refresh itself so a fast refetch still reads
+    // as an event, then the indicator goes home and leaves nothing behind.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+    expect(result.current.phase).toBe("refreshing");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+    expect(result.current.phase).toBe("idle");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(result.current.chipRef.current?.style.transform).toBe("");
+    expect(result.current.chipRef.current?.style.opacity).toBe("");
+  });
+
+  it("snaps back without refreshing when the pull is too short", () => {
+    const { onRefresh, result } = setup();
+
+    dispatch("touchstart", [{ y: 100 }]);
+    dispatch("touchmove", [{ y: 130 }]);
+    dispatch("touchend", [{ y: 130 }]);
+
+    expect(onRefresh).not.toHaveBeenCalled();
+    expect(result.current.phase).toBe("idle");
+    expect(writtenOffset(result.current.chipRef.current)).toBe(0);
+  });
+
+  it("leaves horizontal swipes to the page", () => {
+    const { onRefresh, result } = setup();
+
+    dispatch("touchstart", [{ x: 100, y: 100 }]);
+    dispatch("touchmove", [{ x: 180, y: 112 }]);
+    expect(result.current.phase).toBe("idle");
+
+    // Once the gesture is handed back, carrying on downward must not claim it.
+    dispatch("touchmove", [{ x: 180, y: 100 + PAST_THRESHOLD }]);
+    dispatch("touchend", [{ x: 180, y: 100 + PAST_THRESHOLD }]);
+    expect(result.current.phase).toBe("idle");
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it("ignores a pull that starts below the top of the page", () => {
+    const { onRefresh, result } = setup();
+    window.scrollY = 320;
+
+    dispatch("touchstart", [{ y: 100 }]);
+    dispatch("touchmove", [{ y: 100 + PAST_THRESHOLD }]);
+    dispatch("touchend", [{ y: 100 + PAST_THRESHOLD }]);
+
+    expect(result.current.phase).toBe("idle");
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it("hands the gesture back when a second finger lands", () => {
+    const { onRefresh, result } = setup();
+
+    dispatch("touchstart", [{ y: 100 }]);
+    // The first decisive move only claims the gesture — it re-origins there so
+    // the indicator doesn't jump the slop distance — so it takes a second one
+    // to actually pull.
+    dispatch("touchmove", [{ y: 120 }]);
+    dispatch("touchmove", [{ y: 100 + PAST_THRESHOLD }]);
+    expect(result.current.phase).toBe("armed");
+
+    dispatch("touchmove", [
+      { id: 1, y: 100 + PAST_THRESHOLD },
+      { id: 2, y: 300 },
+    ]);
+    expect(result.current.phase).toBe("idle");
+
+    dispatch("touchend", [{ y: 100 + PAST_THRESHOLD }]);
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it("does not listen at all while disabled", () => {
+    const { onRefresh, result } = setup({ enabled: false });
+
+    dispatch("touchstart", [{ y: 100 }]);
+    dispatch("touchmove", [{ y: 100 + PAST_THRESHOLD }]);
+    dispatch("touchend", [{ y: 100 + PAST_THRESHOLD }]);
+
+    expect(result.current.phase).toBe("idle");
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/apps/standard-reader/src/lib/use-pull-gesture.ts
+++ b/apps/standard-reader/src/lib/use-pull-gesture.ts
@@ -1,0 +1,365 @@
+"use client";
+
+import {
+  animationDuration,
+  animationTimingFunction,
+} from "@standard-reader/design-system/theme/animations.stylex";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  PULL_REST,
+  PULL_SLOP,
+  PULL_THRESHOLD,
+  dampPull,
+  isVerticalPull,
+  pullProgress,
+  shouldCommitPull,
+} from "./pull-gesture";
+
+/**
+ * Keep the spinner up at least this long. A refetch that resolves in 80ms would
+ * otherwise read as "nothing happened" — the reader never sees the state they
+ * asked for.
+ */
+const MIN_SPIN_MS = 550;
+
+/** …and give up waiting on a refresh that never settles. */
+const MAX_SPIN_MS = 10_000;
+
+/**
+ * How long the indicator takes to travel back out of frame. Must match the
+ * duration token in {@link SETTLE_TRANSITION} — the timer exists only to strip
+ * the inline styles once the transition it describes has finished.
+ */
+const SETTLE_MS = 200;
+
+const PARK_TRANSITION = `transform ${animationDuration.slow} ${animationTimingFunction.easeSpring}, opacity ${animationDuration.fast} linear`;
+// The park has a spring because the chip is arriving somewhere and staying;
+// the settle is an exit and just gets out of the way.
+const SETTLE_TRANSITION = `transform ${animationDuration.slow} ${animationTimingFunction.easeOut}, opacity ${animationDuration.slow} linear`;
+
+export type PullPhase = "idle" | "pulling" | "armed" | "refreshing";
+
+/** Surfaces that own their own touch handling and must never be pulled from. */
+const IGNORED_ANCESTORS =
+  '[data-no-pull-refresh],[role="dialog"],[role="alertdialog"],[role="slider"]';
+
+function prefersReducedMotion(): boolean {
+  return (
+    globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false
+  );
+}
+
+/**
+ * True while an overlay has the page's scroll locked. react-aria pins the body
+ * to hold the scroll position on iOS, which also zeroes `scrollY` — without
+ * this the gesture would read a locked page as "at the top" and arm behind an
+ * open sheet.
+ */
+function scrollIsLocked(): boolean {
+  return document.body.style.position === "fixed";
+}
+
+/**
+ * The pull-to-refresh gesture, for a page whose scroll container is the
+ * document.
+ *
+ * Only the *phase* lives in React state — it changes a handful of times per
+ * gesture. The pull distance is written straight to the DOM every frame the
+ * finger moves, the way the shell's other scroll-driven chrome does it: routing
+ * it through state would re-render the page under the reader's thumb.
+ *
+ * The listeners are attached lazily. `touchstart` is passive and bails in a
+ * couple of comparisons when the page isn't at the top; only once a touch
+ * qualifies does the non-passive `touchmove` go on, so the rest of the app never
+ * carries a scroll-blocking listener it isn't using.
+ */
+export function usePullGesture({
+  enabled,
+  onRefresh,
+}: {
+  /** Off on desktop, and off while no page has registered a refresh. */
+  enabled: boolean;
+  /** Resolves when the page's data has been refetched. */
+  onRefresh: (() => Promise<unknown>) | null;
+}) {
+  const chipRef = useRef<HTMLDivElement>(null);
+  const iconRef = useRef<HTMLSpanElement>(null);
+  const [phase, setPhase] = useState<PullPhase>("idle");
+
+  // The handlers below live for the length of one gesture but read state that
+  // outlives it, so anything they share with React sits in a ref.
+  const phaseRef = useRef<PullPhase>("idle");
+  const settleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onRefreshRef = useRef(onRefresh);
+  onRefreshRef.current = onRefresh;
+
+  const setPhaseBoth = useCallback((next: PullPhase) => {
+    phaseRef.current = next;
+    setPhase(next);
+  }, []);
+
+  /** Position the indicator. `transition` is a CSS value, or `null` for none. */
+  const write = useCallback((distance: number, transition: string | null) => {
+    const chip = chipRef.current;
+    if (!chip) return;
+    const progress = pullProgress(distance);
+    chip.style.transition =
+      transition === null || prefersReducedMotion() ? "none" : transition;
+    // Scale and fade in together so the chip grows into the gap the pull opens
+    // rather than sliding out from under the top bar it would otherwise overlap.
+    chip.style.transform = `translate3d(0, ${distance.toFixed(1)}px, 0) scale(${(
+      0.72 +
+      0.28 * progress
+    ).toFixed(3)})`;
+    chip.style.opacity = Math.min(1, progress * 1.4).toFixed(3);
+
+    // While the finger is down the icon tracks the pull. Once the refresh starts
+    // a keyframe animation owns the rotation and an inline transform fights it.
+    const icon = iconRef.current;
+    if (icon)
+      icon.style.transform = `rotate(${(progress * 260).toFixed(1)}deg)`;
+  }, []);
+
+  /**
+   * Drop every inline style the gesture wrote. A resting chip carries none — an
+   * identity transform is still a compositing layer, and this one would sit
+   * there for the whole session on a surface used a second at a time.
+   */
+  const clear = useCallback(() => {
+    const chip = chipRef.current;
+    if (chip) {
+      chip.style.removeProperty("transform");
+      chip.style.removeProperty("opacity");
+      chip.style.removeProperty("transition");
+    }
+    iconRef.current?.style.removeProperty("transform");
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let startX = 0;
+    let startY = 0;
+    let startTime = 0;
+    let touchId: number | null = null;
+    let claimed = false;
+    let rawDistance = 0;
+    let distance = 0;
+    let frame: number | null = null;
+
+    function scheduleWrite() {
+      if (frame !== null) return;
+      frame = requestAnimationFrame(() => {
+        frame = null;
+        write(distance, null);
+      });
+    }
+
+    function detach() {
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+        frame = null;
+      }
+      touchId = null;
+      claimed = false;
+      distance = 0;
+      rawDistance = 0;
+      document.removeEventListener("touchmove", handleMove);
+      document.removeEventListener("touchend", handleEnd);
+      document.removeEventListener("touchcancel", handleCancel);
+    }
+
+    /** Send the indicator home and forget the gesture ever happened. */
+    function settle() {
+      setPhaseBoth("idle");
+      write(0, SETTLE_TRANSITION);
+      if (settleTimer.current !== null) {
+        globalThis.clearTimeout(settleTimer.current);
+      }
+      settleTimer.current = globalThis.setTimeout(() => {
+        settleTimer.current = null;
+        // A new pull may have started inside the settle window; it owns the
+        // chip's styles now.
+        if (phaseRef.current === "idle") clear();
+      }, SETTLE_MS);
+    }
+
+    async function runRefresh() {
+      const refresh = onRefreshRef.current;
+      if (!refresh) {
+        settle();
+        return;
+      }
+
+      setPhaseBoth("refreshing");
+      write(PULL_REST, PARK_TRANSITION);
+      // The keyframe spinner takes the icon over from here.
+      iconRef.current?.style.removeProperty("transform");
+
+      const startedAt = Date.now();
+      try {
+        await Promise.race([
+          refresh(),
+          new Promise((resolve) => globalThis.setTimeout(resolve, MAX_SPIN_MS)),
+        ]);
+      } catch {
+        // Whatever failed owns its own error state — the page's query surfaces
+        // it. The gesture's only job here is to stop spinning.
+      }
+
+      const elapsed = Date.now() - startedAt;
+      if (elapsed < MIN_SPIN_MS) {
+        await new Promise((resolve) =>
+          globalThis.setTimeout(resolve, MIN_SPIN_MS - elapsed),
+        );
+      }
+
+      // A second pull during the spin re-entered `runRefresh`; that call owns
+      // the indicator now.
+      if (phaseRef.current !== "refreshing") return;
+      settle();
+    }
+
+    function handleStart(event: TouchEvent) {
+      if (phaseRef.current === "refreshing") return;
+      if (event.touches.length !== 1) return;
+      const touch = event.touches[0];
+      if (!touch) return;
+      if (globalThis.scrollY > 0 || scrollIsLocked()) return;
+      if (
+        touch.target instanceof Element &&
+        touch.target.closest(IGNORED_ANCESTORS)
+      ) {
+        return;
+      }
+
+      if (settleTimer.current !== null) {
+        globalThis.clearTimeout(settleTimer.current);
+        settleTimer.current = null;
+      }
+
+      touchId = touch.identifier;
+      startX = touch.clientX;
+      startY = touch.clientY;
+      startTime = Date.now();
+      claimed = false;
+      rawDistance = 0;
+      distance = 0;
+
+      // Non-passive: once the pull is claimed the page cannot scroll up anyway,
+      // and preventing the default stops the browser starting a text selection
+      // or a link drag underneath it.
+      document.addEventListener("touchmove", handleMove, { passive: false });
+      document.addEventListener("touchend", handleEnd);
+      document.addEventListener("touchcancel", handleCancel);
+    }
+
+    function endedTouch(event: TouchEvent): boolean {
+      if (touchId === null) return false;
+      return [...event.changedTouches].some(
+        (touch) => touch.identifier === touchId,
+      );
+    }
+
+    function handleMove(event: TouchEvent) {
+      if (touchId === null) return;
+      // A second finger landed: hand the gesture back rather than following
+      // whichever touch the browser happens to report first.
+      if (event.touches.length > 1) {
+        handleCancel();
+        return;
+      }
+      const touch = event.touches[0];
+      if (!touch || touch.identifier !== touchId) return;
+
+      const deltaX = touch.clientX - startX;
+      const deltaY = touch.clientY - startY;
+
+      if (!claimed) {
+        if (Math.abs(deltaY) < PULL_SLOP && Math.abs(deltaX) < PULL_SLOP)
+          return;
+        // The first decisive movement decides who owns the gesture. Anything
+        // that isn't a downward pull from the top of the page belongs to the
+        // page — a scroll, a horizontal swipe, a drag.
+        if (!isVerticalPull(deltaX, deltaY) || globalThis.scrollY > 0) {
+          handleCancel();
+          return;
+        }
+        claimed = true;
+        // Re-origin at the point of claim so the indicator doesn't jump the
+        // slop distance on its first frame.
+        startY = touch.clientY;
+        startTime = Date.now();
+        setPhaseBoth("pulling");
+        return;
+      }
+
+      event.preventDefault();
+      rawDistance = touch.clientY - startY;
+      distance = dampPull(rawDistance);
+      const next = distance >= PULL_THRESHOLD ? "armed" : "pulling";
+      if (phaseRef.current !== next) setPhaseBoth(next);
+      scheduleWrite();
+    }
+
+    function handleEnd(event: TouchEvent) {
+      if (!endedTouch(event)) return;
+      const wasClaimed = claimed;
+      const finalRaw = rawDistance;
+      const finalDamped = distance;
+      const elapsed = Date.now() - startTime;
+      detach();
+      if (!wasClaimed) return;
+
+      if (
+        shouldCommitPull({
+          dampedDistance: finalDamped,
+          elapsedMs: elapsed,
+          rawDistance: finalRaw,
+        })
+      ) {
+        void runRefresh();
+      } else {
+        settle();
+      }
+    }
+
+    function handleCancel() {
+      const wasClaimed = claimed;
+      detach();
+      if (wasClaimed) settle();
+    }
+
+    document.addEventListener("touchstart", handleStart, { passive: true });
+
+    return () => {
+      document.removeEventListener("touchstart", handleStart);
+      detach();
+    };
+  }, [clear, enabled, setPhaseBoth, write]);
+
+  // Turning the gesture off — rotating to a desktop width, or leaving a page
+  // that opted in — must not strand a half-pulled indicator on screen.
+  useEffect(() => {
+    if (enabled) return;
+    if (settleTimer.current !== null) {
+      globalThis.clearTimeout(settleTimer.current);
+      settleTimer.current = null;
+    }
+    phaseRef.current = "idle";
+    setPhase("idle");
+    clear();
+  }, [clear, enabled]);
+
+  useEffect(
+    () => () => {
+      if (settleTimer.current !== null) {
+        globalThis.clearTimeout(settleTimer.current);
+      }
+    },
+    [],
+  );
+
+  return { chipRef, iconRef, phase };
+}

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -1977,6 +1977,10 @@ msgstr ""
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 msgstr ""
 
+#: src/components/reader/pull-to-refresh.tsx
+msgid "Refreshing"
+msgstr ""
+
 #: src/components/reader/notify-button.tsx
 msgid "Notifications aren’t available here"
 msgstr ""

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -1977,6 +1977,10 @@ msgstr ""
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 msgstr ""
 
+#: src/components/reader/pull-to-refresh.tsx
+msgid "Refreshing"
+msgstr ""
+
 #: src/components/reader/notify-button.tsx
 msgid "Notifications aren’t available here"
 msgstr ""

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -1977,6 +1977,10 @@ msgstr ""
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 msgstr ""
 
+#: src/components/reader/pull-to-refresh.tsx
+msgid "Refreshing"
+msgstr ""
+
 #: src/components/reader/notify-button.tsx
 msgid "Notifications aren’t available here"
 msgstr ""

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -1977,6 +1977,10 @@ msgstr "Connect {0} to your account?"
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 msgstr "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 
+#: src/components/reader/pull-to-refresh.tsx
+msgid "Refreshing"
+msgstr "Refreshing"
+
 #: src/components/reader/notify-button.tsx
 msgid "Notifications aren’t available here"
 msgstr "Notifications aren’t available here"

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -1977,6 +1977,10 @@ msgstr ""
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 msgstr ""
 
+#: src/components/reader/pull-to-refresh.tsx
+msgid "Refreshing"
+msgstr ""
+
 #: src/components/reader/notify-button.tsx
 msgid "Notifications aren’t available here"
 msgstr ""

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -1977,6 +1977,10 @@ msgstr ""
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 msgstr ""
 
+#: src/components/reader/pull-to-refresh.tsx
+msgid "Refreshing"
+msgstr ""
+
 #: src/components/reader/notify-button.tsx
 msgid "Notifications aren’t available here"
 msgstr ""

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -1977,6 +1977,10 @@ msgstr ""
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 msgstr ""
 
+#: src/components/reader/pull-to-refresh.tsx
+msgid "Refreshing"
+msgstr ""
+
 #: src/components/reader/notify-button.tsx
 msgid "Notifications aren’t available here"
 msgstr ""

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -1977,6 +1977,10 @@ msgstr ""
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 msgstr ""
 
+#: src/components/reader/pull-to-refresh.tsx
+msgid "Refreshing"
+msgstr ""
+
 #: src/components/reader/notify-button.tsx
 msgid "Notifications aren’t available here"
 msgstr ""

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -1977,6 +1977,10 @@ msgstr ""
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 msgstr ""
 
+#: src/components/reader/pull-to-refresh.tsx
+msgid "Refreshing"
+msgstr ""
+
 #: src/components/reader/notify-button.tsx
 msgid "Notifications aren’t available here"
 msgstr ""

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -1977,6 +1977,10 @@ msgstr ""
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 msgstr ""
 
+#: src/components/reader/pull-to-refresh.tsx
+msgid "Refreshing"
+msgstr ""
+
 #: src/components/reader/notify-button.tsx
 msgid "Notifications aren’t available here"
 msgstr ""

--- a/apps/standard-reader/src/routes/_layout.collections.index.tsx
+++ b/apps/standard-reader/src/routes/_layout.collections.index.tsx
@@ -37,6 +37,7 @@ import { Eye, Layers, Palette, Pencil, Plus, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
 import { CollectionsUpgradeOverlay } from "#/components/reader/collections-upgrade-gate";
+import { usePullToRefresh } from "#/components/reader/pull-to-refresh";
 import { IconButtonLink } from "#/components/router-links";
 import { hasCollectionsScope } from "#/integrations/auth/scope";
 import type {
@@ -737,6 +738,7 @@ function CollectionsEmptyState({
 }
 
 function CollectionsPage() {
+  usePullToRefresh();
   const { t } = useLingui();
   const queryClient = useQueryClient();
   const navigate = useNavigate();

--- a/apps/standard-reader/src/routes/_layout.discover.tsx
+++ b/apps/standard-reader/src/routes/_layout.discover.tsx
@@ -39,6 +39,7 @@ import {
 } from "react";
 import { z } from "zod";
 
+import { usePullToRefresh } from "#/components/reader/pull-to-refresh";
 import { ButtonLink } from "#/components/router-links";
 import {
   DISCOVER_TOPICS_LIMIT,
@@ -1022,6 +1023,7 @@ function DiscoverMastheadDek({
 }
 
 function Discover() {
+  usePullToRefresh();
   const { t } = useLingui();
   const fmt = useFormatters();
   const { data: session } = useQuery(user.getSessionQueryOptions);

--- a/apps/standard-reader/src/routes/_layout.friends.tsx
+++ b/apps/standard-reader/src/routes/_layout.friends.tsx
@@ -27,6 +27,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo } from "react";
 import { z } from "zod";
 
+import { usePullToRefresh } from "#/components/reader/pull-to-refresh";
 import { isArticleUnreadForReader } from "#/components/reader/read-optimistic";
 import { ButtonLink } from "#/components/router-links";
 import { discoverApi } from "#/integrations/tanstack-query/api-discover.functions";
@@ -195,6 +196,7 @@ function useSeededUserFollowStatus(people: Array<FriendPerson>) {
 }
 
 function FriendsPage() {
+  usePullToRefresh();
   const { t } = useLingui();
   const { view } = Route.useSearch();
   const navigate = Route.useNavigate();

--- a/apps/standard-reader/src/routes/_layout.history.tsx
+++ b/apps/standard-reader/src/routes/_layout.history.tsx
@@ -16,6 +16,7 @@ import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useCallback } from "react";
 
+import { usePullToRefresh } from "#/components/reader/pull-to-refresh";
 import { ButtonLink } from "#/components/router-links";
 import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
 import { user } from "#/integrations/tanstack-query/api-user.functions";
@@ -100,6 +101,7 @@ const styles = stylex.create({
 });
 
 function ReaderHistory() {
+  usePullToRefresh();
   const { t } = useLingui();
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useSuspenseInfiniteQuery(readerApi.getReadingHistoryInfiniteQueryOptions());

--- a/apps/standard-reader/src/routes/_layout.index.tsx
+++ b/apps/standard-reader/src/routes/_layout.index.tsx
@@ -33,6 +33,7 @@ import { ArrowRight, Flame, Sparkles } from "lucide-react";
 import { Suspense, useEffect } from "react";
 import { z } from "zod";
 
+import { usePullToRefresh } from "#/components/reader/pull-to-refresh";
 import { ButtonLink } from "#/components/router-links";
 import type { Formatters } from "#/lib/formatters";
 import { DEFAULT_TRACK_READING_HISTORY } from "#/lib/track-reading-history";
@@ -457,6 +458,7 @@ function useHomeReaderScope(): string {
 }
 
 function Home() {
+  usePullToRefresh();
   const scope = useEffectiveHomeScope();
   const readerScope = useHomeReaderScope();
 

--- a/apps/standard-reader/src/routes/_layout.l.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/_layout.l.$did.$rkey.tsx
@@ -51,6 +51,7 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 import { z } from "zod";
 
+import { usePullToRefresh } from "#/components/reader/pull-to-refresh";
 import { feedApi } from "#/integrations/tanstack-query/api-feed.functions";
 import type { ListOwner } from "#/integrations/tanstack-query/api-lists.functions";
 import { listApi } from "#/integrations/tanstack-query/api-lists.functions";
@@ -589,6 +590,7 @@ function ListPeoplePanel({
 }
 
 function ListPage() {
+  usePullToRefresh();
   const { t } = useLingui();
   const { did, rkey } = Route.useParams();
   const { view } = Route.useSearch();

--- a/apps/standard-reader/src/routes/_layout.latest.tsx
+++ b/apps/standard-reader/src/routes/_layout.latest.tsx
@@ -46,6 +46,7 @@ import {
 } from "react";
 import { z } from "zod";
 
+import { usePullToRefresh } from "#/components/reader/pull-to-refresh";
 import { ButtonLink } from "#/components/router-links";
 import {
   TRENDING_PAGE_LIMIT,
@@ -471,6 +472,7 @@ function LatestFeedPanel({
 }
 
 function Latest() {
+  usePullToRefresh();
   const { t } = useLingui();
   const fmt = useFormatters();
   const { filter } = Route.useSearch();

--- a/apps/standard-reader/src/routes/_layout.p.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/_layout.p.$did.$rkey.tsx
@@ -26,6 +26,7 @@ import { Link, createFileRoute } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { z } from "zod";
 
+import { usePullToRefresh } from "#/components/reader/pull-to-refresh";
 import { authorApi } from "#/integrations/tanstack-query/api-author.functions";
 import { notesApi } from "#/integrations/tanstack-query/api-notes.functions";
 import { publicationApi } from "#/integrations/tanstack-query/api-publication.functions";
@@ -546,6 +547,7 @@ function PublicationPending() {
 }
 
 function PublicationProfilePage() {
+  usePullToRefresh();
   return <PublicationProfile />;
 }
 

--- a/apps/standard-reader/src/routes/_layout.recommended.tsx
+++ b/apps/standard-reader/src/routes/_layout.recommended.tsx
@@ -16,6 +16,7 @@ import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useCallback } from "react";
 
+import { usePullToRefresh } from "#/components/reader/pull-to-refresh";
 import { ButtonLink } from "#/components/router-links";
 import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
 import { user } from "#/integrations/tanstack-query/api-user.functions";
@@ -100,6 +101,7 @@ const styles = stylex.create({
 });
 
 function ReaderRecommended() {
+  usePullToRefresh();
   const { t } = useLingui();
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useSuspenseInfiniteQuery(readerApi.getLikesInfiniteQueryOptions());

--- a/apps/standard-reader/src/routes/_layout.saved.tsx
+++ b/apps/standard-reader/src/routes/_layout.saved.tsx
@@ -35,6 +35,7 @@ import { useCallback, useEffect, useState } from "react";
 import type { Selection } from "react-aria-components";
 import { z } from "zod";
 
+import { usePullToRefresh } from "#/components/reader/pull-to-refresh";
 import { ButtonLink } from "#/components/router-links";
 import type {
   SavedSort,
@@ -192,6 +193,7 @@ const styles = stylex.create({
 });
 
 function ReaderSaved() {
+  usePullToRefresh();
   const { t, i18n } = useLingui();
   const { sort, dir } = Route.useSearch();
   const direction = dir ?? defaultSavedSortDirection(sort);

--- a/apps/standard-reader/src/routes/_layout.search.tsx
+++ b/apps/standard-reader/src/routes/_layout.search.tsx
@@ -22,6 +22,7 @@ import { Search as SearchIcon, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { z } from "zod";
 
+import { usePullToRefresh } from "#/components/reader/pull-to-refresh";
 import { searchApi } from "#/integrations/tanstack-query/api-search.functions";
 import { getPublicUrlClient } from "#/lib/public-url";
 import { pageSocialMeta } from "#/lib/site-metadata";
@@ -364,6 +365,7 @@ function formatShownCount(i18n: I18n, shown: number, hasMore: boolean): string {
 }
 
 function Search() {
+  usePullToRefresh();
   const { t, i18n } = useLingui();
   const { q: urlQ = "" } = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });

--- a/apps/standard-reader/src/routes/_layout.subscriptions.tsx
+++ b/apps/standard-reader/src/routes/_layout.subscriptions.tsx
@@ -15,6 +15,7 @@ import * as stylex from "@stylexjs/stylex";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 
+import { usePullToRefresh } from "#/components/reader/pull-to-refresh";
 import { ButtonLink } from "#/components/router-links";
 import { subscriptionsApi } from "#/integrations/tanstack-query/api-subscriptions.functions";
 import { user } from "#/integrations/tanstack-query/api-user.functions";
@@ -114,6 +115,7 @@ const styles = stylex.create({
 });
 
 function ReaderSubscriptions() {
+  usePullToRefresh();
   const { t } = useLingui();
   const { data: sidebar } = useSuspenseQuery(sidebarQueryOptions());
   const { data: lists } = useQuery(listsQueryOptions());

--- a/apps/standard-reader/src/routes/_layout.tag.$tag.tsx
+++ b/apps/standard-reader/src/routes/_layout.tag.$tag.tsx
@@ -82,6 +82,7 @@ import {
   ReaderContent,
   SectionHead,
 } from "#/components/reader/primitives";
+import { usePullToRefresh } from "#/components/reader/pull-to-refresh";
 import { isArticleUnreadForReader } from "#/components/reader/read-optimistic";
 import { RssFeedButton } from "#/components/reader/rss-feed-button";
 import { ButtonLink } from "#/components/router-links";
@@ -984,6 +985,7 @@ function TagFollowAllButton({
 }
 
 function TagPage() {
+  usePullToRefresh();
   const { t, i18n } = useLingui();
   const fmt = useFormatters();
   const { tag: rawTag } = Route.useParams();

--- a/apps/standard-reader/src/routes/_layout.topics.$slug.tsx
+++ b/apps/standard-reader/src/routes/_layout.topics.$slug.tsx
@@ -51,6 +51,7 @@ import {
 } from "react";
 import { z } from "zod";
 
+import { usePullToRefresh } from "#/components/reader/pull-to-refresh";
 import { topicsApi } from "#/integrations/tanstack-query/api-topics.functions";
 import { user } from "#/integrations/tanstack-query/api-user.functions";
 import { getPublicUrlClient } from "#/lib/public-url";
@@ -513,6 +514,7 @@ function TopicPublicationsPanel({
 /* ── Page ─────────────────────────────────────────────────────────────────── */
 
 function TopicPage() {
+  usePullToRefresh();
   const { t, i18n } = useLingui();
   const fmt = useFormatters();
   const { slug } = Route.useParams();

--- a/apps/standard-reader/src/routes/_layout.topics.index.tsx
+++ b/apps/standard-reader/src/routes/_layout.topics.index.tsx
@@ -13,6 +13,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { useDeferredValue, useMemo, useState } from "react";
 
+import { usePullToRefresh } from "#/components/reader/pull-to-refresh";
 import { topicsApi } from "#/integrations/tanstack-query/api-topics.functions";
 import { getPublicUrlClient } from "#/lib/public-url";
 import { SITE_NAME, siteSocialMeta } from "#/lib/site-metadata";
@@ -64,6 +65,7 @@ function matchesQuery(
 }
 
 function TopicsIndex() {
+  usePullToRefresh();
   const { t } = useLingui();
   const fmt = useFormatters();
   const [search, setSearch] = useState("");

--- a/apps/standard-reader/src/routes/_layout.tsx
+++ b/apps/standard-reader/src/routes/_layout.tsx
@@ -14,6 +14,7 @@ import { Suspense } from "react";
 import { AppShell } from "../components/reader/app-shell";
 import { ArticleViewSkeleton } from "../components/reader/article-view-skeleton";
 import { ReaderContent } from "../components/reader/primitives";
+import { PullToRefreshProvider } from "../components/reader/pull-to-refresh";
 import { user } from "../integrations/tanstack-query/api-user.functions";
 import {
   LAYOUT_ROUTE_STALE_TIME_MS,
@@ -63,11 +64,16 @@ function RouteContentFallback() {
 
 function LayoutRoute() {
   return (
-    <AppShell>
-      <Suspense fallback={<RouteContentFallback />}>
-        <Outlet />
-      </Suspense>
-    </AppShell>
+    // Wraps the shell rather than sitting inside it: the indicator the shell
+    // mounts and the route that registers a refresh both have to be under the
+    // same provider, and this is the one place both are in scope.
+    <PullToRefreshProvider>
+      <AppShell>
+        <Suspense fallback={<RouteContentFallback />}>
+          <Outlet />
+        </Suspense>
+      </AppShell>
+    </PullToRefreshProvider>
   );
 }
 

--- a/apps/standard-reader/src/routes/_layout.u.$did.tsx
+++ b/apps/standard-reader/src/routes/_layout.u.$did.tsx
@@ -40,6 +40,7 @@ import { Link as AriaLink } from "react-aria-components";
 import { z } from "zod";
 
 import { formatReaders, initials } from "#/components/reader/format";
+import { usePullToRefresh } from "#/components/reader/pull-to-refresh";
 import { ButtonLink } from "#/components/router-links";
 import type {
   AuthorProfile,
@@ -538,6 +539,7 @@ function LoadMoreFooter({
 }
 
 function AuthorProfilePage() {
+  usePullToRefresh();
   const { did } = Route.useParams();
   const { data: initialPage } = useSuspenseQuery(
     authorApi.getAuthorProfileQueryOptions(did, {

--- a/packages/design-system/src/theme/animations.stylex.tsx
+++ b/packages/design-system/src/theme/animations.stylex.tsx
@@ -133,6 +133,12 @@ export const animationDuration = stylex.defineConsts({
   slow: "200ms",
   verySlow: "300ms",
   extremelySlow: "500ms",
+  /**
+   * One turn of a looping "still working" indicator. Longer than any of the
+   * transition steps above on purpose — those describe a state change that ends,
+   * this one repeats until the work does.
+   */
+  indeterminateCycle: "900ms",
 });
 
 export const animationTimingFunction = stylex.defineConsts({


### PR DESCRIPTION
Adds pull-to-refresh to every feed and directory in the reader shell — the gesture a phone already taught the reader, on the surfaces where "is there anything new" is the actual question.

## Where it works

Home, Latest, Discover, Saved, History, Search, Tag, Topics (index and slug), Subscriptions, Friends, Recommended, Collections, and the list, publication and profile pages. Reading views, settings and the static pages are deliberately left out: there is nothing there a pull would fetch, and an article is the one place a stray downward drag is most likely to be someone adjusting their grip.

## What a pull does

`router.invalidate()` alongside `refetchQueries({ type: "active" })` — the page refetches in place, so scroll position and local UI state survive where a document reload would lose both. Because the shell's own queries are active too, a pull also brings the unread counts and the subscription list up to date. A route that needs something else passes its own handler to `usePullToRefresh()`.

Routes opt in with a one-line hook call rather than a pathname allowlist in the shell, so the opt-in is visible in the route that owns it.

## Mechanics

- **`lib/pull-gesture.ts`** — geometry, as pure functions: distance is rubber-banded toward a 120px asymptote (the pull never hits a wall, it just gets heavier), 64px damped commits, and a flick over 0.11 px/ms commits short of that.
- **`lib/use-pull-gesture.ts`** — the state machine. Pull distance is written straight to the DOM each frame; only the phase goes through React, the same reasoning `useAnimatedNavbar` / `useAnimatedBottomNav` already apply to scroll-driven chrome. The gesture is handed back on a horizontal-dominant drag, a second finger, a page that isn't at the top, or a touch inside a dialog — including react-aria's body scroll-lock, which pins the body and so also reads as `scrollY === 0`.
- **`components/reader/pull-to-refresh.tsx`** — the indicator plus the registry. The registry is a store rather than context state on purpose: the handler changes on every navigation, and pushing that through context would re-render the whole shell a second time after each route commits. Only the indicator subscribes.

`touchstart` is passive and bails in two comparisons when the page isn't at the top; the non-passive `touchmove` is only attached once a touch qualifies, so the app never carries a scroll-blocking listener it isn't using. `overscroll-behavior: none` was already set in `styles.css`, so the browser's own pull-to-refresh isn't competing for the gesture.

## Design

The chip scales and fades in under the mobile top bar rather than sliding out from behind it — it has no business overlapping the bar, and growing into the gap the pull opens avoids the layering question entirely. It picks up the accent when it's far enough to let go, and the spinner is held a minimum 550ms so a refetch that resolves in 80ms still reads as an event rather than a flicker. At rest the chip carries no inline styles at all, not even an identity transform: that would be a compositing layer sitting there for the whole session on a surface used a second at a time.

The indicator is deliberately **not** `aria-busy` — the perf suite treats a cleared `aria-busy` as "the page is ready" (`perf/lib/measure.ts`), and a refresh the reader asked for is not part of that first-paint contract.

## Notes

- Adds `animationDuration.indeterminateCycle: "900ms"` to the design-system theme for the spinner. The lint config already listed that token name as valid but it had never been defined; the alternative was an inline literal the StyleX rule rejects.
- The provider wraps `AppShell` from `_layout.tsx` rather than sitting inside the shell, which keeps the shell's JSX indentation — and ~260 lines of diff noise — untouched.
- `APP_VISION.md` and `TODO.md` updated in the same change.

## Testing

- `pnpm typecheck` clean, `oxlint` 0 warnings across the repo, `oxfmt --check` clean, `pnpm build` succeeds.
- Full app suite green: 868 passing. 21 of those are new — the damping and commit math, plus a jsdom run of the whole state machine (claim, arm, release → handler called, minimum spin hold, settle, inline styles stripped).
- Rendered against a dev server: the lane SSRs at `data-phase="idle"`, `display: flex` at 390px wide, chip at opacity 0 with no inline styles, and no console errors.
- **Not verified here:** the gesture itself. Desktop Safari has no `TouchEvent` constructor, so the feel of the damping, the threshold and iOS momentum need a real phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
