### PR TITLE
Offline reading in the installed PWA

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -1532,12 +1532,15 @@ publication list looked clean.
 - **Follows, likes, save-for-later, and read-state** written back as records (and cached).
 - **URL-backed routing** for every view.
 - Network-powered recommendations & trending (initial heuristics, tunable).
+- **Offline reading in the installed app** — the service worker caches read server functions
+  (`/_serverFn` GETs), and `src/pwa/offline-sync.ts` pre-downloads every unread body and its
+  images so the backlog opens with no connection. Reaching for something never downloaded shows
+  an offline state rather than an error.
 
 ### Later
 
 - Recommendation / trending tuning and quality work.
 - Higher-quality full-text search.
-- Offline / save-for-later body cache (save queue via `app.standard-reader.bookmark` is shipped).
 
 ### Non-goals (for now)
 

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -1146,8 +1146,23 @@ Backend/API exists; UI or copy is missing.
       (`ReadingTypographySubMenu`, `useReadingTypography`, `drizzle/0012_*`).
 - [x] **PWA install readiness** — Phase A: PNG icons (192/512), `apple-touch-icon`, expanded
       [`manifest.json`](public/manifest.json) + head tags in [`__root.tsx`](src/routes/__root.tsx).
-      Regenerate via `pnpm icons:generate`. _Open decision:_ Phase B service worker for asset
-      caching only (not offline articles).
+      Regenerate via `pnpm icons:generate`. Phase B shipped as asset caching only; the
+      "not offline articles" limit was lifted by **Offline reading** below.
+- [x] **Offline reading (installed app)** — the open decision above resolved in favour of full
+      offline support. A `data` runtime-cache rule in [`vite.config.ts`](vite.config.ts) caches
+      `/_serverFn` **GET**s (reads serialise their args into the query string, so each call has a
+      stable URL; Workbox routes are GET-only so mutations are excluded), and
+      `networkMode: "offlineFirst"` in
+      [`query-client.ts`](src/integrations/tanstack-query/query-client.ts) is what lets those
+      requests reach the service worker at all — the default `"online"` parked them at
+      `fetchStatus: "paused"`, so an offline loader `ensureQueryData` hung forever instead of
+      failing. [`offline-sync.ts`](src/pwa/offline-sync.ts) then walks the reader's whole unread
+      set (`getUnreadDocumentUris`, keyset-paginated over `selectUnreadDocumentPage`) and pulls
+      each body through the _same_ `getArticle` call the article loader makes, warming images via
+      real `Image` elements (a `fetch` sets no `destination: "image"`, so the Workbox rule would
+      miss it). Gated on the installed app + a device-scoped toggle; stops at 80% of storage
+      quota; personal caches are dropped on sign-out.
+      [`RouteError`](src/components/route-error.tsx) is the app-wide `defaultErrorComponent`.
 - [x] **Content rendering gaps** — PCKT gallery renderer (`blog.pckt.block.gallery`); prod scan
       found 54 documents — implemented grid/list/carousel/masonry layouts via
       [`pckt-gallery.tsx`](src/components/reader/content/renderers/pckt-gallery.tsx).

--- a/apps/standard-reader/public/offline.html
+++ b/apps/standard-reader/public/offline.html
@@ -80,17 +80,33 @@
         margin: 0 0 1.5rem;
         color: var(--muted);
       }
-      button {
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        justify-content: center;
+      }
+      button,
+      .primary {
         font: inherit;
         font-weight: 600;
         cursor: pointer;
         border: 0;
         border-radius: 999px;
         padding: 0.65rem 1.4rem;
+        text-decoration: none;
         color: var(--bg);
         background: var(--fg);
       }
-      button:hover {
+      /* Secondary: the feed is the useful destination, retrying rarely is. */
+      button {
+        color: var(--fg);
+        background: transparent;
+        box-shadow: inset 0 0 0 1px
+          color-mix(in srgb, var(--fg) 25%, transparent);
+      }
+      button:hover,
+      .primary:hover {
         filter: brightness(1.05);
       }
     </style>
@@ -116,10 +132,13 @@
       </div>
       <h1>You're offline</h1>
       <p>
-        This page hasn't been saved for offline reading yet. Reconnect and try
-        again — pages you've already visited stay available.
+        This page wasn't saved to your device. Your unread articles were — open
+        the app and they're there.
       </p>
-      <button type="button" onclick="location.reload()">Try again</button>
+      <div class="actions">
+        <a class="primary" href="/">Go to your feed</a>
+        <button type="button" onclick="location.reload()">Try again</button>
+      </div>
     </main>
   </body>
 </html>

--- a/apps/standard-reader/scripts/verify-service-worker.mjs
+++ b/apps/standard-reader/scripts/verify-service-worker.mjs
@@ -32,6 +32,22 @@
  * call, Safari does not. So on iOS no `push` listener ever registered, and every
  * notification was dropped on arrival with nothing anywhere reporting a failure.
  *
+ * ## And a third: the worker's own dependency 404s
+ *
+ * Same snapshot, different casualty. `sw.js` opens with
+ * `define(["./workbox-<hash>"])` and loads that chunk via `importScripts`, so
+ * every route and the entire precache live behind it. The plugin's repeated
+ * passes emit *differently hashed* chunks, and Nitro's snapshot recorded an
+ * earlier pass's name — leaving the manifest with `/workbox-4cce69c4.js` while
+ * the shipped `sw.js` asks for `/workbox-d95f8ea8.js`. Both files sit on disk;
+ * only the stale one is served, and the other 404s.
+ *
+ * The failure is completely silent, and worse than the truncation: the worker
+ * parses, registers, installs, activates, and reports itself healthy — its AMD
+ * factory just never runs. No caches are created, no `fetch` handler is
+ * installed, and `navigator.serviceWorker.controller` is set, so every
+ * diagnostic short of "does it actually cache anything" says yes.
+ *
  * ## What this does
  *
  * 1. Inlines `public/push-sw.js` into `sw.js` at top level, so the listeners
@@ -40,11 +56,14 @@
  *    disk — necessarily after (1), which changes that size. Etags are opaque
  *    cache validators, so a recomputed one need not match Nitro's own scheme; it
  *    only has to change with the content.
- * 3. Asserts the result is usable: parses, precaches the offline fallback, and
- *    carries both the `push` and `notificationclick` listeners.
+ * 3. Adds a manifest entry for the workbox chunk `sw.js` actually imports, when
+ *    the snapshot missed it.
+ * 4. Asserts the result is usable: parses, precaches the offline fallback,
+ *    carries both the `push` and `notificationclick` listeners, and can reach
+ *    its own runtime chunk.
  *
  * Runs from `pnpm build`, so a deploy fails loudly rather than shipping a worker
- * that cannot register — or one that registers and silently ignores every push.
+ * that cannot register — or one that registers and silently does nothing.
  */
 
 import { createHash } from "node:crypto";
@@ -147,6 +166,55 @@ if (existsSync(serverEntry)) {
   if (repaired > 0) writeFileSync(serverEntry, bundle);
 }
 
+// ── 2b. Make sure the worker's runtime chunk is servable ────────────────────
+// `sw.js` starts with `define(["./workbox-<hash>"])`; that chunk carries every
+// strategy, route, and the precache itself. A manifest that names a *different*
+// hash serves a 404 for it, and the worker becomes an inert no-op that still
+// reports as activated. Add the entry rather than fail: the file is on disk and
+// correct, only the snapshot is stale.
+let addedChunk = null;
+if (existsSync(swPath) && existsSync(serverEntry)) {
+  const swSource = readFileSync(swPath, "utf8");
+  const referenced = swSource.match(/define\(\[\s*"\.\/(workbox-[^"]+)"/);
+  if (referenced) {
+    const chunkFile = `${referenced[1]}.js`;
+    const chunkUrl = `/${chunkFile}`;
+    const chunkPath = path.join(publicDir, chunkFile);
+    let bundle = readFileSync(serverEntry, "utf8");
+
+    if (!existsSync(chunkPath)) {
+      fail(
+        `sw.js imports ${chunkUrl}, which the build never emitted — the worker would register and then do nothing`,
+      );
+    }
+
+    if (!bundle.includes(`"${chunkUrl}"`)) {
+      const buffer = readFileSync(chunkPath);
+      const entry =
+        `\t"${chunkUrl}": {\n` +
+        `\t\t"type": "text/javascript; charset=utf-8",\n` +
+        `\t\t"etag": ${JSON.stringify(etagFor(buffer))},\n` +
+        `\t\t"mtime": ${JSON.stringify(statSync(chunkPath).mtime.toISOString())},\n` +
+        `\t\t"size": ${buffer.length},\n` +
+        `\t\t"path": "../public/${chunkFile}"\n` +
+        `\t},\n`;
+      // Anchor on `/sw.js`, which is always present in the same object.
+      const anchor = bundle.indexOf('\t"/sw.js": {');
+      if (anchor === -1) {
+        fail(
+          `cannot add a manifest entry for ${chunkUrl}: no "/sw.js" entry to anchor to`,
+        );
+      }
+      bundle = bundle.slice(0, anchor) + entry + bundle.slice(anchor);
+      writeFileSync(serverEntry, bundle);
+      addedChunk = chunkUrl;
+      console.log(
+        `[verify-sw] added missing manifest entry for ${chunkUrl} — Nitro recorded a stale chunk hash and would have 404'd the worker's runtime`,
+      );
+    }
+  }
+}
+
 // ── 3. The worker itself has to be usable ───────────────────────────────────
 if (!existsSync(swPath)) {
   fail(
@@ -214,12 +282,43 @@ if (existsSync(serverEntry)) {
       `Nitro would serve ${recorded[1]} of ${byteLength} bytes of sw.js — the manifest repair did not take`,
     );
   }
+
+  // Every chunk the worker imports has to be reachable, at the right size. A
+  // missing entry 404s and a stale size truncates; either way the AMD factory
+  // never runs and the worker silently caches nothing.
+  const referenced = source.match(/define\(\[\s*"\.\/(workbox-[^"]+)"/);
+  if (referenced) {
+    const chunkUrl = `/${referenced[1]}.js`;
+    const chunkEntry = bundle.match(
+      new RegExp(
+        `"${chunkUrl.replaceAll(".", String.raw`\.`)}":\\s*\\{[^}]*"size":\\s*(\\d+)`,
+      ),
+    );
+    if (!chunkEntry) {
+      fail(
+        `sw.js imports ${chunkUrl} but Nitro has no manifest entry for it — it would 404, and the worker would activate and then do nothing`,
+      );
+    }
+    const chunkBytes = statSync(
+      path.join(publicDir, `${referenced[1]}.js`),
+    ).size;
+    if (Number(chunkEntry[1]) !== chunkBytes) {
+      fail(
+        `Nitro would serve ${chunkEntry[1]} of ${chunkBytes} bytes of ${chunkUrl} — the worker's runtime would be truncated`,
+      );
+    }
+  }
 }
+
+const repairs = [
+  repaired > 0
+    ? `repaired ${repaired} stale manifest entr${repaired === 1 ? "y" : "ies"}`
+    : null,
+  addedChunk ? `added ${addedChunk}` : null,
+].filter(Boolean);
 
 console.log(
   `[verify-sw] ok — ${byteLength} bytes, precaches ${entries.length}: ${entries.join(", ")}${
-    repaired > 0
-      ? ` (repaired ${repaired} stale manifest entr${repaired === 1 ? "y" : "ies"})`
-      : ""
+    repairs.length > 0 ? ` (${repairs.join("; ")})` : ""
   }`,
 );

--- a/apps/standard-reader/src/components/NavbarAuth.tsx
+++ b/apps/standard-reader/src/components/NavbarAuth.tsx
@@ -41,6 +41,8 @@ import { Button as AriaButton } from "react-aria-components";
 import { ButtonLink, MenuItemLink } from "#/components/router-links";
 import { user } from "#/integrations/tanstack-query/api-user.functions";
 import { useTrackReadingHistory } from "#/lib/use-track-reading-history";
+import { clearPersonalOfflineData } from "#/pwa/offline-cache";
+import { stopOfflineSync } from "#/pwa/offline-sync";
 import { useLoginSearch } from "#/utils/use-login-search";
 
 import { LanguageDialog } from "./reader/language-dialog";
@@ -178,6 +180,15 @@ export function NavbarAuth({
   const logoutMutation = useMutation({
     mutationFn: async () => {
       await user.signOut();
+
+      // Stop mid-flight offline sync before clearing, or it writes the
+      // signed-out reader's articles back into the cache we just emptied.
+      stopOfflineSync();
+      // Cached `/_serverFn` responses and rendered documents carry no DID —
+      // the server reads it from the session cookie — so leaving them behind
+      // would serve this reader's feed and saved queue to whoever signs in
+      // next on this device.
+      await clearPersonalOfflineData();
 
       queryClient.setQueryData(user.getSessionQueryOptions.queryKey, null);
       await queryClient.resetQueries();

--- a/apps/standard-reader/src/components/guide/pages/getting-started-guide-page.tsx
+++ b/apps/standard-reader/src/components/guide/pages/getting-started-guide-page.tsx
@@ -200,11 +200,20 @@ export function GettingStartedGuidePage() {
       </h2>
       <p {...stylex.props(docsStyles.prose)}>
         <Trans>
-          Pages you have already visited stay available when your connection
-          drops, and you get a plain offline page rather than a browser error
-          when you reach for something that was never loaded. When a new version
-          of the app is ready it offers to reload, rather than changing under
-          you mid-article.
+          The installed app downloads the articles you have not read yet, with
+          their images, while you are online. Open it on a plane or a tunnel and
+          your unread queue is already there — no planning ahead, and nothing to
+          tap beforehand.
+        </Trans>
+      </p>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          Reach for something that was never downloaded and the app says so,
+          rather than showing you an error. You can turn downloading off, and
+          see how much space it is using, under Settings → Reading. It pauses on
+          its own when your phone asks apps to save data. When a new version of
+          the app is ready it offers to reload, rather than changing under you
+          mid-article.
         </Trans>
       </p>
 

--- a/apps/standard-reader/src/components/offline-settings.tsx
+++ b/apps/standard-reader/src/components/offline-settings.tsx
@@ -73,7 +73,10 @@ export function OfflineReadingSettings() {
 
   return (
     <>
-      <Separator />
+      {/* Separators trail rather than lead. These rows open the Offline
+          section's group, and they render nothing outside the installed app —
+          a leading separator would be left stranded at the top of the group in
+          a `?debug` browser tab, where only the disclosure below survives. */}
       <SettingRow
         label={t`Keep unread articles on this device`}
         description={t`Downloads the articles you haven't read yet, with their images, so they open with no connection. Pauses automatically when your system asks apps to save data.`}
@@ -106,6 +109,7 @@ export function OfflineReadingSettings() {
           <Trans>Remove</Trans>
         </Button>
       </SettingRow>
+      <Separator />
     </>
   );
 }

--- a/apps/standard-reader/src/components/offline-settings.tsx
+++ b/apps/standard-reader/src/components/offline-settings.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { Trans, useLingui } from "@lingui/react/macro";
+import { Button } from "@standard-reader/design-system/button";
+import { Separator } from "@standard-reader/design-system/separator";
+import { Switch } from "@standard-reader/design-system/switch";
+import { useRouter } from "@tanstack/react-router";
+import { useCallback, useEffect, useState } from "react";
+
+import { usePersistentToggle } from "#/lib/use-persistent-toggle";
+import type { OfflineStorageUsage } from "#/pwa/offline-cache";
+import { clearOfflineData, offlineStorageUsage } from "#/pwa/offline-cache";
+import {
+  OFFLINE_READING_STORAGE_KEY,
+  runOfflineSync,
+  stopOfflineSync,
+} from "#/pwa/offline-sync";
+import { isStandalone } from "#/pwa/standalone";
+
+import { SettingRow } from "./settings-row";
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB"];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value < 10 ? value.toFixed(1) : Math.round(value)} ${units[unit]}`;
+}
+
+/**
+ * Offline reading controls.
+ *
+ * Renders nothing outside the installed app: sync only runs there (see
+ * `runOfflineSync`), so on the website these would be switches that do nothing.
+ */
+export function OfflineReadingSettings() {
+  const { t } = useLingui();
+  const router = useRouter();
+  const [installed, setInstalled] = useState(false);
+  const [enabled, setEnabled] = usePersistentToggle(
+    OFFLINE_READING_STORAGE_KEY,
+    true,
+  );
+  const [usage, setUsage] = useState<OfflineStorageUsage | null>(null);
+  const [clearing, setClearing] = useState(false);
+
+  useEffect(() => {
+    setInstalled(isStandalone());
+  }, []);
+
+  const refreshUsage = useCallback(() => {
+    void offlineStorageUsage().then(setUsage);
+  }, []);
+
+  useEffect(refreshUsage, [refreshUsage]);
+
+  if (!installed) return null;
+
+  const onToggle = (next: boolean) => {
+    setEnabled(next);
+    if (next) {
+      // `usePersistentToggle` has already written the key, so the sync's own
+      // enabled check passes on this call.
+      void runOfflineSync(router).then(refreshUsage);
+    } else {
+      stopOfflineSync();
+    }
+  };
+
+  return (
+    <>
+      <Separator />
+      <SettingRow
+        label={t`Keep unread articles on this device`}
+        description={t`Downloads the articles you haven't read yet, with their images, so they open with no connection. Pauses automatically when your system asks apps to save data.`}
+      >
+        <Switch
+          isSelected={enabled}
+          onChange={onToggle}
+          aria-label={t`Keep unread articles on this device`}
+        />
+      </SettingRow>
+      <Separator />
+      <SettingRow
+        label={t`Downloaded articles`}
+        description={
+          usage
+            ? t`Standard Reader is using ${formatBytes(usage.usage)} on this device.`
+            : t`Storage use isn't available in this browser.`
+        }
+      >
+        <Button
+          variant="secondary"
+          isDisabled={clearing}
+          onPress={() => {
+            setClearing(true);
+            void clearOfflineData()
+              .then(refreshUsage)
+              .finally(() => setClearing(false));
+          }}
+        >
+          <Trans>Remove</Trans>
+        </Button>
+      </SettingRow>
+    </>
+  );
+}

--- a/apps/standard-reader/src/components/offline-sync-debug.tsx
+++ b/apps/standard-reader/src/components/offline-sync-debug.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { Button } from "@standard-reader/design-system/button";
+import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
+import {
+  gap,
+  horizontalSpace,
+  verticalSpace,
+} from "@standard-reader/design-system/theme/semantic-spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+} from "@standard-reader/design-system/theme/typography.stylex";
+import * as stylex from "@stylexjs/stylex";
+import { useRouter } from "@tanstack/react-router";
+import { useEffect, useState, useSyncExternalStore } from "react";
+
+import type { OfflineStorageUsage } from "#/pwa/offline-cache";
+import { offlineStorageUsage } from "#/pwa/offline-cache";
+import { runOfflineSync, stopOfflineSync } from "#/pwa/offline-sync";
+import {
+  getOfflineSyncProgress,
+  getOfflineSyncProgressServer,
+  subscribeOfflineSyncProgress,
+} from "#/pwa/offline-sync-progress";
+
+const styles = stylex.create({
+  panel: {
+    display: "flex",
+    flexDirection: "column",
+    paddingBlock: verticalSpace.lg,
+    paddingInlineEnd: horizontalSpace["3xl"],
+    paddingInlineStart: horizontalSpace["3xl"],
+    rowGap: gap.xs,
+  },
+  heading: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.xs,
+    fontWeight: fontWeight.semibold,
+    lineHeight: lineHeight.sm,
+    marginBottom: verticalSpace.xs,
+    marginTop: verticalSpace.none,
+  },
+  row: {
+    columnGap: gap.md,
+    display: "flex",
+    justifyContent: "space-between",
+  },
+  key: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.xs,
+    lineHeight: lineHeight.sm,
+  },
+  value: {
+    color: uiColor.text2,
+    // Monospace so a state string or an error is read exactly as written —
+    // this gets screenshotted from a phone and read back.
+    fontFamily: fontFamily.mono,
+    fontSize: fontSize.xs,
+    lineHeight: lineHeight.sm,
+    overflowWrap: "anywhere",
+    textAlign: "end",
+  },
+  actions: {
+    columnGap: gap.md,
+    display: "flex",
+    marginTop: verticalSpace.md,
+  },
+});
+
+/** `/settings?debug` — the flag that shows this panel. */
+function debugRequested(): boolean {
+  if (globalThis.location === undefined) return false;
+  return new URLSearchParams(globalThis.location.search).has("debug");
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB"];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value < 10 ? value.toFixed(1) : Math.round(value)} ${units[unit]}`;
+}
+
+// Debug surface: the device's own clock format is exactly what's wanted.
+function stamp(at: number | null): string {
+  return at === null ? "—" : new Date(at).toLocaleTimeString();
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div {...stylex.props(styles.row)}>
+      <span {...stylex.props(styles.key)}>{label}</span>
+      <span {...stylex.props(styles.value)}>{value}</span>
+    </div>
+  );
+}
+
+/**
+ * Live view of the offline sync pass, shown only when the settings URL carries
+ * `?debug`. Untranslated on purpose, like the push diagnostics values: this is
+ * a troubleshooting surface whose strings get read back verbatim.
+ *
+ * "Run sync now" bypasses the installed-app gate, which is what makes offline
+ * sync exercisable in a browser tab at all — on a device it also answers "is
+ * sync broken or merely not running".
+ */
+export function OfflineSyncDebugPanel() {
+  const [visible, setVisible] = useState(false);
+  const router = useRouter();
+  const progress = useSyncExternalStore(
+    subscribeOfflineSyncProgress,
+    getOfflineSyncProgress,
+    getOfflineSyncProgressServer,
+  );
+  const [usage, setUsage] = useState<OfflineStorageUsage | null>(null);
+
+  // Client-only: the flag lives in the URL's search string, which the server
+  // render must not depend on (and the settings route doesn't validate it).
+  useEffect(() => {
+    setVisible(debugRequested());
+  }, []);
+
+  // Refresh the storage line while a pass runs; it is the pass's output.
+  useEffect(() => {
+    void offlineStorageUsage().then(setUsage);
+    if (!progress.running) return;
+    const interval = globalThis.setInterval(() => {
+      void offlineStorageUsage().then(setUsage);
+    }, 3000);
+    return () => globalThis.clearInterval(interval);
+  }, [progress.running]);
+
+  if (!visible) return null;
+
+  const { counts } = progress;
+  const status = progress.running
+    ? `running (${progress.pass}) — ${progress.step ?? "…"}`
+    : progress.stopReason
+      ? `${progress.stopReason}${progress.error ? `: ${progress.error}` : ""}`
+      : "not started";
+
+  return (
+    <div {...stylex.props(styles.panel)}>
+      <p {...stylex.props(styles.heading)}>Offline sync (debug)</p>
+      <Row label="status" value={status} />
+      <Row
+        label="started / finished"
+        value={`${stamp(progress.startedAt)} / ${stamp(progress.finishedAt)}`}
+      />
+      <Row label="feed pages" value={String(counts.feedPages)} />
+      <Row label="unread listed" value={String(counts.unreadListed)} />
+      <Row label="publications" value={String(counts.publications)} />
+      <Row label="back-catalog pages" value={String(counts.backCatalogPages)} />
+      <Row label="authors" value={String(counts.authors)} />
+      <Row label="lists" value={String(counts.lists)} />
+      <Row
+        label="bodies"
+        value={`${counts.bodiesCached} of ${counts.bodiesQueued} queued`}
+      />
+      <Row label="images" value={String(counts.imagesWarmed)} />
+      <Row
+        label="storage"
+        value={
+          usage
+            ? `${formatBytes(usage.usage)}${usage.quota ? ` of ${formatBytes(usage.quota)}` : ""}${usage.persisted ? " (persisted)" : ""}`
+            : "unavailable"
+        }
+      />
+      <div {...stylex.props(styles.actions)}>
+        <Button
+          variant="secondary"
+          size="sm"
+          isDisabled={progress.running}
+          onPress={() => void runOfflineSync(router, { force: true })}
+        >
+          Run sync now
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          isDisabled={!progress.running}
+          onPress={stopOfflineSync}
+        >
+          Stop
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/standard-reader/src/components/offline-sync-debug.tsx
+++ b/apps/standard-reader/src/components/offline-sync-debug.tsx
@@ -2,7 +2,12 @@
 
 import { Trans } from "@lingui/react/macro";
 import { Button } from "@standard-reader/design-system/button";
-import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
+import { animationDuration } from "@standard-reader/design-system/theme/animations.stylex";
+import {
+  primaryColor,
+  uiColor,
+} from "@standard-reader/design-system/theme/color.stylex";
+import { radius } from "@standard-reader/design-system/theme/radius.stylex";
 import {
   gap,
   horizontalSpace,
@@ -19,7 +24,11 @@ import { useEffect, useState, useSyncExternalStore } from "react";
 
 import type { OfflineStorageUsage } from "#/pwa/offline-cache";
 import { offlineStorageUsage } from "#/pwa/offline-cache";
-import { runOfflineSync, stopOfflineSync } from "#/pwa/offline-sync";
+import {
+  publishOfflineSyncTotals,
+  runOfflineSync,
+  stopOfflineSync,
+} from "#/pwa/offline-sync";
 import {
   getOfflineSyncProgress,
   getOfflineSyncProgressServer,
@@ -70,6 +79,26 @@ const styles = stylex.create({
     display: "flex",
     marginTop: verticalSpace.md,
   },
+  // A bar rather than another number: the one thing worth seeing at a glance is
+  // how much of the backlog is already on the device.
+  track: {
+    backgroundColor: uiColor.bgSubtle,
+    borderRadius: radius.full,
+    blockSize: verticalSpace.sm,
+    marginBottom: verticalSpace.xs,
+    marginTop: verticalSpace.xs,
+    overflow: "hidden",
+    inlineSize: "100%",
+  },
+  // Dynamic rather than an inline `style`: the width is data, and StyleX is
+  // the only styling layer here.
+  fill: (percent: number) => ({
+    backgroundColor: primaryColor.solid1,
+    blockSize: "100%",
+    inlineSize: `${percent}%`,
+    transitionDuration: animationDuration.default,
+    transitionProperty: "inline-size",
+  }),
 });
 
 function formatBytes(bytes: number): string {
@@ -116,6 +145,13 @@ export function OfflineSyncDebugPanel() {
   );
   const [usage, setUsage] = useState<OfflineStorageUsage | null>(null);
 
+  // Totals describe the device, so they must be readable before any pass has
+  // run this session — otherwise opening the panel on a cold start shows
+  // zeroes for a backlog that is already there.
+  useEffect(() => {
+    publishOfflineSyncTotals();
+  }, []);
+
   // Refresh the storage line while a pass runs; it is the pass's output.
   useEffect(() => {
     void offlineStorageUsage().then(setUsage);
@@ -133,6 +169,12 @@ export function OfflineSyncDebugPanel() {
       ? `${progress.stopReason}${progress.error ? `: ${progress.error}` : ""}`
       : "not started";
 
+  // The plan's shape, not this pass's: what is on the device and what is still
+  // owed. A pass being interrupted no longer resets either, so this is the
+  // number that actually answers "is it getting there?".
+  const total = progress.stored + progress.pending;
+  const percent = total === 0 ? 0 : Math.round((progress.stored / total) * 100);
+
   return (
     <div {...stylex.props(styles.panel)}>
       <p {...stylex.props(styles.intro)}>
@@ -141,6 +183,32 @@ export function OfflineSyncDebugPanel() {
           Sharing a screenshot of it is the fastest way to get it fixed.
         </Trans>
       </p>
+      <div
+        {...stylex.props(styles.track)}
+        role="progressbar"
+        aria-valuenow={percent}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label="Articles stored"
+      >
+        <div {...stylex.props(styles.fill(percent))} />
+      </div>
+      <Row
+        label={<Trans>Downloaded</Trans>}
+        value={
+          total === 0
+            ? "nothing yet"
+            : `${progress.stored} of ${total} (${percent}%)`
+        }
+      />
+      <Row
+        label={<Trans>Still to fetch</Trans>}
+        value={String(progress.pending)}
+      />
+      <Row
+        label={<Trans>Initial fill</Trans>}
+        value={progress.initialComplete ? "complete" : "in progress"}
+      />
       <Row label={<Trans>Status</Trans>} value={status} />
       <Row
         label={<Trans>Started / finished</Trans>}

--- a/apps/standard-reader/src/components/offline-sync-debug.tsx
+++ b/apps/standard-reader/src/components/offline-sync-debug.tsx
@@ -1,6 +1,12 @@
 "use client";
 
+import { Trans } from "@lingui/react/macro";
 import { Button } from "@standard-reader/design-system/button";
+import {
+  Disclosure,
+  DisclosurePanel,
+  DisclosureTitle,
+} from "@standard-reader/design-system/disclosure";
 import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
 import {
   gap,
@@ -25,6 +31,7 @@ import {
   getOfflineSyncProgressServer,
   subscribeOfflineSyncProgress,
 } from "#/pwa/offline-sync-progress";
+import { isStandalone } from "#/pwa/standalone";
 
 const styles = stylex.create({
   panel: {
@@ -105,9 +112,12 @@ function Row({ label, value }: { label: string; value: string }) {
 }
 
 /**
- * Live view of the offline sync pass, shown only when the settings URL carries
- * `?debug`. Untranslated on purpose, like the push diagnostics values: this is
- * a troubleshooting surface whose strings get read back verbatim.
+ * Live view of the offline sync pass, inside a collapsed Troubleshooting
+ * disclosure. Always available in the installed app — sync only matters
+ * there, and a PWA has no address bar to type a flag into — and behind
+ * `?debug` in a browser tab, where it exists for development. The values are
+ * untranslated on purpose, like the push diagnostics: this is a surface whose
+ * strings get read back verbatim.
  *
  * "Run sync now" bypasses the installed-app gate, which is what makes offline
  * sync exercisable in a browser tab at all — on a device it also answers "is
@@ -123,10 +133,11 @@ export function OfflineSyncDebugPanel() {
   );
   const [usage, setUsage] = useState<OfflineStorageUsage | null>(null);
 
-  // Client-only: the flag lives in the URL's search string, which the server
-  // render must not depend on (and the settings route doesn't validate it).
+  // Client-only: display mode and the URL's search string are both things the
+  // server render must not depend on (and the settings route doesn't validate
+  // the flag).
   useEffect(() => {
-    setVisible(debugRequested());
+    setVisible(isStandalone() || debugRequested());
   }, []);
 
   // Refresh the storage line while a pass runs; it is the pass's output.
@@ -149,50 +160,60 @@ export function OfflineSyncDebugPanel() {
       : "not started";
 
   return (
-    <div {...stylex.props(styles.panel)}>
-      <p {...stylex.props(styles.heading)}>Offline sync (debug)</p>
-      <Row label="status" value={status} />
-      <Row
-        label="started / finished"
-        value={`${stamp(progress.startedAt)} / ${stamp(progress.finishedAt)}`}
-      />
-      <Row label="feed pages" value={String(counts.feedPages)} />
-      <Row label="unread listed" value={String(counts.unreadListed)} />
-      <Row label="publications" value={String(counts.publications)} />
-      <Row label="back-catalog pages" value={String(counts.backCatalogPages)} />
-      <Row label="authors" value={String(counts.authors)} />
-      <Row label="lists" value={String(counts.lists)} />
-      <Row
-        label="bodies"
-        value={`${counts.bodiesCached} of ${counts.bodiesQueued} queued`}
-      />
-      <Row label="images" value={String(counts.imagesWarmed)} />
-      <Row
-        label="storage"
-        value={
-          usage
-            ? `${formatBytes(usage.usage)}${usage.quota ? ` of ${formatBytes(usage.quota)}` : ""}${usage.persisted ? " (persisted)" : ""}`
-            : "unavailable"
-        }
-      />
-      <div {...stylex.props(styles.actions)}>
-        <Button
-          variant="secondary"
-          size="sm"
-          isDisabled={progress.running}
-          onPress={() => void runOfflineSync(router, { force: true })}
-        >
-          Run sync now
-        </Button>
-        <Button
-          variant="secondary"
-          size="sm"
-          isDisabled={!progress.running}
-          onPress={stopOfflineSync}
-        >
-          Stop
-        </Button>
-      </div>
-    </div>
+    <Disclosure>
+      <DisclosureTitle>
+        <Trans>Troubleshooting</Trans>
+      </DisclosureTitle>
+      <DisclosurePanel>
+        <div {...stylex.props(styles.panel)}>
+          <p {...stylex.props(styles.heading)}>Offline sync</p>
+          <Row label="status" value={status} />
+          <Row
+            label="started / finished"
+            value={`${stamp(progress.startedAt)} / ${stamp(progress.finishedAt)}`}
+          />
+          <Row label="feed pages" value={String(counts.feedPages)} />
+          <Row label="unread listed" value={String(counts.unreadListed)} />
+          <Row label="publications" value={String(counts.publications)} />
+          <Row
+            label="back-catalog pages"
+            value={String(counts.backCatalogPages)}
+          />
+          <Row label="authors" value={String(counts.authors)} />
+          <Row label="lists" value={String(counts.lists)} />
+          <Row
+            label="bodies"
+            value={`${counts.bodiesCached} of ${counts.bodiesQueued} queued`}
+          />
+          <Row label="images" value={String(counts.imagesWarmed)} />
+          <Row
+            label="storage"
+            value={
+              usage
+                ? `${formatBytes(usage.usage)}${usage.quota ? ` of ${formatBytes(usage.quota)}` : ""}${usage.persisted ? " (persisted)" : ""}`
+                : "unavailable"
+            }
+          />
+          <div {...stylex.props(styles.actions)}>
+            <Button
+              variant="secondary"
+              size="sm"
+              isDisabled={progress.running}
+              onPress={() => void runOfflineSync(router, { force: true })}
+            >
+              Run sync now
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              isDisabled={!progress.running}
+              onPress={stopOfflineSync}
+            >
+              Stop
+            </Button>
+          </div>
+        </div>
+      </DisclosurePanel>
+    </Disclosure>
   );
 }

--- a/apps/standard-reader/src/components/offline-sync-debug.tsx
+++ b/apps/standard-reader/src/components/offline-sync-debug.tsx
@@ -2,11 +2,6 @@
 
 import { Trans } from "@lingui/react/macro";
 import { Button } from "@standard-reader/design-system/button";
-import {
-  Disclosure,
-  DisclosurePanel,
-  DisclosureTitle,
-} from "@standard-reader/design-system/disclosure";
 import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
 import {
   gap,
@@ -16,7 +11,6 @@ import {
 import {
   fontFamily,
   fontSize,
-  fontWeight,
   lineHeight,
 } from "@standard-reader/design-system/theme/typography.stylex";
 import * as stylex from "@stylexjs/stylex";
@@ -31,7 +25,6 @@ import {
   getOfflineSyncProgressServer,
   subscribeOfflineSyncProgress,
 } from "#/pwa/offline-sync-progress";
-import { isStandalone } from "#/pwa/standalone";
 
 const styles = stylex.create({
   panel: {
@@ -42,14 +35,14 @@ const styles = stylex.create({
     paddingInlineStart: horizontalSpace["3xl"],
     rowGap: gap.xs,
   },
-  heading: {
+  intro: {
     color: uiColor.text1,
     fontFamily: fontFamily.sans,
     fontSize: fontSize.xs,
-    fontWeight: fontWeight.semibold,
     lineHeight: lineHeight.sm,
-    marginBottom: verticalSpace.xs,
+    marginBottom: verticalSpace.md,
     marginTop: verticalSpace.none,
+    maxWidth: "42ch",
   },
   row: {
     columnGap: gap.md,
@@ -79,12 +72,6 @@ const styles = stylex.create({
   },
 });
 
-/** `/settings?debug` — the flag that shows this panel. */
-function debugRequested(): boolean {
-  if (globalThis.location === undefined) return false;
-  return new URLSearchParams(globalThis.location.search).has("debug");
-}
-
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   const units = ["KB", "MB", "GB"];
@@ -102,7 +89,7 @@ function stamp(at: number | null): string {
   return at === null ? "—" : new Date(at).toLocaleTimeString();
 }
 
-function Row({ label, value }: { label: string; value: string }) {
+function Row({ label, value }: { label: React.ReactNode; value: string }) {
   return (
     <div {...stylex.props(styles.row)}>
       <span {...stylex.props(styles.key)}>{label}</span>
@@ -112,19 +99,15 @@ function Row({ label, value }: { label: string; value: string }) {
 }
 
 /**
- * Live view of the offline sync pass, inside a collapsed Troubleshooting
- * disclosure. Always available in the installed app — sync only matters
- * there, and a PWA has no address bar to type a flag into — and behind
- * `?debug` in a browser tab, where it exists for development. The values are
- * untranslated on purpose, like the push diagnostics: this is a surface whose
- * strings get read back verbatim.
+ * Live view of the offline sync pass. The values are untranslated on purpose,
+ * like the push diagnostics: this is a surface whose strings get read back
+ * verbatim.
  *
  * "Run sync now" bypasses the installed-app gate, which is what makes offline
  * sync exercisable in a browser tab at all — on a device it also answers "is
  * sync broken or merely not running".
  */
 export function OfflineSyncDebugPanel() {
-  const [visible, setVisible] = useState(false);
   const router = useRouter();
   const progress = useSyncExternalStore(
     subscribeOfflineSyncProgress,
@@ -132,13 +115,6 @@ export function OfflineSyncDebugPanel() {
     getOfflineSyncProgressServer,
   );
   const [usage, setUsage] = useState<OfflineStorageUsage | null>(null);
-
-  // Client-only: display mode and the URL's search string are both things the
-  // server render must not depend on (and the settings route doesn't validate
-  // the flag).
-  useEffect(() => {
-    setVisible(isStandalone() || debugRequested());
-  }, []);
 
   // Refresh the storage line while a pass runs; it is the pass's output.
   useEffect(() => {
@@ -150,8 +126,6 @@ export function OfflineSyncDebugPanel() {
     return () => globalThis.clearInterval(interval);
   }, [progress.running]);
 
-  if (!visible) return null;
-
   const { counts } = progress;
   const status = progress.running
     ? `running (${progress.pass}) — ${progress.step ?? "…"}`
@@ -160,60 +134,64 @@ export function OfflineSyncDebugPanel() {
       : "not started";
 
   return (
-    <Disclosure>
-      <DisclosureTitle>
-        <Trans>Troubleshooting</Trans>
-      </DisclosureTitle>
-      <DisclosurePanel>
-        <div {...stylex.props(styles.panel)}>
-          <p {...stylex.props(styles.heading)}>Offline sync</p>
-          <Row label="status" value={status} />
-          <Row
-            label="started / finished"
-            value={`${stamp(progress.startedAt)} / ${stamp(progress.finishedAt)}`}
-          />
-          <Row label="feed pages" value={String(counts.feedPages)} />
-          <Row label="unread listed" value={String(counts.unreadListed)} />
-          <Row label="publications" value={String(counts.publications)} />
-          <Row
-            label="back-catalog pages"
-            value={String(counts.backCatalogPages)}
-          />
-          <Row label="authors" value={String(counts.authors)} />
-          <Row label="lists" value={String(counts.lists)} />
-          <Row
-            label="bodies"
-            value={`${counts.bodiesCached} of ${counts.bodiesQueued} queued`}
-          />
-          <Row label="images" value={String(counts.imagesWarmed)} />
-          <Row
-            label="storage"
-            value={
-              usage
-                ? `${formatBytes(usage.usage)}${usage.quota ? ` of ${formatBytes(usage.quota)}` : ""}${usage.persisted ? " (persisted)" : ""}`
-                : "unavailable"
-            }
-          />
-          <div {...stylex.props(styles.actions)}>
-            <Button
-              variant="secondary"
-              size="sm"
-              isDisabled={progress.running}
-              onPress={() => void runOfflineSync(router, { force: true })}
-            >
-              Run sync now
-            </Button>
-            <Button
-              variant="secondary"
-              size="sm"
-              isDisabled={!progress.running}
-              onPress={stopOfflineSync}
-            >
-              Stop
-            </Button>
-          </div>
-        </div>
-      </DisclosurePanel>
-    </Disclosure>
+    <div {...stylex.props(styles.panel)}>
+      <p {...stylex.props(styles.intro)}>
+        <Trans>
+          If articles aren’t available offline, this is what the last sync did.
+          Sharing a screenshot of it is the fastest way to get it fixed.
+        </Trans>
+      </p>
+      <Row label={<Trans>Status</Trans>} value={status} />
+      <Row
+        label={<Trans>Started / finished</Trans>}
+        value={`${stamp(progress.startedAt)} / ${stamp(progress.finishedAt)}`}
+      />
+      <Row label={<Trans>Feed pages</Trans>} value={String(counts.feedPages)} />
+      <Row
+        label={<Trans>Unread listed</Trans>}
+        value={String(counts.unreadListed)}
+      />
+      <Row
+        label={<Trans>Publications</Trans>}
+        value={String(counts.publications)}
+      />
+      <Row
+        label={<Trans>Back-catalog pages</Trans>}
+        value={String(counts.backCatalogPages)}
+      />
+      <Row label={<Trans>Authors</Trans>} value={String(counts.authors)} />
+      <Row label={<Trans>Lists</Trans>} value={String(counts.lists)} />
+      <Row
+        label={<Trans>Articles</Trans>}
+        value={`${counts.bodiesCached} of ${counts.bodiesQueued} queued`}
+      />
+      <Row label={<Trans>Images</Trans>} value={String(counts.imagesWarmed)} />
+      <Row
+        label={<Trans>Storage</Trans>}
+        value={
+          usage
+            ? `${formatBytes(usage.usage)}${usage.quota ? ` of ${formatBytes(usage.quota)}` : ""}${usage.persisted ? " (persisted)" : ""}`
+            : "unavailable"
+        }
+      />
+      <div {...stylex.props(styles.actions)}>
+        <Button
+          variant="secondary"
+          size="sm"
+          isDisabled={progress.running}
+          onPress={() => void runOfflineSync(router, { force: true })}
+        >
+          <Trans>Run sync now</Trans>
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          isDisabled={!progress.running}
+          onPress={stopOfflineSync}
+        >
+          <Trans>Stop</Trans>
+        </Button>
+      </div>
+    </div>
   );
 }

--- a/apps/standard-reader/src/components/reader/app-shell.tsx
+++ b/apps/standard-reader/src/components/reader/app-shell.tsx
@@ -171,32 +171,7 @@ const styles = stylex.create({
     paddingInlineStart: horizontalSpace.xs,
     paddingBottom: verticalSpace.xxs,
     paddingTop: verticalSpace.xxs,
-    // Anchors the offline badge to the wordmark.
-    position: "relative",
     width: "fit-content",
-  },
-  offlineBadge: {
-    borderRadius: radius.full,
-    backgroundColor: uiColor.text1,
-    color: uiColor.bg,
-    fontFamily: fontFamily.sans,
-    fontSize: fontSize.xs,
-    fontWeight: fontWeight.semibold,
-    letterSpacing: tracking.wide,
-    lineHeight: 1,
-    // Anchored by its *start* at the wordmark's end, then pulled back a little
-    // so it clips the corner. Anchoring by the end instead puts the badge's
-    // whole width on top of the word — the offset only decides how much of
-    // "Reader" it covers, never whether it does.
-    insetBlockStart: `calc(-1 * ${verticalSpace.xxs})`,
-    insetInlineStart: "100%",
-    marginInlineStart: `calc(-1 * ${horizontalSpace.xl})`,
-    paddingBlock: verticalSpace.xxs,
-    paddingInline: horizontalSpace.xs,
-    pointerEvents: "none",
-    position: "absolute",
-    textTransform: "lowercase",
-    whiteSpace: "nowrap",
   },
   brandSidebar: {
     // Left-align in the sidebar's column flow; only relevant here — in the
@@ -898,28 +873,15 @@ function Brand({
   style?: stylex.StyleXStyles;
   to?: "/" | "/about";
 }) {
-  const { t } = useLingui();
   const focusRingProps = useFocusRingProps();
-  const online = useOnlineStatus();
   return (
     <Link
       to={to}
       {...focusRingProps}
       {...stylex.props(styles.brandLink, style)}
     >
+      {/* `BrandWordmark` says "Offline Reader" when there is no connection. */}
       <BrandWordmark />
-      {/* Pinned to the wordmark rather than shown as a banner: the state is
-          persistent, not an event, and a dismissible bar would either nag or
-          disappear while still being true. */}
-      {online ? null : (
-        <span
-          role="status"
-          aria-label={t`You are offline`}
-          {...stylex.props(styles.offlineBadge)}
-        >
-          <Trans>offline</Trans>
-        </span>
-      )}
     </Link>
   );
 }

--- a/apps/standard-reader/src/components/reader/app-shell.tsx
+++ b/apps/standard-reader/src/components/reader/app-shell.tsx
@@ -184,12 +184,13 @@ const styles = stylex.create({
     fontWeight: fontWeight.semibold,
     letterSpacing: tracking.wide,
     lineHeight: 1,
-    // Sits *on* the wordmark's top-right corner rather than beside it. Hanging
-    // it off the end pushed the brand's effective width past the viewport on
-    // small screens; overlapping the ascender line keeps the whole thing inside
-    // the bar at any width, and the badge is short enough to stay legible.
+    // Anchored by its *start* at the wordmark's end, then pulled back a little
+    // so it clips the corner. Anchoring by the end instead puts the badge's
+    // whole width on top of the word — the offset only decides how much of
+    // "Reader" it covers, never whether it does.
     insetBlockStart: `calc(-1 * ${verticalSpace.xxs})`,
-    insetInlineEnd: `calc(-1 * ${horizontalSpace.xxs})`,
+    insetInlineStart: "100%",
+    marginInlineStart: `calc(-1 * ${horizontalSpace.xl})`,
     paddingBlock: verticalSpace.xxs,
     paddingInline: horizontalSpace.xs,
     pointerEvents: "none",

--- a/apps/standard-reader/src/components/reader/app-shell.tsx
+++ b/apps/standard-reader/src/components/reader/app-shell.tsx
@@ -75,6 +75,7 @@ import { PageReaderProvider } from "#/lib/page-reader/page-reader-provider";
 import type { SidebarNavId } from "#/lib/sidebar-nav";
 import { useFormatters } from "#/lib/use-formatters";
 import { useCompactNav } from "#/lib/use-media-query";
+import { useOnlineStatus } from "#/lib/use-online-status";
 
 import type {
   FollowingPublication,
@@ -170,7 +171,32 @@ const styles = stylex.create({
     paddingInlineStart: horizontalSpace.xs,
     paddingBottom: verticalSpace.xxs,
     paddingTop: verticalSpace.xxs,
+    // Anchors the offline badge to the wordmark.
+    position: "relative",
     width: "fit-content",
+  },
+  offlineBadge: {
+    borderRadius: radius.full,
+    backgroundColor: uiColor.text1,
+    color: uiColor.bg,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.xs,
+    fontWeight: fontWeight.semibold,
+    letterSpacing: tracking.wide,
+    lineHeight: 1,
+    // Superscripted off the wordmark's top-right corner: absolute so it never
+    // reflows the brand, and clear of the letterforms so it annotates the logo
+    // instead of covering it. Tucked back over the corner by a hair, which is
+    // empty space above the cap height.
+    insetBlockStart: `calc(-1 * ${verticalSpace.xs})`,
+    insetInlineStart: "100%",
+    marginInlineStart: `calc(-1 * ${horizontalSpace.xxs})`,
+    paddingBlock: verticalSpace.xxs,
+    paddingInline: horizontalSpace.xs,
+    pointerEvents: "none",
+    position: "absolute",
+    textTransform: "lowercase",
+    whiteSpace: "nowrap",
   },
   brandSidebar: {
     // Left-align in the sidebar's column flow; only relevant here — in the
@@ -612,14 +638,33 @@ const COLLECTIONS_NAV: NavLink = {
 };
 
 /**
+ * Nav items that need the network, and are hidden while offline.
+ *
+ * Offline sync stores the reader's own reading — unread, their backlog, Saved,
+ * Subscriptions — so Home, Latest and Saved keep working. These three are
+ * different in kind: Discover and Search query the whole network for things the
+ * reader has by definition not read, and Collections is editable. Leaving them
+ * in the nav offers three taps that can only end in an error page, so they come
+ * out until the connection is back.
+ */
+const NETWORK_ONLY_NAV: ReadonlySet<SidebarNavId> = new Set([
+  "discover",
+  "search",
+  "collections",
+]);
+
+/**
  * Primary nav links; inserts Saved + Collections after Latest when the reader is
  * signed in (both are personal, repo-backed surfaces).
  */
-function navWithSaved(signedIn: boolean): Array<NavLink> {
-  return NAV.flatMap((item) => {
+function navWithSaved(signedIn: boolean, online: boolean): Array<NavLink> {
+  const items = NAV.flatMap((item) => {
     if (item.to !== "/latest" || !signedIn) return [item];
     return [item, SAVED_NAV, COLLECTIONS_NAV];
   });
+  return online
+    ? items
+    : items.filter((item) => !NETWORK_ONLY_NAV.has(item.id));
 }
 
 /**
@@ -853,7 +898,9 @@ function Brand({
   style?: stylex.StyleXStyles;
   to?: "/" | "/about";
 }) {
+  const { t } = useLingui();
   const focusRingProps = useFocusRingProps();
+  const online = useOnlineStatus();
   return (
     <Link
       to={to}
@@ -861,6 +908,18 @@ function Brand({
       {...stylex.props(styles.brandLink, style)}
     >
       <BrandWordmark />
+      {/* Pinned to the wordmark rather than shown as a banner: the state is
+          persistent, not an event, and a dismissible bar would either nag or
+          disappear while still being true. */}
+      {online ? null : (
+        <span
+          role="status"
+          aria-label={t`You are offline`}
+          {...stylex.props(styles.offlineBadge)}
+        >
+          <Trans>offline</Trans>
+        </span>
+      )}
     </Link>
   );
 }
@@ -941,7 +1000,8 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const followingUsers = sidebar?.followingUsers ?? [];
   const unreadCount = sidebar?.unreadCount ?? null;
   const hasUnread = unreadCount != null && unreadCount > 0;
-  const primaryNav = navWithSaved(signedIn);
+  const online = useOnlineStatus();
+  const primaryNav = navWithSaved(signedIn, online);
   const [subsSheetOpen, setSubsSheetOpen] = useState(false);
   const [addModalOpen, setAddModalOpen] = useState(false);
   const [feedbackOpen, setFeedbackOpen] = useState(false);

--- a/apps/standard-reader/src/components/reader/app-shell.tsx
+++ b/apps/standard-reader/src/components/reader/app-shell.tsx
@@ -184,13 +184,12 @@ const styles = stylex.create({
     fontWeight: fontWeight.semibold,
     letterSpacing: tracking.wide,
     lineHeight: 1,
-    // Superscripted off the wordmark's top-right corner: absolute so it never
-    // reflows the brand, and clear of the letterforms so it annotates the logo
-    // instead of covering it. Tucked back over the corner by a hair, which is
-    // empty space above the cap height.
-    insetBlockStart: `calc(-1 * ${verticalSpace.xs})`,
-    insetInlineStart: "100%",
-    marginInlineStart: `calc(-1 * ${horizontalSpace.xxs})`,
+    // Sits *on* the wordmark's top-right corner rather than beside it. Hanging
+    // it off the end pushed the brand's effective width past the viewport on
+    // small screens; overlapping the ascender line keeps the whole thing inside
+    // the bar at any width, and the badge is short enough to stay legible.
+    insetBlockStart: `calc(-1 * ${verticalSpace.xxs})`,
+    insetInlineEnd: `calc(-1 * ${horizontalSpace.xxs})`,
     paddingBlock: verticalSpace.xxs,
     paddingInline: horizontalSpace.xs,
     pointerEvents: "none",

--- a/apps/standard-reader/src/components/reader/brand-wordmark.tsx
+++ b/apps/standard-reader/src/components/reader/brand-wordmark.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   primaryColor,
   uiColor,
@@ -10,6 +12,8 @@ import {
   tracking,
 } from "@standard-reader/design-system/theme/typography.stylex";
 import * as stylex from "@stylexjs/stylex";
+
+import { useOnlineStatus } from "#/lib/use-online-status";
 
 const styles = stylex.create({
   root: {
@@ -34,9 +38,18 @@ export type BrandWordmarkProps = StyleXComponentProps<
 >;
 
 export function BrandWordmark({ style, ...props }: BrandWordmarkProps) {
+  const online = useOnlineStatus();
   return (
     <span {...props} {...stylex.props(styles.root, style)}>
-      Standard <span {...stylex.props(styles.accent)}>Reader</span>
+      {/* Offline the wordmark reads "Offline Reader". It replaces a badge
+          pinned to the corner of the logo, which had no good resting place —
+          clear of the letterforms it pushed the brand past a narrow viewport,
+          and inside them it covered the word. The state belongs in the brand
+          rather than beside it: same footprint at any width, nothing to
+          collide with, and it still reads as the app's own name. Untranslated,
+          like the wordmark it replaces a word of. */}
+      {online ? "Standard" : "Offline"}{" "}
+      <span {...stylex.props(styles.accent)}>Reader</span>
     </span>
   );
 }

--- a/apps/standard-reader/src/components/reader/cards.tsx
+++ b/apps/standard-reader/src/components/reader/cards.tsx
@@ -55,6 +55,7 @@ import { user } from "#/integrations/tanstack-query/api-user.functions";
 import { parseInternalRoute } from "#/lib/internal-route";
 import { tsHeadlineHasMatch } from "#/lib/search-headline";
 import { useFormatters } from "#/lib/use-formatters";
+import { useOfflineCachedUris } from "#/lib/use-offline-cached-uris";
 import { useOnlineStatus } from "#/lib/use-online-status";
 import { useOpenCollectionsInMagazine } from "#/lib/use-open-collections-in-magazine";
 import { useOpenLinks } from "#/lib/use-open-links";
@@ -96,7 +97,7 @@ import {
 import { useArticleBookmark } from "./use-article-bookmark";
 
 const styles = stylex.create({
-  opensOffsiteOffline: {
+  unavailableOffline: {
     // Enough to read as unavailable next to a full-strength row, not so faint
     // the title stops being legible — the reader still needs to recognise it
     // later. Applied to the link, so it dims the whole card together.
@@ -1389,6 +1390,7 @@ function ArticleLink({
   const { openExternally } = useOpenLinks();
   const { openInMagazine } = useOpenCollectionsInMagazine();
   const online = useOnlineStatus();
+  const cachedOffline = useOfflineCachedUris(online);
   const params = documentLinkParams(article.uri);
   // Mirrors the branches below: which of them ends at an `<a target="_blank">`
   // rather than an in-app route. Those leave the app for the publication's own
@@ -1402,12 +1404,18 @@ function ArticleLink({
         : article.canonicalUrl
           ? parseInternalRoute(article.canonicalUrl) === null
           : false;
+  // Two ways a row can't be opened offline: it leaves for the publication's
+  // site, or its body was never stored. A feed offline is mostly rows that
+  // work, so the few that don't need to look different — otherwise the only
+  // way to find out is to tap and hit an error.
+  const unavailableOffline =
+    !online && (opensExternally || !cachedOffline.has(article.uri));
   const merged = stylex.props(
     styles.cardLink,
     ...extraStyles,
     // Dimmed, not hidden or disabled: the article is still real and still worth
     // seeing in the feed, and the link works the moment the connection is back.
-    !online && opensExternally && styles.opensOffsiteOffline,
+    unavailableOffline && styles.unavailableOffline,
   );
   // "Open on original site" preference: bypass the in-app reader whenever the
   // document has a canonical URL on its publication site.

--- a/apps/standard-reader/src/components/reader/cards.tsx
+++ b/apps/standard-reader/src/components/reader/cards.tsx
@@ -1408,8 +1408,14 @@ function ArticleLink({
   // site, or its body was never stored. A feed offline is mostly rows that
   // work, so the few that don't need to look different — otherwise the only
   // way to find out is to tap and hit an error.
+  //
+  // `cachedOffline == null` is "not known yet", never "nothing is stored": the
+  // scan is async, and dimming the whole feed while it resolves is worse than
+  // dimming nothing. Off-site rows don't need it — that's known synchronously.
   const unavailableOffline =
-    !online && (opensExternally || !cachedOffline.has(article.uri));
+    !online &&
+    (opensExternally ||
+      (cachedOffline !== null && !cachedOffline.has(article.uri)));
   const merged = stylex.props(
     styles.cardLink,
     ...extraStyles,

--- a/apps/standard-reader/src/components/reader/cards.tsx
+++ b/apps/standard-reader/src/components/reader/cards.tsx
@@ -55,6 +55,7 @@ import { user } from "#/integrations/tanstack-query/api-user.functions";
 import { parseInternalRoute } from "#/lib/internal-route";
 import { tsHeadlineHasMatch } from "#/lib/search-headline";
 import { useFormatters } from "#/lib/use-formatters";
+import { useOnlineStatus } from "#/lib/use-online-status";
 import { useOpenCollectionsInMagazine } from "#/lib/use-open-collections-in-magazine";
 import { useOpenLinks } from "#/lib/use-open-links";
 import { useTrackReadingHistory } from "#/lib/use-track-reading-history";
@@ -95,6 +96,12 @@ import {
 import { useArticleBookmark } from "./use-article-bookmark";
 
 const styles = stylex.create({
+  opensOffsiteOffline: {
+    // Enough to read as unavailable next to a full-strength row, not so faint
+    // the title stops being legible — the reader still needs to recognise it
+    // later. Applied to the link, so it dims the whole card together.
+    opacity: 0.45,
+  },
   cardLink: {
     textDecoration: "none",
     color: "inherit",
@@ -1381,8 +1388,27 @@ function ArticleLink({
   const markReadExternal = useMarkReadExternal();
   const { openExternally } = useOpenLinks();
   const { openInMagazine } = useOpenCollectionsInMagazine();
+  const online = useOnlineStatus();
   const params = documentLinkParams(article.uri);
-  const merged = stylex.props(styles.cardLink, ...extraStyles);
+  // Mirrors the branches below: which of them ends at an `<a target="_blank">`
+  // rather than an in-app route. Those leave the app for the publication's own
+  // site, which offline sync never stored and cannot store, so offline they are
+  // rows that lead to a browser error page.
+  const opensExternally =
+    openExternally && article.canonicalUrl
+      ? true
+      : params && article.hasRenderableBody
+        ? false
+        : article.canonicalUrl
+          ? parseInternalRoute(article.canonicalUrl) === null
+          : false;
+  const merged = stylex.props(
+    styles.cardLink,
+    ...extraStyles,
+    // Dimmed, not hidden or disabled: the article is still real and still worth
+    // seeing in the feed, and the link works the moment the connection is back.
+    !online && opensExternally && styles.opensOffsiteOffline,
+  );
   // "Open on original site" preference: bypass the in-app reader whenever the
   // document has a canonical URL on its publication site.
   if (openExternally && article.canonicalUrl) {

--- a/apps/standard-reader/src/components/reader/pull-to-refresh.tsx
+++ b/apps/standard-reader/src/components/reader/pull-to-refresh.tsx
@@ -29,6 +29,7 @@ import {
 
 import { isShellQuery } from "#/integrations/tanstack-query/shell-queries";
 import { useCompactNav } from "#/lib/use-media-query";
+import { useOnlineStatus } from "#/lib/use-online-status";
 import { usePullGesture } from "#/lib/use-pull-gesture";
 
 /** Mirrors the `DESKTOP` breakpoint in `app-shell.tsx`. */
@@ -289,9 +290,14 @@ export function PullToRefreshLane({
     noopHandler,
   );
   const compactNav = useCompactNav();
+  const online = useOnlineStatus();
   const { chipRef, iconRef, phase } = usePullGesture({
     contentRef,
-    enabled: compactNav && handler !== null,
+    // Refreshing offline can only refetch what is already on the device, and
+    // the refetch fails — so the gesture's whole reward is an error. Disabled
+    // rather than silently no-op'd, so the chip never appears and the reader
+    // isn't told the pull did something.
+    enabled: compactNav && handler !== null && online,
     onRefresh: handler,
   });
 

--- a/apps/standard-reader/src/components/route-error.tsx
+++ b/apps/standard-reader/src/components/route-error.tsx
@@ -10,12 +10,25 @@ import {
   EmptyStateTitle,
 } from "@standard-reader/design-system/empty-state";
 import { size } from "@standard-reader/design-system/theme/semantic-spacing.stylex";
+import * as stylex from "@stylexjs/stylex";
 import type { ErrorComponentProps } from "@tanstack/react-router";
 import { useRouter } from "@tanstack/react-router";
 import { CloudOff, RotateCw } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useOnlineStatus } from "#/lib/use-online-status";
+
+const styles = stylex.create({
+  viewportCenter: {
+    // The error replaces a whole page, so it reads as the page — pinned to the
+    // top of the content column it looked like a banner above missing content.
+    // Short of the full viewport so the top bar doesn't push it into a scroll.
+    alignItems: "center",
+    display: "flex",
+    justifyContent: "center",
+    minBlockSize: stylex.firstThatWorks("80dvh", "80vh"),
+  },
+});
 
 /**
  * What every route renders when its loader throws.
@@ -75,54 +88,56 @@ export function RouteError({ error, reset }: ErrorComponentProps) {
   }, [online, retry]);
 
   return (
-    <EmptyState>
-      <EmptyStateImage>
-        <CloudOff size={size["lg"]} strokeWidth={1.5} aria-hidden />
-      </EmptyStateImage>
-      <EmptyStateTitle>
-        {online ? (
-          <Trans>Something went wrong</Trans>
-        ) : (
-          <Trans>You’re offline</Trans>
-        )}
-      </EmptyStateTitle>
-      <EmptyStateDescription>
-        {online ? (
-          <Trans>
-            That page didn’t load. Try again — if it keeps happening, it’s on
-            our side.
-          </Trans>
-        ) : (
-          <Trans>
-            This page wasn’t saved to your device, so it needs a connection.
-            It’ll load on its own when you’re back online — your unread articles
-            are already here.
-          </Trans>
-        )}
-      </EmptyStateDescription>
-      {/* No retry offered offline: there is nothing to retry until the
+    <div {...stylex.props(styles.viewportCenter)}>
+      <EmptyState>
+        <EmptyStateImage>
+          <CloudOff size={size["lg"]} strokeWidth={1.5} aria-hidden />
+        </EmptyStateImage>
+        <EmptyStateTitle>
+          {online ? (
+            <Trans>Something went wrong</Trans>
+          ) : (
+            <Trans>You’re offline</Trans>
+          )}
+        </EmptyStateTitle>
+        <EmptyStateDescription>
+          {online ? (
+            <Trans>
+              That page didn’t load. Try again — if it keeps happening, it’s on
+              our side.
+            </Trans>
+          ) : (
+            <Trans>
+              This page wasn’t saved to your device, so it needs a connection.
+              It’ll load on its own when you’re back online — your unread
+              articles are already here.
+            </Trans>
+          )}
+        </EmptyStateDescription>
+        {/* No retry offered offline: there is nothing to retry until the
           connection returns, and the effect above loads the page the moment it
           does. */}
-      {online ? (
-        <EmptyStateActions>
-          <Button
-            variant="secondary"
-            size="sm"
-            isDisabled={retrying}
-            onPress={retry}
-          >
-            <RotateCw size={14} strokeWidth={2} aria-hidden />{" "}
-            <Trans>Try again</Trans>
-          </Button>
-        </EmptyStateActions>
-      ) : null}
-      {/* The message is for us, not the reader — but hiding it entirely makes
+        {online ? (
+          <EmptyStateActions>
+            <Button
+              variant="secondary"
+              size="sm"
+              isDisabled={retrying}
+              onPress={retry}
+            >
+              <RotateCw size={14} strokeWidth={2} aria-hidden />{" "}
+              <Trans>Try again</Trans>
+            </Button>
+          </EmptyStateActions>
+        ) : null}
+        {/* The message is for us, not the reader — but hiding it entirely makes
           a bug report a guessing game, so keep it out of the way. */}
-      {online && error instanceof Error && error.message ? (
-        <EmptyStateDescription>
-          <small>{error.message}</small>
-        </EmptyStateDescription>
-      ) : null}
-    </EmptyState>
+        {online && error instanceof Error && error.message ? (
+          <EmptyStateDescription>
+            <small>{error.message}</small>
+          </EmptyStateDescription>
+        ) : null}
+      </EmptyState>
+    </div>
   );
 }

--- a/apps/standard-reader/src/components/route-error.tsx
+++ b/apps/standard-reader/src/components/route-error.tsx
@@ -10,9 +10,10 @@ import {
   EmptyStateTitle,
 } from "@standard-reader/design-system/empty-state";
 import { size } from "@standard-reader/design-system/theme/semantic-spacing.stylex";
+import type { ErrorComponentProps } from "@tanstack/react-router";
 import { useRouter } from "@tanstack/react-router";
 import { CloudOff, RotateCw } from "lucide-react";
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useOnlineStatus } from "#/lib/use-online-status";
 
@@ -26,19 +27,52 @@ import { useOnlineStatus } from "#/lib/use-online-status";
  * the page was never downloaded is the difference between "the app is broken"
  * and "this one wasn't saved".
  *
- * The button re-runs the failed loader rather than reloading the document: a
- * full reload inside an installed app risks a cold start with no network at
- * all, which is strictly worse than staying where you are.
+ * Retrying re-runs **only the failed route's loader**, and only when there is a
+ * connection to retry with. A bare `router.invalidate()` re-runs every match
+ * including the root and layout; offline those reject too, the error escapes
+ * past this boundary to the root, and the whole app — navbar and all — is
+ * replaced by an error screen that only quitting the app recovers from. So the
+ * retry is scoped, and offline it is not offered at all: there is nothing to
+ * retry until the connection is back, and the page reloads itself when it is.
+ *
+ * A full document reload is never used: inside an installed app that risks a
+ * cold start with no network, which is strictly worse than staying put.
  */
-export function RouteError({ error }: { error: unknown }) {
+export function RouteError({ error, reset }: ErrorComponentProps) {
   const online = useOnlineStatus();
   const router = useRouter();
   const [retrying, setRetrying] = useState(false);
 
-  const retry = () => {
+  const retry = useCallback(() => {
     setRetrying(true);
-    void router.invalidate().finally(() => setRetrying(false));
-  };
+    // The deepest match is the one that threw. Its parents — root and layout —
+    // are what render the navbar, and re-running them offline is what replaced
+    // the entire app with an error screen.
+    const leafMatchId = router.state.matches.at(-1)?.id;
+    void router
+      .invalidate({
+        filter: (match) => match.id === leafMatchId,
+      })
+      .catch(() => {})
+      .finally(() => {
+        setRetrying(false);
+        reset();
+      });
+  }, [reset, router]);
+
+  // Recover when the connection comes back. Only on the offline → online
+  // transition, never on mount: an error that reproduces would otherwise retry,
+  // re-throw, remount this component and retry again, forever.
+  const wasOffline = useRef(false);
+  useEffect(() => {
+    if (!online) {
+      wasOffline.current = true;
+      return;
+    }
+    if (!wasOffline.current) return;
+    wasOffline.current = false;
+    retry();
+  }, [online, retry]);
 
   return (
     <EmptyState>
@@ -60,23 +94,28 @@ export function RouteError({ error }: { error: unknown }) {
           </Trans>
         ) : (
           <Trans>
-            This page hasn’t been saved to your device, so it needs a
-            connection. Articles you haven’t read yet are downloaded
-            automatically and stay available offline.
+            This page wasn’t saved to your device, so it needs a connection.
+            It’ll load on its own when you’re back online — your unread articles
+            are already here.
           </Trans>
         )}
       </EmptyStateDescription>
-      <EmptyStateActions>
-        <Button
-          variant="secondary"
-          size="sm"
-          isDisabled={retrying}
-          onPress={retry}
-        >
-          <RotateCw size={14} strokeWidth={2} aria-hidden />{" "}
-          <Trans>Try again</Trans>
-        </Button>
-      </EmptyStateActions>
+      {/* No retry offered offline: there is nothing to retry until the
+          connection returns, and the effect above loads the page the moment it
+          does. */}
+      {online ? (
+        <EmptyStateActions>
+          <Button
+            variant="secondary"
+            size="sm"
+            isDisabled={retrying}
+            onPress={retry}
+          >
+            <RotateCw size={14} strokeWidth={2} aria-hidden />{" "}
+            <Trans>Try again</Trans>
+          </Button>
+        </EmptyStateActions>
+      ) : null}
       {/* The message is for us, not the reader — but hiding it entirely makes
           a bug report a guessing game, so keep it out of the way. */}
       {online && error instanceof Error && error.message ? (

--- a/apps/standard-reader/src/components/route-error.tsx
+++ b/apps/standard-reader/src/components/route-error.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { Trans } from "@lingui/react/macro";
+import { Button } from "@standard-reader/design-system/button";
+import {
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateDescription,
+  EmptyStateImage,
+  EmptyStateTitle,
+} from "@standard-reader/design-system/empty-state";
+import { size } from "@standard-reader/design-system/theme/semantic-spacing.stylex";
+import { useRouter } from "@tanstack/react-router";
+import { CloudOff, RotateCw } from "lucide-react";
+import { useEffect, useState } from "react";
+
+/**
+ * Whether the browser currently reports a connection.
+ *
+ * Deliberately starts `true` and corrects after mount: reading `navigator` while
+ * rendering on the server would be a hydration mismatch, and an error boundary
+ * claiming "you're offline" on a server-rendered page would be wrong anyway.
+ */
+function useIsOnline(): boolean {
+  const [online, setOnline] = useState(true);
+
+  useEffect(() => {
+    const sync = () => setOnline(globalThis.navigator?.onLine !== false);
+    sync();
+    globalThis.addEventListener?.("online", sync);
+    globalThis.addEventListener?.("offline", sync);
+    return () => {
+      globalThis.removeEventListener?.("online", sync);
+      globalThis.removeEventListener?.("offline", sync);
+    };
+  }, []);
+
+  return online;
+}
+
+/**
+ * What every route renders when its loader throws.
+ *
+ * Offline is the common case worth naming. The service worker keeps unread
+ * articles on the device, so a reader offline in the app usually gets real
+ * pages — but reaching for something that was never stored used to surface the
+ * router's raw error text, which says nothing about why. Being explicit that
+ * the page was never downloaded is the difference between "the app is broken"
+ * and "this one wasn't saved".
+ *
+ * The button re-runs the failed loader rather than reloading the document: a
+ * full reload inside an installed app risks a cold start with no network at
+ * all, which is strictly worse than staying where you are.
+ */
+export function RouteError({ error }: { error: unknown }) {
+  const online = useIsOnline();
+  const router = useRouter();
+  const [retrying, setRetrying] = useState(false);
+
+  const retry = () => {
+    setRetrying(true);
+    void router.invalidate().finally(() => setRetrying(false));
+  };
+
+  return (
+    <EmptyState>
+      <EmptyStateImage>
+        <CloudOff size={size["lg"]} strokeWidth={1.5} aria-hidden />
+      </EmptyStateImage>
+      <EmptyStateTitle>
+        {online ? (
+          <Trans>Something went wrong</Trans>
+        ) : (
+          <Trans>You’re offline</Trans>
+        )}
+      </EmptyStateTitle>
+      <EmptyStateDescription>
+        {online ? (
+          <Trans>
+            That page didn’t load. Try again — if it keeps happening, it’s on
+            our side.
+          </Trans>
+        ) : (
+          <Trans>
+            This page hasn’t been saved to your device, so it needs a
+            connection. Articles you haven’t read yet are downloaded
+            automatically and stay available offline.
+          </Trans>
+        )}
+      </EmptyStateDescription>
+      <EmptyStateActions>
+        <Button
+          variant="secondary"
+          size="sm"
+          isDisabled={retrying}
+          onPress={retry}
+        >
+          <RotateCw size={14} strokeWidth={2} aria-hidden />{" "}
+          <Trans>Try again</Trans>
+        </Button>
+      </EmptyStateActions>
+      {/* The message is for us, not the reader — but hiding it entirely makes
+          a bug report a guessing game, so keep it out of the way. */}
+      {online && error instanceof Error && error.message ? (
+        <EmptyStateDescription>
+          <small>{error.message}</small>
+        </EmptyStateDescription>
+      ) : null}
+    </EmptyState>
+  );
+}

--- a/apps/standard-reader/src/components/route-error.tsx
+++ b/apps/standard-reader/src/components/route-error.tsx
@@ -13,7 +13,7 @@ import { size } from "@standard-reader/design-system/theme/semantic-spacing.styl
 import * as stylex from "@stylexjs/stylex";
 import type { ErrorComponentProps } from "@tanstack/react-router";
 import { useRouter } from "@tanstack/react-router";
-import { CloudOff, RotateCw } from "lucide-react";
+import { CloudOff, Home, RotateCw } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useOnlineStatus } from "#/lib/use-online-status";
@@ -48,8 +48,10 @@ const styles = stylex.create({
  * retry is scoped, and offline it is not offered at all: there is nothing to
  * retry until the connection is back, and the page reloads itself when it is.
  *
- * A full document reload is never used: inside an installed app that risks a
- * cold start with no network, which is strictly worse than staying put.
+ * There is always a way out, though — offline this rendered no actions at all,
+ * which is defensible per-button and a dead end taken together. "Go home" is
+ * unconditional, and reaches for a document load in the one case a client-side
+ * navigation cannot help (see {@link RouteError} body).
  */
 export function RouteError({ error, reset }: ErrorComponentProps) {
   const online = useOnlineStatus();
@@ -72,6 +74,21 @@ export function RouteError({ error, reset }: ErrorComponentProps) {
         reset();
       });
   }, [reset, router]);
+
+  const goHome = useCallback(() => {
+    // A client-side navigation to `/` is a no-op when `/` is *itself* the route
+    // that failed, which is exactly the dead end this button exists for. A
+    // document load isn't a fallback there, it's the better path: the `pages`
+    // cache holds `/` with its data dehydrated into the HTML, so it renders
+    // offline without needing anything from the data cache.
+    if (router.state.location.pathname === "/") {
+      globalThis.location.assign("/");
+      return;
+    }
+    void router.navigate({ to: "/" }).catch(() => {
+      globalThis.location.assign("/");
+    });
+  }, [router]);
 
   // Recover when the connection comes back. Only on the offline → online
   // transition, never on mount: an error that reproduces would otherwise retry,
@@ -114,11 +131,19 @@ export function RouteError({ error, reset }: ErrorComponentProps) {
             </Trans>
           )}
         </EmptyStateDescription>
-        {/* No retry offered offline: there is nothing to retry until the
-          connection returns, and the effect above loads the page the moment it
-          does. */}
-        {online ? (
-          <EmptyStateActions>
+        <EmptyStateActions>
+          {/* Always a way out. Offline this used to render no actions at all —
+              correct in the narrow sense that retrying a page with no
+              connection is pointless, and a dead end in practice: a reader who
+              landed here had nothing to press and no route back to the
+              articles that *are* on the device. */}
+          <Button variant="primary" size="sm" onPress={goHome}>
+            <Home size={14} strokeWidth={2} aria-hidden />{" "}
+            <Trans>Go home</Trans>
+          </Button>
+          {/* No retry offline: nothing changes until the connection returns,
+              and the effect above loads the page the moment it does. */}
+          {online ? (
             <Button
               variant="secondary"
               size="sm"
@@ -128,8 +153,8 @@ export function RouteError({ error, reset }: ErrorComponentProps) {
               <RotateCw size={14} strokeWidth={2} aria-hidden />{" "}
               <Trans>Try again</Trans>
             </Button>
-          </EmptyStateActions>
-        ) : null}
+          ) : null}
+        </EmptyStateActions>
         {/* The message is for us, not the reader — but hiding it entirely makes
           a bug report a guessing game, so keep it out of the way. */}
         {online && error instanceof Error && error.message ? (

--- a/apps/standard-reader/src/components/route-error.tsx
+++ b/apps/standard-reader/src/components/route-error.tsx
@@ -12,31 +12,9 @@ import {
 import { size } from "@standard-reader/design-system/theme/semantic-spacing.stylex";
 import { useRouter } from "@tanstack/react-router";
 import { CloudOff, RotateCw } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
-/**
- * Whether the browser currently reports a connection.
- *
- * Deliberately starts `true` and corrects after mount: reading `navigator` while
- * rendering on the server would be a hydration mismatch, and an error boundary
- * claiming "you're offline" on a server-rendered page would be wrong anyway.
- */
-function useIsOnline(): boolean {
-  const [online, setOnline] = useState(true);
-
-  useEffect(() => {
-    const sync = () => setOnline(globalThis.navigator?.onLine !== false);
-    sync();
-    globalThis.addEventListener?.("online", sync);
-    globalThis.addEventListener?.("offline", sync);
-    return () => {
-      globalThis.removeEventListener?.("online", sync);
-      globalThis.removeEventListener?.("offline", sync);
-    };
-  }, []);
-
-  return online;
-}
+import { useOnlineStatus } from "#/lib/use-online-status";
 
 /**
  * What every route renders when its loader throws.
@@ -53,7 +31,7 @@ function useIsOnline(): boolean {
  * all, which is strictly worse than staying where you are.
  */
 export function RouteError({ error }: { error: unknown }) {
-  const online = useIsOnline();
+  const online = useOnlineStatus();
   const router = useRouter();
   const [retrying, setRetrying] = useState(false);
 

--- a/apps/standard-reader/src/components/user-settings-view.tsx
+++ b/apps/standard-reader/src/components/user-settings-view.tsx
@@ -115,6 +115,7 @@ import {
   AppearanceAdvancedRows,
   AppearancePalettePanel,
 } from "./appearance-settings";
+import { OfflineReadingSettings } from "./offline-settings";
 import { PushDiagnosticsPanel } from "./push-diagnostics";
 import { IosInstallPrompt } from "./reader/ios-install-prompt";
 import { Masthead, ReaderContent } from "./reader/primitives";
@@ -1155,6 +1156,7 @@ export function UserSettingsView() {
               ))}
             </Select>
           </SettingRow>
+          <OfflineReadingSettings />
         </div>
       </section>
 

--- a/apps/standard-reader/src/components/user-settings-view.tsx
+++ b/apps/standard-reader/src/components/user-settings-view.tsx
@@ -116,6 +116,7 @@ import {
   AppearancePalettePanel,
 } from "./appearance-settings";
 import { OfflineReadingSettings } from "./offline-settings";
+import { OfflineSyncDebugPanel } from "./offline-sync-debug";
 import { PushDiagnosticsPanel } from "./push-diagnostics";
 import { IosInstallPrompt } from "./reader/ios-install-prompt";
 import { Masthead, ReaderContent } from "./reader/primitives";
@@ -1157,6 +1158,8 @@ export function UserSettingsView() {
             </Select>
           </SettingRow>
           <OfflineReadingSettings />
+          {/* Renders only when the URL carries `?debug` (see the component). */}
+          <OfflineSyncDebugPanel />
         </div>
       </section>
 

--- a/apps/standard-reader/src/components/user-settings-view.tsx
+++ b/apps/standard-reader/src/components/user-settings-view.tsx
@@ -102,6 +102,7 @@ import {
 } from "#/lib/use-feed-preferences";
 import { useFormatters } from "#/lib/use-formatters";
 import { useLocale } from "#/lib/use-locale";
+import { useOfflineSyncDebugVisible } from "#/lib/use-offline-sync-debug-visible";
 import { useOpenCollectionsInMagazine } from "#/lib/use-open-collections-in-magazine";
 import { useOpenLinks } from "#/lib/use-open-links";
 import { usePublicationThemePreference } from "#/lib/use-publication-theme-preference";
@@ -579,6 +580,7 @@ export function UserSettingsView() {
   const [digestPreviewLoading, setDigestPreviewLoading] = useState(true);
 
   const push = usePushSettings();
+  const offlineSyncDebugVisible = useOfflineSyncDebugVisible();
   const [iosPromptOpen, setIosPromptOpen] = useState(false);
 
   // One row, five possible states. Ordered most-actionable first so the reader
@@ -1157,11 +1159,37 @@ export function UserSettingsView() {
               ))}
             </Select>
           </SettingRow>
-          <OfflineReadingSettings />
-          {/* Renders only when the URL carries `?debug` (see the component). */}
-          <OfflineSyncDebugPanel />
         </div>
       </section>
+
+      {/* Its own section rather than a tail on Reading: this is about what the
+          device stores and how much space that takes, which is a different
+          question from how articles look. Rendered only where it can do
+          anything — the installed app, or a browser tab with `?debug` — so it
+          never appears as an empty group. */}
+      {offlineSyncDebugVisible ? (
+        <section {...stylex.props(styles.section)}>
+          <h2 {...stylex.props(styles.sectionHeading)}>
+            <Trans>Offline</Trans>
+          </h2>
+          <div {...stylex.props(styles.settingGroup)}>
+            {/* Contributes its own trailing separator, so the disclosure sits
+                flush whether or not these rows render. */}
+            <OfflineReadingSettings />
+            {/* Same chrome as the notifications section's Troubleshooting, so
+                the two read as one convention rather than two panels that
+                happen to share a name. */}
+            <Disclosure>
+              <DisclosureTitle style={styles.advancedTitle}>
+                <Trans>Troubleshooting</Trans>
+              </DisclosureTitle>
+              <DisclosurePanel>
+                <OfflineSyncDebugPanel />
+              </DisclosurePanel>
+            </Disclosure>
+          </div>
+        </section>
+      ) : null}
 
       <section {...stylex.props(styles.section)}>
         <h2 {...stylex.props(styles.sectionHeading)}>

--- a/apps/standard-reader/src/integrations/tanstack-query/api-reader.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-reader.functions.ts
@@ -45,6 +45,7 @@ import {
 import type { SavedFacets } from "#/server/reader/queries";
 import {
   selectSavedFacets,
+  selectUnreadDocumentPage,
   selectUnreadDocumentUris,
 } from "#/server/reader/queries";
 import { attachViewerRecommendedToArticles } from "#/server/reader/recommended-by";
@@ -1520,6 +1521,79 @@ const markPublicationAllRead = createServerFn({ method: "POST" })
     ),
   );
 
+/**
+ * One page of the offline-sync walk. 500 keeps a single response comfortably
+ * small (a URI is ~80 bytes) while letting a several-thousand-item backlog
+ * enumerate in a handful of round trips — which matters given the ~230ms
+ * Railway↔Neon round trip.
+ */
+const OFFLINE_SYNC_PAGE_SIZE = 500;
+
+const unreadDocumentUrisInput = z.object({
+  cursor: z
+    .object({ publishedAt: z.string(), uri: z.string() })
+    .nullish()
+    .transform((value) => value ?? undefined),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(OFFLINE_SYNC_PAGE_SIZE)
+    .default(OFFLINE_SYNC_PAGE_SIZE),
+});
+
+/**
+ * The reader's unread documents, newest first, for offline pre-caching.
+ *
+ * Deliberately returns URIs only — the bodies come from `getArticle` one at a
+ * time so they land in the service worker's `data` cache under the exact URL
+ * the article route will later ask for.
+ *
+ * Returns an empty page when reading history is off: with no `reads` rows
+ * there is no "unread" to speak of, and syncing the entire follow feed is not
+ * what the reader asked for by turning tracking off.
+ */
+const getUnreadDocumentUris = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware])
+  .validator(unreadDocumentUrisInput)
+  .handler(
+    observe("reader.getUnreadDocumentUris", async ({ data, context }, span) => {
+      const did = await getReaderDidForRequest(getRequest());
+      if (!did || !context.trackReadingEnabled) {
+        return { nextCursor: null, uris: [] as Array<string> };
+      }
+      span.set("did", did);
+
+      const { publicationUris, userDids } = await effectiveFollowSets(
+        context.db,
+        context.schema,
+        did,
+      );
+      const rows = await selectUnreadDocumentPage(context.db, context.schema, {
+        countOldPostsAsUnread: context.countOldPostsAsUnreadEnabled,
+        cursor: data.cursor,
+        followedUserDids: userDids,
+        limit: data.limit,
+        publicationUris,
+        readerDid: did,
+      });
+      span.set("count", rows.length);
+
+      const last = rows.at(-1);
+      // A short page means the walk is done. A full page hands back the last
+      // row as the next keyset position.
+      const nextCursor =
+        rows.length === data.limit && last
+          ? {
+              publishedAt: last.publishedAt.toISOString(),
+              uri: last.uri,
+            }
+          : null;
+
+      return { nextCursor, uris: rows.map((row) => row.uri) };
+    }),
+  );
+
 const markFollowsAllUnreadRead = createServerFn({ method: "POST" })
   .middleware([dbMiddleware])
   .handler(
@@ -1836,6 +1910,8 @@ export const readerApi = {
   markPublicationAllReadMutationOptions,
   markFollowsAllUnreadRead,
   markFollowsAllUnreadReadMutationOptions,
+  // offline pre-caching (`#/pwa/offline-sync`)
+  getUnreadDocumentUris,
   markUnread,
   markUnreadMutationOptions,
   getReadingHistory,

--- a/apps/standard-reader/src/integrations/tanstack-query/query-client.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/query-client.ts
@@ -4,10 +4,40 @@ import { isAtprotoScopeMissingError } from "#/lib/atproto/scope-error";
 
 const DEFAULT_QUERY_STALE_TIME_MS = 60 * 1000;
 
+/** React Query's own default, restated because {@link offlineAwareRetry} replaces it. */
+const DEFAULT_QUERY_RETRY_COUNT = 3;
+
+/**
+ * Don't retry while the browser reports no connection.
+ *
+ * With {@link https://tanstack.com/query/latest/docs/framework/react/guides/network-mode `networkMode: "offlineFirst"`}
+ * an offline query fetches, misses the service-worker cache, and rejects. The
+ * default policy then spends three backed-off retries — ~7s of skeleton — to
+ * reach the same answer, because nothing about being offline changes between
+ * attempts. Fail on the first miss so the offline state renders immediately;
+ * React Query refetches on `online` anyway.
+ */
+function offlineAwareRetry(failureCount: number): boolean {
+  if (globalThis.navigator?.onLine === false) return false;
+  return failureCount < DEFAULT_QUERY_RETRY_COUNT;
+}
+
 function makeQueryClient() {
   return new QueryClient({
     defaultOptions: {
       queries: {
+        /**
+         * The service worker caches `/_serverFn/*` GETs (see `vite.config.ts`),
+         * but the default `"online"` mode never issues the request while
+         * offline — it parks the query at `fetchStatus: "paused"`. A route
+         * loader's `ensureQueryData` then awaits a promise that never settles,
+         * so an offline navigation hung on a skeleton forever instead of
+         * failing. `"offlineFirst"` lets the request reach the service worker,
+         * which answers from cache when it has the page and rejects when it
+         * doesn't.
+         */
+        networkMode: "offlineFirst",
+        retry: offlineAwareRetry,
         staleTime: DEFAULT_QUERY_STALE_TIME_MS,
       },
     },

--- a/apps/standard-reader/src/lib/use-offline-cached-uris.ts
+++ b/apps/standard-reader/src/lib/use-offline-cached-uris.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { offlineCachedUris } from "#/pwa/offline-cache";
+
+const NONE: ReadonlySet<string> = new Set();
+
+/**
+ * The documents stored for offline reading, for dimming the ones that aren't.
+ *
+ * Returns an empty set while online — nothing should be dimmed then, and it
+ * keeps the ledger off the render path entirely in the common case. Also empty
+ * during SSR, since the answer is per-device and reading it while rendering on
+ * the server would be a hydration mismatch.
+ */
+export function useOfflineCachedUris(online: boolean): ReadonlySet<string> {
+  const [uris, setUris] = useState<ReadonlySet<string>>(NONE);
+
+  useEffect(() => {
+    if (online) {
+      setUris(NONE);
+      return;
+    }
+    setUris(offlineCachedUris());
+  }, [online]);
+
+  return uris;
+}

--- a/apps/standard-reader/src/lib/use-offline-cached-uris.ts
+++ b/apps/standard-reader/src/lib/use-offline-cached-uris.ts
@@ -2,27 +2,40 @@
 
 import { useEffect, useState } from "react";
 
-import { offlineCachedUris } from "#/pwa/offline-cache";
-
-const NONE: ReadonlySet<string> = new Set();
+import { offlineAvailableUris } from "#/pwa/offline-cache";
 
 /**
- * The documents stored for offline reading, for dimming the ones that aren't.
- *
- * Returns an empty set while online — nothing should be dimmed then, and it
- * keeps the ledger off the render path entirely in the common case. Also empty
- * during SSR, since the answer is per-device and reading it while rendering on
- * the server would be a hydration mismatch.
+ * `null` means "we don't know yet", which is not the same as "nothing is
+ * stored" and must not be rendered as though it were.
  */
-export function useOfflineCachedUris(online: boolean): ReadonlySet<string> {
-  const [uris, setUris] = useState<ReadonlySet<string>>(NONE);
+export type OfflineAvailability = ReadonlySet<string> | null;
+
+/**
+ * The documents that can be opened offline, for dimming the ones that can't.
+ *
+ * Returns `null` while online (nothing should be dimmed then, and this keeps
+ * the cache scan off the render path), during SSR, and until the scan resolves.
+ * Callers must treat `null` as "don't dim" — a set that is merely late, or a
+ * browser with no Cache Storage, would otherwise dim every row in the feed.
+ *
+ * The scan is shared and memoised in `offlineAvailableUris`, so fifty rows
+ * calling this hook cost one pass over the cache, not fifty.
+ */
+export function useOfflineCachedUris(online: boolean): OfflineAvailability {
+  const [uris, setUris] = useState<OfflineAvailability>(null);
 
   useEffect(() => {
     if (online) {
-      setUris(NONE);
+      setUris(null);
       return;
     }
-    setUris(offlineCachedUris());
+    let cancelled = false;
+    void offlineAvailableUris().then((next) => {
+      if (!cancelled) setUris(next);
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [online]);
 
   return uris;

--- a/apps/standard-reader/src/lib/use-offline-sync-debug-visible.ts
+++ b/apps/standard-reader/src/lib/use-offline-sync-debug-visible.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { isStandalone } from "#/pwa/standalone";
+
+/** `/settings?debug` — the flag that shows the panel in a browser tab. */
+function debugRequested(): boolean {
+  if (globalThis.location === undefined) return false;
+  return new URLSearchParams(globalThis.location.search).has("debug");
+}
+
+/**
+ * Whether to offer the offline-sync troubleshooting disclosure in settings.
+ *
+ * Always in the installed app — that is the only place sync runs, and a PWA
+ * launched from an icon has no address bar to type a flag into. In a browser
+ * tab it stays behind `?debug`, where it exists for development.
+ *
+ * Lives apart from the panel so the settings view can own the `Separator` +
+ * `Disclosure` chrome, exactly as it does for push diagnostics; a component
+ * that wrapped its own would drift from the section above it.
+ */
+export function useOfflineSyncDebugVisible(): boolean {
+  const [visible, setVisible] = useState(false);
+
+  // Client-only: display mode and the URL's search string are both things the
+  // server render must not depend on (and the settings route doesn't validate
+  // the flag).
+  useEffect(() => {
+    setVisible(isStandalone() || debugRequested());
+  }, []);
+
+  return visible;
+}

--- a/apps/standard-reader/src/lib/use-online-status.ts
+++ b/apps/standard-reader/src/lib/use-online-status.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Whether the browser currently reports a connection.
+ *
+ * Starts `true` and corrects after mount on purpose: `navigator` does not exist
+ * during SSR, and rendering an "offline" state into server markup that the
+ * client then has to undo is a hydration mismatch on every request.
+ *
+ * `navigator.onLine` only knows whether there is *a* network interface, not
+ * whether anything is reachable — so treat `false` as reliable ("definitely
+ * offline") and `true` as optimistic. Everything here keys off the reliable
+ * direction: hiding what cannot work, and explaining a failure after it happens.
+ */
+export function useOnlineStatus(): boolean {
+  const [online, setOnline] = useState(true);
+
+  useEffect(() => {
+    const sync = () => setOnline(globalThis.navigator?.onLine !== false);
+    sync();
+    globalThis.addEventListener?.("online", sync);
+    globalThis.addEventListener?.("offline", sync);
+    return () => {
+      globalThis.removeEventListener?.("online", sync);
+      globalThis.removeEventListener?.("offline", sync);
+    };
+  }, []);
+
+  return online;
+}

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -2283,6 +2283,10 @@ msgstr "لا توجد مجموعات في هذه السلسلة بعد."
 msgid "None of this labeler’s labels could be verified against the signing key it publishes, so none are applied. That’s a problem on the labeler’s end."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Still to fetch"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "No feedback yet."
 msgstr "لا توجد ملاحظات بعد."
@@ -3076,6 +3080,10 @@ msgstr "ستُحدَّد كل مقالة غير مقروءة من هذه الم�
 
 #: src/components/appearance-settings.tsx
 msgid "Your own colors"
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Initial fill"
 msgstr ""
 
 #: src/components/reader/app-shell.tsx
@@ -7248,6 +7256,10 @@ msgstr "{unreadCount} غير مقروءة"
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "Below those, the publications you follow are listed for quick access. The <0>Subscriptions</0> heading above them opens the full management view. At the very bottom, your avatar opens a menu with your profile, reading history, recommended articles, feedback, settings, and log out."
 #~ msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Downloaded"
+msgstr ""
 
 #: src/components/reader/add-publication-modal.tsx
 #: src/components/reader/app-shell.tsx

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -3847,6 +3847,10 @@ msgstr ""
 msgid "You agree not to use {SITE_NAME} to:"
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "Go home"
+msgstr ""
+
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.new.tsx
 msgid "e.g. Dispatches from the Atmosphere"

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -138,6 +138,10 @@ msgstr "إضافة مقال"
 #~ msgid "Communities"
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Feed pages"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/components/reader/app-shell.tsx
@@ -1070,6 +1074,10 @@ msgstr ""
 msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Offline"
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, zero {الاشتراك في {formattedUnfollowedCount} منشورة؟} one {الاشتراك في منشورة واحدة؟} two {الاشتراك في منشورتين؟} few {الاشتراك في {formattedUnfollowedCount} منشورات؟} many {الاشتراك في {formattedUnfollowedCount} منشورة؟} other {الاشتراك في {formattedUnfollowedCount} منشورة؟}}"
@@ -1266,6 +1274,10 @@ msgstr ""
 msgid "Downloaded articles"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Back-catalog pages"
+msgstr ""
+
 #: src/components/reader/terms-view.tsx
 msgid "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
 msgstr ""
@@ -1301,6 +1313,10 @@ msgstr "حجم النص"
 #: src/components/onboarding/step-intro.tsx
 msgid "A calm reading room for the open web. Let's take two minutes to make it yours."
 msgstr "غرفة قراءة هادئة للويب المفتوح. لنأخذ دقيقتين لجعلها على ذوقك."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Run sync now"
+msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.index.tsx
@@ -1714,6 +1730,10 @@ msgstr ""
 msgid "If you already know what you want, <0>Discover</0> lists everything on the network, and <1>Finding things to read</1> covers every way to get there."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Images"
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
 #~ msgstr "أدرِج تلميح <0>site.standard.publication</0> فقط إذا كان المستند ينتمي إلى سجل منشورة. أضِف كليهما بغضّ النظر عن القارئ الذي يهمّك — فهما وسيلة أي عميل على الشبكة لربط صفحتك بسجلّها، لا إضافتنا وحدها."
@@ -1966,6 +1986,10 @@ msgstr "تضمين زر الاشتراك"
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That GIF is over 1 MB. Try a shorter clip, or attach a still image."
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Storage"
 msgstr ""
 
 #: src/components/reader/blocked-notice.tsx
@@ -2469,6 +2493,7 @@ msgstr "المجموعات"
 msgid "Done"
 msgstr "تم"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/saved-filters.tsx
 msgid "Authors"
 msgstr ""
@@ -3251,6 +3276,7 @@ msgstr "اقرأ دون حساب. سجّل الدخول عبر Bluesky عندم�
 msgid "Remove {itemTitle}"
 msgstr "إزالة {itemTitle}"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Lists"
@@ -4307,6 +4333,10 @@ msgstr ""
 msgid "Last checked {0}. Blocks you make elsewhere show up here within about fifteen minutes."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "If articles aren’t available offline, this is what the last sync did. Sharing a screenshot of it is the fastest way to get it fixed."
+msgstr ""
+
 #: src/components/reader/block-user-menu-item.tsx
 msgid "Block account?"
 msgstr ""
@@ -4819,6 +4849,10 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 msgid "Stop reading this example aloud"
 msgstr "أوقف قراءة هذا المثال بصوت عالٍ"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Unread listed"
+msgstr ""
 
 #. placeholder {0}: issue.ownerHandle
 #: src/magazine/flow.tsx
@@ -5791,7 +5825,6 @@ msgstr "تابِع الجديد"
 msgid "Show all feedback"
 msgstr ""
 
-#: src/components/offline-sync-debug.tsx
 #: src/components/user-settings-view.tsx
 msgid "Troubleshooting"
 msgstr ""
@@ -6652,6 +6685,7 @@ msgstr "تغذية الرئيسية فارغة حاليًا — انتقل إل�
 #~ msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.friends.tsx
@@ -6816,6 +6850,10 @@ msgstr "لا توجد منشورات رائجة بعد."
 #: src/routes/login.tsx
 msgid "Sign in again to refresh your permissions — your session doesn't include save-for-later yet."
 msgstr "سجّل الدخول مجددًا لتحديث أذوناتك — جلستك لا تتضمّن ميزة الحفظ للاحقًا بعد."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Status"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "Account actions"
@@ -7663,6 +7701,7 @@ msgstr "بيانات وصفية للجلسة مثل عنوان IP ونص وكي�
 msgid "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 msgstr "لا ننشر من حسابك إلا عند قيامك بإجراء صريح يستلزم ذلك (مثل متابعة منشورة، أو الإعجاب بمقال أو حفظه، أو الاشتراك عبر مسار الاشتراك المخصص). ولا نبيع معلوماتك الشخصية."
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
@@ -7855,6 +7894,7 @@ msgstr ""
 msgid "Recommend this article"
 msgstr "أوصِ بهذا المقال"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/about-view.tsx
 msgid "Stop"
 msgstr "إيقاف"
@@ -8134,6 +8174,10 @@ msgstr "ابدأ الآن"
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "You don't have any content tabs to show yet."
 msgstr "لا توجد لديك علامات تبويب محتوى لعرضها بعد."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Started / finished"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Body text on paper"

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -5791,6 +5791,7 @@ msgstr "تابِع الجديد"
 msgid "Show all feedback"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/user-settings-view.tsx
 msgid "Troubleshooting"
 msgstr ""

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -3965,6 +3965,10 @@ msgstr ""
 msgid "{0} total"
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "This page wasn’t saved to your device, so it needs a connection. It’ll load on its own when you’re back online — your unread articles are already here."
+msgstr ""
+
 #: src/components/blocks-settings-view.tsx
 msgid "Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours."
 msgstr ""
@@ -5542,8 +5546,8 @@ msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
 
 #: src/components/route-error.tsx
-msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
-msgstr ""
+#~ msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
+#~ msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -3053,6 +3053,10 @@ msgstr "ستُحدَّد كل مقالة غير مقروءة من هذه الم�
 msgid "Your own colors"
 msgstr ""
 
+#: src/components/reader/app-shell.tsx
+msgid "You are offline"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
 msgstr "جارٍ تعيين العدد…"
@@ -3619,6 +3623,10 @@ msgstr ""
 #: src/components/reader/mention-hover-card.tsx
 msgid "{n, plural, one {# publication} other {{value} publications}}"
 msgstr "{n, plural, zero {لا توجد منشورات} one {منشورة واحدة} two {منشورتان} few {{value} منشورات} many {{value} منشورة} other {{value} منشورة}}"
+
+#: src/components/reader/app-shell.tsx
+msgid "offline"
+msgstr ""
 
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -21,6 +21,10 @@ msgstr ""
 msgid "Every publication the network knows about — subscribe to the ones worth your mornings."
 msgstr "كل منشورة تعرفها الشبكة — اشترك في ما يستحق صباحاتك منها."
 
+#: src/components/guide/pages/getting-started-guide-page.tsx
+msgid "The installed app downloads the articles you have not read yet, with their images, while you are online. Open it on a plane or a tunnel and your unread queue is already there — no planning ahead, and nothing to tap beforehand."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Authoring Collections needs additional permissions to publish collections and documents on your behalf. You can revoke this any time from your account settings."
 msgstr "يتطلب تأليف المجموعات أذونات إضافية لنشر المجموعات والمستندات نيابةً عنك. يمكنك إلغاء ذلك في أي وقت من إعدادات حسابك."
@@ -81,6 +85,10 @@ msgstr "الانتقال إلى قسم"
 #: src/routes/_layout.saved.tsx
 msgid "Sort by"
 msgstr "الترتيب حسب"
+
+#: src/components/offline-settings.tsx
+msgid "Downloads the articles you haven't read yet, with their images, so they open with no connection. Pauses automatically when your system asks apps to save data."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/components/reader/about-view.tsx
@@ -936,6 +944,10 @@ msgstr "تعليم كغير مقروء"
 msgid "Grid view"
 msgstr "عرض شبكي"
 
+#: src/components/route-error.tsx
+msgid "You’re offline"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "Subscribe to get new writing in your feed."
 msgstr "اشترك لتصلك الكتابات الجديدة في تغذيتك."
@@ -1248,6 +1260,10 @@ msgstr "فتح المنشورات في موقعها الأصلي"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Which destinations appear at all is a separate setting — <0>Customize sidebar</0> under <1>Making it yours</1> hides the ones you never use. Subscriptions and your lists always stay."
+msgstr ""
+
+#: src/components/offline-settings.tsx
+msgid "Downloaded articles"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -4156,6 +4172,7 @@ msgid "{0, plural, one {# publication} other {# publications}}"
 msgstr "{0, plural, zero {لا توجد منشورات} one {منشورة واحدة} two {منشورتان} few {# منشورات} many {# منشورة} other {# منشورة}}"
 
 #: src/components/feedback/feedback-image-picker.tsx
+#: src/components/route-error.tsx
 msgid "Try again"
 msgstr ""
 
@@ -4674,6 +4691,10 @@ msgstr ""
 msgid "Select <0>Log in</0>, at the bottom of the sidebar on a computer or in the top bar on a phone."
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "That page didn’t load. Try again — if it keeps happening, it’s on our side."
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/routes/_layout.saved.tsx
@@ -5076,6 +5097,7 @@ msgstr ""
 #: src/components/reader/blocked-notice.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
+#: src/components/route-error.tsx
 msgid "Something went wrong"
 msgstr "حدث خطأ ما"
 
@@ -5511,6 +5533,10 @@ msgstr ""
 msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "إذا ثبّت إضافة المتصفح من {SITE_NAME}، فإنها تستخدم الحساب وملف تعريف الارتباط نفسه المستخدم في هذا الموقع. ترسل الإضافة عناوين URL للصفحات إلى نقاط النهاية <0>/api/extension/*</0> لمطابقة الفهرس، وتحفظ إعدادات الطبقة العلوية في مساحة تخزين الإضافات بمتصفحك. راجع <1>سياسة خصوصية الإضافة</1> للتفاصيل الخاصة بالإضافة وحدها."
@@ -5810,6 +5836,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Weekly digest email"
 msgstr "بريد الملخص الأسبوعي"
+
+#: src/components/offline-settings.tsx
+msgid "Keep unread articles on this device"
+msgstr ""
 
 #: src/components/reader/ios-install-prompt.tsx
 msgid "Choose “Add to Home Screen”."
@@ -6423,6 +6453,7 @@ msgid "Top on the network"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/offline-settings.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
@@ -6568,6 +6599,10 @@ msgstr ""
 msgid "On your phone"
 msgstr ""
 
+#: src/components/offline-settings.tsx
+msgid "Storage use isn't available in this browser."
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>2. Serve labels.</0> Sign and emit <1>com.atproto.label.defs#label</1> objects, and expose the standard <2>com.atproto.label.queryLabels</2> (HTTP) and <3>com.atproto.label.subscribeLabels</3> (WebSocket) endpoints."
 msgstr "<0>٢. تقديم التصنيفات.</0> وقّع وأصدر كائنات <1>com.atproto.label.defs#label</1>، وأتِح نقطتَي النهاية القياسيتين <2>com.atproto.label.queryLabels</2> (HTTP) و<3>com.atproto.label.subscribeLabels</3> (WebSocket)."
@@ -6597,8 +6632,8 @@ msgid "Your Home feed is empty for now — head to Discover whenever you're read
 msgstr "تغذية الرئيسية فارغة حاليًا — انتقل إلى الاستكشاف متى شئت، وسيبدأ كل ما تشترك فيه بالتجمّع هنا."
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
-msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
-msgstr ""
+#~ msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
+#~ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-table.tsx
@@ -6772,6 +6807,11 @@ msgstr "إجراءات الحساب"
 #: src/components/reader/mention-hover-card.tsx
 msgid "Read article"
 msgstr "قراءة المقالة"
+
+#. placeholder {0}: formatBytes(usage.usage)
+#: src/components/offline-settings.tsx
+msgid "Standard Reader is using {0} on this device."
+msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Terms of service"
@@ -7507,6 +7547,10 @@ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Subscribe to the publication it came from, in the same click."
+msgstr ""
+
+#: src/components/guide/pages/getting-started-guide-page.tsx
+msgid "Reach for something that was never downloaded and the app says so, rather than showing you an error. You can turn downloading off, and see how much space it is using, under Settings → Reading. It pauses on its own when your phone asks apps to save data. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
 msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -3054,8 +3054,8 @@ msgid "Your own colors"
 msgstr ""
 
 #: src/components/reader/app-shell.tsx
-msgid "You are offline"
-msgstr ""
+#~ msgid "You are offline"
+#~ msgstr ""
 
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
@@ -3625,8 +3625,8 @@ msgid "{n, plural, one {# publication} other {{value} publications}}"
 msgstr "{n, plural, zero {لا توجد منشورات} one {منشورة واحدة} two {منشورتان} few {{value} منشورات} many {{value} منشورة} other {{value} منشورة}}"
 
 #: src/components/reader/app-shell.tsx
-msgid "offline"
-msgstr ""
+#~ msgid "offline"
+#~ msgstr ""
 
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -5791,6 +5791,7 @@ msgstr "Mitlesen"
 msgid "Show all feedback"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/user-settings-view.tsx
 msgid "Troubleshooting"
 msgstr ""

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -21,6 +21,10 @@ msgstr ""
 msgid "Every publication the network knows about — subscribe to the ones worth your mornings."
 msgstr "Jede Publikation, die das Netzwerk kennt – abonnieren Sie die, die Ihre Morgen wert sind."
 
+#: src/components/guide/pages/getting-started-guide-page.tsx
+msgid "The installed app downloads the articles you have not read yet, with their images, while you are online. Open it on a plane or a tunnel and your unread queue is already there — no planning ahead, and nothing to tap beforehand."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Authoring Collections needs additional permissions to publish collections and documents on your behalf. You can revoke this any time from your account settings."
 msgstr "Zum Erstellen von Sammlungen sind zusätzliche Berechtigungen nötig, um Sammlungen und Dokumente in Ihrem Namen zu veröffentlichen. Sie können das jederzeit in den Kontoeinstellungen widerrufen."
@@ -81,6 +85,10 @@ msgstr "Zum Abschnitt springen"
 #: src/routes/_layout.saved.tsx
 msgid "Sort by"
 msgstr "Sortieren nach"
+
+#: src/components/offline-settings.tsx
+msgid "Downloads the articles you haven't read yet, with their images, so they open with no connection. Pauses automatically when your system asks apps to save data."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/components/reader/about-view.tsx
@@ -936,6 +944,10 @@ msgstr "Als ungelesen markieren"
 msgid "Grid view"
 msgstr "Rasteransicht"
 
+#: src/components/route-error.tsx
+msgid "You’re offline"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "Subscribe to get new writing in your feed."
 msgstr "Abonnieren Sie, um neue Texte in Ihrem Feed zu erhalten."
@@ -1248,6 +1260,10 @@ msgstr "Beiträge auf der Originalseite öffnen"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Which destinations appear at all is a separate setting — <0>Customize sidebar</0> under <1>Making it yours</1> hides the ones you never use. Subscriptions and your lists always stay."
+msgstr ""
+
+#: src/components/offline-settings.tsx
+msgid "Downloaded articles"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -4156,6 +4172,7 @@ msgid "{0, plural, one {# publication} other {# publications}}"
 msgstr "{0, plural, one {# Publikation} other {# Publikationen}}"
 
 #: src/components/feedback/feedback-image-picker.tsx
+#: src/components/route-error.tsx
 msgid "Try again"
 msgstr ""
 
@@ -4674,6 +4691,10 @@ msgstr ""
 msgid "Select <0>Log in</0>, at the bottom of the sidebar on a computer or in the top bar on a phone."
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "That page didn’t load. Try again — if it keeps happening, it’s on our side."
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/routes/_layout.saved.tsx
@@ -5076,6 +5097,7 @@ msgstr ""
 #: src/components/reader/blocked-notice.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
+#: src/components/route-error.tsx
 msgid "Something went wrong"
 msgstr "Etwas ist schiefgelaufen"
 
@@ -5511,6 +5533,10 @@ msgstr ""
 msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "Wenn Sie die Browser-Erweiterung von {SITE_NAME} installieren, nutzt sie dasselbe Konto und Sitzungs-Cookie wie diese Seite. Die Erweiterung sendet Seiten-URLs zum Index-Abgleich an unsere <0>/api/extension/*</0>-Endpunkte und speichert Overlay-Einstellungen im Erweiterungsspeicher Ihres Browsers. Details, die nur für die Erweiterung gelten, finden Sie in der <1>Datenschutzerklärung der Erweiterung</1>."
@@ -5810,6 +5836,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Weekly digest email"
 msgstr "Wöchentliche Digest-E-Mail"
+
+#: src/components/offline-settings.tsx
+msgid "Keep unread articles on this device"
+msgstr ""
 
 #: src/components/reader/ios-install-prompt.tsx
 msgid "Choose “Add to Home Screen”."
@@ -6423,6 +6453,7 @@ msgid "Top on the network"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/offline-settings.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
@@ -6568,6 +6599,10 @@ msgstr ""
 msgid "On your phone"
 msgstr ""
 
+#: src/components/offline-settings.tsx
+msgid "Storage use isn't available in this browser."
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>2. Serve labels.</0> Sign and emit <1>com.atproto.label.defs#label</1> objects, and expose the standard <2>com.atproto.label.queryLabels</2> (HTTP) and <3>com.atproto.label.subscribeLabels</3> (WebSocket) endpoints."
 msgstr "<0>2. Label ausliefern.</0> Signieren und senden Sie <1>com.atproto.label.defs#label</1>-Objekte und stellen Sie die Standard-Endpunkte <2>com.atproto.label.queryLabels</2> (HTTP) und <3>com.atproto.label.subscribeLabels</3> (WebSocket) bereit."
@@ -6597,8 +6632,8 @@ msgid "Your Home feed is empty for now — head to Discover whenever you're read
 msgstr "Ihr Home-Feed ist noch leer – schauen Sie bei „Entdecken“ vorbei, wann immer Sie mögen, und alles, was Sie abonnieren, sammelt sich hier."
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
-msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
-msgstr ""
+#~ msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
+#~ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-table.tsx
@@ -6772,6 +6807,11 @@ msgstr "Kontoaktionen"
 #: src/components/reader/mention-hover-card.tsx
 msgid "Read article"
 msgstr "Artikel lesen"
+
+#. placeholder {0}: formatBytes(usage.usage)
+#: src/components/offline-settings.tsx
+msgid "Standard Reader is using {0} on this device."
+msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Terms of service"
@@ -7507,6 +7547,10 @@ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Subscribe to the publication it came from, in the same click."
+msgstr ""
+
+#: src/components/guide/pages/getting-started-guide-page.tsx
+msgid "Reach for something that was never downloaded and the app says so, rather than showing you an error. You can turn downloading off, and see how much space it is using, under Settings → Reading. It pauses on its own when your phone asks apps to save data. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
 msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -3847,6 +3847,10 @@ msgstr ""
 msgid "You agree not to use {SITE_NAME} to:"
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "Go home"
+msgstr ""
+
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.new.tsx
 msgid "e.g. Dispatches from the Atmosphere"

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -3053,6 +3053,10 @@ msgstr "Jeder ungelesene Artikel dieser Publikation wird als gelesen markiert. D
 msgid "Your own colors"
 msgstr ""
 
+#: src/components/reader/app-shell.tsx
+msgid "You are offline"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
 msgstr "Ausgabe wird gesetzt…"
@@ -3619,6 +3623,10 @@ msgstr ""
 #: src/components/reader/mention-hover-card.tsx
 msgid "{n, plural, one {# publication} other {{value} publications}}"
 msgstr "{n, plural, one {# Publikation} other {{value} Publikationen}}"
+
+#: src/components/reader/app-shell.tsx
+msgid "offline"
+msgstr ""
 
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -2283,6 +2283,10 @@ msgstr "Noch keine Sammlungen in dieser Reihe."
 msgid "None of this labeler’s labels could be verified against the signing key it publishes, so none are applied. That’s a problem on the labeler’s end."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Still to fetch"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "No feedback yet."
 msgstr "Noch kein Feedback."
@@ -3076,6 +3080,10 @@ msgstr "Jeder ungelesene Artikel dieser Publikation wird als gelesen markiert. D
 
 #: src/components/appearance-settings.tsx
 msgid "Your own colors"
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Initial fill"
 msgstr ""
 
 #: src/components/reader/app-shell.tsx
@@ -7248,6 +7256,10 @@ msgstr "{unreadCount} ungelesen"
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "Below those, the publications you follow are listed for quick access. The <0>Subscriptions</0> heading above them opens the full management view. At the very bottom, your avatar opens a menu with your profile, reading history, recommended articles, feedback, settings, and log out."
 #~ msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Downloaded"
+msgstr ""
 
 #: src/components/reader/add-publication-modal.tsx
 #: src/components/reader/app-shell.tsx

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -3054,8 +3054,8 @@ msgid "Your own colors"
 msgstr ""
 
 #: src/components/reader/app-shell.tsx
-msgid "You are offline"
-msgstr ""
+#~ msgid "You are offline"
+#~ msgstr ""
 
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
@@ -3625,8 +3625,8 @@ msgid "{n, plural, one {# publication} other {{value} publications}}"
 msgstr "{n, plural, one {# Publikation} other {{value} Publikationen}}"
 
 #: src/components/reader/app-shell.tsx
-msgid "offline"
-msgstr ""
+#~ msgid "offline"
+#~ msgstr ""
 
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -138,6 +138,10 @@ msgstr "Artikel hinzufügen"
 #~ msgid "Communities"
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Feed pages"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/components/reader/app-shell.tsx
@@ -1070,6 +1074,10 @@ msgstr ""
 msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Offline"
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {{formattedUnfollowedCount} Publikation abonnieren?} other {{formattedUnfollowedCount} Publikationen abonnieren?}}"
@@ -1266,6 +1274,10 @@ msgstr ""
 msgid "Downloaded articles"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Back-catalog pages"
+msgstr ""
+
 #: src/components/reader/terms-view.tsx
 msgid "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
 msgstr ""
@@ -1301,6 +1313,10 @@ msgstr "Textgröße"
 #: src/components/onboarding/step-intro.tsx
 msgid "A calm reading room for the open web. Let's take two minutes to make it yours."
 msgstr "Ein ruhiger Leseraum für das offene Web. Nehmen wir uns zwei Minuten, um ihn zu Ihrem zu machen."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Run sync now"
+msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.index.tsx
@@ -1714,6 +1730,10 @@ msgstr ""
 msgid "If you already know what you want, <0>Discover</0> lists everything on the network, and <1>Finding things to read</1> covers every way to get there."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Images"
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
 #~ msgstr "Fügen Sie den Hinweis <0>site.standard.publication</0> nur hinzu, wenn das Dokument zu einer Publikation gehört. Fügen Sie beide hinzu, unabhängig davon, welcher Leser Sie interessiert – so löst jeder Client im Netzwerk Ihre Seite zu ihrem Record auf, nicht nur unsere Erweiterung."
@@ -1966,6 +1986,10 @@ msgstr "Abo einbetten"
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That GIF is over 1 MB. Try a shorter clip, or attach a still image."
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Storage"
 msgstr ""
 
 #: src/components/reader/blocked-notice.tsx
@@ -2469,6 +2493,7 @@ msgstr "Sammlungen"
 msgid "Done"
 msgstr "Fertig"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/saved-filters.tsx
 msgid "Authors"
 msgstr ""
@@ -3251,6 +3276,7 @@ msgstr "Lesen Sie ohne Konto. Melden Sie sich mit Bluesky an, wenn Sie abonniere
 msgid "Remove {itemTitle}"
 msgstr "{itemTitle} entfernen"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Lists"
@@ -4307,6 +4333,10 @@ msgstr ""
 msgid "Last checked {0}. Blocks you make elsewhere show up here within about fifteen minutes."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "If articles aren’t available offline, this is what the last sync did. Sharing a screenshot of it is the fastest way to get it fixed."
+msgstr ""
+
 #: src/components/reader/block-user-menu-item.tsx
 msgid "Block account?"
 msgstr ""
@@ -4819,6 +4849,10 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 msgid "Stop reading this example aloud"
 msgstr "Vorlesen dieses Beispiels stoppen"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Unread listed"
+msgstr ""
 
 #. placeholder {0}: issue.ownerHandle
 #: src/magazine/flow.tsx
@@ -5791,7 +5825,6 @@ msgstr "Mitlesen"
 msgid "Show all feedback"
 msgstr ""
 
-#: src/components/offline-sync-debug.tsx
 #: src/components/user-settings-view.tsx
 msgid "Troubleshooting"
 msgstr ""
@@ -6652,6 +6685,7 @@ msgstr "Ihr Home-Feed ist noch leer – schauen Sie bei „Entdecken“ vorbei, 
 #~ msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.friends.tsx
@@ -6816,6 +6850,10 @@ msgstr "Noch keine Trend-Publikationen."
 #: src/routes/login.tsx
 msgid "Sign in again to refresh your permissions — your session doesn't include save-for-later yet."
 msgstr "Melden Sie sich erneut an, um Ihre Berechtigungen zu aktualisieren — Ihre Sitzung enthält „Später lesen“ noch nicht."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Status"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "Account actions"
@@ -7663,6 +7701,7 @@ msgstr "Sitzungsdaten wie IP-Adresse und Browser-User-Agent, genutzt für Sicher
 msgid "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 msgstr "Wir posten nichts über Ihr Konto, außer Sie lösen es ausdrücklich aus (etwa einer Publikation folgen, einen Artikel liken oder speichern oder über den Abo-Ablauf abonnieren). Wir verkaufen Ihre personenbezogenen Daten nicht."
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
@@ -7855,6 +7894,7 @@ msgstr ""
 msgid "Recommend this article"
 msgstr "Diesen Artikel empfehlen"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/about-view.tsx
 msgid "Stop"
 msgstr "Stopp"
@@ -8134,6 +8174,10 @@ msgstr "Loslegen"
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "You don't have any content tabs to show yet."
 msgstr "Sie haben noch keine Inhalts-Tabs zum Anzeigen."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Started / finished"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Body text on paper"

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -3965,6 +3965,10 @@ msgstr ""
 msgid "{0} total"
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "This page wasn’t saved to your device, so it needs a connection. It’ll load on its own when you’re back online — your unread articles are already here."
+msgstr ""
+
 #: src/components/blocks-settings-view.tsx
 msgid "Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours."
 msgstr ""
@@ -5542,8 +5546,8 @@ msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
 
 #: src/components/route-error.tsx
-msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
-msgstr ""
+#~ msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
+#~ msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -138,6 +138,10 @@ msgstr ""
 #~ msgid "Communities"
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Feed pages"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/components/reader/app-shell.tsx
@@ -1070,6 +1074,10 @@ msgstr ""
 msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Offline"
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr ""
@@ -1266,6 +1274,10 @@ msgstr ""
 msgid "Downloaded articles"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Back-catalog pages"
+msgstr ""
+
 #: src/components/reader/terms-view.tsx
 msgid "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
 msgstr ""
@@ -1300,6 +1312,10 @@ msgstr ""
 
 #: src/components/onboarding/step-intro.tsx
 msgid "A calm reading room for the open web. Let's take two minutes to make it yours."
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Run sync now"
 msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
@@ -1714,6 +1730,10 @@ msgstr ""
 msgid "If you already know what you want, <0>Discover</0> lists everything on the network, and <1>Finding things to read</1> covers every way to get there."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Images"
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
 #~ msgstr ""
@@ -1966,6 +1986,10 @@ msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That GIF is over 1 MB. Try a shorter clip, or attach a still image."
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Storage"
 msgstr ""
 
 #: src/components/reader/blocked-notice.tsx
@@ -2469,6 +2493,7 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/saved-filters.tsx
 msgid "Authors"
 msgstr ""
@@ -3251,6 +3276,7 @@ msgstr ""
 msgid "Remove {itemTitle}"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Lists"
@@ -4307,6 +4333,10 @@ msgstr ""
 msgid "Last checked {0}. Blocks you make elsewhere show up here within about fifteen minutes."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "If articles aren’t available offline, this is what the last sync did. Sharing a screenshot of it is the fastest way to get it fixed."
+msgstr ""
+
 #: src/components/reader/block-user-menu-item.tsx
 msgid "Block account?"
 msgstr ""
@@ -4818,6 +4848,10 @@ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Stop reading this example aloud"
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Unread listed"
 msgstr ""
 
 #. placeholder {0}: issue.ownerHandle
@@ -5791,7 +5825,6 @@ msgstr ""
 msgid "Show all feedback"
 msgstr ""
 
-#: src/components/offline-sync-debug.tsx
 #: src/components/user-settings-view.tsx
 msgid "Troubleshooting"
 msgstr ""
@@ -6652,6 +6685,7 @@ msgstr ""
 #~ msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.friends.tsx
@@ -6815,6 +6849,10 @@ msgstr ""
 
 #: src/routes/login.tsx
 msgid "Sign in again to refresh your permissions — your session doesn't include save-for-later yet."
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Status"
 msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
@@ -7663,6 +7701,7 @@ msgstr ""
 msgid "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
@@ -7855,6 +7894,7 @@ msgstr ""
 msgid "Recommend this article"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/about-view.tsx
 msgid "Stop"
 msgstr ""
@@ -8133,6 +8173,10 @@ msgstr ""
 
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "You don't have any content tabs to show yet."
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Started / finished"
 msgstr ""
 
 #: src/components/appearance-settings.tsx

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -3847,6 +3847,10 @@ msgstr ""
 msgid "You agree not to use {SITE_NAME} to:"
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "Go home"
+msgstr ""
+
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.new.tsx
 msgid "e.g. Dispatches from the Atmosphere"

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -3053,6 +3053,10 @@ msgstr ""
 msgid "Your own colors"
 msgstr ""
 
+#: src/components/reader/app-shell.tsx
+msgid "You are offline"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
 msgstr ""
@@ -3618,6 +3622,10 @@ msgstr ""
 
 #: src/components/reader/mention-hover-card.tsx
 msgid "{n, plural, one {# publication} other {{value} publications}}"
+msgstr ""
+
+#: src/components/reader/app-shell.tsx
+msgid "offline"
 msgstr ""
 
 #: src/components/reader/profile-tabs-settings-modal.tsx

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -3054,8 +3054,8 @@ msgid "Your own colors"
 msgstr ""
 
 #: src/components/reader/app-shell.tsx
-msgid "You are offline"
-msgstr ""
+#~ msgid "You are offline"
+#~ msgstr ""
 
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
@@ -3625,8 +3625,8 @@ msgid "{n, plural, one {# publication} other {{value} publications}}"
 msgstr ""
 
 #: src/components/reader/app-shell.tsx
-msgid "offline"
-msgstr ""
+#~ msgid "offline"
+#~ msgstr ""
 
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -5791,6 +5791,7 @@ msgstr ""
 msgid "Show all feedback"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/user-settings-view.tsx
 msgid "Troubleshooting"
 msgstr ""

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -3965,6 +3965,10 @@ msgstr ""
 msgid "{0} total"
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "This page wasn’t saved to your device, so it needs a connection. It’ll load on its own when you’re back online — your unread articles are already here."
+msgstr ""
+
 #: src/components/blocks-settings-view.tsx
 msgid "Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours."
 msgstr ""
@@ -5542,8 +5546,8 @@ msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
 
 #: src/components/route-error.tsx
-msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
-msgstr ""
+#~ msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
+#~ msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -21,6 +21,10 @@ msgstr ""
 msgid "Every publication the network knows about — subscribe to the ones worth your mornings."
 msgstr ""
 
+#: src/components/guide/pages/getting-started-guide-page.tsx
+msgid "The installed app downloads the articles you have not read yet, with their images, while you are online. Open it on a plane or a tunnel and your unread queue is already there — no planning ahead, and nothing to tap beforehand."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Authoring Collections needs additional permissions to publish collections and documents on your behalf. You can revoke this any time from your account settings."
 msgstr ""
@@ -80,6 +84,10 @@ msgstr ""
 #: src/routes/_layout.feedback.index.tsx
 #: src/routes/_layout.saved.tsx
 msgid "Sort by"
+msgstr ""
+
+#: src/components/offline-settings.tsx
+msgid "Downloads the articles you haven't read yet, with their images, so they open with no connection. Pauses automatically when your system asks apps to save data."
 msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
@@ -936,6 +944,10 @@ msgstr ""
 msgid "Grid view"
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "You’re offline"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "Subscribe to get new writing in your feed."
 msgstr ""
@@ -1248,6 +1260,10 @@ msgstr ""
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Which destinations appear at all is a separate setting — <0>Customize sidebar</0> under <1>Making it yours</1> hides the ones you never use. Subscriptions and your lists always stay."
+msgstr ""
+
+#: src/components/offline-settings.tsx
+msgid "Downloaded articles"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -4156,6 +4172,7 @@ msgid "{0, plural, one {# publication} other {# publications}}"
 msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
+#: src/components/route-error.tsx
 msgid "Try again"
 msgstr ""
 
@@ -4674,6 +4691,10 @@ msgstr ""
 msgid "Select <0>Log in</0>, at the bottom of the sidebar on a computer or in the top bar on a phone."
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "That page didn’t load. Try again — if it keeps happening, it’s on our side."
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/routes/_layout.saved.tsx
@@ -5076,6 +5097,7 @@ msgstr ""
 #: src/components/reader/blocked-notice.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
+#: src/components/route-error.tsx
 msgid "Something went wrong"
 msgstr ""
 
@@ -5511,6 +5533,10 @@ msgstr ""
 msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr ""
@@ -5809,6 +5835,10 @@ msgstr ""
 #: src/components/onboarding/step-settings.tsx
 #: src/components/user-settings-view.tsx
 msgid "Weekly digest email"
+msgstr ""
+
+#: src/components/offline-settings.tsx
+msgid "Keep unread articles on this device"
 msgstr ""
 
 #: src/components/reader/ios-install-prompt.tsx
@@ -6423,6 +6453,7 @@ msgid "Top on the network"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/offline-settings.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
@@ -6568,6 +6599,10 @@ msgstr ""
 msgid "On your phone"
 msgstr ""
 
+#: src/components/offline-settings.tsx
+msgid "Storage use isn't available in this browser."
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>2. Serve labels.</0> Sign and emit <1>com.atproto.label.defs#label</1> objects, and expose the standard <2>com.atproto.label.queryLabels</2> (HTTP) and <3>com.atproto.label.subscribeLabels</3> (WebSocket) endpoints."
 msgstr ""
@@ -6597,8 +6632,8 @@ msgid "Your Home feed is empty for now — head to Discover whenever you're read
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
-msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
-msgstr ""
+#~ msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
+#~ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-table.tsx
@@ -6771,6 +6806,11 @@ msgstr ""
 
 #: src/components/reader/mention-hover-card.tsx
 msgid "Read article"
+msgstr ""
+
+#. placeholder {0}: formatBytes(usage.usage)
+#: src/components/offline-settings.tsx
+msgid "Standard Reader is using {0} on this device."
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -7507,6 +7547,10 @@ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Subscribe to the publication it came from, in the same click."
+msgstr ""
+
+#: src/components/guide/pages/getting-started-guide-page.tsx
+msgid "Reach for something that was never downloaded and the app says so, rather than showing you an error. You can turn downloading off, and see how much space it is using, under Settings → Reading. It pauses on its own when your phone asks apps to save data. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
 msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -2283,6 +2283,10 @@ msgstr ""
 msgid "None of this labeler’s labels could be verified against the signing key it publishes, so none are applied. That’s a problem on the labeler’s end."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Still to fetch"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "No feedback yet."
 msgstr ""
@@ -3076,6 +3080,10 @@ msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Your own colors"
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Initial fill"
 msgstr ""
 
 #: src/components/reader/app-shell.tsx
@@ -7248,6 +7256,10 @@ msgstr ""
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "Below those, the publications you follow are listed for quick access. The <0>Subscriptions</0> heading above them opens the full management view. At the very bottom, your avatar opens a menu with your profile, reading history, recommended articles, feedback, settings, and log out."
 #~ msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Downloaded"
+msgstr ""
 
 #: src/components/reader/add-publication-modal.tsx
 #: src/components/reader/app-shell.tsx

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -3053,6 +3053,10 @@ msgstr "Every unread article from this publication will be marked read. This can
 msgid "Your own colors"
 msgstr "Your own colors"
 
+#: src/components/reader/app-shell.tsx
+msgid "You are offline"
+msgstr "You are offline"
+
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
 msgstr "Setting the issue…"
@@ -3619,6 +3623,10 @@ msgstr "Filter subscriptions"
 #: src/components/reader/mention-hover-card.tsx
 msgid "{n, plural, one {# publication} other {{value} publications}}"
 msgstr "{n, plural, one {# publication} other {{value} publications}}"
+
+#: src/components/reader/app-shell.tsx
+msgid "offline"
+msgstr "offline"
 
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -3965,6 +3965,10 @@ msgstr "No topics match your search."
 msgid "{0} total"
 msgstr "{0} total"
 
+#: src/components/route-error.tsx
+msgid "This page wasn’t saved to your device, so it needs a connection. It’ll load on its own when you’re back online — your unread articles are already here."
+msgstr "This page wasn’t saved to your device, so it needs a connection. It’ll load on its own when you’re back online — your unread articles are already here."
+
 #: src/components/blocks-settings-view.tsx
 msgid "Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours."
 msgstr "Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours."
@@ -5542,8 +5546,8 @@ msgid "Text, borders and every other step are derived from these two colors."
 msgstr "Text, borders and every other step are derived from these two colors."
 
 #: src/components/route-error.tsx
-msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
-msgstr "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
+#~ msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
+#~ msgstr "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
 
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -3054,8 +3054,8 @@ msgid "Your own colors"
 msgstr "Your own colors"
 
 #: src/components/reader/app-shell.tsx
-msgid "You are offline"
-msgstr "You are offline"
+#~ msgid "You are offline"
+#~ msgstr "You are offline"
 
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
@@ -3625,8 +3625,8 @@ msgid "{n, plural, one {# publication} other {{value} publications}}"
 msgstr "{n, plural, one {# publication} other {{value} publications}}"
 
 #: src/components/reader/app-shell.tsx
-msgid "offline"
-msgstr "offline"
+#~ msgid "offline"
+#~ msgstr "offline"
 
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -21,6 +21,10 @@ msgstr "This is the difference between making one anthology and running somethin
 msgid "Every publication the network knows about — subscribe to the ones worth your mornings."
 msgstr "Every publication the network knows about — subscribe to the ones worth your mornings."
 
+#: src/components/guide/pages/getting-started-guide-page.tsx
+msgid "The installed app downloads the articles you have not read yet, with their images, while you are online. Open it on a plane or a tunnel and your unread queue is already there — no planning ahead, and nothing to tap beforehand."
+msgstr "The installed app downloads the articles you have not read yet, with their images, while you are online. Open it on a plane or a tunnel and your unread queue is already there — no planning ahead, and nothing to tap beforehand."
+
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Authoring Collections needs additional permissions to publish collections and documents on your behalf. You can revoke this any time from your account settings."
 msgstr "Authoring Collections needs additional permissions to publish collections and documents on your behalf. You can revoke this any time from your account settings."
@@ -81,6 +85,10 @@ msgstr "Jump to section"
 #: src/routes/_layout.saved.tsx
 msgid "Sort by"
 msgstr "Sort by"
+
+#: src/components/offline-settings.tsx
+msgid "Downloads the articles you haven't read yet, with their images, so they open with no connection. Pauses automatically when your system asks apps to save data."
+msgstr "Downloads the articles you haven't read yet, with their images, so they open with no connection. Pauses automatically when your system asks apps to save data."
 
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/components/reader/about-view.tsx
@@ -936,6 +944,10 @@ msgstr "Mark as unread"
 msgid "Grid view"
 msgstr "Grid view"
 
+#: src/components/route-error.tsx
+msgid "You’re offline"
+msgstr "You’re offline"
+
 #: src/magazine/flow.tsx
 msgid "Subscribe to get new writing in your feed."
 msgstr "Subscribe to get new writing in your feed."
@@ -1249,6 +1261,10 @@ msgstr "Open posts on their original site"
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Which destinations appear at all is a separate setting — <0>Customize sidebar</0> under <1>Making it yours</1> hides the ones you never use. Subscriptions and your lists always stay."
 msgstr "Which destinations appear at all is a separate setting — <0>Customize sidebar</0> under <1>Making it yours</1> hides the ones you never use. Subscriptions and your lists always stay."
+
+#: src/components/offline-settings.tsx
+msgid "Downloaded articles"
+msgstr "Downloaded articles"
 
 #: src/components/reader/terms-view.tsx
 msgid "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
@@ -4156,6 +4172,7 @@ msgid "{0, plural, one {# publication} other {# publications}}"
 msgstr "{0, plural, one {# publication} other {# publications}}"
 
 #: src/components/feedback/feedback-image-picker.tsx
+#: src/components/route-error.tsx
 msgid "Try again"
 msgstr "Try again"
 
@@ -4674,6 +4691,10 @@ msgstr "Filter and sort"
 msgid "Select <0>Log in</0>, at the bottom of the sidebar on a computer or in the top bar on a phone."
 msgstr "Select <0>Log in</0>, at the bottom of the sidebar on a computer or in the top bar on a phone."
 
+#: src/components/route-error.tsx
+msgid "That page didn’t load. Try again — if it keeps happening, it’s on our side."
+msgstr "That page didn’t load. Try again — if it keeps happening, it’s on our side."
+
 #: src/components/feedback/feedback-dialog.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/routes/_layout.saved.tsx
@@ -5076,6 +5097,7 @@ msgstr "Not in the directory yet?"
 #: src/components/reader/blocked-notice.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
+#: src/components/route-error.tsx
 msgid "Something went wrong"
 msgstr "Something went wrong"
 
@@ -5511,6 +5533,10 @@ msgstr "We couldn’t set up notifications on this device. Try again?"
 msgid "Text, borders and every other step are derived from these two colors."
 msgstr "Text, borders and every other step are derived from these two colors."
 
+#: src/components/route-error.tsx
+msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
+msgstr "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
+
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
@@ -5810,6 +5836,10 @@ msgstr "Listen from here"
 #: src/components/user-settings-view.tsx
 msgid "Weekly digest email"
 msgstr "Weekly digest email"
+
+#: src/components/offline-settings.tsx
+msgid "Keep unread articles on this device"
+msgstr "Keep unread articles on this device"
 
 #: src/components/reader/ios-install-prompt.tsx
 msgid "Choose “Add to Home Screen”."
@@ -6423,6 +6453,7 @@ msgid "Top on the network"
 msgstr "Top on the network"
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/offline-settings.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
@@ -6568,6 +6599,10 @@ msgstr "You’ve read every chapter published so far."
 msgid "On your phone"
 msgstr "On your phone"
 
+#: src/components/offline-settings.tsx
+msgid "Storage use isn't available in this browser."
+msgstr "Storage use isn't available in this browser."
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>2. Serve labels.</0> Sign and emit <1>com.atproto.label.defs#label</1> objects, and expose the standard <2>com.atproto.label.queryLabels</2> (HTTP) and <3>com.atproto.label.subscribeLabels</3> (WebSocket) endpoints."
 msgstr "<0>2. Serve labels.</0> Sign and emit <1>com.atproto.label.defs#label</1> objects, and expose the standard <2>com.atproto.label.queryLabels</2> (HTTP) and <3>com.atproto.label.subscribeLabels</3> (WebSocket) endpoints."
@@ -6597,8 +6632,8 @@ msgid "Your Home feed is empty for now — head to Discover whenever you're read
 msgstr "Your Home feed is empty for now — head to Discover whenever you're ready, and everything you subscribe to will start collecting here."
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
-msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
-msgstr "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
+#~ msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
+#~ msgstr "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
 
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-table.tsx
@@ -6772,6 +6807,11 @@ msgstr "Account actions"
 #: src/components/reader/mention-hover-card.tsx
 msgid "Read article"
 msgstr "Read article"
+
+#. placeholder {0}: formatBytes(usage.usage)
+#: src/components/offline-settings.tsx
+msgid "Standard Reader is using {0} on this device."
+msgstr "Standard Reader is using {0} on this device."
 
 #: src/components/reader/terms-view.tsx
 msgid "Terms of service"
@@ -7508,6 +7548,10 @@ msgstr "get this publication's new writing in your feeds."
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Subscribe to the publication it came from, in the same click."
 msgstr "Subscribe to the publication it came from, in the same click."
+
+#: src/components/guide/pages/getting-started-guide-page.tsx
+msgid "Reach for something that was never downloaded and the app says so, rather than showing you an error. You can turn downloading off, and see how much space it is using, under Settings → Reading. It pauses on its own when your phone asks apps to save data. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
+msgstr "Reach for something that was never downloaded and the app says so, rather than showing you an error. You can turn downloading off, and see how much space it is using, under Settings → Reading. It pauses on its own when your phone asks apps to save data. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
 
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "<0>FITV #1 Cover</0> — the same, with a page label instead of a number."

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -3847,6 +3847,10 @@ msgstr "When it still reads as a blog"
 msgid "You agree not to use {SITE_NAME} to:"
 msgstr "You agree not to use {SITE_NAME} to:"
 
+#: src/components/route-error.tsx
+msgid "Go home"
+msgstr "Go home"
+
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.new.tsx
 msgid "e.g. Dispatches from the Atmosphere"

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -138,6 +138,10 @@ msgstr "Add an article"
 #~ msgid "Communities"
 #~ msgstr "Communities"
 
+#: src/components/offline-sync-debug.tsx
+msgid "Feed pages"
+msgstr "Feed pages"
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/components/reader/app-shell.tsx
@@ -1070,6 +1074,10 @@ msgstr "Read the full post"
 msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
 msgstr "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
 
+#: src/components/user-settings-view.tsx
+msgid "Offline"
+msgstr "Offline"
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
@@ -1266,6 +1274,10 @@ msgstr "Which destinations appear at all is a separate setting — <0>Customize 
 msgid "Downloaded articles"
 msgstr "Downloaded articles"
 
+#: src/components/offline-sync-debug.tsx
+msgid "Back-catalog pages"
+msgstr "Back-catalog pages"
+
 #: src/components/reader/terms-view.tsx
 msgid "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
 msgstr "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
@@ -1301,6 +1313,10 @@ msgstr "Text size"
 #: src/components/onboarding/step-intro.tsx
 msgid "A calm reading room for the open web. Let's take two minutes to make it yours."
 msgstr "A calm reading room for the open web. Let's take two minutes to make it yours."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Run sync now"
+msgstr "Run sync now"
 
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.index.tsx
@@ -1714,6 +1730,10 @@ msgstr "“…made to be read, and not to be measured.”"
 msgid "If you already know what you want, <0>Discover</0> lists everything on the network, and <1>Finding things to read</1> covers every way to get there."
 msgstr "If you already know what you want, <0>Discover</0> lists everything on the network, and <1>Finding things to read</1> covers every way to get there."
 
+#: src/components/offline-sync-debug.tsx
+msgid "Images"
+msgstr "Images"
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
 #~ msgstr "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
@@ -1967,6 +1987,10 @@ msgstr "Embed subscribe"
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That GIF is over 1 MB. Try a shorter clip, or attach a still image."
 msgstr "That GIF is over 1 MB. Try a shorter clip, or attach a still image."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Storage"
+msgstr "Storage"
 
 #: src/components/reader/blocked-notice.tsx
 msgid "{Who} has blocked you, so you can't see their writing. Blocks are records in their repo — this isn't a Standard Reader decision, and it applies wherever you read them."
@@ -2469,6 +2493,7 @@ msgstr "Collections"
 msgid "Done"
 msgstr "Done"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/saved-filters.tsx
 msgid "Authors"
 msgstr "Authors"
@@ -3251,6 +3276,7 @@ msgstr "Read without an account. Sign in with Bluesky when you want to subscribe
 msgid "Remove {itemTitle}"
 msgstr "Remove {itemTitle}"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Lists"
@@ -4307,6 +4333,10 @@ msgstr "Open the app"
 msgid "Last checked {0}. Blocks you make elsewhere show up here within about fifteen minutes."
 msgstr "Last checked {0}. Blocks you make elsewhere show up here within about fifteen minutes."
 
+#: src/components/offline-sync-debug.tsx
+msgid "If articles aren’t available offline, this is what the last sync did. Sharing a screenshot of it is the fastest way to get it fixed."
+msgstr "If articles aren’t available offline, this is what the last sync did. Sharing a screenshot of it is the fastest way to get it fixed."
+
 #: src/components/reader/block-user-menu-item.tsx
 msgid "Block account?"
 msgstr "Block account?"
@@ -4819,6 +4849,10 @@ msgstr "If you write software and want to build on the same network, the <0>deve
 #: src/components/reader/about-view.tsx
 msgid "Stop reading this example aloud"
 msgstr "Stop reading this example aloud"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Unread listed"
+msgstr "Unread listed"
 
 #. placeholder {0}: issue.ownerHandle
 #: src/magazine/flow.tsx
@@ -5791,7 +5825,6 @@ msgstr "Follow along"
 msgid "Show all feedback"
 msgstr "Show all feedback"
 
-#: src/components/offline-sync-debug.tsx
 #: src/components/user-settings-view.tsx
 msgid "Troubleshooting"
 msgstr "Troubleshooting"
@@ -6652,6 +6685,7 @@ msgstr "Your Home feed is empty for now — head to Discover whenever you're rea
 #~ msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
 #~ msgstr "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.friends.tsx
@@ -6816,6 +6850,10 @@ msgstr "No trending publications yet."
 #: src/routes/login.tsx
 msgid "Sign in again to refresh your permissions — your session doesn't include save-for-later yet."
 msgstr "Sign in again to refresh your permissions — your session doesn't include save-for-later yet."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Status"
+msgstr "Status"
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "Account actions"
@@ -7663,6 +7701,7 @@ msgstr "Session metadata such as IP address and browser user-agent string, used 
 msgid "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 msgstr "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
@@ -7855,6 +7894,7 @@ msgstr "A few things ask for more, at the moment you first use them rather than 
 msgid "Recommend this article"
 msgstr "Recommend this article"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/about-view.tsx
 msgid "Stop"
 msgstr "Stop"
@@ -8134,6 +8174,10 @@ msgstr "Get started"
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "You don't have any content tabs to show yet."
 msgstr "You don't have any content tabs to show yet."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Started / finished"
+msgstr "Started / finished"
 
 #: src/components/appearance-settings.tsx
 msgid "Body text on paper"

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -5791,6 +5791,7 @@ msgstr "Follow along"
 msgid "Show all feedback"
 msgstr "Show all feedback"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/user-settings-view.tsx
 msgid "Troubleshooting"
 msgstr "Troubleshooting"

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -2283,6 +2283,10 @@ msgstr "No collections in this series yet."
 msgid "None of this labeler’s labels could be verified against the signing key it publishes, so none are applied. That’s a problem on the labeler’s end."
 msgstr "None of this labeler’s labels could be verified against the signing key it publishes, so none are applied. That’s a problem on the labeler’s end."
 
+#: src/components/offline-sync-debug.tsx
+msgid "Still to fetch"
+msgstr "Still to fetch"
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "No feedback yet."
 msgstr "No feedback yet."
@@ -3077,6 +3081,10 @@ msgstr "Every unread article from this publication will be marked read. This can
 #: src/components/appearance-settings.tsx
 msgid "Your own colors"
 msgstr "Your own colors"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Initial fill"
+msgstr "Initial fill"
 
 #: src/components/reader/app-shell.tsx
 #~ msgid "You are offline"
@@ -7248,6 +7256,10 @@ msgstr "{unreadCount} unread"
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "Below those, the publications you follow are listed for quick access. The <0>Subscriptions</0> heading above them opens the full management view. At the very bottom, your avatar opens a menu with your profile, reading history, recommended articles, feedback, settings, and log out."
 #~ msgstr "Below those, the publications you follow are listed for quick access. The <0>Subscriptions</0> heading above them opens the full management view. At the very bottom, your avatar opens a menu with your profile, reading history, recommended articles, feedback, settings, and log out."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Downloaded"
+msgstr "Downloaded"
 
 #: src/components/reader/add-publication-modal.tsx
 #: src/components/reader/app-shell.tsx

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -3847,6 +3847,10 @@ msgstr ""
 msgid "You agree not to use {SITE_NAME} to:"
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "Go home"
+msgstr ""
+
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.new.tsx
 msgid "e.g. Dispatches from the Atmosphere"

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -3053,6 +3053,10 @@ msgstr "Todos los artículos sin leer de esta publicación se marcarán como le�
 msgid "Your own colors"
 msgstr ""
 
+#: src/components/reader/app-shell.tsx
+msgid "You are offline"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
 msgstr "Estableciendo el número…"
@@ -3619,6 +3623,10 @@ msgstr ""
 #: src/components/reader/mention-hover-card.tsx
 msgid "{n, plural, one {# publication} other {{value} publications}}"
 msgstr "{n, plural, one {# publicación} other {{value} publicaciones}}"
+
+#: src/components/reader/app-shell.tsx
+msgid "offline"
+msgstr ""
 
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -138,6 +138,10 @@ msgstr "Añadir un artículo"
 #~ msgid "Communities"
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Feed pages"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/components/reader/app-shell.tsx
@@ -1070,6 +1074,10 @@ msgstr ""
 msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Offline"
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {¿Suscribirse a {formattedUnfollowedCount} publicación?} other {¿Suscribirse a {formattedUnfollowedCount} publicaciones?}}"
@@ -1266,6 +1274,10 @@ msgstr ""
 msgid "Downloaded articles"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Back-catalog pages"
+msgstr ""
+
 #: src/components/reader/terms-view.tsx
 msgid "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
 msgstr ""
@@ -1301,6 +1313,10 @@ msgstr "Tamaño del texto"
 #: src/components/onboarding/step-intro.tsx
 msgid "A calm reading room for the open web. Let's take two minutes to make it yours."
 msgstr "Una sala de lectura tranquila para la web abierta. Dediquemos dos minutos a hacerla suya."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Run sync now"
+msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.index.tsx
@@ -1714,6 +1730,10 @@ msgstr ""
 msgid "If you already know what you want, <0>Discover</0> lists everything on the network, and <1>Finding things to read</1> covers every way to get there."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Images"
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
 #~ msgstr "Incluya la pista <0>site.standard.publication</0> solo si el documento pertenece a un registro de publicación. Agregue ambas sin importar qué lector le interese: así es como cualquier cliente de la red resuelve su página hasta su registro, no solo nuestra extensión."
@@ -1966,6 +1986,10 @@ msgstr "Insertar botón de suscripción"
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That GIF is over 1 MB. Try a shorter clip, or attach a still image."
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Storage"
 msgstr ""
 
 #: src/components/reader/blocked-notice.tsx
@@ -2469,6 +2493,7 @@ msgstr "Colecciones"
 msgid "Done"
 msgstr "Listo"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/saved-filters.tsx
 msgid "Authors"
 msgstr ""
@@ -3251,6 +3276,7 @@ msgstr "Lea sin cuenta. Inicie sesión con Bluesky cuando quiera suscribirse, da
 msgid "Remove {itemTitle}"
 msgstr "Quitar {itemTitle}"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Lists"
@@ -4307,6 +4333,10 @@ msgstr ""
 msgid "Last checked {0}. Blocks you make elsewhere show up here within about fifteen minutes."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "If articles aren’t available offline, this is what the last sync did. Sharing a screenshot of it is the fastest way to get it fixed."
+msgstr ""
+
 #: src/components/reader/block-user-menu-item.tsx
 msgid "Block account?"
 msgstr ""
@@ -4819,6 +4849,10 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 msgid "Stop reading this example aloud"
 msgstr "Dejar de leer este ejemplo en voz alta"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Unread listed"
+msgstr ""
 
 #. placeholder {0}: issue.ownerHandle
 #: src/magazine/flow.tsx
@@ -5791,7 +5825,6 @@ msgstr "Seguir la lectura"
 msgid "Show all feedback"
 msgstr ""
 
-#: src/components/offline-sync-debug.tsx
 #: src/components/user-settings-view.tsx
 msgid "Troubleshooting"
 msgstr ""
@@ -6652,6 +6685,7 @@ msgstr "Su feed de Inicio está vacío por ahora — pase por Descubrir cuando q
 #~ msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.friends.tsx
@@ -6816,6 +6850,10 @@ msgstr "Aún no hay publicaciones en tendencia."
 #: src/routes/login.tsx
 msgid "Sign in again to refresh your permissions — your session doesn't include save-for-later yet."
 msgstr "Inicie sesión de nuevo para actualizar sus permisos: su sesión todavía no incluye guardar para después."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Status"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "Account actions"
@@ -7663,6 +7701,7 @@ msgstr "Metadatos de la sesión, como la dirección IP y la cadena de user-agent
 msgid "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 msgstr "No publicamos nada en su cuenta salvo cuando realiza una acción explícita que lo requiere (por ejemplo, seguir una publicación, dar me gusta o guardar un artículo, o suscribirse mediante el flujo de suscripción específico). No vendemos su información personal."
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
@@ -7855,6 +7894,7 @@ msgstr ""
 msgid "Recommend this article"
 msgstr "Recomendar este artículo"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/about-view.tsx
 msgid "Stop"
 msgstr "Detener"
@@ -8134,6 +8174,10 @@ msgstr "Empezar"
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "You don't have any content tabs to show yet."
 msgstr "Todavía no tiene pestañas de contenido para mostrar."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Started / finished"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Body text on paper"

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -21,6 +21,10 @@ msgstr ""
 msgid "Every publication the network knows about — subscribe to the ones worth your mornings."
 msgstr "Todas las publicaciones que la red conoce: suscríbase a las que valgan sus mañanas."
 
+#: src/components/guide/pages/getting-started-guide-page.tsx
+msgid "The installed app downloads the articles you have not read yet, with their images, while you are online. Open it on a plane or a tunnel and your unread queue is already there — no planning ahead, and nothing to tap beforehand."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Authoring Collections needs additional permissions to publish collections and documents on your behalf. You can revoke this any time from your account settings."
 msgstr "Crear colecciones requiere permisos adicionales para publicar colecciones y documentos en su nombre. Puede revocarlos cuando quiera desde la configuración de la cuenta."
@@ -81,6 +85,10 @@ msgstr "Ir a la sección"
 #: src/routes/_layout.saved.tsx
 msgid "Sort by"
 msgstr "Ordenar por"
+
+#: src/components/offline-settings.tsx
+msgid "Downloads the articles you haven't read yet, with their images, so they open with no connection. Pauses automatically when your system asks apps to save data."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/components/reader/about-view.tsx
@@ -936,6 +944,10 @@ msgstr "Marcar como sin leer"
 msgid "Grid view"
 msgstr "Vista de cuadrícula"
 
+#: src/components/route-error.tsx
+msgid "You’re offline"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "Subscribe to get new writing in your feed."
 msgstr "Suscríbase para recibir nuevos textos en su feed."
@@ -1248,6 +1260,10 @@ msgstr "Abrir los posts en su sitio original"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Which destinations appear at all is a separate setting — <0>Customize sidebar</0> under <1>Making it yours</1> hides the ones you never use. Subscriptions and your lists always stay."
+msgstr ""
+
+#: src/components/offline-settings.tsx
+msgid "Downloaded articles"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -4156,6 +4172,7 @@ msgid "{0, plural, one {# publication} other {# publications}}"
 msgstr "{0, plural, one {# publicación} other {# publicaciones}}"
 
 #: src/components/feedback/feedback-image-picker.tsx
+#: src/components/route-error.tsx
 msgid "Try again"
 msgstr ""
 
@@ -4674,6 +4691,10 @@ msgstr ""
 msgid "Select <0>Log in</0>, at the bottom of the sidebar on a computer or in the top bar on a phone."
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "That page didn’t load. Try again — if it keeps happening, it’s on our side."
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/routes/_layout.saved.tsx
@@ -5076,6 +5097,7 @@ msgstr ""
 #: src/components/reader/blocked-notice.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
+#: src/components/route-error.tsx
 msgid "Something went wrong"
 msgstr "Algo salió mal"
 
@@ -5511,6 +5533,10 @@ msgstr ""
 msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "Si instala la extensión de navegador de {SITE_NAME}, esta usa la misma cuenta y cookie de sesión que este sitio. La extensión envía las URL de las páginas a nuestros endpoints <0>/api/extension/*</0> para cotejar el índice y guarda los ajustes de la superposición en el almacenamiento de extensiones del navegador. Consulte la <1>política de privacidad de la extensión</1> para conocer los detalles que aplican solo a la extensión."
@@ -5810,6 +5836,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Weekly digest email"
 msgstr "Correo del resumen semanal"
+
+#: src/components/offline-settings.tsx
+msgid "Keep unread articles on this device"
+msgstr ""
 
 #: src/components/reader/ios-install-prompt.tsx
 msgid "Choose “Add to Home Screen”."
@@ -6423,6 +6453,7 @@ msgid "Top on the network"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/offline-settings.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
@@ -6568,6 +6599,10 @@ msgstr ""
 msgid "On your phone"
 msgstr ""
 
+#: src/components/offline-settings.tsx
+msgid "Storage use isn't available in this browser."
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>2. Serve labels.</0> Sign and emit <1>com.atproto.label.defs#label</1> objects, and expose the standard <2>com.atproto.label.queryLabels</2> (HTTP) and <3>com.atproto.label.subscribeLabels</3> (WebSocket) endpoints."
 msgstr "<0>2. Servir etiquetas.</0> Firme y emita objetos <1>com.atproto.label.defs#label</1>, y exponga los endpoints estándar <2>com.atproto.label.queryLabels</2> (HTTP) y <3>com.atproto.label.subscribeLabels</3> (WebSocket)."
@@ -6597,8 +6632,8 @@ msgid "Your Home feed is empty for now — head to Discover whenever you're read
 msgstr "Su feed de Inicio está vacío por ahora — pase por Descubrir cuando quiera, y todo aquello a lo que se suscriba empezará a acumularse aquí."
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
-msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
-msgstr ""
+#~ msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
+#~ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-table.tsx
@@ -6772,6 +6807,11 @@ msgstr "Acciones de la cuenta"
 #: src/components/reader/mention-hover-card.tsx
 msgid "Read article"
 msgstr "Leer artículo"
+
+#. placeholder {0}: formatBytes(usage.usage)
+#: src/components/offline-settings.tsx
+msgid "Standard Reader is using {0} on this device."
+msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Terms of service"
@@ -7507,6 +7547,10 @@ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Subscribe to the publication it came from, in the same click."
+msgstr ""
+
+#: src/components/guide/pages/getting-started-guide-page.tsx
+msgid "Reach for something that was never downloaded and the app says so, rather than showing you an error. You can turn downloading off, and see how much space it is using, under Settings → Reading. It pauses on its own when your phone asks apps to save data. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
 msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -2283,6 +2283,10 @@ msgstr "Aún no hay colecciones en esta serie."
 msgid "None of this labeler’s labels could be verified against the signing key it publishes, so none are applied. That’s a problem on the labeler’s end."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Still to fetch"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "No feedback yet."
 msgstr "Aún no hay comentarios."
@@ -3076,6 +3080,10 @@ msgstr "Todos los artículos sin leer de esta publicación se marcarán como le�
 
 #: src/components/appearance-settings.tsx
 msgid "Your own colors"
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Initial fill"
 msgstr ""
 
 #: src/components/reader/app-shell.tsx
@@ -7248,6 +7256,10 @@ msgstr "{unreadCount} sin leer"
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "Below those, the publications you follow are listed for quick access. The <0>Subscriptions</0> heading above them opens the full management view. At the very bottom, your avatar opens a menu with your profile, reading history, recommended articles, feedback, settings, and log out."
 #~ msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Downloaded"
+msgstr ""
 
 #: src/components/reader/add-publication-modal.tsx
 #: src/components/reader/app-shell.tsx

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -5791,6 +5791,7 @@ msgstr "Seguir la lectura"
 msgid "Show all feedback"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/user-settings-view.tsx
 msgid "Troubleshooting"
 msgstr ""

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -3965,6 +3965,10 @@ msgstr ""
 msgid "{0} total"
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "This page wasn’t saved to your device, so it needs a connection. It’ll load on its own when you’re back online — your unread articles are already here."
+msgstr ""
+
 #: src/components/blocks-settings-view.tsx
 msgid "Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours."
 msgstr ""
@@ -5542,8 +5546,8 @@ msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
 
 #: src/components/route-error.tsx
-msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
-msgstr ""
+#~ msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
+#~ msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -3054,8 +3054,8 @@ msgid "Your own colors"
 msgstr ""
 
 #: src/components/reader/app-shell.tsx
-msgid "You are offline"
-msgstr ""
+#~ msgid "You are offline"
+#~ msgstr ""
 
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
@@ -3625,8 +3625,8 @@ msgid "{n, plural, one {# publication} other {{value} publications}}"
 msgstr "{n, plural, one {# publicación} other {{value} publicaciones}}"
 
 #: src/components/reader/app-shell.tsx
-msgid "offline"
-msgstr ""
+#~ msgid "offline"
+#~ msgstr ""
 
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -3847,6 +3847,10 @@ msgstr ""
 msgid "You agree not to use {SITE_NAME} to:"
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "Go home"
+msgstr ""
+
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.new.tsx
 msgid "e.g. Dispatches from the Atmosphere"

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -138,6 +138,10 @@ msgstr "Ajouter un article"
 #~ msgid "Communities"
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Feed pages"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/components/reader/app-shell.tsx
@@ -1070,6 +1074,10 @@ msgstr ""
 msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Offline"
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {S’abonner à {formattedUnfollowedCount} publication ?} other {S’abonner à {formattedUnfollowedCount} publications ?}}"
@@ -1266,6 +1274,10 @@ msgstr ""
 msgid "Downloaded articles"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Back-catalog pages"
+msgstr ""
+
 #: src/components/reader/terms-view.tsx
 msgid "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
 msgstr ""
@@ -1301,6 +1313,10 @@ msgstr "Taille du texte"
 #: src/components/onboarding/step-intro.tsx
 msgid "A calm reading room for the open web. Let's take two minutes to make it yours."
 msgstr "Un salon de lecture paisible pour le web ouvert. Prenons deux minutes pour l’adapter à vos goûts."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Run sync now"
+msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.index.tsx
@@ -1714,6 +1730,10 @@ msgstr ""
 msgid "If you already know what you want, <0>Discover</0> lists everything on the network, and <1>Finding things to read</1> covers every way to get there."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Images"
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
 #~ msgstr "N'incluez l'indice <0>site.standard.publication</0> que si le document appartient à un enregistrement de publication. Ajoutez les deux quel que soit le lecteur qui vous intéresse : c'est ainsi que n'importe quel client du réseau relie votre page à son enregistrement, et pas seulement notre extension."
@@ -1966,6 +1986,10 @@ msgstr "Intégrer le bouton d'abonnement"
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That GIF is over 1 MB. Try a shorter clip, or attach a still image."
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Storage"
 msgstr ""
 
 #: src/components/reader/blocked-notice.tsx
@@ -2469,6 +2493,7 @@ msgstr "Collections"
 msgid "Done"
 msgstr "Terminé"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/saved-filters.tsx
 msgid "Authors"
 msgstr ""
@@ -3251,6 +3276,7 @@ msgstr "Lisez sans compte. Connectez-vous avec Bluesky quand vous voulez vous ab
 msgid "Remove {itemTitle}"
 msgstr "Retirer {itemTitle}"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Lists"
@@ -4307,6 +4333,10 @@ msgstr ""
 msgid "Last checked {0}. Blocks you make elsewhere show up here within about fifteen minutes."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "If articles aren’t available offline, this is what the last sync did. Sharing a screenshot of it is the fastest way to get it fixed."
+msgstr ""
+
 #: src/components/reader/block-user-menu-item.tsx
 msgid "Block account?"
 msgstr ""
@@ -4819,6 +4849,10 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 msgid "Stop reading this example aloud"
 msgstr "Arrêter la lecture à voix haute de cet exemple"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Unread listed"
+msgstr ""
 
 #. placeholder {0}: issue.ownerHandle
 #: src/magazine/flow.tsx
@@ -5791,7 +5825,6 @@ msgstr "Suivre le fil"
 msgid "Show all feedback"
 msgstr ""
 
-#: src/components/offline-sync-debug.tsx
 #: src/components/user-settings-view.tsx
 msgid "Troubleshooting"
 msgstr ""
@@ -6652,6 +6685,7 @@ msgstr "Votre flux Accueil est vide pour le moment — passez par Découvrir qua
 #~ msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.friends.tsx
@@ -6816,6 +6850,10 @@ msgstr "Aucune publication en tendance pour l'instant."
 #: src/routes/login.tsx
 msgid "Sign in again to refresh your permissions — your session doesn't include save-for-later yet."
 msgstr "Reconnectez-vous pour actualiser vos autorisations — votre session n'inclut pas encore la lecture différée."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Status"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "Account actions"
@@ -7663,6 +7701,7 @@ msgstr "Les métadonnées de session telles que l'adresse IP et la chaîne user-
 msgid "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 msgstr "Nous ne publions rien depuis votre compte, sauf lorsque vous effectuez une action explicite qui l'exige (par exemple suivre une publication, aimer ou enregistrer un article, ou vous abonner via le parcours d'abonnement dédié). Nous ne vendons pas vos informations personnelles."
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
@@ -7855,6 +7894,7 @@ msgstr ""
 msgid "Recommend this article"
 msgstr "Recommander cet article"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/about-view.tsx
 msgid "Stop"
 msgstr "Arrêter"
@@ -8134,6 +8174,10 @@ msgstr "Commencer"
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "You don't have any content tabs to show yet."
 msgstr "Vous n'avez pas encore d'onglets de contenu à afficher."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Started / finished"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Body text on paper"

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -3054,8 +3054,8 @@ msgid "Your own colors"
 msgstr ""
 
 #: src/components/reader/app-shell.tsx
-msgid "You are offline"
-msgstr ""
+#~ msgid "You are offline"
+#~ msgstr ""
 
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
@@ -3625,8 +3625,8 @@ msgid "{n, plural, one {# publication} other {{value} publications}}"
 msgstr "{n, plural, one {# publication} other {{value} publications}}"
 
 #: src/components/reader/app-shell.tsx
-msgid "offline"
-msgstr ""
+#~ msgid "offline"
+#~ msgstr ""
 
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -21,6 +21,10 @@ msgstr ""
 msgid "Every publication the network knows about — subscribe to the ones worth your mornings."
 msgstr "Toutes les publications que le réseau connaît — abonnez-vous à celles qui méritent vos matinées."
 
+#: src/components/guide/pages/getting-started-guide-page.tsx
+msgid "The installed app downloads the articles you have not read yet, with their images, while you are online. Open it on a plane or a tunnel and your unread queue is already there — no planning ahead, and nothing to tap beforehand."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Authoring Collections needs additional permissions to publish collections and documents on your behalf. You can revoke this any time from your account settings."
 msgstr "La création de collections nécessite des autorisations supplémentaires pour publier des collections et des documents en votre nom. Vous pouvez les révoquer à tout moment dans les paramètres de votre compte."
@@ -81,6 +85,10 @@ msgstr "Aller à la section"
 #: src/routes/_layout.saved.tsx
 msgid "Sort by"
 msgstr "Trier par"
+
+#: src/components/offline-settings.tsx
+msgid "Downloads the articles you haven't read yet, with their images, so they open with no connection. Pauses automatically when your system asks apps to save data."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/components/reader/about-view.tsx
@@ -936,6 +944,10 @@ msgstr "Marquer comme non lu"
 msgid "Grid view"
 msgstr "Vue en grille"
 
+#: src/components/route-error.tsx
+msgid "You’re offline"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "Subscribe to get new writing in your feed."
 msgstr "Abonnez-vous pour recevoir les nouveaux textes dans votre flux."
@@ -1248,6 +1260,10 @@ msgstr "Ouvrir les articles sur leur site d’origine"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Which destinations appear at all is a separate setting — <0>Customize sidebar</0> under <1>Making it yours</1> hides the ones you never use. Subscriptions and your lists always stay."
+msgstr ""
+
+#: src/components/offline-settings.tsx
+msgid "Downloaded articles"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -4156,6 +4172,7 @@ msgid "{0, plural, one {# publication} other {# publications}}"
 msgstr "{0, plural, one {# publication} other {# publications}}"
 
 #: src/components/feedback/feedback-image-picker.tsx
+#: src/components/route-error.tsx
 msgid "Try again"
 msgstr ""
 
@@ -4674,6 +4691,10 @@ msgstr ""
 msgid "Select <0>Log in</0>, at the bottom of the sidebar on a computer or in the top bar on a phone."
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "That page didn’t load. Try again — if it keeps happening, it’s on our side."
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/routes/_layout.saved.tsx
@@ -5076,6 +5097,7 @@ msgstr ""
 #: src/components/reader/blocked-notice.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
+#: src/components/route-error.tsx
 msgid "Something went wrong"
 msgstr "Une erreur s’est produite"
 
@@ -5511,6 +5533,10 @@ msgstr ""
 msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "Si vous installez l'extension de navigateur {SITE_NAME}, elle utilise le même compte et le même cookie de session que ce site. L'extension envoie les URL des pages à nos points de terminaison <0>/api/extension/*</0> pour la correspondance avec l'index et conserve les réglages de la surcouche dans le stockage d'extension de votre navigateur. Consultez la <1>politique de confidentialité de l'extension</1> pour les détails qui la concernent uniquement."
@@ -5810,6 +5836,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Weekly digest email"
 msgstr "E-mail du condensé hebdomadaire"
+
+#: src/components/offline-settings.tsx
+msgid "Keep unread articles on this device"
+msgstr ""
 
 #: src/components/reader/ios-install-prompt.tsx
 msgid "Choose “Add to Home Screen”."
@@ -6423,6 +6453,7 @@ msgid "Top on the network"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/offline-settings.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
@@ -6568,6 +6599,10 @@ msgstr ""
 msgid "On your phone"
 msgstr ""
 
+#: src/components/offline-settings.tsx
+msgid "Storage use isn't available in this browser."
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>2. Serve labels.</0> Sign and emit <1>com.atproto.label.defs#label</1> objects, and expose the standard <2>com.atproto.label.queryLabels</2> (HTTP) and <3>com.atproto.label.subscribeLabels</3> (WebSocket) endpoints."
 msgstr "<0>2. Diffuser des étiquettes.</0> Signez et émettez des objets <1>com.atproto.label.defs#label</1>, et exposez les points de terminaison standard <2>com.atproto.label.queryLabels</2> (HTTP) et <3>com.atproto.label.subscribeLabels</3> (WebSocket)."
@@ -6597,8 +6632,8 @@ msgid "Your Home feed is empty for now — head to Discover whenever you're read
 msgstr "Votre flux Accueil est vide pour le moment — passez par Découvrir quand vous voulez, et tout ce à quoi vous vous abonnez commencera à s'accumuler ici."
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
-msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
-msgstr ""
+#~ msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
+#~ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-table.tsx
@@ -6772,6 +6807,11 @@ msgstr "Actions du compte"
 #: src/components/reader/mention-hover-card.tsx
 msgid "Read article"
 msgstr "Lire l'article"
+
+#. placeholder {0}: formatBytes(usage.usage)
+#: src/components/offline-settings.tsx
+msgid "Standard Reader is using {0} on this device."
+msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Terms of service"
@@ -7507,6 +7547,10 @@ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Subscribe to the publication it came from, in the same click."
+msgstr ""
+
+#: src/components/guide/pages/getting-started-guide-page.tsx
+msgid "Reach for something that was never downloaded and the app says so, rather than showing you an error. You can turn downloading off, and see how much space it is using, under Settings → Reading. It pauses on its own when your phone asks apps to save data. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
 msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -3053,6 +3053,10 @@ msgstr "Tous les articles non lus de cette publication seront marqués comme lus
 msgid "Your own colors"
 msgstr ""
 
+#: src/components/reader/app-shell.tsx
+msgid "You are offline"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
 msgstr "Composition du numéro…"
@@ -3619,6 +3623,10 @@ msgstr ""
 #: src/components/reader/mention-hover-card.tsx
 msgid "{n, plural, one {# publication} other {{value} publications}}"
 msgstr "{n, plural, one {# publication} other {{value} publications}}"
+
+#: src/components/reader/app-shell.tsx
+msgid "offline"
+msgstr ""
 
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -5791,6 +5791,7 @@ msgstr "Suivre le fil"
 msgid "Show all feedback"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/user-settings-view.tsx
 msgid "Troubleshooting"
 msgstr ""

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -3965,6 +3965,10 @@ msgstr ""
 msgid "{0} total"
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "This page wasn’t saved to your device, so it needs a connection. It’ll load on its own when you’re back online — your unread articles are already here."
+msgstr ""
+
 #: src/components/blocks-settings-view.tsx
 msgid "Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours."
 msgstr ""
@@ -5542,8 +5546,8 @@ msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
 
 #: src/components/route-error.tsx
-msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
-msgstr ""
+#~ msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
+#~ msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -2283,6 +2283,10 @@ msgstr "Aucune collection dans cette série pour l'instant."
 msgid "None of this labeler’s labels could be verified against the signing key it publishes, so none are applied. That’s a problem on the labeler’s end."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Still to fetch"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "No feedback yet."
 msgstr "Aucun retour pour l'instant."
@@ -3076,6 +3080,10 @@ msgstr "Tous les articles non lus de cette publication seront marqués comme lus
 
 #: src/components/appearance-settings.tsx
 msgid "Your own colors"
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Initial fill"
 msgstr ""
 
 #: src/components/reader/app-shell.tsx
@@ -7248,6 +7256,10 @@ msgstr "{unreadCount} non lus"
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "Below those, the publications you follow are listed for quick access. The <0>Subscriptions</0> heading above them opens the full management view. At the very bottom, your avatar opens a menu with your profile, reading history, recommended articles, feedback, settings, and log out."
 #~ msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Downloaded"
+msgstr ""
 
 #: src/components/reader/add-publication-modal.tsx
 #: src/components/reader/app-shell.tsx

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -3847,6 +3847,10 @@ msgstr ""
 msgid "You agree not to use {SITE_NAME} to:"
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "Go home"
+msgstr ""
+
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.new.tsx
 msgid "e.g. Dispatches from the Atmosphere"

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -138,6 +138,10 @@ msgstr "記事を追加"
 #~ msgid "Communities"
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Feed pages"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/components/reader/app-shell.tsx
@@ -1070,6 +1074,10 @@ msgstr ""
 msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Offline"
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {{formattedUnfollowedCount} 件の発行物を購読しますか？} other {{formattedUnfollowedCount} 件の発行物を購読しますか？}}"
@@ -1266,6 +1274,10 @@ msgstr ""
 msgid "Downloaded articles"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Back-catalog pages"
+msgstr ""
+
 #: src/components/reader/terms-view.tsx
 msgid "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
 msgstr ""
@@ -1301,6 +1313,10 @@ msgstr "文字サイズ"
 #: src/components/onboarding/step-intro.tsx
 msgid "A calm reading room for the open web. Let's take two minutes to make it yours."
 msgstr "オープンウェブのための静かな読書室。2分だけ使って、自分好みにしましょう。"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Run sync now"
+msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.index.tsx
@@ -1714,6 +1730,10 @@ msgstr ""
 msgid "If you already know what you want, <0>Discover</0> lists everything on the network, and <1>Finding things to read</1> covers every way to get there."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Images"
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
 #~ msgstr "<0>site.standard.publication</0> のヒントは、そのドキュメントが発行物のレコードに属している場合にのみ含めてください。どのリーダーを想定していても両方を追加してください。これは当社の拡張機能だけでなく、ネットワーク上のあらゆるクライアントがページからレコードを解決するための仕組みです。"
@@ -1966,6 +1986,10 @@ msgstr "購読ボタンを埋め込む"
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That GIF is over 1 MB. Try a shorter clip, or attach a still image."
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Storage"
 msgstr ""
 
 #: src/components/reader/blocked-notice.tsx
@@ -2469,6 +2493,7 @@ msgstr "コレクション"
 msgid "Done"
 msgstr "完了"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/saved-filters.tsx
 msgid "Authors"
 msgstr ""
@@ -3251,6 +3276,7 @@ msgstr "アカウントなしで読めます。購読・いいね・保存をし
 msgid "Remove {itemTitle}"
 msgstr "{itemTitle} を削除"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Lists"
@@ -4307,6 +4333,10 @@ msgstr ""
 msgid "Last checked {0}. Blocks you make elsewhere show up here within about fifteen minutes."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "If articles aren’t available offline, this is what the last sync did. Sharing a screenshot of it is the fastest way to get it fixed."
+msgstr ""
+
 #: src/components/reader/block-user-menu-item.tsx
 msgid "Block account?"
 msgstr ""
@@ -4819,6 +4849,10 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 msgid "Stop reading this example aloud"
 msgstr "この例の読み上げを停止"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Unread listed"
+msgstr ""
 
 #. placeholder {0}: issue.ownerHandle
 #: src/magazine/flow.tsx
@@ -5791,7 +5825,6 @@ msgstr "追って読む"
 msgid "Show all feedback"
 msgstr ""
 
-#: src/components/offline-sync-debug.tsx
 #: src/components/user-settings-view.tsx
 msgid "Troubleshooting"
 msgstr ""
@@ -6652,6 +6685,7 @@ msgstr "ホームフィードは今のところ空です。準備ができたら
 #~ msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.friends.tsx
@@ -6816,6 +6850,10 @@ msgstr "話題の発行物はまだありません。"
 #: src/routes/login.tsx
 msgid "Sign in again to refresh your permissions — your session doesn't include save-for-later yet."
 msgstr "権限を更新するにもう一度サインインしてください。現在のセッションには「あとで読む」が含まれていません。"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Status"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "Account actions"
@@ -7663,6 +7701,7 @@ msgstr "IP アドレスやブラウザのユーザーエージェント文字列
 msgid "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 msgstr "明示的な操作（発行物のフォロー、記事への高評価や保存、専用の購読フローでの購読など）が必要な場合を除き、あなたのアカウントで投稿することはありません。個人情報を販売することもありません。"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
@@ -7855,6 +7894,7 @@ msgstr ""
 msgid "Recommend this article"
 msgstr "この記事をおすすめする"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/about-view.tsx
 msgid "Stop"
 msgstr "停止"
@@ -8134,6 +8174,10 @@ msgstr "はじめる"
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "You don't have any content tabs to show yet."
 msgstr "表示できるコンテンツタブがまだありません。"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Started / finished"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Body text on paper"

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -3053,6 +3053,10 @@ msgstr "この発行物の未読記事がすべて既読になります。この
 msgid "Your own colors"
 msgstr ""
 
+#: src/components/reader/app-shell.tsx
+msgid "You are offline"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
 msgstr "号を設定中…"
@@ -3619,6 +3623,10 @@ msgstr ""
 #: src/components/reader/mention-hover-card.tsx
 msgid "{n, plural, one {# publication} other {{value} publications}}"
 msgstr "{n, plural, one {# 件の発行物} other {{value} 件の発行物}}"
+
+#: src/components/reader/app-shell.tsx
+msgid "offline"
+msgstr ""
 
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -3054,8 +3054,8 @@ msgid "Your own colors"
 msgstr ""
 
 #: src/components/reader/app-shell.tsx
-msgid "You are offline"
-msgstr ""
+#~ msgid "You are offline"
+#~ msgstr ""
 
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
@@ -3625,8 +3625,8 @@ msgid "{n, plural, one {# publication} other {{value} publications}}"
 msgstr "{n, plural, one {# 件の発行物} other {{value} 件の発行物}}"
 
 #: src/components/reader/app-shell.tsx
-msgid "offline"
-msgstr ""
+#~ msgid "offline"
+#~ msgstr ""
 
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -21,6 +21,10 @@ msgstr ""
 msgid "Every publication the network knows about — subscribe to the ones worth your mornings."
 msgstr "ネットワーク上のすべての発行物。朝の時間を使う価値のあるものを購読しましょう。"
 
+#: src/components/guide/pages/getting-started-guide-page.tsx
+msgid "The installed app downloads the articles you have not read yet, with their images, while you are online. Open it on a plane or a tunnel and your unread queue is already there — no planning ahead, and nothing to tap beforehand."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Authoring Collections needs additional permissions to publish collections and documents on your behalf. You can revoke this any time from your account settings."
 msgstr "コレクションの作成には、あなたに代わってコレクションと文書を公開するための追加の権限が必要です。権限はアカウント設定からいつでも取り消せます。"
@@ -81,6 +85,10 @@ msgstr "セクションへ移動"
 #: src/routes/_layout.saved.tsx
 msgid "Sort by"
 msgstr "並び替え"
+
+#: src/components/offline-settings.tsx
+msgid "Downloads the articles you haven't read yet, with their images, so they open with no connection. Pauses automatically when your system asks apps to save data."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/components/reader/about-view.tsx
@@ -936,6 +944,10 @@ msgstr "未読にする"
 msgid "Grid view"
 msgstr "グリッド表示"
 
+#: src/components/route-error.tsx
+msgid "You’re offline"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "Subscribe to get new writing in your feed."
 msgstr "購読すると、新しい文章がフィードに届きます。"
@@ -1248,6 +1260,10 @@ msgstr "投稿を元のサイトで開く"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Which destinations appear at all is a separate setting — <0>Customize sidebar</0> under <1>Making it yours</1> hides the ones you never use. Subscriptions and your lists always stay."
+msgstr ""
+
+#: src/components/offline-settings.tsx
+msgid "Downloaded articles"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -4156,6 +4172,7 @@ msgid "{0, plural, one {# publication} other {# publications}}"
 msgstr "{0, plural, one {# 件の発行物} other {# 件の発行物}}"
 
 #: src/components/feedback/feedback-image-picker.tsx
+#: src/components/route-error.tsx
 msgid "Try again"
 msgstr ""
 
@@ -4674,6 +4691,10 @@ msgstr ""
 msgid "Select <0>Log in</0>, at the bottom of the sidebar on a computer or in the top bar on a phone."
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "That page didn’t load. Try again — if it keeps happening, it’s on our side."
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/routes/_layout.saved.tsx
@@ -5076,6 +5097,7 @@ msgstr ""
 #: src/components/reader/blocked-notice.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
+#: src/components/route-error.tsx
 msgid "Something went wrong"
 msgstr "問題が発生しました"
 
@@ -5511,6 +5533,10 @@ msgstr ""
 msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "{SITE_NAME} のブラウザ拡張機能をインストールすると、このサイトと同じアカウントとセッションクッキーが使われます。拡張機能はインデックス照合のためにページの URL を <0>/api/extension/*</0> エンドポイントへ送信し、オーバーレイの設定はブラウザの拡張機能ストレージに保存します。拡張機能のみに適用される詳細は<1>拡張機能のプライバシーポリシー</1>をご覧ください。"
@@ -5810,6 +5836,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Weekly digest email"
 msgstr "週刊ダイジェストメール"
+
+#: src/components/offline-settings.tsx
+msgid "Keep unread articles on this device"
+msgstr ""
 
 #: src/components/reader/ios-install-prompt.tsx
 msgid "Choose “Add to Home Screen”."
@@ -6423,6 +6453,7 @@ msgid "Top on the network"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/offline-settings.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
@@ -6568,6 +6599,10 @@ msgstr ""
 msgid "On your phone"
 msgstr ""
 
+#: src/components/offline-settings.tsx
+msgid "Storage use isn't available in this browser."
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>2. Serve labels.</0> Sign and emit <1>com.atproto.label.defs#label</1> objects, and expose the standard <2>com.atproto.label.queryLabels</2> (HTTP) and <3>com.atproto.label.subscribeLabels</3> (WebSocket) endpoints."
 msgstr "<0>2. ラベルを配信する。</0><1>com.atproto.label.defs#label</1> オブジェクトに署名して発行し、標準の <2>com.atproto.label.queryLabels</2>（HTTP）と <3>com.atproto.label.subscribeLabels</3>（WebSocket）のエンドポイントを公開します。"
@@ -6597,8 +6632,8 @@ msgid "Your Home feed is empty for now — head to Discover whenever you're read
 msgstr "ホームフィードは今のところ空です。準備ができたら発見ページへどうぞ。購読したものがすべてここに集まり始めます。"
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
-msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
-msgstr ""
+#~ msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
+#~ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-table.tsx
@@ -6772,6 +6807,11 @@ msgstr "アカウント操作"
 #: src/components/reader/mention-hover-card.tsx
 msgid "Read article"
 msgstr "記事を読む"
+
+#. placeholder {0}: formatBytes(usage.usage)
+#: src/components/offline-settings.tsx
+msgid "Standard Reader is using {0} on this device."
+msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Terms of service"
@@ -7507,6 +7547,10 @@ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Subscribe to the publication it came from, in the same click."
+msgstr ""
+
+#: src/components/guide/pages/getting-started-guide-page.tsx
+msgid "Reach for something that was never downloaded and the app says so, rather than showing you an error. You can turn downloading off, and see how much space it is using, under Settings → Reading. It pauses on its own when your phone asks apps to save data. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
 msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -2283,6 +2283,10 @@ msgstr "このシリーズにはまだコレクションがありません。"
 msgid "None of this labeler’s labels could be verified against the signing key it publishes, so none are applied. That’s a problem on the labeler’s end."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Still to fetch"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "No feedback yet."
 msgstr "フィードバックはまだありません。"
@@ -3076,6 +3080,10 @@ msgstr "この発行物の未読記事がすべて既読になります。この
 
 #: src/components/appearance-settings.tsx
 msgid "Your own colors"
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Initial fill"
 msgstr ""
 
 #: src/components/reader/app-shell.tsx
@@ -7248,6 +7256,10 @@ msgstr "未読 {unreadCount} 件"
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "Below those, the publications you follow are listed for quick access. The <0>Subscriptions</0> heading above them opens the full management view. At the very bottom, your avatar opens a menu with your profile, reading history, recommended articles, feedback, settings, and log out."
 #~ msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Downloaded"
+msgstr ""
 
 #: src/components/reader/add-publication-modal.tsx
 #: src/components/reader/app-shell.tsx

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -3965,6 +3965,10 @@ msgstr ""
 msgid "{0} total"
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "This page wasn’t saved to your device, so it needs a connection. It’ll load on its own when you’re back online — your unread articles are already here."
+msgstr ""
+
 #: src/components/blocks-settings-view.tsx
 msgid "Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours."
 msgstr ""
@@ -5542,8 +5546,8 @@ msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
 
 #: src/components/route-error.tsx
-msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
-msgstr ""
+#~ msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
+#~ msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -5791,6 +5791,7 @@ msgstr "追って読む"
 msgid "Show all feedback"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/user-settings-view.tsx
 msgid "Troubleshooting"
 msgstr ""

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -3847,6 +3847,10 @@ msgstr ""
 msgid "You agree not to use {SITE_NAME} to:"
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "Go home"
+msgstr ""
+
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.new.tsx
 msgid "e.g. Dispatches from the Atmosphere"

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -21,6 +21,10 @@ msgstr ""
 msgid "Every publication the network knows about — subscribe to the ones worth your mornings."
 msgstr "네트워크가 알고 있는 모든 발행물 — 아침 시간을 내줄 만한 곳을 구독하세요."
 
+#: src/components/guide/pages/getting-started-guide-page.tsx
+msgid "The installed app downloads the articles you have not read yet, with their images, while you are online. Open it on a plane or a tunnel and your unread queue is already there — no planning ahead, and nothing to tap beforehand."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Authoring Collections needs additional permissions to publish collections and documents on your behalf. You can revoke this any time from your account settings."
 msgstr "컬렉션을 작성하려면 회원님을 대신해 컬렉션과 문서를 게시할 추가 권한이 필요합니다. 계정 설정에서 언제든지 취소할 수 있습니다."
@@ -81,6 +85,10 @@ msgstr "섹션으로 이동"
 #: src/routes/_layout.saved.tsx
 msgid "Sort by"
 msgstr "정렬 기준"
+
+#: src/components/offline-settings.tsx
+msgid "Downloads the articles you haven't read yet, with their images, so they open with no connection. Pauses automatically when your system asks apps to save data."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/components/reader/about-view.tsx
@@ -936,6 +944,10 @@ msgstr "읽지 않음으로 표시"
 msgid "Grid view"
 msgstr "그리드 보기"
 
+#: src/components/route-error.tsx
+msgid "You’re offline"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "Subscribe to get new writing in your feed."
 msgstr "구독하면 새 글이 피드에 표시됩니다."
@@ -1248,6 +1260,10 @@ msgstr "원본 사이트에서 글 열기"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Which destinations appear at all is a separate setting — <0>Customize sidebar</0> under <1>Making it yours</1> hides the ones you never use. Subscriptions and your lists always stay."
+msgstr ""
+
+#: src/components/offline-settings.tsx
+msgid "Downloaded articles"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -4156,6 +4172,7 @@ msgid "{0, plural, one {# publication} other {# publications}}"
 msgstr "{0, plural, one {발행물 #개} other {발행물 #개}}"
 
 #: src/components/feedback/feedback-image-picker.tsx
+#: src/components/route-error.tsx
 msgid "Try again"
 msgstr ""
 
@@ -4674,6 +4691,10 @@ msgstr ""
 msgid "Select <0>Log in</0>, at the bottom of the sidebar on a computer or in the top bar on a phone."
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "That page didn’t load. Try again — if it keeps happening, it’s on our side."
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/routes/_layout.saved.tsx
@@ -5076,6 +5097,7 @@ msgstr ""
 #: src/components/reader/blocked-notice.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
+#: src/components/route-error.tsx
 msgid "Something went wrong"
 msgstr "문제가 발생했습니다"
 
@@ -5511,6 +5533,10 @@ msgstr ""
 msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "{SITE_NAME} 브라우저 확장 프로그램을 설치하면 이 사이트와 동일한 계정 및 세션 쿠키를 사용합니다. 확장 프로그램은 색인 매칭을 위해 페이지 URL을 <0>/api/extension/*</0> 엔드포인트로 전송하고, 오버레이 설정은 브라우저의 확장 프로그램 저장소에 보관합니다. 확장 프로그램에만 적용되는 자세한 내용은 <1>확장 프로그램 개인정보 처리방침</1>을 참고하세요."
@@ -5810,6 +5836,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Weekly digest email"
 msgstr "주간 다이제스트 이메일"
+
+#: src/components/offline-settings.tsx
+msgid "Keep unread articles on this device"
+msgstr ""
 
 #: src/components/reader/ios-install-prompt.tsx
 msgid "Choose “Add to Home Screen”."
@@ -6423,6 +6453,7 @@ msgid "Top on the network"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/offline-settings.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
@@ -6568,6 +6599,10 @@ msgstr ""
 msgid "On your phone"
 msgstr ""
 
+#: src/components/offline-settings.tsx
+msgid "Storage use isn't available in this browser."
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>2. Serve labels.</0> Sign and emit <1>com.atproto.label.defs#label</1> objects, and expose the standard <2>com.atproto.label.queryLabels</2> (HTTP) and <3>com.atproto.label.subscribeLabels</3> (WebSocket) endpoints."
 msgstr "<0>2. 라벨 제공.</0> <1>com.atproto.label.defs#label</1> 객체를 서명해 발행하고, 표준 <2>com.atproto.label.queryLabels</2>(HTTP) 및 <3>com.atproto.label.subscribeLabels</3>(WebSocket) 엔드포인트를 공개하세요."
@@ -6597,8 +6632,8 @@ msgid "Your Home feed is empty for now — head to Discover whenever you're read
 msgstr "홈 피드가 아직 비어 있습니다. 준비되면 언제든 탐색으로 가 보세요. 구독한 글이 모두 여기에 모입니다."
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
-msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
-msgstr ""
+#~ msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
+#~ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-table.tsx
@@ -6772,6 +6807,11 @@ msgstr "계정 작업"
 #: src/components/reader/mention-hover-card.tsx
 msgid "Read article"
 msgstr "글 읽기"
+
+#. placeholder {0}: formatBytes(usage.usage)
+#: src/components/offline-settings.tsx
+msgid "Standard Reader is using {0} on this device."
+msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Terms of service"
@@ -7507,6 +7547,10 @@ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Subscribe to the publication it came from, in the same click."
+msgstr ""
+
+#: src/components/guide/pages/getting-started-guide-page.tsx
+msgid "Reach for something that was never downloaded and the app says so, rather than showing you an error. You can turn downloading off, and see how much space it is using, under Settings → Reading. It pauses on its own when your phone asks apps to save data. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
 msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -3053,6 +3053,10 @@ msgstr "이 발행물의 읽지 않은 아티클이 모두 읽음으로 표시�
 msgid "Your own colors"
 msgstr ""
 
+#: src/components/reader/app-shell.tsx
+msgid "You are offline"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
 msgstr "호 설정 중…"
@@ -3619,6 +3623,10 @@ msgstr ""
 #: src/components/reader/mention-hover-card.tsx
 msgid "{n, plural, one {# publication} other {{value} publications}}"
 msgstr "{n, plural, one {발행물 #개} other {발행물 {value}개}}"
+
+#: src/components/reader/app-shell.tsx
+msgid "offline"
+msgstr ""
 
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -5791,6 +5791,7 @@ msgstr "함께 보기"
 msgid "Show all feedback"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/user-settings-view.tsx
 msgid "Troubleshooting"
 msgstr ""

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -3965,6 +3965,10 @@ msgstr ""
 msgid "{0} total"
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "This page wasn’t saved to your device, so it needs a connection. It’ll load on its own when you’re back online — your unread articles are already here."
+msgstr ""
+
 #: src/components/blocks-settings-view.tsx
 msgid "Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours."
 msgstr ""
@@ -5542,8 +5546,8 @@ msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
 
 #: src/components/route-error.tsx
-msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
-msgstr ""
+#~ msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
+#~ msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -2283,6 +2283,10 @@ msgstr "이 시리즈에는 아직 컬렉션이 없습니다."
 msgid "None of this labeler’s labels could be verified against the signing key it publishes, so none are applied. That’s a problem on the labeler’s end."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Still to fetch"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "No feedback yet."
 msgstr "아직 피드백이 없습니다."
@@ -3076,6 +3080,10 @@ msgstr "이 발행물의 읽지 않은 아티클이 모두 읽음으로 표시�
 
 #: src/components/appearance-settings.tsx
 msgid "Your own colors"
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Initial fill"
 msgstr ""
 
 #: src/components/reader/app-shell.tsx
@@ -7248,6 +7256,10 @@ msgstr "안 읽음 {unreadCount}"
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "Below those, the publications you follow are listed for quick access. The <0>Subscriptions</0> heading above them opens the full management view. At the very bottom, your avatar opens a menu with your profile, reading history, recommended articles, feedback, settings, and log out."
 #~ msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Downloaded"
+msgstr ""
 
 #: src/components/reader/add-publication-modal.tsx
 #: src/components/reader/app-shell.tsx

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -138,6 +138,10 @@ msgstr "글 추가"
 #~ msgid "Communities"
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Feed pages"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/components/reader/app-shell.tsx
@@ -1070,6 +1074,10 @@ msgstr ""
 msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Offline"
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {발행물 {formattedUnfollowedCount}개를 구독할까요?} other {발행물 {formattedUnfollowedCount}개를 구독할까요?}}"
@@ -1266,6 +1274,10 @@ msgstr ""
 msgid "Downloaded articles"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Back-catalog pages"
+msgstr ""
+
 #: src/components/reader/terms-view.tsx
 msgid "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
 msgstr ""
@@ -1301,6 +1313,10 @@ msgstr "글자 크기"
 #: src/components/onboarding/step-intro.tsx
 msgid "A calm reading room for the open web. Let's take two minutes to make it yours."
 msgstr "열린 웹을 위한 차분한 독서 공간. 2분만 들여 나에게 맞게 꾸며 보세요."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Run sync now"
+msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.index.tsx
@@ -1714,6 +1730,10 @@ msgstr ""
 msgid "If you already know what you want, <0>Discover</0> lists everything on the network, and <1>Finding things to read</1> covers every way to get there."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Images"
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
 #~ msgstr "문서가 발행물 레코드에 속한 경우에만 <0>site.standard.publication</0> 힌트를 포함하세요. 어떤 리더를 염두에 두든 둘 다 추가하세요. 이는 우리 확장 프로그램뿐 아니라 네트워크의 모든 클라이언트가 페이지를 해당 레코드로 연결하는 방식입니다."
@@ -1966,6 +1986,10 @@ msgstr "구독 임베드"
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That GIF is over 1 MB. Try a shorter clip, or attach a still image."
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Storage"
 msgstr ""
 
 #: src/components/reader/blocked-notice.tsx
@@ -2469,6 +2493,7 @@ msgstr "컬렉션"
 msgid "Done"
 msgstr "완료"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/saved-filters.tsx
 msgid "Authors"
 msgstr ""
@@ -3251,6 +3276,7 @@ msgstr "계정 없이 읽어 보세요. 구독하고, 좋아요를 누르고, �
 msgid "Remove {itemTitle}"
 msgstr "{itemTitle} 제거"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Lists"
@@ -4307,6 +4333,10 @@ msgstr ""
 msgid "Last checked {0}. Blocks you make elsewhere show up here within about fifteen minutes."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "If articles aren’t available offline, this is what the last sync did. Sharing a screenshot of it is the fastest way to get it fixed."
+msgstr ""
+
 #: src/components/reader/block-user-menu-item.tsx
 msgid "Block account?"
 msgstr ""
@@ -4819,6 +4849,10 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 msgid "Stop reading this example aloud"
 msgstr "이 예시 낭독 중지"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Unread listed"
+msgstr ""
 
 #. placeholder {0}: issue.ownerHandle
 #: src/magazine/flow.tsx
@@ -5791,7 +5825,6 @@ msgstr "함께 보기"
 msgid "Show all feedback"
 msgstr ""
 
-#: src/components/offline-sync-debug.tsx
 #: src/components/user-settings-view.tsx
 msgid "Troubleshooting"
 msgstr ""
@@ -6652,6 +6685,7 @@ msgstr "홈 피드가 아직 비어 있습니다. 준비되면 언제든 탐색�
 #~ msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.friends.tsx
@@ -6816,6 +6850,10 @@ msgstr "아직 인기 발행물이 없습니다."
 #: src/routes/login.tsx
 msgid "Sign in again to refresh your permissions — your session doesn't include save-for-later yet."
 msgstr "다시 로그인해 권한을 새로 고치세요. 현재 세션에는 나중에 읽기 권한이 없습니다."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Status"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "Account actions"
@@ -7663,6 +7701,7 @@ msgstr "보안 및 세션 관리를 위해 사용하는 IP 주소, 브라우저 
 msgid "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 msgstr "발행물 팔로우, 글 좋아요나 저장, 전용 구독 흐름을 통한 구독처럼 이용자가 직접 수행한 동작에 필요한 경우를 제외하고는 계정에 게시하지 않습니다. 개인정보를 판매하지 않습니다."
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
@@ -7855,6 +7894,7 @@ msgstr ""
 msgid "Recommend this article"
 msgstr "이 글 추천하기"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/about-view.tsx
 msgid "Stop"
 msgstr "정지"
@@ -8134,6 +8174,10 @@ msgstr "시작하기"
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "You don't have any content tabs to show yet."
 msgstr "아직 표시할 콘텐츠 탭이 없습니다."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Started / finished"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Body text on paper"

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -3054,8 +3054,8 @@ msgid "Your own colors"
 msgstr ""
 
 #: src/components/reader/app-shell.tsx
-msgid "You are offline"
-msgstr ""
+#~ msgid "You are offline"
+#~ msgstr ""
 
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
@@ -3625,8 +3625,8 @@ msgid "{n, plural, one {# publication} other {{value} publications}}"
 msgstr "{n, plural, one {발행물 #개} other {발행물 {value}개}}"
 
 #: src/components/reader/app-shell.tsx
-msgid "offline"
-msgstr ""
+#~ msgid "offline"
+#~ msgstr ""
 
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -3053,6 +3053,10 @@ msgstr "Todos os artigos não lidos desta publicação serão marcados como lido
 msgid "Your own colors"
 msgstr ""
 
+#: src/components/reader/app-shell.tsx
+msgid "You are offline"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
 msgstr "Preparando a edição…"
@@ -3619,6 +3623,10 @@ msgstr "Filtrar inscrições"
 #: src/components/reader/mention-hover-card.tsx
 msgid "{n, plural, one {# publication} other {{value} publications}}"
 msgstr "{n, plural, one {# publicação} other {{value} publicações}}"
+
+#: src/components/reader/app-shell.tsx
+msgid "offline"
+msgstr ""
 
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -3054,8 +3054,8 @@ msgid "Your own colors"
 msgstr ""
 
 #: src/components/reader/app-shell.tsx
-msgid "You are offline"
-msgstr ""
+#~ msgid "You are offline"
+#~ msgstr ""
 
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
@@ -3625,8 +3625,8 @@ msgid "{n, plural, one {# publication} other {{value} publications}}"
 msgstr "{n, plural, one {# publicação} other {{value} publicações}}"
 
 #: src/components/reader/app-shell.tsx
-msgid "offline"
-msgstr ""
+#~ msgid "offline"
+#~ msgstr ""
 
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -3965,6 +3965,10 @@ msgstr ""
 msgid "{0} total"
 msgstr "{0} total"
 
+#: src/components/route-error.tsx
+msgid "This page wasn’t saved to your device, so it needs a connection. It’ll load on its own when you’re back online — your unread articles are already here."
+msgstr ""
+
 #: src/components/blocks-settings-view.tsx
 msgid "Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours."
 msgstr ""
@@ -5542,8 +5546,8 @@ msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
 
 #: src/components/route-error.tsx
-msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
-msgstr ""
+#~ msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
+#~ msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -5791,6 +5791,7 @@ msgstr "Acompanhar"
 msgid "Show all feedback"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/user-settings-view.tsx
 msgid "Troubleshooting"
 msgstr ""

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -3847,6 +3847,10 @@ msgstr ""
 msgid "You agree not to use {SITE_NAME} to:"
 msgstr "Você concorda em não usar o {SITE_NAME} para:"
 
+#: src/components/route-error.tsx
+msgid "Go home"
+msgstr ""
+
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.new.tsx
 msgid "e.g. Dispatches from the Atmosphere"

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -21,6 +21,10 @@ msgstr ""
 msgid "Every publication the network knows about — subscribe to the ones worth your mornings."
 msgstr "Todas as publicações que a rede conhece — inscreva-se nas que merecem as suas manhãs."
 
+#: src/components/guide/pages/getting-started-guide-page.tsx
+msgid "The installed app downloads the articles you have not read yet, with their images, while you are online. Open it on a plane or a tunnel and your unread queue is already there — no planning ahead, and nothing to tap beforehand."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Authoring Collections needs additional permissions to publish collections and documents on your behalf. You can revoke this any time from your account settings."
 msgstr "A criação de coleções requer permissões adicionais para publicar coleções e documentos em seu nome. Pode revogá-las a qualquer momento nas configurações da conta."
@@ -81,6 +85,10 @@ msgstr "Ir para a secção"
 #: src/routes/_layout.saved.tsx
 msgid "Sort by"
 msgstr "Ordenar por"
+
+#: src/components/offline-settings.tsx
+msgid "Downloads the articles you haven't read yet, with their images, so they open with no connection. Pauses automatically when your system asks apps to save data."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/components/reader/about-view.tsx
@@ -936,6 +944,10 @@ msgstr "Marcar como não lido"
 msgid "Grid view"
 msgstr "Vista de grelha"
 
+#: src/components/route-error.tsx
+msgid "You’re offline"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "Subscribe to get new writing in your feed."
 msgstr "Inscreva-se para receber novos textos no seu feed."
@@ -1248,6 +1260,10 @@ msgstr "Abrir publicações no site original"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Which destinations appear at all is a separate setting — <0>Customize sidebar</0> under <1>Making it yours</1> hides the ones you never use. Subscriptions and your lists always stay."
+msgstr ""
+
+#: src/components/offline-settings.tsx
+msgid "Downloaded articles"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -4156,6 +4172,7 @@ msgid "{0, plural, one {# publication} other {# publications}}"
 msgstr "{0, plural, one {# publicação} other {# publicações}}"
 
 #: src/components/feedback/feedback-image-picker.tsx
+#: src/components/route-error.tsx
 msgid "Try again"
 msgstr ""
 
@@ -4674,6 +4691,10 @@ msgstr ""
 msgid "Select <0>Log in</0>, at the bottom of the sidebar on a computer or in the top bar on a phone."
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "That page didn’t load. Try again — if it keeps happening, it’s on our side."
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/routes/_layout.saved.tsx
@@ -5076,6 +5097,7 @@ msgstr ""
 #: src/components/reader/blocked-notice.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
+#: src/components/route-error.tsx
 msgid "Something went wrong"
 msgstr "Algo deu errado"
 
@@ -5511,6 +5533,10 @@ msgstr ""
 msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "Se instalar a extensão de navegador do {SITE_NAME}, esta usa a mesma conta e o mesmo cookie de sessão que este site. A extensão envia URLs de páginas para os nossos endpoints <0>/api/extension/*</0> para correspondência com o índice e guarda as configurações da sobreposição no armazenamento de extensões do seu navegador. Consulte a <1>política de privacidade da extensão</1> para detalhes que se aplicam apenas à extensão."
@@ -5810,6 +5836,10 @@ msgstr "Ouça a partir daqui"
 #: src/components/user-settings-view.tsx
 msgid "Weekly digest email"
 msgstr "E-mail de resumo semanal"
+
+#: src/components/offline-settings.tsx
+msgid "Keep unread articles on this device"
+msgstr ""
 
 #: src/components/reader/ios-install-prompt.tsx
 msgid "Choose “Add to Home Screen”."
@@ -6423,6 +6453,7 @@ msgid "Top on the network"
 msgstr "Os mais populares da rede"
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/offline-settings.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
@@ -6568,6 +6599,10 @@ msgstr ""
 msgid "On your phone"
 msgstr ""
 
+#: src/components/offline-settings.tsx
+msgid "Storage use isn't available in this browser."
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>2. Serve labels.</0> Sign and emit <1>com.atproto.label.defs#label</1> objects, and expose the standard <2>com.atproto.label.queryLabels</2> (HTTP) and <3>com.atproto.label.subscribeLabels</3> (WebSocket) endpoints."
 msgstr "<0>2. Servir rótulos.</0> Assine e emita objetos <1>com.atproto.label.defs#label</1> e exponha os endpoints padrão <2>com.atproto.label.queryLabels</2> (HTTP) e <3>com.atproto.label.subscribeLabels</3> (WebSocket)."
@@ -6597,8 +6632,8 @@ msgid "Your Home feed is empty for now — head to Discover whenever you're read
 msgstr "O seu feed Início está vazio por agora — passe pelo Descobrir quando quiser, e tudo no que se inscrever começará a aparecer aqui."
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
-msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
-msgstr ""
+#~ msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
+#~ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-table.tsx
@@ -6772,6 +6807,11 @@ msgstr "Ações da conta"
 #: src/components/reader/mention-hover-card.tsx
 msgid "Read article"
 msgstr "Ler artigo"
+
+#. placeholder {0}: formatBytes(usage.usage)
+#: src/components/offline-settings.tsx
+msgid "Standard Reader is using {0} on this device."
+msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Terms of service"
@@ -7507,6 +7547,10 @@ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Subscribe to the publication it came from, in the same click."
+msgstr ""
+
+#: src/components/guide/pages/getting-started-guide-page.tsx
+msgid "Reach for something that was never downloaded and the app says so, rather than showing you an error. You can turn downloading off, and see how much space it is using, under Settings → Reading. It pauses on its own when your phone asks apps to save data. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
 msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -2283,6 +2283,10 @@ msgstr "Ainda não há coleções nesta série."
 msgid "None of this labeler’s labels could be verified against the signing key it publishes, so none are applied. That’s a problem on the labeler’s end."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Still to fetch"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "No feedback yet."
 msgstr "Ainda não há comentários."
@@ -3076,6 +3080,10 @@ msgstr "Todos os artigos não lidos desta publicação serão marcados como lido
 
 #: src/components/appearance-settings.tsx
 msgid "Your own colors"
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Initial fill"
 msgstr ""
 
 #: src/components/reader/app-shell.tsx
@@ -7248,6 +7256,10 @@ msgstr "{unreadCount} não lido"
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "Below those, the publications you follow are listed for quick access. The <0>Subscriptions</0> heading above them opens the full management view. At the very bottom, your avatar opens a menu with your profile, reading history, recommended articles, feedback, settings, and log out."
 #~ msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Downloaded"
+msgstr ""
 
 #: src/components/reader/add-publication-modal.tsx
 #: src/components/reader/app-shell.tsx

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -138,6 +138,10 @@ msgstr "Adicionar um artigo"
 #~ msgid "Communities"
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Feed pages"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/components/reader/app-shell.tsx
@@ -1070,6 +1074,10 @@ msgstr ""
 msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Offline"
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {Se inscrever em {formattedUnfollowedCount} publicação?} other {Se inscrever em {formattedUnfollowedCount} publicações?}}"
@@ -1266,6 +1274,10 @@ msgstr ""
 msgid "Downloaded articles"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Back-catalog pages"
+msgstr ""
+
 #: src/components/reader/terms-view.tsx
 msgid "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
 msgstr "O {SITE_NAME} é um leitor web para publicações do standard.site no AT Protocol. Estes termos regem o seu uso deste site. Ao acessar ou utilizar a instância do Standard Reader em <0>{siteHost}</0>, você concorda com estes termos. Se você não concordar, por favor, não utilize o site."
@@ -1301,6 +1313,10 @@ msgstr "Tamanho do texto"
 #: src/components/onboarding/step-intro.tsx
 msgid "A calm reading room for the open web. Let's take two minutes to make it yours."
 msgstr "Uma sala de leitura tranquila para a web aberta. Vamos levar dois minutos a torná-la sua."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Run sync now"
+msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.index.tsx
@@ -1714,6 +1730,10 @@ msgstr ""
 msgid "If you already know what you want, <0>Discover</0> lists everything on the network, and <1>Finding things to read</1> covers every way to get there."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Images"
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
 #~ msgstr "Inclua a dica <0>site.standard.publication</0> apenas se o documento pertencer a um registo de publicação. Adicione ambas, independentemente do leitor que lhe interessa — é assim que qualquer cliente na rede resolve a sua página para o respetivo registo, não só a nossa extensão."
@@ -1966,6 +1986,10 @@ msgstr "Incorporar inscrição"
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That GIF is over 1 MB. Try a shorter clip, or attach a still image."
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Storage"
 msgstr ""
 
 #: src/components/reader/blocked-notice.tsx
@@ -2469,6 +2493,7 @@ msgstr "Coleções"
 msgid "Done"
 msgstr "Concluído"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/saved-filters.tsx
 msgid "Authors"
 msgstr ""
@@ -3251,6 +3276,7 @@ msgstr "Leia sem uma conta. Inicie sessão com o Bluesky quando quiser se inscre
 msgid "Remove {itemTitle}"
 msgstr "Remover {itemTitle}"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Lists"
@@ -4307,6 +4333,10 @@ msgstr ""
 msgid "Last checked {0}. Blocks you make elsewhere show up here within about fifteen minutes."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "If articles aren’t available offline, this is what the last sync did. Sharing a screenshot of it is the fastest way to get it fixed."
+msgstr ""
+
 #: src/components/reader/block-user-menu-item.tsx
 msgid "Block account?"
 msgstr ""
@@ -4819,6 +4849,10 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 msgid "Stop reading this example aloud"
 msgstr "Parar de ler este exemplo em voz alta"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Unread listed"
+msgstr ""
 
 #. placeholder {0}: issue.ownerHandle
 #: src/magazine/flow.tsx
@@ -5791,7 +5825,6 @@ msgstr "Acompanhar"
 msgid "Show all feedback"
 msgstr ""
 
-#: src/components/offline-sync-debug.tsx
 #: src/components/user-settings-view.tsx
 msgid "Troubleshooting"
 msgstr ""
@@ -6652,6 +6685,7 @@ msgstr "O seu feed Início está vazio por agora — passe pelo Descobrir quando
 #~ msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.friends.tsx
@@ -6816,6 +6850,10 @@ msgstr "Nenhuma publicação em alta ainda."
 #: src/routes/login.tsx
 msgid "Sign in again to refresh your permissions — your session doesn't include save-for-later yet."
 msgstr "Inicie sessão novamente para atualizar as suas permissões — a sua sessão ainda não inclui salvar para mais tarde."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Status"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "Account actions"
@@ -7663,6 +7701,7 @@ msgstr "Metadados da sessão, como o endereço IP e a cadeia user-agent do naveg
 msgid "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 msgstr "Não publicamos na sua conta exceto quando realiza uma ação explícita que o exija (por exemplo seguir uma publicação, curtir ou salvar um artigo, ou se inscrever através do fluxo de inscrição dedicado). Não vendemos as suas informações pessoais."
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
@@ -7855,6 +7894,7 @@ msgstr ""
 msgid "Recommend this article"
 msgstr "Recomendar este artigo"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/about-view.tsx
 msgid "Stop"
 msgstr "Parar"
@@ -8134,6 +8174,10 @@ msgstr "Começar"
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "You don't have any content tabs to show yet."
 msgstr "Ainda não tem separadores de conteúdo para mostrar."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Started / finished"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Body text on paper"

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -2283,6 +2283,10 @@ msgstr "此系列中还没有合集。"
 msgid "None of this labeler’s labels could be verified against the signing key it publishes, so none are applied. That’s a problem on the labeler’s end."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Still to fetch"
+msgstr ""
+
 #: src/routes/_layout.feedback.index.tsx
 msgid "No feedback yet."
 msgstr "暂无反馈。"
@@ -3076,6 +3080,10 @@ msgstr "该刊物的所有未读文章都将标记为已读。此操作无法撤
 
 #: src/components/appearance-settings.tsx
 msgid "Your own colors"
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Initial fill"
 msgstr ""
 
 #: src/components/reader/app-shell.tsx
@@ -7248,6 +7256,10 @@ msgstr "{unreadCount} 篇未读"
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "Below those, the publications you follow are listed for quick access. The <0>Subscriptions</0> heading above them opens the full management view. At the very bottom, your avatar opens a menu with your profile, reading history, recommended articles, feedback, settings, and log out."
 #~ msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Downloaded"
+msgstr ""
 
 #: src/components/reader/add-publication-modal.tsx
 #: src/components/reader/app-shell.tsx

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -3053,6 +3053,10 @@ msgstr "该刊物的所有未读文章都将标记为已读。此操作无法撤
 msgid "Your own colors"
 msgstr ""
 
+#: src/components/reader/app-shell.tsx
+msgid "You are offline"
+msgstr ""
+
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
 msgstr "正在设置该期…"
@@ -3619,6 +3623,10 @@ msgstr ""
 #: src/components/reader/mention-hover-card.tsx
 msgid "{n, plural, one {# publication} other {{value} publications}}"
 msgstr "{n, plural, one {# 个刊物} other {{value} 个刊物}}"
+
+#: src/components/reader/app-shell.tsx
+msgid "offline"
+msgstr ""
 
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -3847,6 +3847,10 @@ msgstr ""
 msgid "You agree not to use {SITE_NAME} to:"
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "Go home"
+msgstr ""
+
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.new.tsx
 msgid "e.g. Dispatches from the Atmosphere"

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -138,6 +138,10 @@ msgstr "添加文章"
 #~ msgid "Communities"
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Feed pages"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/components/reader/app-shell.tsx
@@ -1070,6 +1074,10 @@ msgstr ""
 msgid "Turn on to choose which items appear in the sidebar. Subscriptions and your lists always stay."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Offline"
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "{unfollowedCount, plural, one {Subscribe to {formattedUnfollowedCount} publication?} other {Subscribe to {formattedUnfollowedCount} publications?}}"
 msgstr "{unfollowedCount, plural, one {订阅 {formattedUnfollowedCount} 个刊物？} other {订阅 {formattedUnfollowedCount} 个刊物？}}"
@@ -1266,6 +1274,10 @@ msgstr ""
 msgid "Downloaded articles"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Back-catalog pages"
+msgstr ""
+
 #: src/components/reader/terms-view.tsx
 msgid "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
 msgstr ""
@@ -1301,6 +1313,10 @@ msgstr "文字大小"
 #: src/components/onboarding/step-intro.tsx
 msgid "A calm reading room for the open web. Let's take two minutes to make it yours."
 msgstr "一间为开放网络而设的安静阅读室。花两分钟把它变成你的。"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Run sync now"
+msgstr ""
 
 #: src/components/reader/collection-publication-editor.tsx
 #: src/routes/_layout.collections.index.tsx
@@ -1714,6 +1730,10 @@ msgstr ""
 msgid "If you already know what you want, <0>Discover</0> lists everything on the network, and <1>Finding things to read</1> covers every way to get there."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Images"
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
 #~ msgstr "仅当该文档属于某个刊物记录时，才加入 <0>site.standard.publication</0> 提示。无论你在意哪个阅读器，两者都请加上——网络上任何客户端都靠它们把你的页面解析到对应记录，不只是我们的扩展。"
@@ -1966,6 +1986,10 @@ msgstr "嵌入订阅按钮"
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "That GIF is over 1 MB. Try a shorter clip, or attach a still image."
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Storage"
 msgstr ""
 
 #: src/components/reader/blocked-notice.tsx
@@ -2469,6 +2493,7 @@ msgstr "合集"
 msgid "Done"
 msgstr "完成"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/saved-filters.tsx
 msgid "Authors"
 msgstr ""
@@ -3251,6 +3276,7 @@ msgstr "无需账号即可阅读。想订阅、点赞和保存时，用 Bluesky 
 msgid "Remove {itemTitle}"
 msgstr "移除 {itemTitle}"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Lists"
@@ -4307,6 +4333,10 @@ msgstr ""
 msgid "Last checked {0}. Blocks you make elsewhere show up here within about fifteen minutes."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "If articles aren’t available offline, this is what the last sync did. Sharing a screenshot of it is the fastest way to get it fixed."
+msgstr ""
+
 #: src/components/reader/block-user-menu-item.tsx
 msgid "Block account?"
 msgstr ""
@@ -4819,6 +4849,10 @@ msgstr ""
 #: src/components/reader/about-view.tsx
 msgid "Stop reading this example aloud"
 msgstr "停止朗读此示例"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Unread listed"
+msgstr ""
 
 #. placeholder {0}: issue.ownerHandle
 #: src/magazine/flow.tsx
@@ -5791,7 +5825,6 @@ msgstr "跟随阅读"
 msgid "Show all feedback"
 msgstr ""
 
-#: src/components/offline-sync-debug.tsx
 #: src/components/user-settings-view.tsx
 msgid "Troubleshooting"
 msgstr ""
@@ -6652,6 +6685,7 @@ msgstr "你的首页信息流暂时是空的——随时可以去「发现」看
 #~ msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-table.tsx
 #: src/routes/_layout.friends.tsx
@@ -6816,6 +6850,10 @@ msgstr "暂无热门刊物。"
 #: src/routes/login.tsx
 msgid "Sign in again to refresh your permissions — your session doesn't include save-for-later yet."
 msgstr "请重新登录以刷新权限——你当前的会话还不包含稍后阅读。"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Status"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "Account actions"
@@ -7663,6 +7701,7 @@ msgstr "会话元数据，例如 IP 地址和浏览器 user-agent 字符串，�
 msgid "We do not post to your account except when you take an explicit action that requires it (for example following a publication, liking or saving an article, or subscribing with the dedicated subscribe flow). We do not sell your personal information."
 msgstr "除非你主动执行需要写入的操作（例如关注刊物、点赞或保存文章，或通过专门的订阅流程订阅），我们不会以你的账户发帖。我们不会出售你的个人信息。"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/saved-filters.tsx
 #: src/routes/_layout.discover.tsx
 #: src/routes/_layout.friends.tsx
@@ -7855,6 +7894,7 @@ msgstr ""
 msgid "Recommend this article"
 msgstr "推荐这篇文章"
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/reader/about-view.tsx
 msgid "Stop"
 msgstr "停止"
@@ -8134,6 +8174,10 @@ msgstr "开始使用"
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "You don't have any content tabs to show yet."
 msgstr "你还没有可显示的内容标签页。"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Started / finished"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Body text on paper"

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -5791,6 +5791,7 @@ msgstr "跟随阅读"
 msgid "Show all feedback"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/components/user-settings-view.tsx
 msgid "Troubleshooting"
 msgstr ""

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -3054,8 +3054,8 @@ msgid "Your own colors"
 msgstr ""
 
 #: src/components/reader/app-shell.tsx
-msgid "You are offline"
-msgstr ""
+#~ msgid "You are offline"
+#~ msgstr ""
 
 #: src/magazine/Magazine.tsx
 msgid "Setting the issue…"
@@ -3625,8 +3625,8 @@ msgid "{n, plural, one {# publication} other {{value} publications}}"
 msgstr "{n, plural, one {# 个刊物} other {{value} 个刊物}}"
 
 #: src/components/reader/app-shell.tsx
-msgid "offline"
-msgstr ""
+#~ msgid "offline"
+#~ msgstr ""
 
 #: src/components/reader/profile-tabs-settings-modal.tsx
 msgid "Choose which tabs appear on your public profile."

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -3965,6 +3965,10 @@ msgstr ""
 msgid "{0} total"
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "This page wasn’t saved to your device, so it needs a connection. It’ll load on its own when you’re back online — your unread articles are already here."
+msgstr ""
+
 #: src/components/blocks-settings-view.tsx
 msgid "Blocks live in your own repo as portable records, so the ones you made on Bluesky already apply here — and the ones you make here apply there. Blocked accounts disappear from your feeds, search, discussion, and their pages, and they can't see yours."
 msgstr ""
@@ -5542,8 +5546,8 @@ msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
 
 #: src/components/route-error.tsx
-msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
-msgstr ""
+#~ msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
+#~ msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -21,6 +21,10 @@ msgstr ""
 msgid "Every publication the network knows about — subscribe to the ones worth your mornings."
 msgstr "网络中已知的全部刊物——订阅那些值得你清晨时光的刊物。"
 
+#: src/components/guide/pages/getting-started-guide-page.tsx
+msgid "The installed app downloads the articles you have not read yet, with their images, while you are online. Open it on a plane or a tunnel and your unread queue is already there — no planning ahead, and nothing to tap beforehand."
+msgstr ""
+
 #: src/components/reader/collections-upgrade-gate.tsx
 msgid "Authoring Collections needs additional permissions to publish collections and documents on your behalf. You can revoke this any time from your account settings."
 msgstr "创作合集需要额外权限，以便代表你发布合集和文档。你可以随时在账户设置中撤销。"
@@ -81,6 +85,10 @@ msgstr "跳转到章节"
 #: src/routes/_layout.saved.tsx
 msgid "Sort by"
 msgstr "排序方式"
+
+#: src/components/offline-settings.tsx
+msgid "Downloads the articles you haven't read yet, with their images, so they open with no connection. Pauses automatically when your system asks apps to save data."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/components/reader/about-view.tsx
@@ -936,6 +944,10 @@ msgstr "标记为未读"
 msgid "Grid view"
 msgstr "网格视图"
 
+#: src/components/route-error.tsx
+msgid "You’re offline"
+msgstr ""
+
 #: src/magazine/flow.tsx
 msgid "Subscribe to get new writing in your feed."
 msgstr "订阅后即可在信息流中获取新作品。"
@@ -1248,6 +1260,10 @@ msgstr "在文章原站点打开"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Which destinations appear at all is a separate setting — <0>Customize sidebar</0> under <1>Making it yours</1> hides the ones you never use. Subscriptions and your lists always stay."
+msgstr ""
+
+#: src/components/offline-settings.tsx
+msgid "Downloaded articles"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
@@ -4156,6 +4172,7 @@ msgid "{0, plural, one {# publication} other {# publications}}"
 msgstr "{0, plural, one {# 个刊物} other {# 个刊物}}"
 
 #: src/components/feedback/feedback-image-picker.tsx
+#: src/components/route-error.tsx
 msgid "Try again"
 msgstr ""
 
@@ -4674,6 +4691,10 @@ msgstr ""
 msgid "Select <0>Log in</0>, at the bottom of the sidebar on a computer or in the top bar on a phone."
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "That page didn’t load. Try again — if it keeps happening, it’s on our side."
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/routes/_layout.saved.tsx
@@ -5076,6 +5097,7 @@ msgstr ""
 #: src/components/reader/blocked-notice.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
+#: src/components/route-error.tsx
 msgid "Something went wrong"
 msgstr "出错了"
 
@@ -5511,6 +5533,10 @@ msgstr ""
 msgid "Text, borders and every other step are derived from these two colors."
 msgstr ""
 
+#: src/components/route-error.tsx
+msgid "This page hasn’t been saved to your device, so it needs a connection. Articles you haven’t read yet are downloaded automatically and stay available offline."
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "If you install the {SITE_NAME} browser extension, it uses the same account and session cookie as this site. The extension sends page URLs to our <0>/api/extension/*</0> endpoints for index matching and keeps overlay settings in your browser's extension storage. See the <1>extension privacy policy</1> for details that apply only to the extension."
 msgstr "如果你安装了 {SITE_NAME} 浏览器扩展，它会使用与本站相同的账号和会话 cookie。扩展会将页面 URL 发送到我们的 <0>/api/extension/*</0> 端点用于索引匹配，并将浮层设置保存在浏览器的扩展存储中。详情请参阅仅适用于扩展的<1>扩展隐私政策</1>。"
@@ -5810,6 +5836,10 @@ msgstr ""
 #: src/components/user-settings-view.tsx
 msgid "Weekly digest email"
 msgstr "每周摘要邮件"
+
+#: src/components/offline-settings.tsx
+msgid "Keep unread articles on this device"
+msgstr ""
 
 #: src/components/reader/ios-install-prompt.tsx
 msgid "Choose “Add to Home Screen”."
@@ -6423,6 +6453,7 @@ msgid "Top on the network"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/offline-settings.tsx
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 msgid "Remove"
@@ -6568,6 +6599,10 @@ msgstr ""
 msgid "On your phone"
 msgstr ""
 
+#: src/components/offline-settings.tsx
+msgid "Storage use isn't available in this browser."
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>2. Serve labels.</0> Sign and emit <1>com.atproto.label.defs#label</1> objects, and expose the standard <2>com.atproto.label.queryLabels</2> (HTTP) and <3>com.atproto.label.subscribeLabels</3> (WebSocket) endpoints."
 msgstr "<0>2. 提供标签。</0>签发并输出 <1>com.atproto.label.defs#label</1> 对象，并暴露标准的 <2>com.atproto.label.queryLabels</2>（HTTP）和 <3>com.atproto.label.subscribeLabels</3>（WebSocket）端点。"
@@ -6597,8 +6632,8 @@ msgid "Your Home feed is empty for now — head to Discover whenever you're read
 msgstr "你的首页信息流暂时是空的——随时可以去「发现」看看，你订阅的一切都会在这里汇集起来。"
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
-msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
-msgstr ""
+#~ msgid "Pages you have already visited stay available when your connection drops, and you get a plain offline page rather than a browser error when you reach for something that was never loaded. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
+#~ msgstr ""
 
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/subscriptions-table.tsx
@@ -6772,6 +6807,11 @@ msgstr "账户操作"
 #: src/components/reader/mention-hover-card.tsx
 msgid "Read article"
 msgstr "阅读文章"
+
+#. placeholder {0}: formatBytes(usage.usage)
+#: src/components/offline-settings.tsx
+msgid "Standard Reader is using {0} on this device."
+msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Terms of service"
@@ -7507,6 +7547,10 @@ msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "Subscribe to the publication it came from, in the same click."
+msgstr ""
+
+#: src/components/guide/pages/getting-started-guide-page.tsx
+msgid "Reach for something that was never downloaded and the app says so, rather than showing you an error. You can turn downloading off, and see how much space it is using, under Settings → Reading. It pauses on its own when your phone asks apps to save data. When a new version of the app is ready it offers to reload, rather than changing under you mid-article."
 msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx

--- a/apps/standard-reader/src/pwa/offline-cache.ts
+++ b/apps/standard-reader/src/pwa/offline-cache.ts
@@ -17,6 +17,8 @@
  * ({@link LEDGER_ENTRY_MAX_AGE_MS}) and get re-fetched.
  */
 
+import { clearOfflineSyncState } from "./offline-sync-state";
+
 /** Cache Storage buckets holding reader-specific bytes (see `vite.config.ts`). */
 const PERSONAL_CACHE_NAMES = ["data", "pages"] as const;
 
@@ -178,6 +180,9 @@ async function deleteCaches(names: ReadonlyArray<string>): Promise<void> {
  */
 export async function clearOfflineData(): Promise<void> {
   ledgerClear();
+  // The plan too, or the next pass would resume a walk whose results have just
+  // been deleted — and report the initial fill as long since complete.
+  clearOfflineSyncState();
   await deleteCaches([...PERSONAL_CACHE_NAMES, ...IMPERSONAL_CACHE_NAMES]);
 }
 
@@ -195,6 +200,9 @@ export async function clearOfflineData(): Promise<void> {
  */
 export async function clearPersonalOfflineData(): Promise<void> {
   ledgerClear();
+  // The plan describes the signed-out reader's backlog; the next account must
+  // start its own fill rather than resume theirs.
+  clearOfflineSyncState();
   await deleteCaches(PERSONAL_CACHE_NAMES);
 }
 

--- a/apps/standard-reader/src/pwa/offline-cache.ts
+++ b/apps/standard-reader/src/pwa/offline-cache.ts
@@ -1,0 +1,163 @@
+/**
+ * Storage primitives shared by offline sync, the settings panel, and sign-out.
+ *
+ * Two things live on the device once offline reading is on:
+ *
+ *   1. The service worker's Cache Storage buckets, named in `vite.config.ts`
+ *      (`data` for `/_serverFn` responses, `images` for bodies' images, `pages`
+ *      for boot documents). Workbox owns them; this module only deletes.
+ *   2. A `localStorage` **ledger** of which documents have been pulled through.
+ *      The `data` rule is NetworkFirst, so without a record of prior work every
+ *      sync pass would re-download the reader's whole unread set from the
+ *      network — the ledger is what makes the pass incremental.
+ *
+ * The ledger is not the source of truth for what is *actually* cached: Workbox
+ * expiration can evict an entry behind our back. It is a "don't bother asking
+ * again yet" record, which is why entries age out on their own
+ * ({@link LEDGER_ENTRY_MAX_AGE_MS}) and get re-fetched.
+ */
+
+/** Cache Storage buckets holding reader-specific bytes (see `vite.config.ts`). */
+const PERSONAL_CACHE_NAMES = ["data", "pages"] as const;
+
+/** Cache Storage buckets that are merely expensive, not personal. */
+const IMPERSONAL_CACHE_NAMES = ["images"] as const;
+
+const LEDGER_KEY = "sr:offline-synced";
+
+/**
+ * Re-pull a document after a week even if the ledger says it is stored.
+ *
+ * Covers two drifts at once: Workbox may have evicted the entry, and the
+ * article itself may have been edited since (`site.standard.document` records
+ * are mutable).
+ */
+const LEDGER_ENTRY_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+type Ledger = Record<string, number>;
+
+function readLedger(): Ledger {
+  if (globalThis.localStorage === undefined) return {};
+  try {
+    const raw = globalThis.localStorage.getItem(LEDGER_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return {};
+    return parsed as Ledger;
+  } catch {
+    return {};
+  }
+}
+
+function writeLedger(ledger: Ledger): void {
+  try {
+    globalThis.localStorage?.setItem(LEDGER_KEY, JSON.stringify(ledger));
+  } catch {
+    // Quota or private browsing. Sync still works; it just re-checks documents
+    // it already has, which the NetworkFirst rule makes cheap-ish when online
+    // and irrelevant when offline.
+  }
+}
+
+/** Document URIs pulled through recently enough to skip this pass. */
+export function ledgerFreshUris(now: number): Set<string> {
+  const ledger = readLedger();
+  const fresh = new Set<string>();
+  for (const [uri, storedAt] of Object.entries(ledger)) {
+    if (now - storedAt < LEDGER_ENTRY_MAX_AGE_MS) fresh.add(uri);
+  }
+  return fresh;
+}
+
+/** Record that `uri` has been fetched into the `data` cache. */
+export function ledgerRecord(uri: string, now: number): void {
+  const ledger = readLedger();
+  ledger[uri] = now;
+  writeLedger(ledger);
+}
+
+/**
+ * Drop ledger entries for documents that are no longer unread, so the file
+ * doesn't grow without bound as a reader works through a backlog. Called with
+ * the full unread set at the end of each completed pass.
+ */
+export function ledgerRetainOnly(uris: Set<string>): void {
+  const ledger = readLedger();
+  const next: Ledger = {};
+  for (const [uri, storedAt] of Object.entries(ledger)) {
+    if (uris.has(uri)) next[uri] = storedAt;
+  }
+  writeLedger(next);
+}
+
+export function ledgerClear(): void {
+  try {
+    globalThis.localStorage?.removeItem(LEDGER_KEY);
+  } catch {
+    // Nothing to do — see `writeLedger`.
+  }
+}
+
+async function deleteCaches(names: ReadonlyArray<string>): Promise<void> {
+  if (globalThis.caches === undefined) return;
+  await Promise.all(
+    names.map(async (name) => {
+      try {
+        await globalThis.caches.delete(name);
+      } catch {
+        // A cache that cannot be deleted is not worth failing sign-out over.
+      }
+    }),
+  );
+}
+
+/**
+ * Everything downloaded for offline reading. Used by the settings panel's
+ * "Remove downloaded articles".
+ */
+export async function clearOfflineData(): Promise<void> {
+  ledgerClear();
+  await deleteCaches([...PERSONAL_CACHE_NAMES, ...IMPERSONAL_CACHE_NAMES]);
+}
+
+/**
+ * Drop caches whose contents belong to the reader who is signing out.
+ *
+ * `/_serverFn` responses carry no DID in their URL — the server reads it from
+ * the session cookie — so a second account signing in on the same device would
+ * otherwise be served the first account's feed, saved queue, and read state
+ * from cache. Same for `pages`, which holds rendered SSR documents.
+ *
+ * `images` is left alone deliberately: it is public CDN bytes, keyed by URL,
+ * and re-downloading a shared cache of article images on every sign-out is a
+ * real cost for no privacy gain.
+ */
+export async function clearPersonalOfflineData(): Promise<void> {
+  ledgerClear();
+  await deleteCaches(PERSONAL_CACHE_NAMES);
+}
+
+export interface OfflineStorageUsage {
+  /** Bytes this origin is using, across all caches — not just ours. */
+  usage: number;
+  /** Bytes the browser is willing to grant, when it will say. */
+  quota: number | null;
+  /** Whether storage is exempt from eviction under pressure. */
+  persisted: boolean;
+}
+
+/** Best-effort storage report for the settings panel. */
+export async function offlineStorageUsage(): Promise<OfflineStorageUsage | null> {
+  const storage = globalThis.navigator?.storage;
+  if (!storage?.estimate) return null;
+  try {
+    const estimate = await storage.estimate();
+    return {
+      persisted: (await storage.persisted?.()) ?? false,
+      quota: estimate.quota ?? null,
+      usage: estimate.usage ?? 0,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/apps/standard-reader/src/pwa/offline-cache.ts
+++ b/apps/standard-reader/src/pwa/offline-cache.ts
@@ -59,33 +59,65 @@ function writeLedger(ledger: Ledger): void {
   }
 }
 
-/**
- * Memoised view of {@link ledgerFreshUris} for render paths.
- *
- * Feed rows ask "is this one stored?" per row, and parsing the ledger for each
- * of fifty rows on every render is not worth it. The window is short enough
- * that a sync finishing mid-scroll shows up promptly.
- */
-const LEDGER_MEMO_MS = 5000;
-let memo: { at: number; uris: ReadonlySet<string> } | null = null;
+/** How long one scan of the `data` cache is reused across rows and renders. */
+const AVAILABILITY_MEMO_MS = 5000;
+let availability: { at: number; uris: Promise<ReadonlySet<string>> } | null =
+  null;
 
 /**
- * Which documents offline sync has actually stored.
+ * AT-URIs as they appear inside a decoded request payload, where they are
+ * ordinary JSON strings (`"s":"at://did:plc:…/site.standard.document/…"`) and
+ * so run to the closing quote.
  *
- * Note what this is *not*: proof that a given article is in the service
- * worker's cache, and not a complete list of what is. An article opened by hand
- * while online is very likely cached without appearing here — deliberately, as
- * the alternative is worse. Marking those "available" would mean recording
- * documents that were rendered from SSR dehydration and never issued a
- * `/_serverFn` request at all, so nothing was cached; the row would look
- * available and then fail. Under-reporting dims a row that might have worked;
- * over-reporting promises one that cannot.
+ * Matches *any* AT-URI rather than trying to recognise document collections:
+ * callers only ever ask whether one specific article's URI is present, so a
+ * publication URI in the set is inert, while a document collection this pattern
+ * failed to anticipate — `pub.leaflet.document`, a future renderer's NSID —
+ * would wrongly dim a row that works.
  */
-export function offlineCachedUris(): ReadonlySet<string> {
+const AT_URI_PATTERN = /at:\/\/[^"\\]+/g;
+
+/**
+ * Which documents can actually be opened with no connection.
+ *
+ * Read from the `data` cache itself, not from the sync ledger. The ledger
+ * records what *sync* stored, which is a much smaller set than what is cached —
+ * an article opened by hand, or one seeded by browsing, is in the cache and not
+ * in the ledger. Trusting the ledger meant a reader whose sync had not run
+ * (signed out, toggle off, or simply not finished) saw every row dimmed while
+ * every one of them opened fine.
+ *
+ * A GET server function serialises its arguments into its URL, so an article
+ * whose body is cached has its AT-URI sitting in plain text in that request's
+ * query string. Scanning the cache keys for document URIs therefore answers the
+ * real question — "is this one stored?" — rather than a proxy for it.
+ *
+ * Includes the ledger as well, for the window where sync has recorded a
+ * document whose response has not been written back yet.
+ */
+export async function offlineAvailableUris(): Promise<ReadonlySet<string>> {
   const now = Date.now();
-  if (memo && now - memo.at < LEDGER_MEMO_MS) return memo.uris;
-  memo = { at: now, uris: ledgerFreshUris(now) };
-  return memo.uris;
+  if (!availability || now - availability.at > AVAILABILITY_MEMO_MS) {
+    availability = { at: now, uris: scanAvailableUris(now) };
+  }
+  return availability.uris;
+}
+
+async function scanAvailableUris(now: number): Promise<ReadonlySet<string>> {
+  const uris = ledgerFreshUris(now);
+  if (globalThis.caches === undefined) return uris;
+  try {
+    const cache = await globalThis.caches.open("data");
+    for (const request of await cache.keys()) {
+      const query = decodeURIComponent(new URL(request.url).search);
+      for (const match of query.matchAll(AT_URI_PATTERN)) {
+        uris.add(match[0]);
+      }
+    }
+  } catch {
+    // Cache Storage unavailable (private browsing). Fall back to the ledger.
+  }
+  return uris;
 }
 
 /** Document URIs pulled through recently enough to skip this pass. */

--- a/apps/standard-reader/src/pwa/offline-cache.ts
+++ b/apps/standard-reader/src/pwa/offline-cache.ts
@@ -59,6 +59,35 @@ function writeLedger(ledger: Ledger): void {
   }
 }
 
+/**
+ * Memoised view of {@link ledgerFreshUris} for render paths.
+ *
+ * Feed rows ask "is this one stored?" per row, and parsing the ledger for each
+ * of fifty rows on every render is not worth it. The window is short enough
+ * that a sync finishing mid-scroll shows up promptly.
+ */
+const LEDGER_MEMO_MS = 5000;
+let memo: { at: number; uris: ReadonlySet<string> } | null = null;
+
+/**
+ * Which documents offline sync has actually stored.
+ *
+ * Note what this is *not*: proof that a given article is in the service
+ * worker's cache, and not a complete list of what is. An article opened by hand
+ * while online is very likely cached without appearing here — deliberately, as
+ * the alternative is worse. Marking those "available" would mean recording
+ * documents that were rendered from SSR dehydration and never issued a
+ * `/_serverFn` request at all, so nothing was cached; the row would look
+ * available and then fail. Under-reporting dims a row that might have worked;
+ * over-reporting promises one that cannot.
+ */
+export function offlineCachedUris(): ReadonlySet<string> {
+  const now = Date.now();
+  if (memo && now - memo.at < LEDGER_MEMO_MS) return memo.uris;
+  memo = { at: now, uris: ledgerFreshUris(now) };
+  return memo.uris;
+}
+
 /** Document URIs pulled through recently enough to skip this pass. */
 export function ledgerFreshUris(now: number): Set<string> {
   const ledger = readLedger();

--- a/apps/standard-reader/src/pwa/offline-sync-progress.ts
+++ b/apps/standard-reader/src/pwa/offline-sync-progress.ts
@@ -51,8 +51,17 @@ export type OfflineSyncStopReason =
 
 export interface OfflineSyncProgress {
   running: boolean;
-  /** Full passes fan out to every followed surface; top-ups only re-walk feeds. */
-  pass: "full" | "top-up" | null;
+  /**
+   * `initial` is the first deep fill, which resumes across launches until it
+   * finishes; `top-up` is the cheap pass that follows it forever after.
+   */
+  pass: "initial" | "top-up" | null;
+  /** Whether the initial deep fill has ever finished. */
+  initialComplete: boolean;
+  /** Articles stored on the device right now. */
+  stored: number;
+  /** Articles discovered and still waiting to be stored. */
+  pending: number;
   /** Human-readable name of the stage currently running. */
   step: string | null;
   startedAt: number | null;
@@ -79,10 +88,13 @@ const INITIAL: OfflineSyncProgress = {
   counts: INITIAL_COUNTS,
   error: null,
   finishedAt: null,
+  initialComplete: false,
   pass: null,
+  pending: 0,
   running: false,
   startedAt: null,
   step: null,
+  stored: 0,
   stopReason: null,
 };
 
@@ -118,16 +130,33 @@ export function getOfflineSyncProgressServer(): OfflineSyncProgress {
  */
 let currentPass = 0;
 
-export function progressBegin(pass: "full" | "top-up"): number {
+export function progressBegin(pass: "initial" | "top-up"): number {
   currentPass += 1;
   emit({
     ...INITIAL,
     counts: { ...INITIAL_COUNTS },
+    // Totals carry across passes: they describe the device, not this run, and
+    // blanking them would flash "0 stored" every time a pass starts.
+    initialComplete: snapshot.initialComplete,
     pass,
+    pending: snapshot.pending,
     running: true,
     startedAt: Date.now(),
+    stored: snapshot.stored,
   });
   return currentPass;
+}
+
+/**
+ * The device totals. Published outside a running pass too, so the panel can
+ * answer "what do I have?" on a cold open before anything has started.
+ */
+export function progressTotals(totals: {
+  stored: number;
+  pending: number;
+  initialComplete: boolean;
+}): void {
+  emit({ ...snapshot, ...totals });
 }
 
 export function progressStep(step: string): void {

--- a/apps/standard-reader/src/pwa/offline-sync-progress.ts
+++ b/apps/standard-reader/src/pwa/offline-sync-progress.ts
@@ -1,0 +1,168 @@
+/**
+ * Observable progress for the offline sync pass, for the troubleshooting panel
+ * in settings (`/settings?debug`).
+ *
+ * Sync is invisible by design — it runs in the background of an installed app
+ * and its only user-facing product is pages that happen to work later. That
+ * also makes it undebuggable from a phone: when a surface is missing offline,
+ * nothing says whether sync never ran, ran and was killed mid-pass, stopped on
+ * the storage guard, or finished and the surface was simply never warmed. This
+ * store exists so a device can answer that.
+ *
+ * Kept separate from `offline-sync.ts` so the settings panel can subscribe
+ * without importing the sync machinery (and everything it warms) into its
+ * chunk.
+ */
+
+export interface OfflineSyncCounts {
+  /** `/latest` pages fetched across both tabs. */
+  feedPages: number;
+  /** Unread document URIs enumerated (the list, not the bodies). */
+  unreadListed: number;
+  /** Publications whose pages were warmed. */
+  publications: number;
+  /** Publication back-catalog pages fetched beyond each one's first. */
+  backCatalogPages: number;
+  /** Followed authors whose pages were warmed. */
+  authors: number;
+  /** Lists (own + saved) whose pages were warmed. */
+  lists: number;
+  /** Article bodies queued for this pass, after ledger dedup. */
+  bodiesQueued: number;
+  /** Article bodies actually fetched this pass. */
+  bodiesCached: number;
+  /** Body images warmed this pass. */
+  imagesWarmed: number;
+}
+
+export type OfflineSyncStopReason =
+  /** The pass ran out of work. */
+  | "completed"
+  /** The connection dropped mid-pass. */
+  | "offline"
+  /** The storage-pressure guard ended the body walk. */
+  | "storage"
+  /** `stopOfflineSync()` — sign-out, toggle off, or the app going offline. */
+  | "stopped"
+  /** The pass threw; see `error`. */
+  | "error"
+  /** A gate said no before any work happened; see `error` for which. */
+  | "not-eligible";
+
+export interface OfflineSyncProgress {
+  running: boolean;
+  /** Full passes fan out to every followed surface; top-ups only re-walk feeds. */
+  pass: "full" | "top-up" | null;
+  /** Human-readable name of the stage currently running. */
+  step: string | null;
+  startedAt: number | null;
+  finishedAt: number | null;
+  stopReason: OfflineSyncStopReason | null;
+  /** Which gate refused, or what threw — for the panel, not for code. */
+  error: string | null;
+  counts: OfflineSyncCounts;
+}
+
+const INITIAL_COUNTS: OfflineSyncCounts = {
+  authors: 0,
+  backCatalogPages: 0,
+  bodiesCached: 0,
+  bodiesQueued: 0,
+  feedPages: 0,
+  imagesWarmed: 0,
+  lists: 0,
+  publications: 0,
+  unreadListed: 0,
+};
+
+const INITIAL: OfflineSyncProgress = {
+  counts: INITIAL_COUNTS,
+  error: null,
+  finishedAt: null,
+  pass: null,
+  running: false,
+  startedAt: null,
+  step: null,
+  stopReason: null,
+};
+
+let snapshot: OfflineSyncProgress = INITIAL;
+const listeners = new Set<() => void>();
+
+function emit(next: OfflineSyncProgress): void {
+  snapshot = next;
+  for (const listener of listeners) listener();
+}
+
+/** For `useSyncExternalStore`. The snapshot is replaced, never mutated. */
+export function subscribeOfflineSyncProgress(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function getOfflineSyncProgress(): OfflineSyncProgress {
+  return snapshot;
+}
+
+/** SSR snapshot — progress is per-device state and the server has none. */
+export function getOfflineSyncProgressServer(): OfflineSyncProgress {
+  return INITIAL;
+}
+
+// ── Mutators, used only by offline-sync.ts ───────────────────────────────────
+
+/**
+ * Which pass currently owns the snapshot. A stopped pass takes a moment to
+ * wind down, and a new one can begin inside that window — without the token,
+ * the old pass's `progressEnd` would mark the new one finished.
+ */
+let currentPass = 0;
+
+export function progressBegin(pass: "full" | "top-up"): number {
+  currentPass += 1;
+  emit({
+    ...INITIAL,
+    counts: { ...INITIAL_COUNTS },
+    pass,
+    running: true,
+    startedAt: Date.now(),
+  });
+  return currentPass;
+}
+
+export function progressStep(step: string): void {
+  if (!snapshot.running) return;
+  emit({ ...snapshot, step });
+}
+
+export function progressCount(key: keyof OfflineSyncCounts, by = 1): void {
+  if (!snapshot.running) return;
+  emit({
+    ...snapshot,
+    counts: { ...snapshot.counts, [key]: snapshot.counts[key] + by },
+  });
+}
+
+export function progressEnd(
+  token: number,
+  stopReason: OfflineSyncStopReason,
+  error: string | null = null,
+): void {
+  if (token !== currentPass) return;
+  emit({
+    ...snapshot,
+    error,
+    finishedAt: Date.now(),
+    running: false,
+    step: null,
+    stopReason,
+  });
+}
+
+/** A gate refused before the pass started; record why so the panel can say. */
+export function progressIneligible(reason: string): void {
+  // Don't clobber a finished pass's summary with gate noise from the interval
+  // re-firing — only record it when there is nothing better to show.
+  if (snapshot.running || snapshot.startedAt !== null) return;
+  emit({ ...snapshot, error: reason, stopReason: "not-eligible" });
+}

--- a/apps/standard-reader/src/pwa/offline-sync-state.ts
+++ b/apps/standard-reader/src/pwa/offline-sync-state.ts
@@ -1,0 +1,134 @@
+/**
+ * Sync state that outlives the app being closed.
+ *
+ * Everything here exists because an installed PWA is killed constantly — iOS
+ * reclaims backgrounded web apps within seconds — and a pass that starts from
+ * scratch each launch never gets past its first minute of work.
+ *
+ * The article ledger (`offline-cache.ts`) already makes *bodies* durable: a
+ * document fetched last week is skipped this week. What it cannot express is
+ * how far the walk got. Two things were lost on every restart, and together
+ * they made the deep fill unreachable:
+ *
+ *   - **The walk position.** A top-up walk stops once it reaches pages it
+ *     already has. After a restart the head of the feed is stored, so the walk
+ *     stopped after two pages — never resuming the depth the killed session was
+ *     working through. The backlog could only ever be as deep as the longest
+ *     single uninterrupted session.
+ *   - **The queue.** Documents discovered but not yet fetched were held in
+ *     memory. If the app died between discovering them and storing them, they
+ *     were simply forgotten until some later walk happened to see them again.
+ *
+ * So the plan is persisted, and a pass resumes it. The initial fill runs to
+ * completion across as many launches as it takes; only once it has genuinely
+ * finished does sync switch to cheap top-ups.
+ */
+
+const STATE_KEY = "sr:offline-sync-state";
+
+/**
+ * Cap on the persisted queue. At ~80 bytes per AT-URI this is a few hundred KB
+ * — comfortable in a ~5 MB budget, and far past what the walk caps can produce.
+ * Truncation drops the tail, which is the oldest and least wanted.
+ */
+const MAX_PENDING = 5000;
+
+/** Re-warm the followed-surface fan-out about once a day. */
+export const SURFACES_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+export type LatestFilterKey = "unread" | "subscriptions";
+
+export interface OfflineSyncState {
+  v: 1;
+  /**
+   * When the initial deep fill genuinely finished — every feed page walked and
+   * every discovered body stored. `null` means it is still in progress, which
+   * is what keeps the walk from taking its early exit.
+   */
+  initialCompletedAt: number | null;
+  /** Body URIs discovered but not yet stored, in priority order. */
+  pending: Array<string>;
+  /** Where the deep walk got to, per feed tab. */
+  feedOffsets: Record<LatestFilterKey, number>;
+  /** Feed tabs whose walk has reached the end (or the page cap). */
+  feedDone: Record<LatestFilterKey, boolean>;
+  /** When the publications / authors / lists fan-out last completed. */
+  surfacesWarmedAt: number | null;
+}
+
+const EMPTY: OfflineSyncState = {
+  feedDone: { subscriptions: false, unread: false },
+  feedOffsets: { subscriptions: 0, unread: 0 },
+  initialCompletedAt: null,
+  pending: [],
+  surfacesWarmedAt: null,
+  v: 1,
+};
+
+export function emptyOfflineSyncState(): OfflineSyncState {
+  return {
+    ...EMPTY,
+    feedDone: { ...EMPTY.feedDone },
+    feedOffsets: { ...EMPTY.feedOffsets },
+    pending: [],
+  };
+}
+
+export function readOfflineSyncState(): OfflineSyncState {
+  if (globalThis.localStorage === undefined) return emptyOfflineSyncState();
+  try {
+    const raw = globalThis.localStorage.getItem(STATE_KEY);
+    if (!raw) return emptyOfflineSyncState();
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return emptyOfflineSyncState();
+    const state = parsed as Partial<OfflineSyncState>;
+    // A shape from an older build is not worth migrating — starting the fill
+    // over costs one deep walk, and the ledger still skips stored bodies.
+    if (state.v !== 1) return emptyOfflineSyncState();
+    return {
+      feedDone: { ...EMPTY.feedDone, ...state.feedDone },
+      feedOffsets: { ...EMPTY.feedOffsets, ...state.feedOffsets },
+      initialCompletedAt: state.initialCompletedAt ?? null,
+      pending: Array.isArray(state.pending) ? state.pending : [],
+      surfacesWarmedAt: state.surfacesWarmedAt ?? null,
+      v: 1,
+    };
+  } catch {
+    return emptyOfflineSyncState();
+  }
+}
+
+export function writeOfflineSyncState(state: OfflineSyncState): void {
+  try {
+    globalThis.localStorage?.setItem(
+      STATE_KEY,
+      JSON.stringify({
+        ...state,
+        pending: state.pending.slice(0, MAX_PENDING),
+      }),
+    );
+  } catch {
+    // Quota or private browsing. Sync still works, it just restarts its walk
+    // on the next launch — the behaviour this module exists to avoid, but not
+    // a reason to fail the pass.
+  }
+}
+
+export function clearOfflineSyncState(): void {
+  try {
+    globalThis.localStorage?.removeItem(STATE_KEY);
+  } catch {
+    // Nothing to do — see `writeOfflineSyncState`.
+  }
+}
+
+/** Whether the followed-surface fan-out is due again. */
+export function surfacesAreStale(
+  state: OfflineSyncState,
+  now: number,
+): boolean {
+  return (
+    state.surfacesWarmedAt === null ||
+    now - state.surfacesWarmedAt > SURFACES_MAX_AGE_MS
+  );
+}

--- a/apps/standard-reader/src/pwa/offline-sync.ts
+++ b/apps/standard-reader/src/pwa/offline-sync.ts
@@ -404,13 +404,34 @@ async function warmLatestPages(
  * for it, so there was nothing to serve. Subscriptions are a bounded set the
  * reader chose, which makes them worth fetching up front.
  */
-async function warmPublications(signal: AbortSignal): Promise<void> {
+async function warmPublications(
+  router: AnyRouter,
+  signal: AbortSignal,
+): Promise<void> {
   let following: Array<{ uri: string }>;
   try {
     const sidebar = await feedApi.getSidebar();
     following = sidebar.following;
   } catch {
     return;
+  }
+
+  // The route's own JS chunk, which is code-split
+  // (`_layout.p._did._rkey-*.js`) and cached only on demand. Warming the data
+  // without it left every publication in the sidebar listed but unopenable:
+  // the loader had everything it needed and the chunk that renders it 404'd.
+  // One preload pulls it in; the rest of this function is data for the others.
+  const first = following[0] ? parseAtUri(following[0].uri) : null;
+  if (first) {
+    try {
+      await router.preloadRoute({
+        params: { did: first.did, rkey: first.rkey },
+        to: "/p/$did/$rkey",
+      });
+    } catch {
+      // Preload runs the loader's prefetch branch and may reject; the chunk
+      // load is what matters and has already happened.
+    }
   }
 
   await pool(
@@ -480,7 +501,7 @@ export async function runOfflineSync(router: AnyRouter): Promise<void> {
     // offline state, so the surfaces come first and the articles follow.
     await warmRouteChunks(router, signal);
     await warmFeedData(signal);
-    await warmPublications(signal);
+    await warmPublications(router, signal);
 
     const fresh = ledgerFreshUris(Date.now());
     const seen = new Set<string>();

--- a/apps/standard-reader/src/pwa/offline-sync.ts
+++ b/apps/standard-reader/src/pwa/offline-sync.ts
@@ -54,7 +54,14 @@ import {
   progressEnd,
   progressIneligible,
   progressStep,
+  progressTotals,
 } from "./offline-sync-progress";
+import type { LatestFilterKey, OfflineSyncState } from "./offline-sync-state";
+import {
+  readOfflineSyncState,
+  surfacesAreStale,
+  writeOfflineSyncState,
+} from "./offline-sync-state";
 import { isStandalone } from "./standalone";
 
 /**
@@ -121,8 +128,8 @@ const RESYNC_INTERVAL_MS = 5 * 60_000;
  *
  * A bound on request count, not storage — these pages are small next to article
  * bodies. Set well past what most readers follow so the cap is a backstop
- * rather than something people actually hit; the pass runs once per session
- * (see {@link runOfflineSync}), so it isn't paid repeatedly.
+ * rather than something people actually hit; the fan-out is timestamped on disk
+ * and repeats about daily, so it isn't paid on every launch.
  */
 const MAX_WARMED_PUBLICATIONS = 250;
 
@@ -153,8 +160,6 @@ const LIST_PAGE_SIZE = 20;
 
 let running = false;
 let controller: AbortController | null = null;
-/** Whether the session-scoped, run-once work has been done (see the pass). */
-let didFullPass = false;
 
 export function isOfflineReadingEnabled(): boolean {
   if (globalThis.localStorage === undefined) return true;
@@ -445,15 +450,21 @@ async function warmFeedData(signal: AbortSignal): Promise<void> {
  * every row under URLs the UI never asks for.
  */
 async function warmLatestPages(
-  filter: "unread" | "subscriptions",
+  filter: LatestFilterKey,
   signal: AbortSignal,
   known: ReadonlySet<string>,
+  state: OfflineSyncState,
   onCollection?: (documentUri: string) => void,
 ): Promise<Array<string>> {
   const limit = latestFeedPageSize(filter);
   const uris: Array<string> = [];
-  let offset = 0;
+  const filling = state.initialCompletedAt === null;
+  // The initial fill resumes where the last launch was interrupted; a top-up
+  // always re-reads the head, which is where new posts appear.
+  let offset = filling ? state.feedOffsets[filter] : 0;
   let settledPages = 0;
+
+  if (filling && state.feedDone[filter]) return uris;
 
   for (let page = 0; page < LATEST_WARM_MAX_PAGES; page += 1) {
     if (signal.aborted || isOffline()) break;
@@ -476,16 +487,40 @@ async function warmLatestPages(
       if (item.isCollection) onCollection?.(item.uri);
     }
 
-    // Stop once the walk reaches depth it already has. This is what makes
-    // running every few minutes affordable: the first pass goes as deep as the
-    // cap allows, and each pass after it costs a couple of pages unless
-    // something new arrived. Two consecutive settled pages rather than one, so
-    // a single page of re-reads doesn't end the walk early.
-    settledPages = fresh === 0 ? settledPages + 1 : 0;
-    if (page >= MIN_LATEST_WARM_PAGES && settledPages >= 2) break;
-
-    if (feed.nextOffset == null) break;
+    if (feed.nextOffset == null) {
+      if (filling) {
+        state.feedDone[filter] = true;
+        writeOfflineSyncState(state);
+      }
+      break;
+    }
     offset = feed.nextOffset;
+
+    if (filling) {
+      // Record the resume point *before* the next request, so a kill mid-flight
+      // costs one page rather than the whole walk.
+      state.feedOffsets[filter] = offset;
+      writeOfflineSyncState(state);
+    } else {
+      // Top-up only: stop once the walk reaches depth it already has, which is
+      // what makes running every few minutes affordable. Two consecutive
+      // settled pages rather than one, so a single page of re-reads doesn't end
+      // it early. This exit must never apply during the initial fill — after a
+      // restart the head is always familiar, so it would stop the walk two
+      // pages in and the backlog could never get deeper than one uninterrupted
+      // session managed.
+      settledPages = fresh === 0 ? settledPages + 1 : 0;
+      if (page >= MIN_LATEST_WARM_PAGES && settledPages >= 2) break;
+    }
+
+    // Reaching the page cap counts as done, not as interrupted: the cap *is*
+    // the intended depth, and without this a reader whose history outruns it
+    // would never see the initial fill complete.
+    if (filling && page === LATEST_WARM_MAX_PAGES - 1) {
+      state.feedDone[filter] = true;
+      writeOfflineSyncState(state);
+    }
+
     await whenIdle(signal);
   }
 
@@ -710,6 +745,20 @@ async function warmLists(
   });
 }
 
+/**
+ * Publish the device totals without running a pass, so the troubleshooting
+ * panel can answer "what do I already have?" the moment it opens.
+ */
+export function publishOfflineSyncTotals(): void {
+  const state = readOfflineSyncState();
+  const fresh = ledgerFreshUris(Date.now());
+  progressTotals({
+    initialComplete: state.initialCompletedAt !== null,
+    pending: state.pending.filter((uri) => !fresh.has(uri)).length,
+    stored: fresh.size,
+  });
+}
+
 export function stopOfflineSync(): void {
   controller?.abort();
   controller = null;
@@ -761,9 +810,11 @@ export async function runOfflineSync(
   running = true;
   controller = new AbortController();
   const { signal } = controller;
-  // The first pass of a session goes wide and deep; the ones after it top up.
-  const fullPass = !didFullPass;
-  const passToken = progressBegin(fullPass ? "full" : "top-up");
+  // Resumed from disk, not from this session: the plan has to survive the app
+  // being killed, which is the normal way an installed PWA ends.
+  const state = readOfflineSyncState();
+  const filling = state.initialCompletedAt === null;
+  const passToken = progressBegin(filling ? "initial" : "top-up");
 
   try {
     // Ask once per install. Without this the browser treats the whole origin as
@@ -778,16 +829,31 @@ export async function runOfflineSync(
     // interrupted pass should leave every surface warm and some bodies
     // missing (dimmed), not deep bodies behind surfaces that 404.
     const fresh = ledgerFreshUris(Date.now());
-    // Body order = discovery order: unread first, then the feed walk, then
-    // publication back catalogs. Newest and most-likely-to-be-opened first,
-    // so whatever ends the walk early cuts from the bottom.
-    const queued = new Set<string>();
-    const bodyQueue: Array<string> = [];
+    // Body order = discovery order: whatever the last launch had left over
+    // first, then unread, the feed walk, and publication back catalogs. Newest
+    // and most-likely-to-be-opened first, so whatever ends the walk early cuts
+    // from the bottom.
+    //
+    // The queue is seeded from disk. Documents discovered but not yet stored
+    // used to live only in memory, so a kill between discovering and fetching
+    // them forgot them until some later walk happened past them again.
+    const bodyQueue: Array<string> = state.pending.filter(
+      (uri) => !fresh.has(uri),
+    );
+    const queued = new Set(bodyQueue);
     const enqueueBody = (uri: string) => {
-      if (queued.has(uri)) return;
+      if (queued.has(uri) || fresh.has(uri)) return;
       queued.add(uri);
       bodyQueue.push(uri);
     };
+    const publishTotals = () => {
+      progressTotals({
+        initialComplete: state.initialCompletedAt !== null,
+        pending: bodyQueue.length,
+        stored: fresh.size,
+      });
+    };
+    publishTotals();
 
     progressStep("app shell");
     await warmShell(signal);
@@ -815,19 +881,29 @@ export async function runOfflineSync(
     let collectionWarmed = false;
     for (const filter of ["unread", "subscriptions"] as const) {
       if (signal.aborted || isOffline()) break;
-      const uris = await warmLatestPages(filter, signal, fresh, (uri) => {
-        if (collectionWarmed) return;
-        collectionWarmed = true;
-        void warmArticleRoute(router, uri, "/collection/$did/$rkey");
-      });
+      const uris = await warmLatestPages(
+        filter,
+        signal,
+        fresh,
+        state,
+        (uri) => {
+          if (collectionWarmed) return;
+          collectionWarmed = true;
+          void warmArticleRoute(router, uri, "/collection/$did/$rkey");
+        },
+      );
       for (const uri of uris) enqueueBody(uri);
+      state.pending = bodyQueue;
+      writeOfflineSyncState(state);
+      publishTotals();
     }
 
     // Route chunks, fonts, and every publication / author / list the reader
-    // follows: a large, fixed set that does not change during a session. Once
-    // per session is what lets the pass repeat every few minutes — re-fetching
-    // a few hundred sidebar pages on a timer would be traffic for nothing.
-    if (fullPass) {
+    // follows. Timestamped on disk rather than flagged per session: this is a
+    // few hundred requests, the set changes about as often as the reader
+    // subscribes to something, and redoing it on every launch was pure waste
+    // for an app that gets killed and relaunched all day.
+    if (surfacesAreStale(state, Date.now())) {
       progressStep("app code");
       await warmRouteChunks(router, signal);
       progressStep("fonts");
@@ -839,19 +915,25 @@ export async function runOfflineSync(
       progressStep("lists");
       await warmLists(router, signal);
       // Only once it has actually finished. A pass that lost the connection
-      // two seconds in must not convince the rest of the session that the
-      // sidebar is cached.
-      if (!signal.aborted && !isOffline()) didFullPass = true;
+      // two seconds in must not claim the sidebar is cached for a day.
+      if (!signal.aborted && !isOffline()) {
+        state.surfacesWarmedAt = Date.now();
+      }
+      state.pending = bodyQueue;
+      writeOfflineSyncState(state);
+      publishTotals();
     }
 
     // ── Phase 2: article bodies and their images, in queue order. ──
     progressStep("articles");
-    const pending = bodyQueue.filter((uri) => !fresh.has(uri));
-    progressCount("bodiesQueued", pending.length);
-    if (pending[0]) await warmArticleRoute(router, pending[0]);
+    progressCount("bodiesQueued", bodyQueue.length);
+    if (bodyQueue[0]) await warmArticleRoute(router, bodyQueue[0]);
 
     let stopReason: "completed" | "offline" | "storage" = "completed";
-    for (let i = 0; i < pending.length; i += STORAGE_CHECK_INTERVAL) {
+    // Drains from the front, and the remainder is written back after each
+    // batch — so being killed here costs at most one batch of re-fetching
+    // rather than the whole walk that discovered these.
+    while (bodyQueue.length > 0) {
       if (signal.aborted || isOffline()) {
         stopReason = "offline";
         break;
@@ -860,23 +942,38 @@ export async function runOfflineSync(
         stopReason = "storage";
         break;
       }
-      await pool(
-        pending.slice(i, i + STORAGE_CHECK_INTERVAL),
-        BODY_CONCURRENCY,
-        signal,
-        (uri) => syncDocument(uri, signal),
+      const batch = bodyQueue.splice(0, STORAGE_CHECK_INTERVAL);
+      await pool(batch, BODY_CONCURRENCY, signal, (uri) =>
+        syncDocument(uri, signal),
       );
+      for (const uri of batch) fresh.add(uri);
+      state.pending = bodyQueue;
+      writeOfflineSyncState(state);
+      publishTotals();
       await whenIdle(signal);
     }
 
-    // Prune only after a pass that actually saw everything — the deep first
-    // one. Later passes stop as soon as the feed walk reaches familiar ground,
-    // so `seen` covers the head of the list and nothing below it; pruning to
-    // that would evict the whole backlog and re-download it next time. Entries
-    // the reader has worked through age out of the ledger on their own.
-    if (fullPass && stopReason === "completed" && !cursor && !signal.aborted) {
+    // The initial fill is finished only when both feed tabs have been walked to
+    // the end *and* nothing is left queued. Recorded on disk, so the cheap
+    // top-up behaviour starts from the next launch onwards rather than being
+    // re-derived — and so an interrupted fill resumes as a fill.
+    if (
+      filling &&
+      stopReason === "completed" &&
+      !signal.aborted &&
+      state.feedDone.unread &&
+      state.feedDone.subscriptions &&
+      bodyQueue.length === 0
+    ) {
+      state.initialCompletedAt = Date.now();
+      // Safe to prune only here: this is the one moment the queue is known to
+      // span everything the walk found. A top-up sees only the head of the
+      // feed, so pruning to what it saw would evict the whole backlog.
       ledgerRetainOnly(queued);
     }
+    state.pending = bodyQueue;
+    writeOfflineSyncState(state);
+    publishTotals();
     progressEnd(passToken, signal.aborted ? "stopped" : stopReason);
   } catch (error) {
     // Sync is best-effort by construction. A failure means the reader has

--- a/apps/standard-reader/src/pwa/offline-sync.ts
+++ b/apps/standard-reader/src/pwa/offline-sync.ts
@@ -48,6 +48,13 @@ import {
   ledgerRetainOnly,
   offlineStorageUsage,
 } from "./offline-cache";
+import {
+  progressBegin,
+  progressCount,
+  progressEnd,
+  progressIneligible,
+  progressStep,
+} from "./offline-sync-progress";
 import { isStandalone } from "./standalone";
 
 /**
@@ -126,6 +133,17 @@ const MAX_WARMED_PUBLICATIONS = 250;
  */
 const PUBLICATION_RECENT_LIMIT = 12;
 const PUBLICATION_RECENT_FILTER = "all";
+
+/** Must match the publication page's "load more" (`PUBLICATION_PAGE_SIZE`). */
+const PUBLICATION_PAGE_SIZE = 20;
+
+/**
+ * Back-catalog pages fetched per followed publication, beyond its first.
+ * Three pages of 20 plus the first 12 keeps ~72 posts per publication
+ * scrollable offline; bodies beyond the feed walk queue behind everything
+ * newer, so the storage guard — not this — decides how many actually land.
+ */
+const PUBLICATION_BACK_CATALOG_PAGES = 3;
 
 /** Must match `/u/$did`'s loader (`AUTHOR_PAGE_SIZE`), same caveat as above. */
 const AUTHOR_PAGE_SIZE = 24;
@@ -293,9 +311,11 @@ async function syncDocument(
       signal,
       (url) => warmImage(url, signal),
     );
+    progressCount("imagesWarmed", images.length);
   }
 
   ledgerRecord(documentUri, Date.now());
+  progressCount("bodiesCached");
 }
 
 /**
@@ -444,6 +464,7 @@ async function warmLatestPages(
     } catch {
       break;
     }
+    progressCount("feedPages");
 
     let fresh = 0;
     for (const item of feed.items) {
@@ -482,6 +503,7 @@ async function warmLatestPages(
 async function warmPublications(
   router: AnyRouter,
   signal: AbortSignal,
+  enqueueBody: (documentUri: string) => void,
 ): Promise<void> {
   let following: Array<{ uri: string }>;
   try {
@@ -507,7 +529,7 @@ async function warmPublications(
       // Exactly what `/p/$did/$rkey`'s loader awaits, with the argument values
       // its query options default to. `readerScope` is not passed: it varies
       // the React Query key only, never the request the server sees.
-      await Promise.all([
+      const [, firstDocs] = await Promise.all([
         publicationApi.getPublicationHeader({ data: { publicationUri } }),
         publicationApi.getPublicationDocuments({
           // Key order matters as much as the values: the payload is serialised
@@ -526,6 +548,34 @@ async function warmPublications(
           // Signed-out readers never request this, so a failure is expected.
           .catch(() => null),
       ]);
+      progressCount("publications");
+
+      // The back catalog: the pages behind the publication's "load more",
+      // requested in the exact shape that button sends (`PUBLICATION_PAGE_SIZE`
+      // from the first page's `nextOffset`, not another 12-row page). The
+      // bodies are queued rather than fetched here — a back-catalog article is
+      // the lowest-priority body there is, and the queue keeps it behind
+      // everything the reader is more likely to open.
+      for (const item of firstDocs.items) enqueueBody(item.uri);
+      let nextOffset = firstDocs.nextOffset;
+      for (
+        let page = 0;
+        page < PUBLICATION_BACK_CATALOG_PAGES && nextOffset != null;
+        page += 1
+      ) {
+        if (signal.aborted || isOffline()) return;
+        const docs = await publicationApi.getPublicationDocuments({
+          data: {
+            publicationUri,
+            limit: PUBLICATION_PAGE_SIZE,
+            offset: nextOffset,
+            filter: PUBLICATION_RECENT_FILTER,
+          },
+        });
+        progressCount("backCatalogPages");
+        for (const item of docs.items) enqueueBody(item.uri);
+        nextOffset = docs.nextOffset;
+      }
     },
   );
 }
@@ -610,6 +660,7 @@ async function warmFollowedUsers(
           activityLimit: AUTHOR_ACTIVITY_PAGE_SIZE,
         },
       });
+      progressCount("authors");
     },
   );
 }
@@ -655,6 +706,7 @@ async function warmLists(
         },
       }),
     ]);
+    progressCount("lists");
   });
 }
 
@@ -672,40 +724,119 @@ export function stopOfflineSync(): void {
  * backlog because they opened the website in a tab is not a trade a website
  * visitor agreed to.
  */
-export async function runOfflineSync(router: AnyRouter): Promise<void> {
-  if (running) return;
-  if (globalThis.window === undefined) return;
-  if (!isStandalone()) return;
-  if (!isOfflineReadingEnabled()) return;
-  if (isOffline()) return;
-  if (saveDataRequested()) return;
+export async function runOfflineSync(
+  router: AnyRouter,
+  opts: {
+    /**
+     * Skip the installed-app / toggle / Save-Data gates. Only the settings
+     * debug panel passes this — pressing "Run sync now" *is* the consent those
+     * gates exist to establish, and it lets sync be exercised in a plain
+     * browser tab where `display-mode: standalone` never matches.
+     */
+    force?: boolean;
+  } = {},
+): Promise<void> {
+  if (running || globalThis.window === undefined) return;
+  if (isOffline()) {
+    progressIneligible("offline");
+    return;
+  }
+  if (!opts.force) {
+    // Each gate names itself so the debug panel can say why nothing has run —
+    // "not-eligible: not installed" beats a counter stuck at zero.
+    if (!isStandalone()) {
+      progressIneligible("not installed (browser tab, not the app)");
+      return;
+    }
+    if (!isOfflineReadingEnabled()) {
+      progressIneligible("offline reading is turned off in settings");
+      return;
+    }
+    if (saveDataRequested()) {
+      progressIneligible("the system asked apps to save data");
+      return;
+    }
+  }
 
   running = true;
   controller = new AbortController();
   const { signal } = controller;
   // The first pass of a session goes wide and deep; the ones after it top up.
   const fullPass = !didFullPass;
+  const passToken = progressBegin(fullPass ? "full" : "top-up");
 
   try {
     // Ask once per install. Without this the browser treats the whole origin as
     // discardable and can drop a synced backlog under storage pressure.
     void globalThis.navigator?.storage?.persist?.();
 
+    // ── Phase 1: every *list* surface, breadth-first. ──
+    // These are cheap (one request per page) and they are what makes the app
+    // feel present offline: feeds that scroll, publications that open. They
+    // all run before a single body downloads, because the body walk takes
+    // minutes and phones kill backgrounded PWAs without warning — an
+    // interrupted pass should leave every surface warm and some bodies
+    // missing (dimmed), not deep bodies behind surfaces that 404.
+    const fresh = ledgerFreshUris(Date.now());
+    // Body order = discovery order: unread first, then the feed walk, then
+    // publication back catalogs. Newest and most-likely-to-be-opened first,
+    // so whatever ends the walk early cuts from the bottom.
+    const queued = new Set<string>();
+    const bodyQueue: Array<string> = [];
+    const enqueueBody = (uri: string) => {
+      if (queued.has(uri)) return;
+      queued.add(uri);
+      bodyQueue.push(uri);
+    };
+
+    progressStep("app shell");
     await warmShell(signal);
-    // Before any bodies. An unwarmed feed drops a fully-cached page into the
-    // offline state, so the surfaces come first and the articles follow.
+    progressStep("feeds");
     await warmFeedData(signal);
 
+    // The unread list — URIs only; their bodies queue for phase 2.
+    progressStep("unread list");
+    let cursor: { publishedAt: string; uri: string } | null = null;
+    do {
+      if (signal.aborted || isOffline()) break;
+      const page: Awaited<ReturnType<typeof readerApi.getUnreadDocumentUris>> =
+        await readerApi.getUnreadDocumentUris({
+          data: cursor ? { cursor } : {},
+        });
+      for (const uri of page.uris) enqueueBody(uri);
+      progressCount("unreadListed", page.uris.length);
+      cursor = page.nextCursor;
+    } while (cursor && !signal.aborted);
+
+    // The /latest tabs, deep enough to scroll. Every pass, because this is
+    // where new posts appear — but it stops as soon as it reaches pages it
+    // already knows, so a caught-up pass costs a couple of requests.
+    progressStep("latest pages");
+    let collectionWarmed = false;
+    for (const filter of ["unread", "subscriptions"] as const) {
+      if (signal.aborted || isOffline()) break;
+      const uris = await warmLatestPages(filter, signal, fresh, (uri) => {
+        if (collectionWarmed) return;
+        collectionWarmed = true;
+        void warmArticleRoute(router, uri, "/collection/$did/$rkey");
+      });
+      for (const uri of uris) enqueueBody(uri);
+    }
+
     // Route chunks, fonts, and every publication / author / list the reader
-    // follows: a large, fixed set that does not change during a session. Doing
-    // it once is what lets the pass repeat every few minutes — re-fetching a
-    // few hundred sidebar pages on a timer would be a lot of traffic for
-    // nothing. A new session redoes it, which is when it can have changed.
+    // follows: a large, fixed set that does not change during a session. Once
+    // per session is what lets the pass repeat every few minutes — re-fetching
+    // a few hundred sidebar pages on a timer would be traffic for nothing.
     if (fullPass) {
+      progressStep("app code");
       await warmRouteChunks(router, signal);
+      progressStep("fonts");
       await warmFonts(signal);
-      await warmPublications(router, signal);
+      progressStep("publications");
+      await warmPublications(router, signal, enqueueBody);
+      progressStep("authors");
       await warmFollowedUsers(router, signal);
+      progressStep("lists");
       await warmLists(router, signal);
       // Only once it has actually finished. A pass that lost the connection
       // two seconds in must not convince the rest of the session that the
@@ -713,75 +844,29 @@ export async function runOfflineSync(router: AnyRouter): Promise<void> {
       if (!signal.aborted && !isOffline()) didFullPass = true;
     }
 
-    const fresh = ledgerFreshUris(Date.now());
-    const seen = new Set<string>();
-    let cursor: { publishedAt: string; uri: string } | null = null;
-    let routeWarmed = false;
-    let stoppedEarly = false;
+    // ── Phase 2: article bodies and their images, in queue order. ──
+    progressStep("articles");
+    const pending = bodyQueue.filter((uri) => !fresh.has(uri));
+    progressCount("bodiesQueued", pending.length);
+    if (pending[0]) await warmArticleRoute(router, pending[0]);
 
-    /** Cache a batch of bodies; returns false when storage says stop. */
-    const cacheBodies = async (uris: Array<string>): Promise<boolean> => {
-      for (let i = 0; i < uris.length; i += STORAGE_CHECK_INTERVAL) {
-        if (signal.aborted || isOffline()) return false;
-        if (await underStoragePressure()) return false;
-        await pool(
-          uris.slice(i, i + STORAGE_CHECK_INTERVAL),
-          BODY_CONCURRENCY,
-          signal,
-          (uri) => syncDocument(uri, signal),
-        );
-        await whenIdle(signal);
-      }
-      return true;
-    };
-
-    // ── Unread first. Uncapped: this is the backlog the reader came for. ──
-    do {
-      if (signal.aborted || isOffline()) break;
-
-      const page: Awaited<ReturnType<typeof readerApi.getUnreadDocumentUris>> =
-        await readerApi.getUnreadDocumentUris({
-          data: cursor ? { cursor } : {},
-        });
-      for (const uri of page.uris) seen.add(uri);
-      cursor = page.nextCursor;
-
-      const pending = page.uris.filter((uri) => !fresh.has(uri));
-
-      if (!routeWarmed && pending[0]) {
-        routeWarmed = true;
-        await warmArticleRoute(router, pending[0]);
-      }
-
-      if (!(await cacheBodies(pending))) {
-        stoppedEarly = true;
+    let stopReason: "completed" | "offline" | "storage" = "completed";
+    for (let i = 0; i < pending.length; i += STORAGE_CHECK_INTERVAL) {
+      if (signal.aborted || isOffline()) {
+        stopReason = "offline";
         break;
       }
-    } while (cursor && !signal.aborted);
-
-    // ── Then the /latest tabs, deep enough to scroll. ──
-    // Warming offset 0 alone cached one screenful, so the lists looked short
-    // offline and "load more" had nothing behind it. Walking the pages also
-    // yields the subscriptions backlog — already-read posts that unread alone
-    // misses — so the same requests serve both the list and its bodies.
-    let collectionWarmed = false;
-    for (const filter of ["unread", "subscriptions"] as const) {
-      if (stoppedEarly || signal.aborted || isOffline()) break;
-      const uris = await warmLatestPages(
-        filter,
-        signal,
-        // What the walk already has, so it can stop once it reaches it.
-        fresh,
-        (documentUri) => {
-          if (collectionWarmed) return;
-          collectionWarmed = true;
-          void warmArticleRoute(router, documentUri, "/collection/$did/$rkey");
-        },
-      );
-      for (const uri of uris) seen.add(uri);
-      if (!(await cacheBodies(uris.filter((uri) => !fresh.has(uri))))) {
-        stoppedEarly = true;
+      if (await underStoragePressure()) {
+        stopReason = "storage";
+        break;
       }
+      await pool(
+        pending.slice(i, i + STORAGE_CHECK_INTERVAL),
+        BODY_CONCURRENCY,
+        signal,
+        (uri) => syncDocument(uri, signal),
+      );
+      await whenIdle(signal);
     }
 
     // Prune only after a pass that actually saw everything — the deep first
@@ -789,13 +874,19 @@ export async function runOfflineSync(router: AnyRouter): Promise<void> {
     // so `seen` covers the head of the list and nothing below it; pruning to
     // that would evict the whole backlog and re-download it next time. Entries
     // the reader has worked through age out of the ledger on their own.
-    if (fullPass && !stoppedEarly && !cursor && !signal.aborted) {
-      ledgerRetainOnly(seen);
+    if (fullPass && stopReason === "completed" && !cursor && !signal.aborted) {
+      ledgerRetainOnly(queued);
     }
-  } catch {
+    progressEnd(passToken, signal.aborted ? "stopped" : stopReason);
+  } catch (error) {
     // Sync is best-effort by construction. A failure means the reader has
     // whatever was stored before, which is the same position they were in
     // without this feature.
+    progressEnd(
+      passToken,
+      "error",
+      error instanceof Error ? error.message : String(error),
+    );
   } finally {
     running = false;
     controller = null;

--- a/apps/standard-reader/src/pwa/offline-sync.ts
+++ b/apps/standard-reader/src/pwa/offline-sync.ts
@@ -497,6 +497,52 @@ async function warmPublications(
 }
 
 /**
+ * Every family/weight the interface can ask for, as `document.fonts.load`
+ * shorthand. Mirrors the Google Fonts request in `__root.tsx`.
+ */
+const UI_FONT_FACES = [
+  ...[300, 400, 500, 600].flatMap((weight) => [
+    `${weight} 1rem 'Newsreader'`,
+    `italic ${weight} 1rem 'Newsreader'`,
+  ]),
+  ...[400, 500, 600, 700, 800, 900].map(
+    (weight) => `${weight} 1rem 'Atkinson Hyperlegible Next'`,
+  ),
+  ...[400, 500, 600].map((weight) => `${weight} 1rem 'Spline Sans Mono'`),
+];
+
+/**
+ * Pull down every weight of the interface fonts, not just the ones already on
+ * screen.
+ *
+ * A browser downloads only the faces it actually uses, so a weight that first
+ * appears in a surface the reader hasn't opened — a sheet, a dialog — is never
+ * fetched and never cached. Offline it then has nothing to load, and because
+ * the stylesheet is requested with `display=optional`, the browser silently
+ * keeps the fallback for the rest of the page rather than swapping when it
+ * eventually arrives. The result is one panel in the wrong typeface while
+ * everything around it looks right.
+ *
+ * `document.fonts.load` forces each face to be fetched, which puts it in the
+ * `google-fonts` cache alongside the rest.
+ */
+async function warmFonts(signal: AbortSignal): Promise<void> {
+  const fonts = (globalThis.document as Document & { fonts?: FontFaceSet })
+    ?.fonts;
+  if (!fonts?.load) return;
+  await Promise.all(
+    UI_FONT_FACES.map(async (face) => {
+      if (signal.aborted) return;
+      try {
+        await fonts.load(face);
+      } catch {
+        // A face the reader's chosen interface font doesn't define.
+      }
+    }),
+  );
+}
+
+/**
  * Followed authors, which sit in the same sidebar section as subscriptions and
  * failed the same way: listed, and unopenable.
  */
@@ -613,6 +659,7 @@ export async function runOfflineSync(router: AnyRouter): Promise<void> {
     // Before any bodies. An unwarmed feed drops a fully-cached page into the
     // offline state, so the surfaces come first and the articles follow.
     await warmRouteChunks(router, signal);
+    await warmFonts(signal);
     await warmFeedData(signal);
     await warmPublications(router, signal);
     await warmFollowedUsers(router, signal);

--- a/apps/standard-reader/src/pwa/offline-sync.ts
+++ b/apps/standard-reader/src/pwa/offline-sync.ts
@@ -26,7 +26,11 @@
 
 import type { AnyRouter } from "@tanstack/react-router";
 
-import { feedApi } from "#/integrations/tanstack-query/api-feed.functions";
+import {
+  feedApi,
+  latestFeedPageSize,
+} from "#/integrations/tanstack-query/api-feed.functions";
+import { notesApi } from "#/integrations/tanstack-query/api-notes.functions";
 import { publicationApi } from "#/integrations/tanstack-query/api-publication.functions";
 import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
 import { documentImages } from "#/lib/document/images";
@@ -73,6 +77,22 @@ const STORAGE_CHECK_INTERVAL = 25;
 
 /** Page size for the already-read backlog walk. */
 const BACKLOG_PAGE_SIZE = 50;
+
+/**
+ * How many subscribed publications to store pages for.
+ *
+ * Each costs four requests, so this is a latency bound rather than a storage
+ * one — the pages themselves are small next to article bodies.
+ */
+const MAX_WARMED_PUBLICATIONS = 60;
+
+/**
+ * Must match `/p/$did/$rkey`'s loader. These values reach the server, so a
+ * drift here is not a type error — it is a cache entry stored under a URL the
+ * publication page never requests, and an offline page that silently fails.
+ */
+const PUBLICATION_RECENT_LIMIT = 12;
+const PUBLICATION_RECENT_FILTER = "all";
 
 /**
  * How far back to keep reading history available offline.
@@ -291,7 +311,7 @@ async function warmArticleRoute(
  */
 const OFFLINE_ROUTES = ["/", "/latest", "/saved", "/subscriptions"] as const;
 
-async function warmRoutes(
+async function warmRouteChunks(
   router: AnyRouter,
   signal: AbortSignal,
 ): Promise<void> {
@@ -304,6 +324,95 @@ async function warmRoutes(
       // throws here. Neither is a reason to stop warming the rest.
     }
   }
+}
+
+/**
+ * Fetch the server functions the offline routes' loaders await, by calling them
+ * exactly as those loaders do.
+ *
+ * Explicit rather than inferred. `preloadRoute` cannot be trusted to cache
+ * anything (see {@link warmRouteChunks}), so the surfaces that must survive
+ * offline are named here; each call's response lands in the `data` cache under
+ * the URL its loader will later ask for.
+ */
+async function warmFeedData(signal: AbortSignal): Promise<void> {
+  // These argument objects are cache keys, not just arguments: a GET server
+  // function serialises them into its URL, so an extra or missing property
+  // caches under a URL nothing ever requests. Each call below mirrors the
+  // shape its loader/queryFn sends, key for key.
+  const warmers: Array<() => Promise<unknown>> = [
+    // `_layout.index.tsx`: `getHomePage({ data: { scope: deps.scope } })`,
+    // with `deps.scope` undefined for a plain `/`.
+    () => feedApi.getHomePage({ data: { scope: undefined } }),
+    () => feedApi.getSidebar(),
+    // `getLatestFeedQueryOptions`' queryFn always sends all three keys.
+    // Only the filters that survive offline: `all` and `trending` are
+    // network-wide, and their tabs are hidden.
+    ...(["unread", "subscriptions"] as const).map(
+      (filter) => () =>
+        feedApi.getLatestFeed({
+          data: { filter, limit: latestFeedPageSize(filter), offset: 0 },
+        }),
+    ),
+    () => feedApi.getLatestFeedCounts(),
+  ];
+
+  for (const warm of warmers) {
+    if (signal.aborted || isOffline()) return;
+    try {
+      await warm();
+    } catch {
+      // Signed out, or a surface this reader does not have. Keep going.
+    }
+  }
+}
+
+/**
+ * Cache the reader's subscribed publications.
+ *
+ * Opening a publication from the sidebar or a byline is an obvious thing to do
+ * offline and it failed outright — nothing had ever requested `getPublication`
+ * for it, so there was nothing to serve. Subscriptions are a bounded set the
+ * reader chose, which makes them worth fetching up front.
+ */
+async function warmPublications(signal: AbortSignal): Promise<void> {
+  let following: Array<{ uri: string }>;
+  try {
+    const sidebar = await feedApi.getSidebar();
+    following = sidebar.following;
+  } catch {
+    return;
+  }
+
+  await pool(
+    following.slice(0, MAX_WARMED_PUBLICATIONS).map((pub) => pub.uri),
+    BODY_CONCURRENCY,
+    signal,
+    async (publicationUri) => {
+      // Exactly what `/p/$did/$rkey`'s loader awaits, with the argument values
+      // its query options default to. `readerScope` is not passed: it varies
+      // the React Query key only, never the request the server sees.
+      await Promise.all([
+        publicationApi.getPublicationHeader({ data: { publicationUri } }),
+        publicationApi.getPublicationDocuments({
+          // Key order matters as much as the values: the payload is serialised
+          // into the URL in insertion order, so this must mirror
+          // `getPublicationDocumentsQueryOptions`' queryFn exactly.
+          data: {
+            publicationUri,
+            limit: PUBLICATION_RECENT_LIMIT,
+            offset: 0,
+            filter: PUBLICATION_RECENT_FILTER,
+          },
+        }),
+        notesApi.getPublicationLatestNote({ data: { publicationUri } }),
+        publicationApi
+          .getPublicationSocialProof({ data: { publicationUri } })
+          // Signed-out readers never request this, so a failure is expected.
+          .catch(() => null),
+      ]);
+    },
+  );
 }
 
 export function stopOfflineSync(): void {
@@ -338,9 +447,11 @@ export async function runOfflineSync(router: AnyRouter): Promise<void> {
     void globalThis.navigator?.storage?.persist?.();
 
     await warmShell(signal);
-    // Before any bodies: these are what the offline routes' loaders await, and
-    // an unwarmed one drops a fully-cached page into the offline state.
-    await warmRoutes(router, signal);
+    // Before any bodies. An unwarmed feed drops a fully-cached page into the
+    // offline state, so the surfaces come first and the articles follow.
+    await warmRouteChunks(router, signal);
+    await warmFeedData(signal);
+    await warmPublications(signal);
 
     const fresh = ledgerFreshUris(Date.now());
     const seen = new Set<string>();

--- a/apps/standard-reader/src/pwa/offline-sync.ts
+++ b/apps/standard-reader/src/pwa/offline-sync.ts
@@ -27,14 +27,20 @@
 import type { AnyRouter } from "@tanstack/react-router";
 
 import {
+  AUTHOR_ACTIVITY_PAGE_SIZE,
+  authorApi,
+} from "#/integrations/tanstack-query/api-author.functions";
+import {
   feedApi,
   latestFeedPageSize,
 } from "#/integrations/tanstack-query/api-feed.functions";
+import { listApi } from "#/integrations/tanstack-query/api-lists.functions";
 import { notesApi } from "#/integrations/tanstack-query/api-notes.functions";
 import { publicationApi } from "#/integrations/tanstack-query/api-publication.functions";
 import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
 import { documentImages } from "#/lib/document/images";
 import { parseAtUri } from "#/server/atproto/uri";
+import { listRefFromUri } from "#/server/reader/saved-lists";
 
 import {
   ledgerFreshUris,
@@ -102,6 +108,12 @@ const MAX_WARMED_PUBLICATIONS = 60;
  */
 const PUBLICATION_RECENT_LIMIT = 12;
 const PUBLICATION_RECENT_FILTER = "all";
+
+/** Must match `/u/$did`'s loader (`AUTHOR_PAGE_SIZE`), same caveat as above. */
+const AUTHOR_PAGE_SIZE = 24;
+
+/** Must match `/l/$did/$rkey`'s loader (`PAGE_SIZE`), same caveat as above. */
+const LIST_PAGE_SIZE = 20;
 
 let running = false;
 let controller: AbortController | null = null;
@@ -278,18 +290,14 @@ async function syncDocument(
 async function warmArticleRoute(
   router: AnyRouter,
   documentUri: string,
+  to: "/a/$did/$rkey" | "/collection/$did/$rkey" = "/a/$did/$rkey",
 ): Promise<void> {
   const parsed = parseAtUri(documentUri);
   if (!parsed) return;
-  try {
-    await router.preloadRoute({
-      params: { did: parsed.did, rkey: parsed.rkey },
-      to: "/a/$did/$rkey",
-    });
-  } catch {
-    // A document that redirects (comic, collection) or 404s is not a reason to
-    // abandon the pass — the chunk load is the point, and it already happened.
-  }
+  await preloadRouteChunk(router, to, {
+    did: parsed.did,
+    rkey: parsed.rkey,
+  });
 }
 
 /**
@@ -322,6 +330,32 @@ async function warmRouteChunks(
       // Signed-out readers have no /saved or /subscriptions, and a redirect
       // throws here. Neither is a reason to stop warming the rest.
     }
+  }
+}
+
+/**
+ * Pull one parameterised route's JS into the `assets` cache.
+ *
+ * Every route is code-split, and a chunk is fetched only when someone visits
+ * that route — measuring the cache after a visit to `/` finds exactly one
+ * route chunk in it. Caching a page's *data* without its code produces the
+ * worst kind of failure: the loader has everything it needs and the thing that
+ * renders it 404s. Any surface reachable offline needs both, so it goes through
+ * here.
+ *
+ * One representative page per route is enough; the chunk is shared by all of
+ * them.
+ */
+async function preloadRouteChunk(
+  router: AnyRouter,
+  to: string,
+  params: Record<string, string>,
+): Promise<void> {
+  try {
+    await router.preloadRoute({ params, to });
+  } catch {
+    // Preload runs the loader's prefetch branch and can reject or redirect.
+    // The chunk load is the point and has already happened.
   }
 }
 
@@ -373,6 +407,7 @@ async function warmFeedData(signal: AbortSignal): Promise<void> {
 async function warmLatestPages(
   filter: "unread" | "subscriptions",
   signal: AbortSignal,
+  onCollection?: (documentUri: string) => void,
 ): Promise<Array<string>> {
   const limit = latestFeedPageSize(filter);
   const uris: Array<string> = [];
@@ -387,7 +422,13 @@ async function warmLatestPages(
     } catch {
       break;
     }
-    for (const item of feed.items) uris.push(item.uri);
+    for (const item of feed.items) {
+      uris.push(item.uri);
+      // A collection article redirects `/a/…` → `/collection/…` for readers who
+      // open collections as magazines, so that route is reachable offline even
+      // though its nav entry is hidden — and it needs its own chunk.
+      if (item.isCollection) onCollection?.(item.uri);
+    }
     if (feed.nextOffset == null) break;
     offset = feed.nextOffset;
     await whenIdle(signal);
@@ -416,22 +457,12 @@ async function warmPublications(
     return;
   }
 
-  // The route's own JS chunk, which is code-split
-  // (`_layout.p._did._rkey-*.js`) and cached only on demand. Warming the data
-  // without it left every publication in the sidebar listed but unopenable:
-  // the loader had everything it needed and the chunk that renders it 404'd.
-  // One preload pulls it in; the rest of this function is data for the others.
   const first = following[0] ? parseAtUri(following[0].uri) : null;
   if (first) {
-    try {
-      await router.preloadRoute({
-        params: { did: first.did, rkey: first.rkey },
-        to: "/p/$did/$rkey",
-      });
-    } catch {
-      // Preload runs the loader's prefetch branch and may reject; the chunk
-      // load is what matters and has already happened.
-    }
+    await preloadRouteChunk(router, "/p/$did/$rkey", {
+      did: first.did,
+      rkey: first.rkey,
+    });
   }
 
   await pool(
@@ -463,6 +494,88 @@ async function warmPublications(
       ]);
     },
   );
+}
+
+/**
+ * Followed authors, which sit in the same sidebar section as subscriptions and
+ * failed the same way: listed, and unopenable.
+ */
+async function warmFollowedUsers(
+  router: AnyRouter,
+  signal: AbortSignal,
+): Promise<void> {
+  let dids: Array<string>;
+  try {
+    const sidebar = await feedApi.getSidebar();
+    dids = sidebar.followingUsers.map((followed) => followed.did);
+  } catch {
+    return;
+  }
+  if (dids.length === 0) return;
+
+  await preloadRouteChunk(router, "/u/$did", { did: dids[0] ?? "" });
+
+  await pool(
+    dids.slice(0, MAX_WARMED_PUBLICATIONS),
+    BODY_CONCURRENCY,
+    signal,
+    async (did) => {
+      // `getAuthorProfileQueryOptions(did, { limit: AUTHOR_PAGE_SIZE })` —
+      // offset and activityLimit come from its own defaults.
+      await authorApi.getAuthorProfile({
+        data: {
+          did,
+          limit: AUTHOR_PAGE_SIZE,
+          offset: 0,
+          activityLimit: AUTHOR_ACTIVITY_PAGE_SIZE,
+        },
+      });
+    },
+  );
+}
+
+/**
+ * The reader's own lists and the ones they've saved — the rest of that sidebar.
+ */
+async function warmLists(
+  router: AnyRouter,
+  signal: AbortSignal,
+): Promise<void> {
+  let refs: Array<{ did: string; rkey: string }> = [];
+  try {
+    const [own, saved] = await Promise.all([
+      listApi.getLists(),
+      listApi.getSavedLists().catch(() => []),
+    ]);
+    // A saved list wraps the list it points at; an owned one is the list.
+    refs = [...own, ...saved.map((entry) => entry.list)]
+      .map((list) => listRefFromUri(list.uri))
+      .filter((ref): ref is { did: string; rkey: string } => ref !== null);
+  } catch {
+    return;
+  }
+  if (refs.length === 0) return;
+
+  const first = refs[0];
+  if (first) await preloadRouteChunk(router, "/l/$did/$rkey", first);
+
+  await pool(refs, BODY_CONCURRENCY, signal, async ({ did, rkey }) => {
+    await Promise.all([
+      listApi.getList({ data: { did, rkey } }),
+      // `getListFeedQueryOptions(did, rkey, { limit: PAGE_SIZE, offset: 0,
+      // readerScope })` — `hideRead` defaults false, and `readerScope` scopes
+      // the React Query key only.
+      listApi.getListFeed({
+        data: {
+          did,
+          rkey,
+          limit: LIST_PAGE_SIZE,
+          offset: 0,
+          hideRead: false,
+        },
+      }),
+    ]);
+  });
 }
 
 export function stopOfflineSync(): void {
@@ -502,6 +615,8 @@ export async function runOfflineSync(router: AnyRouter): Promise<void> {
     await warmRouteChunks(router, signal);
     await warmFeedData(signal);
     await warmPublications(router, signal);
+    await warmFollowedUsers(router, signal);
+    await warmLists(router, signal);
 
     const fresh = ledgerFreshUris(Date.now());
     const seen = new Set<string>();
@@ -554,9 +669,14 @@ export async function runOfflineSync(router: AnyRouter): Promise<void> {
     // offline and "load more" had nothing behind it. Walking the pages also
     // yields the subscriptions backlog — already-read posts that unread alone
     // misses — so the same requests serve both the list and its bodies.
+    let collectionWarmed = false;
     for (const filter of ["unread", "subscriptions"] as const) {
       if (stoppedEarly || signal.aborted || isOffline()) break;
-      const uris = await warmLatestPages(filter, signal);
+      const uris = await warmLatestPages(filter, signal, (documentUri) => {
+        if (collectionWarmed) return;
+        collectionWarmed = true;
+        void warmArticleRoute(router, documentUri, "/collection/$did/$rkey");
+      });
       for (const uri of uris) seen.add(uri);
       if (!(await cacheBodies(uris.filter((uri) => !fresh.has(uri))))) {
         stoppedEarly = true;

--- a/apps/standard-reader/src/pwa/offline-sync.ts
+++ b/apps/standard-reader/src/pwa/offline-sync.ts
@@ -1,0 +1,372 @@
+/**
+ * Pre-downloads the reader's unread articles so the installed app works with no
+ * connection.
+ *
+ * The service worker caches `/_serverFn` GETs (`vite.config.ts`), which makes
+ * *revisiting* things work offline. That is not enough on its own: the point of
+ * an installed reader is opening it on a plane and finding the backlog already
+ * there. So this walks the unread set and pulls each body through the network
+ * once, on purpose, while there is still a connection.
+ *
+ * Two details make it work rather than merely look like it works:
+ *
+ *   - Bodies are fetched by calling **the same `getArticle` server function the
+ *     article route's loader calls**, so the response lands in the `data` cache
+ *     under the exact URL that loader will later ask for. Anything cleverer
+ *     (a bespoke bulk endpoint, a hand-built URL) caches under a key nothing
+ *     reads back.
+ *   - Images are warmed with real `Image` elements, not `fetch`. The Workbox
+ *     rule matches on `request.destination === "image"`, which a `fetch()` does
+ *     not set — warming that way would download every image and cache none.
+ *
+ * Results are deliberately **not** written into the React Query cache: several
+ * hundred article bodies held in memory is a real cost, and the service worker
+ * is where they need to be anyway.
+ */
+
+import type { AnyRouter } from "@tanstack/react-router";
+
+import { publicationApi } from "#/integrations/tanstack-query/api-publication.functions";
+import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
+import { documentImages } from "#/lib/document/images";
+import { parseAtUri } from "#/server/atproto/uri";
+
+import {
+  ledgerFreshUris,
+  ledgerRecord,
+  ledgerRetainOnly,
+  offlineStorageUsage,
+} from "./offline-cache";
+import { isStandalone } from "./standalone";
+
+/**
+ * Whether to keep unread articles on this device. Device-scoped rather than a
+ * synced account preference: it is a statement about *this* phone's storage and
+ * data plan, not about the reader.
+ */
+export const OFFLINE_READING_STORAGE_KEY = "sr:offline-reading";
+
+/** Bodies in flight at once. Enough to hide latency, few enough to stay out of
+ * the way of anything the reader is actually doing. */
+const BODY_CONCURRENCY = 3;
+
+/** Images in flight at once, across all articles. */
+const IMAGE_CONCURRENCY = 4;
+
+/** Give up on an image rather than hold a slot forever on a dead CDN URL. */
+const IMAGE_TIMEOUT_MS = 15_000;
+
+/**
+ * Stop syncing once the origin is using this share of its quota.
+ *
+ * The unread set is uncapped by design, but the browser's patience is not: past
+ * roughly this point browsers start evicting the whole origin under pressure,
+ * which would take the already-downloaded backlog with it. Stopping early keeps
+ * what is already stored — and since the walk is newest-first, what is kept is
+ * the most recent unread.
+ */
+const STORAGE_PRESSURE_LIMIT = 0.8;
+
+/** Re-check the storage estimate every N documents rather than per document. */
+const STORAGE_CHECK_INTERVAL = 25;
+
+let running = false;
+let controller: AbortController | null = null;
+
+export function isOfflineReadingEnabled(): boolean {
+  if (globalThis.localStorage === undefined) return true;
+  try {
+    // Default on: absent key means the reader has never expressed a preference.
+    return globalThis.localStorage.getItem(OFFLINE_READING_STORAGE_KEY) !== "0";
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Read through a function rather than inline: an early
+ * `if (navigator.onLine === false) return` narrows the global to `true` for the
+ * rest of the enclosing function, and the loops below re-check it after
+ * awaiting.
+ */
+function isOffline(): boolean {
+  return globalThis.navigator?.onLine === false;
+}
+
+/** True when the reader has asked the OS to conserve data. */
+function saveDataRequested(): boolean {
+  const connection = (
+    globalThis.navigator as Navigator & {
+      connection?: { saveData?: boolean };
+    }
+  ).connection;
+  return connection?.saveData === true;
+}
+
+function whenIdle(signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const idle = (
+      globalThis as typeof globalThis & {
+        requestIdleCallback?: (
+          cb: () => void,
+          opts?: { timeout: number },
+        ) => void;
+      }
+    ).requestIdleCallback;
+    if (idle) {
+      idle(() => resolve(), { timeout: 2000 });
+    } else {
+      globalThis.setTimeout(resolve, 200);
+    }
+  });
+}
+
+/**
+ * Run `worker` over `items` with at most `limit` in flight. Rejections are
+ * swallowed per item — one unreachable document must not end the pass.
+ */
+async function pool<T>(
+  items: Array<T>,
+  limit: number,
+  signal: AbortSignal,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  let index = 0;
+  const runners = Array.from(
+    { length: Math.min(limit, items.length) },
+    async () => {
+      while (index < items.length && !signal.aborted) {
+        const item = items[index++];
+        if (item === undefined) return;
+        try {
+          await worker(item);
+        } catch {
+          // Skip and continue — see the doc comment.
+        }
+      }
+    },
+  );
+  await Promise.all(runners);
+}
+
+/**
+ * Fetch an image the way the article view will, so it lands under the same
+ * cache key. Resolves on success *and* failure — a broken image is not an error
+ * worth propagating.
+ */
+function warmImage(url: string, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted || globalThis.Image === undefined) {
+      resolve();
+      return;
+    }
+    const image = new globalThis.Image();
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      globalThis.clearTimeout(timer);
+      image.src = "";
+      resolve();
+    };
+    const timer = globalThis.setTimeout(done, IMAGE_TIMEOUT_MS);
+    image.addEventListener("load", done);
+    image.addEventListener("error", done);
+    image.src = url;
+  });
+}
+
+/** True when the origin is close enough to its quota that we should stop. */
+async function underStoragePressure(): Promise<boolean> {
+  const usage = await offlineStorageUsage();
+  if (!usage?.quota) return false;
+  return usage.usage / usage.quota > STORAGE_PRESSURE_LIMIT;
+}
+
+/**
+ * Keep a document available for an offline cold start.
+ *
+ * An installed app is launched by icon, so the very first request after going
+ * offline is a navigation to `start_url`. That is served by the `pages`
+ * NetworkFirst rule, which only ever fills from real navigations — and inside
+ * the app every navigation is client-side, so it would otherwise only hold
+ * whatever document happened to boot the session. A plain `fetch("/")` cannot
+ * fill it either (no `navigate` request mode), hence the explicit put.
+ */
+async function warmShell(signal: AbortSignal): Promise<void> {
+  if (globalThis.caches === undefined) return;
+  try {
+    const response = await fetch("/", {
+      credentials: "include",
+      signal,
+    });
+    if (!response.ok) return;
+    const cache = await globalThis.caches.open("pages");
+    await cache.put("/", response);
+  } catch {
+    // Offline mid-pass, or Cache Storage unavailable (private browsing).
+  }
+}
+
+/** Pull one article body — and its images — into the service worker caches. */
+async function syncDocument(
+  documentUri: string,
+  signal: AbortSignal,
+): Promise<void> {
+  const article = await publicationApi.getArticle({ data: { documentUri } });
+  if (!article || signal.aborted) return;
+
+  const images = documentImages(article);
+  if (images.length > 0) {
+    await pool(
+      images.map((image) => image.url),
+      IMAGE_CONCURRENCY,
+      signal,
+      (url) => warmImage(url, signal),
+    );
+  }
+
+  ledgerRecord(documentUri, Date.now());
+}
+
+/**
+ * Warm the article route's JS chunk.
+ *
+ * Hashed chunks are runtime-cached, not precached (`vite.config.ts`), so a
+ * reader who installs the app and syncs a backlog without opening anything
+ * would have every body on device and no code to render them with. Preloading
+ * one article route pulls the chunk into the `assets` cache; it also runs that
+ * route's loader, which is work we wanted done anyway.
+ */
+async function warmArticleRoute(
+  router: AnyRouter,
+  documentUri: string,
+): Promise<void> {
+  const parsed = parseAtUri(documentUri);
+  if (!parsed) return;
+  try {
+    await router.preloadRoute({
+      params: { did: parsed.did, rkey: parsed.rkey },
+      to: "/a/$did/$rkey",
+    });
+  } catch {
+    // A document that redirects (comic, collection) or 404s is not a reason to
+    // abandon the pass — the chunk load is the point, and it already happened.
+  }
+}
+
+export function stopOfflineSync(): void {
+  controller?.abort();
+  controller = null;
+  running = false;
+}
+
+/**
+ * Walk the reader's unread set and make it available offline.
+ *
+ * No-ops unless this is the installed app: the whole point is the launcher
+ * icon that opens with no connection, and silently downloading someone's
+ * backlog because they opened the website in a tab is not a trade a website
+ * visitor agreed to.
+ */
+export async function runOfflineSync(router: AnyRouter): Promise<void> {
+  if (running) return;
+  if (globalThis.window === undefined) return;
+  if (!isStandalone()) return;
+  if (!isOfflineReadingEnabled()) return;
+  if (isOffline()) return;
+  if (saveDataRequested()) return;
+
+  running = true;
+  controller = new AbortController();
+  const { signal } = controller;
+
+  try {
+    // Ask once per install. Without this the browser treats the whole origin as
+    // discardable and can drop a synced backlog under storage pressure.
+    void globalThis.navigator?.storage?.persist?.();
+
+    await warmShell(signal);
+
+    const fresh = ledgerFreshUris(Date.now());
+    const seen = new Set<string>();
+    let cursor: { publishedAt: string; uri: string } | null = null;
+    let routeWarmed = false;
+    let stoppedEarly = false;
+
+    do {
+      if (signal.aborted || isOffline()) break;
+
+      const page: Awaited<ReturnType<typeof readerApi.getUnreadDocumentUris>> =
+        await readerApi.getUnreadDocumentUris({
+          data: cursor ? { cursor } : {},
+        });
+      for (const uri of page.uris) seen.add(uri);
+      cursor = page.nextCursor;
+
+      const pending = page.uris.filter((uri) => !fresh.has(uri));
+
+      if (!routeWarmed && pending[0]) {
+        routeWarmed = true;
+        await warmArticleRoute(router, pending[0]);
+      }
+
+      for (let i = 0; i < pending.length; i += STORAGE_CHECK_INTERVAL) {
+        if (signal.aborted || isOffline()) break;
+        if (await underStoragePressure()) {
+          stoppedEarly = true;
+          break;
+        }
+        await pool(
+          pending.slice(i, i + STORAGE_CHECK_INTERVAL),
+          BODY_CONCURRENCY,
+          signal,
+          (uri) => syncDocument(uri, signal),
+        );
+        await whenIdle(signal);
+      }
+
+      if (stoppedEarly) break;
+    } while (cursor && !signal.aborted);
+
+    // Only prune once the whole set is known — a partial walk would drop ledger
+    // entries for documents that are still unread further down the list, and
+    // they would all be re-downloaded next pass.
+    if (!stoppedEarly && !cursor && !signal.aborted) {
+      ledgerRetainOnly(seen);
+    }
+  } catch {
+    // Sync is best-effort by construction. A failure means the reader has
+    // whatever was stored before, which is the same position they were in
+    // without this feature.
+  } finally {
+    running = false;
+    controller = null;
+  }
+}
+
+/**
+ * Start syncing after the app has settled, and again whenever the connection
+ * comes back. Returns a teardown for the caller's effect.
+ */
+export function startOfflineSync(router: AnyRouter): () => void {
+  const start = () => {
+    void runOfflineSync(router);
+  };
+
+  // Let the first paint and its data finish before competing for bandwidth.
+  const timer = globalThis.setTimeout(start, 5000);
+  globalThis.addEventListener?.("online", start);
+  globalThis.addEventListener?.("offline", stopOfflineSync);
+
+  return () => {
+    globalThis.clearTimeout(timer);
+    globalThis.removeEventListener?.("online", start);
+    globalThis.removeEventListener?.("offline", stopOfflineSync);
+    stopOfflineSync();
+  };
+}

--- a/apps/standard-reader/src/pwa/offline-sync.ts
+++ b/apps/standard-reader/src/pwa/offline-sync.ts
@@ -75,8 +75,17 @@ const STORAGE_PRESSURE_LIMIT = 0.8;
 /** Re-check the storage estimate every N documents rather than per document. */
 const STORAGE_CHECK_INTERVAL = 25;
 
-/** Page size for the already-read backlog walk. */
-const BACKLOG_PAGE_SIZE = 50;
+/**
+ * How deep to walk each `/latest` tab.
+ *
+ * Pages use the route's own size, so every page fetched is one the list asks
+ * for verbatim when the reader scrolls. Unlike the unread set this has no
+ * natural end — a reader with 200 subscriptions has an effectively infinite
+ * history, and "everything ever published" is not what keeping articles on the
+ * device means. 50 pages is ~1,000 rows per tab; the storage guard on bodies
+ * usually stops the pass before this does.
+ */
+const LATEST_WARM_MAX_PAGES = 50;
 
 /**
  * How many subscribed publications to store pages for.
@@ -93,16 +102,6 @@ const MAX_WARMED_PUBLICATIONS = 60;
  */
 const PUBLICATION_RECENT_LIMIT = 12;
 const PUBLICATION_RECENT_FILTER = "all";
-
-/**
- * How far back to keep reading history available offline.
- *
- * Unlike the unread set, this has no natural end — a reader with 200
- * subscriptions has an effectively infinite history, and "everything ever
- * published" is not what "keep my articles on this device" means. 50 pages is
- * roughly a couple of thousand posts; the storage guard usually stops it first.
- */
-const BACKLOG_MAX_PAGES = 50;
 
 let running = false;
 let controller: AbortController | null = null;
@@ -345,15 +344,6 @@ async function warmFeedData(signal: AbortSignal): Promise<void> {
     // with `deps.scope` undefined for a plain `/`.
     () => feedApi.getHomePage({ data: { scope: undefined } }),
     () => feedApi.getSidebar(),
-    // `getLatestFeedQueryOptions`' queryFn always sends all three keys.
-    // Only the filters that survive offline: `all` and `trending` are
-    // network-wide, and their tabs are hidden.
-    ...(["unread", "subscriptions"] as const).map(
-      (filter) => () =>
-        feedApi.getLatestFeed({
-          data: { filter, limit: latestFeedPageSize(filter), offset: 0 },
-        }),
-    ),
     () => feedApi.getLatestFeedCounts(),
   ];
 
@@ -365,6 +355,45 @@ async function warmFeedData(signal: AbortSignal): Promise<void> {
       // Signed out, or a surface this reader does not have. Keep going.
     }
   }
+}
+
+/**
+ * Page through `/latest` so scrolling works offline, not just the first screen.
+ *
+ * Warming offset 0 alone cached one screenful: the list looked short offline
+ * and "load more" had nothing behind it. Each page is a separate cache entry
+ * under its own `offset`, so they have to be walked the way the reader would
+ * walk them.
+ *
+ * Returns the article URIs seen, which is the same set the body pass wants —
+ * these pages *are* the subscriptions backlog, so walking them twice at two
+ * different page sizes would double the requests and cache a second copy of
+ * every row under URLs the UI never asks for.
+ */
+async function warmLatestPages(
+  filter: "unread" | "subscriptions",
+  signal: AbortSignal,
+): Promise<Array<string>> {
+  const limit = latestFeedPageSize(filter);
+  const uris: Array<string> = [];
+  let offset = 0;
+
+  for (let page = 0; page < LATEST_WARM_MAX_PAGES; page += 1) {
+    if (signal.aborted || isOffline()) break;
+    let feed: Awaited<ReturnType<typeof feedApi.getLatestFeed>>;
+    try {
+      // Mirrors both the loader and the route's own load-more call.
+      feed = await feedApi.getLatestFeed({ data: { filter, limit, offset } });
+    } catch {
+      break;
+    }
+    for (const item of feed.items) uris.push(item.uri);
+    if (feed.nextOffset == null) break;
+    offset = feed.nextOffset;
+    await whenIdle(signal);
+  }
+
+  return uris;
 }
 
 /**
@@ -499,34 +528,18 @@ export async function runOfflineSync(router: AnyRouter): Promise<void> {
       }
     } while (cursor && !signal.aborted);
 
-    // ── Then older, already-read posts from the reader's subscriptions. ──
-    // Unread alone leaves the app usable but oddly hollow offline: scrolling
-    // back through Latest or opening a publication hits articles that were
-    // read once and never stored. This walks the same feed `/latest` shows
-    // (`subscriptions` — read and unread alike), oldest work last, and stops on
-    // the storage guard rather than a size the reader never chose.
-    let backlogPage = 0;
-    let offset = 0;
-    while (
-      !stoppedEarly &&
-      backlogPage < BACKLOG_MAX_PAGES &&
-      !signal.aborted &&
-      !isOffline()
-    ) {
-      const feed = await feedApi.getLatestFeed({
-        data: { filter: "subscriptions", limit: BACKLOG_PAGE_SIZE, offset },
-      });
-      const uris = feed.items.map((item) => item.uri);
+    // ── Then the /latest tabs, deep enough to scroll. ──
+    // Warming offset 0 alone cached one screenful, so the lists looked short
+    // offline and "load more" had nothing behind it. Walking the pages also
+    // yields the subscriptions backlog — already-read posts that unread alone
+    // misses — so the same requests serve both the list and its bodies.
+    for (const filter of ["unread", "subscriptions"] as const) {
+      if (stoppedEarly || signal.aborted || isOffline()) break;
+      const uris = await warmLatestPages(filter, signal);
       for (const uri of uris) seen.add(uri);
-
       if (!(await cacheBodies(uris.filter((uri) => !fresh.has(uri))))) {
         stoppedEarly = true;
-        break;
       }
-
-      if (feed.nextOffset == null) break;
-      offset = feed.nextOffset;
-      backlogPage += 1;
     }
 
     // Prune only after a complete pass. A partial walk would drop entries for

--- a/apps/standard-reader/src/pwa/offline-sync.ts
+++ b/apps/standard-reader/src/pwa/offline-sync.ts
@@ -26,6 +26,7 @@
 
 import type { AnyRouter } from "@tanstack/react-router";
 
+import { feedApi } from "#/integrations/tanstack-query/api-feed.functions";
 import { publicationApi } from "#/integrations/tanstack-query/api-publication.functions";
 import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
 import { documentImages } from "#/lib/document/images";
@@ -69,6 +70,19 @@ const STORAGE_PRESSURE_LIMIT = 0.8;
 
 /** Re-check the storage estimate every N documents rather than per document. */
 const STORAGE_CHECK_INTERVAL = 25;
+
+/** Page size for the already-read backlog walk. */
+const BACKLOG_PAGE_SIZE = 50;
+
+/**
+ * How far back to keep reading history available offline.
+ *
+ * Unlike the unread set, this has no natural end — a reader with 200
+ * subscriptions has an effectively infinite history, and "everything ever
+ * published" is not what "keep my articles on this device" means. 50 pages is
+ * roughly a couple of thousand posts; the storage guard usually stops it first.
+ */
+const BACKLOG_MAX_PAGES = 50;
 
 let running = false;
 let controller: AbortController | null = null;
@@ -259,6 +273,39 @@ async function warmArticleRoute(
   }
 }
 
+/**
+ * The routes that must work with no connection, warmed by running their real
+ * loaders.
+ *
+ * This is the fix for pages that flashed their content and then dropped to the
+ * offline state. A route loader `await`s `ensureQueryData`, which **rejects**
+ * when a query has no cached data and the fetch fails — and one rejection in a
+ * `Promise.all` throws the whole loader into the error component, even when the
+ * article or feed it was really after is sitting in the cache. Caching bodies
+ * alone was never enough; what a loader awaits includes preferences, shell
+ * bootstrap, tab counts, and rail data.
+ *
+ * Preloading runs exactly those loaders, so whatever each one awaits is cached
+ * under exactly the URL it will ask for. Guessing that list by hand would go
+ * stale the first time a loader changed.
+ */
+const OFFLINE_ROUTES = ["/", "/latest", "/saved", "/subscriptions"] as const;
+
+async function warmRoutes(
+  router: AnyRouter,
+  signal: AbortSignal,
+): Promise<void> {
+  for (const to of OFFLINE_ROUTES) {
+    if (signal.aborted || isOffline()) return;
+    try {
+      await router.preloadRoute({ to });
+    } catch {
+      // Signed-out readers have no /saved or /subscriptions, and a redirect
+      // throws here. Neither is a reason to stop warming the rest.
+    }
+  }
+}
+
 export function stopOfflineSync(): void {
   controller?.abort();
   controller = null;
@@ -291,6 +338,9 @@ export async function runOfflineSync(router: AnyRouter): Promise<void> {
     void globalThis.navigator?.storage?.persist?.();
 
     await warmShell(signal);
+    // Before any bodies: these are what the offline routes' loaders await, and
+    // an unwarmed one drops a fully-cached page into the offline state.
+    await warmRoutes(router, signal);
 
     const fresh = ledgerFreshUris(Date.now());
     const seen = new Set<string>();
@@ -298,6 +348,23 @@ export async function runOfflineSync(router: AnyRouter): Promise<void> {
     let routeWarmed = false;
     let stoppedEarly = false;
 
+    /** Cache a batch of bodies; returns false when storage says stop. */
+    const cacheBodies = async (uris: Array<string>): Promise<boolean> => {
+      for (let i = 0; i < uris.length; i += STORAGE_CHECK_INTERVAL) {
+        if (signal.aborted || isOffline()) return false;
+        if (await underStoragePressure()) return false;
+        await pool(
+          uris.slice(i, i + STORAGE_CHECK_INTERVAL),
+          BODY_CONCURRENCY,
+          signal,
+          (uri) => syncDocument(uri, signal),
+        );
+        await whenIdle(signal);
+      }
+      return true;
+    };
+
+    // ── Unread first. Uncapped: this is the backlog the reader came for. ──
     do {
       if (signal.aborted || isOffline()) break;
 
@@ -315,27 +382,46 @@ export async function runOfflineSync(router: AnyRouter): Promise<void> {
         await warmArticleRoute(router, pending[0]);
       }
 
-      for (let i = 0; i < pending.length; i += STORAGE_CHECK_INTERVAL) {
-        if (signal.aborted || isOffline()) break;
-        if (await underStoragePressure()) {
-          stoppedEarly = true;
-          break;
-        }
-        await pool(
-          pending.slice(i, i + STORAGE_CHECK_INTERVAL),
-          BODY_CONCURRENCY,
-          signal,
-          (uri) => syncDocument(uri, signal),
-        );
-        await whenIdle(signal);
+      if (!(await cacheBodies(pending))) {
+        stoppedEarly = true;
+        break;
       }
-
-      if (stoppedEarly) break;
     } while (cursor && !signal.aborted);
 
-    // Only prune once the whole set is known — a partial walk would drop ledger
-    // entries for documents that are still unread further down the list, and
-    // they would all be re-downloaded next pass.
+    // ── Then older, already-read posts from the reader's subscriptions. ──
+    // Unread alone leaves the app usable but oddly hollow offline: scrolling
+    // back through Latest or opening a publication hits articles that were
+    // read once and never stored. This walks the same feed `/latest` shows
+    // (`subscriptions` — read and unread alike), oldest work last, and stops on
+    // the storage guard rather than a size the reader never chose.
+    let backlogPage = 0;
+    let offset = 0;
+    while (
+      !stoppedEarly &&
+      backlogPage < BACKLOG_MAX_PAGES &&
+      !signal.aborted &&
+      !isOffline()
+    ) {
+      const feed = await feedApi.getLatestFeed({
+        data: { filter: "subscriptions", limit: BACKLOG_PAGE_SIZE, offset },
+      });
+      const uris = feed.items.map((item) => item.uri);
+      for (const uri of uris) seen.add(uri);
+
+      if (!(await cacheBodies(uris.filter((uri) => !fresh.has(uri))))) {
+        stoppedEarly = true;
+        break;
+      }
+
+      if (feed.nextOffset == null) break;
+      offset = feed.nextOffset;
+      backlogPage += 1;
+    }
+
+    // Prune only after a complete pass. A partial walk would drop entries for
+    // documents still further down the list, and re-download all of them next
+    // time. `seen` deliberately spans unread *and* backlog, so finishing an
+    // article does not evict the copy we just stored.
     if (!stoppedEarly && !cursor && !signal.aborted) {
       ledgerRetainOnly(seen);
     }

--- a/apps/standard-reader/src/pwa/offline-sync.ts
+++ b/apps/standard-reader/src/pwa/offline-sync.ts
@@ -57,9 +57,9 @@ import { isStandalone } from "./standalone";
  */
 export const OFFLINE_READING_STORAGE_KEY = "sr:offline-reading";
 
-/** Bodies in flight at once. Enough to hide latency, few enough to stay out of
- * the way of anything the reader is actually doing. */
-const BODY_CONCURRENCY = 3;
+/** Bodies in flight at once. Enough to hide the round trip, few enough to stay
+ * out of the way of whatever the reader is actually doing. */
+const BODY_CONCURRENCY = 5;
 
 /** Images in flight at once, across all articles. */
 const IMAGE_CONCURRENCY = 4;
@@ -87,19 +87,37 @@ const STORAGE_CHECK_INTERVAL = 25;
  * Pages use the route's own size, so every page fetched is one the list asks
  * for verbatim when the reader scrolls. Unlike the unread set this has no
  * natural end — a reader with 200 subscriptions has an effectively infinite
- * history, and "everything ever published" is not what keeping articles on the
- * device means. 50 pages is ~1,000 rows per tab; the storage guard on bodies
- * usually stops the pass before this does.
+ * history — but the real limit is meant to be the storage guard on bodies, not
+ * this. 150 pages is ~3,000 rows per tab; deep enough that scrolling back
+ * rarely runs out, and bounded so a bug can't walk forever.
  */
-const LATEST_WARM_MAX_PAGES = 50;
+const LATEST_WARM_MAX_PAGES = 150;
 
 /**
- * How many subscribed publications to store pages for.
- *
- * Each costs four requests, so this is a latency bound rather than a storage
- * one — the pages themselves are small next to article bodies.
+ * Always re-walk at least this many pages, even when nothing on them is new.
+ * The head of the list is what a reader sees first, so it stays fresh.
  */
-const MAX_WARMED_PUBLICATIONS = 60;
+const MIN_LATEST_WARM_PAGES = 2;
+
+/** Wait for the first paint and its data before competing for bandwidth. */
+const INITIAL_SYNC_DELAY_MS = 5000;
+
+/**
+ * How often to top up while the app stays open. Frequent enough to pick up new
+ * posts during a session, and affordable because a caught-up pass is a couple
+ * of feed requests (see `warmLatestPages`).
+ */
+const RESYNC_INTERVAL_MS = 5 * 60_000;
+
+/**
+ * How many subscribed publications and followed authors to store pages for.
+ *
+ * A bound on request count, not storage — these pages are small next to article
+ * bodies. Set well past what most readers follow so the cap is a backstop
+ * rather than something people actually hit; the pass runs once per session
+ * (see {@link runOfflineSync}), so it isn't paid repeatedly.
+ */
+const MAX_WARMED_PUBLICATIONS = 250;
 
 /**
  * Must match `/p/$did/$rkey`'s loader. These values reach the server, so a
@@ -117,6 +135,8 @@ const LIST_PAGE_SIZE = 20;
 
 let running = false;
 let controller: AbortController | null = null;
+/** Whether the session-scoped, run-once work has been done (see the pass). */
+let didFullPass = false;
 
 export function isOfflineReadingEnabled(): boolean {
   if (globalThis.localStorage === undefined) return true;
@@ -407,11 +427,13 @@ async function warmFeedData(signal: AbortSignal): Promise<void> {
 async function warmLatestPages(
   filter: "unread" | "subscriptions",
   signal: AbortSignal,
+  known: ReadonlySet<string>,
   onCollection?: (documentUri: string) => void,
 ): Promise<Array<string>> {
   const limit = latestFeedPageSize(filter);
   const uris: Array<string> = [];
   let offset = 0;
+  let settledPages = 0;
 
   for (let page = 0; page < LATEST_WARM_MAX_PAGES; page += 1) {
     if (signal.aborted || isOffline()) break;
@@ -422,13 +444,25 @@ async function warmLatestPages(
     } catch {
       break;
     }
+
+    let fresh = 0;
     for (const item of feed.items) {
       uris.push(item.uri);
+      if (!known.has(item.uri)) fresh += 1;
       // A collection article redirects `/a/…` → `/collection/…` for readers who
       // open collections as magazines, so that route is reachable offline even
       // though its nav entry is hidden — and it needs its own chunk.
       if (item.isCollection) onCollection?.(item.uri);
     }
+
+    // Stop once the walk reaches depth it already has. This is what makes
+    // running every few minutes affordable: the first pass goes as deep as the
+    // cap allows, and each pass after it costs a couple of pages unless
+    // something new arrived. Two consecutive settled pages rather than one, so
+    // a single page of re-reads doesn't end the walk early.
+    settledPages = fresh === 0 ? settledPages + 1 : 0;
+    if (page >= MIN_LATEST_WARM_PAGES && settledPages >= 2) break;
+
     if (feed.nextOffset == null) break;
     offset = feed.nextOffset;
     await whenIdle(signal);
@@ -649,6 +683,8 @@ export async function runOfflineSync(router: AnyRouter): Promise<void> {
   running = true;
   controller = new AbortController();
   const { signal } = controller;
+  // The first pass of a session goes wide and deep; the ones after it top up.
+  const fullPass = !didFullPass;
 
   try {
     // Ask once per install. Without this the browser treats the whole origin as
@@ -658,12 +694,24 @@ export async function runOfflineSync(router: AnyRouter): Promise<void> {
     await warmShell(signal);
     // Before any bodies. An unwarmed feed drops a fully-cached page into the
     // offline state, so the surfaces come first and the articles follow.
-    await warmRouteChunks(router, signal);
-    await warmFonts(signal);
     await warmFeedData(signal);
-    await warmPublications(router, signal);
-    await warmFollowedUsers(router, signal);
-    await warmLists(router, signal);
+
+    // Route chunks, fonts, and every publication / author / list the reader
+    // follows: a large, fixed set that does not change during a session. Doing
+    // it once is what lets the pass repeat every few minutes — re-fetching a
+    // few hundred sidebar pages on a timer would be a lot of traffic for
+    // nothing. A new session redoes it, which is when it can have changed.
+    if (fullPass) {
+      await warmRouteChunks(router, signal);
+      await warmFonts(signal);
+      await warmPublications(router, signal);
+      await warmFollowedUsers(router, signal);
+      await warmLists(router, signal);
+      // Only once it has actually finished. A pass that lost the connection
+      // two seconds in must not convince the rest of the session that the
+      // sidebar is cached.
+      if (!signal.aborted && !isOffline()) didFullPass = true;
+    }
 
     const fresh = ledgerFreshUris(Date.now());
     const seen = new Set<string>();
@@ -719,22 +767,29 @@ export async function runOfflineSync(router: AnyRouter): Promise<void> {
     let collectionWarmed = false;
     for (const filter of ["unread", "subscriptions"] as const) {
       if (stoppedEarly || signal.aborted || isOffline()) break;
-      const uris = await warmLatestPages(filter, signal, (documentUri) => {
-        if (collectionWarmed) return;
-        collectionWarmed = true;
-        void warmArticleRoute(router, documentUri, "/collection/$did/$rkey");
-      });
+      const uris = await warmLatestPages(
+        filter,
+        signal,
+        // What the walk already has, so it can stop once it reaches it.
+        fresh,
+        (documentUri) => {
+          if (collectionWarmed) return;
+          collectionWarmed = true;
+          void warmArticleRoute(router, documentUri, "/collection/$did/$rkey");
+        },
+      );
       for (const uri of uris) seen.add(uri);
       if (!(await cacheBodies(uris.filter((uri) => !fresh.has(uri))))) {
         stoppedEarly = true;
       }
     }
 
-    // Prune only after a complete pass. A partial walk would drop entries for
-    // documents still further down the list, and re-download all of them next
-    // time. `seen` deliberately spans unread *and* backlog, so finishing an
-    // article does not evict the copy we just stored.
-    if (!stoppedEarly && !cursor && !signal.aborted) {
+    // Prune only after a pass that actually saw everything — the deep first
+    // one. Later passes stop as soon as the feed walk reaches familiar ground,
+    // so `seen` covers the head of the list and nothing below it; pruning to
+    // that would evict the whole backlog and re-download it next time. Entries
+    // the reader has worked through age out of the ledger on their own.
+    if (fullPass && !stoppedEarly && !cursor && !signal.aborted) {
       ledgerRetainOnly(seen);
     }
   } catch {
@@ -756,15 +811,30 @@ export function startOfflineSync(router: AnyRouter): () => void {
     void runOfflineSync(router);
   };
 
-  // Let the first paint and its data finish before competing for bandwidth.
-  const timer = globalThis.setTimeout(start, 5000);
+  // Keep going for as long as the app is open, rather than filling once and
+  // stopping: new posts arrive, and a pass that hit the storage guard or lost
+  // the connection has more to do. Repeat passes are cheap by construction —
+  // the ledger skips bodies already stored, and the feed walk stops as soon as
+  // it reaches pages it has already seen (see `warmLatestPages`).
+  const timer = globalThis.setTimeout(start, INITIAL_SYNC_DELAY_MS);
+  const interval = globalThis.setInterval(start, RESYNC_INTERVAL_MS);
+
+  // Coming back to a backgrounded app is the other natural moment to top up:
+  // timers are throttled or suspended while hidden, so the interval alone can
+  // leave a long gap.
+  const onVisible = () => {
+    if (globalThis.document?.visibilityState === "visible") start();
+  };
   globalThis.addEventListener?.("online", start);
   globalThis.addEventListener?.("offline", stopOfflineSync);
+  globalThis.document?.addEventListener("visibilitychange", onVisible);
 
   return () => {
     globalThis.clearTimeout(timer);
+    globalThis.clearInterval(interval);
     globalThis.removeEventListener?.("online", start);
     globalThis.removeEventListener?.("offline", stopOfflineSync);
+    globalThis.document?.removeEventListener("visibilitychange", onVisible);
     stopOfflineSync();
   };
 }

--- a/apps/standard-reader/src/pwa/reload-prompt.tsx
+++ b/apps/standard-reader/src/pwa/reload-prompt.tsx
@@ -10,8 +10,10 @@ import {
   lineHeight,
 } from "@standard-reader/design-system/theme/typography.stylex";
 import * as stylex from "@stylexjs/stylex";
+import { useRouter } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
 
+import { startOfflineSync } from "./offline-sync";
 import { syncPushDevice } from "./push";
 import type { UpdateServiceWorker } from "./register";
 import { registerServiceWorker } from "./register";
@@ -57,6 +59,12 @@ export function ReloadPrompt() {
   const [needRefresh, setNeedRefresh] = useState(false);
   const [installed, setInstalled] = useState(false);
   const updateRef = useRef<UpdateServiceWorker | null>(null);
+  const router = useRouter();
+
+  // Keep the reader's unread backlog on the device. Gated on the installed app
+  // and on the reader's setting inside `startOfflineSync`, and started here
+  // because this is already the one place the app talks to its service worker.
+  useEffect(() => startOfflineSync(router), [router]);
 
   useEffect(() => {
     // Client-only: reading display mode during SSR would be a hydration

--- a/apps/standard-reader/src/router.tsx
+++ b/apps/standard-reader/src/router.tsx
@@ -1,6 +1,7 @@
 import { createRouter as createTanStackRouter } from "@tanstack/react-router";
 import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
 
+import { RouteError } from "./components/route-error";
 import { getContext } from "./integrations/tanstack-query/root-provider";
 import { routeTree } from "./routeTree.gen";
 
@@ -19,6 +20,12 @@ export function getRouter() {
     defaultPreloadStaleTime: 30_000,
     // Keep the `:` in `did:plc:…` literal in `/p/$did/$rkey` (don't %-encode it).
     pathParamsAllowedCharacters: [":"],
+    // A loader that throws is usually a loader that couldn't reach the network.
+    // Since queries run in `offlineFirst` mode (see `query-client.ts`), an
+    // offline navigation to something the service worker never cached rejects
+    // here — this is what tells the reader that, instead of showing raw error
+    // text. Routes with their own `errorComponent` still win.
+    defaultErrorComponent: RouteError,
   });
 
   setupRouterSsrQueryIntegration({ router, queryClient: context.queryClient });

--- a/apps/standard-reader/src/routes/_layout.index.tsx
+++ b/apps/standard-reader/src/routes/_layout.index.tsx
@@ -515,7 +515,9 @@ function HomeFeed({
 
   const { data: extras, isPending: extrasPending } = useQuery({
     ...feedApi.getHomeExtrasQueryOptions({ scope, readerScope }),
-    enabled: hasMainContent,
+    // Everything this feeds is hidden offline, so the request is pure cost —
+    // and it would fail anyway, since the rails scan the network.
+    enabled: hasMainContent && online,
     refetchOnMount: false,
     refetchOnWindowFocus: false,
   });
@@ -546,8 +548,14 @@ function HomeFeed({
   // publications (sidebar) ship in the critical feed payload (above the fold,
   // no loader); only the "You might follow" rail is deferred to `extras`.
   const mainArticles = isTrending ? feed.trending : feed.latestUnread;
-  const trendingPubs = feed.trendingPublications;
-  const youMightFollow = extras?.youMightFollow ?? feed.youMightFollow;
+  // Both rails recommend publications the reader does *not* follow, so nothing
+  // behind them was ever synced — offline they are a column of links to pages
+  // that cannot load. Emptied rather than gated at each render site, so the
+  // rails and the skeleton that stands in for them drop out together.
+  const trendingPubs = online ? feed.trendingPublications : [];
+  const youMightFollow = online
+    ? (extras?.youMightFollow ?? feed.youMightFollow)
+    : [];
   const unreadCount =
     trackReading && feed.personalized
       ? (sidebar?.unreadCount ?? extras?.unreadCount ?? feed.unreadCount)
@@ -779,7 +787,7 @@ function HomeFeed({
             </div>
           ) : null}
 
-          {extrasPending ? (
+          {extrasPending && online ? (
             <HomeYouMightFollowRailSkeleton />
           ) : youMightFollow.length > 0 ? (
             <div {...stylex.props(styles.railCard)}>

--- a/apps/standard-reader/src/routes/_layout.index.tsx
+++ b/apps/standard-reader/src/routes/_layout.index.tsx
@@ -38,6 +38,7 @@ import { ButtonLink } from "#/components/router-links";
 import type { Formatters } from "#/lib/formatters";
 import { DEFAULT_TRACK_READING_HISTORY } from "#/lib/track-reading-history";
 import { useFormatters } from "#/lib/use-formatters";
+import { useOnlineStatus } from "#/lib/use-online-status";
 
 import {
   ArticleRow,
@@ -497,6 +498,7 @@ function HomeFeed({
     refetchOnWindowFocus: false,
   });
   const signedIn = Boolean(session?.user);
+  const online = useOnlineStatus();
   const isTrending = scope === "trending";
   const showNetworkFeed = isTrending || !feed.personalized;
   const trackReading =
@@ -524,12 +526,21 @@ function HomeFeed({
   const canToggleScope = signedIn && (sidebar?.hasFollows ?? feed.hasFollows);
   const otherScope: HomeScope = isTrending ? "follows" : "trending";
   useEffect(() => {
-    if (!canToggleScope) return;
+    // Pointless offline: the other scope is Trending, which is network-wide.
+    if (!canToggleScope || !online) return;
     void router.preloadRoute({
       to: Route.fullPath,
       search: { scope: otherScope },
     });
-  }, [router, canToggleScope, otherScope]);
+  }, [router, canToggleScope, otherScope, online]);
+
+  // Losing the connection on the Trending scope takes its toggle away with it,
+  // which would strand the reader on a feed they can't leave. Send them to the
+  // subscriptions feed, which is the one that's stored.
+  useEffect(() => {
+    if (online || !isTrending) return;
+    void navigate({ replace: true, search: {} });
+  }, [isTrending, navigate, online]);
 
   // Trending articles (main column on the Trending tab) and trending
   // publications (sidebar) ship in the critical feed payload (above the fold,
@@ -615,7 +626,10 @@ function HomeFeed({
     );
   }
 
-  const showScopeToggle = canToggleScope;
+  // Trending is a network-wide scope, so offline the toggle can only switch to
+  // a feed that isn't there. Only the subscriptions feed is stored, so the
+  // control comes out and Home renders it directly.
+  const showScopeToggle = canToggleScope && online;
 
   return (
     <ReaderContent>

--- a/apps/standard-reader/src/routes/_layout.latest.tsx
+++ b/apps/standard-reader/src/routes/_layout.latest.tsx
@@ -59,6 +59,7 @@ import { latestControlsVisibility } from "#/lib/latest-feed-controls";
 import { getPublicUrlClient } from "#/lib/public-url";
 import { latestFeedUrl, pageSocialMeta } from "#/lib/site-metadata";
 import { useFormatters } from "#/lib/use-formatters";
+import { useOnlineStatus } from "#/lib/use-online-status";
 import { useTrackReadingHistory } from "#/lib/use-track-reading-history";
 import { useLoginSearch } from "#/utils/use-login-search";
 
@@ -505,6 +506,7 @@ function Latest() {
   const { enabled: trackReading } = useTrackReadingHistory();
   const signedIn = Boolean(session?.user);
   const loginSearch = useLoginSearch();
+  const online = useOnlineStatus();
 
   // With reading history off there is no Unread tab, so `?filter=unread` is a
   // URL to normalise away, not a page the reader chose. `replace` keeps it out
@@ -513,6 +515,14 @@ function Latest() {
     if (trackReading || filter !== "unread") return;
     void navigate({ replace: true, search: { filter: "subscriptions" } });
   }, [filter, navigate, trackReading]);
+
+  // Same normalisation for losing the connection while on a network-wide tab:
+  // its tab is about to disappear, and leaving the reader on a filter with no
+  // control to leave it by is worse than moving them to one that has data.
+  useEffect(() => {
+    if (online || (filter !== "all" && filter !== "trending")) return;
+    void navigate({ replace: true, search: { filter: "subscriptions" } });
+  }, [filter, navigate, online]);
 
   useEffect(() => {
     // Signed-out readers only see the active feed (no tab switcher) — prefetching
@@ -688,10 +698,17 @@ function Latest() {
             <SegmentedControlItem id="subscriptions">
               {subscriptionsLabel}
             </SegmentedControlItem>
-            <SegmentedControlItem id="all">{allLabel}</SegmentedControlItem>
-            <SegmentedControlItem id="trending">
-              {trendingLabel}
-            </SegmentedControlItem>
+            {/* Network-wide tabs: everything in them is by definition outside
+                what offline sync stored, so offline they are two taps that can
+                only reach an error. */}
+            {online ? (
+              <SegmentedControlItem id="all">{allLabel}</SegmentedControlItem>
+            ) : null}
+            {online ? (
+              <SegmentedControlItem id="trending">
+                {trendingLabel}
+              </SegmentedControlItem>
+            ) : null}
           </SegmentedControl>
         ) : (
           <Flex>

--- a/apps/standard-reader/src/server/reader/queries.ts
+++ b/apps/standard-reader/src/server/reader/queries.ts
@@ -1048,9 +1048,31 @@ export async function selectPublicationArticleCards(
  */
 const DEFAULT_UNREAD_URI_LIMIT = 200;
 
-/** Unread document AT-URIs for a reader, optionally scoped to publications
- * and/or followed users (union — matches the follow feed). */
-export async function selectUnreadDocumentUris(
+/**
+ * Position in the unread walk, matching the `published_at desc, uri desc`
+ * ordering both branches below use. `documents.published_at` is `notNull`, so
+ * a plain row-wise `<` is a complete keyset — no NULL tiebreak needed.
+ */
+export interface UnreadDocumentCursor {
+  /** ISO-8601; cast to `timestamptz` at the comparison. */
+  publishedAt: string;
+  uri: string;
+}
+
+export interface UnreadDocumentRow {
+  uri: string;
+  publishedAt: Date;
+}
+
+/**
+ * One page of a reader's unread documents, newest first.
+ *
+ * Offline sync walks the reader's *entire* unread set, which has no ceiling —
+ * so this pages by keyset rather than accepting a single `limit` the way
+ * "mark all as read" does. Offset would drift as new documents arrive at the
+ * head mid-walk and degrade on deep backlogs; the keyset does neither.
+ */
+export async function selectUnreadDocumentPage(
   db: Db,
   schema: Schema,
   opts: {
@@ -1059,14 +1081,16 @@ export async function selectUnreadDocumentUris(
     followedUserDids?: Array<string>;
     countOldPostsAsUnread?: boolean;
     limit?: number;
+    cursor?: UnreadDocumentCursor;
   },
-): Promise<Array<string>> {
+): Promise<Array<UnreadDocumentRow>> {
   const {
     readerDid,
     publicationUris,
     followedUserDids,
     countOldPostsAsUnread,
     limit = DEFAULT_UNREAD_URI_LIMIT,
+    cursor,
   } = opts;
   const hasFollowedUsers = (followedUserDids?.length ?? 0) > 0;
   if (publicationUris && publicationUris.length === 0 && !hasFollowedUsers) {
@@ -1084,17 +1108,23 @@ export async function selectUnreadDocumentUris(
         ? sql`and (${readerSourceCutoffSql(schema, readerDid, sql`cand.publication_uri`, sql`cand.did`, sql`cand.uri`)} is null
             or cand.published_at >= ${readerSourceCutoffSql(schema, readerDid, sql`cand.publication_uri`, sql`cand.did`, sql`cand.uri`)})`
         : sql``;
+    const cursorFilter = cursor
+      ? sql`and (cand.published_at, cand.uri) < (${cursor.publishedAt}::timestamptz, ${cursor.uri})`
+      : sql``;
     const rows = await db.execute(sql`
       with cand as ${followFeedUnionSql(schema, publicationUris ?? [], followedUserDids ?? [])}
-      select cand.uri
+      select cand.uri, cand.published_at as "publishedAt"
       from cand
       left join ${r} on ${r.documentUri} = cand.uri
         and ${r.ownerDid} = ${readerDid} and ${r.deleted} = false
-      where ${r.uri} is null ${cutoffFilter}
+      where ${r.uri} is null ${cutoffFilter} ${cursorFilter}
       order by cand.published_at desc nulls last, cand.uri desc
       limit ${limit}
     `);
-    return executeRows<{ uri: string }>(rows).map((row) => row.uri);
+    return executeRows<UnreadDocumentRow>(rows).map((row) => ({
+      publishedAt: new Date(row.publishedAt),
+      uri: row.uri,
+    }));
   }
 
   const conds = [eq(d.deleted, false), documentPublishedNotInFuture(d)];
@@ -1111,9 +1141,14 @@ export async function selectUnreadDocumentUris(
     );
     conds.push(sql`(${cutoff} is null or ${d.publishedAt} >= ${cutoff})`);
   }
+  if (cursor) {
+    conds.push(
+      sql`(${d.publishedAt}, ${d.uri}) < (${cursor.publishedAt}::timestamptz, ${cursor.uri})`,
+    );
+  }
 
   const rows = await db
-    .select({ uri: d.uri })
+    .select({ publishedAt: d.publishedAt, uri: d.uri })
     .from(d)
     .leftJoin(
       r,
@@ -1127,6 +1162,23 @@ export async function selectUnreadDocumentUris(
     .orderBy(...documentsNewestFirst(d))
     .limit(limit);
 
+  return rows;
+}
+
+/** Unread document AT-URIs for a reader, optionally scoped to publications
+ * and/or followed users (union — matches the follow feed). */
+export async function selectUnreadDocumentUris(
+  db: Db,
+  schema: Schema,
+  opts: {
+    readerDid: string;
+    publicationUris?: Array<string>;
+    followedUserDids?: Array<string>;
+    countOldPostsAsUnread?: boolean;
+    limit?: number;
+  },
+): Promise<Array<string>> {
+  const rows = await selectUnreadDocumentPage(db, schema, opts);
   return rows.map((row) => row.uri);
 }
 

--- a/apps/standard-reader/vite.config.ts
+++ b/apps/standard-reader/vite.config.ts
@@ -194,7 +194,14 @@ const config = defineConfig({
             options: {
               cacheName: "pages",
               networkTimeoutSeconds: 3,
-              expiration: { maxEntries: 50, maxAgeSeconds: 60 * 60 * 24 },
+              // 30 days, not 24h: an installed app is launched by icon, and a
+              // cold start that lands here after a week away must still find a
+              // document to boot from. `offline-sync.ts` re-warms `/` on every
+              // successful pass, so entries stay fresh while the app is used.
+              expiration: {
+                maxEntries: 50,
+                maxAgeSeconds: 60 * 60 * 24 * 30,
+              },
               precacheFallback: { fallbackURL: "/offline.html" },
             },
           },
@@ -229,8 +236,43 @@ const config = defineConfig({
             handler: "CacheFirst",
             options: {
               cacheName: "images",
-              expiration: { maxEntries: 200, maxAgeSeconds: 60 * 60 * 24 * 30 },
+              // 200 covered "images you happened to scroll past". Offline sync
+              // warms every image in every unread body, and a single
+              // image-heavy article can carry dozens, so 200 evicted the
+              // earliest articles before the pass had finished.
+              expiration: {
+                maxEntries: 1500,
+                maxAgeSeconds: 60 * 60 * 24 * 30,
+              },
               cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+          {
+            // Read server functions. `createServerFn({ method: "GET" })`
+            // serialises its args into the query string, so
+            // `/_serverFn/<id>?payload=…` is a stable per-call URL — that is
+            // what makes offline reading possible at all. Workbox routes are
+            // GET-only, so mutations (POST) never land here.
+            //
+            // NetworkFirst, not StaleWhileRevalidate: this cache backs feeds,
+            // and serving yesterday's Latest for a beat on every navigation is
+            // worse than waiting. Responses may be framed/NDJSON streams —
+            // they are stored as opaque bytes and never parsed here.
+            //
+            // Entries are personal (the reader's DID comes from the session
+            // cookie, not the URL), so signing out drops this whole cache —
+            // see `clearOfflineData()` in `#/pwa/offline-cache`.
+            urlPattern: ({ url, sameOrigin }) =>
+              sameOrigin && url.pathname.startsWith("/_serverFn/"),
+            handler: "NetworkFirst",
+            options: {
+              cacheName: "data",
+              networkTimeoutSeconds: 10,
+              expiration: {
+                maxEntries: 3000,
+                maxAgeSeconds: 60 * 60 * 24 * 30,
+              },
+              cacheableResponse: { statuses: [200] },
             },
           },
         ],


### PR DESCRIPTION
Makes the installed app work with no connection: the reader's unread backlog is
downloaded ahead of time, and reaching for something that was never stored says
so instead of hanging or showing raw error text.

## What was actually broken

Offline support was scoped to assets only — `TODO.md` recorded Phase B as
*"service worker for asset caching only (not offline articles)"*. Investigating
turned up three separate things in the way, one of them a live production bug.

**The service worker had never done anything.** `sw.js` opens with
`define(["./workbox-<hash>"])` and loads that chunk via `importScripts` — every
route and the entire precache live behind it. Nitro's baked static-asset
manifest had **no entry for that chunk**, so it 404'd. The worker parsed,
registered, installed, activated, and set `navigator.serviceWorker.controller`
— its AMD factory simply never ran. Confirmed in a real browser: zero caches
created, zero responses served by the worker.

This is the same snapshot-too-early mechanism as the previously-fixed truncated
`/sw.js`, and quieter: every diagnostic short of *"does it actually cache
anything"* reports healthy. `verify-service-worker.mjs` now adds the missing
entry and **fails the build** if the chunk is unreachable or the wrong size.

**Queries never issued a request when offline.** `networkMode` was left at the
default `"online"`, which parks an offline query at `fetchStatus: "paused"`
rather than failing it. A route loader's `ensureQueryData` then awaited a
promise that never settled — so an offline navigation hung on a skeleton
forever, *and* the service worker never got a chance to answer from cache.

**No application data was cached.** No runtime rule matched `/_serverFn/*`, and
React Query is memory-only.

## The change

- **`data` runtime cache** for `/_serverFn` GETs. Reads are
  `createServerFn({ method: "GET" })` and the client RPC serialises args into
  the query string, so each call has a stable URL; Workbox routes are GET-only,
  so mutations are excluded automatically. This alone makes most read paths work
  offline — feeds, publications, shell bootstrap, not just articles.
- **`networkMode: "offlineFirst"`** plus a retry that gives up immediately while
  offline (three backed-off retries to reach the same answer is ~7s of skeleton).
- **`offline-sync.ts`** walks the reader's entire unread set (keyset-paginated
  via a new `getUnreadDocumentUris`) and pulls each body through *the same*
  `getArticle` call the article loader makes, so responses cache under the URL
  that loader later asks for. Images are warmed with real `Image` elements — a
  `fetch()` sets no `destination: "image"`, so the Workbox rule would have
  downloaded every image and cached none. Bodies are kept out of the React Query
  cache on purpose.
- **`RouteError`** as the app-wide `defaultErrorComponent`.
- Guide copy rewritten. It previously promised *"Pages you have already visited
  stay available"*, which was doubly untrue: in-app navigation is client-side and
  never populated the `pages` cache, and the worker was inert anyway.

## Scope and safety

Sync is gated on the installed app (silently downloading a backlog because
someone opened the website in a tab isn't a trade a visitor agreed to) and on a
device-scoped toggle, defaults on, pauses under Save-Data, and stops at 80% of
storage quota. The unread set is uncapped by request — the quota guard is there
because browsers evict the whole origin under pressure, and the walk is
newest-first so what survives is the most recent unread.

Signing out drops the `data` and `pages` caches: `/_serverFn` responses carry no
DID in their URL (the server reads it from the session cookie), so a second
account on the same device would otherwise be served the first one's feed and
saved queue. `images` is kept — public CDN bytes, no privacy gain in re-fetching.

## Verification

`pnpm build` (gate passes, and now reports both repairs), `typecheck`, `lint`,
`format:check`, and 913 tests all pass. In a headless browser against the built
server: all six caches populate (`assets` 144, `data`, `google-fonts`, `images`
61, `pages`, precache 8), an already-visited route **renders offline from
cache**, and an uncached one lands on the rebuilt offline page.

⚠️ **Still needs a manual pass.** Playwright's offline emulation is inconsistent
for service-worker-originated requests, and neither the installed-app gate
(`display-mode: standalone`) nor signed-in sync can be exercised headlessly. The
things to check by hand: install, let sync run, quit, go offline, launch from the
icon, open an unread article.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
