### PR TITLE
Keep the items nested under an Offprint list item

### DIFF
--- a/apps/standard-reader/src/components/reader/content/body-styles.ts
+++ b/apps/standard-reader/src/components/reader/content/body-styles.ts
@@ -370,6 +370,17 @@ export const articleBodyStyles = stylex.create({
     marginBottom: spacing["6"],
     marginTop: spacing["0"],
   },
+  /**
+   * A list nested inside a list item.
+   *
+   * The block-level bottom margin separates a list from the prose after it;
+   * inside an item it lands mid-list, stacking with the parent item's own
+   * margin and opening a paragraph-sized hole between siblings. A sub-list
+   * closes on the item gap instead.
+   */
+  nestedList: {
+    marginBottom: gap.sm,
+  },
   listItem: {
     marginBottom: gap.sm,
     marginTop: spacing["0"],

--- a/apps/standard-reader/src/components/reader/content/renderers/leaflet-list.tsx
+++ b/apps/standard-reader/src/components/reader/content/renderers/leaflet-list.tsx
@@ -30,6 +30,7 @@ function nestedList(item: LeafletListItem, embedded = false) {
       <LeafletOrderedListBlockView
         block={{ children: item.children }}
         embedded={embedded}
+        nested
       />
     );
   }
@@ -45,6 +46,7 @@ function nestedList(item: LeafletListItem, embedded = false) {
       <LeafletUnorderedListBlockView
         block={unordered as LeafletUnorderedListBlock}
         embedded={embedded}
+        nested
       />
     );
   }
@@ -60,6 +62,7 @@ function nestedList(item: LeafletListItem, embedded = false) {
       <LeafletOrderedListBlockView
         block={ordered as LeafletOrderedListBlock}
         embedded={embedded}
+        nested
       />
     );
   }
@@ -72,11 +75,13 @@ function LeafletListItems({
   ordered,
   startIndex,
   embedded = false,
+  nested = false,
 }: {
   items: Array<LeafletListItem>;
   ordered: boolean;
   startIndex?: number;
   embedded?: boolean;
+  nested?: boolean;
 }) {
   const tracker = useQuoteHighlightTracker();
   const ListTag = ordered ? "ol" : "ul";
@@ -85,14 +90,15 @@ function LeafletListItems({
     <ListTag
       {...stylex.props(
         articleBodyStyles.list,
+        nested && articleBodyStyles.nestedList,
         embedded && articleBodyStyles.pageEmbedBlockSpacing,
       )}
       {...(ordered ? { start: startIndex ?? 1 } : {})}
     >
       {items.map((item, index) => {
         const text = listItemText(item);
-        const nested = nestedList(item, embedded);
-        if (!text && !nested) return null;
+        const subList = nestedList(item, embedded);
+        if (!text && !subList) return null;
 
         const highlightRange =
           text == null
@@ -108,7 +114,7 @@ function LeafletListItems({
                 highlightRange={highlightRange}
               />
             ) : null}
-            {nested}
+            {subList}
           </li>
         );
       })}
@@ -119,25 +125,11 @@ function LeafletListItems({
 export function LeafletUnorderedListBlockView({
   block,
   embedded = false,
+  nested = false,
 }: {
   block: LeafletUnorderedListBlock;
   embedded?: boolean;
-}) {
-  const children = block.children ?? [];
-  const items = children.filter(
-    (child) => listItemText(child) || nestedList(child),
-  );
-  if (items.length === 0) return null;
-
-  return <LeafletListItems embedded={embedded} items={items} ordered={false} />;
-}
-
-export function LeafletOrderedListBlockView({
-  block,
-  embedded = false,
-}: {
-  block: LeafletOrderedListBlock;
-  embedded?: boolean;
+  nested?: boolean;
 }) {
   const children = block.children ?? [];
   const items = children.filter(
@@ -149,6 +141,32 @@ export function LeafletOrderedListBlockView({
     <LeafletListItems
       embedded={embedded}
       items={items}
+      nested={nested}
+      ordered={false}
+    />
+  );
+}
+
+export function LeafletOrderedListBlockView({
+  block,
+  embedded = false,
+  nested = false,
+}: {
+  block: LeafletOrderedListBlock;
+  embedded?: boolean;
+  nested?: boolean;
+}) {
+  const children = block.children ?? [];
+  const items = children.filter(
+    (child) => listItemText(child) || nestedList(child),
+  );
+  if (items.length === 0) return null;
+
+  return (
+    <LeafletListItems
+      embedded={embedded}
+      items={items}
+      nested={nested}
       ordered
       startIndex={block.startIndex}
     />

--- a/apps/standard-reader/src/components/reader/content/renderers/structured-block-view.tsx
+++ b/apps/standard-reader/src/components/reader/content/renderers/structured-block-view.tsx
@@ -71,11 +71,14 @@ export function StructuredBlockView({
   blobContext,
   codeHighlights,
   dropCap = false,
+  nested = false,
 }: {
   block: StructuredRenderableBlock;
   blobContext?: ContentBlobContext;
   codeHighlights?: CodeHighlightsByScheme;
   dropCap?: boolean;
+  /** Set when this block sits inside a list item rather than the article flow. */
+  nested?: boolean;
 }) {
   /** Lists nest; their children are ordinary blocks, rendered right back here. */
   const renderNested = (child: StructuredRenderableBlock, index: number) => (
@@ -84,6 +87,7 @@ export function StructuredBlockView({
       block={child}
       blobContext={blobContext}
       codeHighlights={codeHighlights}
+      nested
     />
   );
 
@@ -128,6 +132,7 @@ export function StructuredBlockView({
       return (
         <StructuredBulletListView
           items={block.items}
+          nested={nested}
           renderChildBlock={renderNested}
         />
       );
@@ -136,6 +141,7 @@ export function StructuredBlockView({
       return (
         <StructuredOrderedListView
           items={block.items}
+          nested={nested}
           renderChildBlock={renderNested}
           start={block.start}
         />

--- a/apps/standard-reader/src/components/reader/content/renderers/structured-views.tsx
+++ b/apps/standard-reader/src/components/reader/content/renderers/structured-views.tsx
@@ -73,6 +73,8 @@ export function WebsiteCardBody({
  */
 interface StructuredListViewProps {
   items: Array<StructuredListItem>;
+  /** Set when this list is itself nested inside a list item. */
+  nested?: boolean;
   renderChildBlock?: (
     block: StructuredRenderableBlock,
     index: number,
@@ -89,13 +91,19 @@ function renderNestedBlocks(
 
 export function StructuredBulletListView({
   items,
+  nested = false,
   renderChildBlock,
 }: StructuredListViewProps) {
   const tracker = useQuoteHighlightTracker();
   if (items.length === 0) return null;
 
   return (
-    <ul {...stylex.props(articleBodyStyles.list)}>
+    <ul
+      {...stylex.props(
+        articleBodyStyles.list,
+        nested && articleBodyStyles.nestedList,
+      )}
+    >
       {items.map((item, index) => {
         const highlightRange =
           tracker?.consume(item.text.plaintext.length) ?? null;
@@ -116,6 +124,7 @@ export function StructuredBulletListView({
 
 export function StructuredOrderedListView({
   items,
+  nested = false,
   renderChildBlock,
   start,
 }: StructuredListViewProps & { start?: number }) {
@@ -123,7 +132,13 @@ export function StructuredOrderedListView({
   if (items.length === 0) return null;
 
   return (
-    <ol {...stylex.props(articleBodyStyles.list)} start={start ?? 1}>
+    <ol
+      {...stylex.props(
+        articleBodyStyles.list,
+        nested && articleBodyStyles.nestedList,
+      )}
+      start={start ?? 1}
+    >
       {items.map((item, index) => {
         const highlightRange =
           tracker?.consume(item.text.plaintext.length) ?? null;

--- a/packages/renderer-core/src/__tests__/structured-lists.test.ts
+++ b/packages/renderer-core/src/__tests__/structured-lists.test.ts
@@ -9,14 +9,17 @@ import {
   prosemirrorBlocks,
 } from "../document/structured-content/prosemirror.js";
 import type { StructuredRenderableBlock } from "../document/structured-content/types.js";
+import { offprintBlocks } from "../offprint/blocks.js";
+import { OFFPRINT_BLOCK, OFFPRINT_CONTENT } from "../offprint/types.js";
 
 /**
  * Nested lists across the block formats.
  *
  * `StructuredListItem` grew `children` when the markdown parser stopped
- * dropping nested branches; these two parsers kept flattening afterwards, each
- * for its own reason — ProseMirror nests a sub-list *inside* the parent item,
- * BlockNote hangs it off the parent block's `children`.
+ * dropping nested branches; these three parsers kept flattening afterwards,
+ * each for its own reason — ProseMirror nests a sub-list *inside* the parent
+ * item, BlockNote hangs it off the parent block's `children`, and Offprint
+ * hangs bare items off the parent *item's* `children`.
  */
 
 function asList(
@@ -49,6 +52,17 @@ const item = (
 const blocknoteDoc = (...blocks: Array<unknown>) => ({
   $type: BLOCKNOTE_CONTENT,
   blocks,
+});
+
+/** An Offprint list item: one text run, plus the items nested beneath it. */
+const offprintItem = (plaintext: string, children: Array<unknown> = []) => ({
+  children,
+  content: { $type: OFFPRINT_BLOCK.text, plaintext },
+});
+
+const offprintDoc = (...items: Array<unknown>) => ({
+  $type: OFFPRINT_CONTENT,
+  items,
 });
 
 describe("prosemirror — nested lists", () => {
@@ -179,5 +193,100 @@ describe("blocknote — nested blocks", () => {
       }),
     );
     expect(asList(blocks[0]).items[0]?.text.plaintext).toBe("orphaned");
+  });
+});
+
+describe("offprint — nested list items", () => {
+  it("keeps the items nested under a bullet item", () => {
+    const blocks = offprintBlocks(
+      offprintDoc({
+        $type: OFFPRINT_BLOCK.bulletList,
+        children: [
+          offprintItem("outer", [
+            offprintItem("inner"),
+            offprintItem("inner sibling"),
+          ]),
+          offprintItem("sibling"),
+        ],
+      }),
+    );
+
+    const list = asList(blocks[0]);
+    expect(list.items.map((entry) => entry.text.plaintext)).toEqual([
+      "outer",
+      "sibling",
+    ]);
+    const nested = asList(list.items[0]?.children?.[0]);
+    expect(nested.kind).toBe("bulletList");
+    expect(nested.items.map((entry) => entry.text.plaintext)).toEqual([
+      "inner",
+      "inner sibling",
+    ]);
+    expect(list.items[1]?.children).toBeUndefined();
+  });
+
+  it("nests an ordered sub-list under an ordered item", () => {
+    const blocks = offprintBlocks(
+      offprintDoc({
+        $type: OFFPRINT_BLOCK.orderedList,
+        children: [offprintItem("first", [offprintItem("first.a")])],
+        start: 3,
+      }),
+    );
+
+    const list = asList(blocks[0]);
+    expect(list.kind).toBe("orderedList");
+    expect(asList(list.items[0]?.children?.[0]).kind).toBe("orderedList");
+  });
+
+  it("keeps arbitrarily deep branches", () => {
+    const blocks = offprintBlocks(
+      offprintDoc({
+        $type: OFFPRINT_BLOCK.bulletList,
+        children: [
+          offprintItem("one", [offprintItem("two", [offprintItem("three")])]),
+        ],
+      }),
+    );
+
+    const list = asList(blocks[0]);
+    const second = asList(list.items[0]?.children?.[0]);
+    const third = asList(second.items[0]?.children?.[0]);
+    expect(third.items[0]?.text.plaintext).toBe("three");
+  });
+
+  it("keeps an item that is only a sub-list", () => {
+    const blocks = offprintBlocks(
+      offprintDoc({
+        $type: OFFPRINT_BLOCK.bulletList,
+        children: [
+          { children: [offprintItem("only child")] },
+          offprintItem("sibling"),
+        ],
+      }),
+    );
+
+    const list = asList(blocks[0]);
+    expect(list.items[0]?.text.plaintext).toBe("");
+    expect(asList(list.items[0]?.children?.[0]).items[0]?.text.plaintext).toBe(
+      "only child",
+    );
+    expect(list.items[1]?.text.plaintext).toBe("sibling");
+  });
+
+  it("still drops an item with neither text nor a subtree", () => {
+    const blocks = offprintBlocks(
+      offprintDoc({
+        $type: OFFPRINT_BLOCK.bulletList,
+        children: [
+          offprintItem("  "),
+          { content: { $type: "app.offprint.block.image" } },
+          offprintItem("kept"),
+        ],
+      }),
+    );
+
+    const list = asList(blocks[0]);
+    expect(list.items.map((entry) => entry.text.plaintext)).toEqual(["kept"]);
   });
 });

--- a/packages/renderer-core/src/offprint/blocks.ts
+++ b/packages/renderer-core/src/offprint/blocks.ts
@@ -21,13 +21,33 @@ function asText(value: unknown): StructuredText | null {
   };
 }
 
-function listItemsFromChildren(children: unknown): Array<StructuredListItem> {
+/**
+ * List items, including the sub-lists Offprint hangs off an item's `children`.
+ *
+ * An Offprint item nests by carrying its own `children` array of items rather
+ * than a list block, so the sub-list is rebuilt here as a list of the parent's
+ * kind — dropping it loses whole branches of a document.
+ */
+function listItemsFromChildren(
+  children: unknown,
+  kind: "bulletList" | "orderedList",
+): Array<StructuredListItem> {
   if (!Array.isArray(children)) return [];
   const items: Array<StructuredListItem> = [];
   for (const child of children) {
     if (!isRecord(child)) continue;
     const text = asText(child.content);
-    if (text?.plaintext.trim()) items.push({ text });
+    const nested = listItemsFromChildren(child.children, kind);
+    const branch: Array<StructuredRenderableBlock> =
+      nested.length > 0 ? [{ items: nested, kind }] : [];
+
+    if (text?.plaintext.trim()) {
+      items.push(branch.length > 0 ? { children: branch, text } : { text });
+    } else if (branch.length > 0) {
+      // An item that is only a sub-list still has to keep the branch, so it
+      // becomes an empty parent rather than disappearing with its children.
+      items.push({ children: branch, text: { plaintext: "" } });
+    }
   }
   return items;
 }
@@ -89,12 +109,12 @@ function asRenderableBlock(value: unknown): StructuredRenderableBlock | null {
   }
 
   if (value.$type === OFFPRINT_BLOCK.bulletList) {
-    const items = listItemsFromChildren(value.children);
+    const items = listItemsFromChildren(value.children, "bulletList");
     return items.length > 0 ? { kind: "bulletList", items } : null;
   }
 
   if (value.$type === OFFPRINT_BLOCK.orderedList) {
-    const items = listItemsFromChildren(value.children);
+    const items = listItemsFromChildren(value.children, "orderedList");
     return items.length > 0
       ? {
           kind: "orderedList",


### PR DESCRIPTION
Fixes [Missing list subitems from Offprint](https://userinput.app/d/did:plc:fip3nyk6tjo3senpq4ei2cxw/3msp2ilpkpv24), reported by `vicwalker.dev.br`.

## The bug

`listItemsFromChildren` in `packages/renderer-core/src/offprint/blocks.ts` read a list's `children` exactly one level deep and pushed `{ text }`, throwing away whatever hung off each item.

Offprint nests differently from the other formats: instead of nesting a *list block* inside the parent item, it hangs bare items off the parent **item's** own `children`. So every sub-list in an Offprint document vanished from the article with nothing in its place.

Confirmed live before touching code — on the reported article the "Everywhere Else" component renders all 8 top-level bullets, but the two Semble collections nested under the Semble link (`AT://links`, `DEEP AT://magic`) are absent from the DOM.

## The fix

Recurse, rebuilding each item's sub-list as a list of the parent's kind. An item that is *only* a sub-list keeps its branch as an empty parent — the same rule the markdown and ProseMirror parsers already follow.

Nothing downstream needed a change: all seven renderer packages plus the app's list view, plaintext extractor, and quote-highlight walker already handle `StructuredListItem.children` (markdown has produced it for a while).

## Second commit: sub-list spacing

With sub-lists finally visible, a latent spacing bug showed up. `articleBodyStyles.list` carries the bottom margin that separates a list from the prose after it — but a nested list isn't followed by prose, it's followed by its parent's next sibling. That margin landed mid-list and collapsed against the parent item's own margin, opening a paragraph-sized hole between two bullets.

A `nested` flag swaps it for the item gap, threaded from the one place that knows a list is nested: the block view's `renderNested`, and Leaflet's `nestedList`. Both formats share the style, so Leaflet had the same gap — fixed there too.

## Testing

- Replayed the real `app.offprint.component/3mqyujdicqo2p` record through the parser — the two sub-items now come back nested.
- 5 new offprint cases in `structured-lists.test.ts`: nesting, ordered-in-ordered, three levels deep, sub-list-only item, and that empty items are still dropped.
- Verified in a browser against the reported article: the sub-items render, and the gap after the nested branch now measures the same 6px as every other item gap in the list.
- `renderer-core` suite 101 passed; reader/leaflet/offprint app tests 116 passed; app typecheck, oxlint, oxfmt clean.

## Left alone

`packages/converter/src/targets/offprint.ts:80` still assumes Offprint list items can't nest and emits a `list-nesting-dropped` warning when converting *into* Offprint. This record proves they can — but that's the write path into someone else's app and I can't test what their editor accepts, so it's a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)