### PR TITLE
Honour Bluesky blocks and block lists

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -847,6 +847,15 @@ review-only OAuth client metadata/callback path rather than widening the default
 client metadata scope. Granted scopes may come back either as `include:` sets or
 expanded `repo:` tokens, so permission checks must accept both formats.
 
+**Blocks** are granular too, and one-sided in an unusual way: _reading_ someone's blocks needs
+no scope at all (`com.atproto.repo.listRecords` is public), so a reader's existing blocks are
+enforced from their first page load whatever they granted. Only _writing_ one needs consent — a
+granular `repo?collection=app.bsky.graph.block&collection=app.bsky.graph.listblock` scope,
+requested by `upgradeToBlocking` the first time they press Block and persisted via
+`user.blockingEnabled` so later logins re-request it silently. It targets Bluesky's lexicon
+deliberately: a block is a portable record, and one that only worked in this app would not be a
+block. See "Blocks & block lists" below.
+
 **userinput.app feedback** takes a different approach: `app.userinput.discussion`
 and `app.userinput.upvote` have no permission-set lexicons, so the default OAuth
 client advertises granular `repo?collection=app.userinput.discussion` and
@@ -1167,6 +1176,57 @@ Standard Reader speaks the standard AT Proto label protocol, so readers can subs
   ever needs to be portable, a record + mirror can be layered on the same table.
   `document_push_queue` is the send outbox. **Notifications are independent of subscribing** —
   the bell doesn't change your feed and doesn't require a subscription.
+
+### Blocks & block lists
+
+A reader's blocks follow them here, in both directions, with no setup and no import step.
+
+- **A block is a record, not a setting.** `app.bsky.graph.block` already lives in the blocker's
+  repo and every AT Protocol app that honours a block reads that same record. So there is no
+  `app.standard-reader.block` and there never should be: we mirror Bluesky's lexicon, and blocking
+  from here writes the record the rest of the network already reads. Block someone in Standard
+  Reader and they are blocked on Bluesky too, and wherever the reader goes next. This is the
+  opposite call from labeler subscriptions, and for a concrete reason — Bluesky keeps _those_ in a
+  preferences blob with no per-key write, which is why they had to be ported into records of our
+  own.
+- **Honouring a block costs no OAuth scope.** `com.atproto.repo.listRecords` is public, so the
+  reader's existing blocks are read straight from their PDS and enforced from their first page
+  load. Only _writing_ a block needs consent (`BSKY_BLOCK_WRITE_SCOPE`, persisted via
+  `user.blockingEnabled`), and it is requested the first time they press Block rather than on
+  sign-in — a reader who never blocks from here never sees the prompt, and one who signed in before
+  the feature existed still has every block they made elsewhere enforced.
+- **Four ways to be blocked, all equal in effect.** The reader blocks someone; someone blocks the
+  reader; the account is on a moderation list the reader blocks (`app.bsky.graph.listblock` +
+  `listitem`); or the account blocks a list the reader is _on_ (Bluesky's `blockedByList`). All
+  four hide content, which is what makes a block feel like a block rather than a mute.
+- **Blocks can't ride the tap.** The firehose ingester tracks the repos we index; a block against
+  one of our readers can be written by any repo on the network. So blocks are pulled **per reader,
+  on a cadence** (`server/blocks/sync.server.ts`): their own records from their PDS, incoming
+  blocks from Constellation's backlink index, and list membership from the public AppView. The
+  sweep is scheduled from the OAuth callback and the signed-in shell read, TTL-guarded so a page
+  load between sweeps costs nothing, and forced inline right after a block/unblock write so the
+  change takes effect on the very next page.
+- **Outgoing replaces, incoming only adds.** The reader's own records are the authoritative set, so
+  a sweep can soft-delete the ones that are gone. Blocks _against_ them come from a best-effort
+  index, and a sweep that came back short must never read as "nobody blocks you any more" — that
+  would un-hide content the moment Constellation hiccuped.
+- **Enforced in SQL where a page paginates, in JS where it doesn't.** Feeds, search, directories and
+  archives filter with a `NOT EXISTS` predicate (`notBlockedByViewer`) so a block never shortens a
+  page or strands results behind an offset; rails, profile tabs and third-party discussion
+  (Bluesky, Margin, Semble, pckt, Leaflet) post-filter, where a shorter list is fine. Every helper
+  is bounded by the DIDs a page is about to render, never by the reader's block set — a reader on a
+  40k-member blocklist has to stay an index probe.
+- **Blocked pages explain themselves.** A blocked profile, publication or article renders the block
+  rather than an empty page or a bare "not found": which direction it runs, and an Unblock control
+  only when the block is the reader's own to undo. The article body is withheld outright — the
+  reason is a separate, opt-in read, so nothing about a blocked document (not even its title)
+  crosses the wire.
+- **Big blocklists are mirrored partially, and say so.** The largest public lists run to six
+  figures; past the mirror cap a list is stored truncated and flagged, because silently
+  under-enforcing a blocklist is worse than admitting the limit.
+- **Settings → Blocked accounts** lists the reader's own blocks and their subscribed block lists,
+  with how much of each list is mirrored. It only offers Unblock for blocks they made: someone
+  else's decision is not theirs to undo, and a button that pretended otherwise would be a lie.
 
 ---
 

--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -1206,27 +1206,64 @@ A reader's blocks follow them here, in both directions, with no setup and no imp
   sweep is scheduled from the OAuth callback and the signed-in shell read, TTL-guarded so a page
   load between sweeps costs nothing, and forced inline right after a block/unblock write so the
   change takes effect on the very next page.
-- **Outgoing replaces, incoming only adds.** The reader's own records are the authoritative set, so
-  a sweep can soft-delete the ones that are gone. Blocks _against_ them come from a best-effort
-  index, and a sweep that came back short must never read as "nobody blocks you any more" — that
-  would un-hide content the moment Constellation hiccuped.
+- **Outgoing replaces; incoming replaces only when the sweep was complete.** The reader's own
+  records are authoritative, so a sweep soft-deletes the ones that are gone. Blocks _against_ them
+  come from a best-effort index, so the delete is gated on the sweep having read every page: a
+  truncated or failed sweep adds but never removes, because it must not read as "nobody blocks you
+  any more". It does have to remove eventually, though — the blocker is usually not a reader here,
+  so nothing else would ever retire the row, and an unblock they made on Bluesky would otherwise
+  hide that account from the reader permanently.
 - **Enforced in SQL where a page paginates, in JS where it doesn't.** Feeds, search, directories and
   archives filter with a `NOT EXISTS` predicate (`notBlockedByViewer`) so a block never shortens a
   page or strands results behind an offset; rails, profile tabs and third-party discussion
-  (Bluesky, Margin, Semble, pckt, Leaflet) post-filter, where a shorter list is fine. Every helper
-  is bounded by the DIDs a page is about to render, never by the reader's block set — a reader on a
-  40k-member blocklist has to stay an index probe.
-- **Blocked pages explain themselves.** A blocked profile, publication or article renders the block
-  rather than an empty page or a bare "not found": which direction it runs, and an Unblock control
-  only when the block is the reader's own to undo. The article body is withheld outright — the
-  reason is a separate, opt-in read, so nothing about a blocked document (not even its title)
-  crosses the wire.
+  (Bluesky, Margin, Semble, pckt, Leaflet) post-filter, where a shorter list is fine. Both check the
+  **author and the publication owner** — a guest post in a blocked owner's publication carries that
+  owner in its byline. Every helper is bounded by the DIDs a page is about to render, never by the
+  reader's block set — a reader on a 40k-member blocklist has to stay an index probe.
+- **The SQL predicate is opt-in per reader, not per request.** `notBlockedByViewer` is three
+  correlated `NOT EXISTS` per candidate row, and on the follow feed it lands inside the per-source
+  laterals whose whole job is an indexed top-k scan — the exact shape that caused the 1651ms
+  corpus-walk regression documented in `reader/queries.ts`. So the only supported way to reach it is
+  `blockFilterDid`, which answers "does this reader block anybody" from an in-process cache and
+  returns `undefined` for the overwhelming majority who don't, keeping the predicate out of the
+  query entirely. `queries.explain.test.ts` (`pnpm perf:explain`) asserts the filtered plan still
+  rides the per-source composite indexes.
+- **A sweep never happens on a request anyone waits for.** A full sweep is dozens to hundreds of
+  round trips against Constellation and the AppView. Blocking a list awaits only the two bounded
+  reads the reader is actually waiting on (their own `listblock` records, and that list's
+  membership) and schedules the rest; Settings → Refresh starts a sweep and says so rather than
+  holding the request open. Sweeps are deduped per reader process-wide, so a doubled press joins the
+  run already in flight.
+- **Blocked pages explain themselves, without a frame of the blocked page first.** A blocked
+  profile, publication or article renders the block rather than an empty page or a bare "not found":
+  which direction it runs, and an Unblock control only when the block is the reader's own to undo.
+  The block state rides on the same query as the content it withholds (`getPublicationHeader`,
+  `getAuthorProfile`, `getAuthorSummary`) — resolving it in a second client query would paint the
+  blocked account's name and avatar and then take them away. Mention hovercards read the same
+  queries, so an inline chip can't summarise someone the profile page withholds. The article body is
+  withheld outright: the reason is a separate, opt-in read that only the not-found state asks for,
+  so nothing about a blocked document (not even its title) crosses the wire, and a signed-out
+  reader — most of that page's traffic — pays nothing for it.
+- **A block outranks an opt-in the reader made earlier.** The weekly digest and push notifications
+  are filtered too. Both arrive uninvited: an emailed article stays in the inbox and a notification
+  lands on a lock screen, so "I asked for this source" made before the block does not survive it.
+  Per-reader RSS (`/feed/latest/$did`, `/feed/l/$did/$rkey`) is filtered for the same reason — a
+  reader who subscribed in an RSS client can't just not look.
 - **Big blocklists are mirrored partially, and say so.** The largest public lists run to six
   figures; past the mirror cap a list is stored truncated and flagged, because silently
   under-enforcing a blocklist is worse than admitting the limit.
-- **Settings → Blocked accounts** lists the reader's own blocks and their subscribed block lists,
-  with how much of each list is mirrored. It only offers Unblock for blocks they made: someone
-  else's decision is not theirs to undo, and a button that pretended otherwise would be a lie.
+- **Settings → Blocked accounts** pages through the reader's own blocks and lists their subscribed
+  block lists, saying in words when a list is larger than we mirror. It only offers Unblock for
+  blocks they made: someone else's decision is not theirs to undo, and a button that pretended
+  otherwise would be a lie.
+- **Blocking is confirmed; failing to block is said out loud.** The overflow-menu item opens a
+  confirmation first — it writes a public record to the reader's repo that the whole network
+  honours, and the menu offers no way back because the profile it sits on becomes a notice. Every
+  block mutation reports failure with a toast; silently doing nothing is indistinguishable from
+  having worked.
+- **A hidden reply is explained, not just missing.** The Discussion badge is the cached, unfiltered
+  count (a per-reader count would need a per-reader cache), so the section reports how many replies
+  the reader's blocks removed instead of showing "No discussion yet" under a badge reading 6.
 
 ---
 

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -1822,9 +1822,10 @@ A reader's Bluesky blocks apply here, in both directions, with no setup. See
       Constellation backlinks (`app.bsky.graph.block:.subject`), and mod-list membership from the
       public AppView. Scheduled from the OAuth callback and the signed-in shell read, TTL-guarded
       (15 min), forced inline after a block/unblock write.
-- [x] **Outgoing replaces, incoming only adds** — the reader's own records are authoritative so a
-      sweep can soft-delete what's gone; incoming blocks come from a best-effort index, and a short
-      sweep must never read as "nobody blocks you any more".
+- [x] **Outgoing replaces; incoming replaces only on a complete sweep** — the reader's own records
+      are authoritative so a sweep can soft-delete what's gone. Incoming rows come from a
+      best-effort index, so their delete is gated on `BacklinkSweep.complete`: a truncated or failed
+      sweep adds but never removes, and must never read as "nobody blocks you any more".
 - [x] **Blocked-by-list** — Bluesky's `blockedByList`: lists the reader is _on_ (Constellation on
       `app.bsky.graph.listitem:.subject`) crossed with who blocks those lists. Bounded to
       `MAX_INCOMING_LISTS`, since being on a list is common and each one costs a record fetch plus a
@@ -1834,23 +1835,54 @@ A reader's Bluesky blocks apply here, in both directions, with no setup. See
       feeds); JS post-filter on rails, profile tabs, friend surfaces and third-party discussion
       (Bluesky / Margin / Semble / pckt / Leaflet). Always bounded by the DIDs a page renders, never
       by the reader's block set — a 40k-member blocklist has to stay an index probe.
+- [x] **Author _and_ publication owner** — `ArticleCard.publicationOwnerDid` carries the owner, and
+      both the SQL predicate and the JS filter check it. A guest post in a blocked owner's
+      publication puts that owner in the byline; before this the field existed and was unit-tested
+      but no production card actually carried it, so the whole owner branch was dead.
+- [x] **`blockFilterDid` gates the SQL predicate** — three correlated `NOT EXISTS` per candidate row
+      inside the follow feed's per-source laterals is the exact shape of the 1651ms corpus-walk
+      regression. The predicate is now added only for readers who actually block somebody, answered
+      from an in-process cache (60s TTL, invalidated on every write). `queries.explain.test.ts`
+      covers the filtered plan.
+- [x] **Detail routes don't serialize a block hop** — `getArticle`, `getPublicationProfile`,
+      `getAuthorProfile` and the per-tab loaders warm the guard concurrently with the read they were
+      making anyway, instead of awaiting a block probe ahead of it.
+- [x] **Digest, push and per-reader RSS** — all filtered. These arrive uninvited (inbox, lock
+      screen, RSS client), so an opt-in made before the block does not survive it.
+- [x] **Friend surfaces filter before ranking** — `resolveFriendPublications` applies blocks up
+      front so the headline counts, the Discover avatar stack (`previewAuthors`) and `nextOffset`
+      all describe the same set as the rendered rows.
 - [x] **Blocked pages explain themselves** — profile, publication and article render the block and
       which direction it runs, with Unblock only when it's the reader's own. The article body is
       withheld outright and the reason is a separate opt-in read, so nothing about a blocked
       document crosses the wire.
+- [x] **No frame of the blocked page first** — block state rides on the query that fetches the
+      content it withholds (`getPublicationHeader`, `getAuthorSummary`), not a second client query
+      that resolves after paint. Mention hovercards read the same queries, so an inline chip can't
+      summarise an account the profile page withholds.
+- [x] **Blocking is confirmed and failure is reported** — the overflow-menu item opens an
+      `AlertDialog` before writing a public record, and every block mutation has an `onError` toast.
+- [x] **Hidden replies are explained** — the Discussion badge stays the cached unfiltered count, so
+      the section says how many replies the reader's blocks removed rather than showing "No
+      discussion yet" under a non-zero badge.
 - [x] **Writing needs consent, reading doesn't** — `listRecords` is public, so existing blocks are
       enforced whatever scope was granted. `upgradeToBlocking` requests the write scope on the first
       Block press, persisted via `user.blockingEnabled` (migration `0032`).
-- [x] **Settings → Blocked accounts** (`/settings/blocks`) — the reader's own blocks and their
-      subscribed block lists, with each list's mirrored size and a Partial badge past the cap.
+- [x] **Settings → Blocked accounts** (`/settings/blocks`) — the reader's own blocks, paged, plus
+      their subscribed block lists with each list's mirrored size, a Partial badge past the cap and
+      a sentence saying what Partial means. Refresh starts a background sweep and says so rather
+      than holding the request open for hundreds of round trips.
 - [ ] **Mutes** — `app.bsky.graph.muteActor` / mute lists are a separate, softer signal (hide from
       feeds but keep the profile reachable) and are not mirrored yet.
 - [ ] **Full mirror for large blocklists** — lists past `MAX_LIST_PAGES` are stored truncated and
       flagged. Fine for the common case; a list with six-figure membership is under-enforced until
       the mirror is paged in the background rather than inline in a reader's sweep.
-- [ ] **Incoming-block freshness** — incoming rows are additive and never expire, so someone who
-      unblocks the reader elsewhere stays blocked here until their own record read (only if they are
-      also a reader here). Needs a periodic re-verification pass against Constellation.
+- [ ] **Translate the blocks UI** — the strings are extracted into all ten catalogs
+      (`pnpm i18n:extract`) but ship untranslated; they render in English outside `en` until a
+      translation pass runs.
+- [ ] **Rate-limit the sweep beyond the in-process guard** — `syncReaderBlocks` dedupes per reader
+      within one process, which is enough for the single web service today. A second instance can
+      still sweep the same reader concurrently; an advisory lock would make the guard cluster-wide.
 
 ---
 

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -1803,6 +1803,55 @@ Standard AT Proto labels: subscribe to labelers, see/blur/hide their labels whil
       live `queryLabels` per page, for lower latency.
 - [ ] **Deploy claudeslop** — Railway service + persistent SQLite volume; publish its did:web.
 
+### Blocks & block lists
+
+A reader's Bluesky blocks apply here, in both directions, with no setup. See
+[`APP_VISION.md` §"Blocks & block lists"](./APP_VISION.md#blocks--block-lists).
+
+- [x] **Honour `app.bsky.graph.block` rather than inventing our own lexicon** — a block is already a
+      portable repo record every AT Protocol app reads, so blocking here writes that record and
+      blocking elsewhere is honoured here. An `app.standard-reader.block` would have been a block
+      that only worked in one app.
+- [x] **Read-model mirror** (migration `0031`) — `blocks`, `block_lists`, `block_list_items`,
+      `block_list_sync_state`, `block_sync_state`. One `blocks` row per record covers both
+      directions (`blocker_did` / `subject_did`), so the four block sources collapse to a four-branch
+      union.
+- [x] **Per-reader sync, not the firehose tap** — a block against one of our readers can be written
+      by any repo on the network, and the tap only tracks repos we index. `syncReaderBlocks` pulls
+      the reader's own records from their PDS (unauthenticated `listRecords`), incoming blocks from
+      Constellation backlinks (`app.bsky.graph.block:.subject`), and mod-list membership from the
+      public AppView. Scheduled from the OAuth callback and the signed-in shell read, TTL-guarded
+      (15 min), forced inline after a block/unblock write.
+- [x] **Outgoing replaces, incoming only adds** — the reader's own records are authoritative so a
+      sweep can soft-delete what's gone; incoming blocks come from a best-effort index, and a short
+      sweep must never read as "nobody blocks you any more".
+- [x] **Blocked-by-list** — Bluesky's `blockedByList`: lists the reader is _on_ (Constellation on
+      `app.bsky.graph.listitem:.subject`) crossed with who blocks those lists. Bounded to
+      `MAX_INCOMING_LISTS`, since being on a list is common and each one costs a record fetch plus a
+      Constellation query.
+- [x] **Enforcement** — SQL `NOT EXISTS` (`notBlockedByViewer`) on everything paginated (home,
+      latest, trending, tag, search, discover directory, publication archives, list feeds, XRPC
+      feeds); JS post-filter on rails, profile tabs, friend surfaces and third-party discussion
+      (Bluesky / Margin / Semble / pckt / Leaflet). Always bounded by the DIDs a page renders, never
+      by the reader's block set — a 40k-member blocklist has to stay an index probe.
+- [x] **Blocked pages explain themselves** — profile, publication and article render the block and
+      which direction it runs, with Unblock only when it's the reader's own. The article body is
+      withheld outright and the reason is a separate opt-in read, so nothing about a blocked
+      document crosses the wire.
+- [x] **Writing needs consent, reading doesn't** — `listRecords` is public, so existing blocks are
+      enforced whatever scope was granted. `upgradeToBlocking` requests the write scope on the first
+      Block press, persisted via `user.blockingEnabled` (migration `0032`).
+- [x] **Settings → Blocked accounts** (`/settings/blocks`) — the reader's own blocks and their
+      subscribed block lists, with each list's mirrored size and a Partial badge past the cap.
+- [ ] **Mutes** — `app.bsky.graph.muteActor` / mute lists are a separate, softer signal (hide from
+      feeds but keep the profile reachable) and are not mirrored yet.
+- [ ] **Full mirror for large blocklists** — lists past `MAX_LIST_PAGES` are stored truncated and
+      flagged. Fine for the common case; a list with six-figure membership is under-enforced until
+      the mirror is paged in the background rather than inline in a reader's sweep.
+- [ ] **Incoming-block freshness** — incoming rows are additive and never expire, so someone who
+      unblocks the reader elsewhere stays blocked here until their own record read (only if they are
+      also a reader here). Needs a periodic re-verification pass against Constellation.
+
 ---
 
 ## 15. Format conversion (`@standard-reader/converter` + CLI)

--- a/apps/standard-reader/drizzle/0035_lush_living_mummy.sql
+++ b/apps/standard-reader/drizzle/0035_lush_living_mummy.sql
@@ -1,0 +1,61 @@
+CREATE TABLE "block_list_items" (
+	"uri" text PRIMARY KEY NOT NULL,
+	"list_uri" text NOT NULL,
+	"subject_did" text NOT NULL,
+	"indexed_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "block_list_sync_state" (
+	"list_uri" text PRIMARY KEY NOT NULL,
+	"owner_did" text NOT NULL,
+	"name" text,
+	"description" text,
+	"purpose" text,
+	"item_count" integer DEFAULT 0 NOT NULL,
+	"truncated" boolean DEFAULT false NOT NULL,
+	"last_error" text,
+	"synced_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "block_lists" (
+	"uri" text PRIMARY KEY NOT NULL,
+	"cid" text,
+	"blocker_did" text NOT NULL,
+	"rkey" text NOT NULL,
+	"list_uri" text NOT NULL,
+	"created_at" timestamp with time zone,
+	"deleted" boolean DEFAULT false NOT NULL,
+	"indexed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "block_sync_state" (
+	"did" text PRIMARY KEY NOT NULL,
+	"outgoing_count" integer DEFAULT 0 NOT NULL,
+	"incoming_count" integer DEFAULT 0 NOT NULL,
+	"list_count" integer DEFAULT 0 NOT NULL,
+	"last_error" text,
+	"synced_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "blocks" (
+	"uri" text PRIMARY KEY NOT NULL,
+	"cid" text,
+	"blocker_did" text NOT NULL,
+	"rkey" text NOT NULL,
+	"subject_did" text NOT NULL,
+	"created_at" timestamp with time zone,
+	"deleted" boolean DEFAULT false NOT NULL,
+	"indexed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "blocking_enabled" boolean;--> statement-breakpoint
+CREATE INDEX "block_list_items_list_idx" ON "block_list_items" USING btree ("list_uri");--> statement-breakpoint
+CREATE INDEX "block_list_items_subject_idx" ON "block_list_items" USING btree ("subject_did");--> statement-breakpoint
+CREATE INDEX "block_list_items_list_subject_idx" ON "block_list_items" USING btree ("list_uri","subject_did");--> statement-breakpoint
+CREATE INDEX "block_lists_blocker_idx" ON "block_lists" USING btree ("blocker_did");--> statement-breakpoint
+CREATE INDEX "block_lists_list_idx" ON "block_lists" USING btree ("list_uri");--> statement-breakpoint
+CREATE INDEX "blocks_blocker_idx" ON "blocks" USING btree ("blocker_did");--> statement-breakpoint
+CREATE INDEX "blocks_subject_idx" ON "blocks" USING btree ("subject_did");--> statement-breakpoint
+CREATE INDEX "blocks_edge_idx" ON "blocks" USING btree ("blocker_did","subject_did");

--- a/apps/standard-reader/drizzle/0036_acoustic_zemo.sql
+++ b/apps/standard-reader/drizzle/0036_acoustic_zemo.sql
@@ -1,0 +1,1 @@
+DROP INDEX "blocks_blocker_idx";

--- a/apps/standard-reader/drizzle/meta/0035_snapshot.json
+++ b/apps/standard-reader/drizzle/meta/0035_snapshot.json
@@ -1,0 +1,5470 @@
+{
+  "id": "dc4472c5-bcea-4f57-adb9-2e00d15f09c5",
+  "prevId": "b83590f2-4647-4768-91ef-65a1e5d3d1ac",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_mode": {
+          "name": "theme_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appearance": {
+          "name": "appearance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale_hint_seen": {
+          "name": "locale_hint_seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reader_voice": {
+          "name": "reader_voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_links_externally": {
+          "name": "open_links_externally",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_collections_in_magazine": {
+          "name": "open_collections_in_magazine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reading_typography": {
+          "name": "reading_typography",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_reading_history": {
+          "name": "track_reading_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count_old_posts_as_unread": {
+          "name": "count_old_posts_as_unread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclude_web_bridge": {
+          "name": "exclude_web_bridge",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_publication_theme": {
+          "name": "use_publication_theme",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hide_feed_metrics": {
+          "name": "hide_feed_metrics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feed_pagination": {
+          "name": "feed_pagination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_scope": {
+          "name": "home_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_hidden_tabs": {
+          "name": "profile_hidden_tabs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_show_likes": {
+          "name": "profile_show_likes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_authoring_enabled": {
+          "name": "collections_authoring_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userinput_feedback_enabled": {
+          "name": "userinput_feedback_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "margin_save_enabled": {
+          "name": "margin_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semble_save_enabled": {
+          "name": "semble_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocking_enabled": {
+          "name": "blocking_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "atstore_review_prompt_dismissed": {
+          "name": "atstore_review_prompt_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_enabled": {
+          "name": "weekly_digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_subscriptions": {
+          "name": "weekly_digest_section_subscriptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_network": {
+          "name": "weekly_digest_section_network",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_saved": {
+          "name": "weekly_digest_section_saved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_recommendations": {
+          "name": "weekly_digest_section_recommendations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_last_sent_at": {
+          "name": "weekly_digest_last_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_welcome_sent_at": {
+          "name": "weekly_digest_welcome_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_labelers_imported_at": {
+          "name": "bsky_labelers_imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_did_unique": {
+          "name": "user_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "did"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pds": {
+          "name": "pds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_url": {
+          "name": "banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_uri": {
+          "name": "bsky_profile_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_cid": {
+          "name": "bsky_profile_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_fetched_at": {
+          "name": "profile_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_handle_idx": {
+          "name": "profiles_handle_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_handle_trgm_idx": {
+          "name": "profiles_handle_trgm_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "profiles_display_name_trgm_idx": {
+          "name": "profiles_display_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publications": {
+      "name": "publications",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_cid": {
+          "name": "icon_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_mime": {
+          "name": "icon_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent": {
+          "name": "theme_accent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_background": {
+          "name": "theme_background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_foreground": {
+          "name": "theme_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent_foreground": {
+          "name": "theme_accent_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_json": {
+          "name": "theme_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_in_discover": {
+          "name": "show_in_discover",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "prev_next_direction": {
+          "name": "prev_next_direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_kind": {
+          "name": "serial_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_publication": {
+          "name": "collections_publication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_checked_at": {
+          "name": "verification_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(name, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(topic, '')), 'B')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publications_did_idx": {
+          "name": "publications_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_name_idx": {
+          "name": "publications_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_discover_idx": {
+          "name": "publications_discover_idx",
+          "columns": [
+            {
+              "expression": "show_in_discover",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_topic_idx": {
+          "name": "publications_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_url_idx": {
+          "name": "publications_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_serial_idx": {
+          "name": "publications_serial_idx",
+          "columns": [
+            {
+              "expression": "prev_next_direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_search_idx": {
+          "name": "publications_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_contributors": {
+      "name": "document_contributors",
+      "schema": "",
+      "columns": {
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "document_contributors_did_idx": {
+          "name": "document_contributors_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_contributors_document_uri_documents_uri_fk": {
+          "name": "document_contributors_document_uri_documents_uri_fk",
+          "tableFrom": "document_contributors",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_contributors_document_uri_did_pk": {
+          "name": "document_contributors_document_uri_did_pk",
+          "columns": [
+            "document_uri",
+            "did"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_uri": {
+          "name": "site_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_json": {
+          "name": "collection_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_renderable_body": {
+          "name": "has_renderable_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "body_image_count": {
+          "name": "body_image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_cid": {
+          "name": "cover_image_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_mime": {
+          "name": "cover_image_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backlink_count": {
+          "name": "backlink_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_count_prev": {
+          "name": "backlink_count_prev",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_synced_at": {
+          "name": "backlink_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_recomputed_at": {
+          "name": "trending_recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_recommender_count": {
+          "name": "distinct_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bsky_post_uri": {
+          "name": "bsky_post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_post_cid": {
+          "name": "bsky_post_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_updated_at": {
+          "name": "record_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(title, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(immutable_array_to_string(tags), '')), 'B') || setweight(to_tsvector('english', coalesce(text_content, '')), 'C')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documents_did_idx": {
+          "name": "documents_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_did_published_idx": {
+          "name": "documents_did_published_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"published_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_publication_published_idx": {
+          "name": "documents_publication_published_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_published_idx": {
+          "name": "documents_published_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_featured_idx": {
+          "name": "documents_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_site_idx": {
+          "name": "documents_site_idx",
+          "columns": [
+            {
+              "expression": "site_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_search_idx": {
+          "name": "documents_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "documents_trending_idx": {
+          "name": "documents_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_idx": {
+          "name": "documents_canonical_url_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_trgm_idx": {
+          "name": "documents_canonical_url_trgm_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommends": {
+      "name": "recommends",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommender_did": {
+          "name": "recommender_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recommends_document_idx": {
+          "name": "recommends_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_recommender_idx": {
+          "name": "recommends_recommender_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_edge_idx": {
+          "name": "recommends_edge_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_doc_recommender_created_idx": {
+          "name": "recommends_doc_recommender_created_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recommends\".\"deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_did": {
+          "name": "publication_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_publication_idx": {
+          "name": "subscriptions_publication_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_subscriber_idx": {
+          "name": "subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_edge_idx": {
+          "name": "subscriptions_edge_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follower_did": {
+          "name": "follower_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excluded_publications": {
+          "name": "excluded_publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_subject_idx": {
+          "name": "user_follows_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_edge_idx": {
+          "name": "user_follows_edge_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_owner_idx": {
+          "name": "bookmarks_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_document_idx": {
+          "name": "bookmarks_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_edge_idx": {
+          "name": "bookmarks_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reads": {
+      "name": "reads",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reads_owner_idx": {
+          "name": "reads_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_document_idx": {
+          "name": "reads_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_edge_idx": {
+          "name": "reads_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidebar_prefs": {
+      "name": "sidebar_prefs",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_order": {
+          "name": "list_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "tree_order": {
+          "name": "tree_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "subscription_sort": {
+          "name": "subscription_sort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customize_nav": {
+          "name": "customize_nav",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_nav": {
+          "name": "hidden_nav",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_push_queue": {
+      "name": "document_push_queue",
+      "schema": "",
+      "columns": {
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_push_queue_claim_idx": {
+          "name": "document_push_queue_claim_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_push_queue_author_idx": {
+          "name": "document_push_queue_author_idx",
+          "columns": [
+            {
+              "expression": "author_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_devices": {
+      "name": "push_devices",
+      "schema": "",
+      "columns": {
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_devices_owner_idx": {
+          "name": "push_devices_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_topics": {
+      "name": "push_topics",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_topics_subject_idx": {
+          "name": "push_topics_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "push_topics_owner_did_subject_type_subject_pk": {
+          "name": "push_topics_owner_did_subject_type_subject_pk",
+          "columns": [
+            "owner_did",
+            "subject_type",
+            "subject"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_saves": {
+      "name": "list_saves",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saver_did": {
+          "name": "saver_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_owner_did": {
+          "name": "list_owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "list_saves_saver_idx": {
+          "name": "list_saves_saver_idx",
+          "columns": [
+            {
+              "expression": "saver_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "list_saves_list_uri_idx": {
+          "name": "list_saves_list_uri_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lists": {
+      "name": "lists",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publications": {
+          "name": "publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "users": {
+          "name": "users",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lists_owner_idx": {
+          "name": "lists_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rkey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_corecommends": {
+      "name": "publication_corecommends",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_recommender_count": {
+          "name": "co_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_corecomm_rank_idx": {
+          "name": "publication_corecomm_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_corecommends_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_corecommends_related_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_corecommends_publication_uri_related_publication_uri_pk": {
+          "name": "publication_corecommends_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_cosubscriptions": {
+      "name": "publication_cosubscriptions",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_subscriber_count": {
+          "name": "co_subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_cosub_rank_idx": {
+          "name": "publication_cosub_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_cosubscriptions_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_cosubscriptions_related_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_cosubscriptions_publication_uri_related_publication_uri_pk": {
+          "name": "publication_cosubscriptions_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_stats": {
+      "name": "publication_stats",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommend_count": {
+          "name": "recommend_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_document_at": {
+          "name": "last_document_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documents_7d": {
+          "name": "documents_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_7d": {
+          "name": "subscribers_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_7d": {
+          "name": "recommends_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "documents_prev_7d": {
+          "name": "documents_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_prev_7d": {
+          "name": "subscribers_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_prev_7d": {
+          "name": "recommends_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlinks_7d": {
+          "name": "backlinks_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_velocity": {
+          "name": "trending_velocity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_window_start": {
+          "name": "trending_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_stats_subscribers_idx": {
+          "name": "publication_stats_subscribers_idx",
+          "columns": [
+            {
+              "expression": "subscriber_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_active_idx": {
+          "name": "publication_stats_active_idx",
+          "columns": [
+            {
+              "expression": "last_document_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_trending_idx": {
+          "name": "publication_stats_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_stats_publication_uri_publications_uri_fk": {
+          "name": "publication_stats_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_stats",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_stats": {
+      "name": "network_stats",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discover_topic_counts": {
+      "name": "discover_topic_counts",
+      "schema": "",
+      "columns": {
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discover_topic_counts_count_idx": {
+          "name": "discover_topic_counts_count_idx",
+          "columns": [
+            {
+              "expression": "publication_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discover_topic_counts_topic_trgm_idx": {
+          "name": "discover_topic_counts_topic_trgm_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag_embeddings": {
+      "name": "tag_embeddings",
+      "schema": "",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "double precision[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_publications": {
+      "name": "topic_publications",
+      "schema": "",
+      "columns": {
+        "topic_slug": {
+          "name": "topic_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "matched_tag_count": {
+          "name": "matched_tag_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "topic_publications_rank_idx": {
+          "name": "topic_publications_rank_idx",
+          "columns": [
+            {
+              "expression": "topic_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_publications_pub_idx": {
+          "name": "topic_publications_pub_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_publications_topic_slug_topics_slug_fk": {
+          "name": "topic_publications_topic_slug_topics_slug_fk",
+          "tableFrom": "topic_publications",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "topic_publications_publication_uri_publications_uri_fk": {
+          "name": "topic_publications_publication_uri_publications_uri_fk",
+          "tableFrom": "topic_publications",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_publications_topic_slug_publication_uri_pk": {
+          "name": "topic_publications_topic_slug_publication_uri_pk",
+          "columns": [
+            "topic_slug",
+            "publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_tags": {
+      "name": "topic_tags",
+      "schema": "",
+      "columns": {
+        "topic_slug": {
+          "name": "topic_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "topic_tags_tag_idx": {
+          "name": "topic_tags_tag_idx",
+          "columns": [
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_tags_weight_idx": {
+          "name": "topic_tags_weight_idx",
+          "columns": [
+            {
+              "expression": "topic_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weight",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_tags_topic_slug_topics_slug_fk": {
+          "name": "topic_tags_topic_slug_topics_slug_fk",
+          "tableFrom": "topic_tags",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_tags_topic_slug_tag_pk": {
+          "name": "topic_tags_topic_slug_tag_pk",
+          "columns": [
+            "topic_slug",
+            "tag"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_tags": {
+          "name": "signature_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_count": {
+          "name": "tag_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author_count": {
+          "name": "author_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_model": {
+          "name": "name_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "named_at": {
+          "name": "named_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topics_published_score_idx": {
+          "name": "topics_published_score_idx",
+          "columns": [
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topics_superseded_by_topics_slug_fk": {
+          "name": "topics_superseded_by_topics_slug_fk",
+          "tableFrom": "topics",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "superseded_by"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_dead_letter": {
+      "name": "ingest_dead_letter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retries": {
+          "name": "retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingest_dead_letter_collection_idx": {
+          "name": "ingest_dead_letter_collection_idx",
+          "columns": [
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_state": {
+      "name": "ingest_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_processed": {
+          "name": "events_processed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_repos": {
+      "name": "tracked_repos",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_to_tap_at": {
+          "name": "added_to_tap_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_state": {
+          "name": "backfill_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_seen_rev": {
+          "name": "last_seen_rev",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_fail_count": {
+          "name": "reconcile_fail_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconcile_retry_after": {
+          "name": "reconcile_retry_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tracked_repos_state_idx": {
+          "name": "tracked_repos_state_idx",
+          "columns": [
+            {
+              "expression": "backfill_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_labels": {
+      "name": "document_labels",
+      "schema": "",
+      "columns": {
+        "src": {
+          "name": "src",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "val": {
+          "name": "val",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cts": {
+          "name": "cts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_labels_uri_idx": {
+          "name": "document_labels_uri_idx",
+          "columns": [
+            {
+              "expression": "uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_labels_src_idx": {
+          "name": "document_labels_src_idx",
+          "columns": [
+            {
+              "expression": "src",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "document_labels_src_uri_val_pk": {
+          "name": "document_labels_src_uri_val_pk",
+          "columns": [
+            "src",
+            "uri",
+            "val"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_sync_state": {
+      "name": "label_sync_state",
+      "schema": "",
+      "columns": {
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_count": {
+          "name": "stored_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rejected_count": {
+          "name": "rejected_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_services": {
+      "name": "labeler_services",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_endpoint": {
+          "name": "service_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels_standard_site": {
+          "name": "labels_standard_site",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels_probed_at": {
+          "name": "labels_probed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reachable": {
+          "name": "reachable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_value_definitions": {
+          "name": "label_value_definitions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_services_labeler_idx": {
+          "name": "labeler_services_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_subscriptions": {
+      "name": "labeler_subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefs": {
+          "name": "prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_subscriptions_subscriber_idx": {
+          "name": "labeler_subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labeler_subscriptions_labeler_idx": {
+          "name": "labeler_subscriptions_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_list_items": {
+      "name": "block_list_items",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "block_list_items_list_idx": {
+          "name": "block_list_items_list_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_list_items_subject_idx": {
+          "name": "block_list_items_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_list_items_list_subject_idx": {
+          "name": "block_list_items_list_subject_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_list_sync_state": {
+      "name": "block_list_sync_state",
+      "schema": "",
+      "columns": {
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_count": {
+          "name": "item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "truncated": {
+          "name": "truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_lists": {
+      "name": "block_lists",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocker_did": {
+          "name": "blocker_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "block_lists_blocker_idx": {
+          "name": "block_lists_blocker_idx",
+          "columns": [
+            {
+              "expression": "blocker_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_lists_list_idx": {
+          "name": "block_lists_list_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_sync_state": {
+      "name": "block_sync_state",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "outgoing_count": {
+          "name": "outgoing_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "incoming_count": {
+          "name": "incoming_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "list_count": {
+          "name": "list_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocker_did": {
+          "name": "blocker_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocks_blocker_idx": {
+          "name": "blocks_blocker_idx",
+          "columns": [
+            {
+              "expression": "blocker_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocks_subject_idx": {
+          "name": "blocks_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocks_edge_idx": {
+          "name": "blocks_edge_idx",
+          "columns": [
+            {
+              "expression": "blocker_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_auth_code": {
+      "name": "mcp_auth_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_auth_code_expires_at_idx": {
+          "name": "mcp_auth_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_auth_code_client_id_mcp_client_id_fk": {
+          "name": "mcp_auth_code_client_id_mcp_client_id_fk",
+          "tableFrom": "mcp_auth_code",
+          "tableTo": "mcp_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_auth_code_user_id_user_id_fk": {
+          "name": "mcp_auth_code_user_id_user_id_fk",
+          "tableFrom": "mcp_auth_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_client": {
+      "name": "mcp_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_uri": {
+          "name": "client_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_uri": {
+          "name": "logo_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_token": {
+      "name": "mcp_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_token_user_id_idx": {
+          "name": "mcp_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_expires_at_idx": {
+          "name": "mcp_token_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_client_id_mcp_client_id_fk": {
+          "name": "mcp_token_client_id_mcp_client_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "mcp_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_user_id_user_id_fk": {
+          "name": "mcp_token_user_id_user_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_token_access_token_hash_unique": {
+          "name": "mcp_token_access_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token_hash"
+          ]
+        },
+        "mcp_token_refresh_token_hash_unique": {
+          "name": "mcp_token_refresh_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_shares": {
+      "name": "quote_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_text": {
+          "name": "quote_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quote_shares_document_uri_idx": {
+          "name": "quote_shares_document_uri_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_draft": {
+      "name": "feedback_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feedback_draft_user_idx": {
+          "name": "feedback_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_draft_expires_idx": {
+          "name": "feedback_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_draft_user_id_user_id_fk": {
+          "name": "feedback_draft_user_id_user_id_fk",
+          "tableFrom": "feedback_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upvote_draft": {
+      "name": "upvote_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "upvote_draft_user_idx": {
+          "name": "upvote_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upvote_draft_expires_idx": {
+          "name": "upvote_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upvote_draft_user_id_user_id_fk": {
+          "name": "upvote_draft_user_id_user_id_fk",
+          "tableFrom": "upvote_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.save_draft": {
+      "name": "save_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_app": {
+          "name": "target_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_uri": {
+          "name": "collection_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_cid": {
+          "name": "collection_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_collection_name": {
+          "name": "new_collection_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motivation": {
+          "name": "motivation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passage": {
+          "name": "passage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "save_draft_user_idx": {
+          "name": "save_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "save_draft_expires_idx": {
+          "name": "save_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "save_draft_user_id_user_id_fk": {
+          "name": "save_draft_user_id_user_id_fk",
+          "tableFrom": "save_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/standard-reader/drizzle/meta/0036_snapshot.json
+++ b/apps/standard-reader/drizzle/meta/0036_snapshot.json
@@ -1,0 +1,5455 @@
+{
+  "id": "7ad10254-71c4-4ff2-b003-e79a5f292d33",
+  "prevId": "dc4472c5-bcea-4f57-adb9-2e00d15f09c5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_mode": {
+          "name": "theme_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appearance": {
+          "name": "appearance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale_hint_seen": {
+          "name": "locale_hint_seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reader_voice": {
+          "name": "reader_voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_links_externally": {
+          "name": "open_links_externally",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_collections_in_magazine": {
+          "name": "open_collections_in_magazine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reading_typography": {
+          "name": "reading_typography",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_reading_history": {
+          "name": "track_reading_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count_old_posts_as_unread": {
+          "name": "count_old_posts_as_unread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclude_web_bridge": {
+          "name": "exclude_web_bridge",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_publication_theme": {
+          "name": "use_publication_theme",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hide_feed_metrics": {
+          "name": "hide_feed_metrics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feed_pagination": {
+          "name": "feed_pagination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_scope": {
+          "name": "home_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_hidden_tabs": {
+          "name": "profile_hidden_tabs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_show_likes": {
+          "name": "profile_show_likes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_authoring_enabled": {
+          "name": "collections_authoring_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userinput_feedback_enabled": {
+          "name": "userinput_feedback_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "margin_save_enabled": {
+          "name": "margin_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semble_save_enabled": {
+          "name": "semble_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocking_enabled": {
+          "name": "blocking_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "atstore_review_prompt_dismissed": {
+          "name": "atstore_review_prompt_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_enabled": {
+          "name": "weekly_digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_subscriptions": {
+          "name": "weekly_digest_section_subscriptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_network": {
+          "name": "weekly_digest_section_network",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_saved": {
+          "name": "weekly_digest_section_saved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_recommendations": {
+          "name": "weekly_digest_section_recommendations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_last_sent_at": {
+          "name": "weekly_digest_last_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_welcome_sent_at": {
+          "name": "weekly_digest_welcome_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_labelers_imported_at": {
+          "name": "bsky_labelers_imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_did_unique": {
+          "name": "user_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "did"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pds": {
+          "name": "pds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_url": {
+          "name": "banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_uri": {
+          "name": "bsky_profile_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_cid": {
+          "name": "bsky_profile_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_fetched_at": {
+          "name": "profile_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_handle_idx": {
+          "name": "profiles_handle_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_handle_trgm_idx": {
+          "name": "profiles_handle_trgm_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "profiles_display_name_trgm_idx": {
+          "name": "profiles_display_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publications": {
+      "name": "publications",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_cid": {
+          "name": "icon_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_mime": {
+          "name": "icon_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent": {
+          "name": "theme_accent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_background": {
+          "name": "theme_background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_foreground": {
+          "name": "theme_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent_foreground": {
+          "name": "theme_accent_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_json": {
+          "name": "theme_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_in_discover": {
+          "name": "show_in_discover",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "prev_next_direction": {
+          "name": "prev_next_direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_kind": {
+          "name": "serial_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_publication": {
+          "name": "collections_publication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_checked_at": {
+          "name": "verification_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(name, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(topic, '')), 'B')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publications_did_idx": {
+          "name": "publications_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_name_idx": {
+          "name": "publications_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_discover_idx": {
+          "name": "publications_discover_idx",
+          "columns": [
+            {
+              "expression": "show_in_discover",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_topic_idx": {
+          "name": "publications_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_url_idx": {
+          "name": "publications_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_serial_idx": {
+          "name": "publications_serial_idx",
+          "columns": [
+            {
+              "expression": "prev_next_direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_search_idx": {
+          "name": "publications_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_contributors": {
+      "name": "document_contributors",
+      "schema": "",
+      "columns": {
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "document_contributors_did_idx": {
+          "name": "document_contributors_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_contributors_document_uri_documents_uri_fk": {
+          "name": "document_contributors_document_uri_documents_uri_fk",
+          "tableFrom": "document_contributors",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_contributors_document_uri_did_pk": {
+          "name": "document_contributors_document_uri_did_pk",
+          "columns": [
+            "document_uri",
+            "did"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_uri": {
+          "name": "site_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_json": {
+          "name": "collection_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_renderable_body": {
+          "name": "has_renderable_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "body_image_count": {
+          "name": "body_image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_cid": {
+          "name": "cover_image_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_mime": {
+          "name": "cover_image_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backlink_count": {
+          "name": "backlink_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_count_prev": {
+          "name": "backlink_count_prev",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_synced_at": {
+          "name": "backlink_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_recomputed_at": {
+          "name": "trending_recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_recommender_count": {
+          "name": "distinct_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bsky_post_uri": {
+          "name": "bsky_post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_post_cid": {
+          "name": "bsky_post_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_updated_at": {
+          "name": "record_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(title, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(immutable_array_to_string(tags), '')), 'B') || setweight(to_tsvector('english', coalesce(text_content, '')), 'C')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documents_did_idx": {
+          "name": "documents_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_did_published_idx": {
+          "name": "documents_did_published_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"published_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_publication_published_idx": {
+          "name": "documents_publication_published_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_published_idx": {
+          "name": "documents_published_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_featured_idx": {
+          "name": "documents_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_site_idx": {
+          "name": "documents_site_idx",
+          "columns": [
+            {
+              "expression": "site_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_search_idx": {
+          "name": "documents_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "documents_trending_idx": {
+          "name": "documents_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_idx": {
+          "name": "documents_canonical_url_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_trgm_idx": {
+          "name": "documents_canonical_url_trgm_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommends": {
+      "name": "recommends",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommender_did": {
+          "name": "recommender_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recommends_document_idx": {
+          "name": "recommends_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_recommender_idx": {
+          "name": "recommends_recommender_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_edge_idx": {
+          "name": "recommends_edge_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_doc_recommender_created_idx": {
+          "name": "recommends_doc_recommender_created_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recommends\".\"deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_did": {
+          "name": "publication_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_publication_idx": {
+          "name": "subscriptions_publication_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_subscriber_idx": {
+          "name": "subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_edge_idx": {
+          "name": "subscriptions_edge_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follower_did": {
+          "name": "follower_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excluded_publications": {
+          "name": "excluded_publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_subject_idx": {
+          "name": "user_follows_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_edge_idx": {
+          "name": "user_follows_edge_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_owner_idx": {
+          "name": "bookmarks_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_document_idx": {
+          "name": "bookmarks_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_edge_idx": {
+          "name": "bookmarks_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reads": {
+      "name": "reads",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reads_owner_idx": {
+          "name": "reads_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_document_idx": {
+          "name": "reads_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_edge_idx": {
+          "name": "reads_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidebar_prefs": {
+      "name": "sidebar_prefs",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_order": {
+          "name": "list_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "tree_order": {
+          "name": "tree_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "subscription_sort": {
+          "name": "subscription_sort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customize_nav": {
+          "name": "customize_nav",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_nav": {
+          "name": "hidden_nav",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_push_queue": {
+      "name": "document_push_queue",
+      "schema": "",
+      "columns": {
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_push_queue_claim_idx": {
+          "name": "document_push_queue_claim_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_push_queue_author_idx": {
+          "name": "document_push_queue_author_idx",
+          "columns": [
+            {
+              "expression": "author_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_devices": {
+      "name": "push_devices",
+      "schema": "",
+      "columns": {
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_devices_owner_idx": {
+          "name": "push_devices_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_topics": {
+      "name": "push_topics",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_topics_subject_idx": {
+          "name": "push_topics_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "push_topics_owner_did_subject_type_subject_pk": {
+          "name": "push_topics_owner_did_subject_type_subject_pk",
+          "columns": [
+            "owner_did",
+            "subject_type",
+            "subject"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_saves": {
+      "name": "list_saves",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saver_did": {
+          "name": "saver_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_owner_did": {
+          "name": "list_owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "list_saves_saver_idx": {
+          "name": "list_saves_saver_idx",
+          "columns": [
+            {
+              "expression": "saver_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "list_saves_list_uri_idx": {
+          "name": "list_saves_list_uri_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lists": {
+      "name": "lists",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publications": {
+          "name": "publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "users": {
+          "name": "users",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lists_owner_idx": {
+          "name": "lists_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rkey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_corecommends": {
+      "name": "publication_corecommends",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_recommender_count": {
+          "name": "co_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_corecomm_rank_idx": {
+          "name": "publication_corecomm_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_corecommends_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_corecommends_related_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_corecommends_publication_uri_related_publication_uri_pk": {
+          "name": "publication_corecommends_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_cosubscriptions": {
+      "name": "publication_cosubscriptions",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_subscriber_count": {
+          "name": "co_subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_cosub_rank_idx": {
+          "name": "publication_cosub_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_cosubscriptions_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_cosubscriptions_related_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_cosubscriptions_publication_uri_related_publication_uri_pk": {
+          "name": "publication_cosubscriptions_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_stats": {
+      "name": "publication_stats",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommend_count": {
+          "name": "recommend_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_document_at": {
+          "name": "last_document_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documents_7d": {
+          "name": "documents_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_7d": {
+          "name": "subscribers_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_7d": {
+          "name": "recommends_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "documents_prev_7d": {
+          "name": "documents_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_prev_7d": {
+          "name": "subscribers_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_prev_7d": {
+          "name": "recommends_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlinks_7d": {
+          "name": "backlinks_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_velocity": {
+          "name": "trending_velocity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_window_start": {
+          "name": "trending_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_stats_subscribers_idx": {
+          "name": "publication_stats_subscribers_idx",
+          "columns": [
+            {
+              "expression": "subscriber_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_active_idx": {
+          "name": "publication_stats_active_idx",
+          "columns": [
+            {
+              "expression": "last_document_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_trending_idx": {
+          "name": "publication_stats_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_stats_publication_uri_publications_uri_fk": {
+          "name": "publication_stats_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_stats",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_stats": {
+      "name": "network_stats",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discover_topic_counts": {
+      "name": "discover_topic_counts",
+      "schema": "",
+      "columns": {
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discover_topic_counts_count_idx": {
+          "name": "discover_topic_counts_count_idx",
+          "columns": [
+            {
+              "expression": "publication_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discover_topic_counts_topic_trgm_idx": {
+          "name": "discover_topic_counts_topic_trgm_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag_embeddings": {
+      "name": "tag_embeddings",
+      "schema": "",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "double precision[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_publications": {
+      "name": "topic_publications",
+      "schema": "",
+      "columns": {
+        "topic_slug": {
+          "name": "topic_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "matched_tag_count": {
+          "name": "matched_tag_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "topic_publications_rank_idx": {
+          "name": "topic_publications_rank_idx",
+          "columns": [
+            {
+              "expression": "topic_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_publications_pub_idx": {
+          "name": "topic_publications_pub_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_publications_topic_slug_topics_slug_fk": {
+          "name": "topic_publications_topic_slug_topics_slug_fk",
+          "tableFrom": "topic_publications",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "topic_publications_publication_uri_publications_uri_fk": {
+          "name": "topic_publications_publication_uri_publications_uri_fk",
+          "tableFrom": "topic_publications",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_publications_topic_slug_publication_uri_pk": {
+          "name": "topic_publications_topic_slug_publication_uri_pk",
+          "columns": [
+            "topic_slug",
+            "publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_tags": {
+      "name": "topic_tags",
+      "schema": "",
+      "columns": {
+        "topic_slug": {
+          "name": "topic_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "topic_tags_tag_idx": {
+          "name": "topic_tags_tag_idx",
+          "columns": [
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_tags_weight_idx": {
+          "name": "topic_tags_weight_idx",
+          "columns": [
+            {
+              "expression": "topic_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weight",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_tags_topic_slug_topics_slug_fk": {
+          "name": "topic_tags_topic_slug_topics_slug_fk",
+          "tableFrom": "topic_tags",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_tags_topic_slug_tag_pk": {
+          "name": "topic_tags_topic_slug_tag_pk",
+          "columns": [
+            "topic_slug",
+            "tag"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_tags": {
+          "name": "signature_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_count": {
+          "name": "tag_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author_count": {
+          "name": "author_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_model": {
+          "name": "name_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "named_at": {
+          "name": "named_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topics_published_score_idx": {
+          "name": "topics_published_score_idx",
+          "columns": [
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topics_superseded_by_topics_slug_fk": {
+          "name": "topics_superseded_by_topics_slug_fk",
+          "tableFrom": "topics",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "superseded_by"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_dead_letter": {
+      "name": "ingest_dead_letter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retries": {
+          "name": "retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingest_dead_letter_collection_idx": {
+          "name": "ingest_dead_letter_collection_idx",
+          "columns": [
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_state": {
+      "name": "ingest_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_processed": {
+          "name": "events_processed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_repos": {
+      "name": "tracked_repos",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_to_tap_at": {
+          "name": "added_to_tap_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_state": {
+          "name": "backfill_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_seen_rev": {
+          "name": "last_seen_rev",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_fail_count": {
+          "name": "reconcile_fail_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconcile_retry_after": {
+          "name": "reconcile_retry_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tracked_repos_state_idx": {
+          "name": "tracked_repos_state_idx",
+          "columns": [
+            {
+              "expression": "backfill_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_labels": {
+      "name": "document_labels",
+      "schema": "",
+      "columns": {
+        "src": {
+          "name": "src",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "val": {
+          "name": "val",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cts": {
+          "name": "cts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_labels_uri_idx": {
+          "name": "document_labels_uri_idx",
+          "columns": [
+            {
+              "expression": "uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_labels_src_idx": {
+          "name": "document_labels_src_idx",
+          "columns": [
+            {
+              "expression": "src",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "document_labels_src_uri_val_pk": {
+          "name": "document_labels_src_uri_val_pk",
+          "columns": [
+            "src",
+            "uri",
+            "val"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_sync_state": {
+      "name": "label_sync_state",
+      "schema": "",
+      "columns": {
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_count": {
+          "name": "stored_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rejected_count": {
+          "name": "rejected_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_services": {
+      "name": "labeler_services",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_endpoint": {
+          "name": "service_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels_standard_site": {
+          "name": "labels_standard_site",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels_probed_at": {
+          "name": "labels_probed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reachable": {
+          "name": "reachable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_value_definitions": {
+          "name": "label_value_definitions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_services_labeler_idx": {
+          "name": "labeler_services_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_subscriptions": {
+      "name": "labeler_subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefs": {
+          "name": "prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_subscriptions_subscriber_idx": {
+          "name": "labeler_subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labeler_subscriptions_labeler_idx": {
+          "name": "labeler_subscriptions_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_list_items": {
+      "name": "block_list_items",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "block_list_items_list_idx": {
+          "name": "block_list_items_list_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_list_items_subject_idx": {
+          "name": "block_list_items_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_list_items_list_subject_idx": {
+          "name": "block_list_items_list_subject_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_list_sync_state": {
+      "name": "block_list_sync_state",
+      "schema": "",
+      "columns": {
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_count": {
+          "name": "item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "truncated": {
+          "name": "truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_lists": {
+      "name": "block_lists",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocker_did": {
+          "name": "blocker_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "block_lists_blocker_idx": {
+          "name": "block_lists_blocker_idx",
+          "columns": [
+            {
+              "expression": "blocker_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_lists_list_idx": {
+          "name": "block_lists_list_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_sync_state": {
+      "name": "block_sync_state",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "outgoing_count": {
+          "name": "outgoing_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "incoming_count": {
+          "name": "incoming_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "list_count": {
+          "name": "list_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocker_did": {
+          "name": "blocker_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocks_subject_idx": {
+          "name": "blocks_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocks_edge_idx": {
+          "name": "blocks_edge_idx",
+          "columns": [
+            {
+              "expression": "blocker_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_auth_code": {
+      "name": "mcp_auth_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_auth_code_expires_at_idx": {
+          "name": "mcp_auth_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_auth_code_client_id_mcp_client_id_fk": {
+          "name": "mcp_auth_code_client_id_mcp_client_id_fk",
+          "tableFrom": "mcp_auth_code",
+          "tableTo": "mcp_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_auth_code_user_id_user_id_fk": {
+          "name": "mcp_auth_code_user_id_user_id_fk",
+          "tableFrom": "mcp_auth_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_client": {
+      "name": "mcp_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_uri": {
+          "name": "client_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_uri": {
+          "name": "logo_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_token": {
+      "name": "mcp_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_token_user_id_idx": {
+          "name": "mcp_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_expires_at_idx": {
+          "name": "mcp_token_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_client_id_mcp_client_id_fk": {
+          "name": "mcp_token_client_id_mcp_client_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "mcp_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_user_id_user_id_fk": {
+          "name": "mcp_token_user_id_user_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_token_access_token_hash_unique": {
+          "name": "mcp_token_access_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token_hash"
+          ]
+        },
+        "mcp_token_refresh_token_hash_unique": {
+          "name": "mcp_token_refresh_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_shares": {
+      "name": "quote_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_text": {
+          "name": "quote_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quote_shares_document_uri_idx": {
+          "name": "quote_shares_document_uri_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_draft": {
+      "name": "feedback_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feedback_draft_user_idx": {
+          "name": "feedback_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_draft_expires_idx": {
+          "name": "feedback_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_draft_user_id_user_id_fk": {
+          "name": "feedback_draft_user_id_user_id_fk",
+          "tableFrom": "feedback_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upvote_draft": {
+      "name": "upvote_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "upvote_draft_user_idx": {
+          "name": "upvote_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upvote_draft_expires_idx": {
+          "name": "upvote_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upvote_draft_user_id_user_id_fk": {
+          "name": "upvote_draft_user_id_user_id_fk",
+          "tableFrom": "upvote_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.save_draft": {
+      "name": "save_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_app": {
+          "name": "target_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_uri": {
+          "name": "collection_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_cid": {
+          "name": "collection_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_collection_name": {
+          "name": "new_collection_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motivation": {
+          "name": "motivation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passage": {
+          "name": "passage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "save_draft_user_idx": {
+          "name": "save_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "save_draft_expires_idx": {
+          "name": "save_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "save_draft_user_id_user_id_fk": {
+          "name": "save_draft_user_id_user_id_fk",
+          "tableFrom": "save_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/standard-reader/drizzle/meta/_journal.json
+++ b/apps/standard-reader/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1786340940231,
       "tag": "0035_lush_living_mummy",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1786344772815,
+      "tag": "0036_acoustic_zemo",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/standard-reader/drizzle/meta/_journal.json
+++ b/apps/standard-reader/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1786303238005,
       "tag": "0034_nostalgic_hairball",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1786340940231,
+      "tag": "0035_lush_living_mummy",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/standard-reader/src/components/blocks-settings-view.tsx
+++ b/apps/standard-reader/src/components/blocks-settings-view.tsx
@@ -19,20 +19,27 @@ import {
   fontSize,
   fontWeight,
 } from "@standard-reader/design-system/theme/typography.stylex";
+import { toasts } from "@standard-reader/design-system/toast";
 import * as stylex from "@stylexjs/stylex";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { TriangleAlert } from "lucide-react";
+import { useEffect, useState } from "react";
 
 import type {
   BlockListRow,
   BlockedAccountRow,
 } from "#/integrations/tanstack-query/api-blocks.functions";
 import { blocksApi } from "#/integrations/tanstack-query/api-blocks.functions";
+import { useFormatters } from "#/lib/use-formatters";
 
+import { FeedLoadMore } from "./reader/feed-load-more";
 import { Masthead, ReaderContent } from "./reader/primitives";
 
 const MOBILE = "@media (max-width: 47.5rem)";
+
+/** Matches the server default in `blockedAccountsInput`. */
+const ACCOUNTS_PAGE_SIZE = 50;
 
 function accountLabel(row: BlockedAccountRow): string {
   return row.displayName ?? row.handle ?? row.did;
@@ -125,6 +132,19 @@ function BlockListItem({
               one="# account"
               other="# accounts"
             />
+            {row.truncated ? (
+              <>
+                {" · "}
+                {/* The cap is stated, not hidden: a reader who thinks a list
+                    covers 40,000 accounts should know we enforce the first
+                    10,000 of them rather than discover the gap in their feed.
+                    The "Partial" badge alone doesn't say what's partial. */}
+                <Trans>
+                  this list is larger than we mirror, so some members aren't
+                  blocked here
+                </Trans>
+              </>
+            ) : null}
           </span>
         </span>
       </span>
@@ -158,30 +178,76 @@ function BlockListItem({
  */
 export function BlocksSettingsView() {
   const { t } = useLingui();
+  const fmt = useFormatters();
   const queryClient = useQueryClient();
   const settings = useQuery(blocksApi.getBlocksSettingsQueryOptions());
 
+  // Pages past the first, appended. Reset whenever the first page is refetched
+  // so an unblock can't leave a stale tail behind the row it removed.
+  const [extraPages, setExtraPages] = useState<Array<BlockedAccountRow>>([]);
+  const [nextOffset, setNextOffset] = useState<number | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  const firstPageOffset = settings.data?.accountsNextOffset ?? null;
+  useEffect(() => {
+    setExtraPages([]);
+    setNextOffset(firstPageOffset);
+  }, [firstPageOffset, settings.dataUpdatedAt]);
+
   const invalidate = () => {
     void queryClient.invalidateQueries({ queryKey: ["blocks"] });
+  };
+  const onMutationError = () => {
+    toasts.add({
+      description: t`We couldn't reach your account to change that. Try again?`,
+      title: t`Something went wrong`,
+    });
   };
 
   const unblockAccount = useMutation({
     mutationFn: async (did: string) =>
       blocksApi.unblockAccount({ data: { did } }),
     onSuccess: invalidate,
+    onError: onMutationError,
   });
   const unblockList = useMutation({
     mutationFn: async (listUri: string) =>
       blocksApi.unblockList({ data: { listUri } }),
     onSuccess: invalidate,
+    onError: onMutationError,
   });
   const refresh = useMutation({
     mutationFn: async () => blocksApi.refreshBlocks(),
-    onSuccess: invalidate,
+    // The sweep runs in the background, so "done" here means "started". Say
+    // that rather than implying the list on screen is now up to date.
+    onSuccess: () => {
+      toasts.add({
+        description: t`We're re-reading your blocks from your account. This page updates when it finishes.`,
+        title: t`Refreshing`,
+      });
+      invalidate();
+    },
+    onError: onMutationError,
   });
 
+  const loadMore = async () => {
+    if (nextOffset == null || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      const page = await blocksApi.getBlockedAccountsPage({
+        data: { limit: ACCOUNTS_PAGE_SIZE, offset: nextOffset },
+      });
+      setExtraPages((rows) => [...rows, ...page.accounts]);
+      setNextOffset(page.nextOffset);
+    } catch {
+      onMutationError();
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
   const data = settings.data ?? null;
-  const accounts = data?.accounts ?? [];
+  const accounts = [...(data?.accounts ?? []), ...extraPages];
   const lists = data?.lists ?? [];
 
   return (
@@ -206,6 +272,15 @@ export function BlocksSettingsView() {
             Your blocks are enforced here already. To add or remove one from
             Standard Reader, you'll be asked to authorize block access the first
             time you try.
+          </Trans>
+        </p>
+      ) : null}
+
+      {data?.syncedAt && !data.syncError ? (
+        <p {...stylex.props(styles.note)}>
+          <Trans>
+            Last checked {fmt.relativeTime(data.syncedAt)}. Blocks you make
+            elsewhere show up here within about fifteen minutes.
           </Trans>
         </p>
       ) : null}
@@ -259,6 +334,12 @@ export function BlocksSettingsView() {
             ))}
           </ul>
         )}
+        <FeedLoadMore
+          hasMore={nextOffset != null}
+          isLoading={loadingMore}
+          onLoadMore={() => void loadMore()}
+          itemCount={accounts.length}
+        />
       </section>
 
       <section {...stylex.props(styles.section)}>

--- a/apps/standard-reader/src/components/blocks-settings-view.tsx
+++ b/apps/standard-reader/src/components/blocks-settings-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Trans, useLingui } from "@lingui/react/macro";
+import { Plural, Trans, useLingui } from "@lingui/react/macro";
 import { Avatar } from "@standard-reader/design-system/avatar";
 import { Badge } from "@standard-reader/design-system/badge";
 import { Button } from "@standard-reader/design-system/button";
@@ -120,7 +120,11 @@ function BlockListItem({
             {row.name ?? t`Moderation list`}
           </span>
           <span {...stylex.props(styles.rowMeta)}>
-            <Trans>{row.memberCount} accounts</Trans>
+            <Plural
+              value={row.memberCount}
+              one="# account"
+              other="# accounts"
+            />
           </span>
         </span>
       </span>

--- a/apps/standard-reader/src/components/blocks-settings-view.tsx
+++ b/apps/standard-reader/src/components/blocks-settings-view.tsx
@@ -1,0 +1,372 @@
+"use client";
+
+import { Trans, useLingui } from "@lingui/react/macro";
+import { Avatar } from "@standard-reader/design-system/avatar";
+import { Badge } from "@standard-reader/design-system/badge";
+import { Button } from "@standard-reader/design-system/button";
+import { Skeleton } from "@standard-reader/design-system/skeleton";
+import {
+  uiColor,
+  warningColor,
+} from "@standard-reader/design-system/theme/color.stylex";
+import { radius } from "@standard-reader/design-system/theme/radius.stylex";
+import {
+  gap,
+  verticalSpace,
+} from "@standard-reader/design-system/theme/semantic-spacing.stylex";
+import { spacing } from "@standard-reader/design-system/theme/spacing.stylex";
+import {
+  fontSize,
+  fontWeight,
+} from "@standard-reader/design-system/theme/typography.stylex";
+import * as stylex from "@stylexjs/stylex";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { TriangleAlert } from "lucide-react";
+
+import type {
+  BlockListRow,
+  BlockedAccountRow,
+} from "#/integrations/tanstack-query/api-blocks.functions";
+import { blocksApi } from "#/integrations/tanstack-query/api-blocks.functions";
+
+import { Masthead, ReaderContent } from "./reader/primitives";
+
+const MOBILE = "@media (max-width: 47.5rem)";
+
+function accountLabel(row: BlockedAccountRow): string {
+  return row.displayName ?? row.handle ?? row.did;
+}
+
+function initials(label: string): string {
+  return label
+    .replace(/^did:\w+:/, "")
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+/**
+ * One blocked account, with the control to undo it.
+ *
+ * Only the reader's own direct blocks reach this list, so the button is always
+ * honest: it removes a record in their repo. Blocks *against* them, and members
+ * of blocklists they subscribe to, are not theirs to undo and are described in
+ * the list section below rather than mixed in here with a button that would lie.
+ */
+function BlockedAccountItem({
+  row,
+  canWrite,
+  onUnblock,
+  pending,
+}: {
+  row: BlockedAccountRow;
+  canWrite: boolean;
+  onUnblock: (did: string) => void;
+  pending: boolean;
+}) {
+  const label = accountLabel(row);
+  return (
+    <li {...stylex.props(styles.row)}>
+      <Link
+        to="/u/$did"
+        params={{ did: row.handle ?? row.did }}
+        {...stylex.props(styles.rowMain)}
+      >
+        <Avatar
+          size="sm"
+          src={row.avatarUrl ?? undefined}
+          fallback={initials(label)}
+          alt={label}
+        />
+        <span {...stylex.props(styles.rowText)}>
+          <span {...stylex.props(styles.rowName)}>{label}</span>
+          {row.handle ? (
+            <span {...stylex.props(styles.rowMeta)}>@{row.handle}</span>
+          ) : null}
+        </span>
+      </Link>
+      {canWrite ? (
+        <Button
+          variant="secondary"
+          size="sm"
+          isPending={pending}
+          onPress={() => onUnblock(row.did)}
+        >
+          <Trans>Unblock</Trans>
+        </Button>
+      ) : null}
+    </li>
+  );
+}
+
+/** One subscribed moderation list, with how much of it is actually mirrored. */
+function BlockListItem({
+  row,
+  canWrite,
+  onUnblock,
+  pending,
+}: {
+  row: BlockListRow;
+  canWrite: boolean;
+  onUnblock: (listUri: string) => void;
+  pending: boolean;
+}) {
+  const { t } = useLingui();
+  return (
+    <li {...stylex.props(styles.row)}>
+      <span {...stylex.props(styles.rowMain)}>
+        <span {...stylex.props(styles.rowText)}>
+          <span {...stylex.props(styles.rowName)}>
+            {row.name ?? t`Moderation list`}
+          </span>
+          <span {...stylex.props(styles.rowMeta)}>
+            <Trans>{row.memberCount} accounts</Trans>
+          </span>
+        </span>
+      </span>
+      <span {...stylex.props(styles.rowActions)}>
+        {row.truncated ? (
+          <Badge variant="warning" size="sm">
+            <Trans>Partial</Trans>
+          </Badge>
+        ) : null}
+        {canWrite ? (
+          <Button
+            variant="secondary"
+            size="sm"
+            isPending={pending}
+            onPress={() => onUnblock(row.listUri)}
+          >
+            <Trans>Remove</Trans>
+          </Button>
+        ) : null}
+      </span>
+    </li>
+  );
+}
+
+/**
+ * Blocked accounts and block lists.
+ *
+ * Reads the reader's `app.bsky.graph.block` records — the same records Bluesky
+ * writes — so this list is their blocks everywhere, not a Standard Reader copy
+ * of them. Removing one here removes it everywhere too.
+ */
+export function BlocksSettingsView() {
+  const { t } = useLingui();
+  const queryClient = useQueryClient();
+  const settings = useQuery(blocksApi.getBlocksSettingsQueryOptions());
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: ["blocks"] });
+  };
+
+  const unblockAccount = useMutation({
+    mutationFn: async (did: string) =>
+      blocksApi.unblockAccount({ data: { did } }),
+    onSuccess: invalidate,
+  });
+  const unblockList = useMutation({
+    mutationFn: async (listUri: string) =>
+      blocksApi.unblockList({ data: { listUri } }),
+    onSuccess: invalidate,
+  });
+  const refresh = useMutation({
+    mutationFn: async () => blocksApi.refreshBlocks(),
+    onSuccess: invalidate,
+  });
+
+  const data = settings.data ?? null;
+  const accounts = data?.accounts ?? [];
+  const lists = data?.lists ?? [];
+
+  return (
+    <ReaderContent>
+      <Masthead
+        kicker={t`Moderation`}
+        title={t`Blocked accounts`}
+        dek={t`Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours.`}
+        metaLabel={t`Blocked`}
+        metaValue={
+          settings.isLoading ? (
+            <Skeleton variant="rectangle" height="2rem" width="3.5rem" />
+          ) : (
+            String(data?.accountCount ?? 0)
+          )
+        }
+      />
+
+      {data && !data.canWrite ? (
+        <p {...stylex.props(styles.note)}>
+          <Trans>
+            Your blocks are enforced here already. To add or remove one from
+            Standard Reader, you'll be asked to authorize block access the first
+            time you try.
+          </Trans>
+        </p>
+      ) : null}
+
+      {data?.syncError ? (
+        <p {...stylex.props(styles.warnNote)}>
+          <TriangleAlert size={16} aria-hidden="true" />
+          <Trans>
+            Some blocks couldn't be refreshed last time, so this list may be
+            incomplete.
+          </Trans>
+        </p>
+      ) : null}
+
+      <section {...stylex.props(styles.section)}>
+        <div {...stylex.props(styles.sectionHead)}>
+          <h2 {...stylex.props(styles.sectionHeading)}>
+            <Trans>Accounts you block</Trans>
+          </h2>
+          <Button
+            variant="tertiary"
+            size="sm"
+            isPending={refresh.isPending}
+            onPress={() => refresh.mutate()}
+          >
+            <Trans>Refresh</Trans>
+          </Button>
+        </div>
+
+        {settings.isLoading ? (
+          <div aria-busy="true" aria-label={t`Loading blocked accounts`}>
+            <Skeleton variant="rectangle" height="3rem" width="100%" />
+          </div>
+        ) : accounts.length === 0 ? (
+          <p {...stylex.props(styles.note)}>
+            <Trans>You haven't blocked anyone.</Trans>
+          </p>
+        ) : (
+          <ul {...stylex.props(styles.list)}>
+            {accounts.map((row) => (
+              <BlockedAccountItem
+                key={row.did}
+                row={row}
+                canWrite={data?.canWrite ?? false}
+                pending={
+                  unblockAccount.isPending &&
+                  unblockAccount.variables === row.did
+                }
+                onUnblock={(did) => unblockAccount.mutate(did)}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section {...stylex.props(styles.section)}>
+        <h2 {...stylex.props(styles.sectionHeading)}>
+          <Trans>Block lists</Trans>
+        </h2>
+        <p {...stylex.props(styles.note)}>
+          <Trans>
+            Moderation lists you subscribe to on Bluesky. Everyone on them is
+            blocked here too, and the list stays live as its owner changes it.
+          </Trans>
+        </p>
+        {lists.length === 0 ? (
+          <p {...stylex.props(styles.note)}>
+            <Trans>You don't subscribe to any block lists.</Trans>
+          </p>
+        ) : (
+          <ul {...stylex.props(styles.list)}>
+            {lists.map((row) => (
+              <BlockListItem
+                key={row.uri}
+                row={row}
+                canWrite={data?.canWrite ?? false}
+                pending={
+                  unblockList.isPending && unblockList.variables === row.listUri
+                }
+                onUnblock={(listUri) => unblockList.mutate(listUri)}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+    </ReaderContent>
+  );
+}
+
+const styles = stylex.create({
+  section: {
+    marginBlockEnd: verticalSpace["2xl"],
+  },
+  sectionHead: {
+    gap: gap.md,
+    alignItems: "center",
+    display: "flex",
+    justifyContent: "space-between",
+  },
+  sectionHeading: {
+    fontSize: fontSize.lg,
+    fontWeight: fontWeight.semibold,
+    marginBlock: spacing["0"],
+  },
+  list: {
+    gap: gap.xs,
+    display: "flex",
+    flexDirection: "column",
+    listStyle: "none",
+    marginBlock: verticalSpace.md,
+    paddingInline: spacing["0"],
+  },
+  row: {
+    gap: gap.md,
+    alignItems: "center",
+    borderRadius: radius.md,
+    display: "flex",
+    justifyContent: "space-between",
+    paddingBlock: verticalSpace.sm,
+    paddingInline: spacing["0"],
+  },
+  rowMain: {
+    gap: gap.sm,
+    alignItems: "center",
+    color: "inherit",
+    display: "flex",
+    minWidth: spacing["0"],
+    textDecoration: "none",
+  },
+  rowText: {
+    gap: gap.xxs,
+    display: "flex",
+    flexDirection: "column",
+    minWidth: spacing["0"],
+  },
+  rowName: {
+    fontSize: fontSize.sm,
+    fontWeight: fontWeight.medium,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  rowMeta: {
+    color: uiColor.text2,
+    fontSize: fontSize.xs,
+  },
+  rowActions: {
+    gap: gap.sm,
+    alignItems: "center",
+    display: {
+      [MOBILE]: "flex",
+      default: "flex",
+    },
+  },
+  note: {
+    color: uiColor.text2,
+    fontSize: fontSize.sm,
+    marginBlock: verticalSpace.md,
+  },
+  warnNote: {
+    gap: gap.xs,
+    alignItems: "center",
+    color: warningColor.text1,
+    display: "flex",
+    fontSize: fontSize.sm,
+    marginBlock: verticalSpace.md,
+  },
+});

--- a/apps/standard-reader/src/components/reader/author-actions.tsx
+++ b/apps/standard-reader/src/components/reader/author-actions.tsx
@@ -34,6 +34,7 @@ import { listApi } from "#/integrations/tanstack-query/api-lists.functions";
 import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
 import { useLoginSearch } from "#/utils/use-login-search";
 
+import { BlockUserMenuItem } from "./block-user-menu-item";
 import { FollowUserButton } from "./follow-user-button";
 import { NotifyButton } from "./notify-button";
 import { RssFeedDialog } from "./rss-feed-button";
@@ -315,6 +316,18 @@ export function AuthorActions({
                 <Trans>Resume</Trans>
               </MenuItem>
             ) : null}
+            {/* Last, and behind its own separator: blocking is the one item
+                here that hides things rather than opening them. */}
+            {isOwnProfile || !signedIn ? null : (
+              <>
+                <MenuSeparator />
+                <BlockUserMenuItem
+                  did={did}
+                  name={user.displayName ?? handle}
+                  iconSize={MENU_ICON}
+                />
+              </>
+            )}
           </Menu>
         </ButtonGroup>
         {isOwnProfile ? null : (

--- a/apps/standard-reader/src/components/reader/author-actions.tsx
+++ b/apps/standard-reader/src/components/reader/author-actions.tsx
@@ -34,7 +34,7 @@ import { listApi } from "#/integrations/tanstack-query/api-lists.functions";
 import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
 import { useLoginSearch } from "#/utils/use-login-search";
 
-import { BlockUserMenuItem } from "./block-user-menu-item";
+import { BlockUserDialog, BlockUserMenuItem } from "./block-user-menu-item";
 import { FollowUserButton } from "./follow-user-button";
 import { NotifyButton } from "./notify-button";
 import { RssFeedDialog } from "./rss-feed-button";
@@ -187,6 +187,7 @@ export function AuthorActions({
   const queryClient = useQueryClient();
   const share = useShareActions({ pageUrl });
   const [rssOpen, setRssOpen] = useState(false);
+  const [blockOpen, setBlockOpen] = useState(false);
 
   const { data: followStatus } = useQuery({
     ...readerApi.getUserFollowStatusQueryOptions(did),
@@ -322,9 +323,9 @@ export function AuthorActions({
               <>
                 <MenuSeparator />
                 <BlockUserMenuItem
-                  did={did}
                   name={user.displayName ?? handle}
                   iconSize={MENU_ICON}
+                  onPress={() => setBlockOpen(true)}
                 />
               </>
             )}
@@ -349,6 +350,17 @@ export function AuthorActions({
         isOpen={rssOpen}
         onOpenChange={setRssOpen}
       />
+
+      {/* Outside `<Menu>`, like the RSS dialog above: a dialog rendered inside
+          the menu unmounts with the popover the moment the item is pressed. */}
+      {isOwnProfile || !signedIn ? null : (
+        <BlockUserDialog
+          did={did}
+          name={user.displayName ?? handle}
+          isOpen={blockOpen}
+          onOpenChange={setBlockOpen}
+        />
+      )}
     </>
   );
 }

--- a/apps/standard-reader/src/components/reader/block-user-menu-item.tsx
+++ b/apps/standard-reader/src/components/reader/block-user-menu-item.tsx
@@ -13,7 +13,6 @@ import { MenuItem } from "@standard-reader/design-system/menu";
 import { toasts } from "@standard-reader/design-system/toast";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Ban } from "lucide-react";
-import { useState } from "react";
 
 import { auth } from "#/integrations/tanstack-query/api-auth.functions";
 import {
@@ -22,7 +21,7 @@ import {
 } from "#/integrations/tanstack-query/api-blocks.functions";
 
 /**
- * "Block" in the author overflow menu.
+ * "Block" in the author overflow menu, and the confirmation it opens.
  *
  * Writes an `app.bsky.graph.block` record to the reader's own repo — the same
  * record Bluesky writes — so the block travels with them rather than being a
@@ -34,19 +33,58 @@ import {
  * than gate the item on it — which would hide the feature from everyone who
  * signed in before it existed — the first press runs the progressive upgrade
  * and returns here. Their *existing* blocks are enforced either way.
+ *
+ * **The item and the dialog are two components on purpose.** `Menu` renders its
+ * children inside the trigger's `Popover`, so a dialog returned alongside the
+ * `MenuItem` mounts *inside* the menu — and pressing the item closes the menu,
+ * which unmounts the dialog in the same frame. It opens and vanishes. The dialog
+ * has to be a sibling of `<Menu>`, not a descendant, which is the shape
+ * `RssFeedDialog` already uses from this same menu.
  */
 export function BlockUserMenuItem({
-  did,
   name,
   iconSize = 14,
+  onPress,
+}: {
+  name?: string | null;
+  iconSize?: number;
+  /** Opens {@link BlockUserDialog}, which the menu's parent renders. */
+  onPress: () => void;
+}) {
+  const { t } = useLingui();
+  return (
+    <MenuItem
+      onPress={onPress}
+      suffix={<Ban size={iconSize} />}
+      textValue={name ? t`Block ${name}` : t`Block account`}
+    >
+      <Trans>Block</Trans>
+    </MenuItem>
+  );
+}
+
+/**
+ * The confirmation for {@link BlockUserMenuItem}. Render outside `<Menu>`.
+ *
+ * Confirmed, not immediate: blocking sits one press away from Share and Copy
+ * link in the same menu, but unlike them it writes a public record to the
+ * reader's repo that every AT Protocol app honours — and this menu offers no way
+ * back, because the profile it lives on turns into a block notice. A mis-tap
+ * should not be able to do that silently.
+ */
+export function BlockUserDialog({
+  did,
+  name,
+  isOpen,
+  onOpenChange,
 }: {
   did: string;
   name?: string | null;
-  iconSize?: number;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
 }) {
   const { t } = useLingui();
   const queryClient = useQueryClient();
-  const [confirming, setConfirming] = useState(false);
 
   const block = useMutation({
     mutationFn: async () => {
@@ -74,7 +112,7 @@ export function BlockUserMenuItem({
         globalThis.location.href = result.authorizationUrl;
         return;
       }
-      setConfirming(false);
+      onOpenChange(false);
       // The write went to the reader's repo, not to a setting here — say so, and
       // point at where it can be undone, because this menu has no unblock and
       // the profile they are standing on is about to become a notice.
@@ -89,9 +127,9 @@ export function BlockUserMenuItem({
       void queryClient.invalidateQueries();
     },
     // Without this a failed write is indistinguishable from a successful one:
-    // the menu closes, the spinner stops, and the account is still there.
+    // the dialog closes, the spinner stops, and the account is still there.
     onError: () => {
-      setConfirming(false);
+      onOpenChange(false);
       toasts.add({
         description: t`We couldn't write the block to your account. Try again?`,
         title: t`Something went wrong`,
@@ -100,52 +138,38 @@ export function BlockUserMenuItem({
   });
 
   return (
-    <>
-      <MenuItem
-        onPress={() => setConfirming(true)}
-        suffix={<Ban size={iconSize} />}
-        textValue={name ? t`Block ${name}` : t`Block account`}
-      >
-        <Trans>Block</Trans>
-      </MenuItem>
-      {/*
-        Confirmed, not immediate. Blocking is one press away from Share and Copy
-        link in the same menu, but unlike them it writes a public record to the
-        reader's repo that every AT Protocol app honours — and this menu offers
-        no way back, because the profile it lives on turns into a block notice.
-        A mis-tap should not be able to do that silently.
-      */}
-      <AlertDialog
-        trigger={null}
-        isOpen={confirming}
-        onOpenChange={(open) => {
-          if (!open && !block.isPending) setConfirming(false);
-        }}
-      >
-        <AlertDialogHeader>
-          {name ? <Trans>Block {name}?</Trans> : <Trans>Block account?</Trans>}
-        </AlertDialogHeader>
-        <AlertDialogDescription>
-          <Trans>
-            This writes a block to your Bluesky account, so it applies here and
-            anywhere else you use it. Their writing disappears from your feeds,
-            search and discussion, and they can't see yours. You can undo it in
-            Settings → Blocked accounts.
-          </Trans>
-        </AlertDialogDescription>
-        <AlertDialogFooter>
-          <AlertDialogCancelButton>
-            <Trans>Cancel</Trans>
-          </AlertDialogCancelButton>
-          <AlertDialogActionButton
-            closeOnPress={false}
-            isPending={block.isPending}
-            onPress={() => block.mutate()}
-          >
-            <Trans>Block</Trans>
-          </AlertDialogActionButton>
-        </AlertDialogFooter>
-      </AlertDialog>
-    </>
+    <AlertDialog
+      trigger={null}
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        // Never yank the dialog out from under a write already in flight.
+        if (!open && block.isPending) return;
+        onOpenChange(open);
+      }}
+    >
+      <AlertDialogHeader>
+        {name ? <Trans>Block {name}?</Trans> : <Trans>Block account?</Trans>}
+      </AlertDialogHeader>
+      <AlertDialogDescription>
+        <Trans>
+          This writes a block to your Bluesky account, so it applies here and
+          anywhere else you use it. Their writing disappears from your feeds,
+          search and discussion, and they can't see yours. You can undo it in
+          Settings → Blocked accounts.
+        </Trans>
+      </AlertDialogDescription>
+      <AlertDialogFooter>
+        <AlertDialogCancelButton>
+          <Trans>Cancel</Trans>
+        </AlertDialogCancelButton>
+        <AlertDialogActionButton
+          closeOnPress={false}
+          isPending={block.isPending}
+          onPress={() => block.mutate()}
+        >
+          <Trans>Block</Trans>
+        </AlertDialogActionButton>
+      </AlertDialogFooter>
+    </AlertDialog>
   );
 }

--- a/apps/standard-reader/src/components/reader/block-user-menu-item.tsx
+++ b/apps/standard-reader/src/components/reader/block-user-menu-item.tsx
@@ -1,9 +1,19 @@
 "use client";
 
 import { Trans, useLingui } from "@lingui/react/macro";
+import {
+  AlertDialog,
+  AlertDialogActionButton,
+  AlertDialogCancelButton,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+} from "@standard-reader/design-system/alert-dialog";
 import { MenuItem } from "@standard-reader/design-system/menu";
+import { toasts } from "@standard-reader/design-system/toast";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Ban } from "lucide-react";
+import { useState } from "react";
 
 import { auth } from "#/integrations/tanstack-query/api-auth.functions";
 import {
@@ -36,6 +46,7 @@ export function BlockUserMenuItem({
 }) {
   const { t } = useLingui();
   const queryClient = useQueryClient();
+  const [confirming, setConfirming] = useState(false);
 
   const block = useMutation({
     mutationFn: async () => {
@@ -63,19 +74,78 @@ export function BlockUserMenuItem({
         globalThis.location.href = result.authorizationUrl;
         return;
       }
+      setConfirming(false);
+      // The write went to the reader's repo, not to a setting here — say so, and
+      // point at where it can be undone, because this menu has no unblock and
+      // the profile they are standing on is about to become a notice.
+      toasts.add({
+        description: name
+          ? t`${name} is hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts.`
+          : t`They're hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts.`,
+        title: t`Blocked`,
+      });
       // A block changes feeds, search, discussion and this very page, so there
       // is no narrower key worth invalidating than everything.
       void queryClient.invalidateQueries();
     },
+    // Without this a failed write is indistinguishable from a successful one:
+    // the menu closes, the spinner stops, and the account is still there.
+    onError: () => {
+      setConfirming(false);
+      toasts.add({
+        description: t`We couldn't write the block to your account. Try again?`,
+        title: t`Something went wrong`,
+      });
+    },
   });
 
   return (
-    <MenuItem
-      onPress={() => block.mutate()}
-      suffix={<Ban size={iconSize} />}
-      textValue={name ? t`Block ${name}` : t`Block account`}
-    >
-      <Trans>Block</Trans>
-    </MenuItem>
+    <>
+      <MenuItem
+        onPress={() => setConfirming(true)}
+        suffix={<Ban size={iconSize} />}
+        textValue={name ? t`Block ${name}` : t`Block account`}
+      >
+        <Trans>Block</Trans>
+      </MenuItem>
+      {/*
+        Confirmed, not immediate. Blocking is one press away from Share and Copy
+        link in the same menu, but unlike them it writes a public record to the
+        reader's repo that every AT Protocol app honours — and this menu offers
+        no way back, because the profile it lives on turns into a block notice.
+        A mis-tap should not be able to do that silently.
+      */}
+      <AlertDialog
+        trigger={null}
+        isOpen={confirming}
+        onOpenChange={(open) => {
+          if (!open && !block.isPending) setConfirming(false);
+        }}
+      >
+        <AlertDialogHeader>
+          {name ? <Trans>Block {name}?</Trans> : <Trans>Block account?</Trans>}
+        </AlertDialogHeader>
+        <AlertDialogDescription>
+          <Trans>
+            This writes a block to your Bluesky account, so it applies here and
+            anywhere else you use it. Their writing disappears from your feeds,
+            search and discussion, and they can't see yours. You can undo it in
+            Settings → Blocked accounts.
+          </Trans>
+        </AlertDialogDescription>
+        <AlertDialogFooter>
+          <AlertDialogCancelButton>
+            <Trans>Cancel</Trans>
+          </AlertDialogCancelButton>
+          <AlertDialogActionButton
+            closeOnPress={false}
+            isPending={block.isPending}
+            onPress={() => block.mutate()}
+          >
+            <Trans>Block</Trans>
+          </AlertDialogActionButton>
+        </AlertDialogFooter>
+      </AlertDialog>
+    </>
   );
 }

--- a/apps/standard-reader/src/components/reader/block-user-menu-item.tsx
+++ b/apps/standard-reader/src/components/reader/block-user-menu-item.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { Trans, useLingui } from "@lingui/react/macro";
+import { MenuItem } from "@standard-reader/design-system/menu";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Ban } from "lucide-react";
+
+import { auth } from "#/integrations/tanstack-query/api-auth.functions";
+import {
+  NEEDS_BLOCK_SCOPE,
+  blocksApi,
+} from "#/integrations/tanstack-query/api-blocks.functions";
+
+/**
+ * "Block" in the author overflow menu.
+ *
+ * Writes an `app.bsky.graph.block` record to the reader's own repo — the same
+ * record Bluesky writes — so the block travels with them rather than being a
+ * Standard Reader setting. There is no unblock counterpart here: once blocked,
+ * the profile renders as the block itself (see `BlockedNotice`), which is where
+ * undoing it belongs.
+ *
+ * Writing needs an OAuth scope the reader hasn't necessarily granted. Rather
+ * than gate the item on it — which would hide the feature from everyone who
+ * signed in before it existed — the first press runs the progressive upgrade
+ * and returns here. Their *existing* blocks are enforced either way.
+ */
+export function BlockUserMenuItem({
+  did,
+  name,
+  iconSize = 14,
+}: {
+  did: string;
+  name?: string | null;
+  iconSize?: number;
+}) {
+  const { t } = useLingui();
+  const queryClient = useQueryClient();
+
+  const block = useMutation({
+    mutationFn: async () => {
+      try {
+        await blocksApi.blockAccount({ data: { did } });
+        return { blocked: true as const };
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message.includes(NEEDS_BLOCK_SCOPE)
+        ) {
+          const here = new URL(globalThis.location.href);
+          const result = await auth.upgradeToBlocking({
+            data: {
+              redirect: `${here.pathname}${here.search}${here.hash}`,
+            },
+          });
+          return { authorizationUrl: result.authorizationUrl };
+        }
+        throw error;
+      }
+    },
+    onSuccess: (result) => {
+      if ("authorizationUrl" in result && result.authorizationUrl) {
+        globalThis.location.href = result.authorizationUrl;
+        return;
+      }
+      // A block changes feeds, search, discussion and this very page, so there
+      // is no narrower key worth invalidating than everything.
+      void queryClient.invalidateQueries();
+    },
+  });
+
+  return (
+    <MenuItem
+      onPress={() => block.mutate()}
+      suffix={<Ban size={iconSize} />}
+      textValue={name ? t`Block ${name}` : t`Block account`}
+    >
+      <Trans>Block</Trans>
+    </MenuItem>
+  );
+}

--- a/apps/standard-reader/src/components/reader/blocked-notice.tsx
+++ b/apps/standard-reader/src/components/reader/blocked-notice.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { Trans } from "@lingui/react/macro";
+import { Button } from "@standard-reader/design-system/button";
+import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
+import { radius } from "@standard-reader/design-system/theme/radius.stylex";
+import {
+  gap,
+  horizontalSpace,
+  verticalSpace,
+} from "@standard-reader/design-system/theme/semantic-spacing.stylex";
+import { spacing } from "@standard-reader/design-system/theme/spacing.stylex";
+import {
+  fontSize,
+  fontWeight,
+} from "@standard-reader/design-system/theme/typography.stylex";
+import * as stylex from "@stylexjs/stylex";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Ban } from "lucide-react";
+
+import { ButtonLink } from "#/components/router-links";
+import { blocksApi } from "#/integrations/tanstack-query/api-blocks.functions";
+import type { BlockEdge } from "#/lib/blocks";
+import { blockIsFromList, blockIsOutgoing } from "#/lib/blocks";
+
+/**
+ * Why a page is withheld, and what (if anything) the reader can do about it.
+ *
+ * The four block directions are not interchangeable here. A block the reader
+ * made is theirs to undo, so it gets an Unblock button; one made against them
+ * is somebody else's decision, and offering a button would be a lie. A block
+ * that came from a moderation list is undone by leaving the list, not by
+ * unblocking one account, so it points at settings instead.
+ */
+export function BlockedNotice({
+  block,
+  name,
+  canWrite = false,
+}: {
+  block: BlockEdge;
+  /** Display name or handle, when we have one. Falls back to "this account". */
+  name?: string | null;
+  /** Whether the reader has granted block-write access (enables Unblock). */
+  canWrite?: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const unblock = useMutation({
+    mutationFn: async () =>
+      blocksApi.unblockAccount({ data: { did: block.did } }),
+    onSuccess: () => {
+      // Blocks gate feeds, profiles, articles and discussion, so there is no
+      // narrower key to invalidate than everything.
+      void queryClient.invalidateQueries();
+    },
+  });
+
+  const direct =
+    blockIsOutgoing(block.direction) && !blockIsFromList(block.direction);
+
+  return (
+    <div {...stylex.props(styles.panel)}>
+      <Ban size={24} aria-hidden="true" {...stylex.props(styles.icon)} />
+      <p {...stylex.props(styles.heading)}>
+        {blockIsOutgoing(block.direction) ? (
+          <Trans>You blocked this account</Trans>
+        ) : (
+          <Trans>You're blocked</Trans>
+        )}
+      </p>
+      <p {...stylex.props(styles.body)}>
+        {block.direction === "blocking" ? (
+          <Trans>
+            You blocked {name ?? "this account"}, so their writing is hidden
+            everywhere you read.
+          </Trans>
+        ) : block.direction === "list-blocking" ? (
+          <Trans>
+            {name ?? "This account"} is on a moderation list you block. To see
+            them again, leave that list.
+          </Trans>
+        ) : block.direction === "blocked-by" ? (
+          <Trans>
+            {name ?? "This account"} has blocked you, so you can't see their
+            writing. Blocks are records in their repo — this isn't a Standard
+            Reader decision, and it applies wherever you read them.
+          </Trans>
+        ) : (
+          <Trans>
+            {name ?? "This account"} blocks a moderation list you're on, so you
+            can't see their writing.
+          </Trans>
+        )}
+      </p>
+      <div {...stylex.props(styles.actions)}>
+        {direct && canWrite ? (
+          <Button
+            variant="secondary"
+            size="sm"
+            isPending={unblock.isPending}
+            onPress={() => unblock.mutate()}
+          >
+            <Trans>Unblock</Trans>
+          </Button>
+        ) : null}
+        <ButtonLink to="/settings/blocks" variant="tertiary" size="sm">
+          <Trans>Manage blocks</Trans>
+        </ButtonLink>
+      </div>
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  panel: {
+    gap: gap.sm,
+    alignItems: "center",
+    backgroundColor: uiColor.bgSubtle,
+    borderRadius: radius.lg,
+    display: "flex",
+    flexDirection: "column",
+    marginBlock: verticalSpace["2xl"],
+    paddingBlock: verticalSpace["2xl"],
+    paddingInline: horizontalSpace.xl,
+    textAlign: "center",
+  },
+  icon: {
+    color: uiColor.text2,
+  },
+  heading: {
+    fontSize: fontSize.lg,
+    fontWeight: fontWeight.semibold,
+    marginBlock: spacing["0"],
+  },
+  body: {
+    color: uiColor.text2,
+    fontSize: fontSize.sm,
+    marginBlock: spacing["0"],
+    maxWidth: "34rem",
+  },
+  actions: {
+    gap: gap.sm,
+    display: "flex",
+    marginBlockStart: verticalSpace.sm,
+  },
+});

--- a/apps/standard-reader/src/components/reader/blocked-notice.tsx
+++ b/apps/standard-reader/src/components/reader/blocked-notice.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Trans } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { Button } from "@standard-reader/design-system/button";
 import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
 import { radius } from "@standard-reader/design-system/theme/radius.stylex";
@@ -14,6 +14,7 @@ import {
   fontSize,
   fontWeight,
 } from "@standard-reader/design-system/theme/typography.stylex";
+import { toasts } from "@standard-reader/design-system/toast";
 import * as stylex from "@stylexjs/stylex";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Ban } from "lucide-react";
@@ -43,6 +44,7 @@ export function BlockedNotice({
   /** Whether the reader has granted block-write access (enables Unblock). */
   canWrite?: boolean;
 }) {
+  const { t } = useLingui();
   const queryClient = useQueryClient();
   const unblock = useMutation({
     mutationFn: async () =>
@@ -52,17 +54,35 @@ export function BlockedNotice({
       // narrower key to invalidate than everything.
       void queryClient.invalidateQueries();
     },
+    // A failed unblock leaves this panel exactly as it was, which reads as the
+    // button doing nothing rather than as an error.
+    onError: () => {
+      toasts.add({
+        description: t`We couldn't remove the block from your account. Try again?`,
+        title: t`Something went wrong`,
+      });
+    },
   });
 
   const direct =
     blockIsOutgoing(block.direction) && !blockIsFromList(block.direction);
+  // Translated rather than an inline English literal: a `??` fallback inside
+  // `<Trans>` is an expression to Lingui, so the default would ship untranslated
+  // into every locale.
+  const who = name ?? t`this account`;
+  const Who = name ?? t`This account`;
 
   return (
     <div {...stylex.props(styles.panel)}>
       <Ban size={24} aria-hidden="true" {...stylex.props(styles.icon)} />
       <p {...stylex.props(styles.heading)}>
-        {blockIsOutgoing(block.direction) ? (
+        {block.direction === "blocking" ? (
           <Trans>You blocked this account</Trans>
+        ) : block.direction === "list-blocking" ? (
+          // Not "you blocked this account": the reader blocked a list, and may
+          // never have heard of the person on it. Claiming the decision as
+          // theirs sends them looking for an unblock button that isn't here.
+          <Trans>Blocked by a list you use</Trans>
         ) : (
           <Trans>You're blocked</Trans>
         )}
@@ -70,24 +90,23 @@ export function BlockedNotice({
       <p {...stylex.props(styles.body)}>
         {block.direction === "blocking" ? (
           <Trans>
-            You blocked {name ?? "this account"}, so their writing is hidden
-            everywhere you read.
+            You blocked {who}, so their writing is hidden everywhere you read.
           </Trans>
         ) : block.direction === "list-blocking" ? (
           <Trans>
-            {name ?? "This account"} is on a moderation list you block. To see
-            them again, leave that list.
+            {Who} is on a moderation list you block. To see them again, leave
+            that list.
           </Trans>
         ) : block.direction === "blocked-by" ? (
           <Trans>
-            {name ?? "This account"} has blocked you, so you can't see their
-            writing. Blocks are records in their repo — this isn't a Standard
-            Reader decision, and it applies wherever you read them.
+            {Who} has blocked you, so you can't see their writing. Blocks are
+            records in their repo — this isn't a Standard Reader decision, and
+            it applies wherever you read them.
           </Trans>
         ) : (
           <Trans>
-            {name ?? "This account"} blocks a moderation list you're on, so you
-            can't see their writing.
+            {Who} blocks a moderation list you're on, so you can't see their
+            writing.
           </Trans>
         )}
       </p>

--- a/apps/standard-reader/src/components/reader/blocked-notice.tsx
+++ b/apps/standard-reader/src/components/reader/blocked-notice.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Trans, useLingui } from "@lingui/react/macro";
+import { Avatar } from "@standard-reader/design-system/avatar";
 import { Button } from "@standard-reader/design-system/button";
 import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
 import { radius } from "@standard-reader/design-system/theme/radius.stylex";
@@ -19,6 +20,7 @@ import * as stylex from "@stylexjs/stylex";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Ban } from "lucide-react";
 
+import { initials } from "#/components/reader/format";
 import { ButtonLink } from "#/components/router-links";
 import { blocksApi } from "#/integrations/tanstack-query/api-blocks.functions";
 import type { BlockEdge } from "#/lib/blocks";
@@ -36,11 +38,17 @@ import { blockIsFromList, blockIsOutgoing } from "#/lib/blocks";
 export function BlockedNotice({
   block,
   name,
+  handle,
+  avatarUrl,
   canWrite = false,
 }: {
   block: BlockEdge;
   /** Display name or handle, when we have one. Falls back to "this account". */
   name?: string | null;
+  /** Handle, shown under the name so the account is identifiable at a glance. */
+  handle?: string | null;
+  /** Avatar, so the notice names a person rather than a policy. */
+  avatarUrl?: string | null;
   /** Whether the reader has granted block-write access (enables Unblock). */
   canWrite?: boolean;
 }) {
@@ -74,7 +82,27 @@ export function BlockedNotice({
 
   return (
     <div {...stylex.props(styles.panel)}>
-      <Ban size={24} aria-hidden="true" {...stylex.props(styles.icon)} />
+      {/* Identity first. A block notice with no face and no handle asks the
+          reader to take the app's word for who this is — and on a shared or
+          quoted link they may not have known whose page they were opening. The
+          Ban badge rides on the avatar so the state is still legible at a
+          glance. */}
+      {avatarUrl || name ? (
+        <span {...stylex.props(styles.avatarWrap)}>
+          <Avatar
+            size="lg"
+            src={avatarUrl ?? undefined}
+            alt={name ?? handle ?? ""}
+            fallback={initials(name ?? handle ?? "?")}
+          />
+          <span {...stylex.props(styles.avatarBadge)}>
+            <Ban size={14} aria-hidden="true" />
+          </span>
+        </span>
+      ) : (
+        <Ban size={24} aria-hidden="true" {...stylex.props(styles.icon)} />
+      )}
+      {handle ? <p {...stylex.props(styles.handle)}>@{handle}</p> : null}
       <p {...stylex.props(styles.heading)}>
         {block.direction === "blocking" ? (
           <Trans>You blocked this account</Trans>
@@ -144,6 +172,26 @@ const styles = stylex.create({
   },
   icon: {
     color: uiColor.text2,
+  },
+  avatarWrap: {
+    display: "inline-flex",
+    position: "relative",
+  },
+  avatarBadge: {
+    alignItems: "center",
+    backgroundColor: uiColor.bgSubtle,
+    borderRadius: radius.full,
+    bottom: spacing["0"],
+    color: uiColor.text2,
+    display: "flex",
+    insetInlineEnd: spacing["0"],
+    padding: verticalSpace.xxs,
+    position: "absolute",
+  },
+  handle: {
+    color: uiColor.text2,
+    fontSize: fontSize.sm,
+    marginBlock: spacing["0"],
   },
   heading: {
     fontSize: fontSize.lg,

--- a/apps/standard-reader/src/components/reader/comments/comments-section.tsx
+++ b/apps/standard-reader/src/components/reader/comments/comments-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Trans, useLingui } from "@lingui/react/macro";
+import { Plural, Trans, useLingui } from "@lingui/react/macro";
 import { Flex } from "@standard-reader/design-system/flex";
 import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
@@ -27,9 +27,11 @@ function CommentsSkeleton() {
 export function CommentsSection({ article }: { article: ArticleDetail }) {
   const { t } = useLingui();
   const [addOpen, setAddOpen] = useState(false);
-  const { data: comments, isPending } = useQuery(
+  const { data, isPending } = useQuery(
     commentsApi.getDocumentCommentsQueryOptions(article.uri),
   );
+  const comments = data?.comments;
+  const hiddenByBlocks = data?.hiddenByBlocks ?? 0;
   // Resolved from the article alone (no query), so the head's action is there
   // from first paint rather than popping in when the comment list resolves.
   const canComment = canAddComment(article);
@@ -53,14 +55,36 @@ export function CommentsSection({ article }: { article: ArticleDetail }) {
         <CommentsSkeleton />
       ) : comments.length === 0 ? (
         <p {...stylex.props(commentStyles.empty)}>
-          <Trans>No discussion yet.</Trans>
+          {hiddenByBlocks > 0 ? (
+            // The card's comment count is deliberately not per-reader (see
+            // `fetchDocumentComments`), so an all-blocked thread would show a
+            // number above the words "No discussion yet" and read as a bug.
+            <Plural
+              value={hiddenByBlocks}
+              one="The only reply here is from someone you're blocked from."
+              other="The replies here are all from accounts you're blocked from."
+            />
+          ) : (
+            <Trans>No discussion yet.</Trans>
+          )}
         </p>
       ) : (
-        <Flex direction="column" gap="lg" style={commentStyles.list}>
-          {comments.map((comment) => (
-            <CommentCard key={comment.postUri} comment={comment} />
-          ))}
-        </Flex>
+        <>
+          <Flex direction="column" gap="lg" style={commentStyles.list}>
+            {comments.map((comment) => (
+              <CommentCard key={comment.postUri} comment={comment} />
+            ))}
+          </Flex>
+          {hiddenByBlocks > 0 ? (
+            <p {...stylex.props(commentStyles.empty)}>
+              <Plural
+                value={hiddenByBlocks}
+                one="# more reply is hidden by your blocks."
+                other="# more replies are hidden by your blocks."
+              />
+            </p>
+          ) : null}
+        </>
       )}
       {canComment ? (
         <AddCommentDialog

--- a/apps/standard-reader/src/components/reader/mention-hover-card.tsx
+++ b/apps/standard-reader/src/components/reader/mention-hover-card.tsx
@@ -36,6 +36,8 @@ import { Popover as AriaPopover } from "react-aria-components";
 
 import { authorApi } from "#/integrations/tanstack-query/api-author.functions";
 import { publicationApi } from "#/integrations/tanstack-query/api-publication.functions";
+import type { BlockDirection } from "#/lib/blocks";
+import { blockIsOutgoing } from "#/lib/blocks";
 import { useFormatters } from "#/lib/use-formatters";
 
 import { useEngagementCountsVisible } from "./engagement-visibility";
@@ -322,6 +324,8 @@ export function UserHoverCardBody({
       </div>
       {isLoading && !data ? (
         <SkeletonLines />
+      ) : data?.block ? (
+        <BlockedHoverNote direction={data.block.direction} />
       ) : (
         <>
           {profile?.description ? (
@@ -331,6 +335,27 @@ export function UserHoverCardBody({
         </>
       )}
     </HoverCardFrame>
+  );
+}
+
+/**
+ * What a hovercard says about an account the viewer is blocked from.
+ *
+ * A card, not an omission: the chip in the prose still has to lead somewhere, so
+ * the card keeps the name and says why there is nothing under it. Which
+ * direction the block runs decides the wording — "you blocked them" and "they
+ * blocked you" are not the same fact, and only one of them is the viewer's to
+ * change.
+ */
+function BlockedHoverNote({ direction }: { direction: BlockDirection }) {
+  return (
+    <p {...stylex.props(styles.desc)}>
+      {blockIsOutgoing(direction) ? (
+        <Trans>You blocked this account, so their writing is hidden.</Trans>
+      ) : (
+        <Trans>This account blocks you, so you can't see their writing.</Trans>
+      )}
+    </p>
   );
 }
 
@@ -358,7 +383,7 @@ export function PublicationHoverCardBody({
   const iconUrl = pub?.iconUrl ?? fallbackIconUrl ?? null;
 
   const statParts: Array<string> = [];
-  if (pub) {
+  if (pub && !data?.block) {
     if (pub.documentCount > 0) {
       statParts.push(articleCount(i18n, pub.documentCount));
     }
@@ -404,6 +429,8 @@ export function PublicationHoverCardBody({
       </div>
       {isLoading && !data ? (
         <SkeletonLines />
+      ) : data?.block ? (
+        <BlockedHoverNote direction={data.block.direction} />
       ) : (
         <>
           {pub?.description ? (

--- a/apps/standard-reader/src/components/reader/read-optimistic.test.ts
+++ b/apps/standard-reader/src/components/reader/read-optimistic.test.ts
@@ -41,6 +41,7 @@ function makeCard(uri: string, isRead: boolean): ArticleCard {
     publicationIconUrl: null,
     publicationOwnerAvatarUrl: null,
     publicationOwnerHandle: null,
+    publicationOwnerDid: null,
     publicationBannerUrl: null,
     publicationTopic: null,
     authorHandle: null,

--- a/apps/standard-reader/src/components/user-settings-view.tsx
+++ b/apps/standard-reader/src/components/user-settings-view.tsx
@@ -68,6 +68,7 @@ import { invalidateReadQueries } from "#/components/reader/read-optimistic";
 import { useSidebarPref } from "#/components/reader/use-sidebar-pref";
 import { ButtonLink } from "#/components/router-links";
 import { auth } from "#/integrations/tanstack-query/api-auth.functions";
+import { blocksApi } from "#/integrations/tanstack-query/api-blocks.functions";
 import { feedApi } from "#/integrations/tanstack-query/api-feed.functions";
 import { labelerApi } from "#/integrations/tanstack-query/api-labelers.functions";
 import { listApi } from "#/integrations/tanstack-query/api-lists.functions";
@@ -412,6 +413,11 @@ export function UserSettingsView() {
   const { t, i18n } = useLingui();
   const queryClient = useQueryClient();
   const labelers = useQuery(labelerApi.getLabelersQueryOptions());
+  // Just the headline count — the list itself lives on `/settings/blocks`.
+  const blocks = useQuery(
+    blocksApi.getBlocksSettingsQueryOptions({ limit: 1 }),
+  );
+  const blockCount = blocks.data?.accountCount ?? null;
   const connections = useQuery(mcpApi.listConnectionsQueryOptions());
   const fmt = useFormatters();
   const revokeConnectionMutation = useMutation({
@@ -1159,6 +1165,19 @@ export function UserSettingsView() {
           <Trans>Moderation</Trans>
         </h2>
         <div {...stylex.props(styles.settingGroup)}>
+          <SettingRow
+            label={t`Blocked accounts`}
+            description={t`Your Bluesky blocks apply here too — blocked accounts disappear from your feeds, search, and discussion, in both directions.`}
+          >
+            <ButtonLink to="/settings/blocks" variant="secondary" size="sm">
+              {blockCount == null ? (
+                <Trans>Manage blocks</Trans>
+              ) : (
+                <Trans>Manage {blockCount} blocks</Trans>
+              )}
+            </ButtonLink>
+          </SettingRow>
+          <Separator />
           <SettingRow
             label={t`Labelers`}
             description={t`Subscribe to labelers to flag, blur, or hide content as you read.`}

--- a/apps/standard-reader/src/components/user-settings-view.tsx
+++ b/apps/standard-reader/src/components/user-settings-view.tsx
@@ -414,9 +414,7 @@ export function UserSettingsView() {
   const queryClient = useQueryClient();
   const labelers = useQuery(labelerApi.getLabelersQueryOptions());
   // Just the headline count — the list itself lives on `/settings/blocks`.
-  const blocks = useQuery(
-    blocksApi.getBlocksSettingsQueryOptions({ limit: 1 }),
-  );
+  const blocks = useQuery(blocksApi.getBlockCapabilityQueryOptions());
   const blockCount = blocks.data?.accountCount ?? null;
   const connections = useQuery(mcpApi.listConnectionsQueryOptions());
   const fmt = useFormatters();

--- a/apps/standard-reader/src/db/schema.ts
+++ b/apps/standard-reader/src/db/schema.ts
@@ -25,6 +25,7 @@ export * from "./schema/discover-topics.ts";
 export * from "./schema/topics.ts";
 export * from "./schema/ingest.ts";
 export * from "./schema/labels.ts";
+export * from "./schema/blocks.ts";
 export * from "./schema/mcp.ts";
 export * from "./schema/quote-shares.ts";
 export * from "./schema/relations.ts";

--- a/apps/standard-reader/src/db/schema/auth.ts
+++ b/apps/standard-reader/src/db/schema/auth.ts
@@ -117,6 +117,15 @@ export const user = pgTable("user", {
   /** `true` enables the Semble/Cosmik (network.cosmik.*) save scope tier on
    * the next sign-in, mirroring {@link marginSaveEnabled}. */
   sembleSaveEnabled: boolean("semble_save_enabled"),
+  /** `true` enables write access to the reader's Bluesky block records
+   * (`app.bsky.graph.block` / `.listblock`) on the next sign-in, mirroring
+   * {@link marginSaveEnabled}. Set when the reader goes through the "block from
+   * here" upgrade flow; the source of truth for "actually granted" is
+   * `account.scope` (see `hasBskyBlockWriteScope`).
+   *
+   * Only *writing* needs this. Blocks the reader already made are enforced for
+   * everyone, granted or not — they are public repo records. */
+  blockingEnabled: boolean("blocking_enabled"),
   /** `true` stops the one-time ATStore review prompt toast from showing again. */
   atstoreReviewPromptDismissed: boolean("atstore_review_prompt_dismissed"),
   /** `true` once the first-run onboarding wizard was finished or dismissed;

--- a/apps/standard-reader/src/db/schema/blocks.ts
+++ b/apps/standard-reader/src/db/schema/blocks.ts
@@ -55,12 +55,14 @@ export const blocks = pgTable(
       .defaultNow(),
   },
   (table) => [
-    // "who does this reader block" — the outgoing half of their block set.
-    index("blocks_blocker_idx").on(table.blockerDid),
-    // "who blocks this reader" — the incoming half. Both halves are read on
-    // every block-filtered query, so both need to be an index-only lookup.
+    // "who blocks this reader" — the incoming half. Read on every
+    // block-filtered query alongside the outgoing half below.
     index("blocks_subject_idx").on(table.subjectDid),
-    // Probe a single edge (does A block B?) for the profile block button.
+    // Probe a single edge (does A block B?) for the profile block button, and
+    // — on its `blocker_did` prefix — "who does this reader block" for the
+    // outgoing half. One index serves both; a separate `blocker_did` index
+    // would be a strict prefix of this one, costing writes to answer nothing
+    // new.
     index("blocks_edge_idx").on(table.blockerDid, table.subjectDid),
   ],
 );

--- a/apps/standard-reader/src/db/schema/blocks.ts
+++ b/apps/standard-reader/src/db/schema/blocks.ts
@@ -1,0 +1,212 @@
+import {
+  boolean,
+  index,
+  integer,
+  pgTable,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core";
+
+/**
+ * Blocks — mirrored `app.bsky.graph.block` records.
+ *
+ * Unlike labeler subscriptions (which Bluesky keeps in an account's preferences
+ * blob, so porting them meant writing *our own* records — see
+ * `server/labeler/import-bsky.server.ts`), a block already **is** a repo record.
+ * It lives in the blocker's repo, it is portable, and every AT Protocol app that
+ * honours it is reading the same record. So there is no Standard Reader block
+ * lexicon and there never should be: we mirror `app.bsky.graph.block` and honour
+ * it, and blocking from here writes that same record. A reader's blocks follow
+ * them to whatever they use next.
+ *
+ * One row per block record, both directions:
+ *  - **outgoing** — records in a reader's own repo, read from their PDS.
+ *  - **incoming** — records in *other* repos whose `subject` is one of our
+ *    readers, discovered through Constellation backlinks. Bluesky's appview
+ *    knows the whole block graph; we don't, so the reverse edge has to be
+ *    looked up per reader rather than derived.
+ *
+ * Both directions hide content, exactly as they do on Bluesky: a block is
+ * mutual in effect even though the record is one-sided.
+ */
+export const blocks = pgTable(
+  "blocks",
+  {
+    /** AT-URI of the `app.bsky.graph.block` record. */
+    uri: text("uri").primaryKey(),
+    cid: text("cid"),
+    /** DID of the blocker (the repo that holds this record). */
+    blockerDid: text("blocker_did").notNull(),
+    rkey: text("rkey").notNull(),
+
+    /** DID of the blocked account (the record's `subject`). */
+    subjectDid: text("subject_did").notNull(),
+
+    /** `createdAt` from the record. */
+    createdAt: timestamp("created_at", { withTimezone: true }),
+
+    deleted: boolean("deleted").notNull().default(false),
+
+    indexedAt: timestamp("indexed_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    // "who does this reader block" — the outgoing half of their block set.
+    index("blocks_blocker_idx").on(table.blockerDid),
+    // "who blocks this reader" — the incoming half. Both halves are read on
+    // every block-filtered query, so both need to be an index-only lookup.
+    index("blocks_subject_idx").on(table.subjectDid),
+    // Probe a single edge (does A block B?) for the profile block button.
+    index("blocks_edge_idx").on(table.blockerDid, table.subjectDid),
+  ],
+);
+
+/**
+ * Block lists — mirrored `app.bsky.graph.listblock` records. Subscribing to a
+ * moderation list blocks everyone on it, and stays live as the list changes.
+ *
+ * Same two directions as {@link blocks}: a reader's own listblocks (read from
+ * their repo), and listblocks by *other* accounts against a list the reader is
+ * a member of — which is how Bluesky's `blockedByList` works, and the reason a
+ * reader can be blocked by someone who never named them.
+ */
+export const blockLists = pgTable(
+  "block_lists",
+  {
+    /** AT-URI of the `app.bsky.graph.listblock` record. */
+    uri: text("uri").primaryKey(),
+    cid: text("cid"),
+    /** DID of the blocker (the repo that holds this record). */
+    blockerDid: text("blocker_did").notNull(),
+    rkey: text("rkey").notNull(),
+
+    /** AT-URI of the blocked `app.bsky.graph.list` (the record's `subject`). */
+    listUri: text("list_uri").notNull(),
+
+    /** `createdAt` from the record. */
+    createdAt: timestamp("created_at", { withTimezone: true }),
+
+    deleted: boolean("deleted").notNull().default(false),
+
+    indexedAt: timestamp("indexed_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    // A reader's subscribed block lists (settings, outgoing resolution).
+    index("block_lists_blocker_idx").on(table.blockerDid),
+    // Everyone blocking a given list (incoming resolution, subscriber counts).
+    index("block_lists_list_idx").on(table.listUri),
+  ],
+);
+
+/**
+ * Membership of the moderation lists we mirror — one row per
+ * `app.bsky.graph.listitem`.
+ *
+ * Only lists somebody actually blocks are mirrored, and only as far as the cap
+ * in `blocks/sync.server.ts`: popular blocklists run to tens of thousands of
+ * members, and storing every list on the network would dwarf the rest of the
+ * read-model for no benefit.
+ */
+export const blockListItems = pgTable(
+  "block_list_items",
+  {
+    /** AT-URI of the `app.bsky.graph.listitem` record. */
+    uri: text("uri").primaryKey(),
+    /** AT-URI of the list this item belongs to. */
+    listUri: text("list_uri").notNull(),
+    /** DID of the listed account. */
+    subjectDid: text("subject_did").notNull(),
+
+    indexedAt: timestamp("indexed_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    // Expand a blocked list into its members (settings, diagnostics).
+    index("block_list_items_list_idx").on(table.listUri),
+    // "which mirrored lists is this account on" — both the incoming
+    // blocked-by-list resolution and the "why am I seeing this" explanation.
+    index("block_list_items_subject_idx").on(table.subjectDid),
+    // The hot one: "is any account on this page a member of a list this reader
+    // blocks". Leading `list_uri` matches the join to the reader's (small) set
+    // of blocked lists, then `subject_did` narrows to the page — so a reader on
+    // a 40k-member blocklist costs an index probe per card, not a list scan.
+    index("block_list_items_list_subject_idx").on(
+      table.listUri,
+      table.subjectDid,
+    ),
+  ],
+);
+
+/**
+ * Per-list mirror bookkeeping, so membership is refreshed on a cadence rather
+ * than on every read, and a list that can't be fetched is distinguishable from
+ * one that is genuinely empty.
+ */
+export const blockListSyncState = pgTable("block_list_sync_state", {
+  /** AT-URI of the `app.bsky.graph.list`. */
+  listUri: text("list_uri").primaryKey(),
+  /** DID of the list's owner (derived from `listUri`). */
+  ownerDid: text("owner_did").notNull(),
+
+  /** Display name from the list record, for the settings surface. */
+  name: text("name"),
+  description: text("description"),
+  /** `purpose` from the list record — we only block `#modlist` lists. */
+  purpose: text("purpose"),
+
+  /** Members mirrored on the last successful run. */
+  itemCount: integer("item_count").notNull().default(0),
+  /**
+   * Set when the list is larger than the mirror cap, so the settings surface can
+   * say the block is partial instead of quietly under-enforcing it.
+   */
+  truncated: boolean("truncated").notNull().default(false),
+  /** Why the last run failed; null when it succeeded. */
+  lastError: text("last_error"),
+
+  syncedAt: timestamp("synced_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+/**
+ * Per-reader block-sync bookkeeping. Blocks are not on the firehose tap (they
+ * live in arbitrary repos across the network, not the ones we track), so they
+ * are pulled per reader on a cadence — this is what makes that cadence cheap to
+ * check on every request.
+ */
+export const blockSyncState = pgTable("block_sync_state", {
+  /** DID of the reader whose blocks were synced. */
+  did: text("did").primaryKey(),
+  /** Outgoing block records mirrored on the last run. */
+  outgoingCount: integer("outgoing_count").notNull().default(0),
+  /** Incoming block records mirrored on the last run. */
+  incomingCount: integer("incoming_count").notNull().default(0),
+  /** Block lists (both directions) mirrored on the last run. */
+  listCount: integer("list_count").notNull().default(0),
+  /** Why the last run failed; null when it succeeded. */
+  lastError: text("last_error"),
+
+  syncedAt: timestamp("synced_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+export type Block = typeof blocks.$inferSelect;
+export type NewBlock = typeof blocks.$inferInsert;
+export type BlockList = typeof blockLists.$inferSelect;
+export type NewBlockList = typeof blockLists.$inferInsert;
+export type BlockListItem = typeof blockListItems.$inferSelect;
+export type NewBlockListItem = typeof blockListItems.$inferInsert;
+export type BlockListSyncState = typeof blockListSyncState.$inferSelect;
+export type BlockSyncState = typeof blockSyncState.$inferSelect;

--- a/apps/standard-reader/src/integrations/auth/callback.server.ts
+++ b/apps/standard-reader/src/integrations/auth/callback.server.ts
@@ -220,6 +220,18 @@ export async function handleAtprotoOAuthCallback(args: {
       }
     }
 
+    // Mirror the reader's Bluesky blocks, so someone they blocked years ago is
+    // already gone from the first page they see. Needs no OAuth scope — blocks
+    // are public repo records — which is why it sits outside the scope check
+    // above. Not awaited, for the same reason as the labeler import.
+    try {
+      const { scheduleReaderBlockSync } =
+        await import("#/server/blocks/sync.server");
+      scheduleReaderBlockSync(did);
+    } catch (error) {
+      console.warn("Failed to schedule Bluesky block sync:", error);
+    }
+
     const sessionToken = crypto.randomUUID();
     const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
 

--- a/apps/standard-reader/src/integrations/auth/scope.ts
+++ b/apps/standard-reader/src/integrations/auth/scope.ts
@@ -98,6 +98,27 @@ export const BSKY_PREFERENCES_READ_SCOPE = atprotoScope.rpc({
 });
 
 /**
+ * Write access to the reader's Bluesky block records — `app.bsky.graph.block`
+ * for an account and `app.bsky.graph.listblock` for a moderation list.
+ *
+ * Deliberately Bluesky's lexicon rather than one of ours. A block is already a
+ * portable repo record that every AT Protocol app honours, so blocking from
+ * here writes the record the rest of the network already reads: block someone
+ * in Standard Reader and they are blocked on Bluesky too, and wherever the
+ * reader goes next. A `app.standard-reader.block` would have been a block that
+ * only worked in one app, which is not what a block means.
+ *
+ * *Reading* blocks needs no scope at all — `com.atproto.repo.listRecords` is
+ * public — so honouring a reader's existing blocks costs them no extra consent.
+ * This is requested only when they choose to block from inside the app,
+ * persisted via `user.blockingEnabled` so it is silently re-requested on every
+ * later login (mirroring {@link MARGIN_FULL_SCOPE}).
+ */
+export const BSKY_BLOCK_WRITE_SCOPE = atprotoScope.repo({
+  collection: ["app.bsky.graph.block", "app.bsky.graph.listblock"],
+});
+
+/**
  * Basic sign-in scope — what 95% of readers need. Covers app-owned reader-state
  * (`authBasicFeatures`) plus standard.site follows & likes (`authSocial`).
  */
@@ -147,6 +168,7 @@ export const clientMetadataScope = [
     MARGIN_FULL_SCOPE,
     SEMBLE_FULL_SCOPE,
     EMAIL_SCOPE,
+    BSKY_BLOCK_WRITE_SCOPE,
   ]),
 ];
 
@@ -185,6 +207,7 @@ export interface ScopeUserLookup {
   marginSaveEnabled?: boolean | null;
   sembleSaveEnabled?: boolean | null;
   weeklyDigestEnabled?: boolean | null;
+  blockingEnabled?: boolean | null;
 }
 
 /** Addenda scopes that can be requested alongside the base tier, keyed by the
@@ -195,6 +218,7 @@ export interface ScopeAddenda {
   margin?: boolean;
   semble?: boolean;
   email?: boolean;
+  blocking?: boolean;
 }
 
 /**
@@ -235,6 +259,9 @@ export function resolveAuthScopeForUser(
   }
   if (addenda.email || user?.weeklyDigestEnabled === true) {
     extra.add(EMAIL_SCOPE);
+  }
+  if (addenda.blocking || user?.blockingEnabled === true) {
+    extra.add(BSKY_BLOCK_WRITE_SCOPE);
   }
   return formatOAuthScope([...extra]);
 }
@@ -472,6 +499,30 @@ export function hasBskyPreferencesScope(
       (token.startsWith("rpc") &&
         (token.includes("lxm=app.bsky.actor.getPreferences") ||
           token.includes("lxm=*"))),
+  );
+}
+
+/**
+ * Detect whether the granted scope includes write access to the reader's
+ * Bluesky block records.
+ *
+ * Accepts the exact scope we request, or (in either serialization) a `repo`
+ * token covering `app.bsky.graph.block`. The source of truth for "the reader
+ * can actually block from here" — as opposed to `user.blockingEnabled`, which
+ * is set optimistically before the re-auth completes.
+ *
+ * A reader without it still has every block they made elsewhere enforced; they
+ * just can't create new ones without re-authorizing, which is what the block
+ * button checks before it offers.
+ */
+export function hasBskyBlockWriteScope(
+  grantedScope: string | null | undefined,
+): boolean {
+  if (!grantedScope) return false;
+  const tokens = grantedScope.split(/\s+/);
+  if (tokens.includes(BSKY_BLOCK_WRITE_SCOPE)) return true;
+  return tokens.some((token) =>
+    repoScopeAllowsCreateForCollection(token, "app.bsky.graph.block"),
   );
 }
 

--- a/apps/standard-reader/src/integrations/tanstack-query/api-auth.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-auth.functions.ts
@@ -14,6 +14,7 @@ import type { AuthScopeIntent } from "#/integrations/auth/scope";
 import {
   ATSTORE_REVIEW_SCOPE,
   formatOAuthScope,
+  hasBskyBlockWriteScope,
   hasCollectionsScope,
   hasEmailScope,
   hasMarginScope,
@@ -268,6 +269,7 @@ interface UpgradeScopeOverrides {
   margin?: boolean;
   semble?: boolean;
   email?: boolean;
+  blocking?: boolean;
 }
 
 /**
@@ -301,6 +303,7 @@ async function resolveUpgradeScope(
       marginSaveEnabled: true,
       sembleSaveEnabled: true,
       weeklyDigestEnabled: true,
+      blockingEnabled: true,
     },
     with: {
       accounts: {
@@ -329,6 +332,9 @@ async function resolveUpgradeScope(
   const requestEmail =
     overrides.email ??
     (row?.weeklyDigestEnabled === true || hasEmailScope(grantedScope));
+  const requestBlocking =
+    overrides.blocking ??
+    (row?.blockingEnabled === true || hasBskyBlockWriteScope(grantedScope));
 
   return resolveAuthScopeForUser(
     {
@@ -337,6 +343,7 @@ async function resolveUpgradeScope(
       marginSaveEnabled: requestMargin,
       sembleSaveEnabled: requestSemble,
       weeklyDigestEnabled: requestEmail,
+      blockingEnabled: requestBlocking,
     },
     undefined,
     {
@@ -344,6 +351,7 @@ async function resolveUpgradeScope(
       margin: requestMargin,
       semble: requestSemble,
       email: requestEmail,
+      blocking: requestBlocking,
     },
   );
 }
@@ -713,6 +721,65 @@ const upgradeToMargin = createServerFn({ method: "POST" })
   });
 
 /**
+ * Progressive scope upgrade: let the signed-in reader create blocks from
+ * inside Standard Reader. Mirrors {@link upgradeToMargin} for
+ * `BSKY_BLOCK_WRITE_SCOPE` / `user.blockingEnabled`.
+ *
+ * Only the *write* needs consent. Blocks the reader already has are enforced
+ * whether or not they ever run this — that is the whole point of honouring the
+ * records rather than storing our own.
+ */
+const upgradeToBlocking = createServerFn({ method: "POST" })
+  .validator(upgradeToCollectionsInputSchema)
+  .handler(async ({ data }) => {
+    const request = getRequest();
+    const [{ db }, schema, { getReaderContextForRequest }] = await Promise.all([
+      import("#/db/index.server"),
+      import("#/db/schema"),
+      import("#/middleware/auth-session.server"),
+    ]);
+
+    const reader = await getReaderContextForRequest(request);
+    if (!reader) {
+      throw new Error("Unauthorized");
+    }
+
+    await db
+      .update(schema.user)
+      .set({ blockingEnabled: true })
+      .where(eq(schema.user.id, reader.userId));
+
+    try {
+      await revokeAtprotoSession(
+        reader.did as Parameters<typeof revokeAtprotoSession>[0],
+      );
+    } catch (error) {
+      console.warn(
+        "Failed to revoke Atproto session during blocking upgrade:",
+        error,
+      );
+    }
+
+    const redirectTarget = sanitizeAuthRedirectTarget(
+      data.redirect,
+      request.url,
+    );
+
+    const { url } = await atprotoOAuth.authorize({
+      target: {
+        type: "account",
+        identifier: reader.did as ActorIdentifier,
+      },
+      scope: await resolveUpgradeScope(reader.userId, { blocking: true }),
+      state: {
+        redirect: redirectTarget,
+      },
+    });
+
+    return { authorizationUrl: url.toString() };
+  });
+
+/**
  * Progressive scope upgrade: opt the signed-in reader into saving articles to
  * their Semble collections. Mirrors {@link upgradeToMargin} for
  * `SEMBLE_FULL_SCOPE` / `user.sembleSaveEnabled`.
@@ -868,6 +935,7 @@ export const auth = {
   upgradeToUserinputFeedback,
   upgradeToMargin,
   upgradeToSemble,
+  upgradeToBlocking,
   upgradeToWeeklyDigest,
   disableWeeklyDigest,
   getSavedHandles: getSavedHandlesServer,

--- a/apps/standard-reader/src/integrations/tanstack-query/api-author.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-author.functions.ts
@@ -12,7 +12,11 @@ import { getReaderDidForRequest } from "#/middleware/auth-session.server";
 import { resolveIdentity } from "#/server/atproto/identity";
 import { resolveAuthorDid } from "#/server/atproto/resolve-author-ref";
 import { resolveSifaProfileUrl } from "#/server/atproto/sifa-profile";
-import { blockEdgeFor, filterBlockedCards } from "#/server/blocks/blocks";
+import {
+  blockEdgeFor,
+  blockFilterDid,
+  filterBlockedCards,
+} from "#/server/blocks/blocks";
 import { readAccountLabels } from "#/server/labeler/labels.server";
 import { observe } from "#/server/observability/log";
 import {
@@ -91,6 +95,13 @@ const authorSummaryInput = z.object({
 export interface AuthorSummary {
   profile: ProfileSummary;
   stats: AuthorProfileStats;
+  /**
+   * Set when the viewer and this account are blocked from each other. Hovercards
+   * render it instead of the bio and counts: the profile page withholds a
+   * blocked account, and a hovercard that still summarised them would be the
+   * same content through a smaller window.
+   */
+  block: BlockEdge | null;
 }
 
 export interface AuthorProfile {
@@ -216,6 +227,25 @@ async function resolveAuthorProfile(
   };
 }
 
+/**
+ * Whether this profile is withheld from the viewer, for the per-tab loaders.
+ *
+ * Two-step so the common case costs nothing: `blockFilterDid` answers "does this
+ * reader block anybody" from an in-process cache, and only a reader who does
+ * pays for the edge probe. Every tab loader calls this on every page, so a
+ * single unconditional round trip here would be a round trip on every
+ * load-more.
+ */
+async function blockedFromAuthor(
+  db: Db,
+  schema: Schema,
+  viewerDid: string | null | undefined,
+  did: string,
+): Promise<boolean> {
+  if (!(await blockFilterDid(db, schema, viewerDid))) return false;
+  return (await blockEdgeFor(db, schema, viewerDid, did)) != null;
+}
+
 function nextOffsetForPage(
   offset: number,
   limit: number,
@@ -274,11 +304,18 @@ const getAuthorProfile = createServerFn({ method: "GET" })
         const includeHidden = viewerDid != null && viewerDid === did;
         span.set("ownProfile", includeHidden);
 
-        // Resolved before anything else is read: a blocked profile renders as
-        // the block, not as a profile with the rows filtered out. Loading the
-        // tabs first and emptying them afterwards would pay for content the
-        // viewer must not see, and would leak counts through the stats.
-        const block = await blockEdgeFor(db, schema, viewerDid, did);
+        // A blocked profile renders as the block, not as a profile with the
+        // rows filtered out — loading the tabs first and emptying them
+        // afterwards would pay for content the viewer must not see, and would
+        // leak counts through the stats. So this one *does* gate the reads.
+        //
+        // What keeps that honest is `blockFilterDid`: for the overwhelming
+        // majority of readers — everyone who blocks nobody — it answers from an
+        // in-process cache and no query runs at all, so the profile fan-out
+        // below starts without waiting on a round trip.
+        const block = (await blockFilterDid(db, schema, viewerDid))
+          ? await blockEdgeFor(db, schema, viewerDid, did)
+          : null;
         if (block) {
           span.set("blocked", block.direction);
           return {
@@ -475,10 +512,18 @@ const getAuthorSummary = createServerFn({ method: "GET" })
         const did = await resolveAuthorDid(db, schema, data.did);
         span.set("did", did);
 
-        const [profile, stats] = await Promise.all([
+        const [profile, stats, viewerDid] = await Promise.all([
           resolveAuthorProfile(db, schema, did),
           authorProfileStats(db, schema, did),
+          getReaderDidForRequest(getRequest()).then(async (viewer) => {
+            if (viewer) await blockFilterDid(db, schema, viewer);
+            return viewer;
+          }),
         ]);
+        const block = (await blockFilterDid(db, schema, viewerDid))
+          ? await blockEdgeFor(db, schema, viewerDid, did)
+          : null;
+        if (block) span.set("blocked", block.direction);
 
         const hasIdentity =
           profile.handle != null ||
@@ -496,7 +541,22 @@ const getAuthorSummary = createServerFn({ method: "GET" })
         }
 
         span.set("found", true);
-        return { profile, stats };
+        // Identity survives the block — the hovercard still has to name
+        // somebody — but the counts do not: they would leak how much a blocked
+        // account has written straight past the block.
+        return block
+          ? {
+              profile,
+              block,
+              stats: {
+                publicationCount: 0,
+                documentCount: 0,
+                subscriberCount: 0,
+                subscriptionCount: 0,
+                recommendationCount: 0,
+              },
+            }
+          : { profile, stats, block: null };
       },
     ),
   );
@@ -538,7 +598,7 @@ const getAuthorPublications = createServerFn({ method: "GET" })
         const includeHidden = viewerDid != null && viewerDid === did;
         span.set("ownProfile", includeHidden);
 
-        if (await blockEdgeFor(db, schema, viewerDid, did)) {
+        if (await blockedFromAuthor(db, schema, viewerDid, did)) {
           span.set("blocked", true);
           return { items: [], nextOffset: null };
         }
@@ -572,7 +632,7 @@ const getAuthorSubscriptions = createServerFn({ method: "GET" })
         span.set("offset", data.offset);
 
         const viewerDid = await getReaderDidForRequest(getRequest());
-        if (await blockEdgeFor(db, schema, viewerDid, did)) {
+        if (await blockedFromAuthor(db, schema, viewerDid, did)) {
           span.set("blocked", true);
           return { items: [], nextOffset: null };
         }
@@ -606,7 +666,7 @@ const getAuthorReaders = createServerFn({ method: "GET" })
         span.set("offset", data.offset);
 
         const viewerDid = await getReaderDidForRequest(getRequest());
-        if (await blockEdgeFor(db, schema, viewerDid, did)) {
+        if (await blockedFromAuthor(db, schema, viewerDid, did)) {
           span.set("blocked", true);
           return { items: [], nextOffset: null };
         }
@@ -639,13 +699,17 @@ const getAuthorRecommendations = createServerFn({ method: "GET" })
         span.set("did", did);
         span.set("offset", data.offset);
 
-        // Resolve the page and the viewer identity together — the follow-set
-        // lookup only needs the viewer's DID, not the page rows.
+        // Resolve the page, the viewer identity and the block check together —
+        // none of them needs the others' rows, and the block check is the one
+        // that decides whether the page is returned at all.
         const [page, viewerDid] = await Promise.all([
           authorRecommendations(db, schema, { ...data, did }),
-          getReaderDidForRequest(getRequest()),
+          getReaderDidForRequest(getRequest()).then(async (viewer) => {
+            if (viewer) await blockFilterDid(db, schema, viewer);
+            return viewer;
+          }),
         ]);
-        if (await blockEdgeFor(db, schema, viewerDid, did)) {
+        if (await blockedFromAuthor(db, schema, viewerDid, did)) {
           span.set("blocked", true);
           return { items: [], nextOffset: null };
         }
@@ -692,13 +756,17 @@ const getAuthorDocuments = createServerFn({ method: "GET" })
         span.set("did", did);
         span.set("offset", data.offset);
 
-        // Resolve the page and the viewer identity together — the follow-set
-        // lookup only needs the viewer's DID, not the page rows.
+        // Resolve the page, the viewer identity and the block check together —
+        // none of them needs the others' rows, and the block check is the one
+        // that decides whether the page is returned at all.
         const [page, viewerDid] = await Promise.all([
           authorDocuments(db, schema, { ...data, did }),
-          getReaderDidForRequest(getRequest()),
+          getReaderDidForRequest(getRequest()).then(async (viewer) => {
+            if (viewer) await blockFilterDid(db, schema, viewer);
+            return viewer;
+          }),
         ]);
-        if (await blockEdgeFor(db, schema, viewerDid, did)) {
+        if (await blockedFromAuthor(db, schema, viewerDid, did)) {
           span.set("blocked", true);
           return { items: [], nextOffset: null };
         }

--- a/apps/standard-reader/src/integrations/tanstack-query/api-author.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-author.functions.ts
@@ -4,6 +4,7 @@ import { getRequest } from "@tanstack/react-start/server";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
+import type { BlockEdge } from "#/lib/blocks";
 import { fetchBlueskyPublicProfileFields } from "#/lib/bluesky-public-profile";
 import type { HideableTabId } from "#/lib/profile-tabs";
 import { parseHiddenTabs } from "#/lib/profile-tabs";
@@ -11,6 +12,7 @@ import { getReaderDidForRequest } from "#/middleware/auth-session.server";
 import { resolveIdentity } from "#/server/atproto/identity";
 import { resolveAuthorDid } from "#/server/atproto/resolve-author-ref";
 import { resolveSifaProfileUrl } from "#/server/atproto/sifa-profile";
+import { blockEdgeFor, filterBlockedCards } from "#/server/blocks/blocks";
 import { readAccountLabels } from "#/server/labeler/labels.server";
 import { observe } from "#/server/observability/log";
 import {
@@ -93,6 +95,15 @@ export interface AuthorSummary {
 
 export interface AuthorProfile {
   profile: ProfileSummary;
+  /**
+   * Set when the viewer and this account are blocked from each other. The
+   * profile still resolves — identity, and *which* way the block runs, are what
+   * the page needs to explain itself — but every content list comes back empty
+   * and the stats read zero, so nothing they wrote reaches the viewer.
+   *
+   * Null for signed-out viewers and for everyone not blocked.
+   */
+  block: BlockEdge | null;
   stats: {
     publicationCount: number;
     documentCount: number;
@@ -263,6 +274,39 @@ const getAuthorProfile = createServerFn({ method: "GET" })
         const includeHidden = viewerDid != null && viewerDid === did;
         span.set("ownProfile", includeHidden);
 
+        // Resolved before anything else is read: a blocked profile renders as
+        // the block, not as a profile with the rows filtered out. Loading the
+        // tabs first and emptying them afterwards would pay for content the
+        // viewer must not see, and would leak counts through the stats.
+        const block = await blockEdgeFor(db, schema, viewerDid, did);
+        if (block) {
+          span.set("blocked", block.direction);
+          return {
+            profile: await resolveAuthorProfile(db, schema, did),
+            block,
+            stats: {
+              publicationCount: 0,
+              documentCount: 0,
+              subscriberCount: 0,
+              subscriptionCount: 0,
+              recommendationCount: 0,
+            },
+            publications: [],
+            publicationsNextOffset: null,
+            subscriptions: [],
+            subscriptionsNextOffset: null,
+            readers: [],
+            readersNextOffset: null,
+            recommendations: [],
+            recommendationsNextOffset: null,
+            documents: [],
+            documentsNextOffset: null,
+            hiddenTabs: [],
+            showLikes: false,
+            labels: [],
+          };
+        }
+
         const [
           profile,
           stats,
@@ -371,6 +415,7 @@ const getAuthorProfile = createServerFn({ method: "GET" })
 
         return {
           profile,
+          block: null,
           stats,
           publications,
           publicationsNextOffset:
@@ -493,6 +538,11 @@ const getAuthorPublications = createServerFn({ method: "GET" })
         const includeHidden = viewerDid != null && viewerDid === did;
         span.set("ownProfile", includeHidden);
 
+        if (await blockEdgeFor(db, schema, viewerDid, did)) {
+          span.set("blocked", true);
+          return { items: [], nextOffset: null };
+        }
+
         const items = await authorPublications(db, schema, {
           ...data,
           did,
@@ -521,11 +571,17 @@ const getAuthorSubscriptions = createServerFn({ method: "GET" })
         span.set("did", did);
         span.set("offset", data.offset);
 
+        const viewerDid = await getReaderDidForRequest(getRequest());
+        if (await blockEdgeFor(db, schema, viewerDid, did)) {
+          span.set("blocked", true);
+          return { items: [], nextOffset: null };
+        }
+
         const page = await authorSubscriptions(db, schema, { ...data, did });
         span.set("count", page.items.length);
 
         return {
-          items: page.items,
+          items: await filterBlockedCards(db, schema, viewerDid, page.items),
           nextOffset: nextOffsetForPage(
             data.offset,
             data.limit,
@@ -549,11 +605,17 @@ const getAuthorReaders = createServerFn({ method: "GET" })
         span.set("did", did);
         span.set("offset", data.offset);
 
+        const viewerDid = await getReaderDidForRequest(getRequest());
+        if (await blockEdgeFor(db, schema, viewerDid, did)) {
+          span.set("blocked", true);
+          return { items: [], nextOffset: null };
+        }
+
         const page = await authorReaders(db, schema, { ...data, did });
         span.set("count", page.items.length);
 
         return {
-          items: page.items,
+          items: await filterBlockedCards(db, schema, viewerDid, page.items),
           nextOffset: nextOffsetForPage(
             data.offset,
             data.limit,
@@ -583,6 +645,10 @@ const getAuthorRecommendations = createServerFn({ method: "GET" })
           authorRecommendations(db, schema, { ...data, did }),
           getReaderDidForRequest(getRequest()),
         ]);
+        if (await blockEdgeFor(db, schema, viewerDid, did)) {
+          span.set("blocked", true);
+          return { items: [], nextOffset: null };
+        }
         span.set("count", page.items.length);
 
         // Likes tab: exclude the profile owner from the attribution (see
@@ -632,6 +698,10 @@ const getAuthorDocuments = createServerFn({ method: "GET" })
           authorDocuments(db, schema, { ...data, did }),
           getReaderDidForRequest(getRequest()),
         ]);
+        if (await blockEdgeFor(db, schema, viewerDid, did)) {
+          span.set("blocked", true);
+          return { items: [], nextOffset: null };
+        }
         span.set("count", page.items.length);
 
         // Writing tab: this author's own posts — the helper already drops

--- a/apps/standard-reader/src/integrations/tanstack-query/api-blocks.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-blocks.functions.ts
@@ -116,8 +116,13 @@ const getBlocksSettings = createServerFn({ method: "GET" })
 
         return {
           accounts,
+          // Against the real total, not `length === limit`. A reader with
+          // exactly 50 blocks fills the page precisely, and the naive test
+          // offers a "Load more" that fetches nothing.
           accountsNextOffset:
-            accounts.length === data.limit ? data.offset + data.limit : null,
+            data.offset + accounts.length < accountCount
+              ? data.offset + accounts.length
+              : null,
           accountCount,
           lists,
           canWrite: hasBskyBlockWriteScope(account?.scope),
@@ -146,15 +151,21 @@ const getBlockedAccountsPage = createServerFn({ method: "GET" })
       const reader = await getReaderContextForRequest(getRequest());
       if (!reader) return { accounts: [], nextOffset: null };
 
-      const accounts = await readerBlockedAccounts(db, schema, reader.did, {
-        limit: data.limit,
-        offset: data.offset,
-      });
+      const [accounts, total] = await Promise.all([
+        readerBlockedAccounts(db, schema, reader.did, {
+          limit: data.limit,
+          offset: data.offset,
+        }),
+        countReaderBlockedAccounts(db, schema, reader.did),
+      ]);
       span.set("count", accounts.length);
       return {
         accounts,
+        // See `getBlocksSettings` — paged against the real total.
         nextOffset:
-          accounts.length === data.limit ? data.offset + data.limit : null,
+          data.offset + accounts.length < total
+            ? data.offset + accounts.length
+            : null,
       };
     }),
   );

--- a/apps/standard-reader/src/integrations/tanstack-query/api-blocks.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-blocks.functions.ts
@@ -1,0 +1,329 @@
+import { queryOptions } from "@tanstack/react-query";
+import { createServerFn } from "@tanstack/react-start";
+import { getRequest } from "@tanstack/react-start/server";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { hasBskyBlockWriteScope } from "#/integrations/auth/scope";
+import type { BlockEdge } from "#/lib/blocks";
+import {
+  getAtprotoSessionForRequest,
+  getReaderContextForRequest,
+} from "#/middleware/auth-session.server";
+import {
+  deleteBskyBlockRecords,
+  deleteBskyListBlockRecords,
+  putBskyBlockRecord,
+  putBskyListBlockRecord,
+} from "#/server/atproto/repo-records";
+import type { BlockListRow, BlockedAccountRow } from "#/server/blocks/blocks";
+import {
+  blockEdgeFor,
+  countReaderBlockedAccounts,
+  readerBlockLists,
+  readerBlockedAccounts,
+} from "#/server/blocks/blocks";
+import {
+  refreshOutgoingBlocks,
+  syncBlockedList,
+  syncReaderBlocks,
+} from "#/server/blocks/sync.server";
+import { observe } from "#/server/observability/log";
+
+import { dbMiddleware } from "./db-middleware";
+
+export type { BlockListRow, BlockedAccountRow };
+export type { BlockDirection, BlockEdge } from "#/lib/blocks";
+
+/**
+ * Blocks — reading and writing the reader's `app.bsky.graph.block` records.
+ *
+ * Writes go to the reader's repo, never to our tables: the record is the block,
+ * and the read-model is a mirror the ingest refreshes afterwards. Every write
+ * here re-syncs the mirror inline (see `refreshOutgoingBlocks`) so the block
+ * takes effect on the very next page rather than at the end of the sweep
+ * cadence — blocking someone and still seeing them would read as a failure.
+ */
+
+const blockInput = z.object({
+  did: z.string().min(1),
+});
+
+const blockListInput = z.object({
+  listUri: z.string().min(1),
+});
+
+const blockedAccountsInput = z.object({
+  limit: z.number().int().min(1).max(100).default(50),
+  offset: z.number().int().min(0).default(0),
+});
+
+/** The reader's moderation state, as the settings page renders it. */
+export interface BlocksSettings {
+  /** Accounts the reader blocks directly, newest first. */
+  accounts: Array<BlockedAccountRow>;
+  accountsNextOffset: number | null;
+  /** Total direct blocks, so the page can head the list with a count. */
+  accountCount: number;
+  /** Moderation lists the reader blocks, with mirror state for each. */
+  lists: Array<BlockListRow>;
+  /**
+   * Whether the reader has granted write access to their block records. When
+   * false the page is read-only: their blocks are still enforced, they just
+   * can't add or remove one without re-authorizing.
+   */
+  canWrite: boolean;
+  /** When their blocks were last mirrored, and what went wrong if anything. */
+  syncedAt: string | null;
+  syncError: string | null;
+}
+
+const getBlocksSettings = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware])
+  .validator(blockedAccountsInput)
+  .handler(
+    observe(
+      "blocks.getSettings",
+      async ({ data, context }, span): Promise<BlocksSettings | null> => {
+        const { db, schema } = context;
+        const reader = await getReaderContextForRequest(getRequest());
+        if (!reader) return null;
+        span.set("did", reader.did);
+
+        const [accounts, accountCount, lists, account, syncRow] =
+          await Promise.all([
+            readerBlockedAccounts(db, schema, reader.did, {
+              limit: data.limit,
+              offset: data.offset,
+            }),
+            countReaderBlockedAccounts(db, schema, reader.did),
+            readerBlockLists(db, schema, reader.did),
+            db.query.account.findFirst({
+              where: and(
+                eq(schema.account.userId, reader.userId),
+                eq(schema.account.providerId, "atproto"),
+              ),
+              columns: { scope: true },
+            }),
+            db.query.blockSyncState.findFirst({
+              where: eq(schema.blockSyncState.did, reader.did),
+            }),
+          ]);
+
+        span.set("accounts", accountCount);
+        span.set("lists", lists.length);
+
+        return {
+          accounts,
+          accountsNextOffset:
+            accounts.length === data.limit ? data.offset + data.limit : null,
+          accountCount,
+          lists,
+          canWrite: hasBskyBlockWriteScope(account?.scope),
+          syncedAt: syncRow?.syncedAt?.toISOString() ?? null,
+          syncError: syncRow?.lastError ?? null,
+        };
+      },
+    ),
+  );
+
+/** The block between the reader and one account, for the profile block button. */
+const getBlockState = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware])
+  .validator(blockInput)
+  .handler(
+    observe(
+      "blocks.getBlockState",
+      async ({ data, context }, span): Promise<BlockEdge | null> => {
+        const reader = await getReaderContextForRequest(getRequest());
+        if (!reader) return null;
+        const edge = await blockEdgeFor(
+          context.db,
+          context.schema,
+          reader.did,
+          data.did,
+        );
+        span.set("blocked", edge?.direction ?? "none");
+        return edge;
+      },
+    ),
+  );
+
+/**
+ * Thrown when the reader hasn't granted block-write access yet, so the UI can
+ * offer the re-authorize flow instead of surfacing a raw PDS rejection.
+ */
+const NEEDS_BLOCK_SCOPE = "needs-block-scope";
+
+/**
+ * The reader's authenticated PDS client, once we know they can write blocks.
+ *
+ * Resolves the full ATProto session (a `manager.resume()` round trip) rather
+ * than the cheap DB-only reader context — a write needs the client, and this
+ * only ever runs on a write.
+ */
+async function requireBlockWriter() {
+  const session = await getAtprotoSessionForRequest(getRequest());
+  if (!session) {
+    throw new Error("Unauthorized");
+  }
+  const [{ db }, schema] = await Promise.all([
+    import("#/db/index.server"),
+    import("#/db/schema"),
+  ]);
+  const account = await db.query.account.findFirst({
+    where: and(
+      eq(schema.account.userId, session.session.user.id),
+      eq(schema.account.providerId, "atproto"),
+    ),
+    columns: { scope: true },
+  });
+  if (!hasBskyBlockWriteScope(account?.scope)) {
+    throw new Error(NEEDS_BLOCK_SCOPE);
+  }
+  return session;
+}
+
+const blockAccount = createServerFn({ method: "POST" })
+  .validator(blockInput)
+  .handler(async ({ data }) => {
+    const session = await requireBlockWriter();
+    if (data.did === session.did) {
+      throw new Error("You can't block yourself");
+    }
+
+    await putBskyBlockRecord(
+      session.client,
+      session.did,
+      data.did,
+      new Date().toISOString(),
+    );
+    // Re-read the reader's own records rather than inserting the row we just
+    // wrote: the PDS is the source of truth, and this also picks up blocks made
+    // elsewhere since the last sweep.
+    await refreshOutgoingBlocks(session.did);
+    return { blocked: true };
+  });
+
+const unblockAccount = createServerFn({ method: "POST" })
+  .validator(blockInput)
+  .handler(async ({ data }) => {
+    const session = await requireBlockWriter();
+
+    // The reader's existing blocks were almost certainly written by Bluesky
+    // under TID rkeys, which the deterministic rkey can't derive — so the
+    // mirror's rkeys are what make unblocking work on a block made anywhere.
+    const [{ db }, schema] = await Promise.all([
+      import("#/db/index.server"),
+      import("#/db/schema"),
+    ]);
+    const rows = await db
+      .select({ rkey: schema.blocks.rkey })
+      .from(schema.blocks)
+      .where(
+        and(
+          eq(schema.blocks.blockerDid, session.did),
+          eq(schema.blocks.subjectDid, data.did),
+          eq(schema.blocks.deleted, false),
+        ),
+      );
+
+    await deleteBskyBlockRecords(
+      session.client,
+      session.did,
+      data.did,
+      rows.map((row) => row.rkey),
+    );
+    await refreshOutgoingBlocks(session.did);
+    return { blocked: false };
+  });
+
+const blockList = createServerFn({ method: "POST" })
+  .validator(blockListInput)
+  .handler(async ({ data }) => {
+    const session = await requireBlockWriter();
+    await putBskyListBlockRecord(
+      session.client,
+      session.did,
+      data.listUri,
+      new Date().toISOString(),
+    );
+    // Full sweep rather than the outgoing-blocks refresh: subscribing to a list
+    // is only meaningful once its membership is mirrored, and that is what the
+    // sweep does. Awaited so the block is in force when this returns.
+    await syncReaderBlocks(session.did);
+    await syncBlockedList(data.listUri);
+    return { blocked: true };
+  });
+
+const unblockList = createServerFn({ method: "POST" })
+  .validator(blockListInput)
+  .handler(async ({ data }) => {
+    const session = await requireBlockWriter();
+
+    const [{ db }, schema] = await Promise.all([
+      import("#/db/index.server"),
+      import("#/db/schema"),
+    ]);
+    const rows = await db
+      .select({ rkey: schema.blockLists.rkey })
+      .from(schema.blockLists)
+      .where(
+        and(
+          eq(schema.blockLists.blockerDid, session.did),
+          eq(schema.blockLists.listUri, data.listUri),
+          eq(schema.blockLists.deleted, false),
+        ),
+      );
+
+    await deleteBskyListBlockRecords(
+      session.client,
+      session.did,
+      data.listUri,
+      rows.map((row) => row.rkey),
+    );
+    await syncReaderBlocks(session.did);
+    return { blocked: false };
+  });
+
+/** Force a block sweep now — the settings page's "refresh" affordance. */
+const refreshBlocks = createServerFn({ method: "POST" }).handler(async () => {
+  const reader = await getReaderContextForRequest(getRequest());
+  if (!reader) {
+    throw new Error("Unauthorized");
+  }
+  return syncReaderBlocks(reader.did);
+});
+
+function getBlocksSettingsQueryOptions({
+  limit = 50,
+  offset = 0,
+}: { limit?: number; offset?: number } = {}) {
+  return queryOptions({
+    queryKey: ["blocks", "settings", limit, offset] as const,
+    queryFn: async () => getBlocksSettings({ data: { limit, offset } }),
+    staleTime: 30_000,
+  });
+}
+
+function getBlockStateQueryOptions(did: string) {
+  return queryOptions({
+    queryKey: ["blocks", "state", did] as const,
+    queryFn: async () => getBlockState({ data: { did } }),
+    staleTime: 30_000,
+  });
+}
+
+export { NEEDS_BLOCK_SCOPE };
+
+export const blocksApi = {
+  getBlocksSettings,
+  getBlocksSettingsQueryOptions,
+  getBlockState,
+  getBlockStateQueryOptions,
+  blockAccount,
+  unblockAccount,
+  blockList,
+  unblockList,
+  refreshBlocks,
+};

--- a/apps/standard-reader/src/integrations/tanstack-query/api-blocks.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-blocks.functions.ts
@@ -25,8 +25,9 @@ import {
 } from "#/server/blocks/blocks";
 import {
   refreshOutgoingBlocks,
+  refreshOutgoingListBlocks,
+  scheduleReaderBlockSync,
   syncBlockedList,
-  syncReaderBlocks,
 } from "#/server/blocks/sync.server";
 import { observe } from "#/server/observability/log";
 
@@ -122,6 +123,82 @@ const getBlocksSettings = createServerFn({ method: "GET" })
           canWrite: hasBskyBlockWriteScope(account?.scope),
           syncedAt: syncRow?.syncedAt?.toISOString() ?? null,
           syncError: syncRow?.lastError ?? null,
+        };
+      },
+    ),
+  );
+
+/**
+ * A further page of the reader's blocked accounts.
+ *
+ * The settings page loads its first page with everything else, then pages
+ * through this. It exists because the list is genuinely unbounded — a reader who
+ * has used Bluesky's moderation tools for years can have hundreds of blocks —
+ * and a first page with no way past it silently disagrees with the count in the
+ * masthead right above it.
+ */
+const getBlockedAccountsPage = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware])
+  .validator(blockedAccountsInput)
+  .handler(
+    observe("blocks.getAccountsPage", async ({ data, context }, span) => {
+      const { db, schema } = context;
+      const reader = await getReaderContextForRequest(getRequest());
+      if (!reader) return { accounts: [], nextOffset: null };
+
+      const accounts = await readerBlockedAccounts(db, schema, reader.did, {
+        limit: data.limit,
+        offset: data.offset,
+      });
+      span.set("count", accounts.length);
+      return {
+        accounts,
+        nextOffset:
+          accounts.length === data.limit ? data.offset + data.limit : null,
+      };
+    }),
+  );
+
+/**
+ * The two facts every surface outside `/settings/blocks` actually wants.
+ *
+ * Separate from {@link BlocksSettings} because the notices only need to know
+ * whether an Unblock button would work, and the settings row only needs a
+ * headline number — asking the full settings query for that ran five reads
+ * (including a page of blocked accounts nobody rendered) under a cache key that
+ * never shared with the settings page's own.
+ */
+export interface BlockCapability {
+  /** Whether the reader has granted write access to their block records. */
+  canWrite: boolean;
+  /** How many accounts they block directly. */
+  accountCount: number;
+}
+
+const getBlockCapability = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware])
+  .handler(
+    observe(
+      "blocks.getCapability",
+      async ({ context }, span): Promise<BlockCapability | null> => {
+        const { db, schema } = context;
+        const reader = await getReaderContextForRequest(getRequest());
+        if (!reader) return null;
+
+        const [account, accountCount] = await Promise.all([
+          db.query.account.findFirst({
+            where: and(
+              eq(schema.account.userId, reader.userId),
+              eq(schema.account.providerId, "atproto"),
+            ),
+            columns: { scope: true },
+          }),
+          countReaderBlockedAccounts(db, schema, reader.did),
+        ]);
+        span.set("accounts", accountCount);
+        return {
+          canWrite: hasBskyBlockWriteScope(account?.scope),
+          accountCount,
         };
       },
     ),
@@ -248,12 +325,20 @@ const blockList = createServerFn({ method: "POST" })
       data.listUri,
       new Date().toISOString(),
     );
-    // Full sweep rather than the outgoing-blocks refresh: subscribing to a list
-    // is only meaningful once its membership is mirrored, and that is what the
-    // sweep does. Awaited so the block is in force when this returns.
-    await syncReaderBlocks(session.did);
-    await syncBlockedList(data.listUri);
-    return { blocked: true };
+
+    // Only the two things the reader is waiting on: their own listblock records
+    // (so the list appears in settings) and this list's membership (so the
+    // block is actually in force). Both are bounded.
+    //
+    // Not a full sweep. That walks the reader's repo, two Constellation
+    // indexes and every list they are on — hundreds of round trips with an 8s
+    // timeout each, held open on an HTTP request the reader is staring at, and
+    // it would re-walk *this* list a second time on top. It runs in the
+    // background instead, where its length costs nobody a spinner.
+    await refreshOutgoingListBlocks(session.did);
+    const mirrored = await syncBlockedList(data.listUri);
+    scheduleReaderBlockSync(session.did, true);
+    return { blocked: true, mirrored };
   });
 
 const unblockList = createServerFn({ method: "POST" })
@@ -282,17 +367,34 @@ const unblockList = createServerFn({ method: "POST" })
       data.listUri,
       rows.map((row) => row.rkey),
     );
-    await syncReaderBlocks(session.did);
+    // Same shape as blocking: re-read the reader's own records so the list is
+    // gone from settings on the next paint, and leave the rest to the sweep.
+    await refreshOutgoingListBlocks(session.did);
+    scheduleReaderBlockSync(session.did, true);
     return { blocked: false };
   });
 
-/** Force a block sweep now — the settings page's "refresh" affordance. */
+/**
+ * Force a block sweep now — the settings page's "Refresh" affordance.
+ *
+ * Starts the sweep and returns; it does not wait for it. A sweep is dozens to
+ * hundreds of network round trips against Constellation and the AppView, with
+ * no bound that a reader would recognise as "a moment" — awaiting it would hang
+ * the request, and since nothing rate-limits a button, awaiting it would also
+ * let one reader hold open as many concurrent sweeps as they can click.
+ * `scheduleReaderBlockSync` dedupes per reader, so the second press joins the
+ * first run rather than starting another.
+ *
+ * The page reflects progress through `syncedAt` on the settings query, which is
+ * the honest signal: it changes when the sweep has actually finished.
+ */
 const refreshBlocks = createServerFn({ method: "POST" }).handler(async () => {
   const reader = await getReaderContextForRequest(getRequest());
   if (!reader) {
     throw new Error("Unauthorized");
   }
-  return syncReaderBlocks(reader.did);
+  scheduleReaderBlockSync(reader.did, true);
+  return { started: true };
 });
 
 function getBlocksSettingsQueryOptions({
@@ -302,6 +404,14 @@ function getBlocksSettingsQueryOptions({
   return queryOptions({
     queryKey: ["blocks", "settings", limit, offset] as const,
     queryFn: async () => getBlocksSettings({ data: { limit, offset } }),
+    staleTime: 30_000,
+  });
+}
+
+function getBlockCapabilityQueryOptions() {
+  return queryOptions({
+    queryKey: ["blocks", "capability"] as const,
+    queryFn: async () => getBlockCapability(),
     staleTime: 30_000,
   });
 }
@@ -319,6 +429,9 @@ export { NEEDS_BLOCK_SCOPE };
 export const blocksApi = {
   getBlocksSettings,
   getBlocksSettingsQueryOptions,
+  getBlockedAccountsPage,
+  getBlockCapability,
+  getBlockCapabilityQueryOptions,
   getBlockState,
   getBlockStateQueryOptions,
   blockAccount,

--- a/apps/standard-reader/src/integrations/tanstack-query/api-comments.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-comments.functions.ts
@@ -3,6 +3,7 @@ import { createServerFn } from "@tanstack/react-start";
 import { getRequest } from "@tanstack/react-start/server";
 import { z } from "zod";
 
+import { getReaderDidForRequest } from "#/middleware/auth-session.server";
 import { observe } from "#/server/observability/log";
 import { attachReaderSpanContext } from "#/server/observability/span-context.ts";
 import { fetchDocumentComments } from "#/server/reader/document-comments";
@@ -25,10 +26,12 @@ const getDocumentComments = createServerFn({ method: "GET" })
     observe("comments.getDocumentComments", async ({ data, context }, span) => {
       span.set("documentUri", data.documentUri);
       await attachReaderSpanContext(span, getRequest());
+      const viewerDid = await getReaderDidForRequest(getRequest());
       const comments = await fetchDocumentComments(
         context.db,
         context.schema,
         data.documentUri,
+        viewerDid,
       );
       span.set("count", comments.length);
       return comments;

--- a/apps/standard-reader/src/integrations/tanstack-query/api-comments.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-comments.functions.ts
@@ -27,14 +27,15 @@ const getDocumentComments = createServerFn({ method: "GET" })
       span.set("documentUri", data.documentUri);
       await attachReaderSpanContext(span, getRequest());
       const viewerDid = await getReaderDidForRequest(getRequest());
-      const comments = await fetchDocumentComments(
+      const result = await fetchDocumentComments(
         context.db,
         context.schema,
         data.documentUri,
         viewerDid,
       );
-      span.set("count", comments.length);
-      return comments;
+      span.set("count", result.comments.length);
+      span.set("hiddenByBlocks", result.hiddenByBlocks);
+      return result;
     }),
   );
 

--- a/apps/standard-reader/src/integrations/tanstack-query/api-discover.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-discover.functions.ts
@@ -4,7 +4,7 @@ import { getRequest } from "@tanstack/react-start/server";
 import { z } from "zod";
 
 import { getAtprotoSessionForRequest } from "#/middleware/auth-session.server";
-import { filterBlockedCards } from "#/server/blocks/blocks";
+import { blockFilterDid, filterBlockedCards } from "#/server/blocks/blocks";
 import type { Span } from "#/server/observability/log";
 import { observe } from "#/server/observability/log";
 import { attachReaderSpanContext } from "#/server/observability/span-context.ts";
@@ -255,21 +255,12 @@ const getFriendPublishers = createServerFn({ method: "GET" })
       span.set("signedIn", true);
       span.set("offset", data.offset);
 
-      const raw = await friendPublishers(db, schema, did, {
+      // Blocks are applied inside `friendPublishers` so the counts and the
+      // avatar stack agree with the rows — see `resolveFriendPublications`.
+      const result = await friendPublishers(db, schema, did, {
         limit: data.limit,
         offset: data.offset,
       });
-      // Following someone on Bluesky and being blocked by them is not a
-      // contradiction — a block is one-sided, and the follow can predate it.
-      const result = {
-        ...raw,
-        publications: await filterBlockedCards(
-          db,
-          schema,
-          did,
-          raw.publications,
-        ),
-      };
       span.set("people", result.totalPeople);
       span.set("publications", result.publicationCount);
       span.set("degraded", result.degraded);
@@ -310,11 +301,13 @@ const getFriendArticles = createServerFn({ method: "GET" })
         followSets.userDids,
         result.items,
       );
-      const items = await filterBlockedCards(
+      // `friendArticles` draws from the same block-filtered publication set, so
+      // the rows are already clear of blocked owners.
+      const items = await attachViewerRecommendedToArticles(
         db,
         schema,
         did,
-        await attachViewerRecommendedToArticles(db, schema, did, withRecs),
+        withRecs,
       );
       span.set("count", items.length);
       span.set("degraded", result.degraded);
@@ -337,14 +330,10 @@ const getFriendPeople = createServerFn({ method: "GET" })
       span.set("signedIn", true);
       span.set("offset", data.offset);
 
-      const raw = await friendPeople(db, schema, did, {
+      const result = await friendPeople(db, schema, did, {
         limit: data.limit,
         offset: data.offset,
       });
-      const result = {
-        ...raw,
-        people: await filterBlockedCards(db, schema, did, raw.people),
-      };
       span.set("people", result.personCount);
       span.set("publications", result.publicationCount);
       span.set("degraded", result.degraded);
@@ -387,7 +376,7 @@ const getPublications = createServerFn({ method: "GET" })
       const session = await getAtprotoSessionForRequest(getRequest());
       const items = await discoverDirectoryPublications(db, schema, {
         topic: data.topic ?? null,
-        viewerDid: session?.did,
+        viewerDid: await blockFilterDid(db, schema, session?.did),
         // The topic chips now surface the full document-tag vocabulary, so a
         // selected chip must match any document tag — not only a publication's
         // single effective topic — or tags past the dominant one return empty.
@@ -610,7 +599,7 @@ const getOnboardingSuggestions = createServerFn({ method: "GET" })
                 limit: 8,
                 offset: 0,
                 excludeWebBridge,
-                viewerDid: did ?? undefined,
+                viewerDid: await blockFilterDid(db, schema, did),
               }),
             })),
           ),

--- a/apps/standard-reader/src/integrations/tanstack-query/api-discover.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-discover.functions.ts
@@ -4,6 +4,7 @@ import { getRequest } from "@tanstack/react-start/server";
 import { z } from "zod";
 
 import { getAtprotoSessionForRequest } from "#/middleware/auth-session.server";
+import { filterBlockedCards } from "#/server/blocks/blocks";
 import type { Span } from "#/server/observability/log";
 import { observe } from "#/server/observability/log";
 import { attachReaderSpanContext } from "#/server/observability/span-context.ts";
@@ -134,7 +135,8 @@ async function loadRecommendedRail(
           followUris,
           seed: rotationSeed("discover", did),
         });
-  return items.filter((pub) => pub.documentCount > 0);
+  const visible = await filterBlockedCards(db, schema, did, items);
+  return visible.filter((pub) => pub.documentCount > 0);
 }
 
 async function loadDiscoverExtras(
@@ -175,7 +177,7 @@ async function loadDiscoverExtras(
           excludeWebBridge,
           followUris,
           seed: rotationSeed("discover-followed-by", did),
-        })
+        }).then((rows) => filterBlockedCards(db, schema, did, rows))
       : Promise.resolve([]),
   ]);
 
@@ -253,10 +255,21 @@ const getFriendPublishers = createServerFn({ method: "GET" })
       span.set("signedIn", true);
       span.set("offset", data.offset);
 
-      const result = await friendPublishers(db, schema, did, {
+      const raw = await friendPublishers(db, schema, did, {
         limit: data.limit,
         offset: data.offset,
       });
+      // Following someone on Bluesky and being blocked by them is not a
+      // contradiction — a block is one-sided, and the follow can predate it.
+      const result = {
+        ...raw,
+        publications: await filterBlockedCards(
+          db,
+          schema,
+          did,
+          raw.publications,
+        ),
+      };
       span.set("people", result.totalPeople);
       span.set("publications", result.publicationCount);
       span.set("degraded", result.degraded);
@@ -297,11 +310,11 @@ const getFriendArticles = createServerFn({ method: "GET" })
         followSets.userDids,
         result.items,
       );
-      const items = await attachViewerRecommendedToArticles(
+      const items = await filterBlockedCards(
         db,
         schema,
         did,
-        withRecs,
+        await attachViewerRecommendedToArticles(db, schema, did, withRecs),
       );
       span.set("count", items.length);
       span.set("degraded", result.degraded);
@@ -324,10 +337,14 @@ const getFriendPeople = createServerFn({ method: "GET" })
       span.set("signedIn", true);
       span.set("offset", data.offset);
 
-      const result = await friendPeople(db, schema, did, {
+      const raw = await friendPeople(db, schema, did, {
         limit: data.limit,
         offset: data.offset,
       });
+      const result = {
+        ...raw,
+        people: await filterBlockedCards(db, schema, did, raw.people),
+      };
       span.set("people", result.personCount);
       span.set("publications", result.publicationCount);
       span.set("degraded", result.degraded);
@@ -367,8 +384,10 @@ const getPublications = createServerFn({ method: "GET" })
       span.set("offset", data.offset);
       span.set("q", data.q ?? null);
 
+      const session = await getAtprotoSessionForRequest(getRequest());
       const items = await discoverDirectoryPublications(db, schema, {
         topic: data.topic ?? null,
+        viewerDid: session?.did,
         // The topic chips now surface the full document-tag vocabulary, so a
         // selected chip must match any document tag — not only a publication's
         // single effective topic — or tags past the dominant one return empty.
@@ -397,9 +416,15 @@ const getTrendingPublications = createServerFn({ method: "GET" })
       "discover.getTrendingPublications",
       async ({ data, context }, span) => {
         const { db, schema } = context;
-        const items = await trendingPublications(db, schema, data.limit, {
-          excludeWebBridge: context.excludeWebBridgeEnabled,
-        });
+        const session = await getAtprotoSessionForRequest(getRequest());
+        const items = await filterBlockedCards(
+          db,
+          schema,
+          session?.did,
+          await trendingPublications(db, schema, data.limit, {
+            excludeWebBridge: context.excludeWebBridgeEnabled,
+          }),
+        );
         span.set("count", items.length);
         return items;
       },
@@ -450,8 +475,14 @@ const getRecommendedPublications = createServerFn({ method: "GET" })
             seed: rotationSeed("discover", session.did),
           },
         );
-        span.set("count", items.length);
-        return items.filter((pub) => pub.documentCount > 0);
+        const visible = await filterBlockedCards(
+          db,
+          schema,
+          session.did,
+          items,
+        );
+        span.set("count", visible.length);
+        return visible.filter((pub) => pub.documentCount > 0);
       },
     ),
   );
@@ -567,7 +598,9 @@ const getOnboardingSuggestions = createServerFn({ method: "GET" })
           : [];
 
         const [trending, topicGroups] = await Promise.all([
-          trendingPublications(db, schema, 6, { excludeWebBridge }),
+          trendingPublications(db, schema, 6, { excludeWebBridge }).then(
+            (rows) => filterBlockedCards(db, schema, did, rows),
+          ),
           Promise.all(
             topics.map(async (topic) => ({
               topic,
@@ -577,19 +610,25 @@ const getOnboardingSuggestions = createServerFn({ method: "GET" })
                 limit: 8,
                 offset: 0,
                 excludeWebBridge,
+                viewerDid: did ?? undefined,
               }),
             })),
           ),
         ]);
 
         const trendingUris = trending.map((pub) => pub.uri);
-        const popular = await popularPublications(
+        const popular = await filterBlockedCards(
           db,
           schema,
-          data.limit,
-          [...new Set([...followUris, ...trendingUris])],
-          rotationSeed("onboarding", did ?? "anon"),
-          { excludeWebBridge },
+          did,
+          await popularPublications(
+            db,
+            schema,
+            data.limit,
+            [...new Set([...followUris, ...trendingUris])],
+            rotationSeed("onboarding", did ?? "anon"),
+            { excludeWebBridge },
+          ),
         );
 
         const sections = buildOnboardingSections({
@@ -664,8 +703,14 @@ const getFollowedByPeopleYouFollow = createServerFn({ method: "GET" })
             seed: rotationSeed("discover-followed-by", session.did),
           },
         );
-        span.set("count", items.length);
-        return items;
+        const visible = await filterBlockedCards(
+          db,
+          schema,
+          session.did,
+          items,
+        );
+        span.set("count", visible.length);
+        return visible;
       },
     ),
   );

--- a/apps/standard-reader/src/integrations/tanstack-query/api-feed.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-feed.functions.ts
@@ -14,6 +14,7 @@ import {
   dbValueToTrackReadingHistory,
 } from "#/lib/track-reading-history";
 import { getReaderContextForRequest } from "#/middleware/auth-session.server";
+import { filterBlockedCards } from "#/server/blocks/blocks";
 import {
   attachLabelsFromMap,
   attachSubscribedLabels,
@@ -295,9 +296,14 @@ async function resolveHomeFeedContext(
         publicationUris: followUris,
         followedUserDids,
         countOldPostsAsUnread,
+        ...(did ? { viewerDid: did } : {}),
         ...(trackReading && did ? { readForDid: did, unreadForDid: did } : {}),
       }
-    : { discoverOnly: true, excludeWebBridge };
+    : {
+        discoverOnly: true,
+        excludeWebBridge,
+        ...(did ? { viewerDid: did } : {}),
+      };
 
   return {
     did,
@@ -327,15 +333,25 @@ async function buildHomeFeedCritical(
   // The publications rail (sidebar) is fetched alongside so both ship in the
   // critical payload.
   if (isTrending) {
-    const [trendingPubs, trendingRaw] = await Promise.all([
+    const [trendingPubsRaw, trendingRaw] = await Promise.all([
       trendingPublications(db, schema, HOME_RAIL_LIMIT, {
         excludeWebBridge: ctx.excludeWebBridge,
       }),
       trendingArticles(db, schema, HOME_TRENDING_ROW_LIMIT + 1, {
         readForDid: trackReading && ctx.did ? ctx.did : undefined,
         excludeWebBridge: ctx.excludeWebBridge,
+        viewerDid: ctx.did ?? undefined,
       }),
     ]);
+    // Publication rails aren't paginated, so blocked owners are dropped from
+    // the page rather than excluded in SQL — a shorter rail is fine where a
+    // shorter *feed* page would strand results behind the offset.
+    const trendingPubs = await filterBlockedCards(
+      db,
+      schema,
+      ctx.did,
+      trendingPubsRaw,
+    );
     span.set("trendingPublications", trendingPubs.length);
 
     const trendingFiltered = await filterHiddenDocuments(
@@ -380,7 +396,7 @@ async function buildHomeFeedCritical(
 
   // Trending publications rail (sidebar). Cheap indexed top-N, fetched
   // alongside the main rows so it's part of the critical payload.
-  const [trendingPubs, featuredLead, rows] = await Promise.all([
+  const [trendingPubsRaw, featuredLead, rows] = await Promise.all([
     trendingPublications(db, schema, HOME_RAIL_LIMIT, {
       excludeWebBridge: ctx.excludeWebBridge,
     }),
@@ -394,6 +410,12 @@ async function buildHomeFeedCritical(
       limit: HOME_ROW_LIMIT + 1,
     }),
   ]);
+  const trendingPubs = await filterBlockedCards(
+    db,
+    schema,
+    ctx.did,
+    trendingPubsRaw,
+  );
   span.set("trendingPublications", trendingPubs.length);
 
   let featured: ArticleCard | null = featuredLead[0] ?? rows[0] ?? null;
@@ -488,7 +510,7 @@ async function buildHomeFeedExtras(
     { excludeWebBridge },
   );
 
-  const youMightFollow =
+  const youMightFollowRaw =
     personalized && did
       ? await recommendedPublications(db, schema, did, HOME_RAIL_LIMIT, {
           excludeUris: trendingPubUris,
@@ -504,6 +526,14 @@ async function buildHomeFeedExtras(
           rotationSeed("home", did ?? "anon"),
           { excludeWebBridge },
         );
+  // Never recommend a publication whose owner the reader is blocked from —
+  // "you might follow" is the one rail where that would read as an endorsement.
+  const youMightFollow = await filterBlockedCards(
+    db,
+    schema,
+    did,
+    youMightFollowRaw,
+  );
 
   span.set("youMightFollow", youMightFollow.length);
 
@@ -695,6 +725,7 @@ async function loadLatestFeedCritical(
             readForDid: trackReading && did ? did : undefined,
             scope: "page",
             excludeWebBridge,
+            viewerDid: did ?? undefined,
           })
         : []
       : await selectArticleCards(db, schema, {
@@ -708,6 +739,7 @@ async function loadLatestFeedCritical(
               }),
           readForDid: trackReading && did ? did : undefined,
           countOldPostsAsUnread,
+          viewerDid: did ?? undefined,
           limit: data.limit,
           offset: data.offset,
         });

--- a/apps/standard-reader/src/integrations/tanstack-query/api-feed.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-feed.functions.ts
@@ -14,7 +14,7 @@ import {
   dbValueToTrackReadingHistory,
 } from "#/lib/track-reading-history";
 import { getReaderContextForRequest } from "#/middleware/auth-session.server";
-import { filterBlockedCards } from "#/server/blocks/blocks";
+import { blockFilterDid, filterBlockedCards } from "#/server/blocks/blocks";
 import {
   attachLabelsFromMap,
   attachSubscribedLabels,
@@ -280,9 +280,15 @@ async function resolveHomeFeedContext(
     : true;
   const excludeWebBridge = did ? (excludeWebBridgeEnabled ?? false) : false;
 
-  const { publicationUris: followUris, userDids: followedUserDids } = did
-    ? await effectiveFollowSets(db, schema, did)
-    : { publicationUris: [], userDids: [] };
+  const [
+    { publicationUris: followUris, userDids: followedUserDids },
+    blockDid,
+  ] = await Promise.all([
+    did
+      ? effectiveFollowSets(db, schema, did)
+      : Promise.resolve({ publicationUris: [], userDids: [] }),
+    blockFilterDid(db, schema, did),
+  ]);
   const hasFollows = followUris.length > 0 || followedUserDids.length > 0;
   const isTrending = scope === "trending";
   const personalized = hasFollows && scope === "follows";
@@ -296,17 +302,18 @@ async function resolveHomeFeedContext(
         publicationUris: followUris,
         followedUserDids,
         countOldPostsAsUnread,
-        ...(did ? { viewerDid: did } : {}),
+        ...(blockDid ? { viewerDid: blockDid } : {}),
         ...(trackReading && did ? { readForDid: did, unreadForDid: did } : {}),
       }
     : {
         discoverOnly: true,
         excludeWebBridge,
-        ...(did ? { viewerDid: did } : {}),
+        ...(blockDid ? { viewerDid: blockDid } : {}),
       };
 
   return {
     did,
+    blockDid,
     followUris,
     followedUserDids,
     trackReading,
@@ -340,7 +347,7 @@ async function buildHomeFeedCritical(
       trendingArticles(db, schema, HOME_TRENDING_ROW_LIMIT + 1, {
         readForDid: trackReading && ctx.did ? ctx.did : undefined,
         excludeWebBridge: ctx.excludeWebBridge,
-        viewerDid: ctx.did ?? undefined,
+        viewerDid: ctx.blockDid,
       }),
     ]);
     // Publication rails aren't paginated, so blocked owners are dropped from
@@ -702,9 +709,15 @@ async function loadLatestFeedCritical(
   span.set("filter", data.filter);
   span.set("offset", data.offset);
 
-  const { publicationUris: followUris, userDids: followedUserDids } = did
-    ? await effectiveFollowSets(db, schema, did)
-    : { publicationUris: [], userDids: [] };
+  const [
+    { publicationUris: followUris, userDids: followedUserDids },
+    blockDid,
+  ] = await Promise.all([
+    did
+      ? effectiveFollowSets(db, schema, did)
+      : Promise.resolve({ publicationUris: [], userDids: [] }),
+    blockFilterDid(db, schema, did),
+  ]);
   span.set("follows", followUris.length);
   span.set("followedUsers", followedUserDids.length);
   const trackReading = did == null ? false : trackReadingEnabled;
@@ -725,7 +738,7 @@ async function loadLatestFeedCritical(
             readForDid: trackReading && did ? did : undefined,
             scope: "page",
             excludeWebBridge,
-            viewerDid: did ?? undefined,
+            viewerDid: blockDid,
           })
         : []
       : await selectArticleCards(db, schema, {
@@ -739,7 +752,7 @@ async function loadLatestFeedCritical(
               }),
           readForDid: trackReading && did ? did : undefined,
           countOldPostsAsUnread,
-          viewerDid: did ?? undefined,
+          viewerDid: blockDid,
           limit: data.limit,
           offset: data.offset,
         });

--- a/apps/standard-reader/src/integrations/tanstack-query/api-labelers.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-labelers.functions.ts
@@ -18,6 +18,7 @@ import {
   subjectRkey,
 } from "#/server/atproto/repo-records";
 import { Collections, buildAtUri } from "#/server/atproto/uri";
+import { blockFilterDid } from "#/server/blocks/blocks";
 import {
   deleteRecord,
   upsertLabelerSubscription,
@@ -763,7 +764,14 @@ const getLabeledDocuments = createServerFn({ method: "GET" })
         context.db,
         context.schema,
         uris,
-        { lite: true, viewerDid: viewerSession?.did },
+        {
+          lite: true,
+          viewerDid: await blockFilterDid(
+            context.db,
+            context.schema,
+            viewerSession?.did,
+          ),
+        },
       );
       span.set("count", documents.length);
       span.set("total", total);

--- a/apps/standard-reader/src/integrations/tanstack-query/api-labelers.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-labelers.functions.ts
@@ -758,11 +758,12 @@ const getLabeledDocuments = createServerFn({ method: "GET" })
         labelsByUri[row.uri] = vals;
       }
 
+      const viewerSession = await getAtprotoSessionForRequest(getRequest());
       const documents = await selectArticleCardsByUris(
         context.db,
         context.schema,
         uris,
-        { lite: true },
+        { lite: true, viewerDid: viewerSession?.did },
       );
       span.set("count", documents.length);
       span.set("total", total);

--- a/apps/standard-reader/src/integrations/tanstack-query/api-lists.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-lists.functions.ts
@@ -19,6 +19,7 @@ import {
   subjectRkey,
 } from "#/server/atproto/repo-records";
 import { Collections, buildAtUri } from "#/server/atproto/uri";
+import { blockFilterDid } from "#/server/blocks/blocks";
 import {
   deleteRecord,
   upsertList,
@@ -578,7 +579,7 @@ const getListFeed = createServerFn({ method: "GET" })
         readForDid: trackReading ? session?.did : undefined,
         unreadForDid,
         countOldPostsAsUnread,
-        viewerDid: session?.did,
+        viewerDid: await blockFilterDid(db, schema, session?.did),
         limit: data.limit,
         offset: data.offset,
       });

--- a/apps/standard-reader/src/integrations/tanstack-query/api-lists.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-lists.functions.ts
@@ -578,6 +578,7 @@ const getListFeed = createServerFn({ method: "GET" })
         readForDid: trackReading ? session?.did : undefined,
         unreadForDid,
         countOldPostsAsUnread,
+        viewerDid: session?.did,
         limit: data.limit,
         offset: data.offset,
       });

--- a/apps/standard-reader/src/integrations/tanstack-query/api-publication.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-publication.functions.ts
@@ -1422,13 +1422,23 @@ const getArticleBlock = createServerFn({ method: "GET" })
           .where(eq(pr.did, block.did))
           .limit(1);
 
+        if (profile?.handle || profile?.displayName || profile?.avatarUrl) {
+          return { block, account: profile };
+        }
+
+        // Same reason as `readerBlockedAccounts`: the blocked account is
+        // usually not one we index, so the notice would name a `did:plc:…`.
+        const { fetchBlueskyPublicProfileFields } =
+          await import("#/lib/bluesky-public-profile");
+        const publicProfile = await fetchBlueskyPublicProfileFields(block.did);
         return {
           block,
-          account: profile ?? {
+          account: {
             did: block.did,
-            handle: null,
-            displayName: null,
-            avatarUrl: null,
+            handle: profile?.handle ?? publicProfile?.handle ?? null,
+            displayName:
+              profile?.displayName ?? publicProfile?.displayName ?? null,
+            avatarUrl: profile?.avatarUrl ?? publicProfile?.avatarUrl ?? null,
           },
         };
       },

--- a/apps/standard-reader/src/integrations/tanstack-query/api-publication.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-publication.functions.ts
@@ -28,8 +28,10 @@ import {
 import { cdnImageUrl } from "#/server/atproto/blob";
 import {
   blockEdgeFor,
+  blockFilterDid,
   filterBlockedCards,
   firstBlockAmong,
+  readerHasBlocks,
 } from "#/server/blocks/blocks";
 import { buildCanonicalUrl } from "#/server/ingest/mappers";
 import { readAccountLabels } from "#/server/labeler/labels.server";
@@ -331,22 +333,49 @@ export interface ArticleExtras {
   marginConnections: Array<MarginConnectionItem>;
 }
 
+/**
+ * The publication header, plus whether the viewer is blocked from its owner.
+ *
+ * `block` rides on the header rather than being a second client query on
+ * purpose. Every surface that renders a publication — the profile route, mention
+ * hovercards, inline publication chips — reads this one query, so a block
+ * resolved anywhere else would have to be resolved *after* first paint, and the
+ * blocked account's name and avatar would render for a frame before being
+ * withheld. Here the caller never has an unblocked version to paint.
+ */
+export type PublicationHeaderView = PublicationHeader & {
+  block: BlockEdge | null;
+};
+
 const getPublicationHeader = createServerFn({ method: "GET" })
   .middleware([dbMiddleware])
   .validator(headerInput)
   .handler(
     observe(
       "publication.getHeader",
-      async ({ data, context }, span): Promise<PublicationHeader | null> => {
+      async (
+        { data, context },
+        span,
+      ): Promise<PublicationHeaderView | null> => {
         const { db, schema } = context;
         span.set("publicationUri", data.publicationUri);
-        const header = await selectPublicationHeader(
-          db,
-          schema,
-          data.publicationUri,
-        );
+        // The publication URI's authority *is* its owner's DID, so the block
+        // check needs no lookup of its own and runs alongside the header rather
+        // than ahead of it — a reader who blocks nobody pays one cached
+        // `EXISTS` here, concurrent with the read they were making anyway.
+        const ownerDid = uriAuthorityDid(data.publicationUri);
+        const resolveBlock = async () => {
+          if (!ownerDid) return null;
+          const viewerDid = await getReaderDidForRequest(getRequest());
+          return blockEdgeFor(db, schema, viewerDid, ownerDid);
+        };
+        const [header, block] = await Promise.all([
+          selectPublicationHeader(db, schema, data.publicationUri),
+          resolveBlock(),
+        ]);
         span.set("found", header != null);
-        return header;
+        if (block) span.set("blocked", block.direction);
+        return header ? { ...header, block } : null;
       },
     ),
   );
@@ -372,23 +401,28 @@ const getPublicationProfile = createServerFn({ method: "GET" })
           did == null ? true : countOldPostsAsUnreadEnabled;
 
         // The publication URI's authority *is* its owner's DID, so the block
-        // check needs no extra lookup and can run before the archive read.
+        // check needs no lookup of its own. It runs *alongside* the header and
+        // archive reads rather than gating them: a blocked owner is the rare
+        // case, and serializing a round trip ahead of every load to catch it
+        // would put the cost on everyone. The archive is discarded below when
+        // the block resolves, which is cheaper than the extra hop.
+        // Resolved first because everything below reuses its cached answer: for
+        // the reader who blocks nobody this is one indexed `EXISTS` per minute,
+        // and it makes `blockEdgeFor` free rather than a second round trip.
         const ownerDid = uriAuthorityDid(data.publicationUri);
-        const block = ownerDid
-          ? await blockEdgeFor(db, schema, did, ownerDid)
-          : null;
-
-        const [header, recentDocuments] = await Promise.all([
+        const blockDid = await blockFilterDid(db, schema, did);
+        const [header, recentDocuments, block] = await Promise.all([
           selectPublicationHeader(db, schema, data.publicationUri),
-          block
-            ? Promise.resolve([])
-            : selectPublicationArticleCards(db, schema, {
-                publicationUri: data.publicationUri,
-                limit: data.recentLimit,
-                readForDid,
-                countOldPostsAsUnread,
-                viewerDid: did ?? undefined,
-              }),
+          selectPublicationArticleCards(db, schema, {
+            publicationUri: data.publicationUri,
+            limit: data.recentLimit,
+            readForDid,
+            countOldPostsAsUnread,
+            viewerDid: blockDid,
+          }),
+          ownerDid && blockDid
+            ? blockEdgeFor(db, schema, did, ownerDid)
+            : Promise.resolve(null),
         ]);
 
         if (!header) {
@@ -469,9 +503,14 @@ const getPublicationDocuments = createServerFn({ method: "GET" })
         span.set("order", order);
         span.set("orderOverridden", orderOverride != null);
 
+        // See `getPublicationProfile`: one cached `EXISTS` gates both the
+        // owner-level check and the guest-post filter, so a reader with no
+        // blocks adds no round trip to the archive.
         const archiveOwnerDid = uriAuthorityDid(data.publicationUri);
+        const blockDid = await blockFilterDid(db, schema, did);
         if (
           archiveOwnerDid &&
+          blockDid &&
           (await blockEdgeFor(db, schema, did, archiveOwnerDid))
         ) {
           span.set("blocked", true);
@@ -492,7 +531,7 @@ const getPublicationDocuments = createServerFn({ method: "GET" })
           filter,
           readerDid: did ?? undefined,
           order,
-          viewerDid: did ?? undefined,
+          viewerDid: blockDid,
         });
 
         // "Recommended by @follow" attribution — same signal, same batched query
@@ -648,7 +687,15 @@ const getArticle = createServerFn({ method: "GET" })
             // `manager.resume()` network round trip on every article view.
             // The full PDS client is restored below only in the rare case
             // where the signed-in reader owns this collection document.
-            getReaderContextForRequest(getRequest()),
+            //
+            // The block check below needs `row.did`, so it can't join this
+            // wave — but its guard doesn't, so warm it here. That turns
+            // "does this reader block anyone" from a round trip on the article
+            // critical path into one that overlaps the document read.
+            getReaderContextForRequest(getRequest()).then(async (viewer) => {
+              if (viewer?.did) await readerHasBlocks(db, schema, viewer.did);
+              return viewer;
+            }),
           ]);
 
         const row = docRows[0];
@@ -894,6 +941,7 @@ const getArticleExtras = createServerFn({ method: "GET" })
         const linkUrls = canonicalUrl ? [canonicalUrl] : [];
 
         const readerDid = await getReaderDidForRequest(getRequest());
+        const blockDid = await blockFilterDid(db, schema, readerDid);
 
         const [
           moreFromRaw,
@@ -906,7 +954,7 @@ const getArticleExtras = createServerFn({ method: "GET" })
             ? selectArticleCards(db, schema, {
                 publicationUris: [row.publicationUri],
                 limit: 4,
-                viewerDid: readerDid ?? undefined,
+                viewerDid: blockDid,
               })
             : Promise.resolve([]),
           relatedArticles(db, schema, {
@@ -996,7 +1044,10 @@ const getArticleCard = createServerFn({ method: "GET" })
           db,
           schema,
           [data.documentUri],
-          { lite: true, viewerDid: viewerDid ?? undefined },
+          {
+            lite: true,
+            viewerDid: await blockFilterDid(db, schema, viewerDid),
+          },
         );
         span.set("found", card != null);
         return card ?? null;

--- a/apps/standard-reader/src/integrations/tanstack-query/api-publication.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-publication.functions.ts
@@ -6,6 +6,8 @@ import { alias } from "drizzle-orm/pg-core";
 import { z } from "zod";
 
 import { publicationLinkParams } from "#/components/reader/format";
+import type { BlockEdge } from "#/lib/blocks";
+import { uriAuthorityDid } from "#/lib/blocks";
 import type { CollectionManifest } from "#/lib/collections/manifest";
 import type { CollectionTheme } from "#/lib/collections/theme";
 import type { InlineMentionRefs } from "#/lib/leaflet/publication-mentions";
@@ -24,6 +26,11 @@ import {
   getReaderDidForRequest,
 } from "#/middleware/auth-session.server";
 import { cdnImageUrl } from "#/server/atproto/blob";
+import {
+  blockEdgeFor,
+  filterBlockedCards,
+  firstBlockAmong,
+} from "#/server/blocks/blocks";
 import { buildCanonicalUrl } from "#/server/ingest/mappers";
 import { readAccountLabels } from "#/server/labeler/labels.server";
 import { observe } from "#/server/observability/log";
@@ -198,6 +205,12 @@ export type { PublicationDocumentFilter } from "#/server/reader/queries";
 export interface PublicationProfile {
   publication: PublicationCard;
   owner: ProfileSummary;
+  /**
+   * Set when the viewer and this publication's owner are blocked from each
+   * other. The header still resolves so the page can explain itself, but
+   * `recentDocuments` comes back empty — see the note on `AuthorProfile.block`.
+   */
+  block: BlockEdge | null;
   recentDocuments: Array<ArticleCard>;
   /**
    * Labels on the **account** that owns this publication, from the viewer's
@@ -358,14 +371,24 @@ const getPublicationProfile = createServerFn({ method: "GET" })
         const countOldPostsAsUnread =
           did == null ? true : countOldPostsAsUnreadEnabled;
 
+        // The publication URI's authority *is* its owner's DID, so the block
+        // check needs no extra lookup and can run before the archive read.
+        const ownerDid = uriAuthorityDid(data.publicationUri);
+        const block = ownerDid
+          ? await blockEdgeFor(db, schema, did, ownerDid)
+          : null;
+
         const [header, recentDocuments] = await Promise.all([
           selectPublicationHeader(db, schema, data.publicationUri),
-          selectPublicationArticleCards(db, schema, {
-            publicationUri: data.publicationUri,
-            limit: data.recentLimit,
-            readForDid,
-            countOldPostsAsUnread,
-          }),
+          block
+            ? Promise.resolve([])
+            : selectPublicationArticleCards(db, schema, {
+                publicationUri: data.publicationUri,
+                limit: data.recentLimit,
+                readForDid,
+                countOldPostsAsUnread,
+                viewerDid: did ?? undefined,
+              }),
         ]);
 
         if (!header) {
@@ -373,6 +396,10 @@ const getPublicationProfile = createServerFn({ method: "GET" })
           return null;
         }
         span.set("found", true);
+        if (block) {
+          span.set("blocked", block.direction);
+          return { ...header, block, recentDocuments: [], labels: [] };
+        }
 
         const [recentWithComments, accountLabels] = await Promise.all([
           attachCommentCountsToArticles(db, schema, recentDocuments),
@@ -386,6 +413,7 @@ const getPublicationProfile = createServerFn({ method: "GET" })
         // viewer-scoped `getAccountLabels` query instead.
         return {
           ...header,
+          block: null,
           recentDocuments: recentWithComments,
           labels: accountLabels.get(header.publication.did) ?? [],
         };
@@ -441,6 +469,20 @@ const getPublicationDocuments = createServerFn({ method: "GET" })
         span.set("order", order);
         span.set("orderOverridden", orderOverride != null);
 
+        const archiveOwnerDid = uriAuthorityDid(data.publicationUri);
+        if (
+          archiveOwnerDid &&
+          (await blockEdgeFor(db, schema, did, archiveOwnerDid))
+        ) {
+          span.set("blocked", true);
+          return {
+            items: [],
+            nextOffset: null,
+            order,
+            orderOverridden: orderOverride != null,
+          };
+        }
+
         const documents = await selectPublicationArticleCards(db, schema, {
           publicationUri: data.publicationUri,
           limit: data.limit,
@@ -450,6 +492,7 @@ const getPublicationDocuments = createServerFn({ method: "GET" })
           filter,
           readerDid: did ?? undefined,
           order,
+          viewerDid: did ?? undefined,
         });
 
         // "Recommended by @follow" attribution — same signal, same batched query
@@ -614,6 +657,20 @@ const getArticle = createServerFn({ method: "GET" })
           return null;
         }
         span.set("found", true);
+
+        // A blocked article is withheld outright rather than returned with its
+        // body stripped: nothing about it — title, excerpt, cover, byline —
+        // should reach the viewer. The page explains itself through
+        // `getArticleBlock`, which the not-found state asks for, so the common
+        // path pays nothing for the rare one.
+        const articleBlock = await firstBlockAmong(db, schema, reader?.did, [
+          row.did,
+          row.pubDid,
+        ]);
+        if (articleBlock) {
+          span.set("blocked", articleBlock.direction);
+          return null;
+        }
 
         const sourceRow = row as ArticleDetailSourceRow;
         const contributors: Array<ArticleContributor> = contributorRows.map(
@@ -849,6 +906,7 @@ const getArticleExtras = createServerFn({ method: "GET" })
             ? selectArticleCards(db, schema, {
                 publicationUris: [row.publicationUri],
                 limit: 4,
+                viewerDid: readerDid ?? undefined,
               })
             : Promise.resolve([]),
           relatedArticles(db, schema, {
@@ -856,18 +914,18 @@ const getArticleExtras = createServerFn({ method: "GET" })
             publicationUri: row.publicationUri,
             limit: data.relatedLimit,
             excludeWebBridge: excludeWebBridgeEnabled,
-          }),
+          }).then((rows) => filterBlockedCards(db, schema, readerDid, rows)),
           articleRecommendedPublications(db, schema, {
             publicationUri: row.publicationUri,
             readerDid,
             limit: data.alsoFollowLimit,
-          }),
+          }).then((rows) => filterBlockedCards(db, schema, readerDid, rows)),
           linkUrls.length > 0
             ? fetchCitedInArticles(db, schema, {
                 urls: linkUrls,
                 excludeDocumentUri: row.uri,
                 limit: 3,
-              })
+              }).then((rows) => filterBlockedCards(db, schema, readerDid, rows))
             : Promise.resolve([]),
           linkUrls.length > 0
             ? fetchMarginConnections(db, schema, {
@@ -933,11 +991,12 @@ const getArticleCard = createServerFn({ method: "GET" })
       async ({ data, context }, span): Promise<ArticleCard | null> => {
         const { db, schema } = context;
         span.set("documentUri", data.documentUri);
+        const viewerDid = await getReaderDidForRequest(getRequest());
         const [card] = await selectArticleCardsByUris(
           db,
           schema,
           [data.documentUri],
-          { lite: true },
+          { lite: true, viewerDid: viewerDid ?? undefined },
         );
         span.set("found", card != null);
         return card ?? null;
@@ -1255,6 +1314,84 @@ function getPublicationDocumentsQueryOptions(
   });
 }
 
+/** Why an article isn't rendering, when the reason is a block. */
+export interface ArticleBlockState {
+  block: BlockEdge;
+  /** The blocked account, so the notice can name somebody rather than a DID. */
+  account: Pick<ProfileSummary, "did" | "handle" | "displayName" | "avatarUrl">;
+}
+
+/**
+ * The block withholding an article, if that is why it didn't render.
+ *
+ * Asked for only by the article page's empty state, so a page that resolves
+ * normally never pays for it. `getArticle` deliberately returns `null` for a
+ * blocked document rather than a stripped-down one — nothing about it should
+ * cross the wire — which is why the explanation is a second, opt-in read.
+ */
+const getArticleBlock = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware])
+  .validator(articleInput)
+  .handler(
+    observe(
+      "publication.getArticleBlock",
+      async ({ data, context }, span): Promise<ArticleBlockState | null> => {
+        const { db, schema } = context;
+        const d = schema.documents;
+        const p = schema.publications;
+        const pr = schema.profiles;
+        span.set("documentUri", data.documentUri);
+
+        const viewerDid = await getReaderDidForRequest(getRequest());
+        if (!viewerDid) return null;
+
+        const [row] = await db
+          .select({ did: d.did, pubDid: p.did })
+          .from(d)
+          .leftJoin(p, eq(p.uri, d.publicationUri))
+          .where(eq(d.uri, data.documentUri))
+          .limit(1);
+        if (!row) return null;
+
+        const block = await firstBlockAmong(db, schema, viewerDid, [
+          row.did,
+          row.pubDid,
+        ]);
+        if (!block) return null;
+        span.set("blocked", block.direction);
+
+        const [profile] = await db
+          .select({
+            did: pr.did,
+            handle: pr.handle,
+            displayName: pr.displayName,
+            avatarUrl: pr.avatarUrl,
+          })
+          .from(pr)
+          .where(eq(pr.did, block.did))
+          .limit(1);
+
+        return {
+          block,
+          account: profile ?? {
+            did: block.did,
+            handle: null,
+            displayName: null,
+            avatarUrl: null,
+          },
+        };
+      },
+    ),
+  );
+
+function getArticleBlockQueryOptions(documentUri: string) {
+  return queryOptions({
+    queryKey: ["article", "block", documentUri] as const,
+    queryFn: async () => getArticleBlock({ data: { documentUri } }),
+    staleTime: 60_000,
+  });
+}
+
 function getArticleQueryOptions(documentUri: string) {
   return queryOptions({
     queryKey: ["article", documentUri] as const,
@@ -1384,6 +1521,8 @@ export const publicationApi = {
   getPublicationSocialProofQueryOptions,
   getArticle,
   getArticleQueryOptions,
+  getArticleBlock,
+  getArticleBlockQueryOptions,
   getArticleCard,
   getArticleCardQueryOptions,
   getCollection,

--- a/apps/standard-reader/src/integrations/tanstack-query/api-search.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-search.functions.ts
@@ -15,7 +15,12 @@ import { blobCid, cdnImageUrl } from "#/server/atproto/blob";
 import { listRepoRecords } from "#/server/atproto/fetch-record";
 import { resolveIdentity } from "#/server/atproto/identity";
 import type { PublicationRecord } from "#/server/atproto/types";
-import { filterBlockedCards, notBlockedByViewer } from "#/server/blocks/blocks";
+import {
+  atUriAuthoritySql,
+  blockFilterDid,
+  filterBlockedCards,
+  notBlockedByViewer,
+} from "#/server/blocks/blocks";
 import { ensureTracked } from "#/server/ingest/tap-client";
 import { observe } from "#/server/observability/log";
 import { attachReaderSpanContext } from "#/server/observability/span-context.ts";
@@ -183,6 +188,7 @@ const searchArticles = createServerFn({ method: "GET" })
         hints,
       );
       const matchClause = documentMatchSql(d, tsq, hints, authorMatch);
+      const blockDid = await blockFilterDid(db, schema, did);
       const articleWhere = and(
         eq(d.deleted, false),
         matchClause,
@@ -190,7 +196,16 @@ const searchArticles = createServerFn({ method: "GET" })
         ...(excludeWebBridgeEnabled ? [notWebBridgeArticleWhere(schema)] : []),
         // Search is paginated, so blocked authors are excluded in SQL rather
         // than dropped from the page — see `notBlockedByViewer`.
-        ...(did ? [notBlockedByViewer(schema, did, sql`${d.did}`)] : []),
+        ...(blockDid
+          ? [
+              notBlockedByViewer(
+                schema,
+                blockDid,
+                sql`${d.did}`,
+                atUriAuthoritySql(sql`${d.publicationUri}`),
+              ),
+            ]
+          : []),
       );
 
       // Page the bare document URIs (newest first) in an inner subquery, then

--- a/apps/standard-reader/src/integrations/tanstack-query/api-search.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-search.functions.ts
@@ -15,6 +15,7 @@ import { blobCid, cdnImageUrl } from "#/server/atproto/blob";
 import { listRepoRecords } from "#/server/atproto/fetch-record";
 import { resolveIdentity } from "#/server/atproto/identity";
 import type { PublicationRecord } from "#/server/atproto/types";
+import { filterBlockedCards, notBlockedByViewer } from "#/server/blocks/blocks";
 import { ensureTracked } from "#/server/ingest/tap-client";
 import { observe } from "#/server/observability/log";
 import { attachReaderSpanContext } from "#/server/observability/span-context.ts";
@@ -100,7 +101,7 @@ const searchPublications = createServerFn({ method: "GET" })
       const { db, schema, excludeWebBridgeEnabled } = context;
       span.set("q", data.q);
       span.set("offset", data.offset);
-      await attachReaderSpanContext(span, getRequest());
+      const did = await attachReaderSpanContext(span, getRequest());
 
       // Only the ranked search is filtered. The URL / handle fallbacks below are
       // a reader naming one specific account — answering "not found" because it
@@ -131,6 +132,12 @@ const searchPublications = createServerFn({ method: "GET" })
           items = await resolvePublicationCards(db, schema, hints.handleLookup);
         }
         total = items.length;
+      }
+
+      const visible = await filterBlockedCards(db, schema, did, items);
+      if (visible.length !== items.length) {
+        total = Math.max(0, total - (items.length - visible.length));
+        items = visible;
       }
 
       span.set("total", total);
@@ -181,6 +188,9 @@ const searchArticles = createServerFn({ method: "GET" })
         matchClause,
         notExcludedPublicationArticleWhere(p),
         ...(excludeWebBridgeEnabled ? [notWebBridgeArticleWhere(schema)] : []),
+        // Search is paginated, so blocked authors are excluded in SQL rather
+        // than dropped from the page — see `notBlockedByViewer`.
+        ...(did ? [notBlockedByViewer(schema, did, sql`${d.did}`)] : []),
       );
 
       // Page the bare document URIs (newest first) in an inner subquery, then

--- a/apps/standard-reader/src/integrations/tanstack-query/api-shapes.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-shapes.ts
@@ -91,6 +91,14 @@ export interface ArticleCard {
   publicationOwnerAvatarUrl: string | null;
   /** Owning profile's handle (e.g. `alice.bsky.social`). */
   publicationOwnerHandle: string | null;
+  /**
+   * DID of the account that owns the publication, when the document is bound to
+   * one. Usually the same as `did` — but not for a guest post, where a
+   * contributor writes into someone else's publication and it is the *owner*
+   * whose name and avatar carry the byline. Blocks are per account, so both have
+   * to be checked: see `BlockableCard` in `#/lib/blocks`.
+   */
+  publicationOwnerDid: string | null;
   /** Owning publication's banner (from the owner profile), for cover fallback. */
   publicationBannerUrl: string | null;
   /** Owning publication's derived topic (e.g. "Design"), for meta labels. */
@@ -506,6 +514,7 @@ export function toArticleCard(row: ArticleCardRow): ArticleCard {
     publicationOwnerAvatarUrl:
       row.publicationOwnerAvatarUrl ?? row.authorAvatarUrl,
     publicationOwnerHandle: row.publicationOwnerHandle ?? row.authorHandle,
+    publicationOwnerDid: row.publicationDid ?? null,
     publicationBannerUrl: row.publicationBannerUrl,
     publicationTopic: row.publicationTopic,
     authorHandle: row.authorHandle,

--- a/apps/standard-reader/src/integrations/tanstack-query/api-shell.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-shell.functions.ts
@@ -44,6 +44,16 @@ const getShellSnapshot = createServerFn({ method: "GET" }).handler(
         session.did,
       );
 
+      // Re-sync the reader's blocks on the same cadence, and for the same
+      // reason: blocks apply on every surface, so they can't wait for a visit
+      // to settings. Unlike the labeler import this repeats — blocks change,
+      // and a block made on Bluesky ten minutes ago should be in force here.
+      // TTL-guarded internally, so a signed-in reader's every page load is a
+      // no-op between sweeps.
+      const { scheduleReaderBlockSync } =
+        await import("#/server/blocks/sync.server");
+      scheduleReaderBlockSync(session.did);
+
       return loadShellSnapshot(db, schema, {
         did: session.did,
         client: session.client,

--- a/apps/standard-reader/src/integrations/tanstack-query/api-tag.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-tag.functions.ts
@@ -9,6 +9,7 @@ import {
   putSubscriptionRecord,
   subjectRkey,
 } from "#/server/atproto/repo-records";
+import { blockFilterDid } from "#/server/blocks/blocks";
 import { upsertSubscription } from "#/server/ingest/handlers";
 import { ensureTracked } from "#/server/ingest/tap-client";
 import { attachSubscribedLabels } from "#/server/labeler/labels.server";
@@ -129,6 +130,7 @@ const getArticles = createServerFn({ method: "GET" })
 
       // The tag rows and the reader's follow set are independent reads (the
       // follow set only needs `did`), so resolve them in one wave.
+      const blockDid = await blockFilterDid(db, schema, did);
       const [rows, followSets] = await Promise.all([
         selectArticleCards(db, schema, {
           tag: data.tag,
@@ -139,7 +141,7 @@ const getArticles = createServerFn({ method: "GET" })
           offset: data.offset,
           readForDid: trackReading && did ? did : undefined,
           countOldPostsAsUnread,
-          viewerDid: did ?? undefined,
+          viewerDid: blockDid,
         }),
         did ? effectiveFollowSets(db, schema, did) : Promise.resolve(null),
       ]);
@@ -191,7 +193,7 @@ const getPublications = createServerFn({ method: "GET" })
         limit: data.limit,
         offset: data.offset,
         excludeWebBridge: excludeWebBridgeEnabled,
-        viewerDid: did ?? undefined,
+        viewerDid: await blockFilterDid(db, schema, did),
       });
 
       span.set("count", items.length);
@@ -257,6 +259,7 @@ const getTagPage = createServerFn({ method: "GET" })
         did == null ? true : countOldPostsAsUnreadEnabled;
       const excludeWebBridge = did == null ? false : excludeWebBridgeEnabled;
 
+      const blockDid = await blockFilterDid(db, schema, did);
       const [articleCount, publicationCount, content, followSets] =
         await Promise.all([
           countTagArticles(db, schema, data.tag, { excludeWebBridge }),
@@ -271,7 +274,7 @@ const getTagPage = createServerFn({ method: "GET" })
                 offset: data.offset,
                 readForDid: trackReading && did ? did : undefined,
                 countOldPostsAsUnread,
-                viewerDid: did ?? undefined,
+                viewerDid: blockDid,
               }).then((rows) => attachCommentCountsToArticles(db, schema, rows))
             : tagDirectoryPublications(db, schema, {
                 tag: data.tag,
@@ -279,7 +282,7 @@ const getTagPage = createServerFn({ method: "GET" })
                 limit: data.limit,
                 offset: data.offset,
                 excludeWebBridge,
-                viewerDid: did ?? undefined,
+                viewerDid: blockDid,
               }),
           data.view === "feed" && did
             ? effectiveFollowSets(db, schema, did)

--- a/apps/standard-reader/src/integrations/tanstack-query/api-tag.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-tag.functions.ts
@@ -139,6 +139,7 @@ const getArticles = createServerFn({ method: "GET" })
           offset: data.offset,
           readForDid: trackReading && did ? did : undefined,
           countOldPostsAsUnread,
+          viewerDid: did ?? undefined,
         }),
         did ? effectiveFollowSets(db, schema, did) : Promise.resolve(null),
       ]);
@@ -179,7 +180,7 @@ const getPublications = createServerFn({ method: "GET" })
   .handler(
     observe("tag.getPublications", async ({ data, context }, span) => {
       const { db, schema, excludeWebBridgeEnabled } = context;
-      await attachReaderSpanContext(span, getRequest());
+      const did = await attachReaderSpanContext(span, getRequest());
       span.set("tag", data.tag);
       span.set("sort", data.sort);
       span.set("offset", data.offset);
@@ -190,6 +191,7 @@ const getPublications = createServerFn({ method: "GET" })
         limit: data.limit,
         offset: data.offset,
         excludeWebBridge: excludeWebBridgeEnabled,
+        viewerDid: did ?? undefined,
       });
 
       span.set("count", items.length);
@@ -269,6 +271,7 @@ const getTagPage = createServerFn({ method: "GET" })
                 offset: data.offset,
                 readForDid: trackReading && did ? did : undefined,
                 countOldPostsAsUnread,
+                viewerDid: did ?? undefined,
               }).then((rows) => attachCommentCountsToArticles(db, schema, rows))
             : tagDirectoryPublications(db, schema, {
                 tag: data.tag,
@@ -276,6 +279,7 @@ const getTagPage = createServerFn({ method: "GET" })
                 limit: data.limit,
                 offset: data.offset,
                 excludeWebBridge,
+                viewerDid: did ?? undefined,
               }),
           data.view === "feed" && did
             ? effectiveFollowSets(db, schema, did)

--- a/apps/standard-reader/src/integrations/tanstack-query/api-topics.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-topics.functions.ts
@@ -4,6 +4,7 @@ import { createServerFn } from "@tanstack/react-start";
 import { getRequest } from "@tanstack/react-start/server";
 import { z } from "zod";
 
+import { blockFilterDid } from "#/server/blocks/blocks";
 import { observe } from "#/server/observability/log";
 import { attachReaderSpanContext } from "#/server/observability/span-context.ts";
 import { attachCommentCountsToArticles } from "#/server/reader/document-comments";
@@ -180,6 +181,7 @@ async function loadTopicArticles(
   const rows = await selectArticleCardsByUris(db, schema, uris, {
     readForDid: trackReading && did ? did : undefined,
     countOldPostsAsUnread,
+    viewerDid: await blockFilterDid(db, schema, did),
   });
 
   const withComments = await attachCommentCountsToArticles(db, schema, rows);

--- a/apps/standard-reader/src/lib/blocks.test.ts
+++ b/apps/standard-reader/src/lib/blocks.test.ts
@@ -162,3 +162,36 @@ describe("uriAuthorityDid", () => {
     expect(uriAuthorityDid("https://example.com/post")).toBeNull();
   });
 });
+
+describe("BlockableCard against real card shapes", () => {
+  // Regression guard: `publicationOwnerDid` was defined and tested here while no
+  // production card actually carried the field, so the whole publication-owner
+  // half of the filter was dead. These fixtures mirror `ArticleCard` /
+  // `PublicationCard` field names so a rename breaks the test rather than
+  // silently reopening that hole.
+  it("reads the owner off an article card's publicationOwnerDid", () => {
+    const articleCard = {
+      uri: "at://did:plc:guest/site.standard.document/1",
+      did: "did:plc:guest",
+      publicationOwnerDid: "did:plc:owner",
+    };
+    expect(blockSubjectDids([articleCard]).toSorted()).toEqual([
+      "did:plc:guest",
+      "did:plc:owner",
+    ]);
+    expect(isCardBlocked(articleCard, new Set(["did:plc:owner"]))).toBe(true);
+  });
+
+  it("treats a loose document (no publication) as author-only", () => {
+    const looseCard = { did: "did:plc:author", publicationOwnerDid: null };
+    expect(blockSubjectDids([looseCard])).toEqual(["did:plc:author"]);
+    expect(isCardBlocked(looseCard, new Set(["did:plc:other"]))).toBe(false);
+  });
+
+  it("reads a publication card's owner off `did`", () => {
+    const publicationCard = { did: "did:plc:owner" };
+    expect(isCardBlocked(publicationCard, new Set(["did:plc:owner"]))).toBe(
+      true,
+    );
+  });
+});

--- a/apps/standard-reader/src/lib/blocks.test.ts
+++ b/apps/standard-reader/src/lib/blocks.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+
+import type { BlockEdge } from "./blocks";
+import {
+  blockIsFromList,
+  blockIsOutgoing,
+  blockSubjectDids,
+  isCardBlocked,
+  mergeBlockEdges,
+  preferredBlockEdge,
+  rejectBlockedCards,
+  uriAuthorityDid,
+} from "./blocks";
+
+const edge = (
+  did: string,
+  direction: BlockEdge["direction"],
+  listUri: string | null = null,
+): BlockEdge => ({ did, direction, listUri });
+
+describe("blockIsOutgoing", () => {
+  it("treats both of the reader's own block sources as theirs", () => {
+    expect(blockIsOutgoing("blocking")).toBe(true);
+    expect(blockIsOutgoing("list-blocking")).toBe(true);
+  });
+
+  it("does not claim a block made against the reader", () => {
+    expect(blockIsOutgoing("blocked-by")).toBe(false);
+    expect(blockIsOutgoing("list-blocked-by")).toBe(false);
+  });
+});
+
+describe("blockIsFromList", () => {
+  it("separates list-sourced blocks from direct records", () => {
+    expect(blockIsFromList("list-blocking")).toBe(true);
+    expect(blockIsFromList("list-blocked-by")).toBe(true);
+    expect(blockIsFromList("blocking")).toBe(false);
+    expect(blockIsFromList("blocked-by")).toBe(false);
+  });
+});
+
+describe("preferredBlockEdge", () => {
+  it("prefers the reader's own direct block, whichever order it arrives in", () => {
+    const mine = edge("did:plc:a", "blocking");
+    const theirs = edge("did:plc:a", "blocked-by");
+    expect(preferredBlockEdge(mine, theirs)).toBe(mine);
+    expect(preferredBlockEdge(theirs, mine)).toBe(mine);
+  });
+
+  it("prefers a direct block over a list block", () => {
+    const direct = edge("did:plc:a", "blocking");
+    const viaList = edge("did:plc:a", "list-blocking", "at://did:plc:l/list/1");
+    expect(preferredBlockEdge(viaList, direct)).toBe(direct);
+  });
+
+  it("prefers an incoming direct block over an incoming list block", () => {
+    const direct = edge("did:plc:a", "blocked-by");
+    const viaList = edge(
+      "did:plc:a",
+      "list-blocked-by",
+      "at://did:plc:l/list/1",
+    );
+    expect(preferredBlockEdge(viaList, direct)).toBe(direct);
+  });
+});
+
+describe("mergeBlockEdges", () => {
+  it("collapses several edges per account to the most actionable one", () => {
+    const merged = mergeBlockEdges([
+      edge("did:plc:a", "blocked-by"),
+      edge("did:plc:a", "list-blocking", "at://did:plc:l/list/1"),
+      edge("did:plc:a", "blocking"),
+      edge("did:plc:b", "list-blocked-by", "at://did:plc:l/list/2"),
+    ]);
+    expect(merged.size).toBe(2);
+    expect(merged.get("did:plc:a")?.direction).toBe("blocking");
+    expect(merged.get("did:plc:b")?.direction).toBe("list-blocked-by");
+  });
+
+  it("keeps the list URI of the edge it settles on", () => {
+    const merged = mergeBlockEdges([
+      edge("did:plc:a", "list-blocking", "at://did:plc:l/list/1"),
+    ]);
+    expect(merged.get("did:plc:a")?.listUri).toBe("at://did:plc:l/list/1");
+  });
+});
+
+describe("blockSubjectDids", () => {
+  it("collects author and publication-owner DIDs, deduped", () => {
+    const dids = blockSubjectDids([
+      { did: "did:plc:author", publicationOwnerDid: "did:plc:owner" },
+      { did: "did:plc:author" },
+      { did: null, publicationOwnerDid: "did:plc:owner" },
+    ]);
+    expect(dids.toSorted()).toEqual(["did:plc:author", "did:plc:owner"]);
+  });
+
+  it("is empty for cards that render no account", () => {
+    expect(blockSubjectDids([{ did: null }, {}])).toEqual([]);
+  });
+});
+
+describe("isCardBlocked", () => {
+  const blocked = new Set(["did:plc:blocked"]);
+
+  it("blocks on the author", () => {
+    expect(isCardBlocked({ did: "did:plc:blocked" }, blocked)).toBe(true);
+  });
+
+  it("blocks on the publication owner even when the author is fine", () => {
+    expect(
+      isCardBlocked(
+        { did: "did:plc:guest", publicationOwnerDid: "did:plc:blocked" },
+        blocked,
+      ),
+    ).toBe(true);
+  });
+
+  it("leaves unrelated cards alone", () => {
+    expect(isCardBlocked({ did: "did:plc:other" }, blocked)).toBe(false);
+  });
+
+  it("is a no-op for a reader with no blocks", () => {
+    expect(isCardBlocked({ did: "did:plc:blocked" }, new Set())).toBe(false);
+  });
+});
+
+describe("rejectBlockedCards", () => {
+  it("drops only the blocked cards", () => {
+    const cards = [
+      { did: "did:plc:a" },
+      { did: "did:plc:blocked" },
+      { did: "did:plc:b", publicationOwnerDid: "did:plc:blocked" },
+    ];
+    expect(rejectBlockedCards(cards, new Set(["did:plc:blocked"]))).toEqual([
+      { did: "did:plc:a" },
+    ]);
+  });
+
+  it("returns the same array identity when nothing is blocked", () => {
+    const cards = [{ did: "did:plc:a" }];
+    expect(rejectBlockedCards(cards, new Set())).toBe(cards);
+  });
+});
+
+describe("uriAuthorityDid", () => {
+  it("reads the owner DID off a record URI", () => {
+    expect(
+      uriAuthorityDid("at://did:plc:abc/site.standard.publication/1"),
+    ).toBe("did:plc:abc");
+  });
+
+  it("reads a bare repo URI", () => {
+    expect(uriAuthorityDid("at://did:plc:abc")).toBe("did:plc:abc");
+  });
+
+  it("rejects a handle authority — blocks are keyed by DID", () => {
+    expect(uriAuthorityDid("at://alice.bsky.social/x/1")).toBeNull();
+  });
+
+  it("rejects anything that isn't an AT-URI", () => {
+    expect(uriAuthorityDid("https://example.com/post")).toBeNull();
+  });
+});

--- a/apps/standard-reader/src/lib/blocks.ts
+++ b/apps/standard-reader/src/lib/blocks.ts
@@ -1,0 +1,132 @@
+/**
+ * Pure block logic, split out from `server/blocks/blocks.ts` so it
+ * carries no database import and can be unit-tested directly.
+ *
+ * A block hides an **account**, not a document — so everything here works in
+ * DIDs. A card is blocked when any account it renders is blocked: the author
+ * (`did`), and for a publication-bound article the publication's owner, which
+ * is the account whose name and avatar appear in the byline.
+ */
+
+/** How a block between the viewer and another account came about. */
+export type BlockDirection =
+  /** The viewer blocked them (`app.bsky.graph.block` in the viewer's repo). */
+  | "blocking"
+  /** They blocked the viewer (a block record in *their* repo). */
+  | "blocked-by"
+  /** They are on a moderation list the viewer blocks. */
+  | "list-blocking"
+  /** They block a moderation list the viewer is on (Bluesky's `blockedByList`). */
+  | "list-blocked-by";
+
+/** A resolved block between the viewer and one account. */
+export interface BlockEdge {
+  /** The other account. */
+  did: string;
+  direction: BlockDirection;
+  /** The moderation list involved, for the list-sourced directions. */
+  listUri: string | null;
+}
+
+/**
+ * Which side of the block the viewer is on.
+ *
+ * The two are not interchangeable in the UI: a block the viewer *made* is
+ * theirs to undo, while a block made against them is not, and offering an
+ * "unblock" button for someone else's decision would be a lie.
+ */
+export function blockIsOutgoing(direction: BlockDirection): boolean {
+  return direction === "blocking" || direction === "list-blocking";
+}
+
+/** Whether a block came from a moderation list rather than a direct record. */
+export function blockIsFromList(direction: BlockDirection): boolean {
+  return direction === "list-blocking" || direction === "list-blocked-by";
+}
+
+/**
+ * Precedence when several block edges resolve for the same account: the
+ * viewer's own direct block first (it is the one they can act on), then their
+ * list block, then the two incoming forms.
+ *
+ * Without an order, "you blocked this account" and "this account blocks you"
+ * would render at the mercy of row order, and a reader would see a Unblock
+ * button that does nothing on some page loads and not others.
+ */
+const DIRECTION_RANK: Record<BlockDirection, number> = {
+  blocking: 0,
+  "list-blocking": 1,
+  "blocked-by": 2,
+  "list-blocked-by": 3,
+};
+
+/** Of two edges for the same account, the one the UI should explain. */
+export function preferredBlockEdge(a: BlockEdge, b: BlockEdge): BlockEdge {
+  return DIRECTION_RANK[a.direction] <= DIRECTION_RANK[b.direction] ? a : b;
+}
+
+/** Collapse raw edges to one per account, keeping the most actionable. */
+export function mergeBlockEdges(
+  edges: Array<BlockEdge>,
+): Map<string, BlockEdge> {
+  const byDid = new Map<string, BlockEdge>();
+  for (const edge of edges) {
+    const existing = byDid.get(edge.did);
+    byDid.set(edge.did, existing ? preferredBlockEdge(existing, edge) : edge);
+  }
+  return byDid;
+}
+
+/** A card that renders one or more accounts, any of which may be blocked. */
+export interface BlockableCard {
+  /** Author DID (documents) or owner DID (publications, profiles). */
+  did?: string | null;
+  /**
+   * Owner of the card's publication, when it differs from `did` — a document
+   * written by a contributor into someone else's publication still puts that
+   * publication's owner in the byline.
+   */
+  publicationOwnerDid?: string | null;
+}
+
+/** Every account DID a set of cards renders, deduped. */
+export function blockSubjectDids(
+  cards: ReadonlyArray<BlockableCard>,
+): Array<string> {
+  const dids = new Set<string>();
+  for (const card of cards) {
+    if (card.did) dids.add(card.did);
+    if (card.publicationOwnerDid) dids.add(card.publicationOwnerDid);
+  }
+  return [...dids];
+}
+
+/** Whether a card renders any blocked account. */
+export function isCardBlocked(
+  card: BlockableCard,
+  blocked: ReadonlySet<string>,
+): boolean {
+  if (blocked.size === 0) return false;
+  if (card.did != null && blocked.has(card.did)) return true;
+  return (
+    card.publicationOwnerDid != null && blocked.has(card.publicationOwnerDid)
+  );
+}
+
+/** Drop every card that renders a blocked account. */
+export function rejectBlockedCards<T extends BlockableCard>(
+  cards: Array<T>,
+  blocked: ReadonlySet<string>,
+): Array<T> {
+  if (blocked.size === 0) return cards;
+  return cards.filter((card) => !isCardBlocked(card, blocked));
+}
+
+/** The `at://did/…` authority of an AT-URI, or null if it isn't one. */
+export function uriAuthorityDid(uri: string): string | null {
+  if (!uri.startsWith("at://")) return null;
+  const rest = uri.slice("at://".length);
+  const slash = rest.indexOf("/");
+  const authority = slash === -1 ? rest : rest.slice(0, slash);
+  return authority.startsWith("did:") ? authority : null;
+}

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -622,6 +622,7 @@ msgid "Please choose a rating."
 msgstr "يرجى اختيار تقييم."
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/reader/block-user-menu-item.tsx
 msgid "Blocked"
 msgstr ""
 
@@ -788,6 +789,10 @@ msgstr "حذف القائمة؟"
 #: src/routes/_layout.latest.tsx
 msgid "Everything published recently across the publications you subscribe to."
 msgstr "كل ما نُشر مؤخرًا عبر المنشورات التي تشترك فيها."
+
+#: src/components/reader/comments/comments-section.tsx
+msgid "{hiddenByBlocks, plural, one {# more reply is hidden by your blocks.} other {# more replies are hidden by your blocks.}}"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1488,6 +1493,10 @@ msgstr ""
 msgid "Compact"
 msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "This account"
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Portrait stacks the card vertically. Height adjusts automatically once the embed loads. Change the iframe width as needed."
 msgstr "الوضع الطولي يرتّب البطاقة عموديًا. يُضبط الارتفاع تلقائيًا بعد تحميل التضمين. غيّر عرض iframe حسب الحاجة."
@@ -1927,6 +1936,10 @@ msgstr "تضمين زر الاشتراك"
 msgid "That GIF is over 1 MB. Try a shorter clip, or attach a still image."
 msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+msgstr ""
+
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Add another screenshot"
 #~ msgstr ""
@@ -1946,6 +1959,10 @@ msgstr "حذف المجموعة"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Interface font"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "We're re-reading your blocks from your account. This page updates when it finishes."
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -2014,6 +2031,7 @@ msgstr ""
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/reader/pull-to-refresh.tsx
 msgid "Refreshing"
 msgstr ""
@@ -2305,6 +2323,7 @@ msgstr "المصنِّف"
 msgid "Articles you've opened — public records in your repo, synced across devices."
 msgstr "المقالات التي فتحتها — سجلات عامة في مستودعك، متزامنة عبر أجهزتك."
 
+#: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-publication-editor.tsx
 #: src/components/reader/collection-theme-editor.tsx
@@ -2581,6 +2600,10 @@ msgstr "<0>Leaflet وPckt وOffprint.</0> <1>pub.leaflet.content</1> و<2>blog.p
 
 #: src/components/appearance-settings.tsx
 msgid "XL"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "We couldn't write the block to your account. Try again?"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -3272,6 +3295,10 @@ msgstr "صورة"
 #~ msgid "<0>Follow</0> is the only subscription there is. New writing from anything you follow appears on Home and in Latest, and the publication is listed in your sidebar. There is no email sign-up and no separate account with the publisher."
 #~ msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "We couldn't remove the block from your account. Try again?"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Selecting anyone's name opens their author page: everything they publish, what they follow, and what they have recommended."
 msgstr ""
@@ -3321,6 +3348,10 @@ msgstr ""
 #~ msgid "Prefer a typed client? The whole API ships as codegen'd AT Protocol lexicon schemas in <0>@standard-reader/lexicons</0>. Pair it with <1>@atproto/lex-client</1> for fully-typed <2>client.call()</2> queries and procedures. Its <3>getDocument</3> also returns a document's renderable body, ready to hand to the <4>renderers</4>."
 #~ msgstr ""
 
+#: src/components/reader/comments/comments-section.tsx
+msgid "{hiddenByBlocks, plural, one {The only reply here is from someone you're blocked from.} other {The replies here are all from accounts you're blocked from.}}"
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Couldn't save your follows"
 msgstr "تعذّر حفظ متابعاتك"
@@ -3357,6 +3388,10 @@ msgstr ""
 msgid "Publications to explore"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+msgid "We couldn't reach your account to change that. Try again?"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Read as comic"
 msgstr ""
@@ -3378,6 +3413,10 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Read and unread"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "This writes a block to your Bluesky account, so it applies here and anywhere else you use it. Their writing disappears from your feeds, search and discussion, and they can't see yours. You can undo it in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -3502,8 +3541,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
-msgstr ""
+#~ msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
@@ -3643,6 +3682,10 @@ msgstr ""
 msgid "Worth subscribing to"
 msgstr "يستحق الاشتراك"
 
+#: src/components/blocks-settings-view.tsx
+msgid "this list is larger than we mirror, so some members aren't blocked here"
+msgstr ""
+
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Angular."
 #~ msgstr ""
@@ -3666,6 +3709,10 @@ msgstr ""
 
 #: src/routes/_layout.subscriptions.tsx
 msgid "Nothing to manage yet"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "They're hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.subscriptions.tsx
@@ -4017,6 +4064,10 @@ msgstr ""
 msgid "No lists yet"
 msgstr "لا توجد قوائم بعد"
 
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} blocks a moderation list you're on, so you can't see their writing."
+msgstr ""
+
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "Saving things while you browse the rest of the web, keeping Standard Reader on your home screen, and passing an article on."
 #~ msgstr ""
@@ -4036,6 +4087,10 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
 msgstr "زر الاستماع يقرأ أي مقال بصوت مسموع على جهازك مباشرةً، ويبرز كل كلمة أثناء القراءة. يرافقك المشغّل في أنحاء التطبيق — بل يقرأ حتى منشور Bluesky المضمّن. وبتسجيل الدخول يمكنك اختيار الصوت."
+
+#: src/components/reader/blocked-notice.tsx
+msgid "this account"
+msgstr ""
 
 #. placeholder {0}: next.title
 #: src/components/reader/series-up-next.tsx
@@ -4175,6 +4230,15 @@ msgstr "اختياري: أضف ملاحظة عن سبب حفظك لهذا"
 msgid "Open the app"
 msgstr ""
 
+#. placeholder {0}: fmt.relativeTime(data.syncedAt)
+#: src/components/blocks-settings-view.tsx
+msgid "Last checked {0}. Blocks you make elsewhere show up here within about fifteen minutes."
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block account?"
+msgstr ""
+
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this note on Semble"
 msgstr ""
@@ -4252,8 +4316,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "this account"
 #: src/components/reader/blocked-notice.tsx
-msgid "You blocked {0}, so their writing is hidden everywhere you read."
-msgstr ""
+#~ msgid "You blocked {0}, so their writing is hidden everywhere you read."
+#~ msgstr ""
 
 #. placeholder {0}: filter.trim()
 #: src/components/reader/subscriptions-table.tsx
@@ -4485,6 +4549,10 @@ msgstr ""
 msgid "Recommended articles"
 msgstr "مقالات موصى بها"
 
+#: src/components/reader/mention-hover-card.tsx
+msgid "You blocked this account, so their writing is hidden."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
 msgstr ""
@@ -4690,6 +4758,10 @@ msgstr ""
 msgid "{0}+ articles"
 msgstr "أكثر من {0} مقال"
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "{name} is hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts."
+msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "Starter pack"
 msgstr ""
@@ -4701,6 +4773,10 @@ msgstr "انتهت صلاحية ذلك الرابط."
 #: src/components/guide/pages/lists-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Lists in the sidebar"
+msgstr ""
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked {who}, so their writing is hidden everywhere you read."
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
@@ -4952,6 +5028,9 @@ msgstr ""
 msgid "Not in the directory yet?"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/reader/block-user-menu-item.tsx
+#: src/components/reader/blocked-notice.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
@@ -5001,8 +5080,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} is on a moderation list you block. To see them again, leave that list."
-msgstr ""
+#~ msgid "{0} is on a moderation list you block. To see them again, leave that list."
+#~ msgstr ""
 
 #: src/routes/_layout.collections.index.tsx
 msgid "Curated, magazine-rendered editions grouped into series you can subscribe to — your special collections on the network."
@@ -6025,6 +6104,10 @@ msgstr "عرض الملاحظات"
 #~ msgid "Pages you have already visited stay available when your connection drops, and Standard Reader shows a plain offline page rather than a browser error when you reach for something it does not have. When a new version of the app is ready, it offers to reload rather than changing under you mid-article."
 #~ msgstr ""
 
+#: src/components/reader/mention-hover-card.tsx
+msgid "This account blocks you, so you can't see their writing."
+msgstr ""
+
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Being in a list does not change your feeds. Everything you subscribe to still arrives on Home and in Latest exactly as before; a list only changes how the sidebar is organised, and gives you a page you can read — or share — on its own."
 msgstr ""
@@ -6233,6 +6316,10 @@ msgstr ""
 #: src/magazine/Magazine.tsx
 msgid "Contents"
 msgstr "المحتويات"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} is on a moderation list you block. To see them again, leave that list."
+msgstr ""
 
 #: src/components/reader/share-menu.tsx
 msgid "Copy embed code"
@@ -6642,8 +6729,8 @@ msgstr "حذف كل سجل القراءة؟"
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} blocks a moderation list you're on, so you can't see their writing."
-msgstr ""
+#~ msgid "{0} blocks a moderation list you're on, so you can't see their writing."
+#~ msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6971,6 +7058,10 @@ msgstr "لا توجد منشورات لـ {handleLabel}."
 msgid "Already subscribed"
 msgstr "مشترك بالفعل"
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block {name}?"
+msgstr ""
+
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "How to wire a personal site's own <0>site.standard.*</0> records so Standard Reader can find it and read articles inline, without going through Leaflet, Pckt, Offprint, or another publishing tool."
 msgstr "كيفية إعداد سجلات <0>site.standard.*</0> الخاصة بموقع شخصي كي يتمكّن Standard Reader من العثور عليه وقراءة مقالاته مباشرةً، دون المرور بـ Leaflet أو Pckt أو Offprint أو أي أداة نشر أخرى."
@@ -6986,6 +7077,10 @@ msgstr "مجموعات أخرى"
 #: src/components/reader/about-view.tsx
 msgid "One tasteful email a week"
 msgstr "رسالة واحدة أنيقة كل أسبوع"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "Blocked by a list you use"
+msgstr ""
 
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "{unreadCount} unread"
@@ -7274,6 +7369,7 @@ msgid "Pages"
 msgstr ""
 
 #: src/components/reader/article-view-skeleton.tsx
+#: src/routes/_layout.a.$did.$rkey.tsx
 msgid "Loading article"
 msgstr "جارٍ تحميل المقال"
 

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -239,6 +239,10 @@ msgstr ""
 msgid "You're signed in"
 msgstr "أنت مسجَّل الدخول"
 
+#: src/components/user-settings-view.tsx
+msgid "Manage {blockCount} blocks"
+msgstr ""
+
 #: src/routes/_layout.subscriptions.tsx
 msgid "Subscribe to a publication or follow a writer and they'll show up here, with their unread count and latest post. Each subscription is an <0>app.standard-reader.subscription</0> record in your repo — yours to take anywhere."
 msgstr ""
@@ -617,6 +621,10 @@ msgstr ""
 msgid "Please choose a rating."
 msgstr "يرجى اختيار تقييم."
 
+#: src/components/blocks-settings-view.tsx
+msgid "Blocked"
+msgstr ""
+
 #: src/components/docs/docs-mobile-nav.tsx
 #: src/components/guide/guide-mobile-nav.tsx
 msgid "(current)"
@@ -634,6 +642,10 @@ msgstr ""
 #: src/components/reader/share-menu.tsx
 msgid "Portrait"
 msgstr "طولي"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Loading blocked accounts"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Select any headline to open it. Articles are laid out as a single column at a comfortable width, with the publication's own colors and typography where it has them."
@@ -655,6 +667,10 @@ msgstr "تحريك لأسفل"
 msgid "Disclaimer and limitation of liability"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+msgid "You don't subscribe to any block lists."
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No articles from this list's publications or people yet."
 msgstr "لا توجد مقالات بعد من منشورات هذه القائمة أو أشخاصها."
@@ -666,6 +682,10 @@ msgstr ""
 #. placeholder {0}: labels[order]
 #: src/components/reader/publication-actions.tsx
 msgid "Order: {0}"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Partial"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -718,6 +738,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Permanently remove data stored in your account. These actions delete records from your account and cannot be undone."
 msgstr "احذف نهائيًا البيانات المخزَّنة في حسابك. تحذف هذه الإجراءات السجلات من حسابك ولا يمكن التراجع عنها."
+
+#: src/components/blocks-settings-view.tsx
+msgid "Moderation lists you subscribe to on Bluesky. Everyone on them is blocked here too, and the list stays live as its owner changes it."
+msgstr ""
 
 #: src/routes/_layout.communities.$slug.tsx
 #~ msgid "Sub-areas"
@@ -1519,6 +1543,11 @@ msgstr "<0/> إلغاء الاشتراك بنقرة واحدة في أي وقت"
 #~ msgid "Wiring up a site that does not publish in this format yet is the one genuinely technical job in the whole product, and it has its own <0>publishing documentation</0>. Everything else in this guide stays where it is."
 #~ msgstr ""
 
+#. placeholder {0}: row.memberCount
+#: src/components/blocks-settings-view.tsx
+msgid "{0, plural, one {# account} other {# accounts}}"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Recommending an article"
@@ -1761,9 +1790,17 @@ msgstr ""
 msgid "Fast full-text search"
 msgstr "بحث سريع في النص الكامل"
 
+#: src/components/blocks-settings-view.tsx
+msgid "You haven't blocked anyone."
+msgstr ""
+
 #: src/lib/guide/navigation.ts
 #~ msgid "Saving, recommending, reading history, and managing what you follow."
 #~ msgstr ""
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked this account"
+msgstr ""
 
 #: src/components/reader/notify-button.tsx
 msgid "Notifications aren’t available"
@@ -2054,6 +2091,10 @@ msgstr ""
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block"
+msgstr ""
 
 #: src/routes/_layout.discover.tsx
 msgid "Known publications"
@@ -2416,6 +2457,7 @@ msgstr "عرض المصنِّف"
 msgid "Read more from the author"
 msgstr "اقرأ المزيد للكاتب"
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/labelers-settings-view.tsx
 #: src/components/user-settings-view.tsx
 msgid "Moderation"
@@ -2440,6 +2482,10 @@ msgstr "المستندات"
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Most unread"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block {name}"
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -2579,6 +2625,10 @@ msgstr "تحرير"
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Removed"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block account"
 msgstr ""
 
 #: src/components/reading-settings-preview.tsx
@@ -2758,6 +2808,10 @@ msgstr ""
 #: src/routes/review.thanks.tsx
 msgid "Return to the app"
 msgstr "العودة إلى التطبيق"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Moderation list"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -3446,6 +3500,11 @@ msgstr "إظهار تبويب {label}"
 msgid "This API is also served as a <0>Model Context Protocol</0> server at <1>{baseUrl}/mcp</1>. Paste that URL into an MCP client and authorize it; the fifty-odd methods above are grouped into fifteen tools, and the client can read the network and act on your behalf."
 msgstr ""
 
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
 msgstr ""
@@ -3477,6 +3536,10 @@ msgstr "{n, plural, zero {لا توجد منشورات} one {منشورة واح
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."
 msgstr "اختر التبويبات التي تظهر في ملفك العام."
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You're blocked"
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "View all latest"
@@ -3797,6 +3860,10 @@ msgstr ""
 #. placeholder {0}: rows.length
 #: src/components/reader/subscriptions-table.tsx
 msgid "{0} total"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours."
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -4174,8 +4241,18 @@ msgstr "غير مقروء"
 msgid "How readers see it"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/user-settings-view.tsx
+msgid "Blocked accounts"
+msgstr ""
+
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "Standard Reader has a reading mode built for comics — a shelf of covers instead of a list of post titles, and a full-screen theater that flips through your pages. You do not author anything specially for it. This page is how to make sure your comic gets it."
+msgstr ""
+
+#. placeholder {0}: name ?? "this account"
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked {0}, so their writing is hidden everywhere you read."
 msgstr ""
 
 #. placeholder {0}: filter.trim()
@@ -4228,6 +4305,10 @@ msgstr "الأكثر قراءة عبر الشبكة الآن."
 
 #: src/components/appearance-settings.tsx
 msgid "The typeface used across the app. Article text follows this too, unless you set a reading font below."
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Refresh"
 msgstr ""
 
 #: src/magazine/magazine-end-like.tsx
@@ -4808,6 +4889,11 @@ msgstr ""
 msgid "There’s a magazine edition of this collection."
 msgstr "توجد نسخة مجلّة من هذه المجموعة."
 
+#: src/components/reader/blocked-notice.tsx
+#: src/components/user-settings-view.tsx
+msgid "Manage blocks"
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "What the extension accesses"
 msgstr "ما تصل إليه الإضافة"
@@ -4911,6 +4997,11 @@ msgstr "<0>عناوين URL للصفحات.</0> عند فتح النافذة ا�
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Comments and related reading"
+msgstr ""
+
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} is on a moderation list you block. To see them again, leave that list."
 msgstr ""
 
 #: src/routes/_layout.collections.index.tsx
@@ -5359,6 +5450,11 @@ msgstr ""
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler hasn’t labeled any documents in the read-model yet."
 msgstr "لم تُصنّف جهة التصنيف هذه أي مستندات في نموذج القراءة بعد."
+
+#. placeholder {0}: row.memberCount
+#: src/components/blocks-settings-view.tsx
+#~ msgid "{0} accounts"
+#~ msgstr ""
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Your lists, their order, and which ones are collapsed are stored in your account rather than in this browser, so the sidebar looks the same on your laptop and your phone."
@@ -5816,6 +5912,10 @@ msgstr ""
 msgid "Standard Reader needs write access to your site.standard publications and documents, plus your collection records, to author Collections. You'll be asked to approve this on your PDS login."
 msgstr "يحتاج Standard Reader إلى صلاحية الكتابة في منشورات ومستندات site.standard الخاصة بك، إضافة إلى سجلات المجموعات، لتأليف المجموعات. سيُطلب منك الموافقة على ذلك عند تسجيل الدخول إلى PDS."
 
+#: src/components/blocks-settings-view.tsx
+msgid "Block lists"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "All articles you have saved for later."
 msgstr "جميع المقالات التي حفظتها لوقت لاحق."
@@ -6176,6 +6276,7 @@ msgstr "يعمل"
 msgid "Top on the network"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
@@ -6197,6 +6298,10 @@ msgstr "التصفية حسب الموضوع: {triggerLabel}"
 #: src/components/reader/page-reader-bar.tsx
 msgid "Return to article and follow along"
 msgstr "العودة إلى المقالة والمتابعة"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Some blocks couldn't be refreshed last time, so this list may be incomplete."
+msgstr ""
 
 #. placeholder {0}: pub.subscriberCount
 #: src/components/reader/cards.tsx
@@ -6381,9 +6486,18 @@ msgstr "تحرير القائمة"
 msgid "The Saved screen: a list of article cards the reader has set aside, each with its publication, headline, and excerpt."
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/reader/blocked-notice.tsx
+msgid "Unblock"
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "What we do not do"
 msgstr "ما لا نفعله"
+
+#: src/components/user-settings-view.tsx
+msgid "Your Bluesky blocks apply here too — blocked accounts disappear from your feeds, search, and discussion, in both directions."
+msgstr ""
 
 #: src/components/docs/docs-side-nav.tsx
 msgid "Documentation"
@@ -6525,6 +6639,11 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Delete all reading history?"
 msgstr "حذف كل سجل القراءة؟"
+
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} blocks a moderation list you're on, so you can't see their writing."
+msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6999,6 +7118,10 @@ msgstr ""
 #: src/components/site-legal-links.tsx
 msgid "Source"
 msgstr "المصدر"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Accounts you block"
+msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That file isn't an image we can read."
@@ -7579,6 +7702,10 @@ msgstr "<0>عند تسجيل الدخول</0> بحساب Atmosphere الخاص �
 #: src/routes/subscribe-login.$did.$rkey.tsx
 msgid "Powered by <0>Standard Reader</0>"
 msgstr "مدعوم بـ <0>Standard Reader</0>"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Your blocks are enforced here already. To add or remove one from Standard Reader, you'll be asked to authorize block access the first time you try."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -239,6 +239,10 @@ msgstr ""
 msgid "You're signed in"
 msgstr "Sie sind angemeldet"
 
+#: src/components/user-settings-view.tsx
+msgid "Manage {blockCount} blocks"
+msgstr ""
+
 #: src/routes/_layout.subscriptions.tsx
 msgid "Subscribe to a publication or follow a writer and they'll show up here, with their unread count and latest post. Each subscription is an <0>app.standard-reader.subscription</0> record in your repo — yours to take anywhere."
 msgstr ""
@@ -617,6 +621,10 @@ msgstr ""
 msgid "Please choose a rating."
 msgstr "Bitte wählen Sie eine Bewertung."
 
+#: src/components/blocks-settings-view.tsx
+msgid "Blocked"
+msgstr ""
+
 #: src/components/docs/docs-mobile-nav.tsx
 #: src/components/guide/guide-mobile-nav.tsx
 msgid "(current)"
@@ -634,6 +642,10 @@ msgstr ""
 #: src/components/reader/share-menu.tsx
 msgid "Portrait"
 msgstr "Hochformat"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Loading blocked accounts"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Select any headline to open it. Articles are laid out as a single column at a comfortable width, with the publication's own colors and typography where it has them."
@@ -655,6 +667,10 @@ msgstr "Nach unten"
 msgid "Disclaimer and limitation of liability"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+msgid "You don't subscribe to any block lists."
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No articles from this list's publications or people yet."
 msgstr "Noch keine Artikel aus den Publikationen oder von den Personen dieser Liste."
@@ -666,6 +682,10 @@ msgstr ""
 #. placeholder {0}: labels[order]
 #: src/components/reader/publication-actions.tsx
 msgid "Order: {0}"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Partial"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -718,6 +738,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Permanently remove data stored in your account. These actions delete records from your account and cannot be undone."
 msgstr "Daten dauerhaft aus Ihrem Konto entfernen. Diese Aktionen löschen Records aus Ihrem Konto und lassen sich nicht rückgängig machen."
+
+#: src/components/blocks-settings-view.tsx
+msgid "Moderation lists you subscribe to on Bluesky. Everyone on them is blocked here too, and the list stays live as its owner changes it."
+msgstr ""
 
 #: src/routes/_layout.communities.$slug.tsx
 #~ msgid "Sub-areas"
@@ -1519,6 +1543,11 @@ msgstr "<0/> Jederzeit mit einem Klick abbestellen"
 #~ msgid "Wiring up a site that does not publish in this format yet is the one genuinely technical job in the whole product, and it has its own <0>publishing documentation</0>. Everything else in this guide stays where it is."
 #~ msgstr ""
 
+#. placeholder {0}: row.memberCount
+#: src/components/blocks-settings-view.tsx
+msgid "{0, plural, one {# account} other {# accounts}}"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Recommending an article"
@@ -1761,9 +1790,17 @@ msgstr ""
 msgid "Fast full-text search"
 msgstr "Schnelle Volltextsuche"
 
+#: src/components/blocks-settings-view.tsx
+msgid "You haven't blocked anyone."
+msgstr ""
+
 #: src/lib/guide/navigation.ts
 #~ msgid "Saving, recommending, reading history, and managing what you follow."
 #~ msgstr ""
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked this account"
+msgstr ""
 
 #: src/components/reader/notify-button.tsx
 msgid "Notifications aren’t available"
@@ -2054,6 +2091,10 @@ msgstr ""
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block"
+msgstr ""
 
 #: src/routes/_layout.discover.tsx
 msgid "Known publications"
@@ -2416,6 +2457,7 @@ msgstr "Labeler ansehen"
 msgid "Read more from the author"
 msgstr "Mehr von diesem Autor lesen"
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/labelers-settings-view.tsx
 #: src/components/user-settings-view.tsx
 msgid "Moderation"
@@ -2440,6 +2482,10 @@ msgstr "Dokumente"
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Most unread"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block {name}"
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -2579,6 +2625,10 @@ msgstr "Bearbeiten"
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Removed"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block account"
 msgstr ""
 
 #: src/components/reading-settings-preview.tsx
@@ -2758,6 +2808,10 @@ msgstr ""
 #: src/routes/review.thanks.tsx
 msgid "Return to the app"
 msgstr "Zurück zur App"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Moderation list"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -3446,6 +3500,11 @@ msgstr "Tab {label} anzeigen"
 msgid "This API is also served as a <0>Model Context Protocol</0> server at <1>{baseUrl}/mcp</1>. Paste that URL into an MCP client and authorize it; the fifty-odd methods above are grouped into fifteen tools, and the client can read the network and act on your behalf."
 msgstr ""
 
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
 msgstr ""
@@ -3477,6 +3536,10 @@ msgstr "{n, plural, one {# Publikation} other {{value} Publikationen}}"
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."
 msgstr "Wählen Sie, welche Tabs in Ihrem öffentlichen Profil erscheinen."
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You're blocked"
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "View all latest"
@@ -3797,6 +3860,10 @@ msgstr ""
 #. placeholder {0}: rows.length
 #: src/components/reader/subscriptions-table.tsx
 msgid "{0} total"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours."
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -4174,8 +4241,18 @@ msgstr "Ungelesen"
 msgid "How readers see it"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/user-settings-view.tsx
+msgid "Blocked accounts"
+msgstr ""
+
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "Standard Reader has a reading mode built for comics — a shelf of covers instead of a list of post titles, and a full-screen theater that flips through your pages. You do not author anything specially for it. This page is how to make sure your comic gets it."
+msgstr ""
+
+#. placeholder {0}: name ?? "this account"
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked {0}, so their writing is hidden everywhere you read."
 msgstr ""
 
 #. placeholder {0}: filter.trim()
@@ -4228,6 +4305,10 @@ msgstr "Die meistgelesenen Texte im Netzwerk gerade jetzt."
 
 #: src/components/appearance-settings.tsx
 msgid "The typeface used across the app. Article text follows this too, unless you set a reading font below."
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Refresh"
 msgstr ""
 
 #: src/magazine/magazine-end-like.tsx
@@ -4808,6 +4889,11 @@ msgstr ""
 msgid "There’s a magazine edition of this collection."
 msgstr "Von dieser Sammlung gibt es eine Magazinausgabe."
 
+#: src/components/reader/blocked-notice.tsx
+#: src/components/user-settings-view.tsx
+msgid "Manage blocks"
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "What the extension accesses"
 msgstr "Worauf die Erweiterung zugreift"
@@ -4911,6 +4997,11 @@ msgstr "<0>Seiten-URLs.</0> Wenn Sie das Popup öffnen, das Seiten-Overlay verwe
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Comments and related reading"
+msgstr ""
+
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} is on a moderation list you block. To see them again, leave that list."
 msgstr ""
 
 #: src/routes/_layout.collections.index.tsx
@@ -5359,6 +5450,11 @@ msgstr ""
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler hasn’t labeled any documents in the read-model yet."
 msgstr "Dieser Labeler hat im Read-Model noch keine Dokumente gelabelt."
+
+#. placeholder {0}: row.memberCount
+#: src/components/blocks-settings-view.tsx
+#~ msgid "{0} accounts"
+#~ msgstr ""
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Your lists, their order, and which ones are collapsed are stored in your account rather than in this browser, so the sidebar looks the same on your laptop and your phone."
@@ -5816,6 +5912,10 @@ msgstr ""
 msgid "Standard Reader needs write access to your site.standard publications and documents, plus your collection records, to author Collections. You'll be asked to approve this on your PDS login."
 msgstr "Standard Reader benötigt Schreibzugriff auf Ihre site.standard-Publikationen und -Dokumente sowie auf Ihre Sammlungs-Records, um Sammlungen anzulegen. Sie werden bei der Anmeldung an Ihrem PDS um Zustimmung gebeten."
 
+#: src/components/blocks-settings-view.tsx
+msgid "Block lists"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "All articles you have saved for later."
 msgstr "Alle Artikel, die Sie für später gespeichert haben."
@@ -6176,6 +6276,7 @@ msgstr "betriebsbereit"
 msgid "Top on the network"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
@@ -6197,6 +6298,10 @@ msgstr "Nach Thema filtern: {triggerLabel}"
 #: src/components/reader/page-reader-bar.tsx
 msgid "Return to article and follow along"
 msgstr "Zurück zum Artikel und mitlesen"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Some blocks couldn't be refreshed last time, so this list may be incomplete."
+msgstr ""
 
 #. placeholder {0}: pub.subscriberCount
 #: src/components/reader/cards.tsx
@@ -6381,9 +6486,18 @@ msgstr "Liste bearbeiten"
 msgid "The Saved screen: a list of article cards the reader has set aside, each with its publication, headline, and excerpt."
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/reader/blocked-notice.tsx
+msgid "Unblock"
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "What we do not do"
 msgstr "Was wir nicht tun"
+
+#: src/components/user-settings-view.tsx
+msgid "Your Bluesky blocks apply here too — blocked accounts disappear from your feeds, search, and discussion, in both directions."
+msgstr ""
 
 #: src/components/docs/docs-side-nav.tsx
 msgid "Documentation"
@@ -6525,6 +6639,11 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Delete all reading history?"
 msgstr "Gesamten Leseverlauf löschen?"
+
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} blocks a moderation list you're on, so you can't see their writing."
+msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6999,6 +7118,10 @@ msgstr ""
 #: src/components/site-legal-links.tsx
 msgid "Source"
 msgstr "Quelle"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Accounts you block"
+msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That file isn't an image we can read."
@@ -7579,6 +7702,10 @@ msgstr "<0>Wenn Sie sich anmelden</0> mit Ihrem Atmosphere-Konto (etwa per Blues
 #: src/routes/subscribe-login.$did.$rkey.tsx
 msgid "Powered by <0>Standard Reader</0>"
 msgstr "Ermöglicht durch <0>Standard Reader</0>"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Your blocks are enforced here already. To add or remove one from Standard Reader, you'll be asked to authorize block access the first time you try."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -622,6 +622,7 @@ msgid "Please choose a rating."
 msgstr "Bitte wählen Sie eine Bewertung."
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/reader/block-user-menu-item.tsx
 msgid "Blocked"
 msgstr ""
 
@@ -788,6 +789,10 @@ msgstr "Liste löschen?"
 #: src/routes/_layout.latest.tsx
 msgid "Everything published recently across the publications you subscribe to."
 msgstr "Alles, was zuletzt in den von Ihnen abonnierten Publikationen erschienen ist."
+
+#: src/components/reader/comments/comments-section.tsx
+msgid "{hiddenByBlocks, plural, one {# more reply is hidden by your blocks.} other {# more replies are hidden by your blocks.}}"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1488,6 +1493,10 @@ msgstr ""
 msgid "Compact"
 msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "This account"
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Portrait stacks the card vertically. Height adjusts automatically once the embed loads. Change the iframe width as needed."
 msgstr "Im Hochformat wird die Karte vertikal gestapelt. Die Höhe passt sich automatisch an, sobald das Embed geladen ist. Ändern Sie die iframe-Breite nach Bedarf."
@@ -1927,6 +1936,10 @@ msgstr "Abo einbetten"
 msgid "That GIF is over 1 MB. Try a shorter clip, or attach a still image."
 msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+msgstr ""
+
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Add another screenshot"
 #~ msgstr ""
@@ -1946,6 +1959,10 @@ msgstr "Sammlung löschen"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Interface font"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "We're re-reading your blocks from your account. This page updates when it finishes."
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -2014,6 +2031,7 @@ msgstr ""
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/reader/pull-to-refresh.tsx
 msgid "Refreshing"
 msgstr ""
@@ -2305,6 +2323,7 @@ msgstr "Labeler"
 msgid "Articles you've opened — public records in your repo, synced across devices."
 msgstr "Von Ihnen geöffnete Artikel – öffentliche Records in Ihrem Repo, geräteübergreifend synchronisiert."
 
+#: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-publication-editor.tsx
 #: src/components/reader/collection-theme-editor.tsx
@@ -2581,6 +2600,10 @@ msgstr "<0>Leaflet, Pckt, Offprint.</0> <1>pub.leaflet.content</1>, <2>blog.pckt
 
 #: src/components/appearance-settings.tsx
 msgid "XL"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "We couldn't write the block to your account. Try again?"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -3272,6 +3295,10 @@ msgstr "Bild"
 #~ msgid "<0>Follow</0> is the only subscription there is. New writing from anything you follow appears on Home and in Latest, and the publication is listed in your sidebar. There is no email sign-up and no separate account with the publisher."
 #~ msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "We couldn't remove the block from your account. Try again?"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Selecting anyone's name opens their author page: everything they publish, what they follow, and what they have recommended."
 msgstr ""
@@ -3321,6 +3348,10 @@ msgstr ""
 #~ msgid "Prefer a typed client? The whole API ships as codegen'd AT Protocol lexicon schemas in <0>@standard-reader/lexicons</0>. Pair it with <1>@atproto/lex-client</1> for fully-typed <2>client.call()</2> queries and procedures. Its <3>getDocument</3> also returns a document's renderable body, ready to hand to the <4>renderers</4>."
 #~ msgstr ""
 
+#: src/components/reader/comments/comments-section.tsx
+msgid "{hiddenByBlocks, plural, one {The only reply here is from someone you're blocked from.} other {The replies here are all from accounts you're blocked from.}}"
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Couldn't save your follows"
 msgstr "Ihre Follows konnten nicht gespeichert werden"
@@ -3357,6 +3388,10 @@ msgstr ""
 msgid "Publications to explore"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+msgid "We couldn't reach your account to change that. Try again?"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Read as comic"
 msgstr ""
@@ -3378,6 +3413,10 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Read and unread"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "This writes a block to your Bluesky account, so it applies here and anywhere else you use it. Their writing disappears from your feeds, search and discussion, and they can't see yours. You can undo it in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -3502,8 +3541,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
-msgstr ""
+#~ msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
@@ -3643,6 +3682,10 @@ msgstr ""
 msgid "Worth subscribing to"
 msgstr "Einen Blick wert"
 
+#: src/components/blocks-settings-view.tsx
+msgid "this list is larger than we mirror, so some members aren't blocked here"
+msgstr ""
+
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Angular."
 #~ msgstr ""
@@ -3666,6 +3709,10 @@ msgstr ""
 
 #: src/routes/_layout.subscriptions.tsx
 msgid "Nothing to manage yet"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "They're hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.subscriptions.tsx
@@ -4017,6 +4064,10 @@ msgstr ""
 msgid "No lists yet"
 msgstr "Noch keine Listen"
 
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} blocks a moderation list you're on, so you can't see their writing."
+msgstr ""
+
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "Saving things while you browse the rest of the web, keeping Standard Reader on your home screen, and passing an article on."
 #~ msgstr ""
@@ -4036,6 +4087,10 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
 msgstr "Ein Vorlesen-Button liest jeden Artikel direkt auf Ihrem Gerät vor und hebt dabei jedes Wort hervor. Der Player folgt Ihnen durch die App — er liest sogar einen eingebetteten Bluesky-Beitrag vor. Angemeldet können Sie eine Stimme wählen."
+
+#: src/components/reader/blocked-notice.tsx
+msgid "this account"
+msgstr ""
 
 #. placeholder {0}: next.title
 #: src/components/reader/series-up-next.tsx
@@ -4175,6 +4230,15 @@ msgstr "Optional: Notiz, warum Sie dies speichern"
 msgid "Open the app"
 msgstr ""
 
+#. placeholder {0}: fmt.relativeTime(data.syncedAt)
+#: src/components/blocks-settings-view.tsx
+msgid "Last checked {0}. Blocks you make elsewhere show up here within about fifteen minutes."
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block account?"
+msgstr ""
+
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this note on Semble"
 msgstr ""
@@ -4252,8 +4316,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "this account"
 #: src/components/reader/blocked-notice.tsx
-msgid "You blocked {0}, so their writing is hidden everywhere you read."
-msgstr ""
+#~ msgid "You blocked {0}, so their writing is hidden everywhere you read."
+#~ msgstr ""
 
 #. placeholder {0}: filter.trim()
 #: src/components/reader/subscriptions-table.tsx
@@ -4485,6 +4549,10 @@ msgstr ""
 msgid "Recommended articles"
 msgstr "Empfohlene Artikel"
 
+#: src/components/reader/mention-hover-card.tsx
+msgid "You blocked this account, so their writing is hidden."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
 msgstr ""
@@ -4690,6 +4758,10 @@ msgstr ""
 msgid "{0}+ articles"
 msgstr "{0}+ Artikel"
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "{name} is hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts."
+msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "Starter pack"
 msgstr ""
@@ -4701,6 +4773,10 @@ msgstr "Dieser Link ist abgelaufen."
 #: src/components/guide/pages/lists-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Lists in the sidebar"
+msgstr ""
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked {who}, so their writing is hidden everywhere you read."
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
@@ -4952,6 +5028,9 @@ msgstr ""
 msgid "Not in the directory yet?"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/reader/block-user-menu-item.tsx
+#: src/components/reader/blocked-notice.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
@@ -5001,8 +5080,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} is on a moderation list you block. To see them again, leave that list."
-msgstr ""
+#~ msgid "{0} is on a moderation list you block. To see them again, leave that list."
+#~ msgstr ""
 
 #: src/routes/_layout.collections.index.tsx
 msgid "Curated, magazine-rendered editions grouped into series you can subscribe to — your special collections on the network."
@@ -6025,6 +6104,10 @@ msgstr "Feedback ansehen"
 #~ msgid "Pages you have already visited stay available when your connection drops, and Standard Reader shows a plain offline page rather than a browser error when you reach for something it does not have. When a new version of the app is ready, it offers to reload rather than changing under you mid-article."
 #~ msgstr ""
 
+#: src/components/reader/mention-hover-card.tsx
+msgid "This account blocks you, so you can't see their writing."
+msgstr ""
+
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Being in a list does not change your feeds. Everything you subscribe to still arrives on Home and in Latest exactly as before; a list only changes how the sidebar is organised, and gives you a page you can read — or share — on its own."
 msgstr ""
@@ -6233,6 +6316,10 @@ msgstr ""
 #: src/magazine/Magazine.tsx
 msgid "Contents"
 msgstr "Inhalt"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} is on a moderation list you block. To see them again, leave that list."
+msgstr ""
 
 #: src/components/reader/share-menu.tsx
 msgid "Copy embed code"
@@ -6642,8 +6729,8 @@ msgstr "Gesamten Leseverlauf löschen?"
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} blocks a moderation list you're on, so you can't see their writing."
-msgstr ""
+#~ msgid "{0} blocks a moderation list you're on, so you can't see their writing."
+#~ msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6971,6 +7058,10 @@ msgstr "Keine Publikationen für {handleLabel} gefunden."
 msgid "Already subscribed"
 msgstr "Bereits abonniert"
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block {name}?"
+msgstr ""
+
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "How to wire a personal site's own <0>site.standard.*</0> records so Standard Reader can find it and read articles inline, without going through Leaflet, Pckt, Offprint, or another publishing tool."
 msgstr "So richten Sie die eigenen <0>site.standard.*</0>-Records einer persönlichen Website ein, damit Standard Reader sie findet und Artikel direkt anzeigt — ohne Umweg über Leaflet, Pckt, Offprint oder ein anderes Publishing-Tool."
@@ -6986,6 +7077,10 @@ msgstr "Weitere Sammlungen"
 #: src/components/reader/about-view.tsx
 msgid "One tasteful email a week"
 msgstr "Eine gute E-Mail pro Woche"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "Blocked by a list you use"
+msgstr ""
 
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "{unreadCount} unread"
@@ -7274,6 +7369,7 @@ msgid "Pages"
 msgstr ""
 
 #: src/components/reader/article-view-skeleton.tsx
+#: src/routes/_layout.a.$did.$rkey.tsx
 msgid "Loading article"
 msgstr "Artikel wird geladen"
 

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -239,6 +239,10 @@ msgstr ""
 msgid "You're signed in"
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Manage {blockCount} blocks"
+msgstr ""
+
 #: src/routes/_layout.subscriptions.tsx
 msgid "Subscribe to a publication or follow a writer and they'll show up here, with their unread count and latest post. Each subscription is an <0>app.standard-reader.subscription</0> record in your repo — yours to take anywhere."
 msgstr ""
@@ -617,6 +621,10 @@ msgstr ""
 msgid "Please choose a rating."
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+msgid "Blocked"
+msgstr ""
+
 #: src/components/docs/docs-mobile-nav.tsx
 #: src/components/guide/guide-mobile-nav.tsx
 msgid "(current)"
@@ -633,6 +641,10 @@ msgstr ""
 
 #: src/components/reader/share-menu.tsx
 msgid "Portrait"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Loading blocked accounts"
 msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
@@ -655,6 +667,10 @@ msgstr ""
 msgid "Disclaimer and limitation of liability"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+msgid "You don't subscribe to any block lists."
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No articles from this list's publications or people yet."
 msgstr ""
@@ -666,6 +682,10 @@ msgstr ""
 #. placeholder {0}: labels[order]
 #: src/components/reader/publication-actions.tsx
 msgid "Order: {0}"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Partial"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -717,6 +737,10 @@ msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Permanently remove data stored in your account. These actions delete records from your account and cannot be undone."
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Moderation lists you subscribe to on Bluesky. Everyone on them is blocked here too, and the list stays live as its owner changes it."
 msgstr ""
 
 #: src/routes/_layout.communities.$slug.tsx
@@ -1519,6 +1543,11 @@ msgstr ""
 #~ msgid "Wiring up a site that does not publish in this format yet is the one genuinely technical job in the whole product, and it has its own <0>publishing documentation</0>. Everything else in this guide stays where it is."
 #~ msgstr ""
 
+#. placeholder {0}: row.memberCount
+#: src/components/blocks-settings-view.tsx
+msgid "{0, plural, one {# account} other {# accounts}}"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Recommending an article"
@@ -1761,9 +1790,17 @@ msgstr ""
 msgid "Fast full-text search"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+msgid "You haven't blocked anyone."
+msgstr ""
+
 #: src/lib/guide/navigation.ts
 #~ msgid "Saving, recommending, reading history, and managing what you follow."
 #~ msgstr ""
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked this account"
+msgstr ""
 
 #: src/components/reader/notify-button.tsx
 msgid "Notifications aren’t available"
@@ -2054,6 +2091,10 @@ msgstr ""
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block"
+msgstr ""
 
 #: src/routes/_layout.discover.tsx
 msgid "Known publications"
@@ -2416,6 +2457,7 @@ msgstr ""
 msgid "Read more from the author"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/labelers-settings-view.tsx
 #: src/components/user-settings-view.tsx
 msgid "Moderation"
@@ -2440,6 +2482,10 @@ msgstr ""
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Most unread"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block {name}"
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -2579,6 +2625,10 @@ msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Removed"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block account"
 msgstr ""
 
 #: src/components/reading-settings-preview.tsx
@@ -2757,6 +2807,10 @@ msgstr ""
 
 #: src/routes/review.thanks.tsx
 msgid "Return to the app"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Moderation list"
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
@@ -3446,6 +3500,11 @@ msgstr ""
 msgid "This API is also served as a <0>Model Context Protocol</0> server at <1>{baseUrl}/mcp</1>. Paste that URL into an MCP client and authorize it; the fifty-odd methods above are grouped into fifteen tools, and the client can read the network and act on your behalf."
 msgstr ""
 
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
 msgstr ""
@@ -3476,6 +3535,10 @@ msgstr ""
 
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."
+msgstr ""
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You're blocked"
 msgstr ""
 
 #: src/routes/_layout.index.tsx
@@ -3797,6 +3860,10 @@ msgstr ""
 #. placeholder {0}: rows.length
 #: src/components/reader/subscriptions-table.tsx
 msgid "{0} total"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours."
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -4174,8 +4241,18 @@ msgstr ""
 msgid "How readers see it"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/user-settings-view.tsx
+msgid "Blocked accounts"
+msgstr ""
+
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "Standard Reader has a reading mode built for comics — a shelf of covers instead of a list of post titles, and a full-screen theater that flips through your pages. You do not author anything specially for it. This page is how to make sure your comic gets it."
+msgstr ""
+
+#. placeholder {0}: name ?? "this account"
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked {0}, so their writing is hidden everywhere you read."
 msgstr ""
 
 #. placeholder {0}: filter.trim()
@@ -4228,6 +4305,10 @@ msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "The typeface used across the app. Article text follows this too, unless you set a reading font below."
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Refresh"
 msgstr ""
 
 #: src/magazine/magazine-end-like.tsx
@@ -4808,6 +4889,11 @@ msgstr ""
 msgid "There’s a magazine edition of this collection."
 msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+#: src/components/user-settings-view.tsx
+msgid "Manage blocks"
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "What the extension accesses"
 msgstr ""
@@ -4911,6 +4997,11 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Comments and related reading"
+msgstr ""
+
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} is on a moderation list you block. To see them again, leave that list."
 msgstr ""
 
 #: src/routes/_layout.collections.index.tsx
@@ -5359,6 +5450,11 @@ msgstr ""
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler hasn’t labeled any documents in the read-model yet."
 msgstr ""
+
+#. placeholder {0}: row.memberCount
+#: src/components/blocks-settings-view.tsx
+#~ msgid "{0} accounts"
+#~ msgstr ""
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Your lists, their order, and which ones are collapsed are stored in your account rather than in this browser, so the sidebar looks the same on your laptop and your phone."
@@ -5816,6 +5912,10 @@ msgstr ""
 msgid "Standard Reader needs write access to your site.standard publications and documents, plus your collection records, to author Collections. You'll be asked to approve this on your PDS login."
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+msgid "Block lists"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "All articles you have saved for later."
 msgstr ""
@@ -6176,6 +6276,7 @@ msgstr ""
 msgid "Top on the network"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
@@ -6196,6 +6297,10 @@ msgstr ""
 
 #: src/components/reader/page-reader-bar.tsx
 msgid "Return to article and follow along"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Some blocks couldn't be refreshed last time, so this list may be incomplete."
 msgstr ""
 
 #. placeholder {0}: pub.subscriberCount
@@ -6381,8 +6486,17 @@ msgstr ""
 msgid "The Saved screen: a list of article cards the reader has set aside, each with its publication, headline, and excerpt."
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/reader/blocked-notice.tsx
+msgid "Unblock"
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "What we do not do"
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Your Bluesky blocks apply here too — blocked accounts disappear from your feeds, search, and discussion, in both directions."
 msgstr ""
 
 #: src/components/docs/docs-side-nav.tsx
@@ -6524,6 +6638,11 @@ msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Delete all reading history?"
+msgstr ""
+
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} blocks a moderation list you're on, so you can't see their writing."
 msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
@@ -6998,6 +7117,10 @@ msgstr ""
 
 #: src/components/site-legal-links.tsx
 msgid "Source"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Accounts you block"
 msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
@@ -7578,6 +7701,10 @@ msgstr ""
 
 #: src/routes/subscribe-login.$did.$rkey.tsx
 msgid "Powered by <0>Standard Reader</0>"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Your blocks are enforced here already. To add or remove one from Standard Reader, you'll be asked to authorize block access the first time you try."
 msgstr ""
 
 #: src/components/appearance-settings.tsx

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -622,6 +622,7 @@ msgid "Please choose a rating."
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/reader/block-user-menu-item.tsx
 msgid "Blocked"
 msgstr ""
 
@@ -787,6 +788,10 @@ msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "Everything published recently across the publications you subscribe to."
+msgstr ""
+
+#: src/components/reader/comments/comments-section.tsx
+msgid "{hiddenByBlocks, plural, one {# more reply is hidden by your blocks.} other {# more replies are hidden by your blocks.}}"
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -1488,6 +1493,10 @@ msgstr ""
 msgid "Compact"
 msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "This account"
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Portrait stacks the card vertically. Height adjusts automatically once the embed loads. Change the iframe width as needed."
 msgstr ""
@@ -1927,6 +1936,10 @@ msgstr ""
 msgid "That GIF is over 1 MB. Try a shorter clip, or attach a still image."
 msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+msgstr ""
+
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Add another screenshot"
 #~ msgstr ""
@@ -1946,6 +1959,10 @@ msgstr ""
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Interface font"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "We're re-reading your blocks from your account. This page updates when it finishes."
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -2014,6 +2031,7 @@ msgstr ""
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/reader/pull-to-refresh.tsx
 msgid "Refreshing"
 msgstr ""
@@ -2305,6 +2323,7 @@ msgstr ""
 msgid "Articles you've opened — public records in your repo, synced across devices."
 msgstr ""
 
+#: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-publication-editor.tsx
 #: src/components/reader/collection-theme-editor.tsx
@@ -2581,6 +2600,10 @@ msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "XL"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "We couldn't write the block to your account. Try again?"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -3272,6 +3295,10 @@ msgstr ""
 #~ msgid "<0>Follow</0> is the only subscription there is. New writing from anything you follow appears on Home and in Latest, and the publication is listed in your sidebar. There is no email sign-up and no separate account with the publisher."
 #~ msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "We couldn't remove the block from your account. Try again?"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Selecting anyone's name opens their author page: everything they publish, what they follow, and what they have recommended."
 msgstr ""
@@ -3321,6 +3348,10 @@ msgstr ""
 #~ msgid "Prefer a typed client? The whole API ships as codegen'd AT Protocol lexicon schemas in <0>@standard-reader/lexicons</0>. Pair it with <1>@atproto/lex-client</1> for fully-typed <2>client.call()</2> queries and procedures. Its <3>getDocument</3> also returns a document's renderable body, ready to hand to the <4>renderers</4>."
 #~ msgstr ""
 
+#: src/components/reader/comments/comments-section.tsx
+msgid "{hiddenByBlocks, plural, one {The only reply here is from someone you're blocked from.} other {The replies here are all from accounts you're blocked from.}}"
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Couldn't save your follows"
 msgstr ""
@@ -3357,6 +3388,10 @@ msgstr ""
 msgid "Publications to explore"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+msgid "We couldn't reach your account to change that. Try again?"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Read as comic"
 msgstr ""
@@ -3378,6 +3413,10 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Read and unread"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "This writes a block to your Bluesky account, so it applies here and anywhere else you use it. Their writing disappears from your feeds, search and discussion, and they can't see yours. You can undo it in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -3502,8 +3541,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
-msgstr ""
+#~ msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
@@ -3643,6 +3682,10 @@ msgstr ""
 msgid "Worth subscribing to"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+msgid "this list is larger than we mirror, so some members aren't blocked here"
+msgstr ""
+
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Angular."
 #~ msgstr ""
@@ -3666,6 +3709,10 @@ msgstr ""
 
 #: src/routes/_layout.subscriptions.tsx
 msgid "Nothing to manage yet"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "They're hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.subscriptions.tsx
@@ -4017,6 +4064,10 @@ msgstr ""
 msgid "No lists yet"
 msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} blocks a moderation list you're on, so you can't see their writing."
+msgstr ""
+
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "Saving things while you browse the rest of the web, keeping Standard Reader on your home screen, and passing an article on."
 #~ msgstr ""
@@ -4035,6 +4086,10 @@ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
+msgstr ""
+
+#: src/components/reader/blocked-notice.tsx
+msgid "this account"
 msgstr ""
 
 #. placeholder {0}: next.title
@@ -4175,6 +4230,15 @@ msgstr ""
 msgid "Open the app"
 msgstr ""
 
+#. placeholder {0}: fmt.relativeTime(data.syncedAt)
+#: src/components/blocks-settings-view.tsx
+msgid "Last checked {0}. Blocks you make elsewhere show up here within about fifteen minutes."
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block account?"
+msgstr ""
+
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this note on Semble"
 msgstr ""
@@ -4252,8 +4316,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "this account"
 #: src/components/reader/blocked-notice.tsx
-msgid "You blocked {0}, so their writing is hidden everywhere you read."
-msgstr ""
+#~ msgid "You blocked {0}, so their writing is hidden everywhere you read."
+#~ msgstr ""
 
 #. placeholder {0}: filter.trim()
 #: src/components/reader/subscriptions-table.tsx
@@ -4485,6 +4549,10 @@ msgstr ""
 msgid "Recommended articles"
 msgstr ""
 
+#: src/components/reader/mention-hover-card.tsx
+msgid "You blocked this account, so their writing is hidden."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
 msgstr ""
@@ -4690,6 +4758,10 @@ msgstr ""
 msgid "{0}+ articles"
 msgstr ""
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "{name} is hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts."
+msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "Starter pack"
 msgstr ""
@@ -4701,6 +4773,10 @@ msgstr ""
 #: src/components/guide/pages/lists-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Lists in the sidebar"
+msgstr ""
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked {who}, so their writing is hidden everywhere you read."
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
@@ -4952,6 +5028,9 @@ msgstr ""
 msgid "Not in the directory yet?"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/reader/block-user-menu-item.tsx
+#: src/components/reader/blocked-notice.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
@@ -5001,8 +5080,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} is on a moderation list you block. To see them again, leave that list."
-msgstr ""
+#~ msgid "{0} is on a moderation list you block. To see them again, leave that list."
+#~ msgstr ""
 
 #: src/routes/_layout.collections.index.tsx
 msgid "Curated, magazine-rendered editions grouped into series you can subscribe to — your special collections on the network."
@@ -6025,6 +6104,10 @@ msgstr ""
 #~ msgid "Pages you have already visited stay available when your connection drops, and Standard Reader shows a plain offline page rather than a browser error when you reach for something it does not have. When a new version of the app is ready, it offers to reload rather than changing under you mid-article."
 #~ msgstr ""
 
+#: src/components/reader/mention-hover-card.tsx
+msgid "This account blocks you, so you can't see their writing."
+msgstr ""
+
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Being in a list does not change your feeds. Everything you subscribe to still arrives on Home and in Latest exactly as before; a list only changes how the sidebar is organised, and gives you a page you can read — or share — on its own."
 msgstr ""
@@ -6232,6 +6315,10 @@ msgstr ""
 
 #: src/magazine/Magazine.tsx
 msgid "Contents"
+msgstr ""
+
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} is on a moderation list you block. To see them again, leave that list."
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -6642,8 +6729,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} blocks a moderation list you're on, so you can't see their writing."
-msgstr ""
+#~ msgid "{0} blocks a moderation list you're on, so you can't see their writing."
+#~ msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6971,6 +7058,10 @@ msgstr ""
 msgid "Already subscribed"
 msgstr ""
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block {name}?"
+msgstr ""
+
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "How to wire a personal site's own <0>site.standard.*</0> records so Standard Reader can find it and read articles inline, without going through Leaflet, Pckt, Offprint, or another publishing tool."
 msgstr ""
@@ -6985,6 +7076,10 @@ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "One tasteful email a week"
+msgstr ""
+
+#: src/components/reader/blocked-notice.tsx
+msgid "Blocked by a list you use"
 msgstr ""
 
 #: src/components/reader/subscriptions-sheet.tsx
@@ -7274,6 +7369,7 @@ msgid "Pages"
 msgstr ""
 
 #: src/components/reader/article-view-skeleton.tsx
+#: src/routes/_layout.a.$did.$rkey.tsx
 msgid "Loading article"
 msgstr ""
 

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -622,6 +622,7 @@ msgid "Please choose a rating."
 msgstr "Please choose a rating."
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/reader/block-user-menu-item.tsx
 msgid "Blocked"
 msgstr "Blocked"
 
@@ -788,6 +789,10 @@ msgstr "Delete list?"
 #: src/routes/_layout.latest.tsx
 msgid "Everything published recently across the publications you subscribe to."
 msgstr "Everything published recently across the publications you subscribe to."
+
+#: src/components/reader/comments/comments-section.tsx
+msgid "{hiddenByBlocks, plural, one {# more reply is hidden by your blocks.} other {# more replies are hidden by your blocks.}}"
+msgstr "{hiddenByBlocks, plural, one {# more reply is hidden by your blocks.} other {# more replies are hidden by your blocks.}}"
 
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1488,6 +1493,10 @@ msgstr "For more about how {SITE_NAME} works, see the <0>About</0> page. For que
 msgid "Compact"
 msgstr "Compact"
 
+#: src/components/reader/blocked-notice.tsx
+msgid "This account"
+msgstr "This account"
+
 #: src/components/reader/share-menu.tsx
 msgid "Portrait stacks the card vertically. Height adjusts automatically once the embed loads. Change the iframe width as needed."
 msgstr "Portrait stacks the card vertically. Height adjusts automatically once the embed loads. Change the iframe width as needed."
@@ -1927,6 +1936,10 @@ msgstr "Embed subscribe"
 msgid "That GIF is over 1 MB. Try a shorter clip, or attach a still image."
 msgstr "That GIF is over 1 MB. Try a shorter clip, or attach a still image."
 
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+msgstr "{Who} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Add another screenshot"
 #~ msgstr "Add another screenshot"
@@ -1947,6 +1960,10 @@ msgstr "Delete collection"
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Interface font"
 msgstr "Interface font"
+
+#: src/components/blocks-settings-view.tsx
+msgid "We're re-reading your blocks from your account. This page updates when it finishes."
+msgstr "We're re-reading your blocks from your account. This page updates when it finishes."
 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No publications in this list."
@@ -2014,6 +2031,7 @@ msgstr "Connect {0} to your account?"
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 msgstr "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/reader/pull-to-refresh.tsx
 msgid "Refreshing"
 msgstr "Refreshing"
@@ -2305,6 +2323,7 @@ msgstr "Labeler"
 msgid "Articles you've opened — public records in your repo, synced across devices."
 msgstr "Articles you've opened — public records in your repo, synced across devices."
 
+#: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-publication-editor.tsx
 #: src/components/reader/collection-theme-editor.tsx
@@ -2582,6 +2601,10 @@ msgstr "<0>Leaflet, Pckt, Offprint.</0> <1>pub.leaflet.content</1>, <2>blog.pckt
 #: src/components/appearance-settings.tsx
 msgid "XL"
 msgstr "XL"
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "We couldn't write the block to your account. Try again?"
+msgstr "We couldn't write the block to your account. Try again?"
 
 #: src/components/reader/about-view.tsx
 msgid "Set your own type"
@@ -3272,6 +3295,10 @@ msgstr "Image"
 #~ msgid "<0>Follow</0> is the only subscription there is. New writing from anything you follow appears on Home and in Latest, and the publication is listed in your sidebar. There is no email sign-up and no separate account with the publisher."
 #~ msgstr "<0>Follow</0> is the only subscription there is. New writing from anything you follow appears on Home and in Latest, and the publication is listed in your sidebar. There is no email sign-up and no separate account with the publisher."
 
+#: src/components/reader/blocked-notice.tsx
+msgid "We couldn't remove the block from your account. Try again?"
+msgstr "We couldn't remove the block from your account. Try again?"
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Selecting anyone's name opens their author page: everything they publish, what they follow, and what they have recommended."
 msgstr "Selecting anyone's name opens their author page: everything they publish, what they follow, and what they have recommended."
@@ -3321,6 +3348,10 @@ msgstr "Sharing an article"
 #~ msgid "Prefer a typed client? The whole API ships as codegen'd AT Protocol lexicon schemas in <0>@standard-reader/lexicons</0>. Pair it with <1>@atproto/lex-client</1> for fully-typed <2>client.call()</2> queries and procedures. Its <3>getDocument</3> also returns a document's renderable body, ready to hand to the <4>renderers</4>."
 #~ msgstr "Prefer a typed client? The whole API ships as codegen'd AT Protocol lexicon schemas in <0>@standard-reader/lexicons</0>. Pair it with <1>@atproto/lex-client</1> for fully-typed <2>client.call()</2> queries and procedures. Its <3>getDocument</3> also returns a document's renderable body, ready to hand to the <4>renderers</4>."
 
+#: src/components/reader/comments/comments-section.tsx
+msgid "{hiddenByBlocks, plural, one {The only reply here is from someone you're blocked from.} other {The replies here are all from accounts you're blocked from.}}"
+msgstr "{hiddenByBlocks, plural, one {The only reply here is from someone you're blocked from.} other {The replies here are all from accounts you're blocked from.}}"
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Couldn't save your follows"
 msgstr "Couldn't save your follows"
@@ -3357,6 +3388,10 @@ msgstr "Signed out?"
 msgid "Publications to explore"
 msgstr "Publications to explore"
 
+#: src/components/blocks-settings-view.tsx
+msgid "We couldn't reach your account to change that. Try again?"
+msgstr "We couldn't reach your account to change that. Try again?"
+
 #: src/components/reader/article-view.tsx
 msgid "Read as comic"
 msgstr "Read as comic"
@@ -3379,6 +3414,10 @@ msgstr "Prefer a typed client? The whole API ships as codegen'd AT Protocol lexi
 #: src/lib/guide/navigation.ts
 msgid "Read and unread"
 msgstr "Read and unread"
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "This writes a block to your Bluesky account, so it applies here and anywhere else you use it. Their writing disappears from your feeds, search and discussion, and they can't see yours. You can undo it in Settings → Blocked accounts."
+msgstr "This writes a block to your Bluesky account, so it applies here and anywhere else you use it. Their writing disappears from your feeds, search and discussion, and they can't see yours. You can undo it in Settings → Blocked accounts."
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.u.$did.tsx
@@ -3502,8 +3541,8 @@ msgstr "This API is also served as a <0>Model Context Protocol</0> server at <1>
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
-msgstr "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+#~ msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+#~ msgstr "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
@@ -3643,6 +3682,10 @@ msgstr "Turning the comic view on"
 msgid "Worth subscribing to"
 msgstr "Worth subscribing to"
 
+#: src/components/blocks-settings-view.tsx
+msgid "this list is larger than we mirror, so some members aren't blocked here"
+msgstr "this list is larger than we mirror, so some members aren't blocked here"
+
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Angular."
 #~ msgstr "Angular."
@@ -3667,6 +3710,10 @@ msgstr "Links inside an article go where the author pointed them. When a link le
 #: src/routes/_layout.subscriptions.tsx
 msgid "Nothing to manage yet"
 msgstr "Nothing to manage yet"
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "They're hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts."
+msgstr "They're hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts."
 
 #: src/routes/_layout.subscriptions.tsx
 msgid "Your library"
@@ -4017,6 +4064,10 @@ msgstr "Standard Reader emits these on its own article, publication, collection,
 msgid "No lists yet"
 msgstr "No lists yet"
 
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} blocks a moderation list you're on, so you can't see their writing."
+msgstr "{Who} blocks a moderation list you're on, so you can't see their writing."
+
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "Saving things while you browse the rest of the web, keeping Standard Reader on your home screen, and passing an article on."
 #~ msgstr "Saving things while you browse the rest of the web, keeping Standard Reader on your home screen, and passing an article on."
@@ -4036,6 +4087,10 @@ msgstr "Then open Standard Reader from your Home Screen and turn the bell on the
 #: src/components/reader/about-view.tsx
 msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
 msgstr "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
+
+#: src/components/reader/blocked-notice.tsx
+msgid "this account"
+msgstr "this account"
 
 #. placeholder {0}: next.title
 #: src/components/reader/series-up-next.tsx
@@ -4175,6 +4230,15 @@ msgstr "Optional: add a note about why you're saving this"
 msgid "Open the app"
 msgstr "Open the app"
 
+#. placeholder {0}: fmt.relativeTime(data.syncedAt)
+#: src/components/blocks-settings-view.tsx
+msgid "Last checked {0}. Blocks you make elsewhere show up here within about fifteen minutes."
+msgstr "Last checked {0}. Blocks you make elsewhere show up here within about fifteen minutes."
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block account?"
+msgstr "Block account?"
+
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this note on Semble"
 msgstr "Open this note on Semble"
@@ -4252,8 +4316,8 @@ msgstr "Standard Reader has a reading mode built for comics — a shelf of cover
 
 #. placeholder {0}: name ?? "this account"
 #: src/components/reader/blocked-notice.tsx
-msgid "You blocked {0}, so their writing is hidden everywhere you read."
-msgstr "You blocked {0}, so their writing is hidden everywhere you read."
+#~ msgid "You blocked {0}, so their writing is hidden everywhere you read."
+#~ msgstr "You blocked {0}, so their writing is hidden everywhere you read."
 
 #. placeholder {0}: filter.trim()
 #: src/components/reader/subscriptions-table.tsx
@@ -4485,6 +4549,10 @@ msgstr "Recent activity"
 msgid "Recommended articles"
 msgstr "Recommended articles"
 
+#: src/components/reader/mention-hover-card.tsx
+msgid "You blocked this account, so their writing is hidden."
+msgstr "You blocked this account, so their writing is hidden."
+
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
 msgstr "Light, dark, match your system — or Custom, to choose a palette of your own."
@@ -4690,6 +4758,10 @@ msgstr "Home, Latest, Discover, search, and topics."
 msgid "{0}+ articles"
 msgstr "{0}+ articles"
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "{name} is hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts."
+msgstr "{name} is hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts."
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "Starter pack"
 msgstr "Starter pack"
@@ -4702,6 +4774,10 @@ msgstr "That link expired."
 #: src/lib/guide/navigation.ts
 msgid "Lists in the sidebar"
 msgstr "Lists in the sidebar"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked {who}, so their writing is hidden everywhere you read."
+msgstr "You blocked {who}, so their writing is hidden everywhere you read."
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "The extension checks the address of the page you are on to work out whether there is anything to offer, and it acts on your account only when you click something. It does not read your browsing history or the contents of pages."
@@ -4952,6 +5028,9 @@ msgstr "{totalPeople, plural, one {# person you follow writes here} other {# peo
 msgid "Not in the directory yet?"
 msgstr "Not in the directory yet?"
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/reader/block-user-menu-item.tsx
+#: src/components/reader/blocked-notice.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
@@ -5001,8 +5080,8 @@ msgstr "Comments and related reading"
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} is on a moderation list you block. To see them again, leave that list."
-msgstr "{0} is on a moderation list you block. To see them again, leave that list."
+#~ msgid "{0} is on a moderation list you block. To see them again, leave that list."
+#~ msgstr "{0} is on a moderation list you block. To see them again, leave that list."
 
 #: src/routes/_layout.collections.index.tsx
 msgid "Curated, magazine-rendered editions grouped into series you can subscribe to — your special collections on the network."
@@ -6025,6 +6104,10 @@ msgstr "View feedback"
 #~ msgid "Pages you have already visited stay available when your connection drops, and Standard Reader shows a plain offline page rather than a browser error when you reach for something it does not have. When a new version of the app is ready, it offers to reload rather than changing under you mid-article."
 #~ msgstr "Pages you have already visited stay available when your connection drops, and Standard Reader shows a plain offline page rather than a browser error when you reach for something it does not have. When a new version of the app is ready, it offers to reload rather than changing under you mid-article."
 
+#: src/components/reader/mention-hover-card.tsx
+msgid "This account blocks you, so you can't see their writing."
+msgstr "This account blocks you, so you can't see their writing."
+
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Being in a list does not change your feeds. Everything you subscribe to still arrives on Home and in Latest exactly as before; a list only changes how the sidebar is organised, and gives you a page you can read — or share — on its own."
 msgstr "Being in a list does not change your feeds. Everything you subscribe to still arrives on Home and in Latest exactly as before; a list only changes how the sidebar is organised, and gives you a page you can read — or share — on its own."
@@ -6233,6 +6316,10 @@ msgstr "Some people would rather read on the publication's own site, with its ow
 #: src/magazine/Magazine.tsx
 msgid "Contents"
 msgstr "Contents"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} is on a moderation list you block. To see them again, leave that list."
+msgstr "{Who} is on a moderation list you block. To see them again, leave that list."
 
 #: src/components/reader/share-menu.tsx
 msgid "Copy embed code"
@@ -6642,8 +6729,8 @@ msgstr "Delete all reading history?"
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} blocks a moderation list you're on, so you can't see their writing."
-msgstr "{0} blocks a moderation list you're on, so you can't see their writing."
+#~ msgid "{0} blocks a moderation list you're on, so you can't see their writing."
+#~ msgstr "{0} blocks a moderation list you're on, so you can't see their writing."
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6971,6 +7058,10 @@ msgstr "No publications found for {handleLabel}."
 msgid "Already subscribed"
 msgstr "Already subscribed"
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block {name}?"
+msgstr "Block {name}?"
+
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "How to wire a personal site's own <0>site.standard.*</0> records so Standard Reader can find it and read articles inline, without going through Leaflet, Pckt, Offprint, or another publishing tool."
 msgstr "How to wire a personal site's own <0>site.standard.*</0> records so Standard Reader can find it and read articles inline, without going through Leaflet, Pckt, Offprint, or another publishing tool."
@@ -6986,6 +7077,10 @@ msgstr "Other collections"
 #: src/components/reader/about-view.tsx
 msgid "One tasteful email a week"
 msgstr "One tasteful email a week"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "Blocked by a list you use"
+msgstr "Blocked by a list you use"
 
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "{unreadCount} unread"
@@ -7274,6 +7369,7 @@ msgid "Pages"
 msgstr "Pages"
 
 #: src/components/reader/article-view-skeleton.tsx
+#: src/routes/_layout.a.$did.$rkey.tsx
 msgid "Loading article"
 msgstr "Loading article"
 

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -239,6 +239,10 @@ msgstr "Settings that have nowhere else to go — your theme and language when y
 msgid "You're signed in"
 msgstr "You're signed in"
 
+#: src/components/user-settings-view.tsx
+msgid "Manage {blockCount} blocks"
+msgstr "Manage {blockCount} blocks"
+
 #: src/routes/_layout.subscriptions.tsx
 msgid "Subscribe to a publication or follow a writer and they'll show up here, with their unread count and latest post. Each subscription is an <0>app.standard-reader.subscription</0> record in your repo — yours to take anywhere."
 msgstr "Subscribe to a publication or follow a writer and they'll show up here, with their unread count and latest post. Each subscription is an <0>app.standard-reader.subscription</0> record in your repo — yours to take anywhere."
@@ -617,6 +621,10 @@ msgstr "Finish reordering"
 msgid "Please choose a rating."
 msgstr "Please choose a rating."
 
+#: src/components/blocks-settings-view.tsx
+msgid "Blocked"
+msgstr "Blocked"
+
 #: src/components/docs/docs-mobile-nav.tsx
 #: src/components/guide/guide-mobile-nav.tsx
 msgid "(current)"
@@ -634,6 +642,10 @@ msgstr "Reading an article"
 #: src/components/reader/share-menu.tsx
 msgid "Portrait"
 msgstr "Portrait"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Loading blocked accounts"
+msgstr "Loading blocked accounts"
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Select any headline to open it. Articles are laid out as a single column at a comfortable width, with the publication's own colors and typography where it has them."
@@ -655,6 +667,10 @@ msgstr "Move down"
 msgid "Disclaimer and limitation of liability"
 msgstr "Disclaimer and limitation of liability"
 
+#: src/components/blocks-settings-view.tsx
+msgid "You don't subscribe to any block lists."
+msgstr "You don't subscribe to any block lists."
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No articles from this list's publications or people yet."
 msgstr "No articles from this list's publications or people yet."
@@ -667,6 +683,10 @@ msgstr "Loading labelers"
 #: src/components/reader/publication-actions.tsx
 msgid "Order: {0}"
 msgstr "Order: {0}"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Partial"
+msgstr "Partial"
 
 #: src/components/reader/share-menu.tsx
 msgid "Landscape fits a compact row. Height adjusts automatically once the embed loads. Change the iframe width as needed."
@@ -718,6 +738,10 @@ msgstr "Attachment {0} on “{title}”"
 #: src/components/user-settings-view.tsx
 msgid "Permanently remove data stored in your account. These actions delete records from your account and cannot be undone."
 msgstr "Permanently remove data stored in your account. These actions delete records from your account and cannot be undone."
+
+#: src/components/blocks-settings-view.tsx
+msgid "Moderation lists you subscribe to on Bluesky. Everyone on them is blocked here too, and the list stays live as its owner changes it."
+msgstr "Moderation lists you subscribe to on Bluesky. Everyone on them is blocked here too, and the list stays live as its owner changes it."
 
 #: src/routes/_layout.communities.$slug.tsx
 #~ msgid "Sub-areas"
@@ -1519,6 +1543,11 @@ msgstr "<0/> Unsubscribe in one click, any time"
 #~ msgid "Wiring up a site that does not publish in this format yet is the one genuinely technical job in the whole product, and it has its own <0>publishing documentation</0>. Everything else in this guide stays where it is."
 #~ msgstr "Wiring up a site that does not publish in this format yet is the one genuinely technical job in the whole product, and it has its own <0>publishing documentation</0>. Everything else in this guide stays where it is."
 
+#. placeholder {0}: row.memberCount
+#: src/components/blocks-settings-view.tsx
+msgid "{0, plural, one {# account} other {# accounts}}"
+msgstr "{0, plural, one {# account} other {# accounts}}"
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Recommending an article"
@@ -1761,9 +1790,17 @@ msgstr "On a computer, a sidebar runs down the left of every screen. From the to
 msgid "Fast full-text search"
 msgstr "Fast full-text search"
 
+#: src/components/blocks-settings-view.tsx
+msgid "You haven't blocked anyone."
+msgstr "You haven't blocked anyone."
+
 #: src/lib/guide/navigation.ts
 #~ msgid "Saving, recommending, reading history, and managing what you follow."
 #~ msgstr "Saving, recommending, reading history, and managing what you follow."
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked this account"
+msgstr "You blocked this account"
 
 #: src/components/reader/notify-button.tsx
 msgid "Notifications aren’t available"
@@ -2054,6 +2091,10 @@ msgstr "Installed to Home Screen"
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr "Pick the package for your framework; all sit on the same core."
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block"
+msgstr "Block"
 
 #: src/routes/_layout.discover.tsx
 msgid "Known publications"
@@ -2416,6 +2457,7 @@ msgstr "View labeler"
 msgid "Read more from the author"
 msgstr "Read more from the author"
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/labelers-settings-view.tsx
 #: src/components/user-settings-view.tsx
 msgid "Moderation"
@@ -2441,6 +2483,10 @@ msgstr "Documents"
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Most unread"
 msgstr "Most unread"
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block {name}"
+msgstr "Block {name}"
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "everything you subscribe to, read or not. This is the default."
@@ -2580,6 +2626,10 @@ msgstr "Edit"
 #: src/components/reader/subscriptions-table.tsx
 msgid "Removed"
 msgstr "Removed"
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block account"
+msgstr "Block account"
 
 #: src/components/reading-settings-preview.tsx
 msgid "Stop sample"
@@ -2758,6 +2808,10 @@ msgstr "{0, plural, one {# publication from your Bluesky follows} other {# publi
 #: src/routes/review.thanks.tsx
 msgid "Return to the app"
 msgstr "Return to the app"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Moderation list"
+msgstr "Moderation list"
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -3446,6 +3500,11 @@ msgstr "Show {label} tab"
 msgid "This API is also served as a <0>Model Context Protocol</0> server at <1>{baseUrl}/mcp</1>. Paste that URL into an MCP client and authorize it; the fifty-odd methods above are grouped into fifteen tools, and the client can read the network and act on your behalf."
 msgstr "This API is also served as a <0>Model Context Protocol</0> server at <1>{baseUrl}/mcp</1>. Paste that URL into an MCP client and authorize it; the fifty-odd methods above are grouped into fifteen tools, and the client can read the network and act on your behalf."
 
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+msgstr "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
 msgstr "Reset filters"
@@ -3477,6 +3536,10 @@ msgstr "{n, plural, one {# publication} other {{value} publications}}"
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."
 msgstr "Choose which tabs appear on your public profile."
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You're blocked"
+msgstr "You're blocked"
 
 #: src/routes/_layout.index.tsx
 msgid "View all latest"
@@ -3798,6 +3861,10 @@ msgstr "No topics match your search."
 #: src/components/reader/subscriptions-table.tsx
 msgid "{0} total"
 msgstr "{0} total"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours."
+msgstr "Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours."
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Five ways in: what is new from your follows, what the whole network is publishing, the directory, search, and topics."
@@ -4174,9 +4241,19 @@ msgstr "Unread"
 msgid "How readers see it"
 msgstr "How readers see it"
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/user-settings-view.tsx
+msgid "Blocked accounts"
+msgstr "Blocked accounts"
+
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "Standard Reader has a reading mode built for comics — a shelf of covers instead of a list of post titles, and a full-screen theater that flips through your pages. You do not author anything specially for it. This page is how to make sure your comic gets it."
 msgstr "Standard Reader has a reading mode built for comics — a shelf of covers instead of a list of post titles, and a full-screen theater that flips through your pages. You do not author anything specially for it. This page is how to make sure your comic gets it."
+
+#. placeholder {0}: name ?? "this account"
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked {0}, so their writing is hidden everywhere you read."
+msgstr "You blocked {0}, so their writing is hidden everywhere you read."
 
 #. placeholder {0}: filter.trim()
 #: src/components/reader/subscriptions-table.tsx
@@ -4229,6 +4306,10 @@ msgstr "The most-read writing across the network right now."
 #: src/components/appearance-settings.tsx
 msgid "The typeface used across the app. Article text follows this too, unless you set a reading font below."
 msgstr "The typeface used across the app. Article text follows this too, unless you set a reading font below."
+
+#: src/components/blocks-settings-view.tsx
+msgid "Refresh"
+msgstr "Refresh"
 
 #: src/magazine/magazine-end-like.tsx
 msgid "Recommend this issue"
@@ -4808,6 +4889,11 @@ msgstr "We used to also accept a labeler registered by a Standard Reader‑speci
 msgid "There’s a magazine edition of this collection."
 msgstr "There’s a magazine edition of this collection."
 
+#: src/components/reader/blocked-notice.tsx
+#: src/components/user-settings-view.tsx
+msgid "Manage blocks"
+msgstr "Manage blocks"
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "What the extension accesses"
 msgstr "What the extension accesses"
@@ -4912,6 +4998,11 @@ msgstr "<0>Page URLs.</0> When you open the popup, use the page overlay, or choo
 #: src/lib/guide/navigation.ts
 msgid "Comments and related reading"
 msgstr "Comments and related reading"
+
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} is on a moderation list you block. To see them again, leave that list."
+msgstr "{0} is on a moderation list you block. To see them again, leave that list."
 
 #: src/routes/_layout.collections.index.tsx
 msgid "Curated, magazine-rendered editions grouped into series you can subscribe to — your special collections on the network."
@@ -5359,6 +5450,11 @@ msgstr "Reply on Bluesky"
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler hasn’t labeled any documents in the read-model yet."
 msgstr "This labeler hasn’t labeled any documents in the read-model yet."
+
+#. placeholder {0}: row.memberCount
+#: src/components/blocks-settings-view.tsx
+#~ msgid "{0} accounts"
+#~ msgstr "{0} accounts"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Your lists, their order, and which ones are collapsed are stored in your account rather than in this browser, so the sidebar looks the same on your laptop and your phone."
@@ -5816,6 +5912,10 @@ msgstr "<0>Reorder subscriptions…</0> lets you drag your lists into the order 
 msgid "Standard Reader needs write access to your site.standard publications and documents, plus your collection records, to author Collections. You'll be asked to approve this on your PDS login."
 msgstr "Standard Reader needs write access to your site.standard publications and documents, plus your collection records, to author Collections. You'll be asked to approve this on your PDS login."
 
+#: src/components/blocks-settings-view.tsx
+msgid "Block lists"
+msgstr "Block lists"
+
 #: src/components/user-settings-view.tsx
 msgid "All articles you have saved for later."
 msgstr "All articles you have saved for later."
@@ -6176,6 +6276,7 @@ msgstr "operational"
 msgid "Top on the network"
 msgstr "Top on the network"
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
@@ -6197,6 +6298,10 @@ msgstr "Filter by topic: {triggerLabel}"
 #: src/components/reader/page-reader-bar.tsx
 msgid "Return to article and follow along"
 msgstr "Return to article and follow along"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Some blocks couldn't be refreshed last time, so this list may be incomplete."
+msgstr "Some blocks couldn't be refreshed last time, so this list may be incomplete."
 
 #. placeholder {0}: pub.subscriberCount
 #: src/components/reader/cards.tsx
@@ -6381,9 +6486,18 @@ msgstr "Edit list"
 msgid "The Saved screen: a list of article cards the reader has set aside, each with its publication, headline, and excerpt."
 msgstr "The Saved screen: a list of article cards the reader has set aside, each with its publication, headline, and excerpt."
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/reader/blocked-notice.tsx
+msgid "Unblock"
+msgstr "Unblock"
+
 #: src/components/reader/privacy-view.tsx
 msgid "What we do not do"
 msgstr "What we do not do"
+
+#: src/components/user-settings-view.tsx
+msgid "Your Bluesky blocks apply here too — blocked accounts disappear from your feeds, search, and discussion, in both directions."
+msgstr "Your Bluesky blocks apply here too — blocked accounts disappear from your feeds, search, and discussion, in both directions."
 
 #: src/components/docs/docs-side-nav.tsx
 msgid "Documentation"
@@ -6525,6 +6639,11 @@ msgstr "What a list is"
 #: src/components/user-settings-view.tsx
 msgid "Delete all reading history?"
 msgstr "Delete all reading history?"
+
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} blocks a moderation list you're on, so you can't see their writing."
+msgstr "{0} blocks a moderation list you're on, so you can't see their writing."
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6999,6 +7118,10 @@ msgstr "Opens a new post linking to this article and tagging <0>@{authorHandle}<
 #: src/components/site-legal-links.tsx
 msgid "Source"
 msgstr "Source"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Accounts you block"
+msgstr "Accounts you block"
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That file isn't an image we can read."
@@ -7579,6 +7702,10 @@ msgstr "<0>When you sign in</0> with your Atmosphere account (for example via Bl
 #: src/routes/subscribe-login.$did.$rkey.tsx
 msgid "Powered by <0>Standard Reader</0>"
 msgstr "Powered by <0>Standard Reader</0>"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Your blocks are enforced here already. To add or remove one from Standard Reader, you'll be asked to authorize block access the first time you try."
+msgstr "Your blocks are enforced here already. To add or remove one from Standard Reader, you'll be asked to authorize block access the first time you try."
 
 #: src/components/appearance-settings.tsx
 msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -622,6 +622,7 @@ msgid "Please choose a rating."
 msgstr "Elija una valoración."
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/reader/block-user-menu-item.tsx
 msgid "Blocked"
 msgstr ""
 
@@ -788,6 +789,10 @@ msgstr "¿Eliminar la lista?"
 #: src/routes/_layout.latest.tsx
 msgid "Everything published recently across the publications you subscribe to."
 msgstr "Todo lo publicado recientemente en las publicaciones a las que está suscrito."
+
+#: src/components/reader/comments/comments-section.tsx
+msgid "{hiddenByBlocks, plural, one {# more reply is hidden by your blocks.} other {# more replies are hidden by your blocks.}}"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1488,6 +1493,10 @@ msgstr ""
 msgid "Compact"
 msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "This account"
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Portrait stacks the card vertically. Height adjusts automatically once the embed loads. Change the iframe width as needed."
 msgstr "El formato vertical apila la tarjeta. La altura se ajusta automáticamente al cargar el embed. Cambie el ancho del iframe según necesite."
@@ -1927,6 +1936,10 @@ msgstr "Insertar botón de suscripción"
 msgid "That GIF is over 1 MB. Try a shorter clip, or attach a still image."
 msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+msgstr ""
+
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Add another screenshot"
 #~ msgstr ""
@@ -1946,6 +1959,10 @@ msgstr "Eliminar colección"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Interface font"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "We're re-reading your blocks from your account. This page updates when it finishes."
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -2014,6 +2031,7 @@ msgstr ""
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/reader/pull-to-refresh.tsx
 msgid "Refreshing"
 msgstr ""
@@ -2305,6 +2323,7 @@ msgstr "Etiquetador"
 msgid "Articles you've opened — public records in your repo, synced across devices."
 msgstr "Artículos que ha abierto: registros públicos en su repositorio, sincronizados entre dispositivos."
 
+#: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-publication-editor.tsx
 #: src/components/reader/collection-theme-editor.tsx
@@ -2581,6 +2600,10 @@ msgstr "<0>Leaflet, Pckt, Offprint.</0> <1>pub.leaflet.content</1>, <2>blog.pckt
 
 #: src/components/appearance-settings.tsx
 msgid "XL"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "We couldn't write the block to your account. Try again?"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -3272,6 +3295,10 @@ msgstr "Imagen"
 #~ msgid "<0>Follow</0> is the only subscription there is. New writing from anything you follow appears on Home and in Latest, and the publication is listed in your sidebar. There is no email sign-up and no separate account with the publisher."
 #~ msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "We couldn't remove the block from your account. Try again?"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Selecting anyone's name opens their author page: everything they publish, what they follow, and what they have recommended."
 msgstr ""
@@ -3321,6 +3348,10 @@ msgstr ""
 #~ msgid "Prefer a typed client? The whole API ships as codegen'd AT Protocol lexicon schemas in <0>@standard-reader/lexicons</0>. Pair it with <1>@atproto/lex-client</1> for fully-typed <2>client.call()</2> queries and procedures. Its <3>getDocument</3> also returns a document's renderable body, ready to hand to the <4>renderers</4>."
 #~ msgstr ""
 
+#: src/components/reader/comments/comments-section.tsx
+msgid "{hiddenByBlocks, plural, one {The only reply here is from someone you're blocked from.} other {The replies here are all from accounts you're blocked from.}}"
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Couldn't save your follows"
 msgstr "No se pudieron guardar sus seguimientos"
@@ -3357,6 +3388,10 @@ msgstr ""
 msgid "Publications to explore"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+msgid "We couldn't reach your account to change that. Try again?"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Read as comic"
 msgstr ""
@@ -3378,6 +3413,10 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Read and unread"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "This writes a block to your Bluesky account, so it applies here and anywhere else you use it. Their writing disappears from your feeds, search and discussion, and they can't see yours. You can undo it in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -3502,8 +3541,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
-msgstr ""
+#~ msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
@@ -3643,6 +3682,10 @@ msgstr ""
 msgid "Worth subscribing to"
 msgstr "Vale la pena suscribirse"
 
+#: src/components/blocks-settings-view.tsx
+msgid "this list is larger than we mirror, so some members aren't blocked here"
+msgstr ""
+
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Angular."
 #~ msgstr ""
@@ -3666,6 +3709,10 @@ msgstr ""
 
 #: src/routes/_layout.subscriptions.tsx
 msgid "Nothing to manage yet"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "They're hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.subscriptions.tsx
@@ -4017,6 +4064,10 @@ msgstr ""
 msgid "No lists yet"
 msgstr "Aún no hay listas"
 
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} blocks a moderation list you're on, so you can't see their writing."
+msgstr ""
+
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "Saving things while you browse the rest of the web, keeping Standard Reader on your home screen, and passing an article on."
 #~ msgstr ""
@@ -4036,6 +4087,10 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
 msgstr "Un botón de Escuchar lee cualquier artículo en voz alta, directamente en su dispositivo, y resalta cada palabra a su paso. El reproductor le acompaña por toda la app e incluso lee una entrada incrustada de Bluesky. Con la sesión iniciada, puede elegir una voz."
+
+#: src/components/reader/blocked-notice.tsx
+msgid "this account"
+msgstr ""
 
 #. placeholder {0}: next.title
 #: src/components/reader/series-up-next.tsx
@@ -4175,6 +4230,15 @@ msgstr "Opcional: añada una nota sobre por qué guarda esto"
 msgid "Open the app"
 msgstr ""
 
+#. placeholder {0}: fmt.relativeTime(data.syncedAt)
+#: src/components/blocks-settings-view.tsx
+msgid "Last checked {0}. Blocks you make elsewhere show up here within about fifteen minutes."
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block account?"
+msgstr ""
+
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this note on Semble"
 msgstr ""
@@ -4252,8 +4316,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "this account"
 #: src/components/reader/blocked-notice.tsx
-msgid "You blocked {0}, so their writing is hidden everywhere you read."
-msgstr ""
+#~ msgid "You blocked {0}, so their writing is hidden everywhere you read."
+#~ msgstr ""
 
 #. placeholder {0}: filter.trim()
 #: src/components/reader/subscriptions-table.tsx
@@ -4485,6 +4549,10 @@ msgstr ""
 msgid "Recommended articles"
 msgstr "Artículos recomendados"
 
+#: src/components/reader/mention-hover-card.tsx
+msgid "You blocked this account, so their writing is hidden."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
 msgstr ""
@@ -4690,6 +4758,10 @@ msgstr ""
 msgid "{0}+ articles"
 msgstr "Más de {0} artículos"
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "{name} is hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts."
+msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "Starter pack"
 msgstr ""
@@ -4701,6 +4773,10 @@ msgstr "Ese enlace caducó."
 #: src/components/guide/pages/lists-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Lists in the sidebar"
+msgstr ""
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked {who}, so their writing is hidden everywhere you read."
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
@@ -4952,6 +5028,9 @@ msgstr ""
 msgid "Not in the directory yet?"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/reader/block-user-menu-item.tsx
+#: src/components/reader/blocked-notice.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
@@ -5001,8 +5080,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} is on a moderation list you block. To see them again, leave that list."
-msgstr ""
+#~ msgid "{0} is on a moderation list you block. To see them again, leave that list."
+#~ msgstr ""
 
 #: src/routes/_layout.collections.index.tsx
 msgid "Curated, magazine-rendered editions grouped into series you can subscribe to — your special collections on the network."
@@ -6025,6 +6104,10 @@ msgstr "Ver comentarios"
 #~ msgid "Pages you have already visited stay available when your connection drops, and Standard Reader shows a plain offline page rather than a browser error when you reach for something it does not have. When a new version of the app is ready, it offers to reload rather than changing under you mid-article."
 #~ msgstr ""
 
+#: src/components/reader/mention-hover-card.tsx
+msgid "This account blocks you, so you can't see their writing."
+msgstr ""
+
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Being in a list does not change your feeds. Everything you subscribe to still arrives on Home and in Latest exactly as before; a list only changes how the sidebar is organised, and gives you a page you can read — or share — on its own."
 msgstr ""
@@ -6233,6 +6316,10 @@ msgstr ""
 #: src/magazine/Magazine.tsx
 msgid "Contents"
 msgstr "Contenido"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} is on a moderation list you block. To see them again, leave that list."
+msgstr ""
 
 #: src/components/reader/share-menu.tsx
 msgid "Copy embed code"
@@ -6642,8 +6729,8 @@ msgstr "¿Eliminar todo el historial de lectura?"
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} blocks a moderation list you're on, so you can't see their writing."
-msgstr ""
+#~ msgid "{0} blocks a moderation list you're on, so you can't see their writing."
+#~ msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6971,6 +7058,10 @@ msgstr "No se encontraron publicaciones para {handleLabel}."
 msgid "Already subscribed"
 msgstr "Ya suscrito"
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block {name}?"
+msgstr ""
+
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "How to wire a personal site's own <0>site.standard.*</0> records so Standard Reader can find it and read articles inline, without going through Leaflet, Pckt, Offprint, or another publishing tool."
 msgstr "Cómo configurar los registros <0>site.standard.*</0> de un sitio personal para que Standard Reader pueda encontrarlo y leer sus artículos en línea, sin pasar por Leaflet, Pckt, Offprint u otra herramienta de publicación."
@@ -6986,6 +7077,10 @@ msgstr "Otras colecciones"
 #: src/components/reader/about-view.tsx
 msgid "One tasteful email a week"
 msgstr "Un correo con buen gusto por semana"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "Blocked by a list you use"
+msgstr ""
 
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "{unreadCount} unread"
@@ -7274,6 +7369,7 @@ msgid "Pages"
 msgstr ""
 
 #: src/components/reader/article-view-skeleton.tsx
+#: src/routes/_layout.a.$did.$rkey.tsx
 msgid "Loading article"
 msgstr "Cargando artículo"
 

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -239,6 +239,10 @@ msgstr ""
 msgid "You're signed in"
 msgstr "Sesión iniciada"
 
+#: src/components/user-settings-view.tsx
+msgid "Manage {blockCount} blocks"
+msgstr ""
+
 #: src/routes/_layout.subscriptions.tsx
 msgid "Subscribe to a publication or follow a writer and they'll show up here, with their unread count and latest post. Each subscription is an <0>app.standard-reader.subscription</0> record in your repo — yours to take anywhere."
 msgstr ""
@@ -617,6 +621,10 @@ msgstr ""
 msgid "Please choose a rating."
 msgstr "Elija una valoración."
 
+#: src/components/blocks-settings-view.tsx
+msgid "Blocked"
+msgstr ""
+
 #: src/components/docs/docs-mobile-nav.tsx
 #: src/components/guide/guide-mobile-nav.tsx
 msgid "(current)"
@@ -634,6 +642,10 @@ msgstr ""
 #: src/components/reader/share-menu.tsx
 msgid "Portrait"
 msgstr "Vertical"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Loading blocked accounts"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Select any headline to open it. Articles are laid out as a single column at a comfortable width, with the publication's own colors and typography where it has them."
@@ -655,6 +667,10 @@ msgstr "Bajar"
 msgid "Disclaimer and limitation of liability"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+msgid "You don't subscribe to any block lists."
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No articles from this list's publications or people yet."
 msgstr "Todavía no hay artículos de las publicaciones o personas de esta lista."
@@ -666,6 +682,10 @@ msgstr ""
 #. placeholder {0}: labels[order]
 #: src/components/reader/publication-actions.tsx
 msgid "Order: {0}"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Partial"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -718,6 +738,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Permanently remove data stored in your account. These actions delete records from your account and cannot be undone."
 msgstr "Elimine de forma permanente los datos guardados en su cuenta. Estas acciones borran registros de su cuenta y no se pueden deshacer."
+
+#: src/components/blocks-settings-view.tsx
+msgid "Moderation lists you subscribe to on Bluesky. Everyone on them is blocked here too, and the list stays live as its owner changes it."
+msgstr ""
 
 #: src/routes/_layout.communities.$slug.tsx
 #~ msgid "Sub-areas"
@@ -1519,6 +1543,11 @@ msgstr "<0/> Cancele la suscripción con un clic, cuando quiera"
 #~ msgid "Wiring up a site that does not publish in this format yet is the one genuinely technical job in the whole product, and it has its own <0>publishing documentation</0>. Everything else in this guide stays where it is."
 #~ msgstr ""
 
+#. placeholder {0}: row.memberCount
+#: src/components/blocks-settings-view.tsx
+msgid "{0, plural, one {# account} other {# accounts}}"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Recommending an article"
@@ -1761,9 +1790,17 @@ msgstr ""
 msgid "Fast full-text search"
 msgstr "Búsqueda rápida de texto completo"
 
+#: src/components/blocks-settings-view.tsx
+msgid "You haven't blocked anyone."
+msgstr ""
+
 #: src/lib/guide/navigation.ts
 #~ msgid "Saving, recommending, reading history, and managing what you follow."
 #~ msgstr ""
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked this account"
+msgstr ""
 
 #: src/components/reader/notify-button.tsx
 msgid "Notifications aren’t available"
@@ -2054,6 +2091,10 @@ msgstr ""
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block"
+msgstr ""
 
 #: src/routes/_layout.discover.tsx
 msgid "Known publications"
@@ -2416,6 +2457,7 @@ msgstr "Ver etiquetador"
 msgid "Read more from the author"
 msgstr "Leer más del autor"
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/labelers-settings-view.tsx
 #: src/components/user-settings-view.tsx
 msgid "Moderation"
@@ -2440,6 +2482,10 @@ msgstr "Documentos"
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Most unread"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block {name}"
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -2579,6 +2625,10 @@ msgstr "Editar"
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Removed"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block account"
 msgstr ""
 
 #: src/components/reading-settings-preview.tsx
@@ -2758,6 +2808,10 @@ msgstr ""
 #: src/routes/review.thanks.tsx
 msgid "Return to the app"
 msgstr "Volver a la aplicación"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Moderation list"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -3446,6 +3500,11 @@ msgstr "Mostrar la pestaña {label}"
 msgid "This API is also served as a <0>Model Context Protocol</0> server at <1>{baseUrl}/mcp</1>. Paste that URL into an MCP client and authorize it; the fifty-odd methods above are grouped into fifteen tools, and the client can read the network and act on your behalf."
 msgstr ""
 
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
 msgstr ""
@@ -3477,6 +3536,10 @@ msgstr "{n, plural, one {# publicación} other {{value} publicaciones}}"
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."
 msgstr "Elija qué pestañas aparecen en su perfil público."
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You're blocked"
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "View all latest"
@@ -3797,6 +3860,10 @@ msgstr ""
 #. placeholder {0}: rows.length
 #: src/components/reader/subscriptions-table.tsx
 msgid "{0} total"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours."
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -4174,8 +4241,18 @@ msgstr "Sin leer"
 msgid "How readers see it"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/user-settings-view.tsx
+msgid "Blocked accounts"
+msgstr ""
+
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "Standard Reader has a reading mode built for comics — a shelf of covers instead of a list of post titles, and a full-screen theater that flips through your pages. You do not author anything specially for it. This page is how to make sure your comic gets it."
+msgstr ""
+
+#. placeholder {0}: name ?? "this account"
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked {0}, so their writing is hidden everywhere you read."
 msgstr ""
 
 #. placeholder {0}: filter.trim()
@@ -4228,6 +4305,10 @@ msgstr "Los textos más leídos de toda la red en este momento."
 
 #: src/components/appearance-settings.tsx
 msgid "The typeface used across the app. Article text follows this too, unless you set a reading font below."
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Refresh"
 msgstr ""
 
 #: src/magazine/magazine-end-like.tsx
@@ -4808,6 +4889,11 @@ msgstr ""
 msgid "There’s a magazine edition of this collection."
 msgstr "Hay una edición en revista de esta colección."
 
+#: src/components/reader/blocked-notice.tsx
+#: src/components/user-settings-view.tsx
+msgid "Manage blocks"
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "What the extension accesses"
 msgstr "A qué accede la extensión"
@@ -4911,6 +4997,11 @@ msgstr "<0>URL de páginas.</0> Al abrir el popup, usar la superposición de pá
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Comments and related reading"
+msgstr ""
+
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} is on a moderation list you block. To see them again, leave that list."
 msgstr ""
 
 #: src/routes/_layout.collections.index.tsx
@@ -5359,6 +5450,11 @@ msgstr ""
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler hasn’t labeled any documents in the read-model yet."
 msgstr "Este etiquetador aún no ha etiquetado ningún documento en el modelo de lectura."
+
+#. placeholder {0}: row.memberCount
+#: src/components/blocks-settings-view.tsx
+#~ msgid "{0} accounts"
+#~ msgstr ""
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Your lists, their order, and which ones are collapsed are stored in your account rather than in this browser, so the sidebar looks the same on your laptop and your phone."
@@ -5816,6 +5912,10 @@ msgstr ""
 msgid "Standard Reader needs write access to your site.standard publications and documents, plus your collection records, to author Collections. You'll be asked to approve this on your PDS login."
 msgstr "Standard Reader necesita acceso de escritura a sus publicaciones y documentos site.standard, además de sus registros de colección, para crear Colecciones. Se le pedirá aprobarlo al iniciar sesión en su PDS."
 
+#: src/components/blocks-settings-view.tsx
+msgid "Block lists"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "All articles you have saved for later."
 msgstr "Todos los artículos que guardó para más tarde."
@@ -6176,6 +6276,7 @@ msgstr "operativo"
 msgid "Top on the network"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
@@ -6197,6 +6298,10 @@ msgstr "Filtrar por tema: {triggerLabel}"
 #: src/components/reader/page-reader-bar.tsx
 msgid "Return to article and follow along"
 msgstr "Volver al artículo y seguir la lectura"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Some blocks couldn't be refreshed last time, so this list may be incomplete."
+msgstr ""
 
 #. placeholder {0}: pub.subscriberCount
 #: src/components/reader/cards.tsx
@@ -6381,9 +6486,18 @@ msgstr "Editar lista"
 msgid "The Saved screen: a list of article cards the reader has set aside, each with its publication, headline, and excerpt."
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/reader/blocked-notice.tsx
+msgid "Unblock"
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "What we do not do"
 msgstr "Lo que no hacemos"
+
+#: src/components/user-settings-view.tsx
+msgid "Your Bluesky blocks apply here too — blocked accounts disappear from your feeds, search, and discussion, in both directions."
+msgstr ""
 
 #: src/components/docs/docs-side-nav.tsx
 msgid "Documentation"
@@ -6525,6 +6639,11 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Delete all reading history?"
 msgstr "¿Eliminar todo el historial de lectura?"
+
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} blocks a moderation list you're on, so you can't see their writing."
+msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6999,6 +7118,10 @@ msgstr ""
 #: src/components/site-legal-links.tsx
 msgid "Source"
 msgstr "Fuente"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Accounts you block"
+msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That file isn't an image we can read."
@@ -7579,6 +7702,10 @@ msgstr "<0>Cuando inicia sesión</0> con su cuenta de Atmosphere (por ejemplo, m
 #: src/routes/subscribe-login.$did.$rkey.tsx
 msgid "Powered by <0>Standard Reader</0>"
 msgstr "Con la tecnología de <0>Standard Reader</0>"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Your blocks are enforced here already. To add or remove one from Standard Reader, you'll be asked to authorize block access the first time you try."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -239,6 +239,10 @@ msgstr ""
 msgid "You're signed in"
 msgstr "Vous êtes connecté"
 
+#: src/components/user-settings-view.tsx
+msgid "Manage {blockCount} blocks"
+msgstr ""
+
 #: src/routes/_layout.subscriptions.tsx
 msgid "Subscribe to a publication or follow a writer and they'll show up here, with their unread count and latest post. Each subscription is an <0>app.standard-reader.subscription</0> record in your repo — yours to take anywhere."
 msgstr ""
@@ -617,6 +621,10 @@ msgstr ""
 msgid "Please choose a rating."
 msgstr "Veuillez choisir une note."
 
+#: src/components/blocks-settings-view.tsx
+msgid "Blocked"
+msgstr ""
+
 #: src/components/docs/docs-mobile-nav.tsx
 #: src/components/guide/guide-mobile-nav.tsx
 msgid "(current)"
@@ -634,6 +642,10 @@ msgstr ""
 #: src/components/reader/share-menu.tsx
 msgid "Portrait"
 msgstr "Portrait"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Loading blocked accounts"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Select any headline to open it. Articles are laid out as a single column at a comfortable width, with the publication's own colors and typography where it has them."
@@ -655,6 +667,10 @@ msgstr "Descendre"
 msgid "Disclaimer and limitation of liability"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+msgid "You don't subscribe to any block lists."
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No articles from this list's publications or people yet."
 msgstr "Aucun article des publications ou personnes de cette liste pour l’instant."
@@ -666,6 +682,10 @@ msgstr ""
 #. placeholder {0}: labels[order]
 #: src/components/reader/publication-actions.tsx
 msgid "Order: {0}"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Partial"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -718,6 +738,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Permanently remove data stored in your account. These actions delete records from your account and cannot be undone."
 msgstr "Supprimez définitivement les données stockées dans votre compte. Ces actions effacent des enregistrements de votre compte et sont irréversibles."
+
+#: src/components/blocks-settings-view.tsx
+msgid "Moderation lists you subscribe to on Bluesky. Everyone on them is blocked here too, and the list stays live as its owner changes it."
+msgstr ""
 
 #: src/routes/_layout.communities.$slug.tsx
 #~ msgid "Sub-areas"
@@ -1519,6 +1543,11 @@ msgstr "<0/> Désabonnement en un clic, à tout moment"
 #~ msgid "Wiring up a site that does not publish in this format yet is the one genuinely technical job in the whole product, and it has its own <0>publishing documentation</0>. Everything else in this guide stays where it is."
 #~ msgstr ""
 
+#. placeholder {0}: row.memberCount
+#: src/components/blocks-settings-view.tsx
+msgid "{0, plural, one {# account} other {# accounts}}"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Recommending an article"
@@ -1761,9 +1790,17 @@ msgstr ""
 msgid "Fast full-text search"
 msgstr "Recherche plein texte rapide"
 
+#: src/components/blocks-settings-view.tsx
+msgid "You haven't blocked anyone."
+msgstr ""
+
 #: src/lib/guide/navigation.ts
 #~ msgid "Saving, recommending, reading history, and managing what you follow."
 #~ msgstr ""
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked this account"
+msgstr ""
 
 #: src/components/reader/notify-button.tsx
 msgid "Notifications aren’t available"
@@ -2054,6 +2091,10 @@ msgstr ""
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block"
+msgstr ""
 
 #: src/routes/_layout.discover.tsx
 msgid "Known publications"
@@ -2416,6 +2457,7 @@ msgstr "Voir le service d'étiquetage"
 msgid "Read more from the author"
 msgstr "Lire d'autres articles de l'auteur"
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/labelers-settings-view.tsx
 #: src/components/user-settings-view.tsx
 msgid "Moderation"
@@ -2440,6 +2482,10 @@ msgstr "Documents"
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Most unread"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block {name}"
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -2579,6 +2625,10 @@ msgstr "Modifier"
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Removed"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block account"
 msgstr ""
 
 #: src/components/reading-settings-preview.tsx
@@ -2758,6 +2808,10 @@ msgstr ""
 #: src/routes/review.thanks.tsx
 msgid "Return to the app"
 msgstr "Revenir à l'application"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Moderation list"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -3446,6 +3500,11 @@ msgstr "Afficher l’onglet {label}"
 msgid "This API is also served as a <0>Model Context Protocol</0> server at <1>{baseUrl}/mcp</1>. Paste that URL into an MCP client and authorize it; the fifty-odd methods above are grouped into fifteen tools, and the client can read the network and act on your behalf."
 msgstr ""
 
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
 msgstr ""
@@ -3477,6 +3536,10 @@ msgstr "{n, plural, one {# publication} other {{value} publications}}"
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."
 msgstr "Choisissez les onglets qui apparaissent sur votre profil public."
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You're blocked"
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "View all latest"
@@ -3797,6 +3860,10 @@ msgstr ""
 #. placeholder {0}: rows.length
 #: src/components/reader/subscriptions-table.tsx
 msgid "{0} total"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours."
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -4174,8 +4241,18 @@ msgstr "Non lus"
 msgid "How readers see it"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/user-settings-view.tsx
+msgid "Blocked accounts"
+msgstr ""
+
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "Standard Reader has a reading mode built for comics — a shelf of covers instead of a list of post titles, and a full-screen theater that flips through your pages. You do not author anything specially for it. This page is how to make sure your comic gets it."
+msgstr ""
+
+#. placeholder {0}: name ?? "this account"
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked {0}, so their writing is hidden everywhere you read."
 msgstr ""
 
 #. placeholder {0}: filter.trim()
@@ -4228,6 +4305,10 @@ msgstr "Les textes les plus lus du réseau en ce moment."
 
 #: src/components/appearance-settings.tsx
 msgid "The typeface used across the app. Article text follows this too, unless you set a reading font below."
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Refresh"
 msgstr ""
 
 #: src/magazine/magazine-end-like.tsx
@@ -4808,6 +4889,11 @@ msgstr ""
 msgid "There’s a magazine edition of this collection."
 msgstr "Il existe une édition magazine de cette collection."
 
+#: src/components/reader/blocked-notice.tsx
+#: src/components/user-settings-view.tsx
+msgid "Manage blocks"
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "What the extension accesses"
 msgstr "Ce à quoi l’extension accède"
@@ -4911,6 +4997,11 @@ msgstr "<0>URL des pages.</0> Lorsque vous ouvrez la fenêtre, utilisez la surco
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Comments and related reading"
+msgstr ""
+
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} is on a moderation list you block. To see them again, leave that list."
 msgstr ""
 
 #: src/routes/_layout.collections.index.tsx
@@ -5359,6 +5450,11 @@ msgstr ""
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler hasn’t labeled any documents in the read-model yet."
 msgstr "Ce service d'étiquetage n'a encore étiqueté aucun document dans le modèle de lecture."
+
+#. placeholder {0}: row.memberCount
+#: src/components/blocks-settings-view.tsx
+#~ msgid "{0} accounts"
+#~ msgstr ""
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Your lists, their order, and which ones are collapsed are stored in your account rather than in this browser, so the sidebar looks the same on your laptop and your phone."
@@ -5816,6 +5912,10 @@ msgstr ""
 msgid "Standard Reader needs write access to your site.standard publications and documents, plus your collection records, to author Collections. You'll be asked to approve this on your PDS login."
 msgstr "Standard Reader a besoin d'un accès en écriture à vos publications et documents site.standard, ainsi qu'à vos enregistrements de collection, pour créer des Collections. Il vous sera demandé d'approuver cela lors de votre connexion au PDS."
 
+#: src/components/blocks-settings-view.tsx
+msgid "Block lists"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "All articles you have saved for later."
 msgstr "Tous les articles que vous avez enregistrés pour plus tard."
@@ -6176,6 +6276,7 @@ msgstr "opérationnel"
 msgid "Top on the network"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
@@ -6197,6 +6298,10 @@ msgstr "Filtrer par sujet : {triggerLabel}"
 #: src/components/reader/page-reader-bar.tsx
 msgid "Return to article and follow along"
 msgstr "Revenir à l'article et suivre le fil"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Some blocks couldn't be refreshed last time, so this list may be incomplete."
+msgstr ""
 
 #. placeholder {0}: pub.subscriberCount
 #: src/components/reader/cards.tsx
@@ -6381,9 +6486,18 @@ msgstr "Modifier la liste"
 msgid "The Saved screen: a list of article cards the reader has set aside, each with its publication, headline, and excerpt."
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/reader/blocked-notice.tsx
+msgid "Unblock"
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "What we do not do"
 msgstr "Ce que nous ne faisons pas"
+
+#: src/components/user-settings-view.tsx
+msgid "Your Bluesky blocks apply here too — blocked accounts disappear from your feeds, search, and discussion, in both directions."
+msgstr ""
 
 #: src/components/docs/docs-side-nav.tsx
 msgid "Documentation"
@@ -6525,6 +6639,11 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Delete all reading history?"
 msgstr "Supprimer tout l'historique de lecture ?"
+
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} blocks a moderation list you're on, so you can't see their writing."
+msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6999,6 +7118,10 @@ msgstr ""
 #: src/components/site-legal-links.tsx
 msgid "Source"
 msgstr "Source"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Accounts you block"
+msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That file isn't an image we can read."
@@ -7579,6 +7702,10 @@ msgstr "<0>Lorsque vous vous connectez</0> avec votre compte Atmosphere (par exe
 #: src/routes/subscribe-login.$did.$rkey.tsx
 msgid "Powered by <0>Standard Reader</0>"
 msgstr "Propulsé par <0>Standard Reader</0>"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Your blocks are enforced here already. To add or remove one from Standard Reader, you'll be asked to authorize block access the first time you try."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -622,6 +622,7 @@ msgid "Please choose a rating."
 msgstr "Veuillez choisir une note."
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/reader/block-user-menu-item.tsx
 msgid "Blocked"
 msgstr ""
 
@@ -788,6 +789,10 @@ msgstr "Supprimer la liste ?"
 #: src/routes/_layout.latest.tsx
 msgid "Everything published recently across the publications you subscribe to."
 msgstr "Tout ce qui a été publié récemment dans les publications auxquelles vous êtes abonné."
+
+#: src/components/reader/comments/comments-section.tsx
+msgid "{hiddenByBlocks, plural, one {# more reply is hidden by your blocks.} other {# more replies are hidden by your blocks.}}"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1488,6 +1493,10 @@ msgstr ""
 msgid "Compact"
 msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "This account"
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Portrait stacks the card vertically. Height adjusts automatically once the embed loads. Change the iframe width as needed."
 msgstr "Le format portrait empile la carte à la verticale. La hauteur s’ajuste automatiquement une fois l’intégration chargée. Modifiez la largeur de l’iframe si besoin."
@@ -1927,6 +1936,10 @@ msgstr "Intégrer le bouton d'abonnement"
 msgid "That GIF is over 1 MB. Try a shorter clip, or attach a still image."
 msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+msgstr ""
+
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Add another screenshot"
 #~ msgstr ""
@@ -1946,6 +1959,10 @@ msgstr "Supprimer la collection"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Interface font"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "We're re-reading your blocks from your account. This page updates when it finishes."
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -2014,6 +2031,7 @@ msgstr ""
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/reader/pull-to-refresh.tsx
 msgid "Refreshing"
 msgstr ""
@@ -2305,6 +2323,7 @@ msgstr "Service d'étiquetage"
 msgid "Articles you've opened — public records in your repo, synced across devices."
 msgstr "Les articles que vous avez ouverts — des enregistrements publics dans votre repo, synchronisés entre vos appareils."
 
+#: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-publication-editor.tsx
 #: src/components/reader/collection-theme-editor.tsx
@@ -2581,6 +2600,10 @@ msgstr "<0>Leaflet, Pckt, Offprint.</0> <1>pub.leaflet.content</1>, <2>blog.pckt
 
 #: src/components/appearance-settings.tsx
 msgid "XL"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "We couldn't write the block to your account. Try again?"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -3272,6 +3295,10 @@ msgstr "Image"
 #~ msgid "<0>Follow</0> is the only subscription there is. New writing from anything you follow appears on Home and in Latest, and the publication is listed in your sidebar. There is no email sign-up and no separate account with the publisher."
 #~ msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "We couldn't remove the block from your account. Try again?"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Selecting anyone's name opens their author page: everything they publish, what they follow, and what they have recommended."
 msgstr ""
@@ -3321,6 +3348,10 @@ msgstr ""
 #~ msgid "Prefer a typed client? The whole API ships as codegen'd AT Protocol lexicon schemas in <0>@standard-reader/lexicons</0>. Pair it with <1>@atproto/lex-client</1> for fully-typed <2>client.call()</2> queries and procedures. Its <3>getDocument</3> also returns a document's renderable body, ready to hand to the <4>renderers</4>."
 #~ msgstr ""
 
+#: src/components/reader/comments/comments-section.tsx
+msgid "{hiddenByBlocks, plural, one {The only reply here is from someone you're blocked from.} other {The replies here are all from accounts you're blocked from.}}"
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Couldn't save your follows"
 msgstr "Impossible d’enregistrer les comptes suivis"
@@ -3357,6 +3388,10 @@ msgstr ""
 msgid "Publications to explore"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+msgid "We couldn't reach your account to change that. Try again?"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Read as comic"
 msgstr ""
@@ -3378,6 +3413,10 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Read and unread"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "This writes a block to your Bluesky account, so it applies here and anywhere else you use it. Their writing disappears from your feeds, search and discussion, and they can't see yours. You can undo it in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -3502,8 +3541,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
-msgstr ""
+#~ msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
@@ -3643,6 +3682,10 @@ msgstr ""
 msgid "Worth subscribing to"
 msgstr "Publications à suivre"
 
+#: src/components/blocks-settings-view.tsx
+msgid "this list is larger than we mirror, so some members aren't blocked here"
+msgstr ""
+
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Angular."
 #~ msgstr ""
@@ -3666,6 +3709,10 @@ msgstr ""
 
 #: src/routes/_layout.subscriptions.tsx
 msgid "Nothing to manage yet"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "They're hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.subscriptions.tsx
@@ -4017,6 +4064,10 @@ msgstr ""
 msgid "No lists yet"
 msgstr "Aucune liste pour l’instant"
 
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} blocks a moderation list you're on, so you can't see their writing."
+msgstr ""
+
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "Saving things while you browse the rest of the web, keeping Standard Reader on your home screen, and passing an article on."
 #~ msgstr ""
@@ -4036,6 +4087,10 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
 msgstr "Un bouton Écouter lit n’importe quel article à voix haute, directement sur votre appareil, en surlignant chaque mot au passage. Le lecteur vous suit dans toute l’application — il lira même un post Bluesky intégré. Une fois connecté, vous pouvez choisir une voix."
+
+#: src/components/reader/blocked-notice.tsx
+msgid "this account"
+msgstr ""
 
 #. placeholder {0}: next.title
 #: src/components/reader/series-up-next.tsx
@@ -4175,6 +4230,15 @@ msgstr "Facultatif : ajoutez une note expliquant pourquoi vous enregistrez ceci"
 msgid "Open the app"
 msgstr ""
 
+#. placeholder {0}: fmt.relativeTime(data.syncedAt)
+#: src/components/blocks-settings-view.tsx
+msgid "Last checked {0}. Blocks you make elsewhere show up here within about fifteen minutes."
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block account?"
+msgstr ""
+
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this note on Semble"
 msgstr ""
@@ -4252,8 +4316,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "this account"
 #: src/components/reader/blocked-notice.tsx
-msgid "You blocked {0}, so their writing is hidden everywhere you read."
-msgstr ""
+#~ msgid "You blocked {0}, so their writing is hidden everywhere you read."
+#~ msgstr ""
 
 #. placeholder {0}: filter.trim()
 #: src/components/reader/subscriptions-table.tsx
@@ -4485,6 +4549,10 @@ msgstr ""
 msgid "Recommended articles"
 msgstr "Articles recommandés"
 
+#: src/components/reader/mention-hover-card.tsx
+msgid "You blocked this account, so their writing is hidden."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
 msgstr ""
@@ -4690,6 +4758,10 @@ msgstr ""
 msgid "{0}+ articles"
 msgstr "{0}+ articles"
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "{name} is hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts."
+msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "Starter pack"
 msgstr ""
@@ -4701,6 +4773,10 @@ msgstr "Ce lien a expiré."
 #: src/components/guide/pages/lists-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Lists in the sidebar"
+msgstr ""
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked {who}, so their writing is hidden everywhere you read."
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
@@ -4952,6 +5028,9 @@ msgstr ""
 msgid "Not in the directory yet?"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/reader/block-user-menu-item.tsx
+#: src/components/reader/blocked-notice.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
@@ -5001,8 +5080,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} is on a moderation list you block. To see them again, leave that list."
-msgstr ""
+#~ msgid "{0} is on a moderation list you block. To see them again, leave that list."
+#~ msgstr ""
 
 #: src/routes/_layout.collections.index.tsx
 msgid "Curated, magazine-rendered editions grouped into series you can subscribe to — your special collections on the network."
@@ -6025,6 +6104,10 @@ msgstr "Voir les retours"
 #~ msgid "Pages you have already visited stay available when your connection drops, and Standard Reader shows a plain offline page rather than a browser error when you reach for something it does not have. When a new version of the app is ready, it offers to reload rather than changing under you mid-article."
 #~ msgstr ""
 
+#: src/components/reader/mention-hover-card.tsx
+msgid "This account blocks you, so you can't see their writing."
+msgstr ""
+
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Being in a list does not change your feeds. Everything you subscribe to still arrives on Home and in Latest exactly as before; a list only changes how the sidebar is organised, and gives you a page you can read — or share — on its own."
 msgstr ""
@@ -6233,6 +6316,10 @@ msgstr ""
 #: src/magazine/Magazine.tsx
 msgid "Contents"
 msgstr "Sommaire"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} is on a moderation list you block. To see them again, leave that list."
+msgstr ""
 
 #: src/components/reader/share-menu.tsx
 msgid "Copy embed code"
@@ -6642,8 +6729,8 @@ msgstr "Supprimer tout l'historique de lecture ?"
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} blocks a moderation list you're on, so you can't see their writing."
-msgstr ""
+#~ msgid "{0} blocks a moderation list you're on, so you can't see their writing."
+#~ msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6971,6 +7058,10 @@ msgstr "Aucune publication trouvée pour {handleLabel}."
 msgid "Already subscribed"
 msgstr "Déjà abonné"
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block {name}?"
+msgstr ""
+
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "How to wire a personal site's own <0>site.standard.*</0> records so Standard Reader can find it and read articles inline, without going through Leaflet, Pckt, Offprint, or another publishing tool."
 msgstr "Comment configurer les enregistrements <0>site.standard.*</0> d'un site personnel pour que Standard Reader le trouve et affiche ses articles en ligne, sans passer par Leaflet, Pckt, Offprint ou un autre outil de publication."
@@ -6986,6 +7077,10 @@ msgstr "Autres collections"
 #: src/components/reader/about-view.tsx
 msgid "One tasteful email a week"
 msgstr "Un e-mail de bon goût par semaine"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "Blocked by a list you use"
+msgstr ""
 
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "{unreadCount} unread"
@@ -7274,6 +7369,7 @@ msgid "Pages"
 msgstr ""
 
 #: src/components/reader/article-view-skeleton.tsx
+#: src/routes/_layout.a.$did.$rkey.tsx
 msgid "Loading article"
 msgstr "Chargement de l'article"
 

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -239,6 +239,10 @@ msgstr ""
 msgid "You're signed in"
 msgstr "サインイン済みです"
 
+#: src/components/user-settings-view.tsx
+msgid "Manage {blockCount} blocks"
+msgstr ""
+
 #: src/routes/_layout.subscriptions.tsx
 msgid "Subscribe to a publication or follow a writer and they'll show up here, with their unread count and latest post. Each subscription is an <0>app.standard-reader.subscription</0> record in your repo — yours to take anywhere."
 msgstr ""
@@ -617,6 +621,10 @@ msgstr ""
 msgid "Please choose a rating."
 msgstr "評価を選んでください。"
 
+#: src/components/blocks-settings-view.tsx
+msgid "Blocked"
+msgstr ""
+
 #: src/components/docs/docs-mobile-nav.tsx
 #: src/components/guide/guide-mobile-nav.tsx
 msgid "(current)"
@@ -634,6 +642,10 @@ msgstr ""
 #: src/components/reader/share-menu.tsx
 msgid "Portrait"
 msgstr "縦長"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Loading blocked accounts"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Select any headline to open it. Articles are laid out as a single column at a comfortable width, with the publication's own colors and typography where it has them."
@@ -655,6 +667,10 @@ msgstr "下へ移動"
 msgid "Disclaimer and limitation of liability"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+msgid "You don't subscribe to any block lists."
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No articles from this list's publications or people yet."
 msgstr "このリストの発行物やユーザーからの記事はまだありません。"
@@ -666,6 +682,10 @@ msgstr ""
 #. placeholder {0}: labels[order]
 #: src/components/reader/publication-actions.tsx
 msgid "Order: {0}"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Partial"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -718,6 +738,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Permanently remove data stored in your account. These actions delete records from your account and cannot be undone."
 msgstr "アカウントに保存されているデータを完全に削除します。これらの操作はアカウントからレコードを削除するもので、取り消せません。"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Moderation lists you subscribe to on Bluesky. Everyone on them is blocked here too, and the list stays live as its owner changes it."
+msgstr ""
 
 #: src/routes/_layout.communities.$slug.tsx
 #~ msgid "Sub-areas"
@@ -1519,6 +1543,11 @@ msgstr "<0/> いつでもワンクリックで購読解除"
 #~ msgid "Wiring up a site that does not publish in this format yet is the one genuinely technical job in the whole product, and it has its own <0>publishing documentation</0>. Everything else in this guide stays where it is."
 #~ msgstr ""
 
+#. placeholder {0}: row.memberCount
+#: src/components/blocks-settings-view.tsx
+msgid "{0, plural, one {# account} other {# accounts}}"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Recommending an article"
@@ -1761,9 +1790,17 @@ msgstr ""
 msgid "Fast full-text search"
 msgstr "高速な全文検索"
 
+#: src/components/blocks-settings-view.tsx
+msgid "You haven't blocked anyone."
+msgstr ""
+
 #: src/lib/guide/navigation.ts
 #~ msgid "Saving, recommending, reading history, and managing what you follow."
 #~ msgstr ""
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked this account"
+msgstr ""
 
 #: src/components/reader/notify-button.tsx
 msgid "Notifications aren’t available"
@@ -2054,6 +2091,10 @@ msgstr ""
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block"
+msgstr ""
 
 #: src/routes/_layout.discover.tsx
 msgid "Known publications"
@@ -2416,6 +2457,7 @@ msgstr "ラベラーを表示"
 msgid "Read more from the author"
 msgstr "この著者の他の記事を読む"
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/labelers-settings-view.tsx
 #: src/components/user-settings-view.tsx
 msgid "Moderation"
@@ -2440,6 +2482,10 @@ msgstr "ドキュメント"
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Most unread"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block {name}"
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -2579,6 +2625,10 @@ msgstr "編集"
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Removed"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block account"
 msgstr ""
 
 #: src/components/reading-settings-preview.tsx
@@ -2758,6 +2808,10 @@ msgstr ""
 #: src/routes/review.thanks.tsx
 msgid "Return to the app"
 msgstr "アプリに戻る"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Moderation list"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -3446,6 +3500,11 @@ msgstr "「{label}」タブを表示"
 msgid "This API is also served as a <0>Model Context Protocol</0> server at <1>{baseUrl}/mcp</1>. Paste that URL into an MCP client and authorize it; the fifty-odd methods above are grouped into fifteen tools, and the client can read the network and act on your behalf."
 msgstr ""
 
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
 msgstr ""
@@ -3477,6 +3536,10 @@ msgstr "{n, plural, one {# 件の発行物} other {{value} 件の発行物}}"
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."
 msgstr "公開プロフィールに表示するタブを選択します。"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You're blocked"
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "View all latest"
@@ -3797,6 +3860,10 @@ msgstr ""
 #. placeholder {0}: rows.length
 #: src/components/reader/subscriptions-table.tsx
 msgid "{0} total"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours."
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -4174,8 +4241,18 @@ msgstr "未読"
 msgid "How readers see it"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/user-settings-view.tsx
+msgid "Blocked accounts"
+msgstr ""
+
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "Standard Reader has a reading mode built for comics — a shelf of covers instead of a list of post titles, and a full-screen theater that flips through your pages. You do not author anything specially for it. This page is how to make sure your comic gets it."
+msgstr ""
+
+#. placeholder {0}: name ?? "this account"
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked {0}, so their writing is hidden everywhere you read."
 msgstr ""
 
 #. placeholder {0}: filter.trim()
@@ -4228,6 +4305,10 @@ msgstr "いまネットワークで最も読まれている記事です。"
 
 #: src/components/appearance-settings.tsx
 msgid "The typeface used across the app. Article text follows this too, unless you set a reading font below."
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Refresh"
 msgstr ""
 
 #: src/magazine/magazine-end-like.tsx
@@ -4808,6 +4889,11 @@ msgstr ""
 msgid "There’s a magazine edition of this collection."
 msgstr "このコレクションにはマガジン版があります。"
 
+#: src/components/reader/blocked-notice.tsx
+#: src/components/user-settings-view.tsx
+msgid "Manage blocks"
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "What the extension accesses"
 msgstr "拡張機能がアクセスするもの"
@@ -4911,6 +4997,11 @@ msgstr "<0>ページの URL。</0>ポップアップを開いたとき、ペー�
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Comments and related reading"
+msgstr ""
+
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} is on a moderation list you block. To see them again, leave that list."
 msgstr ""
 
 #: src/routes/_layout.collections.index.tsx
@@ -5359,6 +5450,11 @@ msgstr ""
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler hasn’t labeled any documents in the read-model yet."
 msgstr "このラベラーは読み取りモデル内のドキュメントにまだラベルを付けていません。"
+
+#. placeholder {0}: row.memberCount
+#: src/components/blocks-settings-view.tsx
+#~ msgid "{0} accounts"
+#~ msgstr ""
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Your lists, their order, and which ones are collapsed are stored in your account rather than in this browser, so the sidebar looks the same on your laptop and your phone."
@@ -5816,6 +5912,10 @@ msgstr ""
 msgid "Standard Reader needs write access to your site.standard publications and documents, plus your collection records, to author Collections. You'll be asked to approve this on your PDS login."
 msgstr "コレクションを作成するには、Standard Reader が site.standard の発行物とドキュメント、およびコレクションのレコードへの書き込み権限を必要とします。PDS のログイン時に承認を求められます。"
 
+#: src/components/blocks-settings-view.tsx
+msgid "Block lists"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "All articles you have saved for later."
 msgstr "後で読むために保存したすべての記事です。"
@@ -6176,6 +6276,7 @@ msgstr "稼働中"
 msgid "Top on the network"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
@@ -6197,6 +6298,10 @@ msgstr "トピックで絞り込む: {triggerLabel}"
 #: src/components/reader/page-reader-bar.tsx
 msgid "Return to article and follow along"
 msgstr "記事に戻って読み進める"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Some blocks couldn't be refreshed last time, so this list may be incomplete."
+msgstr ""
 
 #. placeholder {0}: pub.subscriberCount
 #: src/components/reader/cards.tsx
@@ -6381,9 +6486,18 @@ msgstr "リストを編集"
 msgid "The Saved screen: a list of article cards the reader has set aside, each with its publication, headline, and excerpt."
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/reader/blocked-notice.tsx
+msgid "Unblock"
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "What we do not do"
 msgstr "行わないこと"
+
+#: src/components/user-settings-view.tsx
+msgid "Your Bluesky blocks apply here too — blocked accounts disappear from your feeds, search, and discussion, in both directions."
+msgstr ""
 
 #: src/components/docs/docs-side-nav.tsx
 msgid "Documentation"
@@ -6525,6 +6639,11 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Delete all reading history?"
 msgstr "閲覧履歴をすべて削除しますか？"
+
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} blocks a moderation list you're on, so you can't see their writing."
+msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6999,6 +7118,10 @@ msgstr ""
 #: src/components/site-legal-links.tsx
 msgid "Source"
 msgstr "ソース"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Accounts you block"
+msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That file isn't an image we can read."
@@ -7579,6 +7702,10 @@ msgstr "<0>サインインすると</0>（例えば Bluesky OAuth 経由で）At
 #: src/routes/subscribe-login.$did.$rkey.tsx
 msgid "Powered by <0>Standard Reader</0>"
 msgstr "Powered by <0>Standard Reader</0>"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Your blocks are enforced here already. To add or remove one from Standard Reader, you'll be asked to authorize block access the first time you try."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -622,6 +622,7 @@ msgid "Please choose a rating."
 msgstr "評価を選んでください。"
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/reader/block-user-menu-item.tsx
 msgid "Blocked"
 msgstr ""
 
@@ -788,6 +789,10 @@ msgstr "リストを削除しますか？"
 #: src/routes/_layout.latest.tsx
 msgid "Everything published recently across the publications you subscribe to."
 msgstr "購読中の発行物で最近公開されたものすべて。"
+
+#: src/components/reader/comments/comments-section.tsx
+msgid "{hiddenByBlocks, plural, one {# more reply is hidden by your blocks.} other {# more replies are hidden by your blocks.}}"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1488,6 +1493,10 @@ msgstr ""
 msgid "Compact"
 msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "This account"
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Portrait stacks the card vertically. Height adjusts automatically once the embed loads. Change the iframe width as needed."
 msgstr "縦長はカードを縦に並べます。埋め込みが読み込まれると高さは自動で調整されます。iframe の幅は必要に応じて変更してください。"
@@ -1927,6 +1936,10 @@ msgstr "購読ボタンを埋め込む"
 msgid "That GIF is over 1 MB. Try a shorter clip, or attach a still image."
 msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+msgstr ""
+
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Add another screenshot"
 #~ msgstr ""
@@ -1946,6 +1959,10 @@ msgstr "コレクションを削除"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Interface font"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "We're re-reading your blocks from your account. This page updates when it finishes."
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -2014,6 +2031,7 @@ msgstr ""
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/reader/pull-to-refresh.tsx
 msgid "Refreshing"
 msgstr ""
@@ -2305,6 +2323,7 @@ msgstr "ラベラー"
 msgid "Articles you've opened — public records in your repo, synced across devices."
 msgstr "開いたことのある記事です。リポジトリ内の公開レコードとして、デバイス間で同期されます。"
 
+#: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-publication-editor.tsx
 #: src/components/reader/collection-theme-editor.tsx
@@ -2581,6 +2600,10 @@ msgstr "<0>Leaflet、Pckt、Offprint。</0> <1>pub.leaflet.content</1>、<2>blog
 
 #: src/components/appearance-settings.tsx
 msgid "XL"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "We couldn't write the block to your account. Try again?"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -3272,6 +3295,10 @@ msgstr "画像"
 #~ msgid "<0>Follow</0> is the only subscription there is. New writing from anything you follow appears on Home and in Latest, and the publication is listed in your sidebar. There is no email sign-up and no separate account with the publisher."
 #~ msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "We couldn't remove the block from your account. Try again?"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Selecting anyone's name opens their author page: everything they publish, what they follow, and what they have recommended."
 msgstr ""
@@ -3321,6 +3348,10 @@ msgstr ""
 #~ msgid "Prefer a typed client? The whole API ships as codegen'd AT Protocol lexicon schemas in <0>@standard-reader/lexicons</0>. Pair it with <1>@atproto/lex-client</1> for fully-typed <2>client.call()</2> queries and procedures. Its <3>getDocument</3> also returns a document's renderable body, ready to hand to the <4>renderers</4>."
 #~ msgstr ""
 
+#: src/components/reader/comments/comments-section.tsx
+msgid "{hiddenByBlocks, plural, one {The only reply here is from someone you're blocked from.} other {The replies here are all from accounts you're blocked from.}}"
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Couldn't save your follows"
 msgstr "フォローを保存できませんでした"
@@ -3357,6 +3388,10 @@ msgstr ""
 msgid "Publications to explore"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+msgid "We couldn't reach your account to change that. Try again?"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Read as comic"
 msgstr ""
@@ -3378,6 +3413,10 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Read and unread"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "This writes a block to your Bluesky account, so it applies here and anywhere else you use it. Their writing disappears from your feeds, search and discussion, and they can't see yours. You can undo it in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -3502,8 +3541,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
-msgstr ""
+#~ msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
@@ -3643,6 +3682,10 @@ msgstr ""
 msgid "Worth subscribing to"
 msgstr "購読する価値のある発行物"
 
+#: src/components/blocks-settings-view.tsx
+msgid "this list is larger than we mirror, so some members aren't blocked here"
+msgstr ""
+
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Angular."
 #~ msgstr ""
@@ -3666,6 +3709,10 @@ msgstr ""
 
 #: src/routes/_layout.subscriptions.tsx
 msgid "Nothing to manage yet"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "They're hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.subscriptions.tsx
@@ -4017,6 +4064,10 @@ msgstr ""
 msgid "No lists yet"
 msgstr "リストはまだありません"
 
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} blocks a moderation list you're on, so you can't see their writing."
+msgstr ""
+
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "Saving things while you browse the rest of the web, keeping Standard Reader on your home screen, and passing an article on."
 #~ msgstr ""
@@ -4036,6 +4087,10 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
 msgstr "「読み上げ」ボタンで、どの記事もデバイス上で音声にして読み上げ、単語を1つずつハイライトします。プレーヤーはアプリ内のどこへでも付いてきて、埋め込まれた Bluesky の投稿も読み上げます。サインインすれば声も選べます。"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "this account"
+msgstr ""
 
 #. placeholder {0}: next.title
 #: src/components/reader/series-up-next.tsx
@@ -4175,6 +4230,15 @@ msgstr "任意: 保存する理由をメモに残せます"
 msgid "Open the app"
 msgstr ""
 
+#. placeholder {0}: fmt.relativeTime(data.syncedAt)
+#: src/components/blocks-settings-view.tsx
+msgid "Last checked {0}. Blocks you make elsewhere show up here within about fifteen minutes."
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block account?"
+msgstr ""
+
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this note on Semble"
 msgstr ""
@@ -4252,8 +4316,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "this account"
 #: src/components/reader/blocked-notice.tsx
-msgid "You blocked {0}, so their writing is hidden everywhere you read."
-msgstr ""
+#~ msgid "You blocked {0}, so their writing is hidden everywhere you read."
+#~ msgstr ""
 
 #. placeholder {0}: filter.trim()
 #: src/components/reader/subscriptions-table.tsx
@@ -4485,6 +4549,10 @@ msgstr ""
 msgid "Recommended articles"
 msgstr "おすすめの記事"
 
+#: src/components/reader/mention-hover-card.tsx
+msgid "You blocked this account, so their writing is hidden."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
 msgstr ""
@@ -4690,6 +4758,10 @@ msgstr ""
 msgid "{0}+ articles"
 msgstr "{0}+ 件の記事"
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "{name} is hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts."
+msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "Starter pack"
 msgstr ""
@@ -4701,6 +4773,10 @@ msgstr "このリンクは期限切れです。"
 #: src/components/guide/pages/lists-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Lists in the sidebar"
+msgstr ""
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked {who}, so their writing is hidden everywhere you read."
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
@@ -4952,6 +5028,9 @@ msgstr ""
 msgid "Not in the directory yet?"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/reader/block-user-menu-item.tsx
+#: src/components/reader/blocked-notice.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
@@ -5001,8 +5080,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} is on a moderation list you block. To see them again, leave that list."
-msgstr ""
+#~ msgid "{0} is on a moderation list you block. To see them again, leave that list."
+#~ msgstr ""
 
 #: src/routes/_layout.collections.index.tsx
 msgid "Curated, magazine-rendered editions grouped into series you can subscribe to — your special collections on the network."
@@ -6025,6 +6104,10 @@ msgstr "フィードバックを見る"
 #~ msgid "Pages you have already visited stay available when your connection drops, and Standard Reader shows a plain offline page rather than a browser error when you reach for something it does not have. When a new version of the app is ready, it offers to reload rather than changing under you mid-article."
 #~ msgstr ""
 
+#: src/components/reader/mention-hover-card.tsx
+msgid "This account blocks you, so you can't see their writing."
+msgstr ""
+
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Being in a list does not change your feeds. Everything you subscribe to still arrives on Home and in Latest exactly as before; a list only changes how the sidebar is organised, and gives you a page you can read — or share — on its own."
 msgstr ""
@@ -6233,6 +6316,10 @@ msgstr ""
 #: src/magazine/Magazine.tsx
 msgid "Contents"
 msgstr "目次"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} is on a moderation list you block. To see them again, leave that list."
+msgstr ""
 
 #: src/components/reader/share-menu.tsx
 msgid "Copy embed code"
@@ -6642,8 +6729,8 @@ msgstr "閲覧履歴をすべて削除しますか？"
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} blocks a moderation list you're on, so you can't see their writing."
-msgstr ""
+#~ msgid "{0} blocks a moderation list you're on, so you can't see their writing."
+#~ msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6971,6 +7058,10 @@ msgstr "{handleLabel} の発行物は見つかりませんでした。"
 msgid "Already subscribed"
 msgstr "購読済み"
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block {name}?"
+msgstr ""
+
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "How to wire a personal site's own <0>site.standard.*</0> records so Standard Reader can find it and read articles inline, without going through Leaflet, Pckt, Offprint, or another publishing tool."
 msgstr "Leaflet、Pckt、Offprint などの公開ツールを使わずに、個人サイト自身の <0>site.standard.*</0> レコードを用意して、Standard Reader から見つけて記事をそのまま読めるようにする方法。"
@@ -6986,6 +7077,10 @@ msgstr "その他のコレクション"
 #: src/components/reader/about-view.tsx
 msgid "One tasteful email a week"
 msgstr "週に1通、上質なメールを"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "Blocked by a list you use"
+msgstr ""
 
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "{unreadCount} unread"
@@ -7274,6 +7369,7 @@ msgid "Pages"
 msgstr ""
 
 #: src/components/reader/article-view-skeleton.tsx
+#: src/routes/_layout.a.$did.$rkey.tsx
 msgid "Loading article"
 msgstr "記事を読み込み中"
 

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -239,6 +239,10 @@ msgstr ""
 msgid "You're signed in"
 msgstr "로그인되었습니다"
 
+#: src/components/user-settings-view.tsx
+msgid "Manage {blockCount} blocks"
+msgstr ""
+
 #: src/routes/_layout.subscriptions.tsx
 msgid "Subscribe to a publication or follow a writer and they'll show up here, with their unread count and latest post. Each subscription is an <0>app.standard-reader.subscription</0> record in your repo — yours to take anywhere."
 msgstr ""
@@ -617,6 +621,10 @@ msgstr ""
 msgid "Please choose a rating."
 msgstr "평점을 선택하세요."
 
+#: src/components/blocks-settings-view.tsx
+msgid "Blocked"
+msgstr ""
+
 #: src/components/docs/docs-mobile-nav.tsx
 #: src/components/guide/guide-mobile-nav.tsx
 msgid "(current)"
@@ -634,6 +642,10 @@ msgstr ""
 #: src/components/reader/share-menu.tsx
 msgid "Portrait"
 msgstr "세로형"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Loading blocked accounts"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Select any headline to open it. Articles are laid out as a single column at a comfortable width, with the publication's own colors and typography where it has them."
@@ -655,6 +667,10 @@ msgstr "아래로 이동"
 msgid "Disclaimer and limitation of liability"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+msgid "You don't subscribe to any block lists."
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No articles from this list's publications or people yet."
 msgstr "이 목록의 발행물이나 사람이 쓴 글이 아직 없습니다."
@@ -666,6 +682,10 @@ msgstr ""
 #. placeholder {0}: labels[order]
 #: src/components/reader/publication-actions.tsx
 msgid "Order: {0}"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Partial"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -718,6 +738,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Permanently remove data stored in your account. These actions delete records from your account and cannot be undone."
 msgstr "계정에 저장된 데이터를 영구적으로 삭제합니다. 이 작업은 계정에서 레코드를 삭제하며 되돌릴 수 없습니다."
+
+#: src/components/blocks-settings-view.tsx
+msgid "Moderation lists you subscribe to on Bluesky. Everyone on them is blocked here too, and the list stays live as its owner changes it."
+msgstr ""
 
 #: src/routes/_layout.communities.$slug.tsx
 #~ msgid "Sub-areas"
@@ -1519,6 +1543,11 @@ msgstr "<0/> 언제든 클릭 한 번으로 구독 해지"
 #~ msgid "Wiring up a site that does not publish in this format yet is the one genuinely technical job in the whole product, and it has its own <0>publishing documentation</0>. Everything else in this guide stays where it is."
 #~ msgstr ""
 
+#. placeholder {0}: row.memberCount
+#: src/components/blocks-settings-view.tsx
+msgid "{0, plural, one {# account} other {# accounts}}"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Recommending an article"
@@ -1761,9 +1790,17 @@ msgstr ""
 msgid "Fast full-text search"
 msgstr "빠른 전문 검색"
 
+#: src/components/blocks-settings-view.tsx
+msgid "You haven't blocked anyone."
+msgstr ""
+
 #: src/lib/guide/navigation.ts
 #~ msgid "Saving, recommending, reading history, and managing what you follow."
 #~ msgstr ""
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked this account"
+msgstr ""
 
 #: src/components/reader/notify-button.tsx
 msgid "Notifications aren’t available"
@@ -2054,6 +2091,10 @@ msgstr ""
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block"
+msgstr ""
 
 #: src/routes/_layout.discover.tsx
 msgid "Known publications"
@@ -2416,6 +2457,7 @@ msgstr "라벨러 보기"
 msgid "Read more from the author"
 msgstr "이 작가의 다른 글 보기"
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/labelers-settings-view.tsx
 #: src/components/user-settings-view.tsx
 msgid "Moderation"
@@ -2440,6 +2482,10 @@ msgstr "문서"
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Most unread"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block {name}"
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -2579,6 +2625,10 @@ msgstr "수정"
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Removed"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block account"
 msgstr ""
 
 #: src/components/reading-settings-preview.tsx
@@ -2758,6 +2808,10 @@ msgstr ""
 #: src/routes/review.thanks.tsx
 msgid "Return to the app"
 msgstr "앱으로 돌아가기"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Moderation list"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -3446,6 +3500,11 @@ msgstr "{label} 탭 표시"
 msgid "This API is also served as a <0>Model Context Protocol</0> server at <1>{baseUrl}/mcp</1>. Paste that URL into an MCP client and authorize it; the fifty-odd methods above are grouped into fifteen tools, and the client can read the network and act on your behalf."
 msgstr ""
 
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
 msgstr ""
@@ -3477,6 +3536,10 @@ msgstr "{n, plural, one {발행물 #개} other {발행물 {value}개}}"
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."
 msgstr "공개 프로필에 표시할 탭을 선택하세요."
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You're blocked"
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "View all latest"
@@ -3797,6 +3860,10 @@ msgstr ""
 #. placeholder {0}: rows.length
 #: src/components/reader/subscriptions-table.tsx
 msgid "{0} total"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours."
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -4174,8 +4241,18 @@ msgstr "읽지 않음"
 msgid "How readers see it"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/user-settings-view.tsx
+msgid "Blocked accounts"
+msgstr ""
+
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "Standard Reader has a reading mode built for comics — a shelf of covers instead of a list of post titles, and a full-screen theater that flips through your pages. You do not author anything specially for it. This page is how to make sure your comic gets it."
+msgstr ""
+
+#. placeholder {0}: name ?? "this account"
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked {0}, so their writing is hidden everywhere you read."
 msgstr ""
 
 #. placeholder {0}: filter.trim()
@@ -4228,6 +4305,10 @@ msgstr "지금 네트워크에서 가장 많이 읽히는 글입니다."
 
 #: src/components/appearance-settings.tsx
 msgid "The typeface used across the app. Article text follows this too, unless you set a reading font below."
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Refresh"
 msgstr ""
 
 #: src/magazine/magazine-end-like.tsx
@@ -4808,6 +4889,11 @@ msgstr ""
 msgid "There’s a magazine edition of this collection."
 msgstr "이 컬렉션의 매거진 에디션이 있습니다."
 
+#: src/components/reader/blocked-notice.tsx
+#: src/components/user-settings-view.tsx
+msgid "Manage blocks"
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "What the extension accesses"
 msgstr "확장 프로그램이 접근하는 정보"
@@ -4911,6 +4997,11 @@ msgstr "<0>페이지 URL.</0> 팝업을 열거나, 페이지 오버레이를 사
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Comments and related reading"
+msgstr ""
+
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} is on a moderation list you block. To see them again, leave that list."
 msgstr ""
 
 #: src/routes/_layout.collections.index.tsx
@@ -5359,6 +5450,11 @@ msgstr ""
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler hasn’t labeled any documents in the read-model yet."
 msgstr "이 라벨러는 아직 리드 모델의 어떤 문서에도 라벨을 지정하지 않았습니다."
+
+#. placeholder {0}: row.memberCount
+#: src/components/blocks-settings-view.tsx
+#~ msgid "{0} accounts"
+#~ msgstr ""
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Your lists, their order, and which ones are collapsed are stored in your account rather than in this browser, so the sidebar looks the same on your laptop and your phone."
@@ -5816,6 +5912,10 @@ msgstr ""
 msgid "Standard Reader needs write access to your site.standard publications and documents, plus your collection records, to author Collections. You'll be asked to approve this on your PDS login."
 msgstr "Standard Reader가 컬렉션을 작성하려면 site.standard 발행물과 문서, 그리고 컬렉션 레코드에 대한 쓰기 권한이 필요합니다. PDS 로그인 시 승인 요청이 표시됩니다."
 
+#: src/components/blocks-settings-view.tsx
+msgid "Block lists"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "All articles you have saved for later."
 msgstr "나중에 읽으려고 저장한 모든 글입니다."
@@ -6176,6 +6276,7 @@ msgstr "정상"
 msgid "Top on the network"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
@@ -6197,6 +6298,10 @@ msgstr "주제로 필터링: {triggerLabel}"
 #: src/components/reader/page-reader-bar.tsx
 msgid "Return to article and follow along"
 msgstr "글로 돌아가 따라 읽기"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Some blocks couldn't be refreshed last time, so this list may be incomplete."
+msgstr ""
 
 #. placeholder {0}: pub.subscriberCount
 #: src/components/reader/cards.tsx
@@ -6381,9 +6486,18 @@ msgstr "목록 편집"
 msgid "The Saved screen: a list of article cards the reader has set aside, each with its publication, headline, and excerpt."
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/reader/blocked-notice.tsx
+msgid "Unblock"
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "What we do not do"
 msgstr "저희가 하지 않는 일"
+
+#: src/components/user-settings-view.tsx
+msgid "Your Bluesky blocks apply here too — blocked accounts disappear from your feeds, search, and discussion, in both directions."
+msgstr ""
 
 #: src/components/docs/docs-side-nav.tsx
 msgid "Documentation"
@@ -6525,6 +6639,11 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Delete all reading history?"
 msgstr "읽은 기록을 모두 삭제할까요?"
+
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} blocks a moderation list you're on, so you can't see their writing."
+msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6999,6 +7118,10 @@ msgstr ""
 #: src/components/site-legal-links.tsx
 msgid "Source"
 msgstr "출처"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Accounts you block"
+msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That file isn't an image we can read."
@@ -7579,6 +7702,10 @@ msgstr "<0>Atmosphere 계정으로 로그인하면</0>(예: Bluesky OAuth) AT Pr
 #: src/routes/subscribe-login.$did.$rkey.tsx
 msgid "Powered by <0>Standard Reader</0>"
 msgstr "<0>Standard Reader</0> 제공"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Your blocks are enforced here already. To add or remove one from Standard Reader, you'll be asked to authorize block access the first time you try."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -622,6 +622,7 @@ msgid "Please choose a rating."
 msgstr "평점을 선택하세요."
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/reader/block-user-menu-item.tsx
 msgid "Blocked"
 msgstr ""
 
@@ -788,6 +789,10 @@ msgstr "목록을 삭제할까요?"
 #: src/routes/_layout.latest.tsx
 msgid "Everything published recently across the publications you subscribe to."
 msgstr "구독 중인 발행물에서 최근 발행된 모든 글입니다."
+
+#: src/components/reader/comments/comments-section.tsx
+msgid "{hiddenByBlocks, plural, one {# more reply is hidden by your blocks.} other {# more replies are hidden by your blocks.}}"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1488,6 +1493,10 @@ msgstr ""
 msgid "Compact"
 msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "This account"
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Portrait stacks the card vertically. Height adjusts automatically once the embed loads. Change the iframe width as needed."
 msgstr "세로형은 카드를 세로로 쌓아 배치합니다. 임베드가 로드되면 높이가 자동으로 조정됩니다. iframe 너비는 필요에 따라 변경하세요."
@@ -1927,6 +1936,10 @@ msgstr "구독 임베드"
 msgid "That GIF is over 1 MB. Try a shorter clip, or attach a still image."
 msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+msgstr ""
+
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Add another screenshot"
 #~ msgstr ""
@@ -1946,6 +1959,10 @@ msgstr "컬렉션 삭제"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Interface font"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "We're re-reading your blocks from your account. This page updates when it finishes."
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -2014,6 +2031,7 @@ msgstr ""
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/reader/pull-to-refresh.tsx
 msgid "Refreshing"
 msgstr ""
@@ -2305,6 +2323,7 @@ msgstr "라벨러"
 msgid "Articles you've opened — public records in your repo, synced across devices."
 msgstr "열어본 아티클입니다. 내 저장소의 공개 레코드로, 여러 기기에서 동기화됩니다."
 
+#: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-publication-editor.tsx
 #: src/components/reader/collection-theme-editor.tsx
@@ -2581,6 +2600,10 @@ msgstr "<0>Leaflet, Pckt, Offprint.</0> <1>pub.leaflet.content</1>, <2>blog.pckt
 
 #: src/components/appearance-settings.tsx
 msgid "XL"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "We couldn't write the block to your account. Try again?"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -3272,6 +3295,10 @@ msgstr "이미지"
 #~ msgid "<0>Follow</0> is the only subscription there is. New writing from anything you follow appears on Home and in Latest, and the publication is listed in your sidebar. There is no email sign-up and no separate account with the publisher."
 #~ msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "We couldn't remove the block from your account. Try again?"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Selecting anyone's name opens their author page: everything they publish, what they follow, and what they have recommended."
 msgstr ""
@@ -3321,6 +3348,10 @@ msgstr ""
 #~ msgid "Prefer a typed client? The whole API ships as codegen'd AT Protocol lexicon schemas in <0>@standard-reader/lexicons</0>. Pair it with <1>@atproto/lex-client</1> for fully-typed <2>client.call()</2> queries and procedures. Its <3>getDocument</3> also returns a document's renderable body, ready to hand to the <4>renderers</4>."
 #~ msgstr ""
 
+#: src/components/reader/comments/comments-section.tsx
+msgid "{hiddenByBlocks, plural, one {The only reply here is from someone you're blocked from.} other {The replies here are all from accounts you're blocked from.}}"
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Couldn't save your follows"
 msgstr "팔로우를 저장하지 못했습니다"
@@ -3357,6 +3388,10 @@ msgstr ""
 msgid "Publications to explore"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+msgid "We couldn't reach your account to change that. Try again?"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Read as comic"
 msgstr ""
@@ -3378,6 +3413,10 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Read and unread"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "This writes a block to your Bluesky account, so it applies here and anywhere else you use it. Their writing disappears from your feeds, search and discussion, and they can't see yours. You can undo it in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -3502,8 +3541,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
-msgstr ""
+#~ msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
@@ -3643,6 +3682,10 @@ msgstr ""
 msgid "Worth subscribing to"
 msgstr "구독할 만한 곳"
 
+#: src/components/blocks-settings-view.tsx
+msgid "this list is larger than we mirror, so some members aren't blocked here"
+msgstr ""
+
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Angular."
 #~ msgstr ""
@@ -3666,6 +3709,10 @@ msgstr ""
 
 #: src/routes/_layout.subscriptions.tsx
 msgid "Nothing to manage yet"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "They're hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.subscriptions.tsx
@@ -4017,6 +4064,10 @@ msgstr ""
 msgid "No lists yet"
 msgstr "아직 리스트가 없습니다"
 
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} blocks a moderation list you're on, so you can't see their writing."
+msgstr ""
+
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "Saving things while you browse the rest of the web, keeping Standard Reader on your home screen, and passing an article on."
 #~ msgstr ""
@@ -4036,6 +4087,10 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
 msgstr "듣기 버튼을 누르면 어떤 글이든 기기에서 바로 읽어 주고, 읽는 단어를 하나씩 강조해 줍니다. 플레이어는 앱 어디를 가든 따라오며, 임베드된 Bluesky 게시물도 읽어 줍니다. 로그인하면 목소리를 고를 수 있습니다."
+
+#: src/components/reader/blocked-notice.tsx
+msgid "this account"
+msgstr ""
 
 #. placeholder {0}: next.title
 #: src/components/reader/series-up-next.tsx
@@ -4175,6 +4230,15 @@ msgstr "선택 사항: 저장하는 이유를 메모로 남겨보세요"
 msgid "Open the app"
 msgstr ""
 
+#. placeholder {0}: fmt.relativeTime(data.syncedAt)
+#: src/components/blocks-settings-view.tsx
+msgid "Last checked {0}. Blocks you make elsewhere show up here within about fifteen minutes."
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block account?"
+msgstr ""
+
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this note on Semble"
 msgstr ""
@@ -4252,8 +4316,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "this account"
 #: src/components/reader/blocked-notice.tsx
-msgid "You blocked {0}, so their writing is hidden everywhere you read."
-msgstr ""
+#~ msgid "You blocked {0}, so their writing is hidden everywhere you read."
+#~ msgstr ""
 
 #. placeholder {0}: filter.trim()
 #: src/components/reader/subscriptions-table.tsx
@@ -4485,6 +4549,10 @@ msgstr ""
 msgid "Recommended articles"
 msgstr "추천 아티클"
 
+#: src/components/reader/mention-hover-card.tsx
+msgid "You blocked this account, so their writing is hidden."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
 msgstr ""
@@ -4690,6 +4758,10 @@ msgstr ""
 msgid "{0}+ articles"
 msgstr "아티클 {0}개 이상"
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "{name} is hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts."
+msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "Starter pack"
 msgstr ""
@@ -4701,6 +4773,10 @@ msgstr "링크가 만료되었습니다."
 #: src/components/guide/pages/lists-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Lists in the sidebar"
+msgstr ""
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked {who}, so their writing is hidden everywhere you read."
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
@@ -4952,6 +5028,9 @@ msgstr ""
 msgid "Not in the directory yet?"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/reader/block-user-menu-item.tsx
+#: src/components/reader/blocked-notice.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
@@ -5001,8 +5080,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} is on a moderation list you block. To see them again, leave that list."
-msgstr ""
+#~ msgid "{0} is on a moderation list you block. To see them again, leave that list."
+#~ msgstr ""
 
 #: src/routes/_layout.collections.index.tsx
 msgid "Curated, magazine-rendered editions grouped into series you can subscribe to — your special collections on the network."
@@ -6025,6 +6104,10 @@ msgstr "피드백 보기"
 #~ msgid "Pages you have already visited stay available when your connection drops, and Standard Reader shows a plain offline page rather than a browser error when you reach for something it does not have. When a new version of the app is ready, it offers to reload rather than changing under you mid-article."
 #~ msgstr ""
 
+#: src/components/reader/mention-hover-card.tsx
+msgid "This account blocks you, so you can't see their writing."
+msgstr ""
+
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Being in a list does not change your feeds. Everything you subscribe to still arrives on Home and in Latest exactly as before; a list only changes how the sidebar is organised, and gives you a page you can read — or share — on its own."
 msgstr ""
@@ -6233,6 +6316,10 @@ msgstr ""
 #: src/magazine/Magazine.tsx
 msgid "Contents"
 msgstr "목차"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} is on a moderation list you block. To see them again, leave that list."
+msgstr ""
 
 #: src/components/reader/share-menu.tsx
 msgid "Copy embed code"
@@ -6642,8 +6729,8 @@ msgstr "읽은 기록을 모두 삭제할까요?"
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} blocks a moderation list you're on, so you can't see their writing."
-msgstr ""
+#~ msgid "{0} blocks a moderation list you're on, so you can't see their writing."
+#~ msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6971,6 +7058,10 @@ msgstr "{handleLabel}의 발행물을 찾을 수 없습니다."
 msgid "Already subscribed"
 msgstr "이미 구독 중"
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block {name}?"
+msgstr ""
+
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "How to wire a personal site's own <0>site.standard.*</0> records so Standard Reader can find it and read articles inline, without going through Leaflet, Pckt, Offprint, or another publishing tool."
 msgstr "Leaflet, Pckt, Offprint 같은 퍼블리싱 도구를 거치지 않고, 개인 사이트에 <0>site.standard.*</0> 레코드를 직접 연결해 Standard Reader가 사이트를 찾고 글을 인라인으로 읽게 하는 방법."
@@ -6986,6 +7077,10 @@ msgstr "다른 컬렉션"
 #: src/components/reader/about-view.tsx
 msgid "One tasteful email a week"
 msgstr "일주일에 한 번, 품격 있는 이메일"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "Blocked by a list you use"
+msgstr ""
 
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "{unreadCount} unread"
@@ -7274,6 +7369,7 @@ msgid "Pages"
 msgstr ""
 
 #: src/components/reader/article-view-skeleton.tsx
+#: src/routes/_layout.a.$did.$rkey.tsx
 msgid "Loading article"
 msgstr "글 불러오는 중"
 

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -239,6 +239,10 @@ msgstr ""
 msgid "You're signed in"
 msgstr "Sessão iniciada"
 
+#: src/components/user-settings-view.tsx
+msgid "Manage {blockCount} blocks"
+msgstr ""
+
 #: src/routes/_layout.subscriptions.tsx
 msgid "Subscribe to a publication or follow a writer and they'll show up here, with their unread count and latest post. Each subscription is an <0>app.standard-reader.subscription</0> record in your repo — yours to take anywhere."
 msgstr "Inscreva-se a uma publicação ou siga um autor e eles aparecerão aqui, com a contagem de itens não lidos e o artigo mais recente. Cada inscrição é um registro <0>app.standard-reader.subscription</0> no seu repositório — para você levar aonde quiser."
@@ -617,6 +621,10 @@ msgstr ""
 msgid "Please choose a rating."
 msgstr "Escolha uma nota."
 
+#: src/components/blocks-settings-view.tsx
+msgid "Blocked"
+msgstr ""
+
 #: src/components/docs/docs-mobile-nav.tsx
 #: src/components/guide/guide-mobile-nav.tsx
 msgid "(current)"
@@ -634,6 +642,10 @@ msgstr ""
 #: src/components/reader/share-menu.tsx
 msgid "Portrait"
 msgstr "Vertical"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Loading blocked accounts"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Select any headline to open it. Articles are laid out as a single column at a comfortable width, with the publication's own colors and typography where it has them."
@@ -655,6 +667,10 @@ msgstr "Mover para baixo"
 msgid "Disclaimer and limitation of liability"
 msgstr "Isenção e limitação de responsabilidade"
 
+#: src/components/blocks-settings-view.tsx
+msgid "You don't subscribe to any block lists."
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No articles from this list's publications or people yet."
 msgstr "Ainda não há artigos das publicações ou pessoas desta lista."
@@ -666,6 +682,10 @@ msgstr ""
 #. placeholder {0}: labels[order]
 #: src/components/reader/publication-actions.tsx
 msgid "Order: {0}"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Partial"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -718,6 +738,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Permanently remove data stored in your account. These actions delete records from your account and cannot be undone."
 msgstr "Remova permanentemente dados salvos na sua conta. Estas ações apagam registos da sua conta e não podem ser desfeitas."
+
+#: src/components/blocks-settings-view.tsx
+msgid "Moderation lists you subscribe to on Bluesky. Everyone on them is blocked here too, and the list stays live as its owner changes it."
+msgstr ""
 
 #: src/routes/_layout.communities.$slug.tsx
 #~ msgid "Sub-areas"
@@ -1519,6 +1543,11 @@ msgstr "<0/> Cancele a inscrição num clique, quando quiser"
 #~ msgid "Wiring up a site that does not publish in this format yet is the one genuinely technical job in the whole product, and it has its own <0>publishing documentation</0>. Everything else in this guide stays where it is."
 #~ msgstr ""
 
+#. placeholder {0}: row.memberCount
+#: src/components/blocks-settings-view.tsx
+msgid "{0, plural, one {# account} other {# accounts}}"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Recommending an article"
@@ -1761,9 +1790,17 @@ msgstr ""
 msgid "Fast full-text search"
 msgstr "Pesquisa rápida em texto integral"
 
+#: src/components/blocks-settings-view.tsx
+msgid "You haven't blocked anyone."
+msgstr ""
+
 #: src/lib/guide/navigation.ts
 #~ msgid "Saving, recommending, reading history, and managing what you follow."
 #~ msgstr ""
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked this account"
+msgstr ""
 
 #: src/components/reader/notify-button.tsx
 msgid "Notifications aren’t available"
@@ -2054,6 +2091,10 @@ msgstr ""
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr "Escolha o pacote para o seu framework; todos se baseiam no mesmo núcleo."
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block"
+msgstr ""
 
 #: src/routes/_layout.discover.tsx
 msgid "Known publications"
@@ -2416,6 +2457,7 @@ msgstr "Ver rotulador"
 msgid "Read more from the author"
 msgstr "Ler mais do autor"
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/labelers-settings-view.tsx
 #: src/components/user-settings-view.tsx
 msgid "Moderation"
@@ -2440,6 +2482,10 @@ msgstr "Documentos"
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Most unread"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block {name}"
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -2580,6 +2626,10 @@ msgstr "Editar"
 #: src/components/reader/subscriptions-table.tsx
 msgid "Removed"
 msgstr "Removido"
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block account"
+msgstr ""
 
 #: src/components/reading-settings-preview.tsx
 msgid "Stop sample"
@@ -2758,6 +2808,10 @@ msgstr "{0, plural, one {# publicação} other {# publicações}} de quem você 
 #: src/routes/review.thanks.tsx
 msgid "Return to the app"
 msgstr "Voltar ao aplicativo"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Moderation list"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -3446,6 +3500,11 @@ msgstr "Mostrar aba {label}"
 msgid "This API is also served as a <0>Model Context Protocol</0> server at <1>{baseUrl}/mcp</1>. Paste that URL into an MCP client and authorize it; the fifty-odd methods above are grouped into fifteen tools, and the client can read the network and act on your behalf."
 msgstr ""
 
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
 msgstr ""
@@ -3477,6 +3536,10 @@ msgstr "{n, plural, one {# publicação} other {{value} publicações}}"
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."
 msgstr "Escolha que separadores aparecem no seu perfil público."
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You're blocked"
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "View all latest"
@@ -3798,6 +3861,10 @@ msgstr ""
 #: src/components/reader/subscriptions-table.tsx
 msgid "{0} total"
 msgstr "{0} total"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours."
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Five ways in: what is new from your follows, what the whole network is publishing, the directory, search, and topics."
@@ -4174,8 +4241,18 @@ msgstr "Não lido"
 msgid "How readers see it"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/user-settings-view.tsx
+msgid "Blocked accounts"
+msgstr ""
+
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "Standard Reader has a reading mode built for comics — a shelf of covers instead of a list of post titles, and a full-screen theater that flips through your pages. You do not author anything specially for it. This page is how to make sure your comic gets it."
+msgstr ""
+
+#. placeholder {0}: name ?? "this account"
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked {0}, so their writing is hidden everywhere you read."
 msgstr ""
 
 #. placeholder {0}: filter.trim()
@@ -4228,6 +4305,10 @@ msgstr "Os textos mais lidos em toda a rede neste momento."
 
 #: src/components/appearance-settings.tsx
 msgid "The typeface used across the app. Article text follows this too, unless you set a reading font below."
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Refresh"
 msgstr ""
 
 #: src/magazine/magazine-end-like.tsx
@@ -4808,6 +4889,11 @@ msgstr ""
 msgid "There’s a magazine edition of this collection."
 msgstr "Existe uma edição em revista desta coleção."
 
+#: src/components/reader/blocked-notice.tsx
+#: src/components/user-settings-view.tsx
+msgid "Manage blocks"
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "What the extension accesses"
 msgstr "A que acede a extensão"
@@ -4911,6 +4997,11 @@ msgstr "<0>URLs de páginas.</0> Quando abre a janela, usa a sobreposição de p
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Comments and related reading"
+msgstr ""
+
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} is on a moderation list you block. To see them again, leave that list."
 msgstr ""
 
 #: src/routes/_layout.collections.index.tsx
@@ -5359,6 +5450,11 @@ msgstr ""
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler hasn’t labeled any documents in the read-model yet."
 msgstr "Este rotulador ainda não rotulou documentos no modelo de leitura."
+
+#. placeholder {0}: row.memberCount
+#: src/components/blocks-settings-view.tsx
+#~ msgid "{0} accounts"
+#~ msgstr ""
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Your lists, their order, and which ones are collapsed are stored in your account rather than in this browser, so the sidebar looks the same on your laptop and your phone."
@@ -5816,6 +5912,10 @@ msgstr ""
 msgid "Standard Reader needs write access to your site.standard publications and documents, plus your collection records, to author Collections. You'll be asked to approve this on your PDS login."
 msgstr "O Standard Reader precisa de acesso de escrita às suas publicações e documentos site.standard, além dos seus registos de coleções, para criar Coleções. Ser-lhe-á pedido que aprove isto no início de sessão do seu PDS."
 
+#: src/components/blocks-settings-view.tsx
+msgid "Block lists"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "All articles you have saved for later."
 msgstr "Todos os artigos que salvou para mais tarde."
@@ -6176,6 +6276,7 @@ msgstr "operacional"
 msgid "Top on the network"
 msgstr "Os mais populares da rede"
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
@@ -6197,6 +6298,10 @@ msgstr "Filtrar por tópico: {triggerLabel}"
 #: src/components/reader/page-reader-bar.tsx
 msgid "Return to article and follow along"
 msgstr "Voltar ao artigo e acompanhar"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Some blocks couldn't be refreshed last time, so this list may be incomplete."
+msgstr ""
 
 #. placeholder {0}: pub.subscriberCount
 #: src/components/reader/cards.tsx
@@ -6381,9 +6486,18 @@ msgstr "Editar lista"
 msgid "The Saved screen: a list of article cards the reader has set aside, each with its publication, headline, and excerpt."
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/reader/blocked-notice.tsx
+msgid "Unblock"
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "What we do not do"
 msgstr "O que não fazemos"
+
+#: src/components/user-settings-view.tsx
+msgid "Your Bluesky blocks apply here too — blocked accounts disappear from your feeds, search, and discussion, in both directions."
+msgstr ""
 
 #: src/components/docs/docs-side-nav.tsx
 msgid "Documentation"
@@ -6525,6 +6639,11 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Delete all reading history?"
 msgstr "Apagar todo o histórico de leitura?"
+
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} blocks a moderation list you're on, so you can't see their writing."
+msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6999,6 +7118,10 @@ msgstr ""
 #: src/components/site-legal-links.tsx
 msgid "Source"
 msgstr "Código"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Accounts you block"
+msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That file isn't an image we can read."
@@ -7579,6 +7702,10 @@ msgstr "<0>Quando inicia sessão</0> com a sua conta da Atmosfera (por exemplo v
 #: src/routes/subscribe-login.$did.$rkey.tsx
 msgid "Powered by <0>Standard Reader</0>"
 msgstr "Com tecnologia <0>Standard Reader</0>"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Your blocks are enforced here already. To add or remove one from Standard Reader, you'll be asked to authorize block access the first time you try."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -622,6 +622,7 @@ msgid "Please choose a rating."
 msgstr "Escolha uma nota."
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/reader/block-user-menu-item.tsx
 msgid "Blocked"
 msgstr ""
 
@@ -788,6 +789,10 @@ msgstr "Apagar lista?"
 #: src/routes/_layout.latest.tsx
 msgid "Everything published recently across the publications you subscribe to."
 msgstr "Tudo o que foi publicado recentemente nas suas inscrições."
+
+#: src/components/reader/comments/comments-section.tsx
+msgid "{hiddenByBlocks, plural, one {# more reply is hidden by your blocks.} other {# more replies are hidden by your blocks.}}"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1488,6 +1493,10 @@ msgstr "Para saber mais sobre como o {SITE_NAME} funciona, consulte a página <0
 msgid "Compact"
 msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "This account"
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Portrait stacks the card vertically. Height adjusts automatically once the embed loads. Change the iframe width as needed."
 msgstr "O formato vertical empilha o cartão. A altura ajusta-se automaticamente assim que o elemento carrega. Altere a largura do iframe conforme necessário."
@@ -1927,6 +1936,10 @@ msgstr "Incorporar inscrição"
 msgid "That GIF is over 1 MB. Try a shorter clip, or attach a still image."
 msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+msgstr ""
+
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Add another screenshot"
 #~ msgstr ""
@@ -1946,6 +1959,10 @@ msgstr "Apagar coleção"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Interface font"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "We're re-reading your blocks from your account. This page updates when it finishes."
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -2014,6 +2031,7 @@ msgstr ""
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/reader/pull-to-refresh.tsx
 msgid "Refreshing"
 msgstr ""
@@ -2305,6 +2323,7 @@ msgstr "Rotulador"
 msgid "Articles you've opened — public records in your repo, synced across devices."
 msgstr "Artigos que abriu — registos públicos no seu repositório, sincronizados entre dispositivos."
 
+#: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-publication-editor.tsx
 #: src/components/reader/collection-theme-editor.tsx
@@ -2581,6 +2600,10 @@ msgstr "<0>Leaflet, Pckt, Offprint.</0> <1>pub.leaflet.content</1>, <2>blog.pckt
 
 #: src/components/appearance-settings.tsx
 msgid "XL"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "We couldn't write the block to your account. Try again?"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -3272,6 +3295,10 @@ msgstr "Imagem"
 #~ msgid "<0>Follow</0> is the only subscription there is. New writing from anything you follow appears on Home and in Latest, and the publication is listed in your sidebar. There is no email sign-up and no separate account with the publisher."
 #~ msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "We couldn't remove the block from your account. Try again?"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Selecting anyone's name opens their author page: everything they publish, what they follow, and what they have recommended."
 msgstr ""
@@ -3321,6 +3348,10 @@ msgstr ""
 #~ msgid "Prefer a typed client? The whole API ships as codegen'd AT Protocol lexicon schemas in <0>@standard-reader/lexicons</0>. Pair it with <1>@atproto/lex-client</1> for fully-typed <2>client.call()</2> queries and procedures. Its <3>getDocument</3> also returns a document's renderable body, ready to hand to the <4>renderers</4>."
 #~ msgstr "Prefere um cliente tipificado? Toda a API é fornecida na forma de esquemas de léxico do AT Protocol gerados automaticamente no pacote <0>@standard-reader/lexicons</0>. Combine-o com <1>@atproto/lex-client</1> para realizar consultas e procedimentos via <2>client.call()</2> tipificado. O método <3>getDocument</3> também retorna o corpo renderizável do documento, pronto para ser passado aos <4>renderizadores</4>."
 
+#: src/components/reader/comments/comments-section.tsx
+msgid "{hiddenByBlocks, plural, one {The only reply here is from someone you're blocked from.} other {The replies here are all from accounts you're blocked from.}}"
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Couldn't save your follows"
 msgstr "Não foi possível salvar quem você segue"
@@ -3357,6 +3388,10 @@ msgstr ""
 msgid "Publications to explore"
 msgstr "Publicações para explorar"
 
+#: src/components/blocks-settings-view.tsx
+msgid "We couldn't reach your account to change that. Try again?"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Read as comic"
 msgstr ""
@@ -3378,6 +3413,10 @@ msgstr "Prefere um cliente tipificado? Toda a API é fornecida na forma de esque
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Read and unread"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "This writes a block to your Bluesky account, so it applies here and anywhere else you use it. Their writing disappears from your feeds, search and discussion, and they can't see yours. You can undo it in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -3502,8 +3541,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
-msgstr ""
+#~ msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
@@ -3643,6 +3682,10 @@ msgstr ""
 msgid "Worth subscribing to"
 msgstr "Vale a pena se inscrever"
 
+#: src/components/blocks-settings-view.tsx
+msgid "this list is larger than we mirror, so some members aren't blocked here"
+msgstr ""
+
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Angular."
 #~ msgstr "Angular."
@@ -3667,6 +3710,10 @@ msgstr ""
 #: src/routes/_layout.subscriptions.tsx
 msgid "Nothing to manage yet"
 msgstr "Nada a gerenciar ainda"
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "They're hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts."
+msgstr ""
 
 #: src/routes/_layout.subscriptions.tsx
 msgid "Your library"
@@ -4017,6 +4064,10 @@ msgstr ""
 msgid "No lists yet"
 msgstr "Ainda não há listas"
 
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} blocks a moderation list you're on, so you can't see their writing."
+msgstr ""
+
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "Saving things while you browse the rest of the web, keeping Standard Reader on your home screen, and passing an article on."
 #~ msgstr ""
@@ -4036,6 +4087,10 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
 msgstr "Um botão Ouvir lê qualquer artigo em voz alta, no seu próprio dispositivo, destacando cada palavra à medida que avança. O leitor acompanha-o por toda a aplicação — até lê um artigo do Bluesky incorporado. Com sessão iniciada, pode escolher uma voz."
+
+#: src/components/reader/blocked-notice.tsx
+msgid "this account"
+msgstr ""
 
 #. placeholder {0}: next.title
 #: src/components/reader/series-up-next.tsx
@@ -4175,6 +4230,15 @@ msgstr "Opcional: acrescente uma nota sobre o porquê está salvando isto"
 msgid "Open the app"
 msgstr ""
 
+#. placeholder {0}: fmt.relativeTime(data.syncedAt)
+#: src/components/blocks-settings-view.tsx
+msgid "Last checked {0}. Blocks you make elsewhere show up here within about fifteen minutes."
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block account?"
+msgstr ""
+
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this note on Semble"
 msgstr ""
@@ -4252,8 +4316,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "this account"
 #: src/components/reader/blocked-notice.tsx
-msgid "You blocked {0}, so their writing is hidden everywhere you read."
-msgstr ""
+#~ msgid "You blocked {0}, so their writing is hidden everywhere you read."
+#~ msgstr ""
 
 #. placeholder {0}: filter.trim()
 #: src/components/reader/subscriptions-table.tsx
@@ -4485,6 +4549,10 @@ msgstr ""
 msgid "Recommended articles"
 msgstr "Artigos recomendados"
 
+#: src/components/reader/mention-hover-card.tsx
+msgid "You blocked this account, so their writing is hidden."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
 msgstr ""
@@ -4690,6 +4758,10 @@ msgstr ""
 msgid "{0}+ articles"
 msgstr "{0}+ artigos"
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "{name} is hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts."
+msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "Starter pack"
 msgstr ""
@@ -4701,6 +4773,10 @@ msgstr "Esse link expirou."
 #: src/components/guide/pages/lists-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Lists in the sidebar"
+msgstr ""
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked {who}, so their writing is hidden everywhere you read."
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
@@ -4952,6 +5028,9 @@ msgstr "{totalPeople, plural, one {# pessoa que você segue escreve aqui} other 
 msgid "Not in the directory yet?"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/reader/block-user-menu-item.tsx
+#: src/components/reader/blocked-notice.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
@@ -5001,8 +5080,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} is on a moderation list you block. To see them again, leave that list."
-msgstr ""
+#~ msgid "{0} is on a moderation list you block. To see them again, leave that list."
+#~ msgstr ""
 
 #: src/routes/_layout.collections.index.tsx
 msgid "Curated, magazine-rendered editions grouped into series you can subscribe to — your special collections on the network."
@@ -6025,6 +6104,10 @@ msgstr "Ver feedback"
 #~ msgid "Pages you have already visited stay available when your connection drops, and Standard Reader shows a plain offline page rather than a browser error when you reach for something it does not have. When a new version of the app is ready, it offers to reload rather than changing under you mid-article."
 #~ msgstr ""
 
+#: src/components/reader/mention-hover-card.tsx
+msgid "This account blocks you, so you can't see their writing."
+msgstr ""
+
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Being in a list does not change your feeds. Everything you subscribe to still arrives on Home and in Latest exactly as before; a list only changes how the sidebar is organised, and gives you a page you can read — or share — on its own."
 msgstr ""
@@ -6233,6 +6316,10 @@ msgstr ""
 #: src/magazine/Magazine.tsx
 msgid "Contents"
 msgstr "Índice"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} is on a moderation list you block. To see them again, leave that list."
+msgstr ""
 
 #: src/components/reader/share-menu.tsx
 msgid "Copy embed code"
@@ -6642,8 +6729,8 @@ msgstr "Apagar todo o histórico de leitura?"
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} blocks a moderation list you're on, so you can't see their writing."
-msgstr ""
+#~ msgid "{0} blocks a moderation list you're on, so you can't see their writing."
+#~ msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6971,6 +7058,10 @@ msgstr "Não foram encontradas publicações para {handleLabel}."
 msgid "Already subscribed"
 msgstr "Já é inscrito"
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block {name}?"
+msgstr ""
+
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "How to wire a personal site's own <0>site.standard.*</0> records so Standard Reader can find it and read articles inline, without going through Leaflet, Pckt, Offprint, or another publishing tool."
 msgstr "Como configurar os registos <0>site.standard.*</0> do seu próprio site pessoal para que o Standard Reader o encontre e leia os artigos na aplicação, sem passar pelo Leaflet, Pckt, Offprint ou outra ferramenta de publicação."
@@ -6986,6 +7077,10 @@ msgstr "Outras coleções"
 #: src/components/reader/about-view.tsx
 msgid "One tasteful email a week"
 msgstr "Um e-mail bem selecionado por semana"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "Blocked by a list you use"
+msgstr ""
 
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "{unreadCount} unread"
@@ -7274,6 +7369,7 @@ msgid "Pages"
 msgstr "Páginas"
 
 #: src/components/reader/article-view-skeleton.tsx
+#: src/routes/_layout.a.$did.$rkey.tsx
 msgid "Loading article"
 msgstr "Carregando artigo"
 

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -239,6 +239,10 @@ msgstr ""
 msgid "You're signed in"
 msgstr "你已登录"
 
+#: src/components/user-settings-view.tsx
+msgid "Manage {blockCount} blocks"
+msgstr ""
+
 #: src/routes/_layout.subscriptions.tsx
 msgid "Subscribe to a publication or follow a writer and they'll show up here, with their unread count and latest post. Each subscription is an <0>app.standard-reader.subscription</0> record in your repo — yours to take anywhere."
 msgstr ""
@@ -617,6 +621,10 @@ msgstr ""
 msgid "Please choose a rating."
 msgstr "请选择评分。"
 
+#: src/components/blocks-settings-view.tsx
+msgid "Blocked"
+msgstr ""
+
 #: src/components/docs/docs-mobile-nav.tsx
 #: src/components/guide/guide-mobile-nav.tsx
 msgid "(current)"
@@ -634,6 +642,10 @@ msgstr ""
 #: src/components/reader/share-menu.tsx
 msgid "Portrait"
 msgstr "竖版"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Loading blocked accounts"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Select any headline to open it. Articles are laid out as a single column at a comfortable width, with the publication's own colors and typography where it has them."
@@ -655,6 +667,10 @@ msgstr "下移"
 msgid "Disclaimer and limitation of liability"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+msgid "You don't subscribe to any block lists."
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "No articles from this list's publications or people yet."
 msgstr "此列表中的刊物或人尚无文章。"
@@ -666,6 +682,10 @@ msgstr ""
 #. placeholder {0}: labels[order]
 #: src/components/reader/publication-actions.tsx
 msgid "Order: {0}"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Partial"
 msgstr ""
 
 #: src/components/reader/share-menu.tsx
@@ -718,6 +738,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Permanently remove data stored in your account. These actions delete records from your account and cannot be undone."
 msgstr "永久删除存储在你账户中的数据。这些操作会从你的账户中删除记录，且无法撤销。"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Moderation lists you subscribe to on Bluesky. Everyone on them is blocked here too, and the list stays live as its owner changes it."
+msgstr ""
 
 #: src/routes/_layout.communities.$slug.tsx
 #~ msgid "Sub-areas"
@@ -1519,6 +1543,11 @@ msgstr "<0/> 随时一键退订"
 #~ msgid "Wiring up a site that does not publish in this format yet is the one genuinely technical job in the whole product, and it has its own <0>publishing documentation</0>. Everything else in this guide stays where it is."
 #~ msgstr ""
 
+#. placeholder {0}: row.memberCount
+#: src/components/blocks-settings-view.tsx
+msgid "{0, plural, one {# account} other {# accounts}}"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Recommending an article"
@@ -1761,9 +1790,17 @@ msgstr ""
 msgid "Fast full-text search"
 msgstr "快速全文搜索"
 
+#: src/components/blocks-settings-view.tsx
+msgid "You haven't blocked anyone."
+msgstr ""
+
 #: src/lib/guide/navigation.ts
 #~ msgid "Saving, recommending, reading history, and managing what you follow."
 #~ msgstr ""
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked this account"
+msgstr ""
 
 #: src/components/reader/notify-button.tsx
 msgid "Notifications aren’t available"
@@ -2054,6 +2091,10 @@ msgstr ""
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block"
+msgstr ""
 
 #: src/routes/_layout.discover.tsx
 msgid "Known publications"
@@ -2416,6 +2457,7 @@ msgstr "查看标注服务"
 msgid "Read more from the author"
 msgstr "阅读该作者的更多文章"
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/labelers-settings-view.tsx
 #: src/components/user-settings-view.tsx
 msgid "Moderation"
@@ -2440,6 +2482,10 @@ msgstr "文档"
 #: src/components/reader/app-shell.tsx
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "Most unread"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block {name}"
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -2579,6 +2625,10 @@ msgstr "编辑"
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Removed"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block account"
 msgstr ""
 
 #: src/components/reading-settings-preview.tsx
@@ -2758,6 +2808,10 @@ msgstr ""
 #: src/routes/review.thanks.tsx
 msgid "Return to the app"
 msgstr "返回应用"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Moderation list"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -3446,6 +3500,11 @@ msgstr "显示「{label}」标签页"
 msgid "This API is also served as a <0>Model Context Protocol</0> server at <1>{baseUrl}/mcp</1>. Paste that URL into an MCP client and authorize it; the fifty-odd methods above are grouped into fifteen tools, and the client can read the network and act on your behalf."
 msgstr ""
 
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
 msgstr ""
@@ -3477,6 +3536,10 @@ msgstr "{n, plural, one {# 个刊物} other {{value} 个刊物}}"
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."
 msgstr "选择在你的公开资料页上显示哪些标签页。"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You're blocked"
+msgstr ""
 
 #: src/routes/_layout.index.tsx
 msgid "View all latest"
@@ -3797,6 +3860,10 @@ msgstr ""
 #. placeholder {0}: rows.length
 #: src/components/reader/subscriptions-table.tsx
 msgid "{0} total"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours."
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
@@ -4174,8 +4241,18 @@ msgstr "未读"
 msgid "How readers see it"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/user-settings-view.tsx
+msgid "Blocked accounts"
+msgstr ""
+
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "Standard Reader has a reading mode built for comics — a shelf of covers instead of a list of post titles, and a full-screen theater that flips through your pages. You do not author anything specially for it. This page is how to make sure your comic gets it."
+msgstr ""
+
+#. placeholder {0}: name ?? "this account"
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked {0}, so their writing is hidden everywhere you read."
 msgstr ""
 
 #. placeholder {0}: filter.trim()
@@ -4228,6 +4305,10 @@ msgstr "当下整个网络阅读量最高的文章。"
 
 #: src/components/appearance-settings.tsx
 msgid "The typeface used across the app. Article text follows this too, unless you set a reading font below."
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "Refresh"
 msgstr ""
 
 #: src/magazine/magazine-end-like.tsx
@@ -4808,6 +4889,11 @@ msgstr ""
 msgid "There’s a magazine edition of this collection."
 msgstr "本合集有杂志版。"
 
+#: src/components/reader/blocked-notice.tsx
+#: src/components/user-settings-view.tsx
+msgid "Manage blocks"
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "What the extension accesses"
 msgstr "扩展会访问什么"
@@ -4911,6 +4997,11 @@ msgstr "<0>页面 URL。</0>当你打开弹窗、使用页面浮层或选择右�
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Comments and related reading"
+msgstr ""
+
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} is on a moderation list you block. To see them again, leave that list."
 msgstr ""
 
 #: src/routes/_layout.collections.index.tsx
@@ -5359,6 +5450,11 @@ msgstr ""
 #: src/components/labeler-detail-view.tsx
 msgid "This labeler hasn’t labeled any documents in the read-model yet."
 msgstr "此标注服务尚未在读模型中标注任何文档。"
+
+#. placeholder {0}: row.memberCount
+#: src/components/blocks-settings-view.tsx
+#~ msgid "{0} accounts"
+#~ msgstr ""
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Your lists, their order, and which ones are collapsed are stored in your account rather than in this browser, so the sidebar looks the same on your laptop and your phone."
@@ -5816,6 +5912,10 @@ msgstr ""
 msgid "Standard Reader needs write access to your site.standard publications and documents, plus your collection records, to author Collections. You'll be asked to approve this on your PDS login."
 msgstr "Standard Reader 需要对你的 site.standard 刊物和文档以及合集记录的写入权限，才能创建合集。你将在 PDS 登录时被要求批准。"
 
+#: src/components/blocks-settings-view.tsx
+msgid "Block lists"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "All articles you have saved for later."
 msgstr "你稍后阅读中保存的所有文章。"
@@ -6176,6 +6276,7 @@ msgstr "运行正常"
 msgid "Top on the network"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
@@ -6197,6 +6298,10 @@ msgstr "按主题筛选：{triggerLabel}"
 #: src/components/reader/page-reader-bar.tsx
 msgid "Return to article and follow along"
 msgstr "返回文章并跟随阅读"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Some blocks couldn't be refreshed last time, so this list may be incomplete."
+msgstr ""
 
 #. placeholder {0}: pub.subscriberCount
 #: src/components/reader/cards.tsx
@@ -6381,9 +6486,18 @@ msgstr "编辑列表"
 msgid "The Saved screen: a list of article cards the reader has set aside, each with its publication, headline, and excerpt."
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/reader/blocked-notice.tsx
+msgid "Unblock"
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "What we do not do"
 msgstr "我们不会做什么"
+
+#: src/components/user-settings-view.tsx
+msgid "Your Bluesky blocks apply here too — blocked accounts disappear from your feeds, search, and discussion, in both directions."
+msgstr ""
 
 #: src/components/docs/docs-side-nav.tsx
 msgid "Documentation"
@@ -6525,6 +6639,11 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Delete all reading history?"
 msgstr "删除全部阅读记录？"
+
+#. placeholder {0}: name ?? "This account"
+#: src/components/reader/blocked-notice.tsx
+msgid "{0} blocks a moderation list you're on, so you can't see their writing."
+msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6999,6 +7118,10 @@ msgstr ""
 #: src/components/site-legal-links.tsx
 msgid "Source"
 msgstr "来源"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Accounts you block"
+msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That file isn't an image we can read."
@@ -7579,6 +7702,10 @@ msgstr "<0>当你使用 Atmosphere 账户登录时</0>（例如通过 Bluesky OA
 #: src/routes/subscribe-login.$did.$rkey.tsx
 msgid "Powered by <0>Standard Reader</0>"
 msgstr "由 <0>Standard Reader</0> 提供支持"
+
+#: src/components/blocks-settings-view.tsx
+msgid "Your blocks are enforced here already. To add or remove one from Standard Reader, you'll be asked to authorize block access the first time you try."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Your accent sits close to the paper in tone — it stays exactly as you picked it, but text and links set in it will be hard to read."

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -622,6 +622,7 @@ msgid "Please choose a rating."
 msgstr "请选择评分。"
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/reader/block-user-menu-item.tsx
 msgid "Blocked"
 msgstr ""
 
@@ -788,6 +789,10 @@ msgstr "删除列表？"
 #: src/routes/_layout.latest.tsx
 msgid "Everything published recently across the publications you subscribe to."
 msgstr "你订阅的刊物近期发布的全部内容。"
+
+#: src/components/reader/comments/comments-section.tsx
+msgid "{hiddenByBlocks, plural, one {# more reply is hidden by your blocks.} other {# more replies are hidden by your blocks.}}"
+msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -1488,6 +1493,10 @@ msgstr ""
 msgid "Compact"
 msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "This account"
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Portrait stacks the card vertically. Height adjusts automatically once the embed loads. Change the iframe width as needed."
 msgstr "竖版将卡片纵向排列。嵌入内容加载后高度会自动调整。可按需修改 iframe 宽度。"
@@ -1927,6 +1936,10 @@ msgstr "嵌入订阅按钮"
 msgid "That GIF is over 1 MB. Try a shorter clip, or attach a still image."
 msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+msgstr ""
+
 #: src/components/feedback/feedback-image-picker.tsx
 #~ msgid "Add another screenshot"
 #~ msgstr ""
@@ -1946,6 +1959,10 @@ msgstr "删除合集"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Interface font"
+msgstr ""
+
+#: src/components/blocks-settings-view.tsx
+msgid "We're re-reading your blocks from your account. This page updates when it finishes."
 msgstr ""
 
 #: src/routes/_layout.l.$did.$rkey.tsx
@@ -2014,6 +2031,7 @@ msgstr ""
 msgid "What every control on an article does — including having it read aloud to you, and making the text comfortable for your eyes."
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
 #: src/components/reader/pull-to-refresh.tsx
 msgid "Refreshing"
 msgstr ""
@@ -2305,6 +2323,7 @@ msgstr "标注服务"
 msgid "Articles you've opened — public records in your repo, synced across devices."
 msgstr "你打开过的文章——存为你仓库中的公开记录，跨设备同步。"
 
+#: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-publication-editor.tsx
 #: src/components/reader/collection-theme-editor.tsx
@@ -2581,6 +2600,10 @@ msgstr "<0>Leaflet、Pckt、Offprint。</0> <1>pub.leaflet.content</1>、<2>blog
 
 #: src/components/appearance-settings.tsx
 msgid "XL"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "We couldn't write the block to your account. Try again?"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -3272,6 +3295,10 @@ msgstr "图片"
 #~ msgid "<0>Follow</0> is the only subscription there is. New writing from anything you follow appears on Home and in Latest, and the publication is listed in your sidebar. There is no email sign-up and no separate account with the publisher."
 #~ msgstr ""
 
+#: src/components/reader/blocked-notice.tsx
+msgid "We couldn't remove the block from your account. Try again?"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Selecting anyone's name opens their author page: everything they publish, what they follow, and what they have recommended."
 msgstr ""
@@ -3321,6 +3348,10 @@ msgstr ""
 #~ msgid "Prefer a typed client? The whole API ships as codegen'd AT Protocol lexicon schemas in <0>@standard-reader/lexicons</0>. Pair it with <1>@atproto/lex-client</1> for fully-typed <2>client.call()</2> queries and procedures. Its <3>getDocument</3> also returns a document's renderable body, ready to hand to the <4>renderers</4>."
 #~ msgstr ""
 
+#: src/components/reader/comments/comments-section.tsx
+msgid "{hiddenByBlocks, plural, one {The only reply here is from someone you're blocked from.} other {The replies here are all from accounts you're blocked from.}}"
+msgstr ""
+
 #: src/components/onboarding/welcome-wizard.tsx
 msgid "Couldn't save your follows"
 msgstr "无法保存你的关注"
@@ -3357,6 +3388,10 @@ msgstr ""
 msgid "Publications to explore"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+msgid "We couldn't reach your account to change that. Try again?"
+msgstr ""
+
 #: src/components/reader/article-view.tsx
 msgid "Read as comic"
 msgstr ""
@@ -3378,6 +3413,10 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Read and unread"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "This writes a block to your Bluesky account, so it applies here and anywhere else you use it. Their writing disappears from your feeds, search and discussion, and they can't see yours. You can undo it in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -3502,8 +3541,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
-msgstr ""
+#~ msgid "{0} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
+#~ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
@@ -3643,6 +3682,10 @@ msgstr ""
 msgid "Worth subscribing to"
 msgstr "值得订阅"
 
+#: src/components/blocks-settings-view.tsx
+msgid "this list is larger than we mirror, so some members aren't blocked here"
+msgstr ""
+
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Angular."
 #~ msgstr ""
@@ -3666,6 +3709,10 @@ msgstr ""
 
 #: src/routes/_layout.subscriptions.tsx
 msgid "Nothing to manage yet"
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "They're hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.subscriptions.tsx
@@ -4017,6 +4064,10 @@ msgstr ""
 msgid "No lists yet"
 msgstr "还没有列表"
 
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} blocks a moderation list you're on, so you can't see their writing."
+msgstr ""
+
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "Saving things while you browse the rest of the web, keeping Standard Reader on your home screen, and passing an article on."
 #~ msgstr ""
@@ -4036,6 +4087,10 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 msgid "A Listen button reads any article aloud, right on your device, and highlights each word as it goes. The player follows you around the app — it’ll even read an embedded Bluesky post. Signed in, you can pick a voice."
 msgstr "「朗读」按钮可在你的设备上直接朗读任意文章，并逐词高亮。播放器会跟随你在应用中移动——甚至能读出嵌入的 Bluesky 帖子。登录后还可以挑选音色。"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "this account"
+msgstr ""
 
 #. placeholder {0}: next.title
 #: src/components/reader/series-up-next.tsx
@@ -4175,6 +4230,15 @@ msgstr "可选：写下保存它的原因"
 msgid "Open the app"
 msgstr ""
 
+#. placeholder {0}: fmt.relativeTime(data.syncedAt)
+#: src/components/blocks-settings-view.tsx
+msgid "Last checked {0}. Blocks you make elsewhere show up here within about fifteen minutes."
+msgstr ""
+
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block account?"
+msgstr ""
+
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this note on Semble"
 msgstr ""
@@ -4252,8 +4316,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "this account"
 #: src/components/reader/blocked-notice.tsx
-msgid "You blocked {0}, so their writing is hidden everywhere you read."
-msgstr ""
+#~ msgid "You blocked {0}, so their writing is hidden everywhere you read."
+#~ msgstr ""
 
 #. placeholder {0}: filter.trim()
 #: src/components/reader/subscriptions-table.tsx
@@ -4485,6 +4549,10 @@ msgstr ""
 msgid "Recommended articles"
 msgstr "推荐文章"
 
+#: src/components/reader/mention-hover-card.tsx
+msgid "You blocked this account, so their writing is hidden."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
 msgstr ""
@@ -4690,6 +4758,10 @@ msgstr ""
 msgid "{0}+ articles"
 msgstr "{0}+ 篇文章"
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "{name} is hidden everywhere you read, and on Bluesky. You can undo this in Settings → Blocked accounts."
+msgstr ""
+
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "Starter pack"
 msgstr ""
@@ -4701,6 +4773,10 @@ msgstr "该链接已过期。"
 #: src/components/guide/pages/lists-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Lists in the sidebar"
+msgstr ""
+
+#: src/components/reader/blocked-notice.tsx
+msgid "You blocked {who}, so their writing is hidden everywhere you read."
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
@@ -4952,6 +5028,9 @@ msgstr ""
 msgid "Not in the directory yet?"
 msgstr ""
 
+#: src/components/blocks-settings-view.tsx
+#: src/components/reader/block-user-menu-item.tsx
+#: src/components/reader/blocked-notice.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 msgid "Something went wrong"
@@ -5001,8 +5080,8 @@ msgstr ""
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} is on a moderation list you block. To see them again, leave that list."
-msgstr ""
+#~ msgid "{0} is on a moderation list you block. To see them again, leave that list."
+#~ msgstr ""
 
 #: src/routes/_layout.collections.index.tsx
 msgid "Curated, magazine-rendered editions grouped into series you can subscribe to — your special collections on the network."
@@ -6025,6 +6104,10 @@ msgstr "查看反馈"
 #~ msgid "Pages you have already visited stay available when your connection drops, and Standard Reader shows a plain offline page rather than a browser error when you reach for something it does not have. When a new version of the app is ready, it offers to reload rather than changing under you mid-article."
 #~ msgstr ""
 
+#: src/components/reader/mention-hover-card.tsx
+msgid "This account blocks you, so you can't see their writing."
+msgstr ""
+
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Being in a list does not change your feeds. Everything you subscribe to still arrives on Home and in Latest exactly as before; a list only changes how the sidebar is organised, and gives you a page you can read — or share — on its own."
 msgstr ""
@@ -6233,6 +6316,10 @@ msgstr ""
 #: src/magazine/Magazine.tsx
 msgid "Contents"
 msgstr "目录"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "{Who} is on a moderation list you block. To see them again, leave that list."
+msgstr ""
 
 #: src/components/reader/share-menu.tsx
 msgid "Copy embed code"
@@ -6642,8 +6729,8 @@ msgstr "删除全部阅读记录？"
 
 #. placeholder {0}: name ?? "This account"
 #: src/components/reader/blocked-notice.tsx
-msgid "{0} blocks a moderation list you're on, so you can't see their writing."
-msgstr ""
+#~ msgid "{0} blocks a moderation list you're on, so you can't see their writing."
+#~ msgstr ""
 
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6971,6 +7058,10 @@ msgstr "未找到 {handleLabel} 的刊物。"
 msgid "Already subscribed"
 msgstr "已订阅"
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "Block {name}?"
+msgstr ""
+
 #: src/components/guide/pages/publishing-guide-page.tsx
 msgid "How to wire a personal site's own <0>site.standard.*</0> records so Standard Reader can find it and read articles inline, without going through Leaflet, Pckt, Offprint, or another publishing tool."
 msgstr "如何为个人站点配置自有的 <0>site.standard.*</0> 记录，让 Standard Reader 能发现它并内嵌阅读文章，而无需经由 Leaflet、Pckt、Offprint 或其他发布工具。"
@@ -6986,6 +7077,10 @@ msgstr "其他合集"
 #: src/components/reader/about-view.tsx
 msgid "One tasteful email a week"
 msgstr "每周一封精致的邮件"
+
+#: src/components/reader/blocked-notice.tsx
+msgid "Blocked by a list you use"
+msgstr ""
 
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "{unreadCount} unread"
@@ -7274,6 +7369,7 @@ msgid "Pages"
 msgstr ""
 
 #: src/components/reader/article-view-skeleton.tsx
+#: src/routes/_layout.a.$did.$rkey.tsx
 msgid "Loading article"
 msgstr "正在加载文章"
 

--- a/apps/standard-reader/src/routeTree.gen.ts
+++ b/apps/standard-reader/src/routeTree.gen.ts
@@ -66,6 +66,7 @@ import { Route as LayoutLabelersIndexRouteImport } from './routes/_layout.labele
 import { Route as LayoutLabelersDidRouteImport } from './routes/_layout.labelers.$did'
 import { Route as LayoutPrivacyExtensionRouteImport } from './routes/_layout.privacy.extension'
 import { Route as LayoutSettingsIndexRouteImport } from './routes/_layout.settings.index'
+import { Route as LayoutSettingsBlocksRouteImport } from './routes/_layout.settings.blocks'
 import { Route as LayoutTagTagRouteImport } from './routes/_layout.tag.$tag'
 import { Route as LayoutTopicsIndexRouteImport } from './routes/_layout.topics.index'
 import { Route as LayoutTopicsSlugRouteImport } from './routes/_layout.topics.$slug'
@@ -414,6 +415,11 @@ const LayoutSettingsIndexRoute = LayoutSettingsIndexRouteImport.update({
   path: '/settings/',
   getParentRoute: () => LayoutRoute,
 } as any)
+const LayoutSettingsBlocksRoute = LayoutSettingsBlocksRouteImport.update({
+  id: '/settings/blocks',
+  path: '/settings/blocks',
+  getParentRoute: () => LayoutRoute,
+} as any)
 const LayoutTagTagRoute = LayoutTagTagRouteImport.update({
   id: '/tag/$tag',
   path: '/tag/$tag',
@@ -720,6 +726,7 @@ export interface FileRoutesByFullPath {
   '/feedback/return': typeof LayoutFeedbackReturnRoute
   '/labelers/$did': typeof LayoutLabelersDidRoute
   '/privacy/extension': typeof LayoutPrivacyExtensionRoute
+  '/settings/blocks': typeof LayoutSettingsBlocksRoute
   '/tag/$tag': typeof LayoutTagTagRoute
   '/topics/$slug': typeof LayoutTopicsSlugRoute
   '/u/$did': typeof LayoutUDidRoute
@@ -825,6 +832,7 @@ export interface FileRoutesByTo {
   '/feedback/return': typeof LayoutFeedbackReturnRoute
   '/labelers/$did': typeof LayoutLabelersDidRoute
   '/privacy/extension': typeof LayoutPrivacyExtensionRoute
+  '/settings/blocks': typeof LayoutSettingsBlocksRoute
   '/tag/$tag': typeof LayoutTagTagRoute
   '/topics/$slug': typeof LayoutTopicsSlugRoute
   '/u/$did': typeof LayoutUDidRoute
@@ -935,6 +943,7 @@ export interface FileRoutesById {
   '/_layout/feedback/return': typeof LayoutFeedbackReturnRoute
   '/_layout/labelers/$did': typeof LayoutLabelersDidRoute
   '/_layout/privacy/extension': typeof LayoutPrivacyExtensionRoute
+  '/_layout/settings/blocks': typeof LayoutSettingsBlocksRoute
   '/_layout/tag/$tag': typeof LayoutTagTagRoute
   '/_layout/topics/$slug': typeof LayoutTopicsSlugRoute
   '/_layout/u/$did': typeof LayoutUDidRoute
@@ -1043,6 +1052,7 @@ export interface FileRouteTypes {
     | '/feedback/return'
     | '/labelers/$did'
     | '/privacy/extension'
+    | '/settings/blocks'
     | '/tag/$tag'
     | '/topics/$slug'
     | '/u/$did'
@@ -1148,6 +1158,7 @@ export interface FileRouteTypes {
     | '/feedback/return'
     | '/labelers/$did'
     | '/privacy/extension'
+    | '/settings/blocks'
     | '/tag/$tag'
     | '/topics/$slug'
     | '/u/$did'
@@ -1257,6 +1268,7 @@ export interface FileRouteTypes {
     | '/_layout/feedback/return'
     | '/_layout/labelers/$did'
     | '/_layout/privacy/extension'
+    | '/_layout/settings/blocks'
     | '/_layout/tag/$tag'
     | '/_layout/topics/$slug'
     | '/_layout/u/$did'
@@ -1777,6 +1789,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutSettingsIndexRouteImport
       parentRoute: typeof LayoutRoute
     }
+    '/_layout/settings/blocks': {
+      id: '/_layout/settings/blocks'
+      path: '/settings/blocks'
+      fullPath: '/settings/blocks'
+      preLoaderRoute: typeof LayoutSettingsBlocksRouteImport
+      parentRoute: typeof LayoutRoute
+    }
     '/_layout/tag/$tag': {
       id: '/_layout/tag/$tag'
       path: '/tag/$tag'
@@ -2229,6 +2248,7 @@ interface LayoutRouteChildren {
   LayoutIndexRoute: typeof LayoutIndexRoute
   LayoutFeedbackReturnRoute: typeof LayoutFeedbackReturnRoute
   LayoutLabelersDidRoute: typeof LayoutLabelersDidRoute
+  LayoutSettingsBlocksRoute: typeof LayoutSettingsBlocksRoute
   LayoutTagTagRoute: typeof LayoutTagTagRoute
   LayoutTopicsSlugRoute: typeof LayoutTopicsSlugRoute
   LayoutUDidRoute: typeof LayoutUDidRoute
@@ -2258,6 +2278,7 @@ const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutIndexRoute: LayoutIndexRoute,
   LayoutFeedbackReturnRoute: LayoutFeedbackReturnRoute,
   LayoutLabelersDidRoute: LayoutLabelersDidRoute,
+  LayoutSettingsBlocksRoute: LayoutSettingsBlocksRoute,
   LayoutTagTagRoute: LayoutTagTagRoute,
   LayoutTopicsSlugRoute: LayoutTopicsSlugRoute,
   LayoutUDidRoute: LayoutUDidRoute,

--- a/apps/standard-reader/src/routes/_layout.a.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/_layout.a.$did.$rkey.tsx
@@ -298,6 +298,8 @@ function ArticleMissing({ uri }: { uri: string }) {
     <BlockedNotice
       block={blockState.block}
       name={blockState.account.displayName ?? blockState.account.handle}
+      handle={blockState.account.handle}
+      avatarUrl={blockState.account.avatarUrl}
       canWrite={capability.data?.canWrite ?? false}
     />
   );

--- a/apps/standard-reader/src/routes/_layout.a.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/_layout.a.$did.$rkey.tsx
@@ -1,8 +1,9 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useLayoutEffect } from "react";
 import { z } from "zod";
 
+import { blocksApi } from "#/integrations/tanstack-query/api-blocks.functions";
 import type { ArticleDetail } from "#/integrations/tanstack-query/api-publication.functions";
 import { publicationApi } from "#/integrations/tanstack-query/api-publication.functions";
 import { quoteShareApi } from "#/integrations/tanstack-query/api-quote-share.functions";
@@ -27,6 +28,7 @@ import {
   ArticleView,
 } from "../components/reader/article-view";
 import { ArticleViewSkeleton } from "../components/reader/article-view-skeleton";
+import { BlockedNotice } from "../components/reader/blocked-notice";
 import { hasRenderableArticleBody } from "../components/reader/content/extract-text";
 import {
   articlePublicationUrl,
@@ -250,6 +252,38 @@ export const Route = createFileRoute("/_layout/a/$did/$rkey")({
   component: ArticleRoute,
 });
 
+/**
+ * The article didn't resolve. Usually that means it isn't indexed — but it also
+ * means "withheld because of a block", and those two deserve different words.
+ *
+ * The reason is fetched here rather than returned by `getArticle`, which sends
+ * `null` for a blocked document on purpose: nothing about it, not even its
+ * title, should cross the wire. So the explanation costs one extra read, and
+ * only on the page that already found nothing.
+ */
+function ArticleMissing({ uri }: { uri: string }) {
+  const { data: blockState, isPending } = useQuery(
+    publicationApi.getArticleBlockQueryOptions(uri),
+  );
+  const blocks = useQuery(
+    blocksApi.getBlocksSettingsQueryOptions({ limit: 1 }),
+  );
+
+  // Nothing while the reason is still unknown: flashing "we couldn't find that
+  // article" and then replacing it with "you blocked this account" reads as the
+  // app changing its mind.
+  if (isPending) return null;
+  if (!blockState) return <ArticleNotFound />;
+
+  return (
+    <BlockedNotice
+      block={blockState.block}
+      name={blockState.account.displayName ?? blockState.account.handle}
+      canWrite={blocks.data?.canWrite ?? false}
+    />
+  );
+}
+
 function ArticleRoute() {
   const { did, rkey } = Route.useParams();
   const uri = documentUriFromParams(did, rkey);
@@ -269,7 +303,7 @@ function ArticleRoute() {
   }, [article, openExternally]);
 
   if (!article) {
-    return <ArticleNotFound />;
+    return <ArticleMissing uri={uri} />;
   }
 
   return (

--- a/apps/standard-reader/src/routes/_layout.a.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/_layout.a.$did.$rkey.tsx
@@ -1,3 +1,4 @@
+import { useLingui } from "@lingui/react/macro";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useLayoutEffect } from "react";
@@ -262,24 +263,42 @@ export const Route = createFileRoute("/_layout/a/$did/$rkey")({
  * only on the page that already found nothing.
  */
 function ArticleMissing({ uri }: { uri: string }) {
-  const { data: blockState, isPending } = useQuery(
-    publicationApi.getArticleBlockQueryOptions(uri),
-  );
-  const blocks = useQuery(
-    blocksApi.getBlocksSettingsQueryOptions({ limit: 1 }),
-  );
+  const { t } = useLingui();
+  const { data: session } = useSuspenseQuery(user.getSessionQueryOptions);
+  const signedIn = Boolean(session?.user);
 
-  // Nothing while the reason is still unknown: flashing "we couldn't find that
-  // article" and then replacing it with "you blocked this account" reads as the
-  // app changing its mind.
-  if (isPending) return null;
+  // Only a signed-in reader can be on either side of a block, so a signed-out
+  // reader — most of this page's traffic, since it is also what a stale link or
+  // a crawler hits — gets the answer with no extra request at all.
+  const { data: blockState, isPending } = useQuery({
+    ...publicationApi.getArticleBlockQueryOptions(uri),
+    enabled: signedIn,
+  });
+  const capability = useQuery({
+    ...blocksApi.getBlockCapabilityQueryOptions(),
+    enabled: Boolean(blockState),
+  });
+
+  if (!signedIn) return <ArticleNotFound />;
+
+  // A skeleton, not a blank page and not the wrong words: flashing "we couldn't
+  // find that article" and then replacing it with "you blocked this account"
+  // reads as the app changing its mind, but rendering nothing at all reads as
+  // the page having failed.
+  if (isPending) {
+    return (
+      <div aria-busy="true" aria-label={t`Loading article`}>
+        <ArticleViewSkeleton />
+      </div>
+    );
+  }
   if (!blockState) return <ArticleNotFound />;
 
   return (
     <BlockedNotice
       block={blockState.block}
       name={blockState.account.displayName ?? blockState.account.handle}
-      canWrite={blocks.data?.canWrite ?? false}
+      canWrite={capability.data?.canWrite ?? false}
     />
   );
 }

--- a/apps/standard-reader/src/routes/_layout.p.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/_layout.p.$did.$rkey.tsx
@@ -596,6 +596,8 @@ function PublicationProfile() {
         <BlockedNotice
           block={block}
           name={header.owner.displayName ?? header.owner.handle}
+          handle={header.owner.handle}
+          avatarUrl={header.owner.avatarUrl}
           canWrite={canWrite?.canWrite ?? false}
         />
       </ReaderContent>

--- a/apps/standard-reader/src/routes/_layout.p.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/_layout.p.$did.$rkey.tsx
@@ -566,15 +566,12 @@ function PublicationProfile() {
   );
   const signedIn = Boolean(session?.user);
 
-  // The route's `did` param is the publication owner (an AT-URI's authority),
-  // so the block check needs no extra lookup. The archive query already returns
-  // nothing for a blocked owner; this is what says why.
-  const { data: block } = useQuery({
-    ...blocksApi.getBlockStateQueryOptions(did),
-    enabled: signedIn,
-  });
-  const { data: blocksSettings } = useQuery({
-    ...blocksApi.getBlocksSettingsQueryOptions({ limit: 1 }),
+  // The block rides on the header itself, not a second query: resolving it
+  // after first paint would mean painting the blocked owner's hero — name,
+  // avatar, description — and then taking it away.
+  const block = header?.block ?? null;
+  const { data: canWrite } = useQuery({
+    ...blocksApi.getBlockCapabilityQueryOptions(),
     enabled: Boolean(block),
   });
 
@@ -599,7 +596,7 @@ function PublicationProfile() {
         <BlockedNotice
           block={block}
           name={header.owner.displayName ?? header.owner.handle}
-          canWrite={blocksSettings?.canWrite ?? false}
+          canWrite={canWrite?.canWrite ?? false}
         />
       </ReaderContent>
     );

--- a/apps/standard-reader/src/routes/_layout.p.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/_layout.p.$did.$rkey.tsx
@@ -28,6 +28,7 @@ import { z } from "zod";
 
 import { usePullToRefresh } from "#/components/reader/pull-to-refresh";
 import { authorApi } from "#/integrations/tanstack-query/api-author.functions";
+import { blocksApi } from "#/integrations/tanstack-query/api-blocks.functions";
 import { notesApi } from "#/integrations/tanstack-query/api-notes.functions";
 import { publicationApi } from "#/integrations/tanstack-query/api-publication.functions";
 import type {
@@ -52,6 +53,7 @@ import {
   ComicShelfSkeleton,
 } from "../components/comic/comic-shelf";
 import { AccountLabelsForDid } from "../components/reader/account-labels";
+import { BlockedNotice } from "../components/reader/blocked-notice";
 import { ArticleRow, FeatureArticle } from "../components/reader/cards";
 import { FeedLoadMore } from "../components/reader/feed-load-more";
 import {
@@ -564,6 +566,18 @@ function PublicationProfile() {
   );
   const signedIn = Boolean(session?.user);
 
+  // The route's `did` param is the publication owner (an AT-URI's authority),
+  // so the block check needs no extra lookup. The archive query already returns
+  // nothing for a blocked owner; this is what says why.
+  const { data: block } = useQuery({
+    ...blocksApi.getBlockStateQueryOptions(did),
+    enabled: signedIn,
+  });
+  const { data: blocksSettings } = useQuery({
+    ...blocksApi.getBlocksSettingsQueryOptions({ limit: 1 }),
+    enabled: Boolean(block),
+  });
+
   const { data: socialProof } = useQuery({
     ...publicationApi.getPublicationSocialProofQueryOptions(uri),
     enabled: signedIn,
@@ -575,6 +589,18 @@ function PublicationProfile() {
         <div {...stylex.props(styles.emptyNote)}>
           <Trans>We couldn’t find that publication.</Trans>
         </div>
+      </ReaderContent>
+    );
+  }
+
+  if (block) {
+    return (
+      <ReaderContent>
+        <BlockedNotice
+          block={block}
+          name={header.owner.displayName ?? header.owner.handle}
+          canWrite={blocksSettings?.canWrite ?? false}
+        />
       </ReaderContent>
     );
   }

--- a/apps/standard-reader/src/routes/_layout.settings.blocks.tsx
+++ b/apps/standard-reader/src/routes/_layout.settings.blocks.tsx
@@ -1,0 +1,35 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+import { BlocksSettingsView } from "#/components/blocks-settings-view";
+import { blocksApi } from "#/integrations/tanstack-query/api-blocks.functions";
+import { user } from "#/integrations/tanstack-query/api-user.functions";
+import { getPublicUrlClient } from "#/lib/public-url";
+import { pageSocialMeta } from "#/lib/site-metadata";
+import { buildAuthRedirectPath } from "#/utils/auth-redirect";
+
+export const Route = createFileRoute("/_layout/settings/blocks")({
+  beforeLoad: async ({ context }) => {
+    const session = await context.queryClient.ensureQueryData(
+      user.getSessionQueryOptions,
+    );
+    if (!session?.user) {
+      throw redirect({
+        to: "/login",
+        search: { redirect: buildAuthRedirectPath("/settings/blocks") },
+      });
+    }
+  },
+  loader: async ({ context }) => {
+    await context.queryClient.ensureQueryData(
+      blocksApi.getBlocksSettingsQueryOptions(),
+    );
+  },
+  head: () => ({
+    meta: pageSocialMeta("settings", getPublicUrlClient()),
+  }),
+  component: BlocksPage,
+});
+
+function BlocksPage() {
+  return <BlocksSettingsView />;
+}

--- a/apps/standard-reader/src/routes/_layout.u.$did.tsx
+++ b/apps/standard-reader/src/routes/_layout.u.$did.tsx
@@ -49,13 +49,16 @@ import {
   AUTHOR_ACTIVITY_PAGE_SIZE,
   authorApi,
 } from "#/integrations/tanstack-query/api-author.functions";
+import { blocksApi } from "#/integrations/tanstack-query/api-blocks.functions";
 import { listApi } from "#/integrations/tanstack-query/api-lists.functions";
 import type { SubscriptionList } from "#/integrations/tanstack-query/api-lists.functions";
 import type {
   ArticleCard,
+  ProfileSummary,
   PublicationCard,
 } from "#/integrations/tanstack-query/api-shapes";
 import { user } from "#/integrations/tanstack-query/api-user.functions";
+import type { BlockEdge } from "#/lib/blocks";
 import type { HideableTabId, ProfileTabId } from "#/lib/profile-tabs";
 import { getPublicUrlClient } from "#/lib/public-url";
 import {
@@ -68,6 +71,7 @@ import {
 import { AccountLabels } from "../components/reader/account-labels";
 import { AuthorActions } from "../components/reader/author-actions";
 import { AuthorProfileLink } from "../components/reader/author-profile-link";
+import { BlockedNotice } from "../components/reader/blocked-notice";
 import { ArticleRow, PubDirectoryRow } from "../components/reader/cards";
 import { FeedLoadMore } from "../components/reader/feed-load-more";
 import { LinkifiedText } from "../components/reader/linkified-text";
@@ -530,7 +534,41 @@ function AuthorProfilePage() {
     return null;
   }
 
+  // A blocked profile renders as the block, not as an empty profile: the
+  // server already withheld every tab, and a profile with six zeroed counts
+  // would read as "this person has written nothing" rather than the truth.
+  if (initialPage.block) {
+    return (
+      <BlockedProfile block={initialPage.block} profile={initialPage.profile} />
+    );
+  }
+
   return <AuthorProfileContent key={did} did={did} initialPage={initialPage} />;
+}
+
+/**
+ * A profile the viewer is blocked from, in either direction. Keeps the person's
+ * identity — a name is what makes the notice legible — and nothing else.
+ */
+function BlockedProfile({
+  block,
+  profile,
+}: {
+  block: BlockEdge;
+  profile: ProfileSummary;
+}) {
+  const blocks = useQuery(
+    blocksApi.getBlocksSettingsQueryOptions({ limit: 1 }),
+  );
+  return (
+    <ReaderContent>
+      <BlockedNotice
+        block={block}
+        name={profile.displayName ?? profile.handle}
+        canWrite={blocks.data?.canWrite ?? false}
+      />
+    </ReaderContent>
+  );
 }
 
 function AuthorProfileContent({

--- a/apps/standard-reader/src/routes/_layout.u.$did.tsx
+++ b/apps/standard-reader/src/routes/_layout.u.$did.tsx
@@ -563,6 +563,8 @@ function BlockedProfile({
       <BlockedNotice
         block={block}
         name={profile.displayName ?? profile.handle}
+        handle={profile.handle}
+        avatarUrl={profile.avatarUrl}
         canWrite={capability.data?.canWrite ?? false}
       />
     </ReaderContent>

--- a/apps/standard-reader/src/routes/_layout.u.$did.tsx
+++ b/apps/standard-reader/src/routes/_layout.u.$did.tsx
@@ -557,15 +557,13 @@ function BlockedProfile({
   block: BlockEdge;
   profile: ProfileSummary;
 }) {
-  const blocks = useQuery(
-    blocksApi.getBlocksSettingsQueryOptions({ limit: 1 }),
-  );
+  const capability = useQuery(blocksApi.getBlockCapabilityQueryOptions());
   return (
     <ReaderContent>
       <BlockedNotice
         block={block}
         name={profile.displayName ?? profile.handle}
-        canWrite={blocks.data?.canWrite ?? false}
+        canWrite={capability.data?.canWrite ?? false}
       />
     </ReaderContent>
   );

--- a/apps/standard-reader/src/routes/api/extension/discussion.tsx
+++ b/apps/standard-reader/src/routes/api/extension/discussion.tsx
@@ -1,6 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
 
-import { badRequestResponse } from "#/server/extension/auth.server";
+import {
+  badRequestResponse,
+  getExtensionSession,
+} from "#/server/extension/auth.server";
 import { resolveDiscussion } from "#/server/extension/discussion.server";
 
 export const Route = createFileRoute("/api/extension/discussion")({
@@ -20,10 +23,13 @@ export const Route = createFileRoute("/api/extension/discussion")({
             import("#/server/reader/session-preferences.server"),
           ]);
 
-        const { excludeWebBridgeEnabled } =
-          await resolveReaderSessionPreferences(db, schema);
+        const [{ excludeWebBridgeEnabled }, session] = await Promise.all([
+          resolveReaderSessionPreferences(db, schema),
+          getExtensionSession(request),
+        ]);
         const discussion = await resolveDiscussion(db, schema, documentUri, {
           excludeWebBridge: excludeWebBridgeEnabled,
+          viewerDid: session?.did,
         });
         return Response.json(discussion);
       },

--- a/apps/standard-reader/src/routes/feed.l.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/feed.l.$did.$rkey.tsx
@@ -5,6 +5,7 @@ import * as schema from "#/db/schema";
 import { renderRssFeed } from "#/lib/feeds/rss";
 import { getPublicUrl } from "#/lib/public-url";
 import { listFeedUrl, SITE_DESCRIPTION } from "#/lib/site-metadata";
+import { blockFilterDid } from "#/server/blocks/blocks";
 import { feedItemsFromCards, loadFeedItemBodies } from "#/server/feeds/build";
 import { selectArticleCards } from "#/server/reader/queries";
 import { readList } from "#/server/reader/saved-lists";
@@ -23,8 +24,11 @@ export const Route = createFileRoute("/feed/l/$did/$rkey")({
         }
 
         const baseUrl = getPublicUrl();
+        // The list's owner is the reader this feed is for — see
+        // `feed.latest.$did`.
         const cards = await selectArticleCards(db, schema, {
           publicationUris: list.publications,
+          viewerDid: await blockFilterDid(db, schema, did),
           limit: FEED_LIMIT,
         });
         const bodies = await loadFeedItemBodies(

--- a/apps/standard-reader/src/routes/feed.latest.$did.tsx
+++ b/apps/standard-reader/src/routes/feed.latest.$did.tsx
@@ -5,6 +5,7 @@ import * as schema from "#/db/schema";
 import { renderRssFeed } from "#/lib/feeds/rss";
 import { getPublicUrl } from "#/lib/public-url";
 import { latestFeedUrl, SITE_NAME } from "#/lib/site-metadata";
+import { blockFilterDid } from "#/server/blocks/blocks";
 import { feedItemsFromCards, loadFeedItemBodies } from "#/server/feeds/build";
 import { selectArticleCards } from "#/server/reader/queries";
 import { effectiveFollowUris } from "#/server/reader/saved-lists";
@@ -22,9 +23,16 @@ export const Route = createFileRoute("/feed/latest/$did")({
         }
 
         const baseUrl = getPublicUrl();
-        const followUris = await effectiveFollowUris(db, schema, did);
+        // `$did` is the reader this feed belongs to, so their blocks apply here
+        // as they do on `/latest` itself. The feed URL is the only way in — a
+        // reader who subscribed in an RSS client can't "just not look".
+        const [followUris, blockDid] = await Promise.all([
+          effectiveFollowUris(db, schema, did),
+          blockFilterDid(db, schema, did),
+        ]);
         const cards = await selectArticleCards(db, schema, {
           publicationUris: followUris,
+          viewerDid: blockDid,
           limit: FEED_LIMIT,
         });
         const bodies = await loadFeedItemBodies(

--- a/apps/standard-reader/src/server/atproto/fetch-record.ts
+++ b/apps/standard-reader/src/server/atproto/fetch-record.ts
@@ -6,6 +6,12 @@ const DEFAULT_SLINGSHOT_URL = "https://slingshot.microcosm.blue";
 const DEFAULT_FETCH_TIMEOUT_MS = 8000;
 /** Page size for `com.atproto.repo.listRecords`. */
 const LIST_PAGE = 100;
+/**
+ * Backstop on `listRecords` paging. A repo with more records than this is
+ * pathological for the collections we read; the cap exists so a server that
+ * keeps handing back fresh cursors can't spin this loop forever.
+ */
+const MAX_LIST_PAGES = 200;
 /** Per-request timeout for paginated `listRecords` reconcile calls. */
 const LIST_FETCH_TIMEOUT_MS = 15_000;
 
@@ -254,6 +260,7 @@ async function listRecordsFromHost(
 ): Promise<Array<ListedRecord>> {
   const records: Array<ListedRecord> = [];
   let cursor: string | undefined;
+  let pages = 0;
   do {
     const url = new URL("/xrpc/com.atproto.repo.listRecords", host);
     url.searchParams.set("repo", did);
@@ -289,7 +296,28 @@ async function listRecordsFromHost(
     if (limit && records.length >= limit) {
       return records.slice(0, limit);
     }
-    cursor = page.length === pageSize ? body.cursor : undefined;
+    // Follow the cursor the server gave us, rather than guessing from the page
+    // size that there is nothing left.
+    //
+    // A short page is NOT the end of a collection. `bsky.network` PDSes answer
+    // a `limit=100` request with 50 records *and* a cursor as a matter of
+    // course, so the old `page.length === pageSize` test stopped after one page
+    // and silently returned a prefix of the collection — for blocks that means
+    // the reader's later blocks were never mirrored, and never enforced.
+    //
+    // The guards below are what that test was really reaching for: stop on an
+    // empty page, on a cursor the server didn't advance (either would spin
+    // forever), and at a page cap as a last resort.
+    const nextCursor = body.cursor;
+    const advanced =
+      typeof nextCursor === "string" &&
+      nextCursor.length > 0 &&
+      nextCursor !== cursor;
+    pages += 1;
+    cursor =
+      advanced && page.length > 0 && pages < MAX_LIST_PAGES
+        ? nextCursor
+        : undefined;
   } while (cursor);
   return records;
 }

--- a/apps/standard-reader/src/server/atproto/repo-records.ts
+++ b/apps/standard-reader/src/server/atproto/repo-records.ts
@@ -356,6 +356,106 @@ export async function deleteUserFollowRecords(
   );
 }
 
+// ── Bluesky blocks ──────────────────────────────────────────────────────────
+//
+// A block is a portable `app.bsky.graph.block` record in the reader's own repo,
+// not something we model ourselves — blocking here blocks everywhere. See
+// `db/schema/blocks.ts` for why there is no Standard Reader block lexicon.
+
+export const BSKY_BLOCK_COLLECTION = "app.bsky.graph.block";
+export const BSKY_LISTBLOCK_COLLECTION = "app.bsky.graph.listblock";
+
+/**
+ * Block `subjectDid` for `repo`, or return the existing record if there is one.
+ *
+ * Keyed by {@link subjectRkey} rather than a TID so blocking twice is the same
+ * record: a reader who blocks from two tabs, or re-blocks after a failed sync,
+ * ends up with one block rather than a pile of equivalent ones. Bluesky itself
+ * writes TID rkeys, and those are honoured on read — we just don't add more.
+ */
+export async function putBskyBlockRecord(
+  client: Client,
+  repo: string,
+  subjectDid: string,
+  createdAt: string,
+): Promise<{ uri: string; cid: string }> {
+  return repoPutRecord(client, {
+    repo,
+    collection: BSKY_BLOCK_COLLECTION,
+    rkey: subjectRkey(subjectDid),
+    record: {
+      $type: BSKY_BLOCK_COLLECTION,
+      subject: subjectDid,
+      createdAt,
+    },
+  });
+}
+
+/**
+ * Delete the reader's block records for `subjectDid`.
+ *
+ * Takes `knownRkeys` because the reader's existing blocks were almost certainly
+ * written by Bluesky under TID rkeys, which {@link subjectRkey} can't derive —
+ * callers pass the rkeys from the read-model mirror so unblocking works on a
+ * block made anywhere, not just one made here. Mirrors
+ * {@link deleteUserFollowRecords}.
+ */
+export async function deleteBskyBlockRecords(
+  client: Client,
+  repo: string,
+  subjectDid: string,
+  knownRkeys: Array<string> = [],
+): Promise<void> {
+  const rkeys = new Set([subjectRkey(subjectDid), ...knownRkeys]);
+  await Promise.all(
+    [...rkeys].map((rkey) =>
+      repoDeleteRecord(client, {
+        repo,
+        collection: BSKY_BLOCK_COLLECTION,
+        rkey,
+      }),
+    ),
+  );
+}
+
+/** Subscribe `repo` to a moderation list (`app.bsky.graph.listblock`). */
+export async function putBskyListBlockRecord(
+  client: Client,
+  repo: string,
+  listUri: string,
+  createdAt: string,
+): Promise<{ uri: string; cid: string }> {
+  return repoPutRecord(client, {
+    repo,
+    collection: BSKY_LISTBLOCK_COLLECTION,
+    rkey: subjectRkey(listUri),
+    record: {
+      $type: BSKY_LISTBLOCK_COLLECTION,
+      subject: listUri,
+      createdAt,
+    },
+  });
+}
+
+/** Unsubscribe `repo` from a moderation list. See {@link deleteBskyBlockRecords}. */
+export async function deleteBskyListBlockRecords(
+  client: Client,
+  repo: string,
+  listUri: string,
+  knownRkeys: Array<string> = [],
+): Promise<void> {
+  const rkeys = new Set([subjectRkey(listUri), ...knownRkeys]);
+  await Promise.all(
+    [...rkeys].map((rkey) =>
+      repoDeleteRecord(client, {
+        repo,
+        collection: BSKY_LISTBLOCK_COLLECTION,
+        rkey,
+      }),
+    ),
+  );
+}
+
 /** Write an `app.standard-reader.labeler.subscription` (V2) for `labelerDid`.
  *  V2 is the nested-NSID successor to the flat `labelerSubscription`; new writes
  *  go here. Reads accept both until per-reader migration completes. */

--- a/apps/standard-reader/src/server/blocks/blocks.ts
+++ b/apps/standard-reader/src/server/blocks/blocks.ts
@@ -46,6 +46,24 @@ import {
 
 export type { BlockDirection, BlockEdge };
 
+/**
+ * The DID authority of an AT-URI column, in SQL — the string half of
+ * {@link uriAuthorityDid}.
+ *
+ * A publication's owner DID *is* the authority of its record URI, so a document
+ * row can name its publication's owner without joining `publications` at all.
+ * That matters where the owner check has to live inside a per-source lateral
+ * that only has `documents` in scope, and it keeps the second block branch to a
+ * string split rather than an extra join per candidate row.
+ *
+ * Yields NULL for a loose document (no publication), which then matches nothing.
+ */
+export function atUriAuthoritySql(
+  uriExpr: ReturnType<typeof sql>,
+): ReturnType<typeof sql> {
+  return sql`nullif(split_part(${uriExpr}, '/', 3), '')`;
+}
+
 /** Read rows off a drizzle `db.execute` result (array or `{ rows }`). */
 function executeRows<T>(result: unknown): Array<T> {
   if (Array.isArray(result)) return result as Array<T>;
@@ -99,22 +117,50 @@ function blockEdgeSql(
 }
 
 /**
+ * How long "does this reader block anybody?" is trusted in-process.
+ *
+ * Short, because the answer flipping false→true is a reader who just blocked
+ * someone and expects them gone. Every write path calls
+ * {@link invalidateBlockCache} anyway, so the TTL only covers blocks made
+ * elsewhere and picked up by the sweep.
+ */
+const HAS_BLOCKS_TTL_MS = 60_000;
+
+/**
+ * Bound on the cache. Blocks are checked for every signed-in reader on every
+ * request, so an unbounded map is a slow leak on a long-lived server; past this
+ * the whole map is dropped rather than evicted one by one — the entries are a
+ * single boolean each and re-earning them costs one indexed `EXISTS`.
+ */
+const HAS_BLOCKS_CACHE_MAX = 10_000;
+
+const hasBlocksCache = new Map<string, { value: boolean; expires: number }>();
+
+/** Drop a reader's cached answer, after they block or unblock anything. */
+export function invalidateBlockCache(did: string): void {
+  hasBlocksCache.delete(did);
+}
+
+/**
  * Whether this viewer has any blocks at all, in either direction.
  *
- * Memoized per request ({@link reactCache}) because it is the guard in front of
- * every other helper here, and the overwhelmingly common answer is "no". A
- * single page load filters several card sets (critical rows, then rails, then
- * comments); without this each one would issue a block query for a reader who
- * has never blocked anybody. `db`/`schema` are stable singletons and `viewerDid`
- * is stable within a request, so all of them share one query.
+ * The guard in front of every other helper here, and in front of every SQL
+ * predicate {@link notBlockedByViewer} would otherwise add — and the
+ * overwhelmingly common answer is "no". Cached two ways for that reason:
+ * per-request via {@link reactCache} (one page filters several card sets), and
+ * across requests in-process for {@link HAS_BLOCKS_TTL_MS}, so a signed-in
+ * reader who has never blocked anybody costs nothing at all on the steady path.
  */
-const viewerHasBlocks = reactCache(viewerHasBlocksImpl);
+export const readerHasBlocks = reactCache(readerHasBlocksImpl);
 
-async function viewerHasBlocksImpl(
+async function readerHasBlocksImpl(
   db: Db,
   schema: Schema,
   viewerDid: string,
 ): Promise<boolean> {
+  const cached = hasBlocksCache.get(viewerDid);
+  if (cached && cached.expires > Date.now()) return cached.value;
+
   const b = schema.blocks;
   const bl = schema.blockLists;
   const bli = schema.blockListItems;
@@ -136,7 +182,36 @@ async function viewerHasBlocksImpl(
       )
     ) as has
   `);
-  return executeRows<{ has: boolean }>(result)[0]?.has ?? false;
+  const value = executeRows<{ has: boolean }>(result)[0]?.has ?? false;
+
+  if (hasBlocksCache.size >= HAS_BLOCKS_CACHE_MAX) hasBlocksCache.clear();
+  hasBlocksCache.set(viewerDid, {
+    value,
+    expires: Date.now() + HAS_BLOCKS_TTL_MS,
+  });
+  return value;
+}
+
+/**
+ * The DID to hand a query builder's `viewerDid`, or `undefined` to leave the
+ * query alone.
+ *
+ * **The only supported way to reach {@link notBlockedByViewer} from a feed.**
+ * That predicate is three correlated `NOT EXISTS` evaluated per candidate row,
+ * and on the follow feed it lands inside a per-source lateral whose whole job is
+ * an indexed top-k scan (see the strategy note in `reader/queries.ts`). Paying
+ * that for every signed-in reader — the vast majority of whom block nobody —
+ * would regress the feed for everyone to serve a minority. So the predicate is
+ * added only once we know it can actually match, which the cached
+ * {@link readerHasBlocks} answers without a round trip on the steady path.
+ */
+export async function blockFilterDid(
+  db: Db,
+  schema: Schema,
+  viewerDid: string | null | undefined,
+): Promise<string | undefined> {
+  if (!viewerDid) return undefined;
+  return (await readerHasBlocks(db, schema, viewerDid)) ? viewerDid : undefined;
 }
 
 /**
@@ -157,7 +232,7 @@ export async function blockEdgesAmong(
     (did) => did.startsWith("did:") && did !== viewerDid,
   );
   if (candidates.length === 0) return new Map();
-  if (!(await viewerHasBlocks(db, schema, viewerDid))) return new Map();
+  if (!(await readerHasBlocks(db, schema, viewerDid))) return new Map();
 
   const result = await db.execute(blockEdgeSql(schema, viewerDid, candidates));
   const rows = executeRows<{
@@ -279,12 +354,30 @@ export async function filterBlockedDids(
  *
  * The list branches use `EXISTS` over the join rather than an `IN` expansion so
  * a 40k-member blocklist stays an index probe per candidate row.
+ *
+ * **Never pass a raw session DID here.** Resolve it through
+ * {@link blockFilterDid} first: this is three correlated subqueries per
+ * candidate row, and adding them for a reader who blocks nobody costs the whole
+ * feed to serve an empty result set.
  */
 export function notBlockedByViewer(
   schema: Schema,
   viewerDid: string,
   didExpr: ReturnType<typeof sql>,
+  /**
+   * A second account the row renders, checked the same way — for documents,
+   * the owner of the publication they were published into. A guest post by an
+   * account the reader is fine with, in a publication whose owner they block,
+   * carries that owner in the byline and must not survive the filter.
+   *
+   * `null` at runtime (a loose document with no publication) simply never
+   * matches, so the branch costs an index probe that finds nothing.
+   */
+  ownerDidExpr?: ReturnType<typeof sql>,
 ): ReturnType<typeof sql> {
+  if (ownerDidExpr) {
+    return sql`(${notBlockedByViewer(schema, viewerDid, didExpr)} and ${notBlockedByViewer(schema, viewerDid, ownerDidExpr)})`;
+  }
   const b = schema.blocks;
   const bl = schema.blockLists;
   const bli = schema.blockListItems;

--- a/apps/standard-reader/src/server/blocks/blocks.ts
+++ b/apps/standard-reader/src/server/blocks/blocks.ts
@@ -455,7 +455,7 @@ export async function readerBlockedAccounts(
     order by ${b.createdAt} desc nulls last, ${b.uri} desc
     limit ${opts.limit} offset ${opts.offset ?? 0}
   `);
-  return executeRows<{
+  const rows = executeRows<{
     did: string;
     uri: string;
     created_at: Date | string | null;
@@ -472,6 +472,51 @@ export async function readerBlockedAccounts(
     listUri: null,
     createdAt: toIso(row.created_at),
   }));
+
+  return hydrateBlockedAccounts(rows);
+}
+
+/**
+ * Fill in identity for blocked accounts the read-model has never seen.
+ *
+ * `profiles` only holds accounts this app indexes — publishers, and readers who
+ * signed in. A reader's blocks are mostly neither, so the left join above comes
+ * back empty for them and the row has nothing to render but a `did:plc:…`
+ * string. A moderation list of raw DIDs is unusable: the reader can't tell who
+ * they blocked, let alone decide whether to undo it.
+ *
+ * So anything the mirror can't name is resolved from the public AppView, in one
+ * batched call for the whole page. Best-effort by construction — a DID that
+ * can't be resolved (deactivated, deleted, AppView down) still renders, just as
+ * bare as before. Merged at read time rather than written back into `profiles`,
+ * matching `resolveAuthorProfile`: these are accounts we deliberately don't
+ * index, and a block shouldn't quietly enrol one into the read-model.
+ */
+async function hydrateBlockedAccounts(
+  rows: Array<BlockedAccountRow>,
+): Promise<Array<BlockedAccountRow>> {
+  const missing = rows.filter(
+    (row) => !row.handle && !row.displayName && !row.avatarUrl,
+  );
+  if (missing.length === 0) return rows;
+
+  const { fetchBlueskyPublicProfiles } =
+    await import("#/lib/bluesky-public-profile");
+  const fetched = await fetchBlueskyPublicProfiles(
+    missing.map((row) => row.did),
+  );
+  if (fetched.size === 0) return rows;
+
+  return rows.map((row) => {
+    const profile = fetched.get(row.did);
+    if (!profile) return row;
+    return {
+      ...row,
+      handle: row.handle ?? profile.handle,
+      displayName: row.displayName ?? profile.displayName,
+      avatarUrl: row.avatarUrl ?? profile.avatarUrl,
+    };
+  });
 }
 
 /** How many accounts the reader blocks directly. */

--- a/apps/standard-reader/src/server/blocks/blocks.ts
+++ b/apps/standard-reader/src/server/blocks/blocks.ts
@@ -1,0 +1,473 @@
+/**
+ * Resolve a reader's blocks from the read-model.
+ *
+ * Blocks are mirrored into Postgres by `sync.server.ts` — the only place that
+ * talks to a PDS, the AppView or Constellation about them. Every request path
+ * reads them from here in SQL, so rendering a feed never costs a network call
+ * to work out who the reader can't see.
+ *
+ * No `.server` suffix, deliberately: `reader/queries.ts` needs
+ * {@link notBlockedByViewer} and is itself reachable from the client bundle, so
+ * a server-only module here would fail import protection at build time. Nothing
+ * in this file is server-only — the Drizzle client is threaded in by the
+ * caller, exactly as in `queries.ts`.
+ *
+ * Four things block an account for a viewer, and all four are equal in effect:
+ *
+ * | Direction          | Record                                  | Held by |
+ * | ------------------ | --------------------------------------- | ------- |
+ * | `blocking`         | `app.bsky.graph.block`                  | viewer  |
+ * | `blocked-by`       | `app.bsky.graph.block`                  | them    |
+ * | `list-blocking`    | `app.bsky.graph.listblock` + `listitem` | viewer  |
+ * | `list-blocked-by`  | `app.bsky.graph.listblock` + `listitem` | them    |
+ *
+ * That symmetry is the whole point: Bluesky hides content in both directions,
+ * and a reader who blocked someone on Bluesky last year expects them to still
+ * be gone here.
+ *
+ * **Bounded by the candidate set, never by the block set.** A reader who
+ * subscribes to a large moderation blocklist blocks tens of thousands of
+ * accounts, so "load the reader's blocks and filter in JS" is not an option.
+ * Every helper here takes the DIDs a page is about to render and asks which of
+ * *those* are blocked, which stays an index probe no matter how big the block
+ * set is.
+ */
+
+import { inArray, sql } from "drizzle-orm";
+import { cache as reactCache } from "react";
+
+import type { Db, Schema } from "#/integrations/tanstack-query/api-shapes";
+import type { BlockDirection, BlockEdge, BlockableCard } from "#/lib/blocks";
+import {
+  blockSubjectDids,
+  mergeBlockEdges,
+  rejectBlockedCards,
+} from "#/lib/blocks";
+
+export type { BlockDirection, BlockEdge };
+
+/** Read rows off a drizzle `db.execute` result (array or `{ rows }`). */
+function executeRows<T>(result: unknown): Array<T> {
+  if (Array.isArray(result)) return result as Array<T>;
+  return ((result as { rows?: Array<T> }).rows ?? []) as Array<T>;
+}
+
+/**
+ * The four block branches for `viewerDid`, narrowed to `dids`.
+ *
+ * Each branch is written so the narrowing sits on an indexed column, which is
+ * what keeps this cheap for a reader on a 40k-member blocklist: Postgres probes
+ * `(list_uri, subject_did)` for the handful of DIDs on the page instead of
+ * expanding the list.
+ */
+function blockEdgeSql(
+  schema: Schema,
+  viewerDid: string,
+  dids: ReadonlyArray<string>,
+): ReturnType<typeof sql> {
+  const b = schema.blocks;
+  const bl = schema.blockLists;
+  const bli = schema.blockListItems;
+  const mutable = [...dids];
+  return sql`
+    select ${b.subjectDid} as did, 'blocking' as direction, null as list_uri
+      from ${b}
+      where ${b.blockerDid} = ${viewerDid}
+        and ${b.deleted} = false
+        and ${inArray(b.subjectDid, mutable)}
+    union all
+    select ${b.blockerDid} as did, 'blocked-by' as direction, null as list_uri
+      from ${b}
+      where ${b.subjectDid} = ${viewerDid}
+        and ${b.deleted} = false
+        and ${inArray(b.blockerDid, mutable)}
+    union all
+    select ${bli.subjectDid} as did, 'list-blocking' as direction, ${bl.listUri} as list_uri
+      from ${bli}
+      join ${bl} on ${bl.listUri} = ${bli.listUri}
+      where ${bl.blockerDid} = ${viewerDid}
+        and ${bl.deleted} = false
+        and ${inArray(bli.subjectDid, mutable)}
+    union all
+    select ${bl.blockerDid} as did, 'list-blocked-by' as direction, ${bl.listUri} as list_uri
+      from ${bl}
+      join ${bli} on ${bli.listUri} = ${bl.listUri}
+      where ${bli.subjectDid} = ${viewerDid}
+        and ${bl.deleted} = false
+        and ${inArray(bl.blockerDid, mutable)}
+  `;
+}
+
+/**
+ * Whether this viewer has any blocks at all, in either direction.
+ *
+ * Memoized per request ({@link reactCache}) because it is the guard in front of
+ * every other helper here, and the overwhelmingly common answer is "no". A
+ * single page load filters several card sets (critical rows, then rails, then
+ * comments); without this each one would issue a block query for a reader who
+ * has never blocked anybody. `db`/`schema` are stable singletons and `viewerDid`
+ * is stable within a request, so all of them share one query.
+ */
+const viewerHasBlocks = reactCache(viewerHasBlocksImpl);
+
+async function viewerHasBlocksImpl(
+  db: Db,
+  schema: Schema,
+  viewerDid: string,
+): Promise<boolean> {
+  const b = schema.blocks;
+  const bl = schema.blockLists;
+  const bli = schema.blockListItems;
+  const result = await db.execute(sql`
+    select (
+      exists(
+        select 1 from ${b}
+        where (${b.blockerDid} = ${viewerDid} or ${b.subjectDid} = ${viewerDid})
+          and ${b.deleted} = false
+      )
+      or exists(
+        select 1 from ${bl}
+        where ${bl.blockerDid} = ${viewerDid} and ${bl.deleted} = false
+      )
+      or exists(
+        select 1 from ${bli}
+        join ${bl} on ${bl.listUri} = ${bli.listUri}
+        where ${bli.subjectDid} = ${viewerDid} and ${bl.deleted} = false
+      )
+    ) as has
+  `);
+  return executeRows<{ has: boolean }>(result)[0]?.has ?? false;
+}
+
+/**
+ * Which of `dids` are blocked for `viewerDid`, with the reason for each.
+ *
+ * One row per account, collapsed to the most actionable direction (see
+ * `mergeBlockEdges`) so a card that is both blocked *and* blocking explains
+ * itself as the block the reader can undo.
+ */
+export async function blockEdgesAmong(
+  db: Db,
+  schema: Schema,
+  viewerDid: string | null | undefined,
+  dids: ReadonlyArray<string>,
+): Promise<Map<string, BlockEdge>> {
+  if (!viewerDid) return new Map();
+  const candidates = [...new Set(dids)].filter(
+    (did) => did.startsWith("did:") && did !== viewerDid,
+  );
+  if (candidates.length === 0) return new Map();
+  if (!(await viewerHasBlocks(db, schema, viewerDid))) return new Map();
+
+  const result = await db.execute(blockEdgeSql(schema, viewerDid, candidates));
+  const rows = executeRows<{
+    did: string;
+    direction: BlockDirection;
+    list_uri: string | null;
+  }>(result);
+  return mergeBlockEdges(
+    rows.map((row) => ({
+      did: row.did,
+      direction: row.direction,
+      listUri: row.list_uri,
+    })),
+  );
+}
+
+/** Which of `dids` are blocked for `viewerDid`, without the reason. */
+export async function blockedDidsAmong(
+  db: Db,
+  schema: Schema,
+  viewerDid: string | null | undefined,
+  dids: ReadonlyArray<string>,
+): Promise<Set<string>> {
+  const edges = await blockEdgesAmong(db, schema, viewerDid, dids);
+  return new Set(edges.keys());
+}
+
+/** The block between the viewer and one account, or null if there is none. */
+export async function blockEdgeFor(
+  db: Db,
+  schema: Schema,
+  viewerDid: string | null | undefined,
+  did: string,
+): Promise<BlockEdge | null> {
+  const edges = await blockEdgesAmong(db, schema, viewerDid, [did]);
+  return edges.get(did) ?? null;
+}
+
+/**
+ * The first block between the viewer and any of `dids`, or null.
+ *
+ * For a page that renders several accounts at once — a document has an author
+ * *and* a publication owner — where a block on any of them withholds the whole
+ * thing. Order follows `dids`, so callers list the account they'd rather
+ * explain first.
+ */
+export async function firstBlockAmong(
+  db: Db,
+  schema: Schema,
+  viewerDid: string | null | undefined,
+  dids: Array<string | null | undefined>,
+): Promise<BlockEdge | null> {
+  const candidates: Array<string> = [];
+  for (const did of dids) {
+    if (did) candidates.push(did);
+  }
+  if (candidates.length === 0) return null;
+  const edges = await blockEdgesAmong(db, schema, viewerDid, candidates);
+  for (const did of candidates) {
+    const edge = edges.get(did);
+    if (edge) return edge;
+  }
+  return null;
+}
+
+/** Whether the viewer and this account are blocked from each other. */
+export async function isBlockedForViewer(
+  db: Db,
+  schema: Schema,
+  viewerDid: string | null | undefined,
+  did: string | null | undefined,
+): Promise<boolean> {
+  if (!did) return false;
+  return (await blockEdgeFor(db, schema, viewerDid, did)) !== null;
+}
+
+/**
+ * Drop every card whose author (or publication owner) the viewer is blocked
+ * from. The general-purpose filter: pair it with {@link notBlockedByViewer}
+ * on paginated feeds, and use it alone for rails and third-party content.
+ */
+export async function filterBlockedCards<T extends BlockableCard>(
+  db: Db,
+  schema: Schema,
+  viewerDid: string | null | undefined,
+  cards: Array<T>,
+): Promise<Array<T>> {
+  if (!viewerDid || cards.length === 0) return cards;
+  const blocked = await blockedDidsAmong(
+    db,
+    schema,
+    viewerDid,
+    blockSubjectDids(cards),
+  );
+  return rejectBlockedCards(cards, blocked);
+}
+
+/** {@link filterBlockedCards} for a plain list of account DIDs. */
+export async function filterBlockedDids(
+  db: Db,
+  schema: Schema,
+  viewerDid: string | null | undefined,
+  dids: Array<string>,
+): Promise<Array<string>> {
+  if (!viewerDid || dids.length === 0) return dids;
+  const blocked = await blockedDidsAmong(db, schema, viewerDid, dids);
+  return blocked.size === 0 ? dids : dids.filter((did) => !blocked.has(did));
+}
+
+/**
+ * `NOT EXISTS` predicate excluding accounts blocked for `viewerDid`, for use
+ * inside a paginated query.
+ *
+ * Post-filtering a page is fine for a rail (see {@link filterBlockedCards}) but
+ * wrong for a feed: dropping rows *after* `LIMIT` shortens the page and, on a
+ * reader who blocks a large list, can empty it entirely while more results wait
+ * behind the offset. `didExpr` is the outer author-DID column to correlate on
+ * (e.g. `sql`"documents"."did"``).
+ *
+ * The list branches use `EXISTS` over the join rather than an `IN` expansion so
+ * a 40k-member blocklist stays an index probe per candidate row.
+ */
+export function notBlockedByViewer(
+  schema: Schema,
+  viewerDid: string,
+  didExpr: ReturnType<typeof sql>,
+): ReturnType<typeof sql> {
+  const b = schema.blocks;
+  const bl = schema.blockLists;
+  const bli = schema.blockListItems;
+  return sql`not (
+    exists(
+      select 1 from ${b}
+      where ${b.deleted} = false
+        and (
+          (${b.blockerDid} = ${viewerDid} and ${b.subjectDid} = ${didExpr})
+          or (${b.subjectDid} = ${viewerDid} and ${b.blockerDid} = ${didExpr})
+        )
+    )
+    or exists(
+      select 1 from ${bli}
+      join ${bl} on ${bl.listUri} = ${bli.listUri}
+      where ${bl.blockerDid} = ${viewerDid}
+        and ${bl.deleted} = false
+        and ${bli.subjectDid} = ${didExpr}
+    )
+    or exists(
+      select 1 from ${bl}
+      join ${bli} on ${bli.listUri} = ${bl.listUri}
+      where ${bli.subjectDid} = ${viewerDid}
+        and ${bl.deleted} = false
+        and ${bl.blockerDid} = ${didExpr}
+    )
+  )`;
+}
+
+// ── Settings surfaces ───────────────────────────────────────────────────────
+
+/** A blocked account as rendered in the moderation settings list. */
+export interface BlockedAccountRow {
+  did: string;
+  handle: string | null;
+  displayName: string | null;
+  avatarUrl: string | null;
+  direction: BlockDirection;
+  /** The moderation list responsible, for the list-sourced directions. */
+  listUri: string | null;
+  /** The block record's AT-URI — present (and removable) only when outgoing. */
+  uri: string | null;
+  createdAt: string | null;
+}
+
+/**
+ * The reader's own direct blocks, newest first, joined to whatever profile we
+ * have mirrored.
+ *
+ * Deliberately *only* the outgoing direct blocks: this list is the reader's own
+ * decisions, which they can undo here. Accounts blocking them, and members of
+ * blocklists they subscribe to, are not theirs to edit and are surfaced
+ * separately (see {@link readerBlockLists}) rather than mixed in as though they
+ * were.
+ */
+export async function readerBlockedAccounts(
+  db: Db,
+  schema: Schema,
+  viewerDid: string,
+  opts: { limit: number; offset?: number },
+): Promise<Array<BlockedAccountRow>> {
+  const b = schema.blocks;
+  const p = schema.profiles;
+  const result = await db.execute(sql`
+    select
+      ${b.subjectDid} as did,
+      ${b.uri} as uri,
+      ${b.createdAt} as created_at,
+      ${p.handle} as handle,
+      ${p.displayName} as display_name,
+      ${p.avatarUrl} as avatar_url
+    from ${b}
+    left join ${p} on ${p.did} = ${b.subjectDid}
+    where ${b.blockerDid} = ${viewerDid} and ${b.deleted} = false
+    order by ${b.createdAt} desc nulls last, ${b.uri} desc
+    limit ${opts.limit} offset ${opts.offset ?? 0}
+  `);
+  return executeRows<{
+    did: string;
+    uri: string;
+    created_at: Date | string | null;
+    handle: string | null;
+    display_name: string | null;
+    avatar_url: string | null;
+  }>(result).map((row) => ({
+    did: row.did,
+    uri: row.uri,
+    handle: row.handle,
+    displayName: row.display_name,
+    avatarUrl: row.avatar_url,
+    direction: "blocking" as const,
+    listUri: null,
+    createdAt: toIso(row.created_at),
+  }));
+}
+
+/** How many accounts the reader blocks directly. */
+export async function countReaderBlockedAccounts(
+  db: Db,
+  schema: Schema,
+  viewerDid: string,
+): Promise<number> {
+  const b = schema.blocks;
+  const result = await db.execute(sql`
+    select count(*)::int as count from ${b}
+    where ${b.blockerDid} = ${viewerDid} and ${b.deleted} = false
+  `);
+  return executeRows<{ count: number }>(result)[0]?.count ?? 0;
+}
+
+/** A moderation list the reader blocks, as rendered in settings. */
+export interface BlockListRow {
+  uri: string;
+  listUri: string;
+  listOwnerDid: string;
+  name: string | null;
+  description: string | null;
+  /** Members mirrored for this list — what the block actually covers here. */
+  memberCount: number;
+  /**
+   * The list is bigger than the mirror cap, so the block is partial. Surfaced
+   * rather than hidden: under-enforcing a blocklist silently is worse than
+   * saying so.
+   */
+  truncated: boolean;
+  syncedAt: string | null;
+  createdAt: string | null;
+}
+
+/** The moderation lists the reader blocks, with mirror state for each. */
+export async function readerBlockLists(
+  db: Db,
+  schema: Schema,
+  viewerDid: string,
+): Promise<Array<BlockListRow>> {
+  const bl = schema.blockLists;
+  const ls = schema.blockListSyncState;
+  const result = await db.execute(sql`
+    select
+      ${bl.uri} as uri,
+      ${bl.listUri} as list_uri,
+      ${bl.createdAt} as created_at,
+      ${ls.name} as name,
+      ${ls.description} as description,
+      ${ls.ownerDid} as owner_did,
+      ${ls.itemCount} as item_count,
+      ${ls.truncated} as truncated,
+      ${ls.syncedAt} as synced_at
+    from ${bl}
+    left join ${ls} on ${ls.listUri} = ${bl.listUri}
+    where ${bl.blockerDid} = ${viewerDid} and ${bl.deleted} = false
+    order by ${bl.createdAt} desc nulls last, ${bl.uri} desc
+  `);
+  return executeRows<{
+    uri: string;
+    list_uri: string;
+    created_at: Date | string | null;
+    name: string | null;
+    description: string | null;
+    owner_did: string | null;
+    item_count: number | null;
+    truncated: boolean | null;
+    synced_at: Date | string | null;
+  }>(result).map((row) => ({
+    uri: row.uri,
+    listUri: row.list_uri,
+    listOwnerDid: row.owner_did ?? listOwnerFromUri(row.list_uri),
+    name: row.name,
+    description: row.description,
+    memberCount: row.item_count ?? 0,
+    truncated: row.truncated ?? false,
+    syncedAt: toIso(row.synced_at),
+    createdAt: toIso(row.created_at),
+  }));
+}
+
+function listOwnerFromUri(listUri: string): string {
+  const rest = listUri.slice("at://".length);
+  const slash = rest.indexOf("/");
+  return slash === -1 ? rest : rest.slice(0, slash);
+}
+
+function toIso(value: Date | string | null): string | null {
+  if (value == null) return null;
+  return value instanceof Date ? value.toISOString() : value;
+}

--- a/apps/standard-reader/src/server/blocks/sync.server.ts
+++ b/apps/standard-reader/src/server/blocks/sync.server.ts
@@ -1,0 +1,795 @@
+/**
+ * Mirror a reader's Bluesky blocks into the read-model.
+ *
+ * This is the **only** place that talks to the network about blocks; every
+ * request path reads them from Postgres (see `blocks.server.ts`).
+ *
+ * Blocks can't ride the firehose tap the way documents and subscriptions do.
+ * The tap tracks the repos we index — publishers, and readers who have signed
+ * in — but a block against one of our readers can be written by *any* repo on
+ * the network, and there are far too many to track. So blocks are pulled per
+ * reader, on a cadence, from four sources:
+ *
+ * 1. **Outgoing blocks** — `app.bsky.graph.block` in the reader's own repo.
+ *    Read unauthenticated: `com.atproto.repo.listRecords` is a public endpoint,
+ *    so honouring someone's blocks costs no OAuth scope at all. Only *writing*
+ *    a block needs one (see `scope.ts`).
+ * 2. **Outgoing list blocks** — `app.bsky.graph.listblock` in the reader's repo,
+ *    expanded to the list's membership via the public AppView.
+ * 3. **Incoming blocks** — block records elsewhere on the network whose
+ *    `subject` is the reader, found through Constellation's backlink index.
+ * 4. **Incoming list blocks** — moderation lists the reader is *on*, and who
+ *    blocks those lists. This is Bluesky's `blockedByList`, and it is why a
+ *    reader can be blocked by someone who never named them.
+ *
+ * **Never on a path anyone waits for.** A full sync is dozens of round trips.
+ * Callers use {@link scheduleReaderBlockSync}, which returns immediately and
+ * lets the work land in the DB for the reader's next load.
+ */
+
+import { and, eq, inArray, notInArray, sql } from "drizzle-orm";
+
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import { getBacklinks } from "#/server/atproto/constellation";
+import {
+  fetchRepoRecordWithFallback,
+  listRepoRecords,
+} from "#/server/atproto/fetch-record";
+import { resolveIdentity } from "#/server/atproto/identity";
+
+/** Collections we mirror. Third-party (Bluesky) namespace — not ours. */
+export const BSKY_BLOCK_NSID = "app.bsky.graph.block";
+export const BSKY_LISTBLOCK_NSID = "app.bsky.graph.listblock";
+export const BSKY_LISTITEM_NSID = "app.bsky.graph.listitem";
+export const BSKY_LIST_NSID = "app.bsky.graph.list";
+
+/** Constellation backlink sources for the two incoming directions. */
+const BLOCK_SUBJECT_SOURCE = `${BSKY_BLOCK_NSID}:.subject` as const;
+const LISTBLOCK_SUBJECT_SOURCE = `${BSKY_LISTBLOCK_NSID}:.subject` as const;
+const LISTITEM_SUBJECT_SOURCE = `${BSKY_LISTITEM_NSID}:.subject` as const;
+
+const PUBLIC_APPVIEW = "https://public.api.bsky.app";
+const FETCH_TIMEOUT_MS = 8000;
+
+/**
+ * How long a mirrored list's membership is trusted before it is re-fetched.
+ *
+ * Moderation lists change slowly and cost up to {@link MAX_LIST_PAGES} requests
+ * to walk, so re-reading one on every reader sync would spend the entire budget
+ * on lists that hadn't moved. A block added to a list today takes at most this
+ * long to take effect here.
+ */
+const LIST_TTL_MS = 12 * 60 * 60 * 1000;
+
+/**
+ * Cap on how much of a moderation list we mirror (100 members per page).
+ *
+ * The largest public blocklists run to six figures. Mirroring one in full would
+ * dwarf the rest of the read-model, so a list past this cap is stored truncated
+ * and flagged — the settings surface says the block is partial rather than
+ * quietly under-enforcing it.
+ */
+const MAX_LIST_PAGES = 100;
+const LIST_PAGE_SIZE = 100;
+
+/**
+ * Cap on how many lists a reader's *incoming* sweep will chase.
+ *
+ * Being on a list is not rare — some are auto-generated and hold thousands of
+ * accounts — and each one costs a record fetch plus a Constellation query. The
+ * direct incoming blocks in step 3 are the common case by a wide margin; this
+ * bounds the tail.
+ */
+const MAX_INCOMING_LISTS = 25;
+
+export interface BlockSyncResult {
+  outgoing: number;
+  incoming: number;
+  lists: number;
+  error?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** The `at://did/…` authority of an AT-URI, or null if it isn't a DID. */
+function didFromAtUri(uri: string): string | null {
+  if (!uri.startsWith("at://")) return null;
+  const rest = uri.slice("at://".length);
+  const slash = rest.indexOf("/");
+  const authority = slash === -1 ? rest : rest.slice(0, slash);
+  return authority.startsWith("did:") ? authority : null;
+}
+
+function rkeyFromAtUri(uri: string): string {
+  return uri.slice(uri.lastIndexOf("/") + 1);
+}
+
+function parseDate(value: unknown): Date | null {
+  if (typeof value !== "string") return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * Pages of Constellation backlinks for one target, up to `maxPages`.
+ *
+ * A popular account can be blocked by thousands, and a single page would mirror
+ * an arbitrary hundred of them — which is worse than a bounded sweep, because
+ * it looks complete. The cap is stated rather than silent: past it, the reader
+ * is enforcing the blocks we know about, not every block that exists.
+ */
+async function allBacklinks(
+  target: string,
+  source: string,
+  maxPages: number,
+): Promise<Array<{ did: string; collection: string; rkey: string }>> {
+  const merged: Array<{ did: string; collection: string; rkey: string }> = [];
+  let cursor: string | undefined;
+  let pages = 0;
+  do {
+    const page = await getBacklinks({ target, source, cursor, limit: 100 });
+    merged.push(...page.records);
+    cursor = page.cursor ?? undefined;
+    pages++;
+  } while (cursor && pages < maxPages);
+  return merged;
+}
+
+/** Cap on Constellation pages per backlink sweep (100 records per page). */
+const MAX_BACKLINK_PAGES = 20;
+
+// ── Outgoing: the reader's own records ──────────────────────────────────────
+
+interface ParsedBlock {
+  uri: string;
+  cid: string | null;
+  blockerDid: string;
+  rkey: string;
+  subjectDid: string;
+  createdAt: Date | null;
+}
+
+/**
+ * Replace the mirrored blocks authored by `blockerDid` with `rows`.
+ *
+ * A full replace, not an upsert: unblocking deletes the record, and the only
+ * way to notice a record that is no longer there is to compare the whole set.
+ * Rows are soft-deleted rather than removed so a re-block reuses the row and
+ * the mirror keeps the same shape as every other table here.
+ */
+async function replaceOutgoingBlocks(
+  blockerDid: string,
+  rows: Array<ParsedBlock>,
+): Promise<void> {
+  const b = schema.blocks;
+  if (rows.length > 0) {
+    const values = rows.map((row) => ({
+      uri: row.uri,
+      cid: row.cid,
+      blockerDid: row.blockerDid,
+      rkey: row.rkey,
+      subjectDid: row.subjectDid,
+      createdAt: row.createdAt,
+      deleted: false,
+      updatedAt: sql`now()`,
+    }));
+    await db
+      .insert(b)
+      .values(values)
+      .onConflictDoUpdate({
+        target: b.uri,
+        set: {
+          cid: sql`excluded.cid`,
+          subjectDid: sql`excluded.subject_did`,
+          createdAt: sql`excluded.created_at`,
+          deleted: false,
+          updatedAt: sql`now()`,
+        },
+      });
+  }
+
+  const keep = rows.map((row) => row.uri);
+  await db
+    .update(b)
+    .set({ deleted: true, updatedAt: sql`now()` })
+    .where(
+      and(
+        eq(b.blockerDid, blockerDid),
+        eq(b.deleted, false),
+        ...(keep.length > 0 ? [notInArray(b.uri, keep)] : []),
+      ),
+    );
+}
+
+interface ParsedListBlock {
+  uri: string;
+  cid: string | null;
+  blockerDid: string;
+  rkey: string;
+  listUri: string;
+  createdAt: Date | null;
+}
+
+/** {@link replaceOutgoingBlocks} for `app.bsky.graph.listblock` records. */
+async function replaceOutgoingListBlocks(
+  blockerDid: string,
+  rows: Array<ParsedListBlock>,
+): Promise<void> {
+  const bl = schema.blockLists;
+  if (rows.length > 0) {
+    await db
+      .insert(bl)
+      .values(
+        rows.map((row) => ({
+          uri: row.uri,
+          cid: row.cid,
+          blockerDid: row.blockerDid,
+          rkey: row.rkey,
+          listUri: row.listUri,
+          createdAt: row.createdAt,
+          deleted: false,
+          updatedAt: sql`now()`,
+        })),
+      )
+      .onConflictDoUpdate({
+        target: bl.uri,
+        set: {
+          cid: sql`excluded.cid`,
+          listUri: sql`excluded.list_uri`,
+          createdAt: sql`excluded.created_at`,
+          deleted: false,
+          updatedAt: sql`now()`,
+        },
+      });
+  }
+
+  const keep = rows.map((row) => row.uri);
+  await db
+    .update(bl)
+    .set({ deleted: true, updatedAt: sql`now()` })
+    .where(
+      and(
+        eq(bl.blockerDid, blockerDid),
+        eq(bl.deleted, false),
+        ...(keep.length > 0 ? [notInArray(bl.uri, keep)] : []),
+      ),
+    );
+}
+
+/** The reader's own `app.bsky.graph.block` records, parsed. */
+async function readOutgoingBlocks(
+  did: string,
+  pds: string | null,
+): Promise<Array<ParsedBlock>> {
+  const { records } = await listRepoRecords(did, BSKY_BLOCK_NSID, pds);
+  const rows: Array<ParsedBlock> = [];
+  for (const record of records) {
+    const value = record.value;
+    const subject = isRecord(value) ? value.subject : null;
+    if (typeof subject !== "string" || !subject.startsWith("did:")) continue;
+    if (subject === did) continue;
+    rows.push({
+      uri: record.uri,
+      cid: record.cid ?? null,
+      blockerDid: did,
+      rkey: rkeyFromAtUri(record.uri),
+      subjectDid: subject,
+      createdAt: parseDate(isRecord(value) ? value.createdAt : null),
+    });
+  }
+  return rows;
+}
+
+/** The reader's own `app.bsky.graph.listblock` records, parsed. */
+async function readOutgoingListBlocks(
+  did: string,
+  pds: string | null,
+): Promise<Array<ParsedListBlock>> {
+  const { records } = await listRepoRecords(did, BSKY_LISTBLOCK_NSID, pds);
+  const rows: Array<ParsedListBlock> = [];
+  for (const record of records) {
+    const value = record.value;
+    const subject = isRecord(value) ? value.subject : null;
+    if (typeof subject !== "string" || !subject.startsWith("at://")) continue;
+    rows.push({
+      uri: record.uri,
+      cid: record.cid ?? null,
+      blockerDid: did,
+      rkey: rkeyFromAtUri(record.uri),
+      listUri: subject,
+      createdAt: parseDate(isRecord(value) ? value.createdAt : null),
+    });
+  }
+  return rows;
+}
+
+// ── Moderation lists ────────────────────────────────────────────────────────
+
+interface AppViewListItem {
+  uri: string;
+  subjectDid: string;
+}
+
+interface AppViewList {
+  name: string | null;
+  description: string | null;
+  purpose: string | null;
+  items: Array<AppViewListItem>;
+  truncated: boolean;
+}
+
+/**
+ * Walk a moderation list's membership from the public AppView.
+ *
+ * The AppView rather than the owner's repo: membership is one `listitem` record
+ * per member, so reading it from the PDS means paging the owner's entire repo
+ * and filtering client-side, while `getList` returns exactly this list already
+ * joined to its members.
+ */
+async function fetchListFromAppView(listUri: string): Promise<AppViewList> {
+  const items: Array<AppViewListItem> = [];
+  let cursor: string | undefined;
+  let name: string | null = null;
+  let description: string | null = null;
+  let purpose: string | null = null;
+  let pages = 0;
+  let truncated = false;
+
+  do {
+    const url = new URL("/xrpc/app.bsky.graph.getList", PUBLIC_APPVIEW);
+    url.searchParams.set("list", listUri);
+    url.searchParams.set("limit", String(LIST_PAGE_SIZE));
+    if (cursor) url.searchParams.set("cursor", cursor);
+
+    const response = await fetch(url.toString(), {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { Accept: "application/json" },
+    });
+    if (!response.ok) {
+      throw new Error(`AppView returned HTTP ${response.status}`);
+    }
+    const payload: unknown = await response.json();
+    if (!isRecord(payload)) break;
+
+    const list = payload.list;
+    if (isRecord(list)) {
+      name = typeof list.name === "string" ? list.name : name;
+      description =
+        typeof list.description === "string" ? list.description : description;
+      purpose = typeof list.purpose === "string" ? list.purpose : purpose;
+    }
+
+    for (const item of Array.isArray(payload.items) ? payload.items : []) {
+      if (!isRecord(item)) continue;
+      const subject = item.subject;
+      const uri = item.uri;
+      if (!isRecord(subject) || typeof uri !== "string") continue;
+      if (typeof subject.did !== "string") continue;
+      items.push({ uri, subjectDid: subject.did });
+    }
+
+    cursor = typeof payload.cursor === "string" ? payload.cursor : undefined;
+    pages++;
+    if (cursor && pages >= MAX_LIST_PAGES) {
+      truncated = true;
+      break;
+    }
+  } while (cursor);
+
+  return { name, description, purpose, items, truncated };
+}
+
+/** Whether this list's membership was mirrored recently enough to trust. */
+async function listIsFresh(listUri: string): Promise<boolean> {
+  const ls = schema.blockListSyncState;
+  const rows = await db
+    .select({ syncedAt: ls.syncedAt, lastError: ls.lastError })
+    .from(ls)
+    .where(eq(ls.listUri, listUri))
+    .limit(1);
+  const row = rows[0];
+  if (!row?.syncedAt || row.lastError) return false;
+  return Date.now() - row.syncedAt.getTime() < LIST_TTL_MS;
+}
+
+/**
+ * Mirror one moderation list's membership in full, replacing what we had.
+ *
+ * Best-effort: a list that can't be fetched records the error and keeps its
+ * previous membership rather than dropping them, so a transient AppView failure
+ * can't briefly un-block everyone on somebody's blocklist.
+ */
+async function syncListMembership(
+  listUri: string,
+  force = false,
+): Promise<void> {
+  if (!force && (await listIsFresh(listUri))) return;
+
+  const ownerDid = didFromAtUri(listUri);
+  if (!ownerDid) return;
+  const ls = schema.blockListSyncState;
+
+  let list: AppViewList;
+  try {
+    list = await fetchListFromAppView(listUri);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "unknown error";
+    await db
+      .insert(ls)
+      .values({ listUri, ownerDid, lastError: message, syncedAt: new Date() })
+      .onConflictDoUpdate({
+        target: ls.listUri,
+        set: { lastError: message, syncedAt: sql`now()` },
+      });
+    return;
+  }
+
+  const bli = schema.blockListItems;
+  if (list.items.length > 0) {
+    await db
+      .insert(bli)
+      .values(
+        list.items.map((item) => ({
+          uri: item.uri,
+          listUri,
+          subjectDid: item.subjectDid,
+        })),
+      )
+      .onConflictDoUpdate({
+        target: bli.uri,
+        set: {
+          listUri: sql`excluded.list_uri`,
+          subjectDid: sql`excluded.subject_did`,
+          indexedAt: sql`now()`,
+        },
+      });
+  }
+
+  // Drop members removed from the list upstream. Rows are deleted rather than
+  // soft-deleted: a listitem has no identity worth preserving, and membership
+  // is re-derived in full on every refresh.
+  const keep = list.items.map((item) => item.uri);
+  await db
+    .delete(bli)
+    .where(
+      and(
+        eq(bli.listUri, listUri),
+        ...(keep.length > 0 ? [notInArray(bli.uri, keep)] : []),
+      ),
+    );
+
+  await db
+    .insert(ls)
+    .values({
+      listUri,
+      ownerDid,
+      name: list.name,
+      description: list.description,
+      purpose: list.purpose,
+      itemCount: list.items.length,
+      truncated: list.truncated,
+      lastError: null,
+      syncedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: ls.listUri,
+      set: {
+        name: list.name,
+        description: list.description,
+        purpose: list.purpose,
+        itemCount: list.items.length,
+        truncated: list.truncated,
+        lastError: null,
+        syncedAt: sql`now()`,
+      },
+    });
+}
+
+// ── Incoming: blocks against the reader ─────────────────────────────────────
+
+/**
+ * Block records elsewhere on the network whose `subject` is this reader.
+ *
+ * Constellation's backlink index answers this in one query and returns the
+ * blocker DID and rkey directly, so the block row can be built without fetching
+ * a single record.
+ *
+ * Additive, not a replace: these rows describe other people's repos, and this
+ * index is best-effort. A sweep that came back short (Constellation down, a
+ * partial page) must not be read as "nobody blocks you any more" — that would
+ * un-hide content the moment the index hiccuped. Rows do go away, just on the
+ * slower path: the blocker's own record read, if they are also a reader here.
+ */
+async function syncIncomingBlocks(did: string): Promise<number> {
+  const records = await allBacklinks(
+    did,
+    BLOCK_SUBJECT_SOURCE,
+    MAX_BACKLINK_PAGES,
+  );
+  const rows = records
+    .filter((record) => record.collection === BSKY_BLOCK_NSID)
+    .filter((record) => record.did !== did)
+    .map((record) => ({
+      uri: `at://${record.did}/${BSKY_BLOCK_NSID}/${record.rkey}`,
+      cid: null,
+      blockerDid: record.did,
+      rkey: record.rkey,
+      subjectDid: did,
+      createdAt: null,
+      deleted: false,
+      updatedAt: sql`now()`,
+    }));
+  if (rows.length === 0) return 0;
+
+  const b = schema.blocks;
+  await db
+    .insert(b)
+    .values(rows)
+    .onConflictDoUpdate({
+      target: b.uri,
+      set: { deleted: false, updatedAt: sql`now()` },
+    });
+  return rows.length;
+}
+
+/**
+ * Moderation lists this reader is on, and who blocks those lists.
+ *
+ * Two hops, both through Constellation: `listitem` records naming the reader
+ * give the lists they are on, and `listblock` records naming those lists give
+ * the accounts blocking them. Only the reader's *own* membership row is stored
+ * for these lists — enough for the `list-blocked-by` branch to resolve, without
+ * mirroring a list nobody here has actually subscribed to.
+ */
+async function syncIncomingListBlocks(
+  did: string,
+  pds: string | null,
+): Promise<number> {
+  const records = await allBacklinks(did, LISTITEM_SUBJECT_SOURCE, 1);
+  const listItems = records
+    .filter((record) => record.collection === BSKY_LISTITEM_NSID)
+    .slice(0, MAX_INCOMING_LISTS);
+  if (listItems.length === 0) return 0;
+
+  let blockers = 0;
+  for (const item of listItems) {
+    const itemUri = `at://${item.did}/${BSKY_LISTITEM_NSID}/${item.rkey}`;
+    const record = await fetchRepoRecordWithFallback(itemUri, pds);
+    const value = record?.value;
+    const listUri = isRecord(value) ? value.list : null;
+    if (typeof listUri !== "string" || !listUri.startsWith("at://")) continue;
+
+    const listBlocks = await allBacklinks(
+      listUri,
+      LISTBLOCK_SUBJECT_SOURCE,
+      MAX_BACKLINK_PAGES,
+    );
+    const blockRows = listBlocks
+      .filter((row) => row.collection === BSKY_LISTBLOCK_NSID)
+      .filter((row) => row.did !== did)
+      .map((row) => ({
+        uri: `at://${row.did}/${BSKY_LISTBLOCK_NSID}/${row.rkey}`,
+        cid: null,
+        blockerDid: row.did,
+        rkey: row.rkey,
+        listUri,
+        createdAt: null,
+        deleted: false,
+        updatedAt: sql`now()`,
+      }));
+    if (blockRows.length === 0) continue;
+
+    // Store the reader's membership so the `list-blocked-by` branch can join
+    // through it. The rest of the list is deliberately not mirrored.
+    await db
+      .insert(schema.blockListItems)
+      .values({ uri: itemUri, listUri, subjectDid: did })
+      .onConflictDoUpdate({
+        target: schema.blockListItems.uri,
+        set: { listUri, subjectDid: did, indexedAt: sql`now()` },
+      });
+
+    const bl = schema.blockLists;
+    await db
+      .insert(bl)
+      .values(blockRows)
+      .onConflictDoUpdate({
+        target: bl.uri,
+        set: { deleted: false, updatedAt: sql`now()` },
+      });
+    blockers += blockRows.length;
+  }
+  return blockers;
+}
+
+// ── Entry points ────────────────────────────────────────────────────────────
+
+/**
+ * Mirror everything blocking-related for one reader.
+ *
+ * Best-effort per source: a Constellation outage or an unreachable list must
+ * not throw away the sources that did answer, and must never leave the reader
+ * with *fewer* blocks enforced than before. The outgoing halves — the reader's
+ * own decisions, read from their own repo — are the ones that replace state;
+ * the incoming halves only ever add.
+ */
+export async function syncReaderBlocks(did: string): Promise<BlockSyncResult> {
+  const result: BlockSyncResult = { outgoing: 0, incoming: 0, lists: 0 };
+  const errors: Array<string> = [];
+
+  const { pds } = await resolveIdentity(did);
+
+  try {
+    const outgoing = await readOutgoingBlocks(did, pds);
+    await replaceOutgoingBlocks(did, outgoing);
+    result.outgoing = outgoing.length;
+  } catch (error) {
+    errors.push(`outgoing blocks: ${errorMessage(error)}`);
+  }
+
+  try {
+    const listBlocks = await readOutgoingListBlocks(did, pds);
+    await replaceOutgoingListBlocks(did, listBlocks);
+    result.lists = listBlocks.length;
+    for (const listBlock of listBlocks) {
+      await syncListMembership(listBlock.listUri);
+    }
+  } catch (error) {
+    errors.push(`block lists: ${errorMessage(error)}`);
+  }
+
+  try {
+    result.incoming = await syncIncomingBlocks(did);
+  } catch (error) {
+    errors.push(`incoming blocks: ${errorMessage(error)}`);
+  }
+
+  try {
+    await syncIncomingListBlocks(did, pds);
+  } catch (error) {
+    errors.push(`incoming list blocks: ${errorMessage(error)}`);
+  }
+
+  const error = errors.length > 0 ? errors.join("; ") : null;
+  if (error) result.error = error;
+
+  const state = schema.blockSyncState;
+  await db
+    .insert(state)
+    .values({
+      did,
+      outgoingCount: result.outgoing,
+      incomingCount: result.incoming,
+      listCount: result.lists,
+      lastError: error,
+      syncedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: state.did,
+      set: {
+        outgoingCount: result.outgoing,
+        incomingCount: result.incoming,
+        listCount: result.lists,
+        lastError: error,
+        syncedAt: sql`now()`,
+      },
+    });
+
+  return result;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "unknown error";
+}
+
+/**
+ * Re-read just the reader's own block records, right now.
+ *
+ * Called straight after a block/unblock write so the change is enforced on the
+ * very next page rather than at the end of the sync cadence — blocking someone
+ * and still seeing them would read as the block having failed.
+ */
+export async function refreshOutgoingBlocks(did: string): Promise<void> {
+  const { pds } = await resolveIdentity(did);
+  const outgoing = await readOutgoingBlocks(did, pds);
+  await replaceOutgoingBlocks(did, outgoing);
+}
+
+/**
+ * How long a reader's mirrored blocks are trusted before the next sweep.
+ *
+ * Short enough that a block made on Bluesky takes effect here within the same
+ * session, long enough that an active reader isn't re-walking their repo and
+ * two Constellation indexes on every page load.
+ */
+const SYNC_TTL_MS = 15 * 60 * 1000;
+
+/** Readers whose sync is running in this process, so requests can't stampede. */
+const inFlight = new Set<string>();
+
+/**
+ * Readers checked recently, so the common case ("synced eight minutes ago")
+ * costs nothing. Separate from the DB stamp because it is consulted on every
+ * request for every signed-in reader.
+ */
+const checkedUntil = new Map<string, number>();
+
+/**
+ * Start this reader's block sync in the background, if it's due.
+ *
+ * Returns immediately — **nothing awaits the sync**. It is called from request
+ * paths (the OAuth callback and the signed-in shell read), and a reader should
+ * never wait on a block sweep to see a page. Safe to call on every request: the
+ * in-process guards and the DB stamp make the common case free.
+ */
+export function scheduleReaderBlockSync(did: string): void {
+  const checked = checkedUntil.get(did);
+  if (checked !== undefined && checked > Date.now()) return;
+  if (inFlight.has(did)) return;
+  inFlight.add(did);
+
+  void (async () => {
+    try {
+      const rows = await db
+        .select({ syncedAt: schema.blockSyncState.syncedAt })
+        .from(schema.blockSyncState)
+        .where(eq(schema.blockSyncState.did, did))
+        .limit(1);
+      const syncedAt = rows[0]?.syncedAt;
+      if (syncedAt && Date.now() - syncedAt.getTime() < SYNC_TTL_MS) {
+        checkedUntil.set(did, syncedAt.getTime() + SYNC_TTL_MS);
+        return;
+      }
+
+      const result = await syncReaderBlocks(did);
+      checkedUntil.set(did, Date.now() + SYNC_TTL_MS);
+      if (result.error) {
+        console.warn(`Block sync for ${did} partially failed:`, result.error);
+      }
+    } catch (error) {
+      console.warn("Background block sync failed:", error);
+      // Back off on failure too, so a persistently failing sweep doesn't retry
+      // on every request the reader makes.
+      checkedUntil.set(did, Date.now() + SYNC_TTL_MS);
+    } finally {
+      inFlight.delete(did);
+    }
+  })();
+}
+
+/**
+ * Mirror the membership of a list the reader just blocked, without waiting for
+ * the next sweep. Forced past the TTL: they blocked it *now*.
+ */
+export async function syncBlockedList(listUri: string): Promise<void> {
+  await syncListMembership(listUri, true);
+}
+
+/** DIDs on a mirrored list, for surfaces that explain a list block. */
+export async function listMemberDids(
+  listUri: string,
+  limit: number,
+): Promise<Array<string>> {
+  const bli = schema.blockListItems;
+  const rows = await db
+    .select({ subjectDid: bli.subjectDid })
+    .from(bli)
+    .where(eq(bli.listUri, listUri))
+    .limit(limit);
+  return rows.map((row) => row.subjectDid);
+}
+
+/** Whether any of `dids` sits on a mirrored list (diagnostics + tests). */
+export async function listsContaining(
+  dids: Array<string>,
+): Promise<Array<{ listUri: string; subjectDid: string }>> {
+  if (dids.length === 0) return [];
+  const bli = schema.blockListItems;
+  return db
+    .select({ listUri: bli.listUri, subjectDid: bli.subjectDid })
+    .from(bli)
+    .where(inArray(bli.subjectDid, dids));
+}

--- a/apps/standard-reader/src/server/blocks/sync.server.ts
+++ b/apps/standard-reader/src/server/blocks/sync.server.ts
@@ -27,7 +27,7 @@
  * lets the work land in the DB for the reader's next load.
  */
 
-import { and, eq, inArray, notInArray, sql } from "drizzle-orm";
+import { and, eq, inArray, ne, notInArray, sql } from "drizzle-orm";
 
 import { db } from "#/db/index.server";
 import * as schema from "#/db/schema";
@@ -37,6 +37,7 @@ import {
   listRepoRecords,
 } from "#/server/atproto/fetch-record";
 import { resolveIdentity } from "#/server/atproto/identity";
+import { invalidateBlockCache } from "#/server/blocks/blocks";
 
 /** Collections we mirror. Third-party (Bluesky) namespace — not ours. */
 export const BSKY_BLOCK_NSID = "app.bsky.graph.block";
@@ -90,6 +91,29 @@ export interface BlockSyncResult {
   error?: string;
 }
 
+/**
+ * Rows per `INSERT` statement.
+ *
+ * Postgres caps a statement at 65535 bind parameters, and a `blocks` row binds
+ * eight columns — so a single `insert().values(rows)` breaks at about 8,000
+ * blocks. That is not a hypothetical size for anyone who has used Bluesky's
+ * moderation tools for a while, and the failure mode is the whole sweep
+ * throwing rather than degrading. Chunking ties the ceiling to this constant
+ * instead of to the widest table.
+ *
+ * The tidy-up `NOT IN`s bind one parameter per URI and are bounded by the same
+ * sets, so they stay well inside the limit at every reachable size.
+ */
+const WRITE_CHUNK = 500;
+
+function chunked<T>(rows: ReadonlyArray<T>): Array<Array<T>> {
+  const out: Array<Array<T>> = [];
+  for (let i = 0; i < rows.length; i += WRITE_CHUNK) {
+    out.push(rows.slice(i, i + WRITE_CHUNK));
+  }
+  return out;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -121,21 +145,33 @@ function parseDate(value: unknown): Date | null {
  * it looks complete. The cap is stated rather than silent: past it, the reader
  * is enforcing the blocks we know about, not every block that exists.
  */
+interface BacklinkSweep {
+  records: Array<{ did: string; collection: string; rkey: string }>;
+  /**
+   * Every page was read — no cursor left when we stopped.
+   *
+   * The difference between "these are the blocks" and "these are *some* of the
+   * blocks", and the only thing that makes it safe to delete rows the sweep
+   * didn't return. A truncated sweep must never be read as a removal.
+   */
+  complete: boolean;
+}
+
 async function allBacklinks(
   target: string,
   source: string,
   maxPages: number,
-): Promise<Array<{ did: string; collection: string; rkey: string }>> {
-  const merged: Array<{ did: string; collection: string; rkey: string }> = [];
+): Promise<BacklinkSweep> {
+  const records: Array<{ did: string; collection: string; rkey: string }> = [];
   let cursor: string | undefined;
   let pages = 0;
   do {
     const page = await getBacklinks({ target, source, cursor, limit: 100 });
-    merged.push(...page.records);
+    records.push(...page.records);
     cursor = page.cursor ?? undefined;
     pages++;
   } while (cursor && pages < maxPages);
-  return merged;
+  return { records, complete: !cursor };
 }
 
 /** Cap on Constellation pages per backlink sweep (100 records per page). */
@@ -176,19 +212,21 @@ async function replaceOutgoingBlocks(
       deleted: false,
       updatedAt: sql`now()`,
     }));
-    await db
-      .insert(b)
-      .values(values)
-      .onConflictDoUpdate({
-        target: b.uri,
-        set: {
-          cid: sql`excluded.cid`,
-          subjectDid: sql`excluded.subject_did`,
-          createdAt: sql`excluded.created_at`,
-          deleted: false,
-          updatedAt: sql`now()`,
-        },
-      });
+    for (const chunk of chunked(values)) {
+      await db
+        .insert(b)
+        .values(chunk)
+        .onConflictDoUpdate({
+          target: b.uri,
+          set: {
+            cid: sql`excluded.cid`,
+            subjectDid: sql`excluded.subject_did`,
+            createdAt: sql`excluded.created_at`,
+            deleted: false,
+            updatedAt: sql`now()`,
+          },
+        });
+    }
   }
 
   const keep = rows.map((row) => row.uri);
@@ -220,30 +258,31 @@ async function replaceOutgoingListBlocks(
 ): Promise<void> {
   const bl = schema.blockLists;
   if (rows.length > 0) {
-    await db
-      .insert(bl)
-      .values(
-        rows.map((row) => ({
-          uri: row.uri,
-          cid: row.cid,
-          blockerDid: row.blockerDid,
-          rkey: row.rkey,
-          listUri: row.listUri,
-          createdAt: row.createdAt,
-          deleted: false,
-          updatedAt: sql`now()`,
-        })),
-      )
-      .onConflictDoUpdate({
-        target: bl.uri,
-        set: {
-          cid: sql`excluded.cid`,
-          listUri: sql`excluded.list_uri`,
-          createdAt: sql`excluded.created_at`,
-          deleted: false,
-          updatedAt: sql`now()`,
-        },
-      });
+    const values = rows.map((row) => ({
+      uri: row.uri,
+      cid: row.cid,
+      blockerDid: row.blockerDid,
+      rkey: row.rkey,
+      listUri: row.listUri,
+      createdAt: row.createdAt,
+      deleted: false,
+      updatedAt: sql`now()`,
+    }));
+    for (const chunk of chunked(values)) {
+      await db
+        .insert(bl)
+        .values(chunk)
+        .onConflictDoUpdate({
+          target: bl.uri,
+          set: {
+            cid: sql`excluded.cid`,
+            listUri: sql`excluded.list_uri`,
+            createdAt: sql`excluded.created_at`,
+            deleted: false,
+            updatedAt: sql`now()`,
+          },
+        });
+    }
   }
 
   const keep = rows.map((row) => row.uri);
@@ -429,23 +468,24 @@ async function syncListMembership(
 
   const bli = schema.blockListItems;
   if (list.items.length > 0) {
-    await db
-      .insert(bli)
-      .values(
-        list.items.map((item) => ({
-          uri: item.uri,
-          listUri,
-          subjectDid: item.subjectDid,
-        })),
-      )
-      .onConflictDoUpdate({
-        target: bli.uri,
-        set: {
-          listUri: sql`excluded.list_uri`,
-          subjectDid: sql`excluded.subject_did`,
-          indexedAt: sql`now()`,
-        },
-      });
+    const values = list.items.map((item) => ({
+      uri: item.uri,
+      listUri,
+      subjectDid: item.subjectDid,
+    }));
+    for (const chunk of chunked(values)) {
+      await db
+        .insert(bli)
+        .values(chunk)
+        .onConflictDoUpdate({
+          target: bli.uri,
+          set: {
+            listUri: sql`excluded.list_uri`,
+            subjectDid: sql`excluded.subject_did`,
+            indexedAt: sql`now()`,
+          },
+        });
+    }
   }
 
   // Drop members removed from the list upstream. Rows are deleted rather than
@@ -497,19 +537,26 @@ async function syncListMembership(
  * blocker DID and rkey directly, so the block row can be built without fetching
  * a single record.
  *
- * Additive, not a replace: these rows describe other people's repos, and this
- * index is best-effort. A sweep that came back short (Constellation down, a
- * partial page) must not be read as "nobody blocks you any more" — that would
- * un-hide content the moment the index hiccuped. Rows do go away, just on the
- * slower path: the blocker's own record read, if they are also a reader here.
+ * **Replaces when the sweep was complete, adds when it wasn't.** A block record
+ * that is gone from the index is an unblock, and it has to take effect: the
+ * blocker is usually not a reader here, so their own record read — the only
+ * other way a row could disappear — never runs, and the block would be
+ * permanent. Nobody can undo a block they never made, so leaving these rows to
+ * accumulate meant an account could be hidden from a reader forever because of
+ * something that stopped being true.
+ *
+ * The safety condition is {@link BacklinkSweep.complete}. A sweep that stopped
+ * at the page cap, or threw partway (the caller's `catch`), never reaches the
+ * delete — under-enforcing a block for one cycle is recoverable, silently
+ * un-hiding someone the reader is blocked by is not.
  */
 async function syncIncomingBlocks(did: string): Promise<number> {
-  const records = await allBacklinks(
+  const sweep = await allBacklinks(
     did,
     BLOCK_SUBJECT_SOURCE,
     MAX_BACKLINK_PAGES,
   );
-  const rows = records
+  const rows = sweep.records
     .filter((record) => record.collection === BSKY_BLOCK_NSID)
     .filter((record) => record.did !== did)
     .map((record) => ({
@@ -522,16 +569,37 @@ async function syncIncomingBlocks(did: string): Promise<number> {
       deleted: false,
       updatedAt: sql`now()`,
     }));
-  if (rows.length === 0) return 0;
 
   const b = schema.blocks;
-  await db
-    .insert(b)
-    .values(rows)
-    .onConflictDoUpdate({
-      target: b.uri,
-      set: { deleted: false, updatedAt: sql`now()` },
-    });
+  if (rows.length > 0) {
+    for (const chunk of chunked(rows)) {
+      await db
+        .insert(b)
+        .values(chunk)
+        .onConflictDoUpdate({
+          target: b.uri,
+          set: { deleted: false, updatedAt: sql`now()` },
+        });
+    }
+  }
+
+  if (sweep.complete) {
+    // Scoped to rows *this* sweep owns: incoming blocks against this reader.
+    // The reader's own outgoing blocks live in the same table and are replaced
+    // by `replaceOutgoingBlocks`, which is the authority for those.
+    const keep = rows.map((row) => row.uri);
+    await db
+      .update(b)
+      .set({ deleted: true, updatedAt: sql`now()` })
+      .where(
+        and(
+          eq(b.subjectDid, did),
+          eq(b.deleted, false),
+          ne(b.blockerDid, did),
+          ...(keep.length > 0 ? [notInArray(b.uri, keep)] : []),
+        ),
+      );
+  }
   return rows.length;
 }
 
@@ -548,13 +616,18 @@ async function syncIncomingListBlocks(
   did: string,
   pds: string | null,
 ): Promise<number> {
-  const records = await allBacklinks(did, LISTITEM_SUBJECT_SOURCE, 1);
-  const listItems = records
-    .filter((record) => record.collection === BSKY_LISTITEM_NSID)
-    .slice(0, MAX_INCOMING_LISTS);
-  if (listItems.length === 0) return 0;
+  const sweep = await allBacklinks(did, LISTITEM_SUBJECT_SOURCE, 1);
+  const allListItems = sweep.records.filter(
+    (record) => record.collection === BSKY_LISTITEM_NSID,
+  );
+  const listItems = allListItems.slice(0, MAX_INCOMING_LISTS);
+
+  // The reader may have been removed from every list they were on, so an empty
+  // sweep is a result, not a no-op — but only a *complete, untruncated* one.
+  const capped = !sweep.complete || listItems.length < allListItems.length;
 
   let blockers = 0;
+  const seenMemberships: Array<string> = [];
   for (const item of listItems) {
     const itemUri = `at://${item.did}/${BSKY_LISTITEM_NSID}/${item.rkey}`;
     const record = await fetchRepoRecordWithFallback(itemUri, pds);
@@ -562,12 +635,12 @@ async function syncIncomingListBlocks(
     const listUri = isRecord(value) ? value.list : null;
     if (typeof listUri !== "string" || !listUri.startsWith("at://")) continue;
 
-    const listBlocks = await allBacklinks(
+    const listBlockSweep = await allBacklinks(
       listUri,
       LISTBLOCK_SUBJECT_SOURCE,
       MAX_BACKLINK_PAGES,
     );
-    const blockRows = listBlocks
+    const blockRows = listBlockSweep.records
       .filter((row) => row.collection === BSKY_LISTBLOCK_NSID)
       .filter((row) => row.did !== did)
       .map((row) => ({
@@ -580,10 +653,10 @@ async function syncIncomingListBlocks(
         deleted: false,
         updatedAt: sql`now()`,
       }));
-    if (blockRows.length === 0) continue;
 
     // Store the reader's membership so the `list-blocked-by` branch can join
     // through it. The rest of the list is deliberately not mirrored.
+    seenMemberships.push(itemUri);
     await db
       .insert(schema.blockListItems)
       .values({ uri: itemUri, listUri, subjectDid: did })
@@ -593,14 +666,64 @@ async function syncIncomingListBlocks(
       });
 
     const bl = schema.blockLists;
-    await db
-      .insert(bl)
-      .values(blockRows)
-      .onConflictDoUpdate({
-        target: bl.uri,
-        set: { deleted: false, updatedAt: sql`now()` },
-      });
+    if (blockRows.length > 0) {
+      for (const chunk of chunked(blockRows)) {
+        await db
+          .insert(bl)
+          .values(chunk)
+          .onConflictDoUpdate({
+            target: bl.uri,
+            set: { deleted: false, updatedAt: sql`now()` },
+          });
+      }
+    }
+
+    // Same reasoning as `syncIncomingBlocks`: an unsubscribed listblock has to
+    // stop applying, and its author is almost never a reader here, so nothing
+    // else would ever retire the row. Scoped to this list and to blockers other
+    // than the reader, so their own listblocks stay `replaceOutgoingListBlocks`'
+    // business.
+    if (listBlockSweep.complete) {
+      const keep = blockRows.map((row) => row.uri);
+      await db
+        .update(bl)
+        .set({ deleted: true, updatedAt: sql`now()` })
+        .where(
+          and(
+            eq(bl.listUri, listUri),
+            eq(bl.deleted, false),
+            ne(bl.blockerDid, did),
+            ...(keep.length > 0 ? [notInArray(bl.uri, keep)] : []),
+          ),
+        );
+    }
     blockers += blockRows.length;
+  }
+
+  // Memberships the reader has left, so a list they were removed from stops
+  // blocking them.
+  //
+  // Restricted to lists this function is the *only* writer of. A list somebody
+  // here blocks is mirrored in full by `syncListMembership` and has a
+  // `block_list_sync_state` row; deleting the reader's membership out of one of
+  // those on a Constellation hiccup would quietly weaken that list's block for
+  // whoever subscribed to it, and it would stay weakened until the 12h refresh.
+  // Lists reached only through this sweep have no such row, and only ever hold
+  // the reader's own membership.
+  if (!capped) {
+    const bli = schema.blockListItems;
+    const ls = schema.blockListSyncState;
+    await db
+      .delete(bli)
+      .where(
+        and(
+          eq(bli.subjectDid, did),
+          sql`not exists (select 1 from ${ls} where ${ls.listUri} = ${bli.listUri})`,
+          ...(seenMemberships.length > 0
+            ? [notInArray(bli.uri, seenMemberships)]
+            : []),
+        ),
+      );
   }
   return blockers;
 }
@@ -611,12 +734,31 @@ async function syncIncomingListBlocks(
  * Mirror everything blocking-related for one reader.
  *
  * Best-effort per source: a Constellation outage or an unreachable list must
- * not throw away the sources that did answer, and must never leave the reader
- * with *fewer* blocks enforced than before. The outgoing halves — the reader's
- * own decisions, read from their own repo — are the ones that replace state;
- * the incoming halves only ever add.
+ * not throw away the sources that did answer. The outgoing halves — the
+ * reader's own decisions, read from their own repo — replace state
+ * unconditionally; the incoming halves replace only when their sweep came back
+ * complete (see {@link syncIncomingBlocks}).
+ *
+ * **One sweep per reader at a time, process-wide.** A full sweep is dozens to
+ * hundreds of round trips against Constellation and the AppView; two of them
+ * racing for the same reader would double that load to write the same rows, and
+ * their interleaved replace-then-delete passes could each treat the other's
+ * half-written state as authority. Concurrent callers await the run already in
+ * flight instead of starting a second one.
  */
 export async function syncReaderBlocks(did: string): Promise<BlockSyncResult> {
+  const running = inFlight.get(did);
+  if (running) return running;
+  const run = syncReaderBlocksUncoordinated(did).finally(() => {
+    inFlight.delete(did);
+  });
+  inFlight.set(did, run);
+  return run;
+}
+
+async function syncReaderBlocksUncoordinated(
+  did: string,
+): Promise<BlockSyncResult> {
   const result: BlockSyncResult = { outgoing: 0, incoming: 0, lists: 0 };
   const errors: Array<string> = [];
 
@@ -635,7 +777,13 @@ export async function syncReaderBlocks(did: string): Promise<BlockSyncResult> {
     await replaceOutgoingListBlocks(did, listBlocks);
     result.lists = listBlocks.length;
     for (const listBlock of listBlocks) {
-      await syncListMembership(listBlock.listUri);
+      // Per-list `try`: one unreachable moderation list must not cost the
+      // reader the membership of the others they subscribe to.
+      try {
+        await syncListMembership(listBlock.listUri);
+      } catch (error) {
+        errors.push(`list ${listBlock.listUri}: ${errorMessage(error)}`);
+      }
     }
   } catch (error) {
     errors.push(`block lists: ${errorMessage(error)}`);
@@ -696,6 +844,28 @@ export async function refreshOutgoingBlocks(did: string): Promise<void> {
   const { pds } = await resolveIdentity(did);
   const outgoing = await readOutgoingBlocks(did, pds);
   await replaceOutgoingBlocks(did, outgoing);
+  // The read path caches "does this reader block anybody" for a minute; a block
+  // they just made has to beat that cache or the next page still shows the
+  // account they blocked.
+  invalidateBlockCache(did);
+  checkedUntil.delete(did);
+}
+
+/**
+ * {@link refreshOutgoingBlocks} for the reader's `listblock` records.
+ *
+ * Deliberately does *not* expand the lists it finds — that is what
+ * {@link syncBlockedList} and the background sweep are for. This is the part a
+ * caller can await on a request: one `listRecords` read, so the settings page
+ * shows the list the reader just subscribed to (or stops showing the one they
+ * left) on the very next paint.
+ */
+export async function refreshOutgoingListBlocks(did: string): Promise<void> {
+  const { pds } = await resolveIdentity(did);
+  const listBlocks = await readOutgoingListBlocks(did, pds);
+  await replaceOutgoingListBlocks(did, listBlocks);
+  invalidateBlockCache(did);
+  checkedUntil.delete(did);
 }
 
 /**
@@ -707,8 +877,15 @@ export async function refreshOutgoingBlocks(did: string): Promise<void> {
  */
 const SYNC_TTL_MS = 15 * 60 * 1000;
 
-/** Readers whose sync is running in this process, so requests can't stampede. */
-const inFlight = new Set<string>();
+/**
+ * Sweeps running in this process, keyed by reader.
+ *
+ * Holds the promise rather than a marker so a second caller can await the run
+ * already in flight — {@link syncReaderBlocks} is reachable from a request
+ * handler (blocking a list) as well as from the background scheduler, and those
+ * two must never sweep the same reader at once.
+ */
+const inFlight = new Map<string, Promise<BlockSyncResult>>();
 
 /**
  * Readers checked recently, so the common case ("synced eight minutes ago")
@@ -718,34 +895,55 @@ const inFlight = new Set<string>();
 const checkedUntil = new Map<string, number>();
 
 /**
+ * Cap on {@link checkedUntil}. It is written for every signed-in reader who
+ * makes a request and nothing ever removes an entry, so on a long-lived server
+ * it is otherwise a slow leak — one that grows with the user base rather than
+ * with traffic, which is exactly the kind that survives every load test.
+ * Clearing wholesale is safe: a dropped entry costs one indexed lookup.
+ */
+const CHECKED_CACHE_MAX = 10_000;
+
+function markChecked(did: string, until: number): void {
+  if (checkedUntil.size >= CHECKED_CACHE_MAX) checkedUntil.clear();
+  checkedUntil.set(did, until);
+}
+
+/**
  * Start this reader's block sync in the background, if it's due.
  *
  * Returns immediately — **nothing awaits the sync**. It is called from request
  * paths (the OAuth callback and the signed-in shell read), and a reader should
  * never wait on a block sweep to see a page. Safe to call on every request: the
  * in-process guards and the DB stamp make the common case free.
+ *
+ * `force` skips the TTL but not the in-flight guard: it is what the settings
+ * page's Refresh button uses, and pressing it twice must not start two sweeps.
  */
-export function scheduleReaderBlockSync(did: string): void {
-  const checked = checkedUntil.get(did);
-  if (checked !== undefined && checked > Date.now()) return;
+export function scheduleReaderBlockSync(did: string, force = false): void {
+  if (!force) {
+    const checked = checkedUntil.get(did);
+    if (checked !== undefined && checked > Date.now()) return;
+  }
   if (inFlight.has(did)) return;
-  inFlight.add(did);
 
   void (async () => {
     try {
-      const rows = await db
-        .select({ syncedAt: schema.blockSyncState.syncedAt })
-        .from(schema.blockSyncState)
-        .where(eq(schema.blockSyncState.did, did))
-        .limit(1);
-      const syncedAt = rows[0]?.syncedAt;
-      if (syncedAt && Date.now() - syncedAt.getTime() < SYNC_TTL_MS) {
-        checkedUntil.set(did, syncedAt.getTime() + SYNC_TTL_MS);
-        return;
+      if (!force) {
+        const rows = await db
+          .select({ syncedAt: schema.blockSyncState.syncedAt })
+          .from(schema.blockSyncState)
+          .where(eq(schema.blockSyncState.did, did))
+          .limit(1);
+        const syncedAt = rows[0]?.syncedAt;
+        if (syncedAt && Date.now() - syncedAt.getTime() < SYNC_TTL_MS) {
+          markChecked(did, syncedAt.getTime() + SYNC_TTL_MS);
+          return;
+        }
       }
 
       const result = await syncReaderBlocks(did);
-      checkedUntil.set(did, Date.now() + SYNC_TTL_MS);
+      markChecked(did, Date.now() + SYNC_TTL_MS);
+      invalidateBlockCache(did);
       if (result.error) {
         console.warn(`Block sync for ${did} partially failed:`, result.error);
       }
@@ -753,9 +951,7 @@ export function scheduleReaderBlockSync(did: string): void {
       console.warn("Background block sync failed:", error);
       // Back off on failure too, so a persistently failing sweep doesn't retry
       // on every request the reader makes.
-      checkedUntil.set(did, Date.now() + SYNC_TTL_MS);
-    } finally {
-      inFlight.delete(did);
+      markChecked(did, Date.now() + SYNC_TTL_MS);
     }
   })();
 }
@@ -763,9 +959,25 @@ export function scheduleReaderBlockSync(did: string): void {
 /**
  * Mirror the membership of a list the reader just blocked, without waiting for
  * the next sweep. Forced past the TTL: they blocked it *now*.
+ *
+ * Returns how many members were mirrored and whether the list ran past the
+ * cap, so the UI can say "blocking 4,200 accounts" — or admit the block is
+ * partial — instead of implying a list of any size was taken in whole.
  */
-export async function syncBlockedList(listUri: string): Promise<void> {
+export async function syncBlockedList(
+  listUri: string,
+): Promise<{ memberCount: number; truncated: boolean }> {
   await syncListMembership(listUri, true);
+  const ls = schema.blockListSyncState;
+  const [row] = await db
+    .select({ itemCount: ls.itemCount, truncated: ls.truncated })
+    .from(ls)
+    .where(eq(ls.listUri, listUri))
+    .limit(1);
+  return {
+    memberCount: row?.itemCount ?? 0,
+    truncated: row?.truncated ?? false,
+  };
 }
 
 /** DIDs on a mirrored list, for surfaces that explain a list block. */

--- a/apps/standard-reader/src/server/digest/builder.ts
+++ b/apps/standard-reader/src/server/digest/builder.ts
@@ -22,6 +22,7 @@ import type {
   PublicationCard,
   Schema,
 } from "#/integrations/tanstack-query/api-shapes";
+import { filterBlockedCards } from "#/server/blocks/blocks";
 import {
   bestOfFollows,
   recommendedPublications,
@@ -161,5 +162,29 @@ export async function buildDigestForUser(
       : Promise.resolve([]),
   ]);
 
-  return { articles, networkArticles, saved, recommendations };
+  // Blocks applied last, over every section at once.
+  //
+  // The digest is the one surface that arrives uninvited: a reader who blocked
+  // someone does not get to close the tab if their writing turns up in an
+  // email, and an inbox keeps it for as long as they keep the message. `saved`
+  // is filtered too — a bookmark made before the block is still the reader's,
+  // but mailing it to them is not the same as leaving it in their list.
+  const [
+    visibleArticles,
+    visibleNetwork,
+    visibleSaved,
+    visibleRecommendations,
+  ] = await Promise.all([
+    filterBlockedCards(db, schema, did, articles),
+    filterBlockedCards(db, schema, did, networkArticles),
+    filterBlockedCards(db, schema, did, saved),
+    filterBlockedCards(db, schema, did, recommendations),
+  ]);
+
+  return {
+    articles: visibleArticles,
+    networkArticles: visibleNetwork,
+    saved: visibleSaved,
+    recommendations: visibleRecommendations,
+  };
 }

--- a/apps/standard-reader/src/server/extension/discussion.server.ts
+++ b/apps/standard-reader/src/server/extension/discussion.server.ts
@@ -5,7 +5,7 @@ import type { db } from "#/db/index.server";
 import type * as schema from "#/db/schema";
 import type { ArticleCard } from "#/integrations/tanstack-query/api-shapes";
 import { getPublicUrl } from "#/lib/public-url";
-import { filterBlockedCards } from "#/server/blocks/blocks";
+import { blockFilterDid, filterBlockedCards } from "#/server/blocks/blocks";
 import { buildCanonicalUrl } from "#/server/ingest/mappers";
 import {
   fetchCitedInArticles,
@@ -122,10 +122,10 @@ export async function resolveDiscussion(
   );
 
   if (!row) {
-    const discussions = await commentsPromise;
+    const { comments } = await commentsPromise;
     return {
       keepReading: [],
-      discussions: discussions.map((comment) => toDiscussionComment(comment)),
+      discussions: comments.map((comment) => toDiscussionComment(comment)),
       relatedReading: [],
       citedIn: [],
     };
@@ -134,6 +134,8 @@ export async function resolveDiscussion(
   const canonicalUrl =
     row.canonicalUrl ?? buildCanonicalUrl(row.publicationUrl, row.path);
   const linkUrls = canonicalUrl ? [canonicalUrl] : [];
+
+  const blockDid = await blockFilterDid(dbClient, schemaModule, viewerDid);
 
   const [
     discussions,
@@ -147,7 +149,7 @@ export async function resolveDiscussion(
       ? selectArticleCards(dbClient, schemaModule, {
           publicationUris: [row.publicationUri],
           limit: 4,
-          viewerDid: viewerDid ?? undefined,
+          viewerDid: blockDid,
         })
       : Promise.resolve([]),
     relatedArticles(dbClient, schemaModule, {
@@ -208,7 +210,9 @@ export async function resolveDiscussion(
     keepReading: moreFromWithComments.map((article) =>
       toDiscussionArticle(article),
     ),
-    discussions: discussions.map((comment) => toDiscussionComment(comment)),
+    discussions: discussions.comments.map((comment) =>
+      toDiscussionComment(comment),
+    ),
     relatedReading: mergeRelatedReading(marginConnections, relatedWithComments),
     citedIn: citedInWithComments.map((article) => toDiscussionArticle(article)),
   };

--- a/apps/standard-reader/src/server/extension/discussion.server.ts
+++ b/apps/standard-reader/src/server/extension/discussion.server.ts
@@ -5,6 +5,7 @@ import type { db } from "#/db/index.server";
 import type * as schema from "#/db/schema";
 import type { ArticleCard } from "#/integrations/tanstack-query/api-shapes";
 import { getPublicUrl } from "#/lib/public-url";
+import { filterBlockedCards } from "#/server/blocks/blocks";
 import { buildCanonicalUrl } from "#/server/ingest/mappers";
 import {
   fetchCitedInArticles,
@@ -88,7 +89,14 @@ export async function resolveDiscussion(
   dbClient: typeof db,
   schemaModule: typeof schema,
   documentUri: string,
-  { excludeWebBridge = false }: { excludeWebBridge?: boolean } = {},
+  {
+    excludeWebBridge = false,
+    viewerDid,
+  }: {
+    excludeWebBridge?: boolean;
+    /** The reader this panel is for, so their blocks apply here too. */
+    viewerDid?: string | null;
+  } = {},
 ): Promise<ExtensionDiscussionResponse> {
   const d = schemaModule.documents;
   const p = schemaModule.publications;
@@ -110,6 +118,7 @@ export async function resolveDiscussion(
     dbClient,
     schemaModule,
     documentUri,
+    viewerDid,
   );
 
   if (!row) {
@@ -138,6 +147,7 @@ export async function resolveDiscussion(
       ? selectArticleCards(dbClient, schemaModule, {
           publicationUris: [row.publicationUri],
           limit: 4,
+          viewerDid: viewerDid ?? undefined,
         })
       : Promise.resolve([]),
     relatedArticles(dbClient, schemaModule, {
@@ -145,13 +155,17 @@ export async function resolveDiscussion(
       publicationUri: row.publicationUri,
       limit: 8,
       excludeWebBridge,
-    }),
+    }).then((rows) =>
+      filterBlockedCards(dbClient, schemaModule, viewerDid, rows),
+    ),
     linkUrls.length > 0
       ? fetchCitedInArticles(dbClient, schemaModule, {
           urls: linkUrls,
           excludeDocumentUri: row.uri,
           limit: 8,
-        })
+        }).then((rows) =>
+          filterBlockedCards(dbClient, schemaModule, viewerDid, rows),
+        )
       : Promise.resolve([]),
     linkUrls.length > 0
       ? fetchMarginConnections(dbClient, schemaModule, {

--- a/apps/standard-reader/src/server/push/fan-out.ts
+++ b/apps/standard-reader/src/server/push/fan-out.ts
@@ -4,6 +4,9 @@ import { articleReaderUrl } from "#/components/reader/format";
 
 import { db } from "../../db/index.ts";
 import {
+  blockListItems,
+  blockLists,
+  blocks,
   documentContributors,
   documents,
   profiles,
@@ -176,7 +179,7 @@ export async function resolveTargets(
     .from(pushTopics)
     .where(publicationMatch ? or(authorMatch, publicationMatch) : authorMatch);
 
-  return db
+  const targets = await db
     .selectDistinct({
       endpoint: pushDevices.endpoint,
       p256dh: pushDevices.p256dh,
@@ -185,6 +188,89 @@ export async function resolveTargets(
     })
     .from(pushDevices)
     .where(inArray(pushDevices.ownerDid, optedIn));
+
+  // A block outranks the bell. The opt-in is honoured as written everywhere
+  // else in this file, but "notify me about this source" was said before the
+  // block, and a push notification is the loudest thing this app does — it
+  // arrives on a lock screen whether or not the reader opened the app. Someone
+  // who blocked an account should not learn what they published from a buzz.
+  //
+  // Filtered per recipient rather than per document: the same post is blocked
+  // for one subscriber and fine for another.
+  const blocked = await blockedRecipients(targets, subjectDids);
+  return blocked.size === 0
+    ? targets
+    : targets.filter((target) => !blocked.has(target.ownerDid));
+}
+
+/**
+ * Which recipients are blocked from any of a document's accounts.
+ *
+ * Four queries for the whole fan-out rather than four per recipient — a widely
+ * followed publication can have thousands of opted-in devices, and this runs
+ * once per published document. Each is an index probe over two bounded `IN`
+ * lists (the recipients, and the document's author + contributors + owner).
+ *
+ * Mirrors the four directions in `server/blocks/blocks.ts`; a block hides
+ * content whichever way it runs.
+ */
+async function blockedRecipients(
+  targets: Array<PushTarget>,
+  subjectDids: Array<string>,
+): Promise<Set<string>> {
+  const owners = [...new Set(targets.map((target) => target.ownerDid))];
+  if (owners.length === 0 || subjectDids.length === 0) return new Set();
+
+  const [blocking, blockedBy, listBlocking, listBlockedBy] = await Promise.all([
+    db
+      .selectDistinct({ did: blocks.blockerDid })
+      .from(blocks)
+      .where(
+        and(
+          eq(blocks.deleted, false),
+          inArray(blocks.blockerDid, owners),
+          inArray(blocks.subjectDid, subjectDids),
+        ),
+      ),
+    db
+      .selectDistinct({ did: blocks.subjectDid })
+      .from(blocks)
+      .where(
+        and(
+          eq(blocks.deleted, false),
+          inArray(blocks.subjectDid, owners),
+          inArray(blocks.blockerDid, subjectDids),
+        ),
+      ),
+    db
+      .selectDistinct({ did: blockLists.blockerDid })
+      .from(blockLists)
+      .innerJoin(blockListItems, eq(blockListItems.listUri, blockLists.listUri))
+      .where(
+        and(
+          eq(blockLists.deleted, false),
+          inArray(blockLists.blockerDid, owners),
+          inArray(blockListItems.subjectDid, subjectDids),
+        ),
+      ),
+    db
+      .selectDistinct({ did: blockListItems.subjectDid })
+      .from(blockLists)
+      .innerJoin(blockListItems, eq(blockListItems.listUri, blockLists.listUri))
+      .where(
+        and(
+          eq(blockLists.deleted, false),
+          inArray(blockListItems.subjectDid, owners),
+          inArray(blockLists.blockerDid, subjectDids),
+        ),
+      ),
+  ]);
+
+  const blocked = new Set<string>();
+  for (const rows of [blocking, blockedBy, listBlocking, listBlockedBy]) {
+    for (const row of rows) blocked.add(row.did);
+  }
+  return blocked;
 }
 
 /**

--- a/apps/standard-reader/src/server/reader/bsky-friends.ts
+++ b/apps/standard-reader/src/server/reader/bsky-friends.ts
@@ -31,6 +31,7 @@ import {
   toPublicationCard,
 } from "#/integrations/tanstack-query/api-shapes";
 import { followedDidsForActor } from "#/server/atproto/bsky-relationships";
+import { filterBlockedCards } from "#/server/blocks/blocks";
 import { documentPublishedNotInFuture } from "#/server/reader/document-filters";
 import { discoverEligiblePublicationWhere } from "#/server/reader/publication-filters";
 
@@ -448,13 +449,19 @@ async function resolveFriendPublications(
   ]);
   const subscribed = new Set(subscribedRows.map((row) => row.uri));
 
-  // Blocked owners are dropped by `blockedFriendPublicationUris`, applied by the
-  // callers rather than here: this module is reachable from the client bundle,
-  // so it must not import the server-only block reader. Following someone on
-  // Bluesky and being blocked by them is not a contradiction — a block is
-  // one-sided, and the follow can predate it.
+  // Filtered here rather than by the callers, and *before* ranking, because
+  // everything the callers derive comes off this one list: the headline
+  // publication and people counts, the avatar stack in the Discover prompt, the
+  // page slice and its `nextOffset`. Filtering a page afterwards left the counts
+  // describing a set that included blocked accounts, and put their avatars and
+  // handles in the prompt — the block visibly not applying, on the surface that
+  // exists to introduce people.
+  //
+  // Following someone on Bluesky and being blocked by them is not a
+  // contradiction: a block is one-sided, and the follow can predate it.
+  const ranked = rankFriendPublications(followedDids, byAuthor, subscribed);
   return {
-    publications: rankFriendPublications(followedDids, byAuthor, subscribed),
+    publications: await filterBlockedCards(db, schema, readerDid, ranked),
     degraded,
     truncated,
   };

--- a/apps/standard-reader/src/server/reader/bsky-friends.ts
+++ b/apps/standard-reader/src/server/reader/bsky-friends.ts
@@ -448,6 +448,11 @@ async function resolveFriendPublications(
   ]);
   const subscribed = new Set(subscribedRows.map((row) => row.uri));
 
+  // Blocked owners are dropped by `blockedFriendPublicationUris`, applied by the
+  // callers rather than here: this module is reachable from the client bundle,
+  // so it must not import the server-only block reader. Following someone on
+  // Bluesky and being blocked by them is not a contradiction — a block is
+  // one-sided, and the follow can predate it.
   return {
     publications: rankFriendPublications(followedDids, byAuthor, subscribed),
     degraded,

--- a/apps/standard-reader/src/server/reader/document-comments.test.ts
+++ b/apps/standard-reader/src/server/reader/document-comments.test.ts
@@ -170,8 +170,11 @@ describe("document comment counts", () => {
       DOCUMENT_URI,
     );
 
-    expect(comments.map((comment) => comment.postUri)).toEqual([sharedUri]);
-    expect(count).toBe(comments.length);
+    expect(comments.comments.map((comment) => comment.postUri)).toEqual([
+      sharedUri,
+    ]);
+    expect(count).toBe(comments.comments.length);
+    expect(comments.hiddenByBlocks).toBe(0);
   });
 
   it("counts merged non-Bluesky sources as rendered items", async () => {
@@ -214,7 +217,7 @@ describe("document comment counts", () => {
       DOCUMENT_URI,
     );
 
-    expect(comments).toHaveLength(1);
+    expect(comments.comments).toHaveLength(1);
     expect(count).toBe(1);
   });
 
@@ -251,7 +254,7 @@ describe("document comment counts", () => {
       DOCUMENT_URI,
     );
 
-    expect(reloaded).toHaveLength(2);
+    expect(reloaded.comments).toHaveLength(2);
     await expect(
       countDocumentComments(dbClient, fakeSchema, DOCUMENT_URI),
     ).resolves.toBe(2);

--- a/apps/standard-reader/src/server/reader/document-comments.ts
+++ b/apps/standard-reader/src/server/reader/document-comments.ts
@@ -23,6 +23,7 @@ import {
 } from "#/server/atproto/bsky-posts";
 import { getPostBacklinksForTarget } from "#/server/atproto/constellation";
 import { fetchMarginNotesForUrls } from "#/server/atproto/margin-notes";
+import { blockedDidsAmong } from "#/server/blocks/blocks";
 import { buildCanonicalUrl } from "#/server/ingest/mappers";
 import type { LeafletCommentContext } from "#/server/leaflet/comments";
 import { fetchLeafletCommentsForDocument } from "#/server/leaflet/comments";
@@ -545,12 +546,29 @@ export async function attachCommentCountsToArticles<
  * The Discussion items for a document, rebuilt on every request so an open
  * thread is never stale. The build also refreshes this document's badge count.
  */
-export function fetchDocumentComments(
+export async function fetchDocumentComments(
   dbClient: typeof db,
   schemaModule: typeof schema,
   documentUri: string,
+  /**
+   * The reader this discussion is being rendered for. Comments by an account
+   * they are blocked from are dropped — a block that hides someone's writing
+   * but leaves their replies under it hasn't hidden them.
+   */
+  viewerDid?: string | null,
 ): Promise<Array<DocumentComment>> {
-  return loadDocumentComments(dbClient, schemaModule, documentUri, "fresh");
+  // Filtered *after* the cache, never inside it: the cache is keyed by document
+  // alone, so filtering during the build would let the first reader to open a
+  // thread decide what every later reader sees. The badge count is the cached
+  // (unfiltered) length for the same reason — a per-reader count would need a
+  // per-reader cache, and a badge one too high is a smaller wrong than a
+  // blocked reply showing up in somebody else's thread.
+  return filterBlockedComments(
+    dbClient,
+    schemaModule,
+    viewerDid,
+    await loadDocumentComments(dbClient, schemaModule, documentUri, "fresh"),
+  );
 }
 
 async function buildDocumentComments(
@@ -619,4 +637,29 @@ async function buildDocumentComments(
   return comments.toSorted(
     (a, b) => new Date(a.indexedAt).getTime() - new Date(b.indexedAt).getTime(),
   );
+}
+
+/**
+ * Drop comments whose author the reader is blocked from.
+ *
+ * These come from Bluesky, Margin, Semble, pckt and Leaflet rather than our
+ * read-model, so there is no query to filter — the authors are resolved and
+ * checked after the fact.
+ */
+async function filterBlockedComments(
+  dbClient: typeof db,
+  schemaModule: typeof schema,
+  viewerDid: string | null | undefined,
+  comments: Array<DocumentComment>,
+): Promise<Array<DocumentComment>> {
+  if (!viewerDid || comments.length === 0) return comments;
+  const blocked = await blockedDidsAmong(
+    dbClient,
+    schemaModule,
+    viewerDid,
+    comments.map((comment) => comment.author.did),
+  );
+  return blocked.size === 0
+    ? comments
+    : comments.filter((comment) => !blocked.has(comment.author.did));
 }

--- a/apps/standard-reader/src/server/reader/document-comments.ts
+++ b/apps/standard-reader/src/server/reader/document-comments.ts
@@ -546,6 +546,20 @@ export async function attachCommentCountsToArticles<
  * The Discussion items for a document, rebuilt on every request so an open
  * thread is never stale. The build also refreshes this document's badge count.
  */
+export interface DocumentCommentsResult {
+  comments: Array<DocumentComment>;
+  /**
+   * How many comments this reader's blocks removed.
+   *
+   * Reported rather than swallowed because the badge count on the card is the
+   * cached, unfiltered length (see below), so a thread whose every reply is by a
+   * blocked account would otherwise read "6 comments" above the words "No
+   * discussion yet" — which looks like the page failing, not like the block
+   * working.
+   */
+  hiddenByBlocks: number;
+}
+
 export async function fetchDocumentComments(
   dbClient: typeof db,
   schemaModule: typeof schema,
@@ -556,19 +570,26 @@ export async function fetchDocumentComments(
    * but leaves their replies under it hasn't hidden them.
    */
   viewerDid?: string | null,
-): Promise<Array<DocumentComment>> {
+): Promise<DocumentCommentsResult> {
   // Filtered *after* the cache, never inside it: the cache is keyed by document
   // alone, so filtering during the build would let the first reader to open a
   // thread decide what every later reader sees. The badge count is the cached
   // (unfiltered) length for the same reason — a per-reader count would need a
   // per-reader cache, and a badge one too high is a smaller wrong than a
   // blocked reply showing up in somebody else's thread.
-  return filterBlockedComments(
+  const all = await loadDocumentComments(
+    dbClient,
+    schemaModule,
+    documentUri,
+    "fresh",
+  );
+  const comments = await filterBlockedComments(
     dbClient,
     schemaModule,
     viewerDid,
-    await loadDocumentComments(dbClient, schemaModule, documentUri, "fresh"),
+    all,
   );
+  return { comments, hiddenByBlocks: all.length - comments.length };
 }
 
 async function buildDocumentComments(

--- a/apps/standard-reader/src/server/reader/queries.explain.test.ts
+++ b/apps/standard-reader/src/server/reader/queries.explain.test.ts
@@ -60,6 +60,15 @@ const TAG_OVERLAP_BUDGET_MS = Number(
   process.env.FEED_PERF_TAG_BUDGET_MS ?? 6000,
 );
 
+/**
+ * Looser than {@link EXEC_TIME_BUDGET_MS} because the block branches add real
+ * per-row probes, but still far below the corpus-walk this must never become.
+ * A blown budget here means the block predicate stopped being index-served.
+ */
+const BLOCK_FILTER_BUDGET_MS = Number(
+  process.env.FEED_PERF_BLOCK_BUDGET_MS ?? 900,
+);
+
 describe.skipIf(!RUN)("follow-feed candidate query — EXPLAIN", () => {
   // EXPLAIN ANALYZE runs the query for real over the prod Neon RTT (~230ms),
   // after two follow-fetch round trips — generous timeout to avoid flake.
@@ -82,6 +91,52 @@ describe.skipIf(!RUN)("follow-feed candidate query — EXPLAIN", () => {
 
     assertNoSeqScanOnDocuments(plan);
     assertPerSourceIndexScans(plan);
+  }, 30_000);
+});
+
+/**
+ * The block filter on the follow feed.
+ *
+ * `notBlockedByViewer` is three correlated `NOT EXISTS` evaluated per candidate
+ * row, and it lands inside `baseWhere` — the same predicate the strategy note in
+ * `queries.ts` warns against adding to, because the per-source laterals depend
+ * on an indexed `ORDER BY published_at DESC LIMIT k` scan that a correlated
+ * subquery can push off its index. That is exactly the shape of the original
+ * 1651ms regression.
+ *
+ * Two things are asserted, because either alone would pass a broken build:
+ *  - With the filter on, the plan still rides the per-source composite indexes
+ *    and does not seq-scan `documents`.
+ *  - The filter costs little enough that the page budget still holds.
+ *
+ * Note this is the *worst* case by construction — the reader passed here is
+ * treated as having blocks. In production `blockFilterDid` keeps the predicate
+ * out of the query entirely for readers who block nobody, which is nearly all
+ * of them.
+ */
+describe.skipIf(!RUN)("follow-feed block filter — EXPLAIN", () => {
+  test("block filter does not defeat the per-source index scans", async () => {
+    const plan = await explainCandidate({
+      unreadForDid: READER_DID,
+      countOldPostsAsUnread: true,
+      viewerDid: READER_DID,
+    });
+
+    assertNoSeqScanOnDocuments(plan);
+    assertPerSourceIndexScans(plan);
+    assertExecTimeUnder(plan, BLOCK_FILTER_BUDGET_MS);
+  }, 30_000);
+
+  test("block filter does not defeat the suppressed-old path either", async () => {
+    const plan = await explainCandidate({
+      unreadForDid: READER_DID,
+      countOldPostsAsUnread: false,
+      viewerDid: READER_DID,
+    });
+
+    assertNoSeqScanOnDocuments(plan);
+    assertPerSourceIndexScans(plan);
+    assertExecTimeUnder(plan, BLOCK_FILTER_BUDGET_MS);
   }, 30_000);
 });
 
@@ -182,9 +237,12 @@ async function selectTagAnchorDocument(): Promise<{
 async function explainCandidate({
   unreadForDid,
   countOldPostsAsUnread,
+  viewerDid,
 }: {
   unreadForDid: string;
   countOldPostsAsUnread: boolean | undefined;
+  /** Set to force the block predicate on — see the block-filter describe. */
+  viewerDid?: string;
 }): Promise<string> {
   const [publicationUris, followedUserDids] = await Promise.all([
     selectFollowUris(db, schema, READER_DID),
@@ -205,6 +263,7 @@ async function explainCandidate({
     followedUserDids,
     unreadForDid,
     countOldPostsAsUnread,
+    viewerDid,
     limit: PAGE_LIMIT,
     offset: PAGE_OFFSET,
   });

--- a/apps/standard-reader/src/server/reader/queries.ts
+++ b/apps/standard-reader/src/server/reader/queries.ts
@@ -56,7 +56,7 @@ import {
   WEB_BRIDGE_HANDLE_PATTERN,
 } from "#/lib/atproto/bridged-repo";
 import { EXCLUDED_PUBLICATION_URL_PATTERN } from "#/lib/publication/exclusions";
-import { notBlockedByViewer } from "#/server/blocks/blocks";
+import { atUriAuthoritySql, notBlockedByViewer } from "#/server/blocks/blocks";
 import { documentPublishedNotInFuture } from "#/server/reader/document-filters";
 import {
   discoverEligibleArticleWhere,
@@ -516,9 +516,21 @@ export function buildFollowFeedCandidateSql(
     base.push(documentNotReadWhere(schema, opts.unreadForDid));
   // Applied to every union branch, not just the direct one: a followed
   // publication can carry a guest post by an account the reader blocks, and a
-  // followed user can recommend one.
+  // followed user can recommend one. Both the author and the publication's
+  // owner are checked — a guest post carries the owner in its byline.
+  //
+  // Reached only through `blockFilterDid`, so this never enters the lateral for
+  // a reader who blocks nobody. That gate is what makes it safe to add a
+  // correlated predicate to `baseWhere` at all: see the strategy note below.
   if (opts.viewerDid) {
-    base.push(notBlockedByViewer(schema, opts.viewerDid, sql`${d.did}`));
+    base.push(
+      notBlockedByViewer(
+        schema,
+        opts.viewerDid,
+        sql`${d.did}`,
+        atUriAuthoritySql(sql`${d.publicationUri}`),
+      ),
+    );
   }
   const baseWhere = and(...base) ?? sql`true`;
 
@@ -803,7 +815,14 @@ export async function selectArticleCards(
     conds.push(documentCarriesTagWhere(d, opts.tag));
   }
   if (opts.viewerDid) {
-    conds.push(notBlockedByViewer(schema, opts.viewerDid, sql`${d.did}`));
+    conds.push(
+      notBlockedByViewer(
+        schema,
+        opts.viewerDid,
+        sql`${d.did}`,
+        atUriAuthoritySql(sql`${d.publicationUri}`),
+      ),
+    );
   }
 
   const columns = articleCardColumns(schema);
@@ -980,7 +999,14 @@ export async function selectPublicationArticleCards(
         // A publication the reader can still open (they are not blocked from
         // its owner) can carry guest posts by accounts they are blocked from.
         ...(opts.viewerDid
-          ? [notBlockedByViewer(schema, opts.viewerDid, sql`${d.did}`)]
+          ? [
+              notBlockedByViewer(
+                schema,
+                opts.viewerDid,
+                sql`${d.did}`,
+                atUriAuthoritySql(sql`${d.publicationUri}`),
+              ),
+            ]
           : []),
       ),
     )
@@ -1638,7 +1664,14 @@ function trendingArticleWhere(
   }
 
   if (viewerDid) {
-    conds.push(notBlockedByViewer(schema, viewerDid, sql`${d.did}`));
+    conds.push(
+      notBlockedByViewer(
+        schema,
+        viewerDid,
+        sql`${d.did}`,
+        atUriAuthoritySql(sql`${d.publicationUri}`),
+      ),
+    );
   }
 
   return conds;
@@ -3400,7 +3433,14 @@ export async function selectArticleCardsByUris(
         eq(d.deleted, false),
         documentPublishedNotInFuture(d),
         ...(opts?.viewerDid
-          ? [notBlockedByViewer(schema, opts.viewerDid, sql`${d.did}`)]
+          ? [
+              notBlockedByViewer(
+                schema,
+                opts.viewerDid,
+                sql`${d.did}`,
+                atUriAuthoritySql(sql`${d.publicationUri}`),
+              ),
+            ]
           : []),
       ),
     );

--- a/apps/standard-reader/src/server/reader/queries.ts
+++ b/apps/standard-reader/src/server/reader/queries.ts
@@ -56,6 +56,7 @@ import {
   WEB_BRIDGE_HANDLE_PATTERN,
 } from "#/lib/atproto/bridged-repo";
 import { EXCLUDED_PUBLICATION_URL_PATTERN } from "#/lib/publication/exclusions";
+import { notBlockedByViewer } from "#/server/blocks/blocks";
 import { documentPublishedNotInFuture } from "#/server/reader/document-filters";
 import {
   discoverEligibleArticleWhere,
@@ -163,6 +164,17 @@ export interface ArticleCardQuery {
    * `recent`.
    */
   sort?: ArticleCardSort;
+  /**
+   * The reader this page is being rendered for. Documents by an account they
+   * are blocked from — in either direction — are excluded in SQL rather than
+   * dropped afterwards, so a block never shortens a page or strands results
+   * behind an offset. See {@link notBlockedByViewer}.
+   *
+   * Distinct from `readForDid` / `unreadForDid`, which are about read state:
+   * blocks apply whether or not the reader tracks reading, and to signed-in
+   * readers on discover surfaces where the other two are unset.
+   */
+  viewerDid?: string;
   limit: number;
   offset?: number;
 }
@@ -447,6 +459,8 @@ async function selectFollowFeedCandidateUris(
     featuredOnly?: boolean;
     unreadForDid?: string;
     countOldPostsAsUnread?: boolean;
+    /** See {@link ArticleCardQuery.viewerDid}. */
+    viewerDid?: string;
     limit: number;
     offset: number;
   },
@@ -471,6 +485,8 @@ export function buildFollowFeedCandidateSql(
     featuredOnly?: boolean;
     unreadForDid?: string;
     countOldPostsAsUnread?: boolean;
+    /** See {@link ArticleCardQuery.viewerDid}. */
+    viewerDid?: string;
     limit: number;
     offset: number;
   },
@@ -498,6 +514,12 @@ export function buildFollowFeedCandidateSql(
   if (opts.featuredOnly) base.push(eq(d.featured, true));
   if (opts.unreadForDid)
     base.push(documentNotReadWhere(schema, opts.unreadForDid));
+  // Applied to every union branch, not just the direct one: a followed
+  // publication can carry a guest post by an account the reader blocks, and a
+  // followed user can recommend one.
+  if (opts.viewerDid) {
+    base.push(notBlockedByViewer(schema, opts.viewerDid, sql`${d.did}`));
+  }
   const baseWhere = and(...base) ?? sql`true`;
 
   // Cutoff strategy: apply the cutoff AFTER the union, on a small bounded
@@ -725,6 +747,7 @@ export async function selectArticleCards(
       featuredOnly: opts.featuredOnly,
       unreadForDid: opts.unreadForDid,
       countOldPostsAsUnread: opts.countOldPostsAsUnread,
+      viewerDid: opts.viewerDid,
       limit: opts.limit,
       offset: opts.offset ?? 0,
     });
@@ -732,6 +755,7 @@ export async function selectArticleCards(
     return selectArticleCardsByUris(db, schema, pageUris, {
       readForDid: opts.readForDid,
       countOldPostsAsUnread: opts.countOldPostsAsUnread,
+      viewerDid: opts.viewerDid,
     });
   }
 
@@ -777,6 +801,9 @@ export async function selectArticleCards(
   }
   if (opts.tag) {
     conds.push(documentCarriesTagWhere(d, opts.tag));
+  }
+  if (opts.viewerDid) {
+    conds.push(notBlockedByViewer(schema, opts.viewerDid, sql`${d.did}`));
   }
 
   const columns = articleCardColumns(schema);
@@ -899,6 +926,8 @@ export async function selectPublicationArticleCards(
      * computed against one ordering.
      */
     order?: "newest" | "oldest";
+    /** See {@link ArticleCardQuery.viewerDid}. */
+    viewerDid?: string;
   },
 ): Promise<Array<ArticleCard>> {
   const d = schema.documents;
@@ -948,6 +977,11 @@ export async function selectPublicationArticleCards(
         publicationFilterWhere(schema, opts.filter, opts.readerDid, {
           countOldPostsAsUnread: opts.countOldPostsAsUnread,
         }),
+        // A publication the reader can still open (they are not blocked from
+        // its owner) can carry guest posts by accounts they are blocked from.
+        ...(opts.viewerDid
+          ? [notBlockedByViewer(schema, opts.viewerDid, sql`${d.did}`)]
+          : []),
       ),
     )
     .orderBy(
@@ -1564,6 +1598,8 @@ export interface TrendingArticlesQuery {
   scope?: TrendingArticlesScope;
   /** Hide web-bridge mirrors — see {@link ArticleCardQuery.excludeWebBridge}. */
   excludeWebBridge?: boolean;
+  /** See {@link ArticleCardQuery.viewerDid}. */
+  viewerDid?: string;
 }
 
 function trendingArticleWhere(
@@ -1571,6 +1607,7 @@ function trendingArticleWhere(
   scope: TrendingArticlesScope,
   excludeUris: Array<string> = [],
   excludeWebBridge = false,
+  viewerDid?: string,
 ) {
   const d = schema.documents;
   const p = schema.publications;
@@ -1600,6 +1637,10 @@ function trendingArticleWhere(
     conds.push(notInArray(d.uri, excludeUris));
   }
 
+  if (viewerDid) {
+    conds.push(notBlockedByViewer(schema, viewerDid, sql`${d.did}`));
+  }
+
   return conds;
 }
 
@@ -1624,6 +1665,7 @@ export async function trendingArticles(
     offset = 0,
     readForDid,
     scope = "rail",
+    viewerDid,
   }: TrendingArticlesQuery = {},
 ): Promise<Array<ArticleCard>> {
   const d = schema.documents;
@@ -1640,7 +1682,13 @@ export async function trendingArticles(
       .leftJoin(pa, eq(pa.did, d.did))
       .where(
         and(
-          ...trendingArticleWhere(schema, scope, excludeUris, excludeWebBridge),
+          ...trendingArticleWhere(
+            schema,
+            scope,
+            excludeUris,
+            excludeWebBridge,
+            viewerDid,
+          ),
         ),
       )
       .orderBy(desc(d.trendingScore), desc(d.publishedAt))
@@ -1661,7 +1709,13 @@ export async function trendingArticles(
     .leftJoin(pa, eq(pa.did, d.did))
     .where(
       and(
-        ...trendingArticleWhere(schema, scope, excludeUris, excludeWebBridge),
+        ...trendingArticleWhere(
+          schema,
+          scope,
+          excludeUris,
+          excludeWebBridge,
+          viewerDid,
+        ),
       ),
     )
     .orderBy(desc(d.trendingScore), desc(d.publishedAt))
@@ -2173,6 +2227,7 @@ export async function discoverDirectoryPublications(
     offset,
     query = null,
     excludeWebBridge = false,
+    viewerDid,
   }: {
     topic?: string | null;
     /** `effective` = publication topic only; `document` = topic or any document tag. */
@@ -2183,6 +2238,8 @@ export async function discoverDirectoryPublications(
     query?: string | null;
     /** Hide web-bridge mirrors — see {@link ArticleCardQuery.excludeWebBridge}. */
     excludeWebBridge?: boolean;
+    /** See {@link ArticleCardQuery.viewerDid}. */
+    viewerDid?: string;
   },
 ): Promise<Array<PublicationCard>> {
   const p = schema.publications;
@@ -2194,6 +2251,9 @@ export async function discoverDirectoryPublications(
   const conds = [discoverEligiblePublicationWhere(p)];
   if (excludeWebBridge) {
     conds.push(notWebBridgePublicationOwnerWhere(schema));
+  }
+  if (viewerDid) {
+    conds.push(notBlockedByViewer(schema, viewerDid, sql`${p.did}`));
   }
   if (topic) {
     conds.push(
@@ -2522,6 +2582,7 @@ export async function tagDirectoryPublications(
     limit,
     offset,
     excludeWebBridge = false,
+    viewerDid,
   }: {
     tag: string;
     sort: TagDirectorySort;
@@ -2529,6 +2590,8 @@ export async function tagDirectoryPublications(
     offset: number;
     /** Hide web-bridge mirrors — see {@link ArticleCardQuery.excludeWebBridge}. */
     excludeWebBridge?: boolean;
+    /** See {@link ArticleCardQuery.viewerDid}. */
+    viewerDid?: string;
   },
 ): Promise<Array<TagPublicationCard>> {
   const p = schema.publications;
@@ -2544,6 +2607,9 @@ export async function tagDirectoryPublications(
     publicationHasTaggedDocumentSql(p, d, tag),
     ...(excludeWebBridge ? [notWebBridgePublicationOwnerWhere(schema)] : []),
   ];
+  if (viewerDid) {
+    conds.push(notBlockedByViewer(schema, viewerDid, sql`${p.did}`));
+  }
 
   const sortName = publicationSortNameSql(p.name, p.url);
 
@@ -3299,6 +3365,8 @@ export async function selectArticleCardsByUris(
     lite?: boolean;
     readForDid?: string;
     countOldPostsAsUnread?: boolean;
+    /** See {@link ArticleCardQuery.viewerDid}. */
+    viewerDid?: string;
   },
 ): Promise<Array<ArticleCard>> {
   if (uris.length === 0) {
@@ -3331,6 +3399,9 @@ export async function selectArticleCardsByUris(
         inArray(d.uri, uris),
         eq(d.deleted, false),
         documentPublishedNotInFuture(d),
+        ...(opts?.viewerDid
+          ? [notBlockedByViewer(schema, opts.viewerDid, sql`${d.did}`)]
+          : []),
       ),
     );
 

--- a/apps/standard-reader/src/server/xrpc/handlers/catalog.ts
+++ b/apps/standard-reader/src/server/xrpc/handlers/catalog.ts
@@ -5,7 +5,7 @@ import { fetchBlueskyPublicProfileFields } from "#/lib/bluesky-public-profile";
 import { isUsableHandle, resolveIdentity } from "#/server/atproto/identity";
 import { ipldToLexJson } from "#/server/atproto/ipld-json";
 import { resolveAuthorDid } from "#/server/atproto/resolve-author-ref";
-import { filterBlockedCards } from "#/server/blocks/blocks";
+import { blockFilterDid, filterBlockedCards } from "#/server/blocks/blocks";
 import {
   resolvePageUrl,
   resolvePageUrls,
@@ -162,7 +162,7 @@ export async function handleGetDocument(ctx: XrpcRequestContext) {
     ctx.db,
     ctx.schema,
     [documentUri],
-    { viewerDid: ctx.auth?.did },
+    { viewerDid: await blockFilterDid(ctx.db, ctx.schema, ctx.auth?.did) },
   );
   let card = cards[0];
   if (!card) {
@@ -222,6 +222,7 @@ export async function handleGetPublications(ctx: XrpcRequestContext) {
     offset,
     query: q ?? undefined,
     excludeWebBridge: ctx.excludeWebBridgeEnabled,
+    viewerDid: await blockFilterDid(ctx.db, ctx.schema, ctx.auth?.did),
   });
 
   const total =
@@ -329,7 +330,7 @@ export async function handleGetPublicationDocuments(ctx: XrpcRequestContext) {
     offset,
     readForDid,
     countOldPostsAsUnread: ctx.auth ? ctx.countOldPostsAsUnreadEnabled : true,
-    viewerDid: ctx.auth?.did,
+    viewerDid: await blockFilterDid(ctx.db, ctx.schema, ctx.auth?.did),
   });
   const items = await enrichDocuments(ctx, rows, readForDid);
   return {
@@ -426,12 +427,13 @@ export async function handleGetDocumentContext(ctx: XrpcRequestContext) {
   } = await import("#/server/reader/queries");
 
   const readerDid = ctx.auth?.did;
+  const blockDid = await blockFilterDid(ctx.db, ctx.schema, readerDid);
   const [moreFromRaw, relatedRaw, readersAlsoFollowRaw] = await Promise.all([
     row.publicationUri
       ? selectCards(ctx.db, ctx.schema, {
           publicationUris: [row.publicationUri],
           limit: 4,
-          viewerDid: readerDid,
+          viewerDid: blockDid,
         })
       : Promise.resolve([]),
     relatedArticles(ctx.db, ctx.schema, {

--- a/apps/standard-reader/src/server/xrpc/handlers/catalog.ts
+++ b/apps/standard-reader/src/server/xrpc/handlers/catalog.ts
@@ -5,6 +5,7 @@ import { fetchBlueskyPublicProfileFields } from "#/lib/bluesky-public-profile";
 import { isUsableHandle, resolveIdentity } from "#/server/atproto/identity";
 import { ipldToLexJson } from "#/server/atproto/ipld-json";
 import { resolveAuthorDid } from "#/server/atproto/resolve-author-ref";
+import { filterBlockedCards } from "#/server/blocks/blocks";
 import {
   resolvePageUrl,
   resolvePageUrls,
@@ -157,9 +158,12 @@ export async function handleGetDocument(ctx: XrpcRequestContext) {
   const documentUri = requireParam(ctx.params, "document");
   const readForDid =
     ctx.auth && ctx.trackReadingEnabled ? ctx.auth.did : undefined;
-  const cards = await selectArticleCardsByUris(ctx.db, ctx.schema, [
-    documentUri,
-  ]);
+  const cards = await selectArticleCardsByUris(
+    ctx.db,
+    ctx.schema,
+    [documentUri],
+    { viewerDid: ctx.auth?.did },
+  );
   let card = cards[0];
   if (!card) {
     throw new InvalidRequestError("Document not found");
@@ -325,6 +329,7 @@ export async function handleGetPublicationDocuments(ctx: XrpcRequestContext) {
     offset,
     readForDid,
     countOldPostsAsUnread: ctx.auth ? ctx.countOldPostsAsUnreadEnabled : true,
+    viewerDid: ctx.auth?.did,
   });
   const items = await enrichDocuments(ctx, rows, readForDid);
   return {
@@ -426,6 +431,7 @@ export async function handleGetDocumentContext(ctx: XrpcRequestContext) {
       ? selectCards(ctx.db, ctx.schema, {
           publicationUris: [row.publicationUri],
           limit: 4,
+          viewerDid: readerDid,
         })
       : Promise.resolve([]),
     relatedArticles(ctx.db, ctx.schema, {
@@ -433,12 +439,12 @@ export async function handleGetDocumentContext(ctx: XrpcRequestContext) {
       publicationUri: row.publicationUri,
       limit: 6,
       excludeWebBridge: ctx.excludeWebBridgeEnabled,
-    }),
+    }).then((rows) => filterBlockedCards(ctx.db, ctx.schema, readerDid, rows)),
     articleRecommendedPublications(ctx.db, ctx.schema, {
       publicationUri: row.publicationUri,
       readerDid,
       limit: 6,
-    }),
+    }).then((rows) => filterBlockedCards(ctx.db, ctx.schema, readerDid, rows)),
   ]);
 
   const moreFrom = moreFromRaw.filter((doc) => doc.uri !== row.uri).slice(0, 3);

--- a/apps/standard-reader/src/server/xrpc/handlers/feeds.ts
+++ b/apps/standard-reader/src/server/xrpc/handlers/feeds.ts
@@ -2,7 +2,7 @@ import { TRENDING_PAGE_LIMIT } from "#/integrations/tanstack-query/api-feed.func
 import { articleCardsAsAllRead } from "#/lib/track-reading-history";
 import { resolveAuthorDid } from "#/server/atproto/resolve-author-ref";
 import { parseAtUri } from "#/server/atproto/uri";
-import { filterBlockedCards } from "#/server/blocks/blocks";
+import { blockFilterDid, filterBlockedCards } from "#/server/blocks/blocks";
 import {
   followedPublications,
   selectArticleCards,
@@ -52,7 +52,7 @@ export async function handleGetLatestFeed(ctx: XrpcRequestContext) {
             readForDid: trackReading && subjectDid ? subjectDid : undefined,
             scope: "page",
             excludeWebBridge,
-            viewerDid: ctx.auth?.did,
+            viewerDid: await blockFilterDid(ctx.db, ctx.schema, ctx.auth?.did),
           })
         : []
       : await selectArticleCards(ctx.db, ctx.schema, {
@@ -65,7 +65,7 @@ export async function handleGetLatestFeed(ctx: XrpcRequestContext) {
               }),
           readForDid: trackReading && subjectDid ? subjectDid : undefined,
           countOldPostsAsUnread,
-          viewerDid: ctx.auth?.did,
+          viewerDid: await blockFilterDid(ctx.db, ctx.schema, ctx.auth?.did),
           limit,
           offset,
         });
@@ -111,7 +111,7 @@ export async function handleGetTrendingDocuments(ctx: XrpcRequestContext) {
     scope,
     readForDid,
     excludeWebBridge: ctx.excludeWebBridgeEnabled,
-    viewerDid: ctx.auth?.did,
+    viewerDid: await blockFilterDid(ctx.db, ctx.schema, ctx.auth?.did),
   });
   const enriched = await enrichDocuments(ctx, items, readForDid);
   return { items: enriched.map((item) => toDocumentView(item)) };
@@ -130,7 +130,7 @@ export async function handleGetTagFeed(ctx: XrpcRequestContext) {
       limit,
       offset,
       excludeWebBridge: ctx.excludeWebBridgeEnabled,
-      viewerDid: ctx.auth?.did,
+      viewerDid: await blockFilterDid(ctx.db, ctx.schema, ctx.auth?.did),
     });
     return {
       view: "publications" as const,
@@ -152,7 +152,7 @@ export async function handleGetTagFeed(ctx: XrpcRequestContext) {
     offset,
     readForDid,
     countOldPostsAsUnread: ctx.auth ? ctx.countOldPostsAsUnreadEnabled : true,
-    viewerDid: ctx.auth?.did,
+    viewerDid: await blockFilterDid(ctx.db, ctx.schema, ctx.auth?.did),
   });
   const items = await enrichDocuments(ctx, rows, readForDid);
   return {
@@ -244,7 +244,7 @@ export async function handleGetListFeed(ctx: XrpcRequestContext) {
     publicationUris: list.publications,
     readForDid,
     countOldPostsAsUnread: ctx.auth ? ctx.countOldPostsAsUnreadEnabled : true,
-    viewerDid: ctx.auth?.did,
+    viewerDid: await blockFilterDid(ctx.db, ctx.schema, ctx.auth?.did),
     limit,
     offset,
   });

--- a/apps/standard-reader/src/server/xrpc/handlers/feeds.ts
+++ b/apps/standard-reader/src/server/xrpc/handlers/feeds.ts
@@ -2,6 +2,7 @@ import { TRENDING_PAGE_LIMIT } from "#/integrations/tanstack-query/api-feed.func
 import { articleCardsAsAllRead } from "#/lib/track-reading-history";
 import { resolveAuthorDid } from "#/server/atproto/resolve-author-ref";
 import { parseAtUri } from "#/server/atproto/uri";
+import { filterBlockedCards } from "#/server/blocks/blocks";
 import {
   followedPublications,
   selectArticleCards,
@@ -51,6 +52,7 @@ export async function handleGetLatestFeed(ctx: XrpcRequestContext) {
             readForDid: trackReading && subjectDid ? subjectDid : undefined,
             scope: "page",
             excludeWebBridge,
+            viewerDid: ctx.auth?.did,
           })
         : []
       : await selectArticleCards(ctx.db, ctx.schema, {
@@ -63,6 +65,7 @@ export async function handleGetLatestFeed(ctx: XrpcRequestContext) {
               }),
           readForDid: trackReading && subjectDid ? subjectDid : undefined,
           countOldPostsAsUnread,
+          viewerDid: ctx.auth?.did,
           limit,
           offset,
         });
@@ -88,9 +91,14 @@ export async function handleGetLatestFeed(ctx: XrpcRequestContext) {
 
 export async function handleGetTrendingPublications(ctx: XrpcRequestContext) {
   const limit = intParam(ctx.params, "limit", 12, { min: 1, max: 100 });
-  const items = await trendingPublications(ctx.db, ctx.schema, limit, {
-    excludeWebBridge: ctx.excludeWebBridgeEnabled,
-  });
+  const items = await filterBlockedCards(
+    ctx.db,
+    ctx.schema,
+    ctx.auth?.did,
+    await trendingPublications(ctx.db, ctx.schema, limit, {
+      excludeWebBridge: ctx.excludeWebBridgeEnabled,
+    }),
+  );
   return { items: items.map((item) => toPublicationView(item)) };
 }
 
@@ -103,6 +111,7 @@ export async function handleGetTrendingDocuments(ctx: XrpcRequestContext) {
     scope,
     readForDid,
     excludeWebBridge: ctx.excludeWebBridgeEnabled,
+    viewerDid: ctx.auth?.did,
   });
   const enriched = await enrichDocuments(ctx, items, readForDid);
   return { items: enriched.map((item) => toDocumentView(item)) };
@@ -121,6 +130,7 @@ export async function handleGetTagFeed(ctx: XrpcRequestContext) {
       limit,
       offset,
       excludeWebBridge: ctx.excludeWebBridgeEnabled,
+      viewerDid: ctx.auth?.did,
     });
     return {
       view: "publications" as const,
@@ -142,6 +152,7 @@ export async function handleGetTagFeed(ctx: XrpcRequestContext) {
     offset,
     readForDid,
     countOldPostsAsUnread: ctx.auth ? ctx.countOldPostsAsUnreadEnabled : true,
+    viewerDid: ctx.auth?.did,
   });
   const items = await enrichDocuments(ctx, rows, readForDid);
   return {
@@ -233,6 +244,7 @@ export async function handleGetListFeed(ctx: XrpcRequestContext) {
     publicationUris: list.publications,
     readForDid,
     countOldPostsAsUnread: ctx.auth ? ctx.countOldPostsAsUnreadEnabled : true,
+    viewerDid: ctx.auth?.did,
     limit,
     offset,
   });

--- a/apps/standard-reader/src/server/xrpc/handlers/reader.ts
+++ b/apps/standard-reader/src/server/xrpc/handlers/reader.ts
@@ -44,11 +44,13 @@ export async function handleGetHomeFeed(ctx: XrpcRequestContext) {
     ? {
         publicationUris: followUris,
         countOldPostsAsUnread: ctx.countOldPostsAsUnreadEnabled,
+        viewerDid: did,
         ...(trackReading ? { readForDid: did, unreadForDid: did } : {}),
       }
     : {
         discoverOnly: true as const,
         excludeWebBridge: ctx.excludeWebBridgeEnabled,
+        viewerDid: did,
       };
 
   const [featuredLead, rows] = await Promise.all([

--- a/apps/standard-reader/src/server/xrpc/handlers/reader.ts
+++ b/apps/standard-reader/src/server/xrpc/handlers/reader.ts
@@ -6,6 +6,7 @@ import {
   articleQueueCardColumns,
   toArticleCard,
 } from "#/integrations/tanstack-query/api-shapes";
+import { blockFilterDid } from "#/server/blocks/blocks";
 import {
   followedByPeopleYouFollow,
   recommendedPublications,
@@ -40,17 +41,18 @@ export async function handleGetHomeFeed(ctx: XrpcRequestContext) {
   const hasFollows = followUris.length > 0;
   const personalized = hasFollows && scope === "follows";
 
+  const blockDid = await blockFilterDid(ctx.db, ctx.schema, did);
   const rowQuery = personalized
     ? {
         publicationUris: followUris,
         countOldPostsAsUnread: ctx.countOldPostsAsUnreadEnabled,
-        viewerDid: did,
+        viewerDid: blockDid,
         ...(trackReading ? { readForDid: did, unreadForDid: did } : {}),
       }
     : {
         discoverOnly: true as const,
         excludeWebBridge: ctx.excludeWebBridgeEnabled,
-        viewerDid: did,
+        viewerDid: blockDid,
       };
 
   const [featuredLead, rows] = await Promise.all([


### PR DESCRIPTION
A reader's blocks now follow them into Standard Reader, in both directions, with no setup and no import step. Same idea as the labeler port — but the mechanism is deliberately the opposite, for a reason worth reading before the diff.

## A block is a record, not a setting

`app.bsky.graph.block` already lives in the blocker's repo, and every AT Protocol app that honours a block reads that same record. So there is no `app.standard-reader.block` and there never should be: we mirror Bluesky's lexicon, and blocking from here writes the record the rest of the network already reads. Block someone in Standard Reader and they're blocked on Bluesky too, and wherever the reader goes next.

That's the opposite call from labeler subscriptions, and only because Bluesky keeps *those* in a preferences blob with no per-key write — which is why they had to be ported into records of our own. Nothing about blocks needs that.

One useful consequence: `com.atproto.repo.listRecords` is public, so **honouring** a reader's existing blocks costs no OAuth scope at all. Enforced from their first page load, whatever they granted. Only *writing* asks for consent.

## Four ways to be blocked, all equal in effect

| Direction | Record | Held by |
| --- | --- | --- |
| `blocking` | `app.bsky.graph.block` | viewer |
| `blocked-by` | `app.bsky.graph.block` | them |
| `list-blocking` | `listblock` + `listitem` | viewer |
| `list-blocked-by` | `listblock` + `listitem` | them |

All four hide content. That symmetry is what makes a block feel like a block rather than a mute — and `list-blocked-by` is Bluesky's `blockedByList`, the reason a reader can be blocked by someone who never named them.

## Sync: per reader, not the firehose

Blocks can't ride the tap. It tracks the repos we index; a block against one of our readers can be written by any repo on the network. So `server/blocks/sync.server.ts` pulls per reader on a 15-minute TTL, from four sources: their own records from their PDS, incoming blocks via Constellation backlinks, mod-list membership via the public AppView, and the listitem→listblock chain for `blockedByList`. Scheduled from the OAuth callback and the signed-in shell read; forced inline right after a block/unblock write so the change lands on the very next page.

**Outgoing replaces; incoming replaces only on a complete sweep.** The reader's own records are authoritative, so a sweep can soft-delete what's gone. Blocks *against* them come from a best-effort index, so their delete is gated on the sweep having read every page — a truncated or failed sweep adds but never removes, because it must not read as "nobody blocks you any more".

It does have to remove *eventually*, though, and the first cut of this got that wrong: incoming rows were additive-only, and the blocker is almost never a reader here, so nothing else would ever retire the row. An unblock made on Bluesky would have hidden that account from the reader permanently, with no path to clear it.

**A sweep never happens on a request anyone waits for.** A full sweep is dozens to hundreds of round trips. Blocking a list awaits only the two bounded reads the reader is actually waiting on — their own `listblock` records, and that list's membership — and schedules the rest; Settings → Refresh starts a sweep and says so rather than holding the request open. Sweeps are deduped per reader process-wide, so a doubled press joins the run already in flight.

## Enforcement

SQL `NOT EXISTS` (`notBlockedByViewer`) wherever a page paginates — home, latest, trending, tag, search, discover directory, publication archives, list feeds, XRPC feeds — so a block never shortens a page or strands results behind an offset. JS post-filter on rails, profile tabs, friend surfaces, and third-party discussion (Bluesky / Margin / Semble / pckt / Leaflet), where a shorter list is fine.

Every helper is bounded by the DIDs a page is about to render, never by the reader's block set. A reader on a 40k-member blocklist has to stay an index probe, which is what `block_list_items (list_uri, subject_did)` is for.

Both paths check the **author and the publication owner** — a guest post in a blocked owner's publication carries that owner in its byline. (`publicationOwnerDid` existed and was unit-tested from the start, but no production card actually carried the field, so that half of the filter was dead until `ArticleCard` grew it. In SQL the owner comes from the publication URI's authority, so it needs no join and works inside the lateral.)

### The SQL predicate is opt-in per reader

`notBlockedByViewer` is three correlated `NOT EXISTS` per candidate row, and on the follow feed it lands inside `baseWhere` — which is interpolated into the per-source laterals whose whole job is an indexed `ORDER BY published_at DESC LIMIT k` scan. That is precisely the shape the strategy note in `queries.ts` warns about, and precisely what caused the 1651ms corpus-walk regression that note exists to document.

So the only supported way to reach it is `blockFilterDid`, which answers "does this reader block anybody" from an in-process cache (60s TTL, invalidated on every write) and returns `undefined` for the overwhelming majority who don't — keeping the predicate out of the query entirely rather than paying for it on every signed-in feed load. `queries.explain.test.ts` (`pnpm perf:explain`) gained two cases asserting the *filtered* plan still rides the per-source composite indexes.

Detail routes (`getArticle`, `getPublicationProfile`, `getAuthorProfile`, the per-tab loaders) warm that guard concurrently with the read they were making anyway, rather than awaiting a block probe ahead of it.

Discussion comments are filtered **after** the shared comment cache, never inside it — the cache is keyed by document alone, so filtering during the build would let the first reader to open a thread decide what every later reader sees.

## Blocked pages explain themselves

A blocked profile, publication, or article renders the block rather than an empty page or a bare "not found": which direction it runs, and an Unblock control **only** when the block is the reader's own to undo. Someone else's decision isn't theirs to reverse, and a button that pretended otherwise would be a lie.

The article body is withheld outright — `getArticle` returns `null`, and the reason is a separate opt-in read from the not-found state. Nothing about a blocked document, not even its title, crosses the wire on the happy path. A signed-out reader — most of that page's traffic — skips both queries, since only a signed-in reader can be on either side of a block.

**And without a frame of the blocked page first.** Block state rides on the same query as the content it withholds (`getPublicationHeader`, `getAuthorProfile`, `getAuthorSummary`). Resolving it in a second client query would paint the blocked account's hero — name, avatar, description — and then take it away. Mention hovercards read those same queries, so an inline chip can't summarise someone the profile page withholds.

**A block outranks an opt-in the reader made earlier.** The weekly digest, push notifications, and per-reader RSS (`/feed/latest/$did`, `/feed/l/$did/$rkey`) are filtered too. All three arrive uninvited: an emailed article sits in the inbox, a notification lands on a lock screen, and a reader who subscribed in an RSS client can't just not look. "I asked for this source", said before the block, doesn't survive it.

**Blocking is confirmed; failing to block is said out loud.** The overflow-menu item opens a confirmation before writing a public record the whole network honours — the menu offers no way back, because the profile it sits on becomes a notice. Every block mutation reports failure with a toast; silently doing nothing is indistinguishable from having worked.

## Writing needs consent; reading doesn't

`upgradeToBlocking` requests `repo?collection=app.bsky.graph.block&collection=app.bsky.graph.listblock` on the first Block press, persisted via `user.blockingEnabled` so later logins re-request it silently. Same progressive pattern as Margin/Semble. A reader who never blocks from here never sees the prompt; one who signed in before this existed still has every block they made elsewhere enforced.

Block lives in the author overflow menu (last, behind its own separator — it's the one item that hides things rather than opening them). `/settings/blocks` pages through the reader's own blocks and lists their subscribed block lists, saying in words when a list is larger than we mirror.

## Migration

`0035`: `blocks`, `block_lists`, `block_list_items`, `block_list_sync_state`, `block_sync_state`, plus `user.blocking_enabled`. Additive only.

`0036`: drops `blocks_blocker_idx`, a strict prefix of `blocks_edge_idx (blocker_did, subject_did)` — it cost writes to answer nothing the composite couldn't. Kept as a separate migration rather than folded into `0035`, since `0035` may already be applied on a dev branch and rewriting its hash is how you strand a migration ledger.

## What the review pass changed

This describes the final state; `b88790a` is a second pass over the first cut, after an adversarial review. Worth knowing which parts moved, if you read the earlier version:

- The SQL block predicate was applied to **every** signed-in reader, in the one predicate `queries.ts` documents as having caused a 1651ms regression. Now gated behind `blockFilterDid`.
- Incoming blocks were additive-only and **permanently unremovable** in the common case.
- `publicationOwnerDid` was dead — defined, tested, carried by nothing.
- A blocked publication painted in full for a frame before the notice replaced it.
- Blocking a list, and Settings → Refresh, held the HTTP request open for the whole sweep.
- Friend-rail counts and the Discover avatar stack were computed pre-filter, so blocked accounts' avatars still rendered.
- Digest, push and per-reader RSS honoured no blocks at all.

## Verification

`pnpm lint`, `format:check`, `typecheck`, `build`, and `test` (897 passed) all green. 23 unit tests cover the pure block logic — including a regression guard that pins the fixtures to real `ArticleCard` / `PublicationCard` field names, so the dead-`publicationOwnerDid` hole can't silently reopen under a rename.

**Not smoke-tested against live data** — no DB in the authoring environment. Two things worth one run against a real account with blocks before merge:

- The Constellation backlink sources (`app.bsky.graph.block:.subject`, `app.bsky.graph.listitem:.subject`) are the part most likely to need a `forceLegacyLinks` tweak.
- `pnpm perf:explain` against prod-scale data, to confirm the block predicate's plan in practice and not just in principle.

## Known gaps (documented in TODO.md, not papered over)

- **The block UI ships untranslated.** The strings are extracted into all ten catalogs, but the translations are empty — they render in English outside `en` until a translation pass runs.
- **The sweep guard is per-process.** Enough for the single web service today, but a second instance could still sweep the same reader concurrently. Wants an advisory lock.
- **Large blocklists are mirrored partially** (cap ~10k members) and flagged `truncated`. The settings page now says what "Partial" means rather than just badging it.
- **Mutes aren't handled.** `muteActor` / mute lists are a softer signal and out of scope here.
- **Comment badge counts stay unfiltered** for a blocking reader — a per-reader count would need a per-reader cache, and a badge one too high is a smaller wrong than a blocked reply leaking into someone else's thread. The Discussion section now *explains* the gap ("2 more replies are hidden by your blocks") instead of showing "No discussion yet" under a badge reading 6.
- **The collection editor is deliberately unfiltered.** A curator editing their own list should see everything they put in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UY5qvjn48qNmaY3wAoVptX

---
_Generated by [Claude Code](https://claude.ai/code/session_01UY5qvjn48qNmaY3wAoVptX)_
