### PR TITLE
Publish a spec-compliant did:web so PDS proxying works

### DIFF
--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -1482,6 +1482,26 @@ cookies on `/xrpc`. Live developer docs at [`/docs/api`](/docs/api).
       field (app-password sessions, which grant unrestricted repo access) was coerced to `[]`,
       403-ing every scoped write. `scopes` is now `Array<string> | null`, where `null` means "no
       scope restriction to enforce". Covered by `src/server/xrpc/auth.test.ts`.
+- [x] **The PDS-proxy path was unusable for everyone** — reported by `mihaizaurus.at` on
+      [userinput.app](https://userinput.app/d/did:plc:7qubw2z53qzfturlblaozz4a/3msqg3okp3kc7),
+      two independent bugs on the same path. (1) `appviewDid()` percent-swapped the host's dots
+      for colons, publishing `did:web:standard-reader:app` — which per the did:web spec names the
+      host `standard-reader` with a path segment `app`. A spec-compliant PDS either failed to
+      fetch that location or, given the corrected dot-form, fetched the real document and
+      rejected it on the self-consistency check, since its `id` still said the colon form. Both
+      show up as a 500 from the caller's own PDS, before the request ever reaches us. (2) With
+      the DID fixed, `verifyServiceJwt` would still have rejected every proxied call with
+      `BadJwtAudience`: it required `did#fragment` as the JWT audience, but `pipethrough` signs
+      with the **bare DID** and keeps the fragment form only for matching OAuth `rpc:` scopes.
+      Both forms are now accepted, and nothing else. Covered by `config.test.ts` +
+      `auth.test.ts`; the docs page now also states the proxy path serves reads, not writes.
+- [x] **did:web path segments resolved to the wrong URL everywhere** — the same class of bug in
+      all four DID-document resolvers: colons were mapped to `.` (`xrpc/auth.ts`) or to `/` but
+      with `/.well-known/` still appended (`atproto/identity.ts`, `labeler/verify.server.ts`,
+      `packages/cli`). A path-bearing `did:web:example.com:user:alice` resolves to
+      `https://example.com/user/alice/did.json` — no `/.well-known/`. Extracted to
+      `src/lib/atproto/did-web.ts` (`didWebDocumentUrl`) with tests; the CLI keeps its own copy
+      since it cannot import `#/`.
 
 ### Remote MCP server (`/mcp`)
 

--- a/apps/standard-reader/src/components/docs/api-docs-intro.tsx
+++ b/apps/standard-reader/src/components/docs/api-docs-intro.tsx
@@ -147,6 +147,14 @@ export function ApiDocsIntro() {
         </p>
         <p {...stylex.props(docsStyles.prose)}>
           <Trans>
+            The proxy header is best for reads. It cannot serve writes: the
+            service JWT your PDS mints tells us who you are but carries no
+            credential to write to your repo with, so write procedures reject
+            it. Call the AppView directly with your own token for those.
+          </Trans>
+        </p>
+        <p {...stylex.props(docsStyles.prose)}>
+          <Trans>
             Reader state endpoints also accept an optional{" "}
             <code {...stylex.props(docsStyles.codeInline)}>did</code> query
             param to read a reader&apos;s public indexed state without auth.

--- a/apps/standard-reader/src/lib/api-docs/discovery.test.ts
+++ b/apps/standard-reader/src/lib/api-docs/discovery.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { appviewDid } from "#/server/xrpc/config";
+
+import { appviewDidClient } from "./discovery";
+
+const originalPublicUrl = process.env.PUBLIC_URL;
+
+beforeEach(() => {
+  process.env.PUBLIC_URL = "https://standard-reader.app";
+});
+
+afterEach(() => {
+  if (originalPublicUrl === undefined) {
+    delete process.env.PUBLIC_URL;
+  } else {
+    process.env.PUBLIC_URL = originalPublicUrl;
+  }
+});
+
+describe("appviewDidClient", () => {
+  it("keeps the host's dots, like the server-side DID", () => {
+    expect(appviewDidClient()).toBe("did:web:standard-reader.app");
+  });
+
+  it("agrees with the DID the service actually publishes", () => {
+    // The docs page renders this value as the DID callers paste into
+    // `atproto-proxy`. If it drifts from `appviewDid()`, we hand developers a
+    // DID that does not resolve to us.
+    expect(appviewDidClient()).toBe(appviewDid());
+  });
+});

--- a/apps/standard-reader/src/lib/api-docs/discovery.ts
+++ b/apps/standard-reader/src/lib/api-docs/discovery.ts
@@ -3,8 +3,15 @@ import { getPublicUrlClient } from "#/lib/public-url";
 /** Fragment id on did:web for the AppView XRPC service. */
 export const APPVIEW_SERVICE_ID = "standard_reader_appview";
 
+/**
+ * Client-side mirror of `appviewDid()` in `#/server/xrpc/config`.
+ *
+ * The host keeps its dots: colons in a `did:web` encode path segments, not the
+ * hostname separator. Keep the two in lockstep — the docs page renders this
+ * value as the DID callers paste into `atproto-proxy`.
+ */
 export function appviewDidClient(): string {
-  const host = new URL(getPublicUrlClient()).hostname.replaceAll(".", ":");
+  const host = new URL(getPublicUrlClient()).hostname;
   return `did:web:${host}`;
 }
 

--- a/apps/standard-reader/src/lib/atproto/did-web.test.ts
+++ b/apps/standard-reader/src/lib/atproto/did-web.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { didWebDocumentUrl } from "./did-web";
+
+describe("didWebDocumentUrl", () => {
+  it("keeps the dots in a domain-root host", () => {
+    // The bug this file exists for: `standard-reader.app` must not be spelled
+    // `standard-reader:app`, which names the host `standard-reader` instead.
+    expect(didWebDocumentUrl("did:web:standard-reader.app")).toBe(
+      "https://standard-reader.app/.well-known/did.json",
+    );
+  });
+
+  it("resolves a path-bearing DID without /.well-known/", () => {
+    expect(didWebDocumentUrl("did:web:example.com:user:alice")).toBe(
+      "https://example.com/user/alice/did.json",
+    );
+  });
+
+  it("decodes a percent-escaped port", () => {
+    expect(didWebDocumentUrl("did:web:localhost%3A3000")).toBe(
+      "https://localhost:3000/.well-known/did.json",
+    );
+  });
+
+  it("rejects a non-did:web identifier", () => {
+    expect(didWebDocumentUrl("did:plc:abc123")).toBeNull();
+    expect(didWebDocumentUrl("https://example.com")).toBeNull();
+  });
+
+  it("rejects a DID with no host", () => {
+    expect(didWebDocumentUrl("did:web:")).toBeNull();
+    expect(didWebDocumentUrl("did:web::user")).toBeNull();
+  });
+
+  it("rejects empty path segments rather than collapsing them", () => {
+    expect(didWebDocumentUrl("did:web:example.com::alice")).toBeNull();
+  });
+
+  it("rejects a host smuggling a path, query, or fragment", () => {
+    expect(didWebDocumentUrl("did:web:example.com%2Fevil")).toBeNull();
+    expect(didWebDocumentUrl("did:web:example.com%3Fa=1")).toBeNull();
+    expect(didWebDocumentUrl("did:web:example.com%23frag")).toBeNull();
+  });
+});

--- a/apps/standard-reader/src/lib/atproto/did-web.ts
+++ b/apps/standard-reader/src/lib/atproto/did-web.ts
@@ -1,0 +1,55 @@
+/**
+ * `did:web` location rules, in one place.
+ *
+ * The method encodes a hostname **with its dots intact** and reserves the colon
+ * as the path separator:
+ *
+ * - `did:web:example.com` → `https://example.com/.well-known/did.json`
+ * - `did:web:example.com:user:alice` → `https://example.com/user/alice/did.json`
+ *
+ * Note the second form drops `/.well-known/` entirely — a path-bearing DID
+ * points at `did.json` directly under its path. Every resolver here used to
+ * concatenate the two, which meant a path-bearing DID was fetched from a URL
+ * the spec never names.
+ *
+ * A port is encoded as a percent-escaped colon in the first segment
+ * (`did:web:localhost%3A3000`), which is why the host is decoded before use.
+ */
+
+/** Prefix of a `did:web` identifier. */
+const DID_WEB_PREFIX = "did:web:";
+
+/**
+ * The URL a `did:web` identifier's DID document lives at, or `null` when `did`
+ * is not a well-formed `did:web`.
+ *
+ * Callers are still responsible for SSRF-checking the result — the host comes
+ * from whoever authored the DID.
+ */
+export function didWebDocumentUrl(did: string): string | null {
+  if (!did.startsWith(DID_WEB_PREFIX)) return null;
+  const segments = did.slice(DID_WEB_PREFIX.length).split(":");
+  const [rawHost, ...path] = segments;
+  if (!rawHost) return null;
+  // Reject empty path segments (`did:web:example.com::a`) rather than
+  // collapsing them into a different URL than the DID names.
+  if (path.some((segment) => segment === "")) return null;
+
+  let host: string;
+  try {
+    host = decodeURIComponent(rawHost);
+  } catch {
+    return null;
+  }
+  if (host.includes("/") || host.includes("?") || host.includes("#")) {
+    return null;
+  }
+
+  const suffix =
+    path.length > 0 ? `/${path.join("/")}/did.json` : "/.well-known/did.json";
+  try {
+    return new URL(`https://${host}${suffix}`).toString();
+  } catch {
+    return null;
+  }
+}

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -5679,6 +5679,10 @@ msgstr ""
 msgid "Feedback submitted"
 msgstr "تم إرسال الملاحظات"
 
+#: src/components/docs/api-docs-intro.tsx
+msgid "The proxy header is best for reads. It cannot serve writes: the service JWT your PDS mints tells us who you are but carries no credential to write to your repo with, so write procedures reject it. Call the AppView directly with your own token for those."
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Move up"
 msgstr "نقل لأعلى"

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -5679,6 +5679,10 @@ msgstr ""
 msgid "Feedback submitted"
 msgstr "Feedback gesendet"
 
+#: src/components/docs/api-docs-intro.tsx
+msgid "The proxy header is best for reads. It cannot serve writes: the service JWT your PDS mints tells us who you are but carries no credential to write to your repo with, so write procedures reject it. Call the AppView directly with your own token for those."
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Move up"
 msgstr "Nach oben"

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -5679,6 +5679,10 @@ msgstr ""
 msgid "Feedback submitted"
 msgstr ""
 
+#: src/components/docs/api-docs-intro.tsx
+msgid "The proxy header is best for reads. It cannot serve writes: the service JWT your PDS mints tells us who you are but carries no credential to write to your repo with, so write procedures reject it. Call the AppView directly with your own token for those."
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Move up"
 msgstr ""

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -5679,6 +5679,10 @@ msgstr "Reading offline"
 msgid "Feedback submitted"
 msgstr "Feedback submitted"
 
+#: src/components/docs/api-docs-intro.tsx
+msgid "The proxy header is best for reads. It cannot serve writes: the service JWT your PDS mints tells us who you are but carries no credential to write to your repo with, so write procedures reject it. Call the AppView directly with your own token for those."
+msgstr "The proxy header is best for reads. It cannot serve writes: the service JWT your PDS mints tells us who you are but carries no credential to write to your repo with, so write procedures reject it. Call the AppView directly with your own token for those."
+
 #: src/components/reader/collection-builder.tsx
 msgid "Move up"
 msgstr "Move up"

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -5679,6 +5679,10 @@ msgstr ""
 msgid "Feedback submitted"
 msgstr "Comentario enviado"
 
+#: src/components/docs/api-docs-intro.tsx
+msgid "The proxy header is best for reads. It cannot serve writes: the service JWT your PDS mints tells us who you are but carries no credential to write to your repo with, so write procedures reject it. Call the AppView directly with your own token for those."
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Move up"
 msgstr "Subir"

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -5679,6 +5679,10 @@ msgstr ""
 msgid "Feedback submitted"
 msgstr "Retour envoyé"
 
+#: src/components/docs/api-docs-intro.tsx
+msgid "The proxy header is best for reads. It cannot serve writes: the service JWT your PDS mints tells us who you are but carries no credential to write to your repo with, so write procedures reject it. Call the AppView directly with your own token for those."
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Move up"
 msgstr "Monter"

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -5679,6 +5679,10 @@ msgstr ""
 msgid "Feedback submitted"
 msgstr "フィードバックを送信しました"
 
+#: src/components/docs/api-docs-intro.tsx
+msgid "The proxy header is best for reads. It cannot serve writes: the service JWT your PDS mints tells us who you are but carries no credential to write to your repo with, so write procedures reject it. Call the AppView directly with your own token for those."
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Move up"
 msgstr "上へ移動"

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -5679,6 +5679,10 @@ msgstr ""
 msgid "Feedback submitted"
 msgstr "피드백이 제출되었습니다"
 
+#: src/components/docs/api-docs-intro.tsx
+msgid "The proxy header is best for reads. It cannot serve writes: the service JWT your PDS mints tells us who you are but carries no credential to write to your repo with, so write procedures reject it. Call the AppView directly with your own token for those."
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Move up"
 msgstr "위로 이동"

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -5679,6 +5679,10 @@ msgstr ""
 msgid "Feedback submitted"
 msgstr "Feedback enviado"
 
+#: src/components/docs/api-docs-intro.tsx
+msgid "The proxy header is best for reads. It cannot serve writes: the service JWT your PDS mints tells us who you are but carries no credential to write to your repo with, so write procedures reject it. Call the AppView directly with your own token for those."
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Move up"
 msgstr "Mover para cima"

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -5679,6 +5679,10 @@ msgstr ""
 msgid "Feedback submitted"
 msgstr "反馈已提交"
 
+#: src/components/docs/api-docs-intro.tsx
+msgid "The proxy header is best for reads. It cannot serve writes: the service JWT your PDS mints tells us who you are but carries no credential to write to your repo with, so write procedures reject it. Call the AppView directly with your own token for those."
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Move up"
 msgstr "上移"

--- a/apps/standard-reader/src/server/atproto/identity.ts
+++ b/apps/standard-reader/src/server/atproto/identity.ts
@@ -1,3 +1,4 @@
+import { didWebDocumentUrl } from "#/lib/atproto/did-web";
 import { assertSafeFetchUrl } from "#/server/security/ssrf-guard";
 
 /**
@@ -136,11 +137,11 @@ async function fetchDidDoc(did: string): Promise<DidDocument | null> {
     if (did.startsWith("did:plc:")) {
       url = `${PLC_URL}/${encodeURIComponent(did)}`;
     } else if (did.startsWith("did:web:")) {
-      const host = did.slice("did:web:".length).replaceAll(":", "/");
-      url = `https://${host}/.well-known/did.json`;
+      url = didWebDocumentUrl(did);
       // did:web host is attacker-controlled — validate before fetching to
       // prevent SSRF (security audit C1/C2).
       try {
+        if (!url) return null;
         assertSafeFetchUrl(url);
       } catch {
         return null;

--- a/apps/standard-reader/src/server/labeler/verify.server.ts
+++ b/apps/standard-reader/src/server/labeler/verify.server.ts
@@ -19,6 +19,7 @@
 import { parseDidKey, verifySignature } from "@atproto/crypto";
 import * as dagCbor from "@ipld/dag-cbor";
 
+import { didWebDocumentUrl } from "#/lib/atproto/did-web";
 import { assertSafeFetchUrl } from "#/server/security/ssrf-guard";
 
 import type { DisplayLabel } from "./labels.server.ts";
@@ -67,8 +68,9 @@ async function fetchDidDoc(did: string): Promise<DidDocument | null> {
   if (did.startsWith("did:plc:")) {
     url = `${PLC_URL}/${encodeURIComponent(did)}`;
   } else if (did.startsWith("did:web:")) {
-    const host = did.slice("did:web:".length).replaceAll(":", "/");
-    url = `https://${host}/.well-known/did.json`;
+    const docUrl = didWebDocumentUrl(did);
+    if (!docUrl) return null;
+    url = docUrl;
     // did:web host comes from a record we indexed — validate before fetching so
     // a hostile registration can't point us at internal infrastructure.
     try {

--- a/apps/standard-reader/src/server/xrpc/auth.test.ts
+++ b/apps/standard-reader/src/server/xrpc/auth.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { XrpcAuthContext } from "./auth";
-import { requireScopes } from "./auth";
+import { acceptedServiceJwtAudiences, requireScopes } from "./auth";
+import { APPVIEW_SERVICE_ID } from "./config";
 import { ForbiddenError } from "./errors";
 import { XRPC_WRITE_SCOPES } from "./scopes";
 
@@ -14,6 +15,49 @@ function auth(overrides: Partial<XrpcAuthContext> = {}): XrpcAuthContext {
     ...overrides,
   };
 }
+
+describe("acceptedServiceJwtAudiences", () => {
+  const originalPublicUrl = process.env.PUBLIC_URL;
+
+  beforeEach(() => {
+    process.env.PUBLIC_URL = "https://standard-reader.app";
+  });
+
+  afterEach(() => {
+    if (originalPublicUrl === undefined) {
+      delete process.env.PUBLIC_URL;
+    } else {
+      process.env.PUBLIC_URL = originalPublicUrl;
+    }
+  });
+
+  it("accepts the bare DID a PDS actually mints", () => {
+    // `pipethrough` strips the fragment off `atproto-proxy` before signing.
+    // Requiring the fragment form rejected every proxied call as
+    // `BadJwtAudience`.
+    expect(
+      acceptedServiceJwtAudiences().has("did:web:standard-reader.app"),
+    ).toBe(true);
+  });
+
+  it("also accepts the did#fragment form", () => {
+    expect(
+      acceptedServiceJwtAudiences().has(
+        `did:web:standard-reader.app#${APPVIEW_SERVICE_ID}`,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a token minted for another service", () => {
+    expect(acceptedServiceJwtAudiences().has("did:web:api.bsky.app")).toBe(
+      false,
+    );
+    // The old, malformed spelling of our own DID must not be honoured either.
+    expect(
+      acceptedServiceJwtAudiences().has("did:web:standard-reader:app"),
+    ).toBe(false);
+  });
+});
 
 describe("requireScopes", () => {
   it("allows a scope the credential was granted", () => {

--- a/apps/standard-reader/src/server/xrpc/auth.ts
+++ b/apps/standard-reader/src/server/xrpc/auth.ts
@@ -3,10 +3,11 @@ import { Client as AtpClient } from "@atcute/client";
 import type { Did } from "@atcute/lexicons";
 import { verifyJwt } from "@atproto/xrpc-server";
 
+import { didWebDocumentUrl } from "#/lib/atproto/did-web";
 import { resolveIdentity } from "#/server/atproto/identity";
 import { assertSafeFetchUrl } from "#/server/security/ssrf-guard";
 
-import { appviewAudience } from "./config";
+import { appviewAudience, appviewDid } from "./config";
 import { AuthRequiredError, ForbiddenError } from "./errors";
 
 export type XrpcAuthContext = {
@@ -62,11 +63,11 @@ async function getSigningKey(
     const plcUrl = process.env.TAP_PLC_URL || "https://plc.directory";
     docUrl = `${plcUrl}/${encodeURIComponent(did)}`;
   } else if (did.startsWith("did:web:")) {
-    const host = did.slice("did:web:".length).replaceAll(":", ".");
-    docUrl = `https://${host}/.well-known/did.json`;
+    docUrl = didWebDocumentUrl(did);
     // did:web host is attacker-controlled (from the unverified JWT iss) —
     // validate before fetching to prevent SSRF (security audit C1).
     try {
+      if (!docUrl) throw new Error("malformed did:web");
       assertSafeFetchUrl(docUrl);
     } catch {
       throw new AuthRequiredError("Unable to resolve signing key for issuer");
@@ -98,11 +99,31 @@ async function getSigningKey(
   return verificationMethod.publicKeyMultibase;
 }
 
+/**
+ * Audiences we accept on a PDS-minted service JWT.
+ *
+ * `pipethrough` splits the `atproto-proxy` header and signs the token with the
+ * **bare DID** as `aud`, keeping the `did#fragment` form only for matching
+ * OAuth `rpc:` scopes. Requiring the fragment form rejected every proxied call
+ * with `BadJwtAudience`; accepting only the bare form would break any
+ * implementation that echoes the whole header back. Take either — but nothing
+ * else, so a token minted for a different service still cannot be replayed at
+ * us.
+ */
+export function acceptedServiceJwtAudiences(): ReadonlySet<string> {
+  return new Set([appviewDid(), appviewAudience()]);
+}
+
 async function verifyServiceJwt(
   jwt: string,
   lxm: string,
 ): Promise<XrpcAuthContext> {
-  const payload = await verifyJwt(jwt, appviewAudience(), lxm, getSigningKey);
+  // `null` skips xrpc-server's built-in single-value audience check so we can
+  // accept both spellings below; every other claim is still verified there.
+  const payload = await verifyJwt(jwt, null, lxm, getSigningKey);
+  if (!acceptedServiceJwtAudiences().has(payload.aud)) {
+    throw new AuthRequiredError("jwt audience does not match service did");
+  }
   const iss = payload.iss.split("#")[0] as Did;
   return {
     did: iss,

--- a/apps/standard-reader/src/server/xrpc/config.test.ts
+++ b/apps/standard-reader/src/server/xrpc/config.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { APPVIEW_SERVICE_ID, appviewAudience, appviewDid } from "./config";
+
+const originalPublicUrl = process.env.PUBLIC_URL;
+
+beforeEach(() => {
+  process.env.PUBLIC_URL = "https://standard-reader.app";
+});
+
+afterEach(() => {
+  if (originalPublicUrl === undefined) {
+    delete process.env.PUBLIC_URL;
+  } else {
+    process.env.PUBLIC_URL = originalPublicUrl;
+  }
+});
+
+describe("appviewDid", () => {
+  it("embeds the host with its dots intact", () => {
+    // Regression: the host used to be spelled `standard-reader:app`, which per
+    // the did:web spec names the host `standard-reader` with a path segment
+    // `app`. Every PDS-proxied call failed to resolve us.
+    expect(appviewDid()).toBe("did:web:standard-reader.app");
+  });
+
+  it("matches the DID document's own location", () => {
+    // Self-consistency is what resolvers check: fetching the document named by
+    // this DID must yield a document whose `id` is this DID.
+    const host = appviewDid().slice("did:web:".length);
+    expect(`https://${host}/.well-known/did.json`).toBe(
+      "https://standard-reader.app/.well-known/did.json",
+    );
+  });
+
+  it("tracks a non-production public URL", () => {
+    process.env.PUBLIC_URL = "https://pr-42.up.railway.app";
+    expect(appviewDid()).toBe("did:web:pr-42.up.railway.app");
+  });
+});
+
+describe("appviewAudience", () => {
+  it("is the did#fragment service reference", () => {
+    expect(appviewAudience()).toBe(
+      `did:web:standard-reader.app#${APPVIEW_SERVICE_ID}`,
+    );
+  });
+});

--- a/apps/standard-reader/src/server/xrpc/config.ts
+++ b/apps/standard-reader/src/server/xrpc/config.ts
@@ -3,11 +3,34 @@ import { getPublicUrl } from "#/lib/public-url";
 /** Fragment id on did:web:standard-reader.app for the AppView XRPC service. */
 export const APPVIEW_SERVICE_ID = "standard_reader_appview";
 
+/**
+ * The AppView's `did:web` identifier.
+ *
+ * Per the did:web method spec the host is embedded **with its dots intact** —
+ * `standard-reader.app` → `did:web:standard-reader.app`, resolved from
+ * `https://standard-reader.app/.well-known/did.json`. Colons are reserved for
+ * encoding *path* segments (`did:web:example.com:user:alice` →
+ * `https://example.com/user/alice/did.json`), so percent-encoding the dots as
+ * colons produced a DID that resolves to the host `standard-reader` with a path
+ * segment `app` — a name that does not exist.
+ *
+ * That broke every PDS-proxied call: a spec-compliant resolver either failed to
+ * fetch the bogus location, or (given the corrected dot-form) fetched the real
+ * document and rejected it because its `id` did not match the DID asked for.
+ * Reported at https://userinput.app/d/did:plc:7qubw2z53qzfturlblaozz4a/3msqg3okp3kc7.
+ */
 export function appviewDid(): string {
-  const host = new URL(getPublicUrl()).hostname.replaceAll(".", ":");
+  const host = new URL(getPublicUrl()).hostname;
   return `did:web:${host}`;
 }
 
+/**
+ * The `did#fragment` service reference — what callers put in `atproto-proxy`
+ * and what an OAuth `rpc:` scope names as its audience.
+ *
+ * This is **not** the audience of a PDS-minted service JWT: `pipethrough` keeps
+ * the bare DID there. Use {@link appviewDid} for that check.
+ */
 export function appviewAudience(): string {
   return `${appviewDid()}#${APPVIEW_SERVICE_ID}`;
 }

--- a/packages/cli/src/atproto.ts
+++ b/packages/cli/src/atproto.ts
@@ -192,8 +192,13 @@ async function resolveDid(
   if (did.startsWith("did:plc:")) {
     document = await fetchJson(`${PLC_DIRECTORY}/${did}`);
   } else if (did.startsWith("did:web:")) {
-    const host = did.slice("did:web:".length).replaceAll(":", "/");
-    document = await fetchJson(`https://${host}/.well-known/did.json`);
+    // Colons encode path segments, and a path-bearing did:web puts `did.json`
+    // directly under that path rather than in `/.well-known/`.
+    const [host, ...path] = did.slice("did:web:".length).split(":");
+    if (!host) throw new CliError(`Malformed did:web: ${did}`);
+    const suffix =
+      path.length > 0 ? `/${path.join("/")}/did.json` : "/.well-known/did.json";
+    document = await fetchJson(`https://${decodeURIComponent(host)}${suffix}`);
   } else {
     throw new CliError(`Unsupported DID method: ${did}`);
   }


### PR DESCRIPTION
Reported by `mihaizaurus.at` on [userinput.app](https://userinput.app/d/did:plc:7qubw2z53qzfturlblaozz4a/3msqg3okp3kc7). The report is correct, and there were **two** independent bugs on the same path — fixing only the reported one would have moved the failure from 500 to 401.

## The published DID

`appviewDid()` did `hostname.replaceAll(".", ":")`, publishing `did:web:standard-reader:app`. Per the [did:web spec](https://w3c-ccg.github.io/did-method-web/) dots stay and colons encode *path* segments, so that DID names the host `standard-reader` with a path segment `app` — not a name that exists.

The reporter's deduction about the second failure was also exactly right: given the corrected dot-form, a resolver fetches the real document and rejects it on the self-consistency check, because its `id` still said the colon form. Both failures surface as a 500 from the caller's own PDS, before the request ever reaches us.

## The service-JWT audience

`verifyServiceJwt` passed `appviewAudience()` (`did#fragment`) as `verifyJwt`'s expected `aud`. But [`pipethrough.ts:102-105`](https://github.com/bluesky-social/atproto/blob/main/packages/pds/src/pipethrough.ts) signs with the **bare DID**, keeping `did#serviceId` only so OAuth `rpc:?aud=` scopes match:

```js
// did#serviceId form (so OAuth callers' rpc:?aud=did#service scopes
// match), while the outbound service-auth JWT keeps bare-DID aud
```

So every proxied call would have hit `BadJwtAudience`. Both spellings are now accepted, and nothing else — a token minted for another service still can't be replayed at us.

## did:web path segments, everywhere

While confirming the above, the same mistake turned up in all four DID-document resolvers: colons mapped to `.` (`xrpc/auth.ts`) or to `/` but with `/.well-known/` still appended (`atproto/identity.ts`, `labeler/verify.server.ts`, `packages/cli`). A path-bearing `did:web:example.com:user:alice` resolves to `https://example.com/user/alice/did.json` — no `/.well-known/`. Extracted to `src/lib/atproto/did-web.ts` (`didWebDocumentUrl`) with tests; the CLI keeps its own copy since it can't import `#/`.

## Docs

The proxy path serves reads, not writes — a service JWT gives us the reader's identity but no credential to write to their repo, so `requireAuthClient` rejects Tier 4. `APP_VISION.md` already said this; the public `/docs/api` page didn't, which is what the reporter hit (they were trying to bookmark). Added a sentence there and re-ran `i18n:extract`. Their direct-call workaround is in fact the supported path for writes, not a hack.

## Verification

Booted the app and curled the real routes:

```
$ curl http://127.0.0.1:3241/.well-known/did.json
{"@context":["https://www.w3.org/ns/did/v1"],
 "id":"did:web:standard-reader.app",
 "service":[{"id":"#standard_reader_appview","type":"StandardReaderAppView",
             "serviceEndpoint":"https://standard-reader.app/xrpc"}]}
```

Self-consistent with its own location now. Full suite 890 passed / 7 skipped (+13 new tests), `pnpm lint` 0 errors, `pnpm format:check` clean, typecheck clean for both the app and the CLI.

Nothing needs migrating — the DID document is served, not stored — but nothing changes for the reporter until this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
