### PR TITLE
Give author pages the publication hero's action cluster

### DIFF
--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -1078,8 +1078,10 @@ Backend/API exists; UI or copy is missing.
 
 - [x] **Web push notifications (v1)** — a bell on a publication page
       ([`publication-actions.tsx`](src/components/reader/publication-actions.tsx)) and an author
-      page ([`_layout.u.$did.tsx`](src/routes/_layout.u.$did.tsx)) that notifies you when that
-      source publishes. Deliberately independent of subscribing: the bell doesn't touch your feed.
+      page ([`author-actions.tsx`](src/components/reader/author-actions.tsx)) that notifies you when
+      that source publishes. Both heroes share one shape: a Follow/Subscribe split button whose
+      chevron holds every other action, with the bell trailing it.
+      Deliberately independent of subscribing: the bell doesn't touch your feed.
       Three tables ([`push.ts`](src/db/schema/push.ts), `drizzle/0034_*`), push listeners imported
       into the existing Workbox SW ([`push-sw.js`](public/push-sw.js) via `workbox.importScripts`),
       the tap worker's whole involvement is one `INSERT`

--- a/apps/standard-reader/src/components/reader/author-actions.tsx
+++ b/apps/standard-reader/src/components/reader/author-actions.tsx
@@ -1,0 +1,341 @@
+"use client";
+
+import { Trans, useLingui } from "@lingui/react/macro";
+import { Button } from "@standard-reader/design-system/button";
+import { ButtonGroup } from "@standard-reader/design-system/button-group";
+import { IconButton } from "@standard-reader/design-system/icon-button";
+import {
+  Menu,
+  MenuItem,
+  MenuSeparator,
+  SubMenu,
+} from "@standard-reader/design-system/menu";
+import { primaryColor } from "@standard-reader/design-system/theme/color.stylex";
+import { breakpoints } from "@standard-reader/design-system/theme/media-queries.stylex";
+import { gap } from "@standard-reader/design-system/theme/semantic-spacing.stylex";
+import { spacing } from "@standard-reader/design-system/theme/spacing.stylex";
+import * as stylex from "@stylexjs/stylex";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Check,
+  ChevronDown,
+  ExternalLink,
+  FileText,
+  ListPlus,
+  Rss,
+  Settings,
+} from "lucide-react";
+import { useState } from "react";
+
+import { MenuItemLink } from "#/components/router-links";
+import { authorApi } from "#/integrations/tanstack-query/api-author.functions";
+import type { FollowingUser } from "#/integrations/tanstack-query/api-feed.functions";
+import { listApi } from "#/integrations/tanstack-query/api-lists.functions";
+import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
+import { useLoginSearch } from "#/utils/use-login-search";
+
+import { FollowUserButton } from "./follow-user-button";
+import { NotifyButton } from "./notify-button";
+import { RssFeedDialog } from "./rss-feed-button";
+import { ShareMenuItems, useShareActions } from "./share-menu";
+
+const MENU_ICON = 14;
+
+const styles = stylex.create({
+  /**
+   * Mirrors the publication hero (`publication-actions.tsx`): the bell trails
+   * the Follow split button rather than sitting inside it, because the chevron
+   * is Follow's own dropdown and a third segment between them would read as one
+   * three-part control.
+   *
+   * On desktop this row sits at the end of the hero's top row; on mobile it
+   * wraps onto its own full-width line under the author's handle.
+   */
+  row: {
+    alignItems: "center",
+    columnGap: gap.sm,
+    display: "flex",
+    flexBasis: { default: "100%", [breakpoints.sm]: "auto" },
+    flexShrink: 0,
+    marginInlineStart: { default: null, [breakpoints.sm]: "auto" },
+    paddingTop: { default: null, [breakpoints.sm]: spacing["1"] },
+  },
+  /** The split button itself. Takes the row's slack on mobile so it fills the
+   * line; the bell stays square at its end. */
+  group: {
+    flexGrow: { default: 1, [breakpoints.sm]: 0 },
+    flexShrink: 0,
+  },
+  /**
+   * The label segment takes the slack, so on mobile it fills the row and the
+   * chevron stays square. On desktop the group is content-width, so there is no
+   * slack to take and this is a no-op.
+   *
+   * `FollowUserButton` takes a single style, not a list — passing an array here
+   * leaks straight through to the DOM `style` prop, so the accent variant below
+   * repeats these rules rather than layering on top of them.
+   */
+  follow: {
+    flexGrow: 1,
+    justifyContent: "center",
+  },
+  /**
+   * Same, plus the seam. Grouped buttons drop their inline-start border, so the
+   * divider is the label segment's inline-end border; on the accent state the
+   * design system paints it in the accent's own border step, which all but
+   * disappears against the accent fill. One step darker keeps the split legible.
+   */
+  followAccent: {
+    borderInlineEndColor: primaryColor.border3,
+    flexGrow: 1,
+    justifyContent: "center",
+  },
+});
+
+/**
+ * List membership for this author, as a submenu off "Add to list". Each list
+ * shows a check when the author is already a member; selecting toggles it.
+ *
+ * The lists themselves are fetched by {@link AuthorActions} rather than here —
+ * menu children only render once the popover opens, and hoisting the query keeps
+ * the data-fetching out of the collection render.
+ */
+function ListsSubMenu({
+  did,
+  lists,
+  onToggle,
+}: {
+  did: string;
+  lists: Array<{ rkey: string; name: string; users: Array<string> }>;
+  onToggle: (rkey: string, isMember: boolean) => void;
+}) {
+  const { t } = useLingui();
+
+  return (
+    <SubMenu
+      trigger={
+        <MenuItem
+          suffix={<ListPlus size={MENU_ICON} />}
+          textValue={t`Add to list`}
+        >
+          <Trans>Add to list</Trans>
+        </MenuItem>
+      }
+    >
+      {lists.length === 0 ? (
+        <MenuItem isDisabled textValue={t`No lists yet`}>
+          <Trans>No lists yet</Trans>
+        </MenuItem>
+      ) : (
+        lists.map((list) => {
+          const isMember = list.users.includes(did);
+          return (
+            <MenuItem
+              key={list.rkey}
+              onPress={() => onToggle(list.rkey, isMember)}
+              suffix={isMember ? <Check size={MENU_ICON} /> : undefined}
+              textValue={list.name}
+            >
+              <span dir="auto">{list.name}</span>
+            </MenuItem>
+          );
+        })
+      )}
+    </SubMenu>
+  );
+}
+
+/**
+ * The author hero's action cluster, mirroring the publication hero: a split
+ * button whose primary segment follows the author and whose chevron opens every
+ * other action for the profile, then a notification bell.
+ *
+ * Two controls instead of six keeps the hero calm and reads the same on mobile,
+ * where the split button goes full-width — the old profile shipped two separate
+ * icon rows (one per breakpoint) with the same six buttons in each.
+ *
+ * On the reader's own profile the primary segment is "Profile settings" instead
+ * of Follow, and the bell is dropped: there is nothing to follow or be notified
+ * about that you don't already know.
+ */
+export function AuthorActions({
+  did,
+  handle,
+  name,
+  pageUrl,
+  feedUrl,
+  signedIn,
+  isOwnProfile,
+  user,
+  onOpenSettings,
+}: {
+  did: string;
+  handle: string | null;
+  /** Author display name — used in the RSS dialog copy. */
+  name: string;
+  pageUrl: string;
+  feedUrl: string;
+  signedIn: boolean;
+  isOwnProfile: boolean;
+  /** Byline for the optimistic sidebar "People" row when following. */
+  user: FollowingUser;
+  onOpenSettings: () => void;
+}) {
+  const { t } = useLingui();
+  const loginSearch = useLoginSearch();
+  const queryClient = useQueryClient();
+  const share = useShareActions({ pageUrl });
+  const [rssOpen, setRssOpen] = useState(false);
+
+  const { data: followStatus } = useQuery({
+    ...readerApi.getUserFollowStatusQueryOptions(did),
+    enabled: signedIn && !isOwnProfile,
+  });
+  // Both segments share one variant so the split button reads as a single
+  // control. Following is a settled state, so the group goes quiet with it — as
+  // does the signed-out group, whose Follow is really a login link, and the
+  // owner's group, whose primary is a settings shortcut rather than a call.
+  const variant =
+    signedIn && !isOwnProfile && !followStatus?.isFollowing
+      ? "primary"
+      : "secondary";
+
+  const { data: lists } = useQuery({
+    ...listApi.getListsQueryOptions(),
+    enabled: signedIn && !isOwnProfile,
+  });
+  const addToList = useMutation(listApi.addUserToListMutationOptions());
+  const removeFromList = useMutation(
+    listApi.removeUserFromListMutationOptions(),
+  );
+  const toggleList = (rkey: string, isMember: boolean) => {
+    const mutation = isMember ? removeFromList : addToList;
+    mutation.mutate(
+      { rkey, did },
+      {
+        onSettled: () => {
+          void queryClient.invalidateQueries({ queryKey: ["reader", "lists"] });
+          void queryClient.invalidateQueries({ queryKey: ["feed", "sidebar"] });
+        },
+      },
+    );
+  };
+
+  // The author's Sifa résumé, if they published one. Fetched here rather than in
+  // the menu item so the request doesn't ride on the collection render.
+  const { data: resumeUrl } = useQuery(
+    authorApi.getAuthorSifaProfileQueryOptions(did, handle),
+  );
+
+  return (
+    <>
+      <div {...stylex.props(styles.row)}>
+        <ButtonGroup style={styles.group}>
+          {isOwnProfile ? (
+            <Button
+              variant="secondary"
+              size="lg"
+              onPress={onOpenSettings}
+              style={styles.follow}
+            >
+              <Settings size={18} aria-hidden />
+              <Trans>Profile settings</Trans>
+            </Button>
+          ) : (
+            <FollowUserButton
+              did={did}
+              signedIn={signedIn}
+              user={user}
+              size="lg"
+              style={
+                variant === "primary" ? styles.followAccent : styles.follow
+              }
+            />
+          )}
+          <Menu
+            placement="bottom end"
+            trigger={
+              <IconButton variant={variant} label={t`More actions`} size="lg">
+                <ChevronDown size={16} />
+              </IconButton>
+            }
+          >
+            {isOwnProfile ? null : signedIn ? (
+              <ListsSubMenu
+                did={did}
+                lists={lists ?? []}
+                onToggle={toggleList}
+              />
+            ) : (
+              <MenuItemLink
+                to="/login"
+                search={loginSearch}
+                suffix={<ListPlus size={MENU_ICON} />}
+                textValue={t`Add to list`}
+              >
+                <Trans>Add to list</Trans>
+              </MenuItemLink>
+            )}
+            {isOwnProfile ? null : <MenuSeparator />}
+
+            <ShareMenuItems share={share} />
+
+            <MenuSeparator />
+
+            <MenuItem
+              onPress={() => setRssOpen(true)}
+              suffix={<Rss size={MENU_ICON} />}
+              textValue={t`RSS feed`}
+            >
+              <Trans>RSS feed</Trans>
+            </MenuItem>
+            {handle ? (
+              <MenuItem
+                onPress={() => {
+                  globalThis.open(
+                    `https://bsky.app/profile/${handle}`,
+                    "_blank",
+                    "noopener,noreferrer",
+                  );
+                }}
+                suffix={<ExternalLink size={MENU_ICON} />}
+                textValue={t`View on Bluesky`}
+              >
+                <Trans>View on Bluesky</Trans>
+              </MenuItem>
+            ) : null}
+            {resumeUrl ? (
+              <MenuItem
+                onPress={() => {
+                  globalThis.open(resumeUrl, "_blank", "noopener,noreferrer");
+                }}
+                suffix={<FileText size={MENU_ICON} />}
+                textValue={t`Resume`}
+              >
+                <Trans>Resume</Trans>
+              </MenuItem>
+            ) : null}
+          </Menu>
+        </ButtonGroup>
+        {isOwnProfile ? null : (
+          <NotifyButton
+            subjectType="author"
+            subject={did}
+            signedIn={signedIn}
+            size="lg"
+            // Takes the same variant as the split button beside it, so the two
+            // controls read as one cluster instead of two unrelated buttons.
+            variant={variant}
+          />
+        )}
+      </div>
+
+      <RssFeedDialog
+        name={name}
+        feedUrl={feedUrl}
+        isOpen={rssOpen}
+        onOpenChange={setRssOpen}
+      />
+    </>
+  );
+}

--- a/apps/standard-reader/src/components/reader/follow-user-button.tsx
+++ b/apps/standard-reader/src/components/reader/follow-user-button.tsx
@@ -1,5 +1,6 @@
 import { Trans } from "@lingui/react/macro";
 import { Button } from "@standard-reader/design-system/button";
+import type * as stylex from "@stylexjs/stylex";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Check, Plus } from "lucide-react";
 
@@ -25,12 +26,16 @@ export function FollowUserButton({
   signedIn,
   user,
   size = "md",
+  style,
 }: {
   did: string;
   signedIn: boolean;
   /** Byline for the optimistic sidebar "People" row (handle / name / avatar). */
   user?: FollowingUser;
-  size?: "sm" | "md";
+  size?: "sm" | "md" | "lg";
+  /** Layout hook for the author hero, where this is a split button's label
+   * segment and has to take the row's slack. */
+  style?: stylex.StyleXStyles;
 }) {
   const queryClient = useQueryClient();
   const loginSearch = useLoginSearch();
@@ -42,7 +47,7 @@ export function FollowUserButton({
   const followMutation = useMutation(readerApi.followUserMutationOptions());
   const unfollowMutation = useMutation(readerApi.unfollowUserMutationOptions());
 
-  const iconSize = size === "md" ? 18 : 15;
+  const iconSize = size === "sm" ? 15 : 18;
   const icon = following ? (
     <Check size={iconSize} aria-hidden />
   ) : (
@@ -56,8 +61,9 @@ export function FollowUserButton({
         search={loginSearch}
         variant="secondary"
         size={size}
+        style={style}
       >
-        {icon} Follow
+        {icon} <Trans>Follow</Trans>
       </ButtonLink>
     );
   }
@@ -86,6 +92,7 @@ export function FollowUserButton({
       variant={following ? "secondary" : "primary"}
       size={size}
       onPress={onPress}
+      style={style}
     >
       {icon}
       {following ? <Trans>Following</Trans> : <Trans>Follow</Trans>}

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -2696,6 +2696,7 @@ msgstr ""
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -3239,6 +3240,7 @@ msgstr "رمز رابط الاشتراك"
 
 #: src/components/reader/add-to-list-button.tsx
 #: src/components/reader/add-to-list-modal.tsx
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 msgid "Add to list"
@@ -3758,6 +3760,7 @@ msgid "The <0>Connected apps</0> section of settings lists anything signed in to
 msgstr ""
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "More actions"
@@ -3939,6 +3942,7 @@ msgid "Standard Reader emits these on its own article, publication, collection, 
 msgstr ""
 
 #: src/components/reader/add-to-list-button.tsx
+#: src/components/reader/author-actions.tsx
 msgid "No lists yet"
 msgstr "لا توجد قوائم بعد"
 
@@ -4976,8 +4980,8 @@ msgstr ""
 msgid "Use the <0>at:</0> meta tags — the convention the Atmosphere settled on in 2026. <1>at:canonical</1> names the records the page is made of, the ones it would have no reason to exist without. <2>at:alternate</2> names records the page merely shows — the publication a document belongs to, a companion Bluesky post. <3>at:author</3> names the identity that wrote it. Every name repeats, so a page with two alternates emits two tags."
 msgstr ""
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/profile-tabs-settings-modal.tsx
-#: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "إعدادات الملف الشخصي"
 
@@ -6572,6 +6576,7 @@ msgstr ""
 msgid "Wander the directory"
 msgstr "تجوّل في الدليل"
 
+#: src/components/reader/author-actions.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "View on Bluesky"
 msgstr "عرض على Bluesky"
@@ -6652,6 +6657,7 @@ msgstr "اشترك في المصنِّفات للإشارة إلى المحتو�
 msgid "Tap the bookmark on any article to save it here. Your queue lives in your repo as <0>app.standard-reader.bookmark</0> records in your repo."
 msgstr "انقر على علامة الحفظ في أي مقالة لحفظها هنا. قائمتك محفوظة في مستودعك على شكل سجلات <0>app.standard-reader.bookmark</0>."
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/sifa-resume-chip.tsx
 msgid "Resume"
 msgstr "استئناف"

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -2696,6 +2696,7 @@ msgstr ""
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -3239,6 +3240,7 @@ msgstr "Code für Abo-Link"
 
 #: src/components/reader/add-to-list-button.tsx
 #: src/components/reader/add-to-list-modal.tsx
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 msgid "Add to list"
@@ -3758,6 +3760,7 @@ msgid "The <0>Connected apps</0> section of settings lists anything signed in to
 msgstr ""
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "More actions"
@@ -3939,6 +3942,7 @@ msgid "Standard Reader emits these on its own article, publication, collection, 
 msgstr ""
 
 #: src/components/reader/add-to-list-button.tsx
+#: src/components/reader/author-actions.tsx
 msgid "No lists yet"
 msgstr "Noch keine Listen"
 
@@ -4976,8 +4980,8 @@ msgstr ""
 msgid "Use the <0>at:</0> meta tags — the convention the Atmosphere settled on in 2026. <1>at:canonical</1> names the records the page is made of, the ones it would have no reason to exist without. <2>at:alternate</2> names records the page merely shows — the publication a document belongs to, a companion Bluesky post. <3>at:author</3> names the identity that wrote it. Every name repeats, so a page with two alternates emits two tags."
 msgstr ""
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/profile-tabs-settings-modal.tsx
-#: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "Profileinstellungen"
 
@@ -6572,6 +6576,7 @@ msgstr ""
 msgid "Wander the directory"
 msgstr "Durchs Verzeichnis stöbern"
 
+#: src/components/reader/author-actions.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "View on Bluesky"
 msgstr "Auf Bluesky ansehen"
@@ -6652,6 +6657,7 @@ msgstr "Abonnieren Sie Labeler, um Inhalte beim Lesen zu markieren, zu verwische
 msgid "Tap the bookmark on any article to save it here. Your queue lives in your repo as <0>app.standard-reader.bookmark</0> records in your repo."
 msgstr "Tippen Sie bei einem Artikel auf das Lesezeichen, um ihn hier zu speichern. Ihre Warteliste liegt als <0>app.standard-reader.bookmark</0>-Records in Ihrem Repo."
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/sifa-resume-chip.tsx
 msgid "Resume"
 msgstr "Fortsetzen"

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -2696,6 +2696,7 @@ msgstr ""
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -3239,6 +3240,7 @@ msgstr ""
 
 #: src/components/reader/add-to-list-button.tsx
 #: src/components/reader/add-to-list-modal.tsx
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 msgid "Add to list"
@@ -3758,6 +3760,7 @@ msgid "The <0>Connected apps</0> section of settings lists anything signed in to
 msgstr ""
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "More actions"
@@ -3939,6 +3942,7 @@ msgid "Standard Reader emits these on its own article, publication, collection, 
 msgstr ""
 
 #: src/components/reader/add-to-list-button.tsx
+#: src/components/reader/author-actions.tsx
 msgid "No lists yet"
 msgstr ""
 
@@ -4976,8 +4980,8 @@ msgstr ""
 msgid "Use the <0>at:</0> meta tags — the convention the Atmosphere settled on in 2026. <1>at:canonical</1> names the records the page is made of, the ones it would have no reason to exist without. <2>at:alternate</2> names records the page merely shows — the publication a document belongs to, a companion Bluesky post. <3>at:author</3> names the identity that wrote it. Every name repeats, so a page with two alternates emits two tags."
 msgstr ""
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/profile-tabs-settings-modal.tsx
-#: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr ""
 
@@ -6572,6 +6576,7 @@ msgstr ""
 msgid "Wander the directory"
 msgstr ""
 
+#: src/components/reader/author-actions.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "View on Bluesky"
 msgstr ""
@@ -6652,6 +6657,7 @@ msgstr ""
 msgid "Tap the bookmark on any article to save it here. Your queue lives in your repo as <0>app.standard-reader.bookmark</0> records in your repo."
 msgstr ""
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/sifa-resume-chip.tsx
 msgid "Resume"
 msgstr ""

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -2696,6 +2696,7 @@ msgstr "Read straight through, or jump to whatever you are trying to do."
 msgid "Clear selection"
 msgstr "Clear selection"
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -3239,6 +3240,7 @@ msgstr "Subscribe link code"
 
 #: src/components/reader/add-to-list-button.tsx
 #: src/components/reader/add-to-list-modal.tsx
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 msgid "Add to list"
@@ -3758,6 +3760,7 @@ msgid "The <0>Connected apps</0> section of settings lists anything signed in to
 msgstr "The <0>Connected apps</0> section of settings lists anything signed in to your account through Standard Reader — the browser extension, most commonly. <1>Disconnect</1> ends that session without touching the others or logging you out here."
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "More actions"
@@ -3939,6 +3942,7 @@ msgid "Standard Reader emits these on its own article, publication, collection, 
 msgstr "Standard Reader emits these on its own article, publication, collection, list and profile pages, and reads them from yours."
 
 #: src/components/reader/add-to-list-button.tsx
+#: src/components/reader/author-actions.tsx
 msgid "No lists yet"
 msgstr "No lists yet"
 
@@ -4976,8 +4980,8 @@ msgstr "Add comment"
 msgid "Use the <0>at:</0> meta tags — the convention the Atmosphere settled on in 2026. <1>at:canonical</1> names the records the page is made of, the ones it would have no reason to exist without. <2>at:alternate</2> names records the page merely shows — the publication a document belongs to, a companion Bluesky post. <3>at:author</3> names the identity that wrote it. Every name repeats, so a page with two alternates emits two tags."
 msgstr "Use the <0>at:</0> meta tags — the convention the Atmosphere settled on in 2026. <1>at:canonical</1> names the records the page is made of, the ones it would have no reason to exist without. <2>at:alternate</2> names records the page merely shows — the publication a document belongs to, a companion Bluesky post. <3>at:author</3> names the identity that wrote it. Every name repeats, so a page with two alternates emits two tags."
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/profile-tabs-settings-modal.tsx
-#: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "Profile settings"
 
@@ -6572,6 +6576,7 @@ msgstr "Lists and your sidebar"
 msgid "Wander the directory"
 msgstr "Wander the directory"
 
+#: src/components/reader/author-actions.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "View on Bluesky"
 msgstr "View on Bluesky"
@@ -6652,6 +6657,7 @@ msgstr "Subscribe to labelers to flag, blur, or hide content as you read."
 msgid "Tap the bookmark on any article to save it here. Your queue lives in your repo as <0>app.standard-reader.bookmark</0> records in your repo."
 msgstr "Tap the bookmark on any article to save it here. Your queue lives in your repo as <0>app.standard-reader.bookmark</0> records in your repo."
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/sifa-resume-chip.tsx
 msgid "Resume"
 msgstr "Resume"

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -2696,6 +2696,7 @@ msgstr ""
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -3239,6 +3240,7 @@ msgstr "Código del enlace de suscripción"
 
 #: src/components/reader/add-to-list-button.tsx
 #: src/components/reader/add-to-list-modal.tsx
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 msgid "Add to list"
@@ -3758,6 +3760,7 @@ msgid "The <0>Connected apps</0> section of settings lists anything signed in to
 msgstr ""
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "More actions"
@@ -3939,6 +3942,7 @@ msgid "Standard Reader emits these on its own article, publication, collection, 
 msgstr ""
 
 #: src/components/reader/add-to-list-button.tsx
+#: src/components/reader/author-actions.tsx
 msgid "No lists yet"
 msgstr "Aún no hay listas"
 
@@ -4976,8 +4980,8 @@ msgstr ""
 msgid "Use the <0>at:</0> meta tags — the convention the Atmosphere settled on in 2026. <1>at:canonical</1> names the records the page is made of, the ones it would have no reason to exist without. <2>at:alternate</2> names records the page merely shows — the publication a document belongs to, a companion Bluesky post. <3>at:author</3> names the identity that wrote it. Every name repeats, so a page with two alternates emits two tags."
 msgstr ""
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/profile-tabs-settings-modal.tsx
-#: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "Ajustes del perfil"
 
@@ -6572,6 +6576,7 @@ msgstr ""
 msgid "Wander the directory"
 msgstr "Recorrer el directorio"
 
+#: src/components/reader/author-actions.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "View on Bluesky"
 msgstr "Ver en Bluesky"
@@ -6652,6 +6657,7 @@ msgstr "Suscríbase a etiquetadores para marcar, difuminar u ocultar contenido m
 msgid "Tap the bookmark on any article to save it here. Your queue lives in your repo as <0>app.standard-reader.bookmark</0> records in your repo."
 msgstr "Toque el marcador en cualquier artículo para guardarlo aquí. Su cola vive en su repositorio como registros <0>app.standard-reader.bookmark</0>."
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/sifa-resume-chip.tsx
 msgid "Resume"
 msgstr "Reanudar"

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -2696,6 +2696,7 @@ msgstr ""
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -3239,6 +3240,7 @@ msgstr "Code du lien d’abonnement"
 
 #: src/components/reader/add-to-list-button.tsx
 #: src/components/reader/add-to-list-modal.tsx
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 msgid "Add to list"
@@ -3758,6 +3760,7 @@ msgid "The <0>Connected apps</0> section of settings lists anything signed in to
 msgstr ""
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "More actions"
@@ -3939,6 +3942,7 @@ msgid "Standard Reader emits these on its own article, publication, collection, 
 msgstr ""
 
 #: src/components/reader/add-to-list-button.tsx
+#: src/components/reader/author-actions.tsx
 msgid "No lists yet"
 msgstr "Aucune liste pour l’instant"
 
@@ -4976,8 +4980,8 @@ msgstr ""
 msgid "Use the <0>at:</0> meta tags — the convention the Atmosphere settled on in 2026. <1>at:canonical</1> names the records the page is made of, the ones it would have no reason to exist without. <2>at:alternate</2> names records the page merely shows — the publication a document belongs to, a companion Bluesky post. <3>at:author</3> names the identity that wrote it. Every name repeats, so a page with two alternates emits two tags."
 msgstr ""
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/profile-tabs-settings-modal.tsx
-#: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "Paramètres du profil"
 
@@ -6572,6 +6576,7 @@ msgstr ""
 msgid "Wander the directory"
 msgstr "Parcourir l'annuaire"
 
+#: src/components/reader/author-actions.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "View on Bluesky"
 msgstr "Voir sur Bluesky"
@@ -6652,6 +6657,7 @@ msgstr "Abonnez-vous à des services d'étiquetage pour signaler, flouter ou mas
 msgid "Tap the bookmark on any article to save it here. Your queue lives in your repo as <0>app.standard-reader.bookmark</0> records in your repo."
 msgstr "Touchez le signet sur n'importe quel article pour l'enregistrer ici. Votre file d'attente vit dans votre dépôt sous forme d'enregistrements <0>app.standard-reader.bookmark</0>."
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/sifa-resume-chip.tsx
 msgid "Resume"
 msgstr "Reprendre"

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -2696,6 +2696,7 @@ msgstr ""
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -3239,6 +3240,7 @@ msgstr "購読リンクのコード"
 
 #: src/components/reader/add-to-list-button.tsx
 #: src/components/reader/add-to-list-modal.tsx
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 msgid "Add to list"
@@ -3758,6 +3760,7 @@ msgid "The <0>Connected apps</0> section of settings lists anything signed in to
 msgstr ""
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "More actions"
@@ -3939,6 +3942,7 @@ msgid "Standard Reader emits these on its own article, publication, collection, 
 msgstr ""
 
 #: src/components/reader/add-to-list-button.tsx
+#: src/components/reader/author-actions.tsx
 msgid "No lists yet"
 msgstr "リストはまだありません"
 
@@ -4976,8 +4980,8 @@ msgstr ""
 msgid "Use the <0>at:</0> meta tags — the convention the Atmosphere settled on in 2026. <1>at:canonical</1> names the records the page is made of, the ones it would have no reason to exist without. <2>at:alternate</2> names records the page merely shows — the publication a document belongs to, a companion Bluesky post. <3>at:author</3> names the identity that wrote it. Every name repeats, so a page with two alternates emits two tags."
 msgstr ""
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/profile-tabs-settings-modal.tsx
-#: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "プロフィール設定"
 
@@ -6572,6 +6576,7 @@ msgstr ""
 msgid "Wander the directory"
 msgstr "ディレクトリを見て回る"
 
+#: src/components/reader/author-actions.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "View on Bluesky"
 msgstr "Bluesky で見る"
@@ -6652,6 +6657,7 @@ msgstr "ラベラーを購読すると、読みながらコンテンツにフラ
 msgid "Tap the bookmark on any article to save it here. Your queue lives in your repo as <0>app.standard-reader.bookmark</0> records in your repo."
 msgstr "記事のブックマークをタップすると、ここに保存されます。キューはリポジトリ内に <0>app.standard-reader.bookmark</0> レコードとして保存されます。"
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/sifa-resume-chip.tsx
 msgid "Resume"
 msgstr "再開"

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -2696,6 +2696,7 @@ msgstr ""
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -3239,6 +3240,7 @@ msgstr "구독 링크 코드"
 
 #: src/components/reader/add-to-list-button.tsx
 #: src/components/reader/add-to-list-modal.tsx
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 msgid "Add to list"
@@ -3758,6 +3760,7 @@ msgid "The <0>Connected apps</0> section of settings lists anything signed in to
 msgstr ""
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "More actions"
@@ -3939,6 +3942,7 @@ msgid "Standard Reader emits these on its own article, publication, collection, 
 msgstr ""
 
 #: src/components/reader/add-to-list-button.tsx
+#: src/components/reader/author-actions.tsx
 msgid "No lists yet"
 msgstr "아직 리스트가 없습니다"
 
@@ -4976,8 +4980,8 @@ msgstr ""
 msgid "Use the <0>at:</0> meta tags — the convention the Atmosphere settled on in 2026. <1>at:canonical</1> names the records the page is made of, the ones it would have no reason to exist without. <2>at:alternate</2> names records the page merely shows — the publication a document belongs to, a companion Bluesky post. <3>at:author</3> names the identity that wrote it. Every name repeats, so a page with two alternates emits two tags."
 msgstr ""
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/profile-tabs-settings-modal.tsx
-#: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "프로필 설정"
 
@@ -6572,6 +6576,7 @@ msgstr ""
 msgid "Wander the directory"
 msgstr "디렉터리 거닐기"
 
+#: src/components/reader/author-actions.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "View on Bluesky"
 msgstr "Bluesky에서 보기"
@@ -6652,6 +6657,7 @@ msgstr "라벨러를 구독하면 읽는 동안 콘텐츠를 표시하거나 흐
 msgid "Tap the bookmark on any article to save it here. Your queue lives in your repo as <0>app.standard-reader.bookmark</0> records in your repo."
 msgstr "어떤 글이든 북마크를 누르면 여기에 저장됩니다. 대기열은 내 저장소에 <0>app.standard-reader.bookmark</0> 레코드로 보관됩니다."
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/sifa-resume-chip.tsx
 msgid "Resume"
 msgstr "계속"

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -2696,6 +2696,7 @@ msgstr ""
 msgid "Clear selection"
 msgstr "Limpar a seleção"
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -3239,6 +3240,7 @@ msgstr "Código do link de inscrição"
 
 #: src/components/reader/add-to-list-button.tsx
 #: src/components/reader/add-to-list-modal.tsx
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 msgid "Add to list"
@@ -3758,6 +3760,7 @@ msgid "The <0>Connected apps</0> section of settings lists anything signed in to
 msgstr ""
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "More actions"
@@ -3939,6 +3942,7 @@ msgid "Standard Reader emits these on its own article, publication, collection, 
 msgstr ""
 
 #: src/components/reader/add-to-list-button.tsx
+#: src/components/reader/author-actions.tsx
 msgid "No lists yet"
 msgstr "Ainda não há listas"
 
@@ -4976,8 +4980,8 @@ msgstr ""
 msgid "Use the <0>at:</0> meta tags — the convention the Atmosphere settled on in 2026. <1>at:canonical</1> names the records the page is made of, the ones it would have no reason to exist without. <2>at:alternate</2> names records the page merely shows — the publication a document belongs to, a companion Bluesky post. <3>at:author</3> names the identity that wrote it. Every name repeats, so a page with two alternates emits two tags."
 msgstr ""
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/profile-tabs-settings-modal.tsx
-#: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "Configurações do perfil"
 
@@ -6572,6 +6576,7 @@ msgstr ""
 msgid "Wander the directory"
 msgstr "Explorar o diretório"
 
+#: src/components/reader/author-actions.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "View on Bluesky"
 msgstr "Ver no Bluesky"
@@ -6652,6 +6657,7 @@ msgstr "Inscreva-se em rotuladores para rotular, desfocar ou ocultar conteúdo e
 msgid "Tap the bookmark on any article to save it here. Your queue lives in your repo as <0>app.standard-reader.bookmark</0> records in your repo."
 msgstr "Toque no ícone de marca páginas de qualquer artigo para salvá-lo aqui. A sua fila vive no seu repositório como registos <0>app.standard-reader.bookmark</0>."
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/sifa-resume-chip.tsx
 msgid "Resume"
 msgstr "Retomar"

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -2696,6 +2696,7 @@ msgstr ""
 msgid "Clear selection"
 msgstr ""
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -3239,6 +3240,7 @@ msgstr "订阅链接代码"
 
 #: src/components/reader/add-to-list-button.tsx
 #: src/components/reader/add-to-list-modal.tsx
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/components/reader/subscriptions-table.tsx
 msgid "Add to list"
@@ -3758,6 +3760,7 @@ msgid "The <0>Connected apps</0> section of settings lists anything signed in to
 msgstr ""
 
 #: src/components/reader/article-view.tsx
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/publication-actions.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "More actions"
@@ -3939,6 +3942,7 @@ msgid "Standard Reader emits these on its own article, publication, collection, 
 msgstr ""
 
 #: src/components/reader/add-to-list-button.tsx
+#: src/components/reader/author-actions.tsx
 msgid "No lists yet"
 msgstr "还没有列表"
 
@@ -4976,8 +4980,8 @@ msgstr ""
 msgid "Use the <0>at:</0> meta tags — the convention the Atmosphere settled on in 2026. <1>at:canonical</1> names the records the page is made of, the ones it would have no reason to exist without. <2>at:alternate</2> names records the page merely shows — the publication a document belongs to, a companion Bluesky post. <3>at:author</3> names the identity that wrote it. Every name repeats, so a page with two alternates emits two tags."
 msgstr ""
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/profile-tabs-settings-modal.tsx
-#: src/routes/_layout.u.$did.tsx
 msgid "Profile settings"
 msgstr "个人资料设置"
 
@@ -6572,6 +6576,7 @@ msgstr ""
 msgid "Wander the directory"
 msgstr "随意逛逛目录"
 
+#: src/components/reader/author-actions.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "View on Bluesky"
 msgstr "在 Bluesky 上查看"
@@ -6652,6 +6657,7 @@ msgstr "订阅标注服务，在阅读时标记、模糊或隐藏内容。"
 msgid "Tap the bookmark on any article to save it here. Your queue lives in your repo as <0>app.standard-reader.bookmark</0> records in your repo."
 msgstr "点按任意文章上的书签图标即可保存到这里。你的清单以 <0>app.standard-reader.bookmark</0> 记录形式存放在你的仓库中。"
 
+#: src/components/reader/author-actions.tsx
 #: src/components/reader/sifa-resume-chip.tsx
 msgid "Resume"
 msgstr "继续"

--- a/apps/standard-reader/src/routes/_layout.u.$did.tsx
+++ b/apps/standard-reader/src/routes/_layout.u.$did.tsx
@@ -2,7 +2,6 @@ import { Plural, Trans, useLingui } from "@lingui/react/macro";
 import { Avatar } from "@standard-reader/design-system/avatar";
 import { Badge } from "@standard-reader/design-system/badge";
 import { Button } from "@standard-reader/design-system/button";
-import { IconButton } from "@standard-reader/design-system/icon-button";
 import {
   Tab,
   TabList,
@@ -34,7 +33,7 @@ import {
   redirect,
   useNavigate,
 } from "@tanstack/react-router";
-import { Bot, ExternalLink, ListPlus, Settings } from "lucide-react";
+import { Bot, ExternalLink, ListPlus } from "lucide-react";
 import { useCallback, useRef, useState } from "react";
 import { Link as AriaLink } from "react-aria-components";
 import { z } from "zod";
@@ -66,13 +65,11 @@ import {
 } from "#/lib/site-metadata";
 
 import { AccountLabels } from "../components/reader/account-labels";
-import { AddToListButton } from "../components/reader/add-to-list-button";
+import { AuthorActions } from "../components/reader/author-actions";
 import { AuthorProfileLink } from "../components/reader/author-profile-link";
 import { ArticleRow, PubDirectoryRow } from "../components/reader/cards";
 import { FeedLoadMore } from "../components/reader/feed-load-more";
-import { FollowUserButton } from "../components/reader/follow-user-button";
 import { LinkifiedText } from "../components/reader/linkified-text";
-import { NotifyButton } from "../components/reader/notify-button";
 import {
   Handle,
   Kicker,
@@ -80,9 +77,6 @@ import {
   SectionHead,
 } from "../components/reader/primitives";
 import { ProfileTabsSettingsModal } from "../components/reader/profile-tabs-settings-modal";
-import { RssFeedButton } from "../components/reader/rss-feed-button";
-import { ShareMenu } from "../components/reader/share-menu";
-import { AuthorSifaResumeChip } from "../components/reader/sifa-resume-chip";
 
 const AUTHOR_PAGE_SIZE = 24;
 
@@ -270,22 +264,6 @@ const styles = stylex.create({
     marginBottom: spacing["0"],
     marginTop: spacing["0"],
     maxWidth: "60ch",
-  },
-  heroActsMobile: {
-    columnGap: spacing["1.5"],
-    display: { [HERO_DESKTOP]: "none", default: "flex" },
-    flexWrap: "wrap",
-    rowGap: spacing["1.5"],
-  },
-  heroActs: {
-    alignItems: "center",
-    columnGap: spacing["1.5"],
-    display: { [HERO_DESKTOP]: "flex", default: "none" },
-    flexShrink: 0,
-    flexWrap: "wrap",
-    justifyContent: "flex-end",
-    rowGap: spacing["2.5"],
-    paddingTop: spacing["1"],
   },
   tabs: {
     paddingBottom: spacing["10"],
@@ -728,65 +706,23 @@ function AuthorProfileContent({
               ) : null}
             </div>
 
-            <div {...stylex.props(styles.heroActs)}>
-              <ShareMenu variant="icon" pageUrl={pageUrl} />
-              <RssFeedButton
-                name={name}
-                feedUrl={authorFeedUrl(getPublicUrlClient(), did)}
-                size="md"
-              />
-              {profile.handle ? (
-                <IconButton
-                  variant="secondary"
-                  size="md"
-                  label={t`View on Bluesky`}
-                  onPress={() => {
-                    window.open(
-                      `https://bsky.app/profile/${profile.handle}`,
-                      "_blank",
-                      "noopener,noreferrer",
-                    );
-                  }}
-                >
-                  <ExternalLink size={15} />
-                </IconButton>
-              ) : null}
-              <AuthorSifaResumeChip
-                did={did}
-                handle={profile.handle}
-                variant="icon"
-              />
-              {isOwnProfile ? (
-                <IconButton
-                  variant="secondary"
-                  size="md"
-                  label={t`Profile settings`}
-                  onPress={() => setSettingsOpen(true)}
-                >
-                  <Settings size={15} />
-                </IconButton>
-              ) : (
-                <>
-                  {session?.user?.did ? <AddToListButton did={did} /> : null}
-                  <NotifyButton
-                    subjectType="author"
-                    subject={did}
-                    signedIn={session?.user?.did != null}
-                  />
-                  <FollowUserButton
-                    did={did}
-                    signedIn={session?.user?.did != null}
-                    user={{
-                      did,
-                      handle: profile.handle,
-                      displayName: profile.displayName ?? null,
-                      avatarUrl: profile.avatarUrl ?? null,
-                      followedAt: new Date().toISOString(),
-                    }}
-                  />
-                </>
-              )}
-            </div>
+            <AuthorActions
+              did={did}
+              handle={profile.handle}
+              name={name}
+              pageUrl={pageUrl}
+              feedUrl={authorFeedUrl(getPublicUrlClient(), did)}
+              signedIn={session?.user?.did != null}
+              isOwnProfile={isOwnProfile}
+              user={{
+                did,
+                handle: profile.handle,
+                displayName: profile.displayName ?? null,
+                avatarUrl: profile.avatarUrl ?? null,
+                followedAt: new Date().toISOString(),
+              }}
+              onOpenSettings={() => setSettingsOpen(true)}
+            />
           </div>
 
           {profile.description ? (
@@ -799,66 +735,6 @@ function AuthorProfileContent({
               third party says about this account, so it reads after the account's
               own words instead of interrupting its identity line. */}
           <AccountLabels labels={accountLabels} />
-
-          <div {...stylex.props(styles.heroActsMobile)}>
-            <ShareMenu variant="icon" size="md" pageUrl={pageUrl} />
-            <RssFeedButton
-              name={name}
-              feedUrl={authorFeedUrl(getPublicUrlClient(), did)}
-              size="md"
-            />
-            {profile.handle ? (
-              <IconButton
-                variant="secondary"
-                size="md"
-                label={t`View on Bluesky`}
-                onPress={() => {
-                  window.open(
-                    `https://bsky.app/profile/${profile.handle}`,
-                    "_blank",
-                    "noopener,noreferrer",
-                  );
-                }}
-              >
-                <ExternalLink size={15} />
-              </IconButton>
-            ) : null}
-            <AuthorSifaResumeChip
-              did={did}
-              handle={profile.handle}
-              variant="icon"
-            />
-            {isOwnProfile ? (
-              <IconButton
-                variant="secondary"
-                size="md"
-                label={t`Profile settings`}
-                onPress={() => setSettingsOpen(true)}
-              >
-                <Settings size={15} />
-              </IconButton>
-            ) : (
-              <>
-                {session?.user?.did ? <AddToListButton did={did} /> : null}
-                <NotifyButton
-                  subjectType="author"
-                  subject={did}
-                  signedIn={session?.user?.did != null}
-                />
-                <FollowUserButton
-                  did={did}
-                  signedIn={session?.user?.did != null}
-                  user={{
-                    did,
-                    handle: profile.handle,
-                    displayName: profile.displayName ?? null,
-                    avatarUrl: profile.avatarUrl ?? null,
-                    followedAt: new Date().toISOString(),
-                  }}
-                />
-              </>
-            )}
-          </div>
         </div>
       </div>
 


### PR DESCRIPTION
An author profile carried two rows of six icon buttons — one for desktop, one duplicated for mobile — while a publication hero had settled on a Subscribe split button whose chevron holds everything else, with the bell trailing it. Same page furniture, two different shapes.

## What changed

**New `author-actions.tsx`**, a direct mirror of `publication-actions.tsx`:

- **Split button** — `Follow` as the label segment (takes the row's slack), a chevron `IconButton` as its dropdown. Both segments share one variant, so the group goes accent while you're not following and quiet once you are (or when signed out). Same `borderInlineEndColor` seam fix on the accent state.
- **Bell** trails the group rather than sitting inside it — the chevron is Follow's own dropdown, and a third segment between them would read as one three-part control.
- **Menu** — `Add to list` (a submenu of your lists, checked where the author is a member; a `/login` link when signed out) → separator → share items → separator → `RSS feed`, `View on Bluesky`, `Resume` (the Sifa profile, when they have one).
- **Own profile** — the primary segment becomes `Profile settings` and the bell is dropped; the menu keeps share/RSS/Bluesky/Resume.

**`_layout.u.$did.tsx`** drops both hero action rows for one `<AuthorActions />`. The row wraps to its own full-width line below 40rem the way the publication's does, so the breakpoint-duplicated markup and its styles are gone.

**`follow-user-button.tsx`** gains `size="lg"` and a `style` prop so it can serve as a split-button segment. Its signed-out `Follow` label was the one bare string in the file; it's wrapped in `<Trans>` now.

## Verification

Checked against a real profile in Safari at 1280px and 390px: desktop shows `+ Follow ⌄ 🔔` at the end of the hero's top row with the menu matching the publication's; mobile gives a full-width Follow with the chevron and bell square at its end.

`tsc`, repo-wide `oxlint`, `oxfmt`, and the reader component tests pass. `pnpm i18n:extract` produced only source-reference churn — no new message IDs.

**Not exercised:** the signed-in states (following accent, list toggles, own-profile `Profile settings`) — the browser session was signed out. Those paths are code-identical to the publication ones but haven't been clicked through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)