### PR TITLE
Search and filter the saved queue

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -582,10 +582,30 @@ comic issue with no pages falls back to it outright.
 
 - Signed-in reader's **save queue** (`app.standard-reader.bookmark`), newest-saved first by default.
 - Sortable via `?sort=` — date saved (default), published date, publication (alphabetical), or
-  title (alphabetical); Menu (compact) / Select (full) control, mirroring `/tag`'s article sort.
-- Reversible via `?dir=` — an icon button beside the sort control flips the order. Each field runs
-  its natural way until flipped (dates newest-first, names A–Z), and the direction is named for
-  what it ranks: "Newest first" / "Oldest first" for dates, "A–Z" / "Z–A" for names.
+  title (alphabetical).
+- Reversible via `?dir=`. Each field runs its natural way until flipped (dates newest-first, names
+  A–Z), and the direction is named for what it ranks: "Newest first" / "Oldest first" for dates,
+  "A–Z" / "Z–A" for names.
+- Both live in **one icon menu** at every viewport — two sections ("Sort by" / "Order") in a single
+  sheet that stays open between the two picks. With the order behind a menu, the trigger's tooltip
+  and accessible name state the current order ("Sort — Date saved, Newest first") rather than only
+  naming the action.
+- **Search and filter**, in a toolbar above the list (search field · filter · sort). Both are
+  server-side and live in the URL, so paging, the result count, and a reloaded or bookmarked link
+  all agree:
+  - `?q=` matches title, description, publication name, and the author's handle / display name.
+    Deliberately not the article body — `/saved` omits `text_content` from its projection, and a
+    hit the row can't visibly explain reads as a bug.
+  - `?pubs=` / `?authors=` / `?tags=` are multi-select facets. Values within a facet are OR-ed,
+    facets are AND-ed. Tags match through `immutable_normalized_tags`, so case and whitespace
+    variants are one tag.
+  - The options come from `reader.getSavedFacets` — every publication, author, and tag present in
+    that reader's own queue, with counts, in one `UNION ALL` round trip. Fetched on idle or on the
+    popover's first open, never on the critical path. A real queue runs to ~90 publications and
+    ~185 tags, so the popover is type-ahead filtered across all three facets at once rather than a
+    plain menu.
+  - Applied filters show as removable chips under the toolbar; the masthead count stays the whole
+    queue and a "Showing N of M saved" line carries what matched.
 - Route `/saved`; linked from the sidebar (with saved count badge). Requires auth (redirects to login).
 
 ### Reader profile (liked articles)

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -1341,14 +1341,28 @@ not offline body cache). Route slug **`/saved`**.
       bar + feed cards; user-menu link; empty state copy; infinite scroll (20 per page). Update [`APP_VISION.md`](APP_VISION.md) §5
       when landing.
 - [x] **Saved queue sort** — `?sort=` on `/saved` (date saved / published date / publication /
-      title), mirroring `/tag`'s article-sort Menu+Select control; `savedOrderBy` in
+      title); `savedOrderBy` in
       [`api-reader.functions.ts`](src/integrations/tanstack-query/api-reader.functions.ts), sort
       included in the infinite-query key so paging never mixes sort orders.
-- [x] **Saved queue sort direction** — `?dir=asc|desc` beside `?sort=`, flipped by an icon button
-      next to the sort control. Absent from the URL until the reader flips it, so each field keeps
-      its natural direction (dates newest-first, names A–Z) via `defaultSavedSortDirection`; an
-      explicit choice carries across a change of field. NULLS stay LAST in both directions so a
-      bookmark whose document is gone never floats to the top.
+- [x] **Saved queue sort direction** — `?dir=asc|desc` beside `?sort=`. Absent from the URL until
+      the reader flips it, so each field keeps its natural direction (dates newest-first, names
+      A–Z) via `defaultSavedSortDirection`; an explicit choice carries across a change of field.
+      NULLS stay LAST in both directions so a bookmark whose document is gone never floats to the
+      top. Field and order share **one icon menu at every viewport** (two sections in a sheet that
+      stays open between picks) — the desktop Select + flip-button pair was dropped, so the
+      trigger's tooltip / accessible name now states the current order.
+- [x] **Saved queue search + filters** ([userinput.app feature request](https://userinput.app/d/did:plc:fip3nyk6tjo3senpq4ei2cxw/3mrqbtf4pk22o))
+      — search and multi-select publication / author / tag filters on `/saved`, in a toolbar above
+      the list (the sort control moved out of the masthead's trailing slot to join it, and
+      `Masthead`'s now-unused `metaAction` prop was removed). All state lives in the URL
+      (`?q=` `?pubs=` `?authors=` `?tags=`) and all filtering is server-side in `getSaved`, so
+      paging and counts stay correct across pages. Values within a facet OR, facets AND; tags match
+      through `immutable_normalized_tags`. Options come from `reader.getSavedFacets` →
+      `selectSavedFacets` (one `UNION ALL` round trip, fetched on idle or first popover open).
+      Real queues run to ~90 publications / ~185 tags, so the popover is a react-aria
+      `Autocomplete` type-ahead over all three facets at once rather than a plain menu; applied
+      filters render as removable chips, and over-filtering gets its own empty state distinct from
+      an empty queue.
 - [x] **Reading history** — `/history` queue backed by existing
       `app.standard-reader.read` / `reads` table (no new lexicon); `readerApi.getReadingHistory` + user-menu link + empty state; infinite scroll (20 per page). Update [`APP_VISION.md`](APP_VISION.md) when landing.
 - [x] **Track reading history setting** — user-menu toggle (cookie + `user.track_reading_history`);

--- a/apps/standard-reader/src/components/reader/bookmark-optimistic.ts
+++ b/apps/standard-reader/src/components/reader/bookmark-optimistic.ts
@@ -3,8 +3,7 @@ import type { InfiniteData, QueryClient } from "@tanstack/react-query";
 import type { SidebarData } from "../../integrations/tanstack-query/api-feed.functions";
 import type {
   BookmarkStatus,
-  ReaderListPage,
-  SavedArticleItem,
+  SavedListPage,
 } from "../../integrations/tanstack-query/api-reader.functions";
 
 export interface BookmarkOptimisticContext {
@@ -12,7 +11,7 @@ export interface BookmarkOptimisticContext {
   prevSavedEntries: Array<[readonly unknown[], unknown]>;
 }
 
-type SavedInfiniteData = InfiniteData<ReaderListPage<SavedArticleItem>>;
+type SavedInfiniteData = InfiniteData<SavedListPage>;
 
 function isSavedInfiniteData(data: unknown): data is SavedInfiniteData {
   return (
@@ -47,7 +46,11 @@ function removeFromSavedInfinite(
     ...data,
     pages: pages.map((page) => ({
       ...page,
+      // Both counts move: `total` is what the filtered list paginates on, and
+      // `totalSaved` is the masthead's headline figure. Dropping one leaves
+      // `/saved` reading "148 saved" over 147 rows until the next fetch.
       total: Math.max(0, page.total - 1),
+      totalSaved: Math.max(0, page.totalSaved - 1),
     })),
   };
 }

--- a/apps/standard-reader/src/components/reader/primitives.tsx
+++ b/apps/standard-reader/src/components/reader/primitives.tsx
@@ -509,7 +509,6 @@ export function Masthead({
   metaLabel,
   metaValue,
   metaAccessory,
-  metaAction,
   style,
 }: {
   kicker?: React.ReactNode;
@@ -519,14 +518,6 @@ export function Masthead({
   metaLabel?: React.ReactNode;
   metaValue?: React.ReactNode;
   metaAccessory?: React.ReactNode;
-  /**
-   * A control docked to the trailing edge, under the meta figure — for page
-   * chrome that would otherwise float in its own row between the masthead rule
-   * and the content (e.g. `/saved`'s sort). Unlike the label/value above it,
-   * this stays visible on narrow screens, so pass a control that is compact
-   * there (see `/saved`'s icon-menu ⇄ select swap).
-   */
-  metaAction?: React.ReactNode;
   style?: StyleXComponentProps<React.ComponentProps<"div">>["style"];
 }) {
   return (
@@ -539,18 +530,17 @@ export function Masthead({
         </Flex>
         {dek != null && <p {...stylex.props(styles.mastheadDek)}>{dek}</p>}
       </Flex>
-      {metaValue != null || metaAccessory != null || metaAction != null ? (
+      {metaValue != null || metaAccessory != null ? (
         <Flex
           direction="column"
           gap="lg"
           align="end"
           style={[
             styles.mastheadMeta,
-            (metaAccessory != null || metaAction != null) &&
-              styles.mastheadMetaWithAccessory,
+            metaAccessory != null && styles.mastheadMetaWithAccessory,
           ]}
         >
-          {/* The figure keeps its own ≥48rem visibility so a `metaAction`
+          {/* The figure keeps its own ≥48rem visibility so a `metaAccessory`
               forcing the column open does not surface it on narrow screens. */}
           {metaLabel != null || metaValue != null ? (
             <Flex direction="column" gap="lg" style={styles.mastheadMetaFigure}>
@@ -562,7 +552,6 @@ export function Masthead({
               )}
             </Flex>
           ) : null}
-          {metaAction}
         </Flex>
       ) : null}
     </div>

--- a/apps/standard-reader/src/components/reader/reader-queue-rows.tsx
+++ b/apps/standard-reader/src/components/reader/reader-queue-rows.tsx
@@ -59,6 +59,7 @@ export function ReaderQueueRows({
   saveButtonPlacement = "header",
   showMarkUnreadButton = false,
   assumeBookmarked,
+  flushFirstRow = true,
 }: {
   items: Array<ReaderQueueRowItem>;
   showSaveButton?: boolean;
@@ -67,6 +68,14 @@ export function ReaderQueueRows({
   showMarkUnreadButton?: boolean;
   /** Skip per-row bookmark status fetches when rendering the save queue. */
   assumeBookmarked?: boolean;
+  /**
+   * Whether the first row hugs the top, with no padding above it. True for a
+   * list that sits directly under a section head. Pass `false` when the list
+   * carries its own rule above the first row (`/saved`, under its toolbar), so
+   * the row breathes under that rule the same way every other row breathes
+   * under the one above it.
+   */
+  flushFirstRow?: boolean;
 }) {
   const fmt = useFormatters();
 
@@ -76,7 +85,7 @@ export function ReaderQueueRows({
         <ArticleRow
           key={item.id}
           article={item.article}
-          isFirstInSection={index === 0}
+          isFirstInSection={flushFirstRow && index === 0}
           showSaveButton={showSaveButton}
           saveButtonPlacement={saveButtonPlacement}
           showMarkUnreadButton={showMarkUnreadButton}

--- a/apps/standard-reader/src/components/reader/saved-filters.tsx
+++ b/apps/standard-reader/src/components/reader/saved-filters.tsx
@@ -1,0 +1,457 @@
+"use client";
+
+import { plural } from "@lingui/core/macro";
+import { Plural, Trans, useLingui } from "@lingui/react/macro";
+import { Button } from "@standard-reader/design-system/button";
+import { Flex } from "@standard-reader/design-system/flex";
+import { IconButton } from "@standard-reader/design-system/icon-button";
+import {
+  ListBox,
+  ListBoxItem,
+  ListBoxSection,
+  ListBoxSectionHeader,
+} from "@standard-reader/design-system/listbox";
+import { Popover } from "@standard-reader/design-system/popover";
+import { SearchField } from "@standard-reader/design-system/search-field";
+import { Skeleton } from "@standard-reader/design-system/skeleton";
+import { TagGroup, Tag } from "@standard-reader/design-system/tag-group";
+import {
+  primaryColor,
+  uiColor,
+} from "@standard-reader/design-system/theme/color.stylex";
+import { radius } from "@standard-reader/design-system/theme/radius.stylex";
+import { spacing } from "@standard-reader/design-system/theme/spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+  lineHeight,
+} from "@standard-reader/design-system/theme/typography.stylex";
+import * as stylex from "@stylexjs/stylex";
+import { ListFilter } from "lucide-react";
+import { useMemo, useState } from "react";
+import type { Selection } from "react-aria-components";
+import { Autocomplete, useFilter } from "react-aria-components";
+
+import type {
+  SavedFacetOption,
+  SavedFacets,
+} from "#/integrations/tanstack-query/api-reader.functions";
+import type { SavedFacetName, SavedFilterValues } from "#/lib/saved-filters";
+import {
+  countSavedFilters,
+  facetKey,
+  parseFacetKey,
+} from "#/lib/saved-filters";
+
+const styles = stylex.create({
+  trigger: {
+    position: "relative",
+  },
+  // Marks the closed trigger while a filter is narrowing the list, so a
+  // filtered-down page never reads as an empty queue. Drawn as a
+  // pseudo-element, not a child span: an extra element after the icon matches
+  // the design system's `:has(svg+*)` padding rule for icon+label buttons and
+  // pulls the centred icon off-centre. Same treatment as `/feedback`.
+  triggerActive: {
+    "::after": {
+      backgroundColor: primaryColor.solid1,
+      borderRadius: radius.full,
+      content: "''",
+      insetBlockStart: spacing["2"],
+      insetInlineEnd: spacing["2"],
+      position: "absolute",
+      height: spacing["1.5"],
+      width: spacing["1.5"],
+    },
+  },
+  // The popover's own padding is stripped so the search field can sit flush
+  // against the top edge and the list can scroll under it.
+  popover: {
+    boxSizing: "border-box",
+    paddingBottom: 0,
+    paddingInlineEnd: 0,
+    paddingInlineStart: 0,
+    paddingTop: 0,
+    maxWidth: "100%",
+    width: spacing["80"],
+  },
+  searchRow: {
+    borderBottomColor: uiColor.border1,
+    borderBottomStyle: "solid",
+    borderBottomWidth: 1,
+    paddingBottom: spacing["2"],
+    paddingInlineEnd: spacing["2"],
+    paddingInlineStart: spacing["2"],
+    paddingTop: spacing["2"],
+  },
+  listScroller: {
+    // Capped against the viewport as well as an absolute ceiling: on a short
+    // window the popover must not run off the bottom of the screen.
+    maxHeight: "min(24rem, 50vh)",
+    overflowY: "auto",
+    overscrollBehavior: "contain",
+    paddingBottom: spacing["2"],
+    paddingInlineEnd: spacing["2"],
+    paddingInlineStart: spacing["2"],
+    paddingTop: spacing["2"],
+  },
+  itemLabel: {
+    minWidth: 0,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  itemDetail: {
+    color: uiColor.text1,
+    fontSize: fontSize.xs,
+  },
+  itemCount: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.mono,
+    fontSize: fontSize.xs,
+    fontVariantNumeric: "tabular-nums",
+  },
+  emptyState: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.sm,
+    lineHeight: lineHeight.base,
+    paddingBottom: spacing["4"],
+    paddingInlineEnd: spacing["3"],
+    paddingInlineStart: spacing["3"],
+    paddingTop: spacing["4"],
+    textAlign: "center",
+  },
+  footer: {
+    borderTopColor: uiColor.border1,
+    borderTopStyle: "solid",
+    borderTopWidth: 1,
+    paddingBottom: spacing["2"],
+    paddingInlineEnd: spacing["2"],
+    paddingInlineStart: spacing["3"],
+    paddingTop: spacing["2"],
+  },
+  footerCount: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.sm,
+  },
+  loadingRows: {
+    paddingBottom: spacing["3"],
+    paddingInlineEnd: spacing["3"],
+    paddingInlineStart: spacing["3"],
+    paddingTop: spacing["3"],
+  },
+  chipRow: {
+    marginTop: spacing["4"],
+  },
+});
+
+interface FacetSection {
+  name: SavedFacetName;
+  heading: React.ReactNode;
+  options: Array<SavedFacetOption>;
+}
+
+/**
+ * The filter surface for `/saved`: a popover holding every publication,
+ * author, and tag the reader has saved something from, type-ahead filtered and
+ * multi-select.
+ *
+ * Selections apply immediately and the popover stays open — narrowing a queue
+ * is usually two or three ticks, and a confirm step would make each one cost a
+ * round of open/close.
+ */
+export function SavedFilterPopover({
+  facets,
+  isPending,
+  value,
+  onChange,
+  onOpenChange,
+}: {
+  facets: SavedFacets | undefined;
+  /** Facet options are still loading. The popover opens to skeleton rows
+   * rather than an empty list that reads as "nothing to filter by". */
+  isPending: boolean;
+  value: SavedFilterValues;
+  onChange: (next: SavedFilterValues) => void;
+  /** Fired on open so the page can start the facets fetch for a reader who
+   * never idles long enough to prefetch it. */
+  onOpenChange?: (open: boolean) => void;
+}) {
+  const { t } = useLingui();
+  const { contains } = useFilter({ sensitivity: "base" });
+  const [query, setQuery] = useState("");
+  const activeCount = countSavedFilters(value);
+
+  const sections: Array<FacetSection> = useMemo(
+    () =>
+      [
+        {
+          heading: <Trans>Publications</Trans>,
+          name: "pubs" as const,
+          options: facets?.publications ?? [],
+        },
+        {
+          heading: <Trans>Authors</Trans>,
+          name: "authors" as const,
+          options: facets?.authors ?? [],
+        },
+        {
+          heading: <Trans>Tags</Trans>,
+          name: "tags" as const,
+          options: facets?.tags ?? [],
+        },
+      ].filter((section) => section.options.length > 0),
+    [facets],
+  );
+
+  const selectedKeys = useMemo(
+    () =>
+      new Set([
+        ...value.pubs.map((id) => facetKey("pubs", id)),
+        ...value.authors.map((id) => facetKey("authors", id)),
+        ...value.tags.map((id) => facetKey("tags", id)),
+      ]),
+    [value],
+  );
+
+  const handleSelectionChange = (keys: Selection) => {
+    // "all" only arrives from select-all, which this list doesn't offer.
+    if (keys === "all") return;
+    const next: SavedFilterValues = { authors: [], pubs: [], tags: [] };
+    for (const key of keys) {
+      const parsed = parseFacetKey(key);
+      if (parsed) next[parsed.facet].push(parsed.id);
+    }
+    onChange(next);
+  };
+
+  const label =
+    activeCount === 0
+      ? t`Filter saved articles`
+      : t`Filter saved articles — ${plural(activeCount, {
+          one: "# filter active",
+          other: "# filters active",
+        })}`;
+
+  return (
+    <Popover
+      placement="bottom end"
+      style={styles.popover}
+      onOpenChange={(open) => {
+        // Reset the type-ahead between visits: reopening to yesterday's search
+        // term, with most options hidden, reads as data loss.
+        if (!open) setQuery("");
+        onOpenChange?.(open);
+      }}
+      trigger={
+        <IconButton
+          size="lg"
+          variant="secondary"
+          label={label}
+          // `label` only feeds the tooltip (react-aria wires it through
+          // `aria-describedby`, and only while open), so name the button
+          // explicitly for assistive tech and touch users.
+          aria-label={label}
+          style={[styles.trigger, activeCount > 0 && styles.triggerActive]}
+        >
+          <ListFilter size={16} strokeWidth={2} />
+        </IconButton>
+      }
+    >
+      <Autocomplete
+        filter={contains}
+        inputValue={query}
+        onInputChange={setQuery}
+      >
+        <div {...stylex.props(styles.searchRow)}>
+          {/* No `autoFocus`: the popover is a react-aria dialog, so it already
+              moves focus to its first focusable child — this field — on open. */}
+          <SearchField
+            size="md"
+            variant="secondary"
+            aria-label={t`Find a publication, author, or tag`}
+            placeholder={t`Filter by…`}
+          />
+        </div>
+
+        {isPending && sections.length === 0 ? (
+          <div
+            {...stylex.props(styles.loadingRows)}
+            aria-busy="true"
+            aria-label={t`Loading filter options`}
+          >
+            <Flex direction="column" gap="lg">
+              {["a", "b", "c", "d"].map((row) => (
+                <Skeleton key={row} variant="rectangle" height="1.25rem" />
+              ))}
+            </Flex>
+          </div>
+        ) : (
+          <div {...stylex.props(styles.listScroller)}>
+            <ListBox
+              variant="checkbox"
+              size="md"
+              selectionMode="multiple"
+              selectedKeys={selectedKeys}
+              onSelectionChange={handleSelectionChange}
+              aria-label={t`Filter saved articles`}
+              renderEmptyState={() => (
+                <p {...stylex.props(styles.emptyState)}>
+                  {query
+                    ? t`Nothing saved matches “${query}”.`
+                    : t`Nothing to filter by yet.`}
+                </p>
+              )}
+            >
+              {sections.map((section) => (
+                <ListBoxSection key={section.name} id={section.name}>
+                  <ListBoxSectionHeader>{section.heading}</ListBoxSectionHeader>
+                  {section.options.map((option) => (
+                    <ListBoxItem
+                      key={facetKey(section.name, option.id)}
+                      id={facetKey(section.name, option.id)}
+                      // Handles join the searchable text so typing
+                      // "@alice.dev" finds the author whose display name is
+                      // "Alice", which is how people actually look for a byline.
+                      textValue={
+                        option.detail && option.detail !== option.label
+                          ? `${option.label} ${option.detail}`
+                          : option.label
+                      }
+                      suffix={
+                        <span {...stylex.props(styles.itemCount)}>
+                          {option.count}
+                        </span>
+                      }
+                    >
+                      <span {...stylex.props(styles.itemLabel)}>
+                        {option.label}
+                        {option.detail && option.detail !== option.label ? (
+                          <>
+                            {" "}
+                            <span {...stylex.props(styles.itemDetail)}>
+                              @{option.detail}
+                            </span>
+                          </>
+                        ) : null}
+                      </span>
+                    </ListBoxItem>
+                  ))}
+                </ListBoxSection>
+              ))}
+            </ListBox>
+          </div>
+        )}
+
+        {activeCount > 0 ? (
+          <Flex
+            direction="row"
+            gap="md"
+            align="center"
+            justify="between"
+            style={styles.footer}
+          >
+            <span {...stylex.props(styles.footerCount)}>
+              {/* `<Plural>`, not the bare `plural()` macro: standalone
+                  `plural()` compiles against Lingui's global singleton, which
+                  this app never activates — it runs a per-locale instance (see
+                  `src/lib/i18n.ts`). The component reads that instance from
+                  context. */}
+              <Plural value={activeCount} one="# filter" other="# filters" />
+            </span>
+            <Button
+              size="sm"
+              variant="tertiary"
+              onPress={() => onChange({ authors: [], pubs: [], tags: [] })}
+            >
+              <Trans>Clear all</Trans>
+            </Button>
+          </Flex>
+        ) : null}
+      </Autocomplete>
+    </Popover>
+  );
+}
+
+/**
+ * The applied filters, spelled out and individually removable.
+ *
+ * The trigger's dot says *that* something is filtered; this says *what*. On a
+ * page a reader comes back to days later — with filters restored from the URL
+ * — that difference is the whole story of why the queue looks short.
+ */
+export function SavedFilterChips({
+  facets,
+  value,
+  onChange,
+  onClear,
+}: {
+  facets: SavedFacets | undefined;
+  value: SavedFilterValues;
+  onChange: (next: SavedFilterValues) => void;
+  onClear: () => void;
+}) {
+  const { t } = useLingui();
+
+  const chips = useMemo(() => {
+    const labelFor = (options: Array<SavedFacetOption>, id: string) =>
+      options.find((option) => option.id === id)?.label;
+    return [
+      ...value.pubs.map((id) => ({
+        facet: "pubs" as const,
+        id,
+        // Until the facets land there's no name for an AT-URI or a DID, so the
+        // chip says what it is rather than showing raw identifier soup.
+        label: labelFor(facets?.publications ?? [], id) ?? t`Publication`,
+      })),
+      ...value.authors.map((id) => ({
+        facet: "authors" as const,
+        id,
+        label: labelFor(facets?.authors ?? [], id) ?? t`Author`,
+      })),
+      ...value.tags.map((id) => ({
+        facet: "tags" as const,
+        id,
+        label: labelFor(facets?.tags ?? [], id) ?? id,
+      })),
+    ].map((chip) => ({ ...chip, key: facetKey(chip.facet, chip.id) }));
+  }, [facets, t, value]);
+
+  if (chips.length === 0) return null;
+
+  return (
+    <Flex direction="row" gap="md" align="center" wrap style={styles.chipRow}>
+      <TagGroup
+        items={chips}
+        aria-label={t`Active filters`}
+        onRemove={(keys) => {
+          const next: SavedFilterValues = {
+            authors: [...value.authors],
+            pubs: [...value.pubs],
+            tags: [...value.tags],
+          };
+          for (const key of keys) {
+            const parsed = parseFacetKey(key);
+            if (parsed) {
+              next[parsed.facet] = next[parsed.facet].filter(
+                (id) => id !== parsed.id,
+              );
+            }
+          }
+          onChange(next);
+        }}
+      >
+        {(chip: (typeof chips)[number]) => (
+          <Tag key={chip.key} id={chip.key} textValue={chip.label}>
+            {chip.label}
+          </Tag>
+        )}
+      </TagGroup>
+      <Button size="md" variant="tertiary" onPress={onClear}>
+        <Trans>Clear all</Trans>
+      </Button>
+    </Flex>
+  );
+}

--- a/apps/standard-reader/src/components/reader/use-article-bookmark.ts
+++ b/apps/standard-reader/src/components/reader/use-article-bookmark.ts
@@ -53,6 +53,15 @@ export function useArticleBookmark(
         // Missing-scope errors are handled globally (a reconnect toast) by the
         // mutation cache in query-client.ts.
       },
+      onSettled: () => {
+        // `/saved`'s filter facets are per-publication / per-author / per-tag
+        // counts over exactly this set, so saving or unsaving moves them.
+        // Invalidated after the write lands rather than optimistically — a
+        // refetch racing the mutation would just re-read the old counts.
+        void queryClient.invalidateQueries({
+          queryKey: ["reader", "savedFacets"],
+        });
+      },
     });
   };
 

--- a/apps/standard-reader/src/integrations/tanstack-query/api-reader.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-reader.functions.ts
@@ -6,7 +6,7 @@ import {
 import { createServerFn } from "@tanstack/react-start";
 import { getRequest } from "@tanstack/react-start/server";
 import type { SQL } from "drizzle-orm";
-import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, ilike, inArray, or, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { z } from "zod";
 
@@ -42,7 +42,11 @@ import {
   mirrorRecommendAdded,
   mirrorRecommendRemoved,
 } from "#/server/reader/personal-state-mirror";
-import { selectUnreadDocumentUris } from "#/server/reader/queries";
+import type { SavedFacets } from "#/server/reader/queries";
+import {
+  selectSavedFacets,
+  selectUnreadDocumentUris,
+} from "#/server/reader/queries";
 import { attachViewerRecommendedToArticles } from "#/server/reader/recommended-by";
 import { effectiveFollowSets } from "#/server/reader/saved-lists";
 import {
@@ -66,6 +70,10 @@ import { dbMiddleware } from "./db-middleware";
  * `~/Documents/at-store` server-fn + query-options layout, with structured
  * observability around every call (`src/server/observability/log.ts`).
  */
+
+/** Re-exported so the UI takes its filter-option shapes off the API layer
+ * rather than reaching into a server-only query module. */
+export type { SavedFacetOption, SavedFacets } from "#/server/reader/queries";
 
 const publicationInput = z.object({
   publicationUri: z.string().min(1),
@@ -113,11 +121,144 @@ export function defaultSavedSortDirection(sort: SavedSort): SavedSortDirection {
   return sort === "publication" || sort === "title" ? "asc" : "desc";
 }
 
+/**
+ * Ceiling on how many values one facet can carry in the URL. Far above what a
+ * reader will ever tick by hand; it exists so a hand-edited or stale link
+ * can't turn into an unbounded `IN (...)`.
+ */
+export const SAVED_FILTER_MAX_VALUES = 100;
+
+/** Longest search string we'll send to the server. */
+export const SAVED_SEARCH_MAX_LENGTH = 200;
+
+/**
+ * The filter half of `/saved`'s state, shared by the route's search params and
+ * the server fn's validator so the two can't drift. Every field is optional:
+ * absent, empty, and all-blank all mean "not filtering on this".
+ */
+export const savedFiltersSchema = z.object({
+  /** Free text, matched against title, description, publication name, and the
+   * author's handle / display name. */
+  q: z.string().max(SAVED_SEARCH_MAX_LENGTH).optional(),
+  /** Publication AT-URIs. */
+  pubs: z.array(z.string().min(1)).max(SAVED_FILTER_MAX_VALUES).optional(),
+  /** Author DIDs. */
+  authors: z.array(z.string().min(1)).max(SAVED_FILTER_MAX_VALUES).optional(),
+  /** Normalized (lowercased, trimmed) tags. */
+  tags: z.array(z.string().min(1)).max(SAVED_FILTER_MAX_VALUES).optional(),
+});
+
+export type SavedFilters = z.infer<typeof savedFiltersSchema>;
+
 const savedListInput = readerListInput.extend({
   sort: z.enum(SAVED_SORT_VALUES).default("added"),
   /** Absent means "whatever this field's natural direction is". */
   dir: z.enum(SAVED_SORT_DIRECTIONS).optional(),
+  ...savedFiltersSchema.shape,
 });
+
+/**
+ * Drop the noise from a filter set: trim the query, sort and de-duplicate each
+ * facet, and omit anything empty.
+ *
+ * Both halves of this matter. Omitting empties keeps `?pubs=[]` out of the URL
+ * and off the query key, and sorting makes ticking A-then-B and B-then-A the
+ * same cache entry — otherwise every click order is its own server round trip.
+ */
+export function normalizeSavedFilters(filters: SavedFilters): SavedFilters {
+  const q = filters.q?.trim();
+  return {
+    authors: normalizeFacetValues(filters.authors),
+    pubs: normalizeFacetValues(filters.pubs),
+    q: q ? q.slice(0, SAVED_SEARCH_MAX_LENGTH) : undefined,
+    tags: normalizeFacetValues(filters.tags),
+  };
+}
+
+function normalizeFacetValues(
+  values: Array<string> | undefined,
+): Array<string> | undefined {
+  if (!values?.length) return;
+  const unique = [...new Set(values.map((value) => value.trim()))].filter(
+    Boolean,
+  );
+  return unique.length > 0 ? unique.toSorted() : undefined;
+}
+
+/** Whether anything in this filter set would narrow the list. */
+export function hasSavedFilters(filters: SavedFilters): boolean {
+  return Boolean(
+    filters.q?.trim() ||
+    filters.pubs?.length ||
+    filters.authors?.length ||
+    filters.tags?.length,
+  );
+}
+
+/** Escape LIKE metacharacters so a literal `%` or `_` a reader types stays
+ * literal instead of becoming a wildcard. Postgres' default LIKE escape is
+ * `\`, so no `ESCAPE` clause is needed. */
+function escapeLikePattern(input: string): string {
+  return input
+    .replaceAll("\\", String.raw`\\`)
+    .replaceAll("%", String.raw`\%`)
+    .replaceAll("_", String.raw`\_`);
+}
+
+/**
+ * `WHERE` fragments for a saved-list filter set — AND-ed together, with the
+ * values inside one facet OR-ed. Ticking two publications widens; adding a tag
+ * on top narrows.
+ *
+ * Every fragment reads off the joins the saved query already carries
+ * (`documents`, `publications`, and the `pa` author-profile alias), so callers
+ * only have to make sure those joins are present.
+ */
+function savedFilterConditions(
+  schema: Schema,
+  filters: SavedFilters,
+): Array<SQL> {
+  const d = schema.documents;
+  const p = schema.publications;
+  const pa = alias(schema.profiles, "pa");
+  const conditions: Array<SQL> = [];
+
+  if (filters.pubs?.length) {
+    conditions.push(inArray(d.publicationUri, filters.pubs));
+  }
+  if (filters.authors?.length) {
+    conditions.push(inArray(d.did, filters.authors));
+  }
+  if (filters.tags?.length) {
+    // Matched through `immutable_normalized_tags` for the same reason the tag
+    // pages do (see `documentCarriesTagWhere`): case and whitespace variants of
+    // one tag are one tag, and the expression is the indexed one.
+    conditions.push(
+      sql`immutable_normalized_tags(${d.tags}) && array[${sql.join(
+        filters.tags.map((tag) => sql`lower(btrim(${tag}))`),
+        sql`, `,
+      )}]::text[]`,
+    );
+  }
+
+  const q = filters.q?.trim();
+  if (q) {
+    const pattern = `%${escapeLikePattern(q)}%`;
+    // Deliberately not the document body: `/saved` omits `text_content` from
+    // its projection, and a hit the row can't visibly explain reads as a bug.
+    conditions.push(
+      or(
+        ilike(d.title, pattern),
+        ilike(d.description, pattern),
+        ilike(p.name, pattern),
+        ilike(pa.handle, pattern),
+        ilike(pa.displayName, pattern),
+      ) as SQL,
+    );
+  }
+
+  return conditions;
+}
 
 /** One offset page of a personal reader queue (likes, saved, history). */
 export interface ReaderListPage<T> {
@@ -284,6 +425,16 @@ export interface SavedArticleItem {
   documentUri: string;
   /** Null when the document is no longer in the read-model. */
   article: ArticleCard | null;
+}
+
+/**
+ * One page of `/saved`. `total` is how many rows the *current* filters match
+ * (what pagination runs on); `totalSaved` is the reader's whole queue, which
+ * the masthead keeps showing so its headline figure doesn't move as filters
+ * come and go.
+ */
+export interface SavedListPage extends ReaderListPage<SavedArticleItem> {
+  totalSaved: number;
 }
 
 /** A read article (`app.standard-reader.read`) with hydrated card data. */
@@ -1083,7 +1234,10 @@ const getSaved = createServerFn({ method: "GET" })
     observe("reader.getSaved", async ({ data, context }, span) => {
       const did = await getReaderDidForRequest(getRequest());
       if (!did) {
-        return buildReaderListPage<SavedArticleItem>([], data.offset, 0);
+        return {
+          ...buildReaderListPage<SavedArticleItem>([], data.offset, 0),
+          totalSaved: 0,
+        } satisfies SavedListPage;
       }
       const direction = data.dir ?? defaultSavedSortDirection(data.sort);
       span.set("did", did);
@@ -1100,11 +1254,36 @@ const getSaved = createServerFn({ method: "GET" })
       const cols = articleQueueCardColumns(context.schema);
       const where = and(eq(b.ownerDid, did), eq(b.deleted, false));
 
+      const conditions = savedFilterConditions(context.schema, data);
+      const filterWhere =
+        conditions.length > 0 ? (and(...conditions) as SQL) : null;
+      span.set("filtered", filterWhere != null);
+
+      // Both totals come off one aggregate: `total` is the headline figure the
+      // masthead keeps showing regardless of filters, `matching` is what drives
+      // pagination. Unfiltered, the two are the same count and the query stays
+      // the lean `bookmarks`-only scan it has always been — the joins are only
+      // paid for when a filter actually references them.
+      const countBase = context.db
+        .select({
+          matching: filterWhere
+            ? sql<number>`count(*) filter (where ${filterWhere})::int`.mapWith(
+                Number,
+              )
+            : sql<number>`count(*)::int`.mapWith(Number),
+          total: sql<number>`count(*)::int`.mapWith(Number),
+        })
+        .from(b)
+        .$dynamic();
+
       const [countRow, rows] = await Promise.all([
-        context.db
-          .select({ count: sql<number>`count(*)::int` })
-          .from(b)
-          .where(where),
+        filterWhere
+          ? countBase
+              .leftJoin(d, eq(d.uri, b.documentUri))
+              .leftJoin(p, eq(p.uri, d.publicationUri))
+              .leftJoin(pa, eq(pa.did, d.did))
+              .where(where)
+          : countBase.where(where),
         context.db
           .select({
             bookmarkUri: b.uri,
@@ -1117,7 +1296,7 @@ const getSaved = createServerFn({ method: "GET" })
           .leftJoin(p, eq(p.uri, d.publicationUri))
           .leftJoin(pr, eq(pr.did, p.did))
           .leftJoin(pa, eq(pa.did, d.did))
-          .where(where)
+          .where(filterWhere ? and(where, filterWhere) : where)
           // The "added" sort in its default direction matches
           // `bookmarks_owner_idx` (owner_did, created_at DESC NULLS LAST); see
           // getReadingHistory for why bare `desc()` is slow. Every other
@@ -1128,9 +1307,11 @@ const getSaved = createServerFn({ method: "GET" })
           .offset(data.offset),
       ]);
 
-      const total = countRow[0]?.count ?? 0;
+      const totalSaved = countRow[0]?.total ?? 0;
+      const total = countRow[0]?.matching ?? 0;
       span.set("count", rows.length);
       span.set("total", total);
+      span.set("totalSaved", totalSaved);
 
       const items = rows.map((row) => ({
         bookmarkUri: row.bookmarkUri,
@@ -1146,7 +1327,40 @@ const getSaved = createServerFn({ method: "GET" })
         items,
       );
 
-      return buildReaderListPage(withViewerRecs, data.offset, total);
+      return {
+        ...buildReaderListPage(withViewerRecs, data.offset, total),
+        totalSaved,
+      };
+    }),
+  );
+
+/**
+ * The reader's own publications / authors / tags, for `/saved`'s filter
+ * popover. Separate from the list itself so the rows paint first — the options
+ * are only needed once the popover opens, and this page's cost is dominated by
+ * round trips (see the `railway-neon-region-mismatch` note).
+ */
+const getSavedFacets = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware])
+  .handler(
+    observe("reader.getSavedFacets", async ({ context }, span) => {
+      const did = await getReaderDidForRequest(getRequest());
+      if (!did) {
+        return {
+          authors: [],
+          publications: [],
+          tags: [],
+          truncated: false,
+        } satisfies SavedFacets;
+      }
+      span.set("did", did);
+
+      const facets = await selectSavedFacets(context.db, context.schema, did);
+      span.set("publications", facets.publications.length);
+      span.set("authors", facets.authors.length);
+      span.set("tags", facets.tags.length);
+      span.set("truncated", facets.truncated);
+      return facets;
     }),
   );
 
@@ -1398,20 +1612,41 @@ function getSavedInfiniteQueryOptions({
   sort = "added",
   dir,
   limit = READER_QUEUE_PAGE_SIZE,
+  ...filters
 }: {
   sort?: SavedSort;
   dir?: SavedSortDirection;
   limit?: number;
-} = {}) {
-  // Resolved here, not in the key builder's caller, so `/saved?sort=added` and
-  // `/saved?sort=added&dir=desc` share one cache entry instead of refetching.
+} & SavedFilters = {}) {
+  // Both resolved here, not in the key builder's caller, so `/saved?sort=added`
+  // and `/saved?sort=added&dir=desc` share one cache entry instead of
+  // refetching — and so does ticking two filters in either order.
   const direction = dir ?? defaultSavedSortDirection(sort);
+  const normalized = normalizeSavedFilters(filters);
   return infiniteQueryOptions({
-    queryKey: ["reader", "saved", sort, direction, limit] as const,
+    queryKey: ["reader", "saved", sort, direction, limit, normalized] as const,
     queryFn: async ({ pageParam }) =>
-      getSaved({ data: { sort, dir: direction, limit, offset: pageParam } }),
+      getSaved({
+        data: {
+          ...normalized,
+          sort,
+          dir: direction,
+          limit,
+          offset: pageParam,
+        },
+      }),
     initialPageParam: 0,
     getNextPageParam: (lastPage) => lastPage.nextOffset ?? undefined,
+  });
+}
+
+function getSavedFacetsQueryOptions() {
+  return queryOptions({
+    // Deliberately outside the `["reader", "saved"]` prefix that the bookmark
+    // optimistic update rewrites — facets are counts, not list pages, and
+    // shouldn't be walked by a helper looking for infinite data.
+    queryKey: ["reader", "savedFacets"] as const,
+    queryFn: async () => getSavedFacets(),
   });
 }
 
@@ -1610,6 +1845,8 @@ export const readerApi = {
   getBookmarkStatusQueryOptions,
   getSaved,
   getSavedInfiniteQueryOptions,
+  getSavedFacets,
+  getSavedFacetsQueryOptions,
   bookmarkDocument,
   bookmarkDocumentMutationOptions,
   unbookmarkDocument,

--- a/apps/standard-reader/src/lib/saved-filters.ts
+++ b/apps/standard-reader/src/lib/saved-filters.ts
@@ -1,0 +1,44 @@
+import type { Key } from "react-aria-components";
+
+/**
+ * The `/saved` filter state, as the page holds it. Order within each array
+ * doesn't matter — the query layer normalizes before building a cache key.
+ */
+export interface SavedFilterValues {
+  pubs: Array<string>;
+  authors: Array<string>;
+  tags: Array<string>;
+}
+
+export type SavedFacetName = keyof SavedFilterValues;
+
+/**
+ * One flat list carries all three facets in the filter popover, so the
+ * type-ahead searches across them at once ("offprint" finds the publication and
+ * the author without the reader picking a category first). Keys are namespaced
+ * to say which facet a selection came back from — an AT-URI, a DID, and a tag
+ * are all just strings otherwise.
+ */
+const KEY_SEPARATOR = ":";
+
+export function facetKey(facet: SavedFacetName, id: string): string {
+  return `${facet}${KEY_SEPARATOR}${id}`;
+}
+
+export function parseFacetKey(
+  key: Key,
+): { facet: SavedFacetName; id: string } | null {
+  const raw = String(key);
+  const index = raw.indexOf(KEY_SEPARATOR);
+  // Index 0 would mean an empty facet name; AT-URIs are full of colons, so only
+  // the first one separates.
+  if (index < 1) return null;
+  const facet = raw.slice(0, index);
+  const id = raw.slice(index + 1);
+  if (facet !== "pubs" && facet !== "authors" && facet !== "tags") return null;
+  return id ? { facet, id } : null;
+}
+
+export function countSavedFilters(value: SavedFilterValues): number {
+  return value.pubs.length + value.authors.length + value.tags.length;
+}

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -288,6 +288,10 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Nothing to filter by yet."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Recommendations from real reading patterns"
 msgstr "توصيات مبنية على أنماط قراءة حقيقية"
@@ -802,6 +806,10 @@ msgstr "ابحث في المنشورات"
 msgid "Small"
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Loading filter options"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Only mine"
 msgstr ""
@@ -907,6 +915,10 @@ msgstr "اشترك لتصلك الكتابات الجديدة في تغذيتك.
 msgid "A minimal loose document — no publication, Markpub markdown body:"
 msgstr "مستند مستقل بالحد الأدنى — بلا منشورة، وبمتن Markpub بصيغة markdown:"
 
+#: src/routes/_layout.saved.tsx
+msgid "Updating saved articles"
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>4. Let readers subscribe.</0> When a reader subscribes we write an <1>app.standard-reader.labeler.subscription</1> record to their repo, carrying their per-label warn/hide preferences."
 msgstr "<0>4. دع القرّاء يشتركون.</0> عند اشتراك القارئ نكتب سجل <1>app.standard-reader.labeler.subscription</1> في مستودعه، يحمل تفضيلاته بالتحذير أو الإخفاء لكل تصنيف."
@@ -973,8 +985,8 @@ msgid "Loading voice sample"
 msgstr "جارٍ تحميل عينة الصوت"
 
 #: src/routes/_layout.saved.tsx
-msgid "Sort saved articles"
-msgstr ""
+#~ msgid "Sort saved articles"
+#~ msgstr ""
 
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
@@ -1397,6 +1409,10 @@ msgstr ""
 #: src/components/appearance-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Custom"
+msgstr ""
+
+#: src/routes/_layout.saved.tsx
+msgid "No saved articles match"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -2151,6 +2167,10 @@ msgstr ""
 #~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
 #~ msgstr "تحصل المنشورات والقوائم والمجموعات على رابط أنيق مع بطاقة معاينة غنية — إضافةً إلى زر اشتراك يمكن للمنشورة وضعه على موقعها."
 
+#: src/components/reader/saved-filters.tsx
+msgid "Filter saved articles — {activeCount, plural, one {# filter active} other {# filters active}}"
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 #: src/routes/_layout.topics.index.tsx
 msgid "Search topics"
@@ -2183,6 +2203,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "System"
 msgstr "النظام"
+
+#: src/components/reader/saved-filters.tsx
+msgid "Filter by…"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Every feed, directory, and search query the app itself runs."
@@ -2369,6 +2393,10 @@ msgstr "المجموعات"
 msgid "Done"
 msgstr "تم"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Authors"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
@@ -2411,6 +2439,10 @@ msgstr "قد تتابع"
 #: src/components/reader/labeler-pill.tsx
 msgid "View labeler"
 msgstr "عرض المصنِّف"
+
+#: src/routes/_layout.saved.tsx
+msgid "Search saved articles"
+msgstr ""
 
 #: src/magazine/magazine-feature-end.tsx
 msgid "Read more from the author"
@@ -3936,6 +3968,7 @@ msgid "No labeled accounts"
 msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
+#: src/components/reader/saved-filters.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.saved.tsx
 msgid "Publication"
@@ -4071,6 +4104,12 @@ msgstr ""
 #: src/routes/_layout.collections.new.tsx
 msgid "On your first collection we create one series to hold them — a special collection you can subscribe to, rename, and theme later."
 msgstr "عند إنشاء مجموعتك الأولى ننشئ سلسلة واحدة تضمّها — وهي مجموعة خاصة يمكنك الاشتراك فيها وإعادة تسميتها وتغيير سمتها لاحقًا."
+
+#. placeholder {0}: i18n._( SAVED_SORT_OPTIONS.find((option) => option.id === shownSort)?.label ?? SAVED_SORT_OPTIONS[0].label, )
+#. placeholder {1}: i18n._( shownDirection === "asc" ? directionLabels.asc : directionLabels.desc, )
+#: src/routes/_layout.saved.tsx
+msgid "Sort — {0}, {1}"
+msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-theme-editor.tsx
@@ -4732,6 +4771,10 @@ msgstr ""
 msgid "The voice used when you listen to an article with read aloud."
 msgstr "الصوت المستخدم عند الاستماع إلى مقال عبر القراءة الصوتية."
 
+#: src/components/reader/saved-filters.tsx
+msgid "{activeCount, plural, one {# filter} other {# filters}}"
+msgstr ""
+
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Remove image {position}"
 msgstr ""
@@ -5134,6 +5177,10 @@ msgstr ""
 #: src/routes/mcp/authorize.tsx
 #~ msgid "Connect {0}?"
 #~ msgstr ""
+
+#: src/components/reader/saved-filters.tsx
+msgid "Tags"
+msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Person"
@@ -5887,6 +5934,10 @@ msgstr "الويب البطيء، إعادة نظر"
 msgid "+{0} more"
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Nothing in your queue matches the current search and filters. Try removing one."
+msgstr ""
+
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #~ msgid "Eight presets, or your own paper and accent. The rest of the interface is derived from them."
 #~ msgstr ""
@@ -5900,6 +5951,10 @@ msgstr "‏Google Font"
 #: src/components/reader/collection-builder.tsx
 msgid "Create collection"
 msgstr "إنشاء مجموعة"
+
+#: src/components/reader/saved-filters.tsx
+msgid "Find a publication, author, or tag"
+msgstr ""
 
 #: src/components/labelers-settings-view.tsx
 msgid "Labels articles here"
@@ -6649,6 +6704,10 @@ msgstr "يمرّ تسجيل الدخول والوصول إلى السجلات ع
 msgid "An included article"
 msgstr "مقالة مضمّنة"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Nothing saved matches “{query}”."
+msgstr ""
+
 #: src/components/appearance-settings.tsx
 msgid "Puts the palette, font, size, roundness and density back to their defaults."
 msgstr ""
@@ -6707,6 +6766,7 @@ msgstr "افتح أي مقالة وأنت مسجّل الدخول وستظهر �
 #~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
 #~ msgstr "أنشئ قوائم منشورات مسمّاة وقابلة للمشاركة — قائمة تشغيل للقراءة. يمكن لأي شخص إضافة قائمتك إلى قارئه بنقرة واحدة."
 
+#: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
 msgstr "الكاتب"
@@ -7125,6 +7185,10 @@ msgstr "عُد إلى إضافة Standard Reader — ستُغلق هذه الع�
 msgid "To start from a particular paragraph instead of the beginning, select the text and choose <0>Read from here</0>."
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Search saved articles…"
+msgstr ""
+
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.index.tsx
 msgid "Edit series"
@@ -7315,6 +7379,7 @@ msgstr "بيانات وصفية للجلسة مثل عنوان IP ونص وكي�
 msgid "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 msgstr "لا ننشر من حسابك إلا عند قيامك بإجراء صريح يستلزم ذلك (مثل متابعة منشورة، أو الإعجاب بمقال أو حفظه، أو الاشتراك عبر مسار الاشتراك المخصص). ولا نبيع معلوماتك الشخصية."
 
+#: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -7360,8 +7425,8 @@ msgid "Notifications on this device"
 msgstr ""
 
 #: src/routes/_layout.saved.tsx
-msgid "Reordering saved articles"
-msgstr ""
+#~ msgid "Reordering saved articles"
+#~ msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "No unread articles from your follows right now."
@@ -7669,6 +7734,14 @@ msgstr ""
 msgid "Discover, from recommendations at the top to the full directory at the bottom."
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Active filters"
+msgstr ""
+
+#: src/components/reader/saved-filters.tsx
+msgid "Clear all"
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/components/reader/share-menu.tsx
@@ -7837,6 +7910,10 @@ msgstr "قارئ"
 msgid "Your day: a featured lead and the latest from your subscriptions."
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Filter saved articles"
+msgstr ""
+
 #: src/components/reader/series-up-next.tsx
 msgid "You’ve read every issue published so far."
 msgstr ""
@@ -7859,6 +7936,10 @@ msgstr "{minutes}د"
 
 #: src/components/docs/labelers-docs-page.tsx
 msgid "That record also carries an <0>enabled</0> flag. A reader can mute your labeler here — keeping the subscription and their per-label settings, but not applying your labels while they read — without unsubscribing, which is useful when they follow a labeler on another app that they don’t want acting on long-form reading. Its absence means enabled."
+msgstr ""
+
+#: src/routes/_layout.saved.tsx
+msgid "Showing {total} of {totalSaved} saved"
 msgstr ""
 
 #. placeholder {0}: account.handle

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -288,6 +288,10 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Nothing to filter by yet."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Recommendations from real reading patterns"
 msgstr "Empfehlungen aus echtem Leseverhalten"
@@ -802,6 +806,10 @@ msgstr "Publikationen suchen"
 msgid "Small"
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Loading filter options"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Only mine"
 msgstr ""
@@ -907,6 +915,10 @@ msgstr "Abonnieren Sie, um neue Texte in Ihrem Feed zu erhalten."
 msgid "A minimal loose document — no publication, Markpub markdown body:"
 msgstr "Ein minimales loses Dokument – ohne Publikation, mit Markpub-Markdown-Text:"
 
+#: src/routes/_layout.saved.tsx
+msgid "Updating saved articles"
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>4. Let readers subscribe.</0> When a reader subscribes we write an <1>app.standard-reader.labeler.subscription</1> record to their repo, carrying their per-label warn/hide preferences."
 msgstr "<0>4. Leser abonnieren lassen.</0> Wenn ein Leser abonniert, schreiben wir einen <1>app.standard-reader.labeler.subscription</1>-Record in sein Repo, der seine Warnen/Ausblenden-Einstellungen pro Label enthält."
@@ -973,8 +985,8 @@ msgid "Loading voice sample"
 msgstr "Stimmprobe wird geladen"
 
 #: src/routes/_layout.saved.tsx
-msgid "Sort saved articles"
-msgstr ""
+#~ msgid "Sort saved articles"
+#~ msgstr ""
 
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
@@ -1397,6 +1409,10 @@ msgstr ""
 #: src/components/appearance-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Custom"
+msgstr ""
+
+#: src/routes/_layout.saved.tsx
+msgid "No saved articles match"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -2151,6 +2167,10 @@ msgstr ""
 #~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
 #~ msgstr "Publikationen, Listen und Sammlungen bekommen jeweils einen sauberen Link mit einer schönen Vorschaukarte – plus einen Abo-Button, den eine Publikation auf ihrer eigenen Website einbauen kann."
 
+#: src/components/reader/saved-filters.tsx
+msgid "Filter saved articles — {activeCount, plural, one {# filter active} other {# filters active}}"
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 #: src/routes/_layout.topics.index.tsx
 msgid "Search topics"
@@ -2183,6 +2203,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "System"
 msgstr "System"
+
+#: src/components/reader/saved-filters.tsx
+msgid "Filter by…"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Every feed, directory, and search query the app itself runs."
@@ -2369,6 +2393,10 @@ msgstr "Sammlungen"
 msgid "Done"
 msgstr "Fertig"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Authors"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
@@ -2411,6 +2439,10 @@ msgstr "Vielleicht interessant für Sie"
 #: src/components/reader/labeler-pill.tsx
 msgid "View labeler"
 msgstr "Labeler ansehen"
+
+#: src/routes/_layout.saved.tsx
+msgid "Search saved articles"
+msgstr ""
 
 #: src/magazine/magazine-feature-end.tsx
 msgid "Read more from the author"
@@ -3936,6 +3968,7 @@ msgid "No labeled accounts"
 msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
+#: src/components/reader/saved-filters.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.saved.tsx
 msgid "Publication"
@@ -4071,6 +4104,12 @@ msgstr ""
 #: src/routes/_layout.collections.new.tsx
 msgid "On your first collection we create one series to hold them — a special collection you can subscribe to, rename, and theme later."
 msgstr "Bei Ihrer ersten Sammlung erstellen wir eine Reihe dafür — eine besondere Sammlung, die Sie abonnieren, umbenennen und später gestalten können."
+
+#. placeholder {0}: i18n._( SAVED_SORT_OPTIONS.find((option) => option.id === shownSort)?.label ?? SAVED_SORT_OPTIONS[0].label, )
+#. placeholder {1}: i18n._( shownDirection === "asc" ? directionLabels.asc : directionLabels.desc, )
+#: src/routes/_layout.saved.tsx
+msgid "Sort — {0}, {1}"
+msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-theme-editor.tsx
@@ -4732,6 +4771,10 @@ msgstr ""
 msgid "The voice used when you listen to an article with read aloud."
 msgstr "Die Stimme, mit der Ihnen ein Artikel vorgelesen wird."
 
+#: src/components/reader/saved-filters.tsx
+msgid "{activeCount, plural, one {# filter} other {# filters}}"
+msgstr ""
+
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Remove image {position}"
 msgstr ""
@@ -5134,6 +5177,10 @@ msgstr ""
 #: src/routes/mcp/authorize.tsx
 #~ msgid "Connect {0}?"
 #~ msgstr ""
+
+#: src/components/reader/saved-filters.tsx
+msgid "Tags"
+msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Person"
@@ -5887,6 +5934,10 @@ msgstr "Das langsame Web, neu betrachtet"
 msgid "+{0} more"
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Nothing in your queue matches the current search and filters. Try removing one."
+msgstr ""
+
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #~ msgid "Eight presets, or your own paper and accent. The rest of the interface is derived from them."
 #~ msgstr ""
@@ -5900,6 +5951,10 @@ msgstr "Google Font"
 #: src/components/reader/collection-builder.tsx
 msgid "Create collection"
 msgstr "Sammlung erstellen"
+
+#: src/components/reader/saved-filters.tsx
+msgid "Find a publication, author, or tag"
+msgstr ""
 
 #: src/components/labelers-settings-view.tsx
 msgid "Labels articles here"
@@ -6649,6 +6704,10 @@ msgstr "Anmeldung und Zugriff auf Records laufen über Ihren Personal Data Serve
 msgid "An included article"
 msgstr "Ein enthaltener Artikel"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Nothing saved matches “{query}”."
+msgstr ""
+
 #: src/components/appearance-settings.tsx
 msgid "Puts the palette, font, size, roundness and density back to their defaults."
 msgstr ""
@@ -6707,6 +6766,7 @@ msgstr "Öffnen Sie angemeldet einen beliebigen Artikel und er erscheint hier. I
 #~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
 #~ msgstr "Erstellen Sie benannte, teilbare Listen von Publikationen — eine Playlist zum Lesen. Jeder kann Ihre Liste mit einem Tipp in den eigenen Reader übernehmen."
 
+#: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
 msgstr "Autor"
@@ -7125,6 +7185,10 @@ msgstr "Zurück zur Standard-Reader-Erweiterung — dieser Tab schließt sich au
 msgid "To start from a particular paragraph instead of the beginning, select the text and choose <0>Read from here</0>."
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Search saved articles…"
+msgstr ""
+
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.index.tsx
 msgid "Edit series"
@@ -7315,6 +7379,7 @@ msgstr "Sitzungsdaten wie IP-Adresse und Browser-User-Agent, genutzt für Sicher
 msgid "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 msgstr "Wir posten nichts über Ihr Konto, außer Sie lösen es ausdrücklich aus (etwa einer Publikation folgen, einen Artikel liken oder speichern oder über den Abo-Ablauf abonnieren). Wir verkaufen Ihre personenbezogenen Daten nicht."
 
+#: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -7360,8 +7425,8 @@ msgid "Notifications on this device"
 msgstr ""
 
 #: src/routes/_layout.saved.tsx
-msgid "Reordering saved articles"
-msgstr ""
+#~ msgid "Reordering saved articles"
+#~ msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "No unread articles from your follows right now."
@@ -7669,6 +7734,14 @@ msgstr ""
 msgid "Discover, from recommendations at the top to the full directory at the bottom."
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Active filters"
+msgstr ""
+
+#: src/components/reader/saved-filters.tsx
+msgid "Clear all"
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/components/reader/share-menu.tsx
@@ -7837,6 +7910,10 @@ msgstr "Reader"
 msgid "Your day: a featured lead and the latest from your subscriptions."
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Filter saved articles"
+msgstr ""
+
 #: src/components/reader/series-up-next.tsx
 msgid "You’ve read every issue published so far."
 msgstr ""
@@ -7859,6 +7936,10 @@ msgstr "{minutes} Min."
 
 #: src/components/docs/labelers-docs-page.tsx
 msgid "That record also carries an <0>enabled</0> flag. A reader can mute your labeler here — keeping the subscription and their per-label settings, but not applying your labels while they read — without unsubscribing, which is useful when they follow a labeler on another app that they don’t want acting on long-form reading. Its absence means enabled."
+msgstr ""
+
+#: src/routes/_layout.saved.tsx
+msgid "Showing {total} of {totalSaved} saved"
 msgstr ""
 
 #. placeholder {0}: account.handle

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -288,6 +288,10 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Nothing to filter by yet."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Recommendations from real reading patterns"
 msgstr ""
@@ -802,6 +806,10 @@ msgstr ""
 msgid "Small"
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Loading filter options"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Only mine"
 msgstr ""
@@ -907,6 +915,10 @@ msgstr ""
 msgid "A minimal loose document — no publication, Markpub markdown body:"
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Updating saved articles"
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>4. Let readers subscribe.</0> When a reader subscribes we write an <1>app.standard-reader.labeler.subscription</1> record to their repo, carrying their per-label warn/hide preferences."
 msgstr ""
@@ -973,8 +985,8 @@ msgid "Loading voice sample"
 msgstr ""
 
 #: src/routes/_layout.saved.tsx
-msgid "Sort saved articles"
-msgstr ""
+#~ msgid "Sort saved articles"
+#~ msgstr ""
 
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
@@ -1397,6 +1409,10 @@ msgstr ""
 #: src/components/appearance-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Custom"
+msgstr ""
+
+#: src/routes/_layout.saved.tsx
+msgid "No saved articles match"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -2151,6 +2167,10 @@ msgstr ""
 #~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
 #~ msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Filter saved articles — {activeCount, plural, one {# filter active} other {# filters active}}"
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 #: src/routes/_layout.topics.index.tsx
 msgid "Search topics"
@@ -2182,6 +2202,10 @@ msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "System"
+msgstr ""
+
+#: src/components/reader/saved-filters.tsx
+msgid "Filter by…"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -2369,6 +2393,10 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Authors"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
@@ -2410,6 +2438,10 @@ msgstr ""
 
 #: src/components/reader/labeler-pill.tsx
 msgid "View labeler"
+msgstr ""
+
+#: src/routes/_layout.saved.tsx
+msgid "Search saved articles"
 msgstr ""
 
 #: src/magazine/magazine-feature-end.tsx
@@ -3936,6 +3968,7 @@ msgid "No labeled accounts"
 msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
+#: src/components/reader/saved-filters.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.saved.tsx
 msgid "Publication"
@@ -4070,6 +4103,12 @@ msgstr ""
 
 #: src/routes/_layout.collections.new.tsx
 msgid "On your first collection we create one series to hold them — a special collection you can subscribe to, rename, and theme later."
+msgstr ""
+
+#. placeholder {0}: i18n._( SAVED_SORT_OPTIONS.find((option) => option.id === shownSort)?.label ?? SAVED_SORT_OPTIONS[0].label, )
+#. placeholder {1}: i18n._( shownDirection === "asc" ? directionLabels.asc : directionLabels.desc, )
+#: src/routes/_layout.saved.tsx
+msgid "Sort — {0}, {1}"
 msgstr ""
 
 #: src/components/reader/collection-builder.tsx
@@ -4732,6 +4771,10 @@ msgstr ""
 msgid "The voice used when you listen to an article with read aloud."
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "{activeCount, plural, one {# filter} other {# filters}}"
+msgstr ""
+
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Remove image {position}"
 msgstr ""
@@ -5134,6 +5177,10 @@ msgstr ""
 #: src/routes/mcp/authorize.tsx
 #~ msgid "Connect {0}?"
 #~ msgstr ""
+
+#: src/components/reader/saved-filters.tsx
+msgid "Tags"
+msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Person"
@@ -5887,6 +5934,10 @@ msgstr ""
 msgid "+{0} more"
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Nothing in your queue matches the current search and filters. Try removing one."
+msgstr ""
+
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #~ msgid "Eight presets, or your own paper and accent. The rest of the interface is derived from them."
 #~ msgstr ""
@@ -5899,6 +5950,10 @@ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 msgid "Create collection"
+msgstr ""
+
+#: src/components/reader/saved-filters.tsx
+msgid "Find a publication, author, or tag"
 msgstr ""
 
 #: src/components/labelers-settings-view.tsx
@@ -6649,6 +6704,10 @@ msgstr ""
 msgid "An included article"
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Nothing saved matches “{query}”."
+msgstr ""
+
 #: src/components/appearance-settings.tsx
 msgid "Puts the palette, font, size, roundness and density back to their defaults."
 msgstr ""
@@ -6707,6 +6766,7 @@ msgstr ""
 #~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
 #~ msgstr ""
 
+#: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
 msgstr ""
@@ -7125,6 +7185,10 @@ msgstr ""
 msgid "To start from a particular paragraph instead of the beginning, select the text and choose <0>Read from here</0>."
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Search saved articles…"
+msgstr ""
+
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.index.tsx
 msgid "Edit series"
@@ -7315,6 +7379,7 @@ msgstr ""
 msgid "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -7360,8 +7425,8 @@ msgid "Notifications on this device"
 msgstr ""
 
 #: src/routes/_layout.saved.tsx
-msgid "Reordering saved articles"
-msgstr ""
+#~ msgid "Reordering saved articles"
+#~ msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "No unread articles from your follows right now."
@@ -7669,6 +7734,14 @@ msgstr ""
 msgid "Discover, from recommendations at the top to the full directory at the bottom."
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Active filters"
+msgstr ""
+
+#: src/components/reader/saved-filters.tsx
+msgid "Clear all"
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/components/reader/share-menu.tsx
@@ -7837,6 +7910,10 @@ msgstr ""
 msgid "Your day: a featured lead and the latest from your subscriptions."
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Filter saved articles"
+msgstr ""
+
 #: src/components/reader/series-up-next.tsx
 msgid "You’ve read every issue published so far."
 msgstr ""
@@ -7859,6 +7936,10 @@ msgstr ""
 
 #: src/components/docs/labelers-docs-page.tsx
 msgid "That record also carries an <0>enabled</0> flag. A reader can mute your labeler here — keeping the subscription and their per-label settings, but not applying your labels while they read — without unsubscribing, which is useful when they follow a labeler on another app that they don’t want acting on long-form reading. Its absence means enabled."
+msgstr ""
+
+#: src/routes/_layout.saved.tsx
+msgid "Showing {total} of {totalSaved} saved"
 msgstr ""
 
 #. placeholder {0}: account.handle

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -288,6 +288,10 @@ msgstr "Labels can’t be verified"
 msgid "Type"
 msgstr "Type"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Nothing to filter by yet."
+msgstr "Nothing to filter by yet."
+
 #: src/components/reader/about-view.tsx
 msgid "Recommendations from real reading patterns"
 msgstr "Recommendations from real reading patterns"
@@ -802,6 +806,10 @@ msgstr "Search publications"
 msgid "Small"
 msgstr "Small"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Loading filter options"
+msgstr "Loading filter options"
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Only mine"
 msgstr "Only mine"
@@ -907,6 +915,10 @@ msgstr "Subscribe to get new writing in your feed."
 msgid "A minimal loose document — no publication, Markpub markdown body:"
 msgstr "A minimal loose document — no publication, Markpub markdown body:"
 
+#: src/routes/_layout.saved.tsx
+msgid "Updating saved articles"
+msgstr "Updating saved articles"
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>4. Let readers subscribe.</0> When a reader subscribes we write an <1>app.standard-reader.labeler.subscription</1> record to their repo, carrying their per-label warn/hide preferences."
 msgstr "<0>4. Let readers subscribe.</0> When a reader subscribes we write an <1>app.standard-reader.labeler.subscription</1> record to their repo, carrying their per-label warn/hide preferences."
@@ -973,8 +985,8 @@ msgid "Loading voice sample"
 msgstr "Loading voice sample"
 
 #: src/routes/_layout.saved.tsx
-msgid "Sort saved articles"
-msgstr "Sort saved articles"
+#~ msgid "Sort saved articles"
+#~ msgstr "Sort saved articles"
 
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
@@ -1398,6 +1410,10 @@ msgstr "Adding and removing publications"
 #: src/components/user-settings-view.tsx
 msgid "Custom"
 msgstr "Custom"
+
+#: src/routes/_layout.saved.tsx
+msgid "No saved articles match"
+msgstr "No saved articles match"
 
 #: src/components/reader/about-view.tsx
 #~ msgid "Read the API docs"
@@ -2151,6 +2167,10 @@ msgstr "Newest first"
 #~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
 #~ msgstr "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
 
+#: src/components/reader/saved-filters.tsx
+msgid "Filter saved articles — {activeCount, plural, one {# filter active} other {# filters active}}"
+msgstr "Filter saved articles — {activeCount, plural, one {# filter active} other {# filters active}}"
+
 #: src/components/reader/discover-topic-filters.tsx
 #: src/routes/_layout.topics.index.tsx
 msgid "Search topics"
@@ -2183,6 +2203,10 @@ msgstr "Loading more labels…"
 #: src/components/user-settings-view.tsx
 msgid "System"
 msgstr "System"
+
+#: src/components/reader/saved-filters.tsx
+msgid "Filter by…"
+msgstr "Filter by…"
 
 #: src/components/reader/about-view.tsx
 msgid "Every feed, directory, and search query the app itself runs."
@@ -2369,6 +2393,10 @@ msgstr "Collections"
 msgid "Done"
 msgstr "Done"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Authors"
+msgstr "Authors"
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
@@ -2411,6 +2439,10 @@ msgstr "You might follow"
 #: src/components/reader/labeler-pill.tsx
 msgid "View labeler"
 msgstr "View labeler"
+
+#: src/routes/_layout.saved.tsx
+msgid "Search saved articles"
+msgstr "Search saved articles"
 
 #: src/magazine/magazine-feature-end.tsx
 msgid "Read more from the author"
@@ -3936,6 +3968,7 @@ msgid "No labeled accounts"
 msgstr "No labeled accounts"
 
 #: src/components/reader/article-below-fold.tsx
+#: src/components/reader/saved-filters.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.saved.tsx
 msgid "Publication"
@@ -4071,6 +4104,12 @@ msgstr "{value, plural, one {# like} other {# likes}}"
 #: src/routes/_layout.collections.new.tsx
 msgid "On your first collection we create one series to hold them — a special collection you can subscribe to, rename, and theme later."
 msgstr "On your first collection we create one series to hold them — a special collection you can subscribe to, rename, and theme later."
+
+#. placeholder {0}: i18n._( SAVED_SORT_OPTIONS.find((option) => option.id === shownSort)?.label ?? SAVED_SORT_OPTIONS[0].label, )
+#. placeholder {1}: i18n._( shownDirection === "asc" ? directionLabels.asc : directionLabels.desc, )
+#: src/routes/_layout.saved.tsx
+msgid "Sort — {0}, {1}"
+msgstr "Sort — {0}, {1}"
 
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-theme-editor.tsx
@@ -4732,6 +4771,10 @@ msgstr "These schemas are published, codegen'd from the lexicons, as <0>@standar
 msgid "The voice used when you listen to an article with read aloud."
 msgstr "The voice used when you listen to an article with read aloud."
 
+#: src/components/reader/saved-filters.tsx
+msgid "{activeCount, plural, one {# filter} other {# filters}}"
+msgstr "{activeCount, plural, one {# filter} other {# filters}}"
+
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Remove image {position}"
 msgstr "Remove image {position}"
@@ -5134,6 +5177,10 @@ msgstr "{0, plural, one {# publication} other {{1} publications}}"
 #: src/routes/mcp/authorize.tsx
 #~ msgid "Connect {0}?"
 #~ msgstr "Connect {0}?"
+
+#: src/components/reader/saved-filters.tsx
+msgid "Tags"
+msgstr "Tags"
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Person"
@@ -5887,6 +5934,10 @@ msgstr "The Slow Web, Revisited"
 msgid "+{0} more"
 msgstr "+{0} more"
 
+#: src/routes/_layout.saved.tsx
+msgid "Nothing in your queue matches the current search and filters. Try removing one."
+msgstr "Nothing in your queue matches the current search and filters. Try removing one."
+
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #~ msgid "Eight presets, or your own paper and accent. The rest of the interface is derived from them."
 #~ msgstr "Eight presets, or your own paper and accent. The rest of the interface is derived from them."
@@ -5900,6 +5951,10 @@ msgstr "Google Font"
 #: src/components/reader/collection-builder.tsx
 msgid "Create collection"
 msgstr "Create collection"
+
+#: src/components/reader/saved-filters.tsx
+msgid "Find a publication, author, or tag"
+msgstr "Find a publication, author, or tag"
 
 #: src/components/labelers-settings-view.tsx
 msgid "Labels articles here"
@@ -6649,6 +6704,10 @@ msgstr "Sign-in and record access go through your Personal Data Server and the w
 msgid "An included article"
 msgstr "An included article"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Nothing saved matches “{query}”."
+msgstr "Nothing saved matches “{query}”."
+
 #: src/components/appearance-settings.tsx
 msgid "Puts the palette, font, size, roundness and density back to their defaults."
 msgstr "Puts the palette, font, size, roundness and density back to their defaults."
@@ -6707,6 +6766,7 @@ msgstr "Open any article while signed in and it'll show up here. Your history li
 #~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
 #~ msgstr "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
 
+#: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
 msgstr "Author"
@@ -7125,6 +7185,10 @@ msgstr "Return to the Standard Reader extension — this tab will close automati
 msgid "To start from a particular paragraph instead of the beginning, select the text and choose <0>Read from here</0>."
 msgstr "To start from a particular paragraph instead of the beginning, select the text and choose <0>Read from here</0>."
 
+#: src/routes/_layout.saved.tsx
+msgid "Search saved articles…"
+msgstr "Search saved articles…"
+
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.index.tsx
 msgid "Edit series"
@@ -7315,6 +7379,7 @@ msgstr "Session metadata such as IP address and browser user-agent string, used 
 msgid "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 msgstr "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 
+#: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -7360,8 +7425,8 @@ msgid "Notifications on this device"
 msgstr "Notifications on this device"
 
 #: src/routes/_layout.saved.tsx
-msgid "Reordering saved articles"
-msgstr "Reordering saved articles"
+#~ msgid "Reordering saved articles"
+#~ msgstr "Reordering saved articles"
 
 #: src/routes/_layout.latest.tsx
 msgid "No unread articles from your follows right now."
@@ -7669,6 +7734,14 @@ msgstr "what your corner of Bluesky reads."
 msgid "Discover, from recommendations at the top to the full directory at the bottom."
 msgstr "Discover, from recommendations at the top to the full directory at the bottom."
 
+#: src/components/reader/saved-filters.tsx
+msgid "Active filters"
+msgstr "Active filters"
+
+#: src/components/reader/saved-filters.tsx
+msgid "Clear all"
+msgstr "Clear all"
+
 #: src/components/reader/discover-topic-filters.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/components/reader/share-menu.tsx
@@ -7837,6 +7910,10 @@ msgstr "Reader"
 msgid "Your day: a featured lead and the latest from your subscriptions."
 msgstr "Your day: a featured lead and the latest from your subscriptions."
 
+#: src/components/reader/saved-filters.tsx
+msgid "Filter saved articles"
+msgstr "Filter saved articles"
+
 #: src/components/reader/series-up-next.tsx
 msgid "You’ve read every issue published so far."
 msgstr "You’ve read every issue published so far."
@@ -7860,6 +7937,10 @@ msgstr "{minutes}m"
 #: src/components/docs/labelers-docs-page.tsx
 msgid "That record also carries an <0>enabled</0> flag. A reader can mute your labeler here — keeping the subscription and their per-label settings, but not applying your labels while they read — without unsubscribing, which is useful when they follow a labeler on another app that they don’t want acting on long-form reading. Its absence means enabled."
 msgstr "That record also carries an <0>enabled</0> flag. A reader can mute your labeler here — keeping the subscription and their per-label settings, but not applying your labels while they read — without unsubscribing, which is useful when they follow a labeler on another app that they don’t want acting on long-form reading. Its absence means enabled."
+
+#: src/routes/_layout.saved.tsx
+msgid "Showing {total} of {totalSaved} saved"
+msgstr "Showing {total} of {totalSaved} saved"
 
 #. placeholder {0}: account.handle
 #: src/components/reader/add-publication-modal.tsx

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -288,6 +288,10 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Nothing to filter by yet."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Recommendations from real reading patterns"
 msgstr "Recomendaciones a partir de hábitos de lectura reales"
@@ -802,6 +806,10 @@ msgstr "Buscar publicaciones"
 msgid "Small"
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Loading filter options"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Only mine"
 msgstr ""
@@ -907,6 +915,10 @@ msgstr "Suscríbase para recibir nuevos textos en su feed."
 msgid "A minimal loose document — no publication, Markpub markdown body:"
 msgstr "Un documento suelto mínimo, sin publicación y con cuerpo en markdown de Markpub:"
 
+#: src/routes/_layout.saved.tsx
+msgid "Updating saved articles"
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>4. Let readers subscribe.</0> When a reader subscribes we write an <1>app.standard-reader.labeler.subscription</1> record to their repo, carrying their per-label warn/hide preferences."
 msgstr "<0>4. Permita que los lectores se suscriban.</0> Cuando un lector se suscribe, escribimos un registro <1>app.standard-reader.labeler.subscription</1> en su repo con sus preferencias de advertir/ocultar por etiqueta."
@@ -973,8 +985,8 @@ msgid "Loading voice sample"
 msgstr "Cargando muestra de voz"
 
 #: src/routes/_layout.saved.tsx
-msgid "Sort saved articles"
-msgstr ""
+#~ msgid "Sort saved articles"
+#~ msgstr ""
 
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
@@ -1397,6 +1409,10 @@ msgstr ""
 #: src/components/appearance-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Custom"
+msgstr ""
+
+#: src/routes/_layout.saved.tsx
+msgid "No saved articles match"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -2151,6 +2167,10 @@ msgstr ""
 #~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
 #~ msgstr "Las publicaciones, las listas y las colecciones tienen cada una un enlace limpio con una tarjeta de vista previa enriquecida, además de un botón de suscripción que una publicación puede colocar en su propio sitio."
 
+#: src/components/reader/saved-filters.tsx
+msgid "Filter saved articles — {activeCount, plural, one {# filter active} other {# filters active}}"
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 #: src/routes/_layout.topics.index.tsx
 msgid "Search topics"
@@ -2183,6 +2203,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "System"
 msgstr "Sistema"
+
+#: src/components/reader/saved-filters.tsx
+msgid "Filter by…"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Every feed, directory, and search query the app itself runs."
@@ -2369,6 +2393,10 @@ msgstr "Colecciones"
 msgid "Done"
 msgstr "Listo"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Authors"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
@@ -2411,6 +2439,10 @@ msgstr "Podría seguir a"
 #: src/components/reader/labeler-pill.tsx
 msgid "View labeler"
 msgstr "Ver etiquetador"
+
+#: src/routes/_layout.saved.tsx
+msgid "Search saved articles"
+msgstr ""
 
 #: src/magazine/magazine-feature-end.tsx
 msgid "Read more from the author"
@@ -3936,6 +3968,7 @@ msgid "No labeled accounts"
 msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
+#: src/components/reader/saved-filters.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.saved.tsx
 msgid "Publication"
@@ -4071,6 +4104,12 @@ msgstr ""
 #: src/routes/_layout.collections.new.tsx
 msgid "On your first collection we create one series to hold them — a special collection you can subscribe to, rename, and theme later."
 msgstr "Con su primera colección creamos una serie que las agrupa: una colección especial a la que puede suscribirse, cambiar de nombre y personalizar más adelante."
+
+#. placeholder {0}: i18n._( SAVED_SORT_OPTIONS.find((option) => option.id === shownSort)?.label ?? SAVED_SORT_OPTIONS[0].label, )
+#. placeholder {1}: i18n._( shownDirection === "asc" ? directionLabels.asc : directionLabels.desc, )
+#: src/routes/_layout.saved.tsx
+msgid "Sort — {0}, {1}"
+msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-theme-editor.tsx
@@ -4732,6 +4771,10 @@ msgstr ""
 msgid "The voice used when you listen to an article with read aloud."
 msgstr "La voz que se usa al escuchar un artículo con la lectura en voz alta."
 
+#: src/components/reader/saved-filters.tsx
+msgid "{activeCount, plural, one {# filter} other {# filters}}"
+msgstr ""
+
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Remove image {position}"
 msgstr ""
@@ -5134,6 +5177,10 @@ msgstr ""
 #: src/routes/mcp/authorize.tsx
 #~ msgid "Connect {0}?"
 #~ msgstr ""
+
+#: src/components/reader/saved-filters.tsx
+msgid "Tags"
+msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Person"
@@ -5887,6 +5934,10 @@ msgstr "La web lenta, revisitada"
 msgid "+{0} more"
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Nothing in your queue matches the current search and filters. Try removing one."
+msgstr ""
+
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #~ msgid "Eight presets, or your own paper and accent. The rest of the interface is derived from them."
 #~ msgstr ""
@@ -5900,6 +5951,10 @@ msgstr "Google Font"
 #: src/components/reader/collection-builder.tsx
 msgid "Create collection"
 msgstr "Crear colección"
+
+#: src/components/reader/saved-filters.tsx
+msgid "Find a publication, author, or tag"
+msgstr ""
 
 #: src/components/labelers-settings-view.tsx
 msgid "Labels articles here"
@@ -6649,6 +6704,10 @@ msgstr "El inicio de sesión y el acceso a los registros pasan por su Personal D
 msgid "An included article"
 msgstr "Un artículo incluido"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Nothing saved matches “{query}”."
+msgstr ""
+
 #: src/components/appearance-settings.tsx
 msgid "Puts the palette, font, size, roundness and density back to their defaults."
 msgstr ""
@@ -6707,6 +6766,7 @@ msgstr "Abra cualquier artículo con la sesión iniciada y aparecerá aquí. Su 
 #~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
 #~ msgstr "Cree listas de publicaciones con nombre y fáciles de compartir: una playlist para leer. Cualquiera puede añadir su lista a su propio lector con un solo toque."
 
+#: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
 msgstr "Autor"
@@ -7125,6 +7185,10 @@ msgstr "Vuelva a la extensión de Standard Reader: esta pestaña se cerrará aut
 msgid "To start from a particular paragraph instead of the beginning, select the text and choose <0>Read from here</0>."
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Search saved articles…"
+msgstr ""
+
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.index.tsx
 msgid "Edit series"
@@ -7315,6 +7379,7 @@ msgstr "Metadatos de la sesión, como la dirección IP y la cadena de user-agent
 msgid "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 msgstr "No publicamos nada en su cuenta salvo cuando realiza una acción explícita que lo requiere (por ejemplo, seguir una publicación, dar me gusta o guardar un artículo, o suscribirse mediante el flujo de suscripción específico). No vendemos su información personal."
 
+#: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -7360,8 +7425,8 @@ msgid "Notifications on this device"
 msgstr ""
 
 #: src/routes/_layout.saved.tsx
-msgid "Reordering saved articles"
-msgstr ""
+#~ msgid "Reordering saved articles"
+#~ msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "No unread articles from your follows right now."
@@ -7669,6 +7734,14 @@ msgstr ""
 msgid "Discover, from recommendations at the top to the full directory at the bottom."
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Active filters"
+msgstr ""
+
+#: src/components/reader/saved-filters.tsx
+msgid "Clear all"
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/components/reader/share-menu.tsx
@@ -7837,6 +7910,10 @@ msgstr "Lector"
 msgid "Your day: a featured lead and the latest from your subscriptions."
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Filter saved articles"
+msgstr ""
+
 #: src/components/reader/series-up-next.tsx
 msgid "You’ve read every issue published so far."
 msgstr ""
@@ -7859,6 +7936,10 @@ msgstr "{minutes}m"
 
 #: src/components/docs/labelers-docs-page.tsx
 msgid "That record also carries an <0>enabled</0> flag. A reader can mute your labeler here — keeping the subscription and their per-label settings, but not applying your labels while they read — without unsubscribing, which is useful when they follow a labeler on another app that they don’t want acting on long-form reading. Its absence means enabled."
+msgstr ""
+
+#: src/routes/_layout.saved.tsx
+msgid "Showing {total} of {totalSaved} saved"
 msgstr ""
 
 #. placeholder {0}: account.handle

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -288,6 +288,10 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Nothing to filter by yet."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Recommendations from real reading patterns"
 msgstr "Des recommandations issues de vraies habitudes de lecture"
@@ -802,6 +806,10 @@ msgstr "Rechercher des publications"
 msgid "Small"
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Loading filter options"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Only mine"
 msgstr ""
@@ -907,6 +915,10 @@ msgstr "Abonnez-vous pour recevoir les nouveaux textes dans votre flux."
 msgid "A minimal loose document — no publication, Markpub markdown body:"
 msgstr "Un document libre minimal — sans publication, corps en markdown Markpub :"
 
+#: src/routes/_layout.saved.tsx
+msgid "Updating saved articles"
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>4. Let readers subscribe.</0> When a reader subscribes we write an <1>app.standard-reader.labeler.subscription</1> record to their repo, carrying their per-label warn/hide preferences."
 msgstr "<0>4. Laissez les lecteurs s’abonner.</0> Lorsqu’un lecteur s’abonne, nous écrivons un enregistrement <1>app.standard-reader.labeler.subscription</1> dans son repo, avec ses préférences d’avertissement ou de masquage par étiquette."
@@ -973,8 +985,8 @@ msgid "Loading voice sample"
 msgstr "Chargement de l’extrait de voix"
 
 #: src/routes/_layout.saved.tsx
-msgid "Sort saved articles"
-msgstr ""
+#~ msgid "Sort saved articles"
+#~ msgstr ""
 
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
@@ -1397,6 +1409,10 @@ msgstr ""
 #: src/components/appearance-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Custom"
+msgstr ""
+
+#: src/routes/_layout.saved.tsx
+msgid "No saved articles match"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -2151,6 +2167,10 @@ msgstr ""
 #~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
 #~ msgstr "Publications, listes et collections disposent chacune d'un lien épuré avec un aperçu enrichi — ainsi que d'un bouton d'abonnement qu'une publication peut installer sur son propre site."
 
+#: src/components/reader/saved-filters.tsx
+msgid "Filter saved articles — {activeCount, plural, one {# filter active} other {# filters active}}"
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 #: src/routes/_layout.topics.index.tsx
 msgid "Search topics"
@@ -2183,6 +2203,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "System"
 msgstr "Système"
+
+#: src/components/reader/saved-filters.tsx
+msgid "Filter by…"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Every feed, directory, and search query the app itself runs."
@@ -2369,6 +2393,10 @@ msgstr "Collections"
 msgid "Done"
 msgstr "Terminé"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Authors"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
@@ -2411,6 +2439,10 @@ msgstr "Vous pourriez suivre"
 #: src/components/reader/labeler-pill.tsx
 msgid "View labeler"
 msgstr "Voir le service d'étiquetage"
+
+#: src/routes/_layout.saved.tsx
+msgid "Search saved articles"
+msgstr ""
 
 #: src/magazine/magazine-feature-end.tsx
 msgid "Read more from the author"
@@ -3936,6 +3968,7 @@ msgid "No labeled accounts"
 msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
+#: src/components/reader/saved-filters.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.saved.tsx
 msgid "Publication"
@@ -4071,6 +4104,12 @@ msgstr ""
 #: src/routes/_layout.collections.new.tsx
 msgid "On your first collection we create one series to hold them — a special collection you can subscribe to, rename, and theme later."
 msgstr "Dès votre première collection, nous créons une série pour les regrouper — une collection spéciale à laquelle vous pouvez vous abonner, que vous pourrez renommer et personnaliser plus tard."
+
+#. placeholder {0}: i18n._( SAVED_SORT_OPTIONS.find((option) => option.id === shownSort)?.label ?? SAVED_SORT_OPTIONS[0].label, )
+#. placeholder {1}: i18n._( shownDirection === "asc" ? directionLabels.asc : directionLabels.desc, )
+#: src/routes/_layout.saved.tsx
+msgid "Sort — {0}, {1}"
+msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-theme-editor.tsx
@@ -4732,6 +4771,10 @@ msgstr ""
 msgid "The voice used when you listen to an article with read aloud."
 msgstr "La voix utilisée lorsque vous écoutez un article en lecture à voix haute."
 
+#: src/components/reader/saved-filters.tsx
+msgid "{activeCount, plural, one {# filter} other {# filters}}"
+msgstr ""
+
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Remove image {position}"
 msgstr ""
@@ -5134,6 +5177,10 @@ msgstr ""
 #: src/routes/mcp/authorize.tsx
 #~ msgid "Connect {0}?"
 #~ msgstr ""
+
+#: src/components/reader/saved-filters.tsx
+msgid "Tags"
+msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Person"
@@ -5887,6 +5934,10 @@ msgstr "Le Slow Web, revisité"
 msgid "+{0} more"
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Nothing in your queue matches the current search and filters. Try removing one."
+msgstr ""
+
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #~ msgid "Eight presets, or your own paper and accent. The rest of the interface is derived from them."
 #~ msgstr ""
@@ -5900,6 +5951,10 @@ msgstr "Google Font"
 #: src/components/reader/collection-builder.tsx
 msgid "Create collection"
 msgstr "Créer une collection"
+
+#: src/components/reader/saved-filters.tsx
+msgid "Find a publication, author, or tag"
+msgstr ""
 
 #: src/components/labelers-settings-view.tsx
 msgid "Labels articles here"
@@ -6649,6 +6704,10 @@ msgstr "La connexion et l'accès aux enregistrements passent par votre Personal 
 msgid "An included article"
 msgstr "Un article inclus"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Nothing saved matches “{query}”."
+msgstr ""
+
 #: src/components/appearance-settings.tsx
 msgid "Puts the palette, font, size, roundness and density back to their defaults."
 msgstr ""
@@ -6707,6 +6766,7 @@ msgstr "Ouvrez un article en étant connecté et il apparaîtra ici. Votre histo
 #~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
 #~ msgstr "Composez des listes de publications nommées et partageables — une playlist de lecture. N'importe qui peut ajouter votre liste à son propre lecteur en un seul geste."
 
+#: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
 msgstr "Auteur"
@@ -7125,6 +7185,10 @@ msgstr "Retournez à l'extension Standard Reader — cet onglet se fermera autom
 msgid "To start from a particular paragraph instead of the beginning, select the text and choose <0>Read from here</0>."
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Search saved articles…"
+msgstr ""
+
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.index.tsx
 msgid "Edit series"
@@ -7315,6 +7379,7 @@ msgstr "Les métadonnées de session telles que l'adresse IP et la chaîne user-
 msgid "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 msgstr "Nous ne publions rien depuis votre compte, sauf lorsque vous effectuez une action explicite qui l'exige (par exemple suivre une publication, aimer ou enregistrer un article, ou vous abonner via le parcours d'abonnement dédié). Nous ne vendons pas vos informations personnelles."
 
+#: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -7360,8 +7425,8 @@ msgid "Notifications on this device"
 msgstr ""
 
 #: src/routes/_layout.saved.tsx
-msgid "Reordering saved articles"
-msgstr ""
+#~ msgid "Reordering saved articles"
+#~ msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "No unread articles from your follows right now."
@@ -7669,6 +7734,14 @@ msgstr ""
 msgid "Discover, from recommendations at the top to the full directory at the bottom."
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Active filters"
+msgstr ""
+
+#: src/components/reader/saved-filters.tsx
+msgid "Clear all"
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/components/reader/share-menu.tsx
@@ -7837,6 +7910,10 @@ msgstr "Lecteur"
 msgid "Your day: a featured lead and the latest from your subscriptions."
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Filter saved articles"
+msgstr ""
+
 #: src/components/reader/series-up-next.tsx
 msgid "You’ve read every issue published so far."
 msgstr ""
@@ -7859,6 +7936,10 @@ msgstr "{minutes} min"
 
 #: src/components/docs/labelers-docs-page.tsx
 msgid "That record also carries an <0>enabled</0> flag. A reader can mute your labeler here — keeping the subscription and their per-label settings, but not applying your labels while they read — without unsubscribing, which is useful when they follow a labeler on another app that they don’t want acting on long-form reading. Its absence means enabled."
+msgstr ""
+
+#: src/routes/_layout.saved.tsx
+msgid "Showing {total} of {totalSaved} saved"
 msgstr ""
 
 #. placeholder {0}: account.handle

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -288,6 +288,10 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Nothing to filter by yet."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Recommendations from real reading patterns"
 msgstr "実際の読書傾向にもとづくおすすめ"
@@ -802,6 +806,10 @@ msgstr "発行物を検索"
 msgid "Small"
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Loading filter options"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Only mine"
 msgstr ""
@@ -907,6 +915,10 @@ msgstr "購読すると、新しい文章がフィードに届きます。"
 msgid "A minimal loose document — no publication, Markpub markdown body:"
 msgstr "最小限の単体文書 — 発行物なし、Markpub の Markdown 本文:"
 
+#: src/routes/_layout.saved.tsx
+msgid "Updating saved articles"
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>4. Let readers subscribe.</0> When a reader subscribes we write an <1>app.standard-reader.labeler.subscription</1> record to their repo, carrying their per-label warn/hide preferences."
 msgstr "<0>4. 読者に購読してもらう。</0> 読者が購読すると、ラベルごとの警告・非表示の設定を含む <1>app.standard-reader.labeler.subscription</1> レコードをその読者のリポジトリに書き込みます。"
@@ -973,8 +985,8 @@ msgid "Loading voice sample"
 msgstr "音声サンプルを読み込み中"
 
 #: src/routes/_layout.saved.tsx
-msgid "Sort saved articles"
-msgstr ""
+#~ msgid "Sort saved articles"
+#~ msgstr ""
 
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
@@ -1397,6 +1409,10 @@ msgstr ""
 #: src/components/appearance-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Custom"
+msgstr ""
+
+#: src/routes/_layout.saved.tsx
+msgid "No saved articles match"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -2151,6 +2167,10 @@ msgstr ""
 #~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
 #~ msgstr "発行物・リスト・コレクションのそれぞれに、リッチなプレビューカード付きのすっきりしたリンクが用意されます。発行物が自分のサイトに設置できる購読ボタンも使えます。"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Filter saved articles — {activeCount, plural, one {# filter active} other {# filters active}}"
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 #: src/routes/_layout.topics.index.tsx
 msgid "Search topics"
@@ -2183,6 +2203,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "System"
 msgstr "システム"
+
+#: src/components/reader/saved-filters.tsx
+msgid "Filter by…"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Every feed, directory, and search query the app itself runs."
@@ -2369,6 +2393,10 @@ msgstr "コレクション"
 msgid "Done"
 msgstr "完了"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Authors"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
@@ -2411,6 +2439,10 @@ msgstr "フォローするとよいかも"
 #: src/components/reader/labeler-pill.tsx
 msgid "View labeler"
 msgstr "ラベラーを表示"
+
+#: src/routes/_layout.saved.tsx
+msgid "Search saved articles"
+msgstr ""
 
 #: src/magazine/magazine-feature-end.tsx
 msgid "Read more from the author"
@@ -3936,6 +3968,7 @@ msgid "No labeled accounts"
 msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
+#: src/components/reader/saved-filters.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.saved.tsx
 msgid "Publication"
@@ -4071,6 +4104,12 @@ msgstr ""
 #: src/routes/_layout.collections.new.tsx
 msgid "On your first collection we create one series to hold them — a special collection you can subscribe to, rename, and theme later."
 msgstr "初めてコレクションを作成すると、それをまとめるシリーズを1つ作成します。購読・名前変更・テーマ設定が後からできる特別なコレクションです。"
+
+#. placeholder {0}: i18n._( SAVED_SORT_OPTIONS.find((option) => option.id === shownSort)?.label ?? SAVED_SORT_OPTIONS[0].label, )
+#. placeholder {1}: i18n._( shownDirection === "asc" ? directionLabels.asc : directionLabels.desc, )
+#: src/routes/_layout.saved.tsx
+msgid "Sort — {0}, {1}"
+msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-theme-editor.tsx
@@ -4732,6 +4771,10 @@ msgstr ""
 msgid "The voice used when you listen to an article with read aloud."
 msgstr "読み上げで記事を聴くときに使う声です。"
 
+#: src/components/reader/saved-filters.tsx
+msgid "{activeCount, plural, one {# filter} other {# filters}}"
+msgstr ""
+
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Remove image {position}"
 msgstr ""
@@ -5134,6 +5177,10 @@ msgstr ""
 #: src/routes/mcp/authorize.tsx
 #~ msgid "Connect {0}?"
 #~ msgstr ""
+
+#: src/components/reader/saved-filters.tsx
+msgid "Tags"
+msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Person"
@@ -5887,6 +5934,10 @@ msgstr "スロー・ウェブ再訪"
 msgid "+{0} more"
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Nothing in your queue matches the current search and filters. Try removing one."
+msgstr ""
+
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #~ msgid "Eight presets, or your own paper and accent. The rest of the interface is derived from them."
 #~ msgstr ""
@@ -5900,6 +5951,10 @@ msgstr "Google Font"
 #: src/components/reader/collection-builder.tsx
 msgid "Create collection"
 msgstr "コレクションを作成"
+
+#: src/components/reader/saved-filters.tsx
+msgid "Find a publication, author, or tag"
+msgstr ""
 
 #: src/components/labelers-settings-view.tsx
 msgid "Labels articles here"
@@ -6649,6 +6704,10 @@ msgstr "サインインとレコードへのアクセスは、あなたの Perso
 msgid "An included article"
 msgstr "収録記事"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Nothing saved matches “{query}”."
+msgstr ""
+
 #: src/components/appearance-settings.tsx
 msgid "Puts the palette, font, size, roundness and density back to their defaults."
 msgstr ""
@@ -6707,6 +6766,7 @@ msgstr "サインイン状態で記事を開くと、ここに表示されます
 #~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
 #~ msgstr "名前を付けて共有できる発行物のリストを作りましょう。読書のプレイリストです。だれでもワンタップで自分のリーダーに追加できます。"
 
+#: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
 msgstr "著者"
@@ -7125,6 +7185,10 @@ msgstr "Standard Reader の拡張機能に戻ってください。このタブ�
 msgid "To start from a particular paragraph instead of the beginning, select the text and choose <0>Read from here</0>."
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Search saved articles…"
+msgstr ""
+
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.index.tsx
 msgid "Edit series"
@@ -7315,6 +7379,7 @@ msgstr "IP アドレスやブラウザのユーザーエージェント文字列
 msgid "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 msgstr "明示的な操作（発行物のフォロー、記事への高評価や保存、専用の購読フローでの購読など）が必要な場合を除き、あなたのアカウントで投稿することはありません。個人情報を販売することもありません。"
 
+#: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -7360,8 +7425,8 @@ msgid "Notifications on this device"
 msgstr ""
 
 #: src/routes/_layout.saved.tsx
-msgid "Reordering saved articles"
-msgstr ""
+#~ msgid "Reordering saved articles"
+#~ msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "No unread articles from your follows right now."
@@ -7669,6 +7734,14 @@ msgstr ""
 msgid "Discover, from recommendations at the top to the full directory at the bottom."
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Active filters"
+msgstr ""
+
+#: src/components/reader/saved-filters.tsx
+msgid "Clear all"
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/components/reader/share-menu.tsx
@@ -7837,6 +7910,10 @@ msgstr "リーダー"
 msgid "Your day: a featured lead and the latest from your subscriptions."
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Filter saved articles"
+msgstr ""
+
 #: src/components/reader/series-up-next.tsx
 msgid "You’ve read every issue published so far."
 msgstr ""
@@ -7859,6 +7936,10 @@ msgstr "{minutes}分"
 
 #: src/components/docs/labelers-docs-page.tsx
 msgid "That record also carries an <0>enabled</0> flag. A reader can mute your labeler here — keeping the subscription and their per-label settings, but not applying your labels while they read — without unsubscribing, which is useful when they follow a labeler on another app that they don’t want acting on long-form reading. Its absence means enabled."
+msgstr ""
+
+#: src/routes/_layout.saved.tsx
+msgid "Showing {total} of {totalSaved} saved"
 msgstr ""
 
 #. placeholder {0}: account.handle

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -288,6 +288,10 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Nothing to filter by yet."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Recommendations from real reading patterns"
 msgstr "실제 읽기 패턴에서 나온 추천"
@@ -802,6 +806,10 @@ msgstr "발행물 검색"
 msgid "Small"
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Loading filter options"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Only mine"
 msgstr ""
@@ -907,6 +915,10 @@ msgstr "구독하면 새 글이 피드에 표시됩니다."
 msgid "A minimal loose document — no publication, Markpub markdown body:"
 msgstr "최소한의 느슨한 문서 — 발행물 없음, Markpub 마크다운 본문:"
 
+#: src/routes/_layout.saved.tsx
+msgid "Updating saved articles"
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>4. Let readers subscribe.</0> When a reader subscribes we write an <1>app.standard-reader.labeler.subscription</1> record to their repo, carrying their per-label warn/hide preferences."
 msgstr "<0>4. 독자가 구독할 수 있게 합니다.</0> 독자가 구독하면 저희는 해당 독자의 repo에 <1>app.standard-reader.labeler.subscription</1> 레코드를 기록하며, 여기에 레이블별 경고/숨김 설정이 담깁니다."
@@ -973,8 +985,8 @@ msgid "Loading voice sample"
 msgstr "음성 샘플 불러오는 중"
 
 #: src/routes/_layout.saved.tsx
-msgid "Sort saved articles"
-msgstr ""
+#~ msgid "Sort saved articles"
+#~ msgstr ""
 
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
@@ -1397,6 +1409,10 @@ msgstr ""
 #: src/components/appearance-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Custom"
+msgstr ""
+
+#: src/routes/_layout.saved.tsx
+msgid "No saved articles match"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -2151,6 +2167,10 @@ msgstr ""
 #~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
 #~ msgstr "발행물, 리스트, 컬렉션마다 리치 미리보기 카드가 달린 깔끔한 링크가 생깁니다. 발행물이 자체 사이트에 넣을 수 있는 구독 버튼도 함께 제공됩니다."
 
+#: src/components/reader/saved-filters.tsx
+msgid "Filter saved articles — {activeCount, plural, one {# filter active} other {# filters active}}"
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 #: src/routes/_layout.topics.index.tsx
 msgid "Search topics"
@@ -2183,6 +2203,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "System"
 msgstr "시스템"
+
+#: src/components/reader/saved-filters.tsx
+msgid "Filter by…"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Every feed, directory, and search query the app itself runs."
@@ -2369,6 +2393,10 @@ msgstr "컬렉션"
 msgid "Done"
 msgstr "완료"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Authors"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
@@ -2411,6 +2439,10 @@ msgstr "팔로우할 만한 계정"
 #: src/components/reader/labeler-pill.tsx
 msgid "View labeler"
 msgstr "라벨러 보기"
+
+#: src/routes/_layout.saved.tsx
+msgid "Search saved articles"
+msgstr ""
 
 #: src/magazine/magazine-feature-end.tsx
 msgid "Read more from the author"
@@ -3936,6 +3968,7 @@ msgid "No labeled accounts"
 msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
+#: src/components/reader/saved-filters.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.saved.tsx
 msgid "Publication"
@@ -4071,6 +4104,12 @@ msgstr ""
 #: src/routes/_layout.collections.new.tsx
 msgid "On your first collection we create one series to hold them — a special collection you can subscribe to, rename, and theme later."
 msgstr "첫 컬렉션을 만들면 이를 담을 시리즈가 하나 생성됩니다. 구독하고, 이름을 바꾸고, 나중에 테마를 지정할 수 있는 특별한 컬렉션입니다."
+
+#. placeholder {0}: i18n._( SAVED_SORT_OPTIONS.find((option) => option.id === shownSort)?.label ?? SAVED_SORT_OPTIONS[0].label, )
+#. placeholder {1}: i18n._( shownDirection === "asc" ? directionLabels.asc : directionLabels.desc, )
+#: src/routes/_layout.saved.tsx
+msgid "Sort — {0}, {1}"
+msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-theme-editor.tsx
@@ -4732,6 +4771,10 @@ msgstr ""
 msgid "The voice used when you listen to an article with read aloud."
 msgstr "읽어주기로 아티클을 들을 때 사용하는 음성입니다."
 
+#: src/components/reader/saved-filters.tsx
+msgid "{activeCount, plural, one {# filter} other {# filters}}"
+msgstr ""
+
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Remove image {position}"
 msgstr ""
@@ -5134,6 +5177,10 @@ msgstr ""
 #: src/routes/mcp/authorize.tsx
 #~ msgid "Connect {0}?"
 #~ msgstr ""
+
+#: src/components/reader/saved-filters.tsx
+msgid "Tags"
+msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Person"
@@ -5887,6 +5934,10 @@ msgstr "느린 웹, 다시 보기"
 msgid "+{0} more"
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Nothing in your queue matches the current search and filters. Try removing one."
+msgstr ""
+
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #~ msgid "Eight presets, or your own paper and accent. The rest of the interface is derived from them."
 #~ msgstr ""
@@ -5900,6 +5951,10 @@ msgstr "Google Font"
 #: src/components/reader/collection-builder.tsx
 msgid "Create collection"
 msgstr "컬렉션 만들기"
+
+#: src/components/reader/saved-filters.tsx
+msgid "Find a publication, author, or tag"
+msgstr ""
 
 #: src/components/labelers-settings-view.tsx
 msgid "Labels articles here"
@@ -6649,6 +6704,10 @@ msgstr "로그인과 레코드 접근은 사용자의 Personal Data Server와 �
 msgid "An included article"
 msgstr "포함된 글"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Nothing saved matches “{query}”."
+msgstr ""
+
 #: src/components/appearance-settings.tsx
 msgid "Puts the palette, font, size, roundness and density back to their defaults."
 msgstr ""
@@ -6707,6 +6766,7 @@ msgstr "로그인한 상태로 글을 열면 여기에 표시됩니다. 기록�
 #~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
 #~ msgstr "이름을 붙여 공유할 수 있는 발행물 목록을 만드세요. 읽기용 플레이리스트입니다. 누구나 한 번의 탭으로 자기 리더에 추가할 수 있습니다."
 
+#: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
 msgstr "작성자"
@@ -7125,6 +7185,10 @@ msgstr "Standard Reader 확장 프로그램으로 돌아가세요 — 이 탭은
 msgid "To start from a particular paragraph instead of the beginning, select the text and choose <0>Read from here</0>."
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Search saved articles…"
+msgstr ""
+
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.index.tsx
 msgid "Edit series"
@@ -7315,6 +7379,7 @@ msgstr "보안 및 세션 관리를 위해 사용하는 IP 주소, 브라우저 
 msgid "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 msgstr "발행물 팔로우, 글 좋아요나 저장, 전용 구독 흐름을 통한 구독처럼 이용자가 직접 수행한 동작에 필요한 경우를 제외하고는 계정에 게시하지 않습니다. 개인정보를 판매하지 않습니다."
 
+#: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -7360,8 +7425,8 @@ msgid "Notifications on this device"
 msgstr ""
 
 #: src/routes/_layout.saved.tsx
-msgid "Reordering saved articles"
-msgstr ""
+#~ msgid "Reordering saved articles"
+#~ msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "No unread articles from your follows right now."
@@ -7669,6 +7734,14 @@ msgstr ""
 msgid "Discover, from recommendations at the top to the full directory at the bottom."
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Active filters"
+msgstr ""
+
+#: src/components/reader/saved-filters.tsx
+msgid "Clear all"
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/components/reader/share-menu.tsx
@@ -7837,6 +7910,10 @@ msgstr "리더"
 msgid "Your day: a featured lead and the latest from your subscriptions."
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Filter saved articles"
+msgstr ""
+
 #: src/components/reader/series-up-next.tsx
 msgid "You’ve read every issue published so far."
 msgstr ""
@@ -7859,6 +7936,10 @@ msgstr "{minutes}분"
 
 #: src/components/docs/labelers-docs-page.tsx
 msgid "That record also carries an <0>enabled</0> flag. A reader can mute your labeler here — keeping the subscription and their per-label settings, but not applying your labels while they read — without unsubscribing, which is useful when they follow a labeler on another app that they don’t want acting on long-form reading. Its absence means enabled."
+msgstr ""
+
+#: src/routes/_layout.saved.tsx
+msgid "Showing {total} of {totalSaved} saved"
 msgstr ""
 
 #. placeholder {0}: account.handle

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -288,6 +288,10 @@ msgstr ""
 msgid "Type"
 msgstr "Tipo"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Nothing to filter by yet."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Recommendations from real reading patterns"
 msgstr "Recomendações a partir de padrões de leitura reais"
@@ -802,6 +806,10 @@ msgstr "Pesquisar publicações"
 msgid "Small"
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Loading filter options"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Only mine"
 msgstr ""
@@ -907,6 +915,10 @@ msgstr "Inscreva-se para receber novos textos no seu feed."
 msgid "A minimal loose document — no publication, Markpub markdown body:"
 msgstr "Um documento avulso minimalista — sem publicação, com corpo em markdown Markpub:"
 
+#: src/routes/_layout.saved.tsx
+msgid "Updating saved articles"
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>4. Let readers subscribe.</0> When a reader subscribes we write an <1>app.standard-reader.labeler.subscription</1> record to their repo, carrying their per-label warn/hide preferences."
 msgstr "<0>4. Deixe os leitores se inscrever.</0> Quando um leitor se inscreve, escrevemos um registo <1>app.standard-reader.labeler.subscription</1> no repositório dele, com as suas preferências de aviso/ocultação por rótulo."
@@ -973,8 +985,8 @@ msgid "Loading voice sample"
 msgstr "Carregando amostra de voz"
 
 #: src/routes/_layout.saved.tsx
-msgid "Sort saved articles"
-msgstr ""
+#~ msgid "Sort saved articles"
+#~ msgstr ""
 
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
@@ -1397,6 +1409,10 @@ msgstr ""
 #: src/components/appearance-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Custom"
+msgstr ""
+
+#: src/routes/_layout.saved.tsx
+msgid "No saved articles match"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -2151,6 +2167,10 @@ msgstr ""
 #~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
 #~ msgstr "Publicações, listas e coleções, cada uma têm um link com um cartão de pré-visualização — mais um botão de inscrição que uma publicação pode colocar no seu próprio site."
 
+#: src/components/reader/saved-filters.tsx
+msgid "Filter saved articles — {activeCount, plural, one {# filter active} other {# filters active}}"
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 #: src/routes/_layout.topics.index.tsx
 msgid "Search topics"
@@ -2183,6 +2203,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "System"
 msgstr "Sistema"
+
+#: src/components/reader/saved-filters.tsx
+msgid "Filter by…"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Every feed, directory, and search query the app itself runs."
@@ -2369,6 +2393,10 @@ msgstr "Coleções"
 msgid "Done"
 msgstr "Concluído"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Authors"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
@@ -2411,6 +2439,10 @@ msgstr "Você pode gostar"
 #: src/components/reader/labeler-pill.tsx
 msgid "View labeler"
 msgstr "Ver rotulador"
+
+#: src/routes/_layout.saved.tsx
+msgid "Search saved articles"
+msgstr ""
 
 #: src/magazine/magazine-feature-end.tsx
 msgid "Read more from the author"
@@ -3936,6 +3968,7 @@ msgid "No labeled accounts"
 msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
+#: src/components/reader/saved-filters.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.saved.tsx
 msgid "Publication"
@@ -4071,6 +4104,12 @@ msgstr ""
 #: src/routes/_layout.collections.new.tsx
 msgid "On your first collection we create one series to hold them — a special collection you can subscribe to, rename, and theme later."
 msgstr "Na sua primeira coleção criamos uma série para as agrupar — uma coleção especial em que pode se inscrever, renomear e personalizar mais tarde."
+
+#. placeholder {0}: i18n._( SAVED_SORT_OPTIONS.find((option) => option.id === shownSort)?.label ?? SAVED_SORT_OPTIONS[0].label, )
+#. placeholder {1}: i18n._( shownDirection === "asc" ? directionLabels.asc : directionLabels.desc, )
+#: src/routes/_layout.saved.tsx
+msgid "Sort — {0}, {1}"
+msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-theme-editor.tsx
@@ -4732,6 +4771,10 @@ msgstr "Esses esquemas são publicados — gerados a partir dos léxicos — com
 msgid "The voice used when you listen to an article with read aloud."
 msgstr "A voz usada quando ouve um artigo com a leitura em voz alta."
 
+#: src/components/reader/saved-filters.tsx
+msgid "{activeCount, plural, one {# filter} other {# filters}}"
+msgstr ""
+
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Remove image {position}"
 msgstr ""
@@ -5134,6 +5177,10 @@ msgstr "{0, plural, one {# publicação} other {{1} publicações}}"
 #: src/routes/mcp/authorize.tsx
 #~ msgid "Connect {0}?"
 #~ msgstr ""
+
+#: src/components/reader/saved-filters.tsx
+msgid "Tags"
+msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Person"
@@ -5887,6 +5934,10 @@ msgstr "A Slow Web, Revisitada"
 msgid "+{0} more"
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Nothing in your queue matches the current search and filters. Try removing one."
+msgstr ""
+
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #~ msgid "Eight presets, or your own paper and accent. The rest of the interface is derived from them."
 #~ msgstr ""
@@ -5900,6 +5951,10 @@ msgstr "Fonte do Google"
 #: src/components/reader/collection-builder.tsx
 msgid "Create collection"
 msgstr "Criar coleção"
+
+#: src/components/reader/saved-filters.tsx
+msgid "Find a publication, author, or tag"
+msgstr ""
 
 #: src/components/labelers-settings-view.tsx
 msgid "Labels articles here"
@@ -6649,6 +6704,10 @@ msgstr "O início de sessão e o acesso aos registos passam pelo seu Personal Da
 msgid "An included article"
 msgstr "Um artigo incluído"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Nothing saved matches “{query}”."
+msgstr ""
+
 #: src/components/appearance-settings.tsx
 msgid "Puts the palette, font, size, roundness and density back to their defaults."
 msgstr ""
@@ -6707,6 +6766,7 @@ msgstr "Abra qualquer artigo com sessão iniciada e ele aparecerá aqui. O seu h
 #~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
 #~ msgstr "Crie listas de publicações com nome e partilháveis — uma playlist para ler. Qualquer pessoa pode adicionar a sua lista ao próprio leitor com um só toque."
 
+#: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
 msgstr "Autor"
@@ -7125,6 +7185,10 @@ msgstr "Volte à extensão do Standard Reader — este separador fecha automatic
 msgid "To start from a particular paragraph instead of the beginning, select the text and choose <0>Read from here</0>."
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Search saved articles…"
+msgstr ""
+
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.index.tsx
 msgid "Edit series"
@@ -7315,6 +7379,7 @@ msgstr "Metadados da sessão, como o endereço IP e a cadeia user-agent do naveg
 msgid "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 msgstr "Não publicamos na sua conta exceto quando realiza uma ação explícita que o exija (por exemplo seguir uma publicação, curtir ou salvar um artigo, ou se inscrever através do fluxo de inscrição dedicado). Não vendemos as suas informações pessoais."
 
+#: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -7360,8 +7425,8 @@ msgid "Notifications on this device"
 msgstr ""
 
 #: src/routes/_layout.saved.tsx
-msgid "Reordering saved articles"
-msgstr ""
+#~ msgid "Reordering saved articles"
+#~ msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "No unread articles from your follows right now."
@@ -7669,6 +7734,14 @@ msgstr ""
 msgid "Discover, from recommendations at the top to the full directory at the bottom."
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Active filters"
+msgstr ""
+
+#: src/components/reader/saved-filters.tsx
+msgid "Clear all"
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/components/reader/share-menu.tsx
@@ -7837,6 +7910,10 @@ msgstr "Leitor"
 msgid "Your day: a featured lead and the latest from your subscriptions."
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Filter saved articles"
+msgstr ""
+
 #: src/components/reader/series-up-next.tsx
 msgid "You’ve read every issue published so far."
 msgstr ""
@@ -7859,6 +7936,10 @@ msgstr "{minutes}m"
 
 #: src/components/docs/labelers-docs-page.tsx
 msgid "That record also carries an <0>enabled</0> flag. A reader can mute your labeler here — keeping the subscription and their per-label settings, but not applying your labels while they read — without unsubscribing, which is useful when they follow a labeler on another app that they don’t want acting on long-form reading. Its absence means enabled."
+msgstr ""
+
+#: src/routes/_layout.saved.tsx
+msgid "Showing {total} of {totalSaved} saved"
 msgstr ""
 
 #. placeholder {0}: account.handle

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -288,6 +288,10 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Nothing to filter by yet."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Recommendations from real reading patterns"
 msgstr "来自真实阅读行为的推荐"
@@ -802,6 +806,10 @@ msgstr "搜索刊物"
 msgid "Small"
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Loading filter options"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Only mine"
 msgstr ""
@@ -907,6 +915,10 @@ msgstr "订阅后即可在信息流中获取新作品。"
 msgid "A minimal loose document — no publication, Markpub markdown body:"
 msgstr "一个最简的松散文档——没有刊物，正文为 Markpub markdown："
 
+#: src/routes/_layout.saved.tsx
+msgid "Updating saved articles"
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>4. Let readers subscribe.</0> When a reader subscribes we write an <1>app.standard-reader.labeler.subscription</1> record to their repo, carrying their per-label warn/hide preferences."
 msgstr "<0>4. 让读者订阅。</0>读者订阅时，我们会向其 repo 写入一条 <1>app.standard-reader.labeler.subscription</1> 记录，其中包含他们针对每个标签的警告/隐藏偏好。"
@@ -973,8 +985,8 @@ msgid "Loading voice sample"
 msgstr "正在加载语音样本"
 
 #: src/routes/_layout.saved.tsx
-msgid "Sort saved articles"
-msgstr ""
+#~ msgid "Sort saved articles"
+#~ msgstr ""
 
 #: src/components/docs/api-docs-intro.tsx
 #: src/components/docs/docs-api-nav.tsx
@@ -1397,6 +1409,10 @@ msgstr ""
 #: src/components/appearance-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Custom"
+msgstr ""
+
+#: src/routes/_layout.saved.tsx
+msgid "No saved articles match"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -2151,6 +2167,10 @@ msgstr ""
 #~ msgid "Publications, lists, and collections each get a clean link with a rich preview card — plus a subscribe button a publication can drop on its own site."
 #~ msgstr "刊物、列表和合集都有简洁的链接与丰富的预览卡片——刊物还能把订阅按钮放到自己的网站上。"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Filter saved articles — {activeCount, plural, one {# filter active} other {# filters active}}"
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 #: src/routes/_layout.topics.index.tsx
 msgid "Search topics"
@@ -2183,6 +2203,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "System"
 msgstr "跟随系统"
+
+#: src/components/reader/saved-filters.tsx
+msgid "Filter by…"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Every feed, directory, and search query the app itself runs."
@@ -2369,6 +2393,10 @@ msgstr "合集"
 msgid "Done"
 msgstr "完成"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Authors"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.tag.$tag.tsx
@@ -2411,6 +2439,10 @@ msgstr "你可能想关注"
 #: src/components/reader/labeler-pill.tsx
 msgid "View labeler"
 msgstr "查看标注服务"
+
+#: src/routes/_layout.saved.tsx
+msgid "Search saved articles"
+msgstr ""
 
 #: src/magazine/magazine-feature-end.tsx
 msgid "Read more from the author"
@@ -3936,6 +3968,7 @@ msgid "No labeled accounts"
 msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
+#: src/components/reader/saved-filters.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.saved.tsx
 msgid "Publication"
@@ -4071,6 +4104,12 @@ msgstr ""
 #: src/routes/_layout.collections.new.tsx
 msgid "On your first collection we create one series to hold them — a special collection you can subscribe to, rename, and theme later."
 msgstr "在你创建第一个合集时，我们会新建一个系列来收纳它们——这个特殊合集可以订阅，之后也能重命名和更换主题。"
+
+#. placeholder {0}: i18n._( SAVED_SORT_OPTIONS.find((option) => option.id === shownSort)?.label ?? SAVED_SORT_OPTIONS[0].label, )
+#. placeholder {1}: i18n._( shownDirection === "asc" ? directionLabels.asc : directionLabels.desc, )
+#: src/routes/_layout.saved.tsx
+msgid "Sort — {0}, {1}"
+msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-theme-editor.tsx
@@ -4732,6 +4771,10 @@ msgstr ""
 msgid "The voice used when you listen to an article with read aloud."
 msgstr "朗读文章时使用的音色。"
 
+#: src/components/reader/saved-filters.tsx
+msgid "{activeCount, plural, one {# filter} other {# filters}}"
+msgstr ""
+
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Remove image {position}"
 msgstr ""
@@ -5134,6 +5177,10 @@ msgstr ""
 #: src/routes/mcp/authorize.tsx
 #~ msgid "Connect {0}?"
 #~ msgstr ""
+
+#: src/components/reader/saved-filters.tsx
+msgid "Tags"
+msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Person"
@@ -5887,6 +5934,10 @@ msgstr "重访慢速网络"
 msgid "+{0} more"
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Nothing in your queue matches the current search and filters. Try removing one."
+msgstr ""
+
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #~ msgid "Eight presets, or your own paper and accent. The rest of the interface is derived from them."
 #~ msgstr ""
@@ -5900,6 +5951,10 @@ msgstr "Google Font"
 #: src/components/reader/collection-builder.tsx
 msgid "Create collection"
 msgstr "创建合集"
+
+#: src/components/reader/saved-filters.tsx
+msgid "Find a publication, author, or tag"
+msgstr ""
 
 #: src/components/labelers-settings-view.tsx
 msgid "Labels articles here"
@@ -6649,6 +6704,10 @@ msgstr "登录和记录访问都经由你的 Personal Data Server 以及更广�
 msgid "An included article"
 msgstr "收录的一篇文章"
 
+#: src/components/reader/saved-filters.tsx
+msgid "Nothing saved matches “{query}”."
+msgstr ""
+
 #: src/components/appearance-settings.tsx
 msgid "Puts the palette, font, size, roundness and density back to their defaults."
 msgstr ""
@@ -6707,6 +6766,7 @@ msgstr "登录后打开任意文章，它就会出现在这里。你的阅读记
 #~ msgid "Build named, shareable lists of publications — a playlist for reading. Anyone can add your list to their own reader in a single tap."
 #~ msgstr "建立有名字、可分享的刊物列表——像阅读歌单一样。任何人都能一键把你的列表加进自己的阅读器。"
 
+#: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Author"
 msgstr "作者"
@@ -7125,6 +7185,10 @@ msgstr "返回 Standard Reader 扩展——此标签页将自动关闭。"
 msgid "To start from a particular paragraph instead of the beginning, select the text and choose <0>Read from here</0>."
 msgstr ""
 
+#: src/routes/_layout.saved.tsx
+msgid "Search saved articles…"
+msgstr ""
+
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.index.tsx
 msgid "Edit series"
@@ -7315,6 +7379,7 @@ msgstr "会话元数据，例如 IP 地址和浏览器 user-agent 字符串，�
 msgid "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 msgstr "除非你主动执行需要写入的操作（例如关注刊物、点赞或保存文章，或通过专门的订阅流程订阅），我们不会以你的账户发帖。我们不会出售你的个人信息。"
 
+#: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -7360,8 +7425,8 @@ msgid "Notifications on this device"
 msgstr ""
 
 #: src/routes/_layout.saved.tsx
-msgid "Reordering saved articles"
-msgstr ""
+#~ msgid "Reordering saved articles"
+#~ msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "No unread articles from your follows right now."
@@ -7669,6 +7734,14 @@ msgstr ""
 msgid "Discover, from recommendations at the top to the full directory at the bottom."
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Active filters"
+msgstr ""
+
+#: src/components/reader/saved-filters.tsx
+msgid "Clear all"
+msgstr ""
+
 #: src/components/reader/discover-topic-filters.tsx
 #: src/components/reader/rss-feed-button.tsx
 #: src/components/reader/share-menu.tsx
@@ -7837,6 +7910,10 @@ msgstr "阅读器"
 msgid "Your day: a featured lead and the latest from your subscriptions."
 msgstr ""
 
+#: src/components/reader/saved-filters.tsx
+msgid "Filter saved articles"
+msgstr ""
+
 #: src/components/reader/series-up-next.tsx
 msgid "You’ve read every issue published so far."
 msgstr ""
@@ -7859,6 +7936,10 @@ msgstr "{minutes} 分"
 
 #: src/components/docs/labelers-docs-page.tsx
 msgid "That record also carries an <0>enabled</0> flag. A reader can mute your labeler here — keeping the subscription and their per-label settings, but not applying your labels while they read — without unsubscribing, which is useful when they follow a labeler on another app that they don’t want acting on long-form reading. Its absence means enabled."
+msgstr ""
+
+#: src/routes/_layout.saved.tsx
+msgid "Showing {total} of {totalSaved} saved"
 msgstr ""
 
 #. placeholder {0}: account.handle

--- a/apps/standard-reader/src/routes/_layout.saved.tsx
+++ b/apps/standard-reader/src/routes/_layout.saved.tsx
@@ -12,10 +12,10 @@ import {
   MenuSeparator,
 } from "@standard-reader/design-system/menu";
 import { ProgressCircle } from "@standard-reader/design-system/progress-circle";
-import { Select, SelectItem } from "@standard-reader/design-system/select";
+import { SearchField } from "@standard-reader/design-system/search-field";
 import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
-import { breakpoints } from "@standard-reader/design-system/theme/media-queries.stylex";
 import { radius } from "@standard-reader/design-system/theme/radius.stylex";
+import { gap } from "@standard-reader/design-system/theme/semantic-spacing.stylex";
 import { spacing } from "@standard-reader/design-system/theme/spacing.stylex";
 import {
   fontFamily,
@@ -24,31 +24,41 @@ import {
   lineHeight,
 } from "@standard-reader/design-system/theme/typography.stylex";
 import * as stylex from "@stylexjs/stylex";
-import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
-import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
+import { useQuery, useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import {
-  ArrowDownWideNarrow,
-  ArrowUpDown,
-  ArrowUpNarrowWide,
-} from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+  createFileRoute,
+  redirect,
+  useNavigate,
+  useRouterState,
+} from "@tanstack/react-router";
+import { ArrowUpDown } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Selection } from "react-aria-components";
 import { z } from "zod";
 
 import { usePullToRefresh } from "#/components/reader/pull-to-refresh";
+import {
+  SavedFilterChips,
+  SavedFilterPopover,
+} from "#/components/reader/saved-filters";
 import { ButtonLink } from "#/components/router-links";
 import type {
+  SavedFacets,
   SavedSort,
   SavedSortDirection,
 } from "#/integrations/tanstack-query/api-reader.functions";
 import {
   defaultSavedSortDirection,
+  hasSavedFilters,
   readerApi,
+  SAVED_FILTER_MAX_VALUES,
+  SAVED_SEARCH_MAX_LENGTH,
   SAVED_SORT_DIRECTIONS,
   SAVED_SORT_VALUES,
 } from "#/integrations/tanstack-query/api-reader.functions";
 import { user } from "#/integrations/tanstack-query/api-user.functions";
 import { getPublicUrlClient } from "#/lib/public-url";
+import type { SavedFilterValues } from "#/lib/saved-filters";
 import { pageSocialMeta } from "#/lib/site-metadata";
 import { useDelayedLoading } from "#/lib/use-delayed-loading";
 import { buildAuthRedirectPath } from "#/utils/auth-redirect";
@@ -57,12 +67,43 @@ import { FeedLoadMore } from "../components/reader/feed-load-more";
 import { Masthead, ReaderContent } from "../components/reader/primitives";
 import { ReaderQueueRows } from "../components/reader/reader-queue-rows";
 
+/**
+ * Facet values ride the URL as JSON arrays, which is what the router's default
+ * search serializer emits. Read leniently rather than validated strictly: a
+ * bookmarked link outlives the tags in it, and a stale or hand-mangled
+ * `?tags=…` should quietly filter nothing, not throw the page into an error
+ * boundary. Empty stays `undefined` so it never reaches the URL at all.
+ */
+const facetParam = z
+  .unknown()
+  .transform((value) => {
+    if (!Array.isArray(value)) return;
+    const values = value
+      .filter((entry): entry is string => typeof entry === "string" && !!entry)
+      .slice(0, SAVED_FILTER_MAX_VALUES);
+    return values.length > 0 ? values : undefined;
+  })
+  // Outermost, so the key stays optional on the route's search type and every
+  // plain `<Link to="/saved">` in the app keeps type-checking.
+  .optional();
+
 const savedSearchSchema = z.object({
   sort: z.enum(SAVED_SORT_VALUES).default("added"),
   /** Left out of the URL until the reader flips a field off its natural
    * direction, so a chosen direction carries across a change of field but an
    * untouched one still follows the field (dates newest-first, names A–Z). */
   dir: z.enum(SAVED_SORT_DIRECTIONS).optional(),
+  /** Clamped rather than rejected, for the same reason as {@link facetParam}. */
+  q: z
+    .unknown()
+    .transform((value) => {
+      const text = typeof value === "string" ? value.trim() : "";
+      return text ? text.slice(0, SAVED_SEARCH_MAX_LENGTH) : undefined;
+    })
+    .optional(),
+  pubs: facetParam,
+  authors: facetParam,
+  tags: facetParam,
 });
 
 type SavedSearch = z.infer<typeof savedSearchSchema>;
@@ -98,9 +139,20 @@ const SAVED_MENU_KEYS: Array<string> = [
  * that lands inside it never flashes a loading state at all. */
 const ORDER_PENDING_DELAY_MS = 150;
 
+/** Matches `/search`. Long enough that typing a title doesn't fire a request
+ * per keystroke, short enough that the list feels answerable. */
+const SEARCH_DEBOUNCE_MS = 300;
+
 export const Route = createFileRoute("/_layout/saved")({
   validateSearch: savedSearchSchema,
-  loaderDeps: ({ search }) => ({ sort: search.sort, dir: search.dir }),
+  loaderDeps: ({ search }) => ({
+    sort: search.sort,
+    dir: search.dir,
+    q: search.q,
+    pubs: search.pubs,
+    authors: search.authors,
+    tags: search.tags,
+  }),
   beforeLoad: async ({ context }) => {
     const session = await context.queryClient.ensureQueryData(
       user.getSessionQueryOptions,
@@ -114,10 +166,13 @@ export const Route = createFileRoute("/_layout/saved")({
   },
   loader: async ({ context, deps }) => {
     await context.queryClient.ensureInfiniteQueryData(
-      readerApi.getSavedInfiniteQueryOptions({
-        sort: deps.sort,
-        dir: deps.dir,
-      }),
+      readerApi.getSavedInfiniteQueryOptions(deps),
+    );
+    // The filter options are never above the fold — the popover has to be
+    // opened before they're visible — so they're warmed, never awaited. A
+    // reader arriving on a filtered link still gets chip labels from this.
+    void context.queryClient.prefetchQuery(
+      readerApi.getSavedFacetsQueryOptions(),
     );
   },
   head: () => ({
@@ -173,52 +228,128 @@ const styles = stylex.create({
     textAlign: "center",
     marginTop: spacing["6"],
   },
-  // Two controls occupy the masthead's action slot — a compact icon menu and
-  // the full select-plus-direction pair — swapped by media query rather than a
-  // JS viewport check, so SSR emits both and neither can hydrate to the wrong
-  // one (mirrors `/tag`'s article sort). The swap is at `md` to match where the
-  // masthead drops its meta figure: below that the trailing edge is tight, so
-  // the pair collapses into the single icon menu, which carries the order as a
-  // second section rather than a second button — two arrow glyphs side by side
-  // read as one repeated idea, not as field and direction.
-  sortSlotCompact: {
-    display: { default: "flex", [breakpoints.md]: "none" },
+  // The controls sit above the list rather than in the masthead's trailing
+  // slot: there are four of them now, and a search field belongs at the head of
+  // the thing it searches, not tucked under a count.
+  toolbar: {
+    alignItems: "center",
+    columnGap: gap.md,
+    display: "flex",
+    flexDirection: "row",
+    flexWrap: "wrap",
+    rowGap: gap.md,
+    // Asymmetric on purpose: closer to the masthead it belongs to than to the
+    // list it acts on, so the row reads as page chrome rather than as the first
+    // item in the queue.
+    marginBottom: spacing["8"],
+    marginTop: spacing["6"],
   },
-  sortSlotFull: {
-    display: { default: "none", [breakpoints.md]: "flex" },
+  toolbarSearch: {
+    flexBasis: spacing["48"],
+    flexGrow: 1,
+    minWidth: 0,
   },
-  sortSelect: {
-    minWidth: spacing["40"],
+  // Keeps the buttons together on one line when the search field wraps to its
+  // own row, so they never strand as a lone square against the left edge.
+  toolbarControls: {
+    columnGap: gap.md,
+    display: "flex",
+    flexDirection: "row",
+    flexShrink: 0,
+    marginInlineStart: "auto",
+  },
+  // Same token and weight as the rule under every row, so the list is bounded
+  // by one repeating line rather than by two that nearly match.
+  listRule: {
+    borderTopColor: uiColor.border1,
+    borderTopStyle: "solid",
+    borderTopWidth: 1,
+  },
+  resultCount: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.sm,
+    marginBottom: spacing["4"],
+    marginTop: spacing["4"],
   },
 });
+
+/** The filter half of the URL, in the shape the popover speaks. */
+function filterValuesFromSearch(search: SavedSearch): SavedFilterValues {
+  return {
+    authors: search.authors ?? [],
+    pubs: search.pubs ?? [],
+    tags: search.tags ?? [],
+  };
+}
 
 function ReaderSaved() {
   usePullToRefresh();
   const { t, i18n } = useLingui();
-  const { sort, dir } = Route.useSearch();
+  const search = Route.useSearch();
+  const { sort, dir } = search;
   const direction = dir ?? defaultSavedSortDirection(sort);
+  const filters = useMemo(() => filterValuesFromSearch(search), [search]);
   const navigate = useNavigate({ from: Route.fullPath });
+
   /**
    * What the reader just asked for, until the router commits it. The route
    * loader resolves before the search params change, so the old rows stay on
-   * screen with nothing to say a new order is on the way — this drives the
+   * screen with nothing to say a new list is on the way — this drives the
    * controls to the new choice immediately and marks the wait.
    *
    * Scoped to this page's own navigations rather than the router's global
    * `isLoading`, which would also fire when the reader clicks through to an
-   * article and spin a sort control on the page they are leaving.
+   * article and spin a control on the page they are leaving.
    */
   const [requested, setRequested] = useState<{
     sort: SavedSort;
     dir: SavedSortDirection;
   } | null>(null);
+  /** Set while a filter or search change is in flight. Unlike a reorder, these
+   * don't freeze their own control — ticking three boxes in a row is normal,
+   * and each tick should land. */
+  const [filtersPending, setFiltersPending] = useState(false);
+
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useSuspenseInfiniteQuery(
-      readerApi.getSavedInfiniteQueryOptions({ sort, dir: direction }),
+      readerApi.getSavedInfiniteQueryOptions({
+        sort,
+        dir: direction,
+        q: search.q,
+        pubs: search.pubs,
+        authors: search.authors,
+        tags: search.tags,
+      }),
     );
 
   const saved = data.pages.flatMap((page) => page.items);
   const total = data.pages[0]?.total ?? 0;
+  const totalSaved = data.pages[0]?.totalSaved ?? 0;
+  const isFiltering = hasSavedFilters(search);
+
+  // Filter options are wanted the moment the popover opens, and never before —
+  // so they're fetched on the first open, or once the page has gone quiet,
+  // whichever comes first. That keeps them off the critical path without
+  // making the first open feel like it's booting something.
+  const routerLoading = useRouterState({ select: (state) => state.isLoading });
+  const [facetsWanted, setFacetsWanted] = useState(false);
+  useEffect(() => {
+    if (facetsWanted || routerLoading) return;
+    const idle = globalThis.requestIdleCallback?.(() => setFacetsWanted(true));
+    if (idle == null) {
+      // Safari has no requestIdleCallback; a timeout is close enough for a
+      // prefetch whose only job is to not compete with the critical path.
+      const timer = globalThis.setTimeout(() => setFacetsWanted(true), 500);
+      return () => globalThis.clearTimeout(timer);
+    }
+    return () => globalThis.cancelIdleCallback?.(idle);
+  }, [facetsWanted, routerLoading]);
+
+  const { data: facets, isPending: facetsPending } = useQuery({
+    ...readerApi.getSavedFacetsQueryOptions(),
+    enabled: facetsWanted,
+  });
 
   const loadMore = useCallback(() => {
     if (hasNextPage && !isFetchingNextPage) {
@@ -242,10 +373,20 @@ function ReaderSaved() {
     }
   }, [direction, requested, sort]);
 
+  // Same for filters, keyed off the committed search rather than a snapshot —
+  // several changes can be in flight at once, and the last one to land wins.
+  useEffect(() => {
+    setFiltersPending(false);
+  }, [search.q, search.pubs, search.authors, search.tags]);
+
   const shownSort = requested?.sort ?? sort;
   const shownDirection = requested?.dir ?? direction;
   const changingOrder = useDelayedLoading(
     requested !== null,
+    ORDER_PENDING_DELAY_MS,
+  );
+  const busy = useDelayedLoading(
+    requested !== null || filtersPending,
     ORDER_PENDING_DELAY_MS,
   );
 
@@ -281,119 +422,33 @@ function ReaderSaved() {
     if (next === "asc" || next === "desc") setDirection(next);
   };
 
+  const applyFilters = (next: SavedFilterValues) => {
+    setFiltersPending(true);
+    void navigate({
+      replace: true,
+      resetScroll: false,
+      search: (prev: SavedSearch) => ({
+        ...prev,
+        authors: next.authors.length > 0 ? next.authors : undefined,
+        pubs: next.pubs.length > 0 ? next.pubs : undefined,
+        tags: next.tags.length > 0 ? next.tags : undefined,
+      }),
+    });
+  };
+
   const directionLabels = SAVED_DIRECTION_LABELS[SAVED_SORT_RANKS[shownSort]];
-  /** The button names what it will do, and shows what is true now. */
-  const flipLabel = i18n._(
-    shownDirection === "asc" ? directionLabels.desc : directionLabels.asc,
-  );
-
-  const sortControl =
-    total === 0 ? undefined : (
-      <Flex direction="row" gap="sm" align="center">
-        {/* Leading the row, so it grows leftward off the masthead's trailing
-            edge and the controls themselves never shift. */}
-        {changingOrder ? (
-          <ProgressCircle
-            isIndeterminate
-            size="sm"
-            aria-label={t`Reordering saved articles`}
-          />
-        ) : null}
-
-        <div {...stylex.props(styles.sortSlotCompact)}>
-          <Menu
-            placement="bottom end"
-            // The trigger stays live — it only opens the sheet. What's frozen
-            // is the choices inside it, which is also the half the reader is
-            // looking at: the menu stays open across a pick.
-            disabledKeys={changingOrder ? SAVED_MENU_KEYS : undefined}
-            trigger={
-              <IconButton
-                aria-label={t`Sort saved articles`}
-                size="md"
-                variant="secondary"
-              >
-                <ArrowUpDown size={16} />
-              </IconButton>
-            }
-          >
-            {/* Selection lives on each section (see `/feedback`'s filter menu),
-                so field and order read as one sheet and the menu stays open
-                between the two choices. */}
-            <MenuSection
-              selectionMode="single"
-              disallowEmptySelection
-              shouldCloseOnSelect={false}
-              selectedKeys={new Set([shownSort])}
-              onSelectionChange={onSortSelection}
-            >
-              <MenuSectionHeader>
-                <Trans>Sort by</Trans>
-              </MenuSectionHeader>
-              {SAVED_SORT_OPTIONS.map((option) => (
-                <MenuItem key={option.id} id={option.id}>
-                  {i18n._(option.label)}
-                </MenuItem>
-              ))}
-            </MenuSection>
-            <MenuSeparator />
-            <MenuSection
-              selectionMode="single"
-              disallowEmptySelection
-              shouldCloseOnSelect={false}
-              selectedKeys={new Set([shownDirection])}
-              onSelectionChange={onDirectionSelection}
-            >
-              <MenuSectionHeader>
-                <Trans>Order</Trans>
-              </MenuSectionHeader>
-              <MenuItem id="desc">{i18n._(directionLabels.desc)}</MenuItem>
-              <MenuItem id="asc">{i18n._(directionLabels.asc)}</MenuItem>
-            </MenuSection>
-          </Menu>
-        </div>
-
-        <div {...stylex.props(styles.sortSlotFull)}>
-          <Flex direction="row" gap="sm" align="center">
-            <Select
-              aria-label={t`Sort saved articles`}
-              size="md"
-              variant="secondary"
-              isDisabled={changingOrder}
-              selectedKey={shownSort}
-              style={styles.sortSelect}
-              onSelectionChange={onSortChange}
-            >
-              {SAVED_SORT_OPTIONS.map((option) => (
-                <SelectItem
-                  key={option.id}
-                  id={option.id}
-                  textValue={i18n._(option.label)}
-                >
-                  {i18n._(option.label)}
-                </SelectItem>
-              ))}
-            </Select>
-            <IconButton
-              size="md"
-              variant="secondary"
-              label={flipLabel}
-              aria-label={flipLabel}
-              isDisabled={changingOrder}
-              onPress={() =>
-                setDirection(shownDirection === "asc" ? "desc" : "asc")
-              }
-            >
-              {shownDirection === "asc" ? (
-                <ArrowUpNarrowWide size={16} />
-              ) : (
-                <ArrowDownWideNarrow size={16} />
-              )}
-            </IconButton>
-          </Flex>
-        </div>
-      </Flex>
-    );
+  /**
+   * With the order living behind a menu on every viewport, the trigger is the
+   * only place the current order can be read without opening something — so it
+   * names the state, not just the action. Feeds the tooltip and the accessible
+   * name both.
+   */
+  const sortLabel = t`Sort — ${i18n._(
+    SAVED_SORT_OPTIONS.find((option) => option.id === shownSort)?.label ??
+      SAVED_SORT_OPTIONS[0].label,
+  )}, ${i18n._(
+    shownDirection === "asc" ? directionLabels.asc : directionLabels.desc,
+  )}`;
 
   return (
     <ReaderContent>
@@ -402,11 +457,14 @@ function ReaderSaved() {
         title={t`Saved for later`}
         dek={t`Articles you've saved for later — in your repo, synced across devices.`}
         metaLabel={t`Saved`}
-        metaValue={String(total)}
-        metaAction={sortControl}
+        // Always the whole queue, never the filtered subset: this is the page's
+        // headline figure, and a number that drops to 3 while you narrow reads
+        // as articles disappearing rather than as a filter doing its job. What
+        // the filters matched is said below the toolbar instead.
+        metaValue={String(totalSaved)}
       />
 
-      {total === 0 ? (
+      {totalSaved === 0 ? (
         <div {...stylex.props(styles.emptyCard)}>
           <Flex
             direction="column"
@@ -434,24 +492,237 @@ function ReaderSaved() {
         </div>
       ) : (
         <>
-          <ReaderQueueRows
-            items={queueRows}
-            saveButtonPlacement="besideMedia"
-            assumeBookmarked
+          <SavedToolbar
+            committedQuery={search.q ?? ""}
+            onQueryChange={(next) => {
+              setFiltersPending(true);
+              void navigate({
+                replace: true,
+                resetScroll: false,
+                search: (prev: SavedSearch) => ({
+                  ...prev,
+                  q: next || undefined,
+                }),
+              });
+            }}
+            filters={filters}
+            onFiltersChange={applyFilters}
+            facets={facets}
+            facetsPending={facetsWanted && facetsPending}
+            onFilterPopoverOpen={() => setFacetsWanted(true)}
+            busy={busy}
+            sortControl={
+              <Menu
+                placement="bottom end"
+                // The trigger stays live — it only opens the sheet. What's
+                // frozen is the choices inside it, which is also the half the
+                // reader is looking at: the menu stays open across a pick.
+                disabledKeys={changingOrder ? SAVED_MENU_KEYS : undefined}
+                trigger={
+                  <IconButton
+                    aria-label={sortLabel}
+                    label={sortLabel}
+                    size="lg"
+                    variant="secondary"
+                  >
+                    <ArrowUpDown size={16} />
+                  </IconButton>
+                }
+              >
+                {/* Selection lives on each section (see `/feedback`'s filter
+                    menu), so field and order read as one sheet and the menu
+                    stays open between the two choices. */}
+                <MenuSection
+                  selectionMode="single"
+                  disallowEmptySelection
+                  shouldCloseOnSelect={false}
+                  selectedKeys={new Set([shownSort])}
+                  onSelectionChange={onSortSelection}
+                >
+                  <MenuSectionHeader>
+                    <Trans>Sort by</Trans>
+                  </MenuSectionHeader>
+                  {SAVED_SORT_OPTIONS.map((option) => (
+                    <MenuItem key={option.id} id={option.id}>
+                      {i18n._(option.label)}
+                    </MenuItem>
+                  ))}
+                </MenuSection>
+                <MenuSeparator />
+                <MenuSection
+                  selectionMode="single"
+                  disallowEmptySelection
+                  shouldCloseOnSelect={false}
+                  selectedKeys={new Set([shownDirection])}
+                  onSelectionChange={onDirectionSelection}
+                >
+                  <MenuSectionHeader>
+                    <Trans>Order</Trans>
+                  </MenuSectionHeader>
+                  <MenuItem id="desc">{i18n._(directionLabels.desc)}</MenuItem>
+                  <MenuItem id="asc">{i18n._(directionLabels.asc)}</MenuItem>
+                </MenuSection>
+              </Menu>
+            }
           />
-          {isFetchingNextPage ? (
-            <p {...stylex.props(styles.loadingNote)}>
-              <Trans>Loading…</Trans>
+
+          <SavedFilterChips
+            facets={facets}
+            value={filters}
+            onChange={applyFilters}
+            onClear={() => {
+              setFiltersPending(true);
+              void navigate({
+                replace: true,
+                resetScroll: false,
+                search: (prev: SavedSearch) => ({
+                  ...prev,
+                  authors: undefined,
+                  pubs: undefined,
+                  tags: undefined,
+                }),
+              });
+            }}
+          />
+
+          {isFiltering ? (
+            <p {...stylex.props(styles.resultCount)} aria-live="polite">
+              {t`Showing ${total} of ${totalSaved} saved`}
             </p>
           ) : null}
-          <FeedLoadMore
-            hasMore={hasNextPage}
-            isLoading={isFetchingNextPage}
-            onLoadMore={loadMore}
-            itemCount={saved.length}
-          />
+
+          {total === 0 ? (
+            <div {...stylex.props(styles.emptyCard)}>
+              <Flex
+                direction="column"
+                gap="lg"
+                align="start"
+                style={styles.emptyInner}
+              >
+                <span {...stylex.props(styles.emptyTitle)}>
+                  <Trans>No saved articles match</Trans>
+                </span>
+                <p {...stylex.props(styles.emptyDek)}>
+                  <Trans>
+                    Nothing in your queue matches the current search and
+                    filters. Try removing one.
+                  </Trans>
+                </p>
+              </Flex>
+            </div>
+          ) : (
+            <>
+              {/* Closes the list at the top the same way every row closes at
+                  the bottom — without it the toolbar's controls float above an
+                  unruled first row, and the list reads as starting mid-air. */}
+              <div {...stylex.props(styles.listRule)}>
+                <ReaderQueueRows
+                  items={queueRows}
+                  saveButtonPlacement="besideMedia"
+                  assumeBookmarked
+                  flushFirstRow={false}
+                />
+              </div>
+              {isFetchingNextPage ? (
+                <p {...stylex.props(styles.loadingNote)}>
+                  <Trans>Loading…</Trans>
+                </p>
+              ) : null}
+              <FeedLoadMore
+                hasMore={hasNextPage}
+                isLoading={isFetchingNextPage}
+                onLoadMore={loadMore}
+                itemCount={saved.length}
+              />
+            </>
+          )}
         </>
       )}
     </ReaderContent>
+  );
+}
+
+/**
+ * Search, filter, and sort, in one row above the list.
+ *
+ * The search field owns local state and pushes to the URL on a debounce — the
+ * URL is the source of truth for what's shown, but typing into it directly
+ * would fire a navigation per keystroke.
+ */
+function SavedToolbar({
+  committedQuery,
+  onQueryChange,
+  filters,
+  onFiltersChange,
+  facets,
+  facetsPending,
+  onFilterPopoverOpen,
+  busy,
+  sortControl,
+}: {
+  committedQuery: string;
+  onQueryChange: (next: string) => void;
+  filters: SavedFilterValues;
+  onFiltersChange: (next: SavedFilterValues) => void;
+  facets: SavedFacets | undefined;
+  facetsPending: boolean;
+  onFilterPopoverOpen: () => void;
+  busy: boolean;
+  sortControl: React.ReactNode;
+}) {
+  const { t } = useLingui();
+  const [input, setInput] = useState(committedQuery);
+
+  // Adopt the URL when it changes underneath the field — a back/forward, or the
+  // reader clearing everything from the chip row.
+  useEffect(() => {
+    setInput((current) =>
+      current.trim() === committedQuery.trim() ? current : committedQuery,
+    );
+  }, [committedQuery]);
+
+  useEffect(() => {
+    const trimmed = input.trim();
+    if (trimmed === committedQuery.trim()) return;
+    const timer = globalThis.setTimeout(() => {
+      onQueryChange(trimmed);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => globalThis.clearTimeout(timer);
+  }, [committedQuery, input, onQueryChange]);
+
+  return (
+    <div {...stylex.props(styles.toolbar)}>
+      <SearchField
+        aria-label={t`Search saved articles`}
+        placeholder={t`Search saved articles…`}
+        size="lg"
+        variant="secondary"
+        style={styles.toolbarSearch}
+        value={input}
+        maxLength={SAVED_SEARCH_MAX_LENGTH}
+        onChange={setInput}
+      />
+      <div {...stylex.props(styles.toolbarControls)}>
+        {/* Leads the control cluster, so it grows leftward and the buttons
+            themselves never shift as it comes and goes. */}
+        {busy ? (
+          <ProgressCircle
+            isIndeterminate
+            size="md"
+            aria-label={t`Updating saved articles`}
+          />
+        ) : null}
+        <SavedFilterPopover
+          facets={facets}
+          isPending={facetsPending}
+          value={filters}
+          onChange={onFiltersChange}
+          onOpenChange={(open) => {
+            if (open) onFilterPopoverOpen();
+          }}
+        />
+        {sortControl}
+      </div>
+    </div>
   );
 }

--- a/apps/standard-reader/src/server/reader/queries.ts
+++ b/apps/standard-reader/src/server/reader/queries.ts
@@ -4119,3 +4119,149 @@ export async function authorDocuments(
     total: (ownCount[0]?.count ?? 0) + (creditCount[0]?.count ?? 0),
   };
 }
+
+// ── Saved-page facets ───────────────────────────────────────────────────────
+
+/** One selectable value in a `/saved` filter facet, and how many of the
+ * reader's saved articles carry it. */
+export interface SavedFacetOption {
+  /** What the URL carries back: a publication AT-URI, an author DID, or a
+   * normalized tag. */
+  id: string;
+  label: string;
+  /** Second line under the label — an author's handle. Null where the label is
+   * already the whole identity (publications, tags). */
+  detail: string | null;
+  count: number;
+}
+
+export interface SavedFacets {
+  publications: Array<SavedFacetOption>;
+  authors: Array<SavedFacetOption>;
+  tags: Array<SavedFacetOption>;
+  /** A facet hit {@link SAVED_FACET_LIMIT} and was cut. The popover says so
+   * rather than presenting a partial list as the whole set. */
+  truncated: boolean;
+}
+
+/**
+ * Payload guard, not a design decision: the popover is type-ahead filtered and
+ * scrolls, so it can hold every publication, author, and tag a reader has saved
+ * — and cutting the list would quietly hide the rare value a reader is most
+ * likely to be searching for. This only stops a pathological repo from shipping
+ * tens of thousands of rows to the client. `truncated` says when it bit.
+ */
+const SAVED_FACET_LIMIT = 500;
+
+/**
+ * Every publication, author, and tag present in one reader's saved articles,
+ * with counts — the option list behind `/saved`'s filter popover.
+ *
+ * One round trip for all three facets (a `UNION ALL` over a shared CTE) rather
+ * than three queries: the Railway↔Neon hop dominates this page's latency, so
+ * what costs is the number of statements, not the size of the SQL.
+ *
+ * Tags group by their normalized form (`lower(btrim(...))`, matching
+ * `immutable_normalized_tags`) so "AT Proto" and "atproto" are one option, and
+ * the id sent back through the URL is that same normalized value.
+ */
+export async function selectSavedFacets(
+  db: Db,
+  schema: Schema,
+  did: string,
+): Promise<SavedFacets> {
+  const b = schema.bookmarks;
+  const d = schema.documents;
+  const p = schema.publications;
+  const pr = schema.profiles;
+
+  // `rank` is applied per facet (`partition by kind`) and one row past the cap
+  // is kept, so the caller can tell "exactly at the cap" from "cut" without a
+  // second count.
+  const result = await db.execute(sql`
+    with saved as (
+      select ${d.did} as author_did,
+             ${d.publicationUri} as publication_uri,
+             ${d.tags} as tags
+      from ${b}
+      join ${d} on ${d.uri} = ${b.documentUri}
+      where ${b.ownerDid} = ${did}
+        and ${b.deleted} = false
+        and ${d.deleted} = false
+    ),
+    facets as (
+      select 'publication' as kind,
+             s.publication_uri as id,
+             coalesce(${p.name}, s.publication_uri) as label,
+             null::text as detail,
+             count(*)::int as hits
+      from saved s
+      join ${p} on ${p.uri} = s.publication_uri
+      group by s.publication_uri, ${p.name}
+      union all
+      select 'author' as kind,
+             s.author_did as id,
+             coalesce(nullif(btrim(${pr.displayName}), ''), ${pr.handle}, s.author_did) as label,
+             ${pr.handle} as detail,
+             count(*)::int as hits
+      from saved s
+      left join ${pr} on ${pr.did} = s.author_did
+      group by s.author_did, ${pr.displayName}, ${pr.handle}
+      union all
+      select 'tag' as kind,
+             lower(btrim(t.tag)) as id,
+             lower(btrim(t.tag)) as label,
+             null::text as detail,
+             count(*)::int as hits
+      from saved s
+      cross join lateral unnest(s.tags) as t(tag)
+      where btrim(t.tag) <> ''
+      group by lower(btrim(t.tag))
+    )
+    select kind, id, label, detail, hits
+    from (
+      select f.*,
+             row_number() over (
+               partition by f.kind order by f.hits desc, f.label asc
+             ) as rank
+      from facets f
+    ) ranked
+    where rank <= ${SAVED_FACET_LIMIT + 1}
+    order by kind asc, hits desc, label asc
+  `);
+
+  const facets: SavedFacets = {
+    authors: [],
+    publications: [],
+    tags: [],
+    truncated: false,
+  };
+  const buckets: Record<string, Array<SavedFacetOption>> = {
+    author: facets.authors,
+    publication: facets.publications,
+    tag: facets.tags,
+  };
+
+  for (const row of executeRows<{
+    kind: string;
+    id: string | null;
+    label: string | null;
+    detail: string | null;
+    hits: number | string;
+  }>(result)) {
+    const bucket = buckets[row.kind];
+    if (!bucket || row.id == null) continue;
+    if (bucket.length >= SAVED_FACET_LIMIT) {
+      facets.truncated = true;
+      continue;
+    }
+    bucket.push({
+      count: Number(row.hits) || 0,
+      detail: row.detail,
+      id: row.id,
+      label: row.label ?? row.id,
+    });
+  }
+
+  return facets;
+}


### PR DESCRIPTION
Adds search and multi-select publication / author / tag filters to `/saved` — [requested on userinput.app](https://userinput.app/d/did:plc:fip3nyk6tjo3senpq4ei2cxw/3mrqbtf4pk22o) ("It would be great to be able to filter the whole 'Saved for later' page by: tags, authors, publications").

## What changed

**The controls moved above the list.** Sort came out of the masthead's trailing slot to join the new search field and filter button in a toolbar; `Masthead`'s now-unused `metaAction` prop went away with it. Sort field and order share **one icon menu at every viewport** — the desktop `Select` + flip-button pair is gone. Since the order is now only readable by opening something, the trigger's tooltip and accessible name state it: "Sort — Date saved, Newest first".

**Filtering is server-side and lives in the URL** (`?q=` `?pubs=` `?authors=` `?tags=`), so paging, the result count, and a reloaded or bookmarked link all agree. Client-side filtering would silently only filter the loaded page.

- Values within a facet **OR**; facets **AND**. Two publications + one tag = "either publication, and that tag".
- Tags match through `immutable_normalized_tags`, so case and whitespace variants are one tag — same rule the tag pages use.
- Search covers title, description, publication name, and the author's handle / display name. Deliberately **not** the article body: `/saved` omits `text_content` from its projection, and a hit the row can't visibly explain reads as a bug.

**Filter options come from a new `reader.getSavedFacets` → `selectSavedFacets`** — every publication, author, and tag in that reader's own queue, with counts, in one `UNION ALL` round trip (the Railway↔Neon hop is what costs on this page, not the size of the SQL). Fetched on idle or on the popover's first open, never on the critical path.

## Verified against the read-model

Ran the new queries against the real database for the heaviest saved queue in it — which happens to belong to the person who filed the request: **136 bookmarks, 90 publications, 46 authors, 185 tags**, facets in **338ms**.

| Check | Result |
|---|---|
| Facet counts vs. actual filter results | exact (pub 16=16, author 16=16, tag `atproto` 39=39) |
| OR within a facet | `atproto` + `atmosphere` → 46, not 57 — overlapping docs counted once |
| AND across facets | pub + tag → 1 |
| LIKE escaping | a literal `_` matches 0; no wildcard leak |

That 90/185 spread drove two decisions: the popover is a **type-ahead across all three facets at once** rather than a plain sectioned menu, and the facet list is **not capped** (a top-N cut would hide the rare tag a reader is most likely searching for). There's a 500-per-facet payload guard with a `truncated` flag instead of a silent truncation.

## Smaller calls

- **The masthead count stays the whole queue.** A headline figure that drops to 3 while you narrow reads as articles disappearing. A quiet "Showing 12 of 136 saved" line carries what matched.
- **Two empty states**, not one: "Nothing saved yet" vs. "No saved articles match".
- **Applied filters render as removable chips.** The trigger's dot says *that* something is filtered; chips say *what* — which matters on a page you return to days later with filters restored from the URL.
- **The first row gets a top rule** matching the one under every other row, so the list doesn't start mid-air under the toolbar.
- Un-saving now decrements both `total` and the new `totalSaved` optimistically, and invalidates the facet counts on settle.
- Search params are read leniently (`z.unknown()` + transform) rather than strictly validated — a bookmarked link outlives the tags in it, and a stale `?tags=` should quietly filter nothing rather than throw the page into an error boundary.

## Testing

`tsc`, `oxlint`, `oxfmt`, and the full vitest suite (874 passed) are clean; i18n catalogs re-extracted.

**Not yet visually verified** — `/saved` needs a signed-in session and I couldn't get one in the browser. The server behaviour above is verified against real data, but the popover's layout and scroll behaviour with 185 tags, the chip row's wrapping, and the responsive toolbar have not been looked at on screen yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)