### PR TITLE
Log in on Enter instead of wiping the handle

### DIFF
--- a/apps/standard-reader/src/routes/login.tsx
+++ b/apps/standard-reader/src/routes/login.tsx
@@ -253,6 +253,14 @@ function AuthPage() {
     void navigate({ to: "/" });
   };
 
+  /** Log in with whatever is typed. Shared by the button and Enter-to-submit. */
+  const submitTypedHandle = () => {
+    if (loginMutation.isPending) return;
+    const trimmed = handle.trim().replace(/^@/, "");
+    if (trimmed === "") return;
+    loginMutation.mutate(trimmed);
+  };
+
   return (
     <main {...stylex.props(styles.main)}>
       <IconButton
@@ -265,7 +273,18 @@ function AuthPage() {
         <DirectionalIcon as={ArrowLeft} size={18} />
       </IconButton>
       <div {...stylex.props(styles.container)}>
-        <Form style={styles.content}>
+        <Form
+          style={styles.content}
+          // The handle field is the form's only input, so the browser submits
+          // implicitly on Enter. Without this, that native GET submit reloads
+          // /login (dropping the search params) and wipes the typed handle
+          // instead of signing in.
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (view !== "login") return;
+            submitTypedHandle();
+          }}
+        >
           <Flex direction="column" gap="5xl" style={styles.form}>
             <Flex
               direction="column"
@@ -384,11 +403,7 @@ function AuthPage() {
                   type="button"
                   isDisabled={!handle.trim() || loginMutation.isPending}
                   isPending={loginMutation.isPending}
-                  onPress={() => {
-                    const trimmed = handle.trim().replace(/^@/, "");
-                    if (trimmed === "") return;
-                    loginMutation.mutate(trimmed);
-                  }}
+                  onPress={submitTypedHandle}
                   style={styles.loginButton}
                 >
                   <Trans>Log in</Trans>

--- a/apps/standard-reader/src/routes/subscribe-login.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/subscribe-login.$did.$rkey.tsx
@@ -185,6 +185,14 @@ function SubscribeLoginPage() {
     },
   });
 
+  /** Sign in with whatever is typed. Shared by the button and Enter-to-submit. */
+  const submitTypedHandle = () => {
+    if (loginMutation.isPending) return;
+    const trimmed = handle.trim().replace(/^@/, "");
+    if (trimmed === "") return;
+    loginMutation.mutate(trimmed);
+  };
+
   const avatarUrl = meta.iconUrl ?? meta.ownerAvatarUrl ?? undefined;
   const publicationName = meta.name;
 
@@ -193,7 +201,16 @@ function SubscribeLoginPage() {
       {...stylex.props(styles.shell, publicationUi, publicationPrimary)}
       style={scaleVars}
     >
-      <Form style={styles.card}>
+      <Form
+        style={styles.card}
+        // The handle field is the form's only input, so the browser submits
+        // implicitly on Enter. Without this, that native GET submit reloads the
+        // page and wipes the typed handle instead of signing in.
+        onSubmit={(event) => {
+          event.preventDefault();
+          submitTypedHandle();
+        }}
+      >
         <Flex direction="column" align="center" gap="xl" style={styles.header}>
           <Avatar
             src={avatarUrl}
@@ -233,11 +250,7 @@ function SubscribeLoginPage() {
             type="button"
             isDisabled={!handle.trim() || loginMutation.isPending}
             isPending={loginMutation.isPending}
-            onPress={() => {
-              const trimmed = handle.trim().replace(/^@/, "");
-              if (trimmed === "") return;
-              loginMutation.mutate(trimmed);
-            }}
+            onPress={submitTypedHandle}
           >
             <Trans>Subscribe</Trans>
           </Button>


### PR DESCRIPTION
## The bug

On `/login`, typing a full handle and pressing <kbd>Enter</kbd> cleared the field instead of signing in.

The handle field is the only input in the form, so the browser does [implicit form submission](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#implicit-submission) on Enter. React Aria's `Form` renders a plain `<form>` with no submit handler, so that submit did a native GET to the current URL — reloading `/login`, dropping the search params (`redirect`, `intent`), and resetting the component state that held the typed handle. The OAuth flow never started.

React Aria's autocomplete only swallows Enter when a suggestion has virtual focus; with nothing focused in the list (the common case when you type the whole handle) the key falls through to the form.

## The fix

Both sign-in forms now handle `onSubmit`: `preventDefault()` and run the same login mutation the button runs. The button and Enter share one `submitTypedHandle` helper, which also no-ops while the mutation is pending.

- `/login` — guarded on `view === "login"` so Enter does nothing in the saved-handles view.
- `/subscribe-login/$did/$rkey` — same form, same bug.

## Verification

- Reproduced and confirmed fixed in the dev server on the real login page.
- `pnpm typecheck`, `pnpm oxlint` (both files), `pnpm format:check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)