### PR TITLE
Show what's stored on the device in the offline troubleshooting panel

### DIFF
--- a/apps/standard-reader/src/components/offline-sync-debug.tsx
+++ b/apps/standard-reader/src/components/offline-sync-debug.tsx
@@ -16,14 +16,18 @@ import {
 import {
   fontFamily,
   fontSize,
+  fontWeight,
   lineHeight,
 } from "@standard-reader/design-system/theme/typography.stylex";
 import * as stylex from "@stylexjs/stylex";
 import { useRouter } from "@tanstack/react-router";
 import { useEffect, useState, useSyncExternalStore } from "react";
 
-import type { OfflineStorageUsage } from "#/pwa/offline-cache";
-import { offlineStorageUsage } from "#/pwa/offline-cache";
+import type {
+  OfflineCacheCounts,
+  OfflineStorageUsage,
+} from "#/pwa/offline-cache";
+import { offlineCacheCounts, offlineStorageUsage } from "#/pwa/offline-cache";
 import {
   publishOfflineSyncTotals,
   runOfflineSync,
@@ -34,6 +38,8 @@ import {
   getOfflineSyncProgressServer,
   subscribeOfflineSyncProgress,
 } from "#/pwa/offline-sync-progress";
+import type { OfflineSyncState } from "#/pwa/offline-sync-state";
+import { readOfflineSyncState } from "#/pwa/offline-sync-state";
 
 const styles = stylex.create({
   panel: {
@@ -79,6 +85,17 @@ const styles = stylex.create({
     display: "flex",
     marginTop: verticalSpace.md,
   },
+  // Separates "what I have" from "what the last run did" — the distinction the
+  // panel exists to make once a reader is fully synced.
+  groupLabel: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.xs,
+    fontWeight: fontWeight.semibold,
+    lineHeight: lineHeight.sm,
+    marginBottom: verticalSpace.none,
+    marginTop: verticalSpace.md,
+  },
   // A bar rather than another number: the one thing worth seeing at a glance is
   // how much of the backlog is already on the device.
   track: {
@@ -118,6 +135,23 @@ function stamp(at: number | null): string {
   return at === null ? "—" : new Date(at).toLocaleTimeString();
 }
 
+/**
+ * `null` means the bucket does not exist yet, which is a different fact from
+ * an empty one — the first says the service worker has never handled that kind
+ * of request, the second that it handled some and kept nothing.
+ */
+function countValue(count: number | null | undefined): string {
+  return count == null ? "—" : String(count);
+}
+
+function ago(at: number): string {
+  const minutes = Math.round((Date.now() - at) / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  return hours < 48 ? `${hours}h ago` : `${Math.round(hours / 24)}d ago`;
+}
+
 function Row({ label, value }: { label: React.ReactNode; value: string }) {
   return (
     <div {...stylex.props(styles.row)}>
@@ -144,6 +178,8 @@ export function OfflineSyncDebugPanel() {
     getOfflineSyncProgressServer,
   );
   const [usage, setUsage] = useState<OfflineStorageUsage | null>(null);
+  const [cached, setCached] = useState<OfflineCacheCounts | null>(null);
+  const [plan, setPlan] = useState<OfflineSyncState | null>(null);
 
   // Totals describe the device, so they must be readable before any pass has
   // run this session — otherwise opening the panel on a cold start shows
@@ -152,13 +188,16 @@ export function OfflineSyncDebugPanel() {
     publishOfflineSyncTotals();
   }, []);
 
-  // Refresh the storage line while a pass runs; it is the pass's output.
+  // Device state, refreshed while a pass runs because a pass changes it.
   useEffect(() => {
-    void offlineStorageUsage().then(setUsage);
-    if (!progress.running) return;
-    const interval = globalThis.setInterval(() => {
+    const read = () => {
       void offlineStorageUsage().then(setUsage);
-    }, 3000);
+      void offlineCacheCounts().then(setCached);
+      setPlan(readOfflineSyncState());
+    };
+    read();
+    if (!progress.running) return;
+    const interval = globalThis.setInterval(read, 3000);
     return () => globalThis.clearInterval(interval);
   }, [progress.running]);
 
@@ -207,8 +246,51 @@ export function OfflineSyncDebugPanel() {
       />
       <Row
         label={<Trans>Initial fill</Trans>}
-        value={progress.initialComplete ? "complete" : "in progress"}
+        value={
+          progress.initialComplete
+            ? "complete"
+            : plan
+              ? `in progress (unread ${plan.feedDone.unread ? "done" : `@${plan.feedOffsets.unread}`}, subs ${plan.feedDone.subscriptions ? "done" : `@${plan.feedOffsets.subscriptions}`})`
+              : "in progress"
+        }
       />
+      <Row
+        label={<Trans>Followed pages warmed</Trans>}
+        value={
+          plan?.surfacesWarmedAt == null ? "never" : ago(plan.surfacesWarmedAt)
+        }
+      />
+
+      {/* What is on the device, counted from Cache Storage. Separate from the
+          rows below because those describe one pass: once a reader is fully
+          synced every one of them is legitimately zero, and a screenshot of
+          nine zeroes reads as "sync is broken" rather than "nothing left to
+          do". These stay true when there is no work. */}
+      <p {...stylex.props(styles.groupLabel)}>
+        <Trans>On this device</Trans>
+      </p>
+      <Row
+        label={<Trans>Cached responses</Trans>}
+        value={countValue(cached?.data)}
+      />
+      <Row
+        label={<Trans>Cached images</Trans>}
+        value={countValue(cached?.images)}
+      />
+      <Row
+        label={<Trans>Cached pages</Trans>}
+        value={countValue(cached?.pages)}
+      />
+      <Row
+        label={<Trans>Cached app files</Trans>}
+        value={countValue(cached?.assets)}
+      />
+
+      {/* Everything below counts one pass, so zeroes here are the expected
+          reading for a reader who is already caught up. */}
+      <p {...stylex.props(styles.groupLabel)}>
+        <Trans>Fetched in the last pass</Trans>
+      </p>
       <Row label={<Trans>Status</Trans>} value={status} />
       <Row
         label={<Trans>Started / finished</Trans>}

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -129,6 +129,10 @@ msgstr "مقالات تحظى بالاهتمام عبر الشبكة الآن."
 msgid "{value, plural, one {# member} other {# members}}"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Cached responses"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Add an article"
 msgstr "إضافة مقال"
@@ -1282,6 +1286,10 @@ msgstr ""
 msgid "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Followed pages warmed"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
 msgstr ""
@@ -2149,6 +2157,10 @@ msgstr "المزيد من <0>{0}</0>"
 #~ msgid "Community"
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "On this device"
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
 msgstr "قد نحدّث هذه السياسة مع تطوّر الإضافة. وسيتغيّر تاريخ «آخر تحديث» في الأعلى عند حدوث ذلك. ويعني استمرارك في استخدام الإضافة بعد التحديث قبولك للسياسة المعدَّلة."
@@ -2248,6 +2260,10 @@ msgstr "ملف تعريف ارتباط للجلسة من نوع HttpOnly يُب�
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "Everything you save shows up in the app straight away — it is the same account."
 #~ msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached app files"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Standard Reader has no comment box of its own. Instead, below each article it gathers the conversation that already happened elsewhere: Bluesky posts linking to the piece, replies to the author's own announcement, and notes people made on it in annotation tools. Select any of them to reply where the conversation actually is."
@@ -2426,6 +2442,10 @@ msgstr "شكرًا لك."
 #: src/magazine/Magazine.tsx
 msgid "Previous"
 msgstr "السابق"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Fetched in the last pass"
+msgstr ""
 
 #: src/components/reader/content/renderers/shared/footnotes-section.tsx
 msgid "Back to content"
@@ -3133,6 +3153,10 @@ msgstr ""
 #: src/components/reader/collection-theme-editor.tsx
 msgid "A sentence of body copy, set in your chosen fonts and colors, so you can see how it all reads together before you save."
 msgstr "جملة من نص المتن، بالخطوط والألوان التي اخترتها، لترى كيف يبدو ذلك كله معًا قبل الحفظ."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached images"
+msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #~ msgid "Find your corner"
@@ -5073,6 +5097,10 @@ msgstr "افتح الصورة {position}"
 
 #: src/components/labeler-detail-view.tsx
 msgid "Not responding"
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached pages"
 msgstr ""
 
 #: src/components/docs/api-docs-intro.tsx

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -129,6 +129,10 @@ msgstr "Artikel, die gerade im Netzwerk Aufmerksamkeit gewinnen."
 msgid "{value, plural, one {# member} other {# members}}"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Cached responses"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Add an article"
 msgstr "Artikel hinzufügen"
@@ -1282,6 +1286,10 @@ msgstr ""
 msgid "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Followed pages warmed"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
 msgstr ""
@@ -2149,6 +2157,10 @@ msgstr "Mehr von <0>{0}</0>"
 #~ msgid "Community"
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "On this device"
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
 msgstr "Wir können diese Richtlinie ändern, wenn sich die Erweiterung ändert. Das Datum „Zuletzt aktualisiert“ oben ändert sich dann entsprechend. Wenn Sie die Erweiterung nach einer Änderung weiter nutzen, akzeptieren Sie die überarbeitete Richtlinie."
@@ -2248,6 +2260,10 @@ msgstr "Ein HttpOnly-Session-Cookie, das Sie angemeldet hält."
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "Everything you save shows up in the app straight away — it is the same account."
 #~ msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached app files"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Standard Reader has no comment box of its own. Instead, below each article it gathers the conversation that already happened elsewhere: Bluesky posts linking to the piece, replies to the author's own announcement, and notes people made on it in annotation tools. Select any of them to reply where the conversation actually is."
@@ -2426,6 +2442,10 @@ msgstr "Vielen Dank."
 #: src/magazine/Magazine.tsx
 msgid "Previous"
 msgstr "Zurück"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Fetched in the last pass"
+msgstr ""
 
 #: src/components/reader/content/renderers/shared/footnotes-section.tsx
 msgid "Back to content"
@@ -3133,6 +3153,10 @@ msgstr ""
 #: src/components/reader/collection-theme-editor.tsx
 msgid "A sentence of body copy, set in your chosen fonts and colors, so you can see how it all reads together before you save."
 msgstr "Ein Satz Fließtext, gesetzt in Ihren gewählten Schriften und Farben, damit Sie vor dem Speichern sehen, wie alles zusammen wirkt."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached images"
+msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #~ msgid "Find your corner"
@@ -5073,6 +5097,10 @@ msgstr "Bild {position} öffnen"
 
 #: src/components/labeler-detail-view.tsx
 msgid "Not responding"
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached pages"
 msgstr ""
 
 #: src/components/docs/api-docs-intro.tsx

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -129,6 +129,10 @@ msgstr ""
 msgid "{value, plural, one {# member} other {# members}}"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Cached responses"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Add an article"
 msgstr ""
@@ -1282,6 +1286,10 @@ msgstr ""
 msgid "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Followed pages warmed"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
 msgstr ""
@@ -2149,6 +2157,10 @@ msgstr ""
 #~ msgid "Community"
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "On this device"
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
 msgstr ""
@@ -2248,6 +2260,10 @@ msgstr ""
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "Everything you save shows up in the app straight away — it is the same account."
 #~ msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached app files"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Standard Reader has no comment box of its own. Instead, below each article it gathers the conversation that already happened elsewhere: Bluesky posts linking to the piece, replies to the author's own announcement, and notes people made on it in annotation tools. Select any of them to reply where the conversation actually is."
@@ -2425,6 +2441,10 @@ msgstr ""
 #: src/components/guide/guide-shell.tsx
 #: src/magazine/Magazine.tsx
 msgid "Previous"
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Fetched in the last pass"
 msgstr ""
 
 #: src/components/reader/content/renderers/shared/footnotes-section.tsx
@@ -3132,6 +3152,10 @@ msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "A sentence of body copy, set in your chosen fonts and colors, so you can see how it all reads together before you save."
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached images"
 msgstr ""
 
 #: src/routes/_layout.discover.tsx
@@ -5073,6 +5097,10 @@ msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Not responding"
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached pages"
 msgstr ""
 
 #: src/components/docs/api-docs-intro.tsx

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -129,6 +129,10 @@ msgstr "Articles gaining attention across the network right now."
 msgid "{value, plural, one {# member} other {# members}}"
 msgstr "{value, plural, one {# member} other {# members}}"
 
+#: src/components/offline-sync-debug.tsx
+msgid "Cached responses"
+msgstr "Cached responses"
+
 #: src/components/reader/collection-builder.tsx
 msgid "Add an article"
 msgstr "Add an article"
@@ -1282,6 +1286,10 @@ msgstr "Back-catalog pages"
 msgid "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
 msgstr "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
 
+#: src/components/offline-sync-debug.tsx
+msgid "Followed pages warmed"
+msgstr "Followed pages warmed"
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
 msgstr "the directory of every publication the network knows about."
@@ -2149,6 +2157,10 @@ msgstr "More from <0>{0}</0>"
 #~ msgid "Community"
 #~ msgstr "Community"
 
+#: src/components/offline-sync-debug.tsx
+msgid "On this device"
+msgstr "On this device"
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
 msgstr "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
@@ -2248,6 +2260,10 @@ msgstr "An HttpOnly session cookie that keeps you signed in."
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "Everything you save shows up in the app straight away — it is the same account."
 #~ msgstr "Everything you save shows up in the app straight away — it is the same account."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached app files"
+msgstr "Cached app files"
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Standard Reader has no comment box of its own. Instead, below each article it gathers the conversation that already happened elsewhere: Bluesky posts linking to the piece, replies to the author's own announcement, and notes people made on it in annotation tools. Select any of them to reply where the conversation actually is."
@@ -2426,6 +2442,10 @@ msgstr "Thank you."
 #: src/magazine/Magazine.tsx
 msgid "Previous"
 msgstr "Previous"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Fetched in the last pass"
+msgstr "Fetched in the last pass"
 
 #: src/components/reader/content/renderers/shared/footnotes-section.tsx
 msgid "Back to content"
@@ -3133,6 +3153,10 @@ msgstr "Under <0>Sidebar</0>, you can hide destinations you never use. Subscript
 #: src/components/reader/collection-theme-editor.tsx
 msgid "A sentence of body copy, set in your chosen fonts and colors, so you can see how it all reads together before you save."
 msgstr "A sentence of body copy, set in your chosen fonts and colors, so you can see how it all reads together before you save."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached images"
+msgstr "Cached images"
 
 #: src/routes/_layout.discover.tsx
 #~ msgid "Find your corner"
@@ -5074,6 +5098,10 @@ msgstr "Open image {position}"
 #: src/components/labeler-detail-view.tsx
 msgid "Not responding"
 msgstr "Not responding"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached pages"
+msgstr "Cached pages"
 
 #: src/components/docs/api-docs-intro.tsx
 msgid "AppView API"

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -129,6 +129,10 @@ msgstr "Artículos que están ganando atención en la red ahora mismo."
 msgid "{value, plural, one {# member} other {# members}}"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Cached responses"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Add an article"
 msgstr "Añadir un artículo"
@@ -1282,6 +1286,10 @@ msgstr ""
 msgid "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Followed pages warmed"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
 msgstr ""
@@ -2149,6 +2157,10 @@ msgstr "Más de <0>{0}</0>"
 #~ msgid "Community"
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "On this device"
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
 msgstr "Podemos actualizar esta política a medida que cambie la extensión. La fecha de «Última actualización» en la parte superior cambiará cuando lo hagamos. Seguir usando la extensión después de una actualización implica que acepta la política revisada."
@@ -2248,6 +2260,10 @@ msgstr "Una cookie de sesión HttpOnly que mantiene su sesión iniciada."
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "Everything you save shows up in the app straight away — it is the same account."
 #~ msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached app files"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Standard Reader has no comment box of its own. Instead, below each article it gathers the conversation that already happened elsewhere: Bluesky posts linking to the piece, replies to the author's own announcement, and notes people made on it in annotation tools. Select any of them to reply where the conversation actually is."
@@ -2426,6 +2442,10 @@ msgstr "Gracias."
 #: src/magazine/Magazine.tsx
 msgid "Previous"
 msgstr "Anterior"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Fetched in the last pass"
+msgstr ""
 
 #: src/components/reader/content/renderers/shared/footnotes-section.tsx
 msgid "Back to content"
@@ -3133,6 +3153,10 @@ msgstr ""
 #: src/components/reader/collection-theme-editor.tsx
 msgid "A sentence of body copy, set in your chosen fonts and colors, so you can see how it all reads together before you save."
 msgstr "Una frase de texto de cuerpo, compuesta con las fuentes y los colores que eligió, para que vea cómo se lee todo junto antes de guardar."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached images"
+msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #~ msgid "Find your corner"
@@ -5073,6 +5097,10 @@ msgstr "Abrir la imagen {position}"
 
 #: src/components/labeler-detail-view.tsx
 msgid "Not responding"
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached pages"
 msgstr ""
 
 #: src/components/docs/api-docs-intro.tsx

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -129,6 +129,10 @@ msgstr "Les articles qui font parler d’eux sur le réseau en ce moment."
 msgid "{value, plural, one {# member} other {# members}}"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Cached responses"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Add an article"
 msgstr "Ajouter un article"
@@ -1282,6 +1286,10 @@ msgstr ""
 msgid "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Followed pages warmed"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
 msgstr ""
@@ -2149,6 +2157,10 @@ msgstr "Plus de <0>{0}</0>"
 #~ msgid "Community"
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "On this device"
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
 msgstr "Nous pouvons faire évoluer cette politique à mesure que l'extension change. La date de « dernière mise à jour » en haut de page sera modifiée en conséquence. Continuer à utiliser l'extension après une mise à jour vaut acceptation de la politique révisée."
@@ -2248,6 +2260,10 @@ msgstr "Un cookie de session HttpOnly qui vous maintient connecté."
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "Everything you save shows up in the app straight away — it is the same account."
 #~ msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached app files"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Standard Reader has no comment box of its own. Instead, below each article it gathers the conversation that already happened elsewhere: Bluesky posts linking to the piece, replies to the author's own announcement, and notes people made on it in annotation tools. Select any of them to reply where the conversation actually is."
@@ -2426,6 +2442,10 @@ msgstr "Merci."
 #: src/magazine/Magazine.tsx
 msgid "Previous"
 msgstr "Précédent"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Fetched in the last pass"
+msgstr ""
 
 #: src/components/reader/content/renderers/shared/footnotes-section.tsx
 msgid "Back to content"
@@ -3133,6 +3153,10 @@ msgstr ""
 #: src/components/reader/collection-theme-editor.tsx
 msgid "A sentence of body copy, set in your chosen fonts and colors, so you can see how it all reads together before you save."
 msgstr "Une phrase de texte courant, composée avec les polices et les couleurs que vous avez choisies, pour voir le rendu d'ensemble avant d'enregistrer."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached images"
+msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #~ msgid "Find your corner"
@@ -5073,6 +5097,10 @@ msgstr "Ouvrir l’image {position}"
 
 #: src/components/labeler-detail-view.tsx
 msgid "Not responding"
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached pages"
 msgstr ""
 
 #: src/components/docs/api-docs-intro.tsx

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -129,6 +129,10 @@ msgstr "いまネットワークで注目を集めている記事です。"
 msgid "{value, plural, one {# member} other {# members}}"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Cached responses"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Add an article"
 msgstr "記事を追加"
@@ -1282,6 +1286,10 @@ msgstr ""
 msgid "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Followed pages warmed"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
 msgstr ""
@@ -2149,6 +2157,10 @@ msgstr "<0>{0}</0>の他の記事"
 #~ msgid "Community"
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "On this device"
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
 msgstr "拡張機能の変更に合わせて、このポリシーを更新する場合があります。更新した際は、上部の「最終更新日」も変更されます。更新後も拡張機能を使い続けた場合、改訂後のポリシーに同意したものとみなされます。"
@@ -2248,6 +2260,10 @@ msgstr "サインイン状態を保つための HttpOnly セッション Cookie 
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "Everything you save shows up in the app straight away — it is the same account."
 #~ msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached app files"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Standard Reader has no comment box of its own. Instead, below each article it gathers the conversation that already happened elsewhere: Bluesky posts linking to the piece, replies to the author's own announcement, and notes people made on it in annotation tools. Select any of them to reply where the conversation actually is."
@@ -2426,6 +2442,10 @@ msgstr "ありがとうございます。"
 #: src/magazine/Magazine.tsx
 msgid "Previous"
 msgstr "前へ"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Fetched in the last pass"
+msgstr ""
 
 #: src/components/reader/content/renderers/shared/footnotes-section.tsx
 msgid "Back to content"
@@ -3133,6 +3153,10 @@ msgstr ""
 #: src/components/reader/collection-theme-editor.tsx
 msgid "A sentence of body copy, set in your chosen fonts and colors, so you can see how it all reads together before you save."
 msgstr "選んだフォントと色で組まれた本文のサンプルです。保存する前に、全体の読み心地を確認できます。"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached images"
+msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #~ msgid "Find your corner"
@@ -5073,6 +5097,10 @@ msgstr "画像 {position} を開く"
 
 #: src/components/labeler-detail-view.tsx
 msgid "Not responding"
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached pages"
 msgstr ""
 
 #: src/components/docs/api-docs-intro.tsx

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -129,6 +129,10 @@ msgstr "지금 네트워크 전반에서 주목받고 있는 글입니다."
 msgid "{value, plural, one {# member} other {# members}}"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Cached responses"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Add an article"
 msgstr "글 추가"
@@ -1282,6 +1286,10 @@ msgstr ""
 msgid "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Followed pages warmed"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
 msgstr ""
@@ -2149,6 +2157,10 @@ msgstr "<0>{0}</0>의 다른 글"
 #~ msgid "Community"
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "On this device"
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
 msgstr "확장 프로그램이 변경되면 본 정책을 업데이트할 수 있습니다. 업데이트 시 상단의 “최종 수정일”이 변경됩니다. 업데이트 후에도 확장 프로그램을 계속 사용하면 개정된 정책에 동의한 것으로 간주됩니다."
@@ -2248,6 +2260,10 @@ msgstr "로그인 상태를 유지하는 HttpOnly 세션 쿠키입니다."
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "Everything you save shows up in the app straight away — it is the same account."
 #~ msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached app files"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Standard Reader has no comment box of its own. Instead, below each article it gathers the conversation that already happened elsewhere: Bluesky posts linking to the piece, replies to the author's own announcement, and notes people made on it in annotation tools. Select any of them to reply where the conversation actually is."
@@ -2426,6 +2442,10 @@ msgstr "감사합니다."
 #: src/magazine/Magazine.tsx
 msgid "Previous"
 msgstr "이전"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Fetched in the last pass"
+msgstr ""
 
 #: src/components/reader/content/renderers/shared/footnotes-section.tsx
 msgid "Back to content"
@@ -3133,6 +3153,10 @@ msgstr ""
 #: src/components/reader/collection-theme-editor.tsx
 msgid "A sentence of body copy, set in your chosen fonts and colors, so you can see how it all reads together before you save."
 msgstr "선택한 서체와 색으로 표시된 본문 예시 문장입니다. 저장하기 전에 전체적인 느낌을 확인해 보세요."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached images"
+msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #~ msgid "Find your corner"
@@ -5073,6 +5097,10 @@ msgstr "{position}번째 이미지 열기"
 
 #: src/components/labeler-detail-view.tsx
 msgid "Not responding"
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached pages"
 msgstr ""
 
 #: src/components/docs/api-docs-intro.tsx

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -129,6 +129,10 @@ msgstr "Artigos ganhando atenção na rede neste momento."
 msgid "{value, plural, one {# member} other {# members}}"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Cached responses"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Add an article"
 msgstr "Adicionar um artigo"
@@ -1282,6 +1286,10 @@ msgstr ""
 msgid "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
 msgstr "O {SITE_NAME} é um leitor web para publicações do standard.site no AT Protocol. Estes termos regem o seu uso deste site. Ao acessar ou utilizar a instância do Standard Reader em <0>{siteHost}</0>, você concorda com estes termos. Se você não concordar, por favor, não utilize o site."
 
+#: src/components/offline-sync-debug.tsx
+msgid "Followed pages warmed"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
 msgstr ""
@@ -2149,6 +2157,10 @@ msgstr "Mais de <0>{0}</0>"
 #~ msgid "Community"
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "On this device"
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
 msgstr "Podemos atualizar esta política à medida que a extensão evolui. A data de “Última atualização” no topo mudará quando o fizermos. A utilização continuada da extensão após uma atualização significa que aceita a política revista."
@@ -2248,6 +2260,10 @@ msgstr "Um cookie de sessão HttpOnly que mantém a sua sessão iniciada."
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "Everything you save shows up in the app straight away — it is the same account."
 #~ msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached app files"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Standard Reader has no comment box of its own. Instead, below each article it gathers the conversation that already happened elsewhere: Bluesky posts linking to the piece, replies to the author's own announcement, and notes people made on it in annotation tools. Select any of them to reply where the conversation actually is."
@@ -2426,6 +2442,10 @@ msgstr "Obrigado."
 #: src/magazine/Magazine.tsx
 msgid "Previous"
 msgstr "Anterior"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Fetched in the last pass"
+msgstr ""
 
 #: src/components/reader/content/renderers/shared/footnotes-section.tsx
 msgid "Back to content"
@@ -3133,6 +3153,10 @@ msgstr ""
 #: src/components/reader/collection-theme-editor.tsx
 msgid "A sentence of body copy, set in your chosen fonts and colors, so you can see how it all reads together before you save."
 msgstr "Uma frase de texto corrido, composta com as fontes e as cores que escolheu, para ver como tudo se lê em conjunto antes de salvar."
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached images"
+msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #~ msgid "Find your corner"
@@ -5073,6 +5097,10 @@ msgstr "Abrir imagem {position}"
 
 #: src/components/labeler-detail-view.tsx
 msgid "Not responding"
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached pages"
 msgstr ""
 
 #: src/components/docs/api-docs-intro.tsx

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -129,6 +129,10 @@ msgstr "此刻正在全网获得关注的文章。"
 msgid "{value, plural, one {# member} other {# members}}"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Cached responses"
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "Add an article"
 msgstr "添加文章"
@@ -1282,6 +1286,10 @@ msgstr ""
 msgid "{SITE_NAME} is a web reader for standard.site publications on the AT Protocol. These terms govern your use of this site. By accessing or using the Standard Reader deployment at <0>{siteHost}</0>, you agree to these terms. If you do not agree, please do not use the site."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Followed pages warmed"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
 msgstr ""
@@ -2149,6 +2157,10 @@ msgstr "更多来自 <0>{0}</0>"
 #~ msgid "Community"
 #~ msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "On this device"
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
 msgstr "我们可能会随着扩展的变化更新本政策。更新时，顶部的「最后更新」日期也会随之改变。更新后继续使用本扩展即表示你接受修订后的政策。"
@@ -2248,6 +2260,10 @@ msgstr "一个 HttpOnly 会话 cookie，用于保持你的登录状态。"
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "Everything you save shows up in the app straight away — it is the same account."
 #~ msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached app files"
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Standard Reader has no comment box of its own. Instead, below each article it gathers the conversation that already happened elsewhere: Bluesky posts linking to the piece, replies to the author's own announcement, and notes people made on it in annotation tools. Select any of them to reply where the conversation actually is."
@@ -2426,6 +2442,10 @@ msgstr "谢谢。"
 #: src/magazine/Magazine.tsx
 msgid "Previous"
 msgstr "上一篇"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Fetched in the last pass"
+msgstr ""
 
 #: src/components/reader/content/renderers/shared/footnotes-section.tsx
 msgid "Back to content"
@@ -3133,6 +3153,10 @@ msgstr ""
 #: src/components/reader/collection-theme-editor.tsx
 msgid "A sentence of body copy, set in your chosen fonts and colors, so you can see how it all reads together before you save."
 msgstr "一句正文示例，使用你选定的字体与颜色排版，让你在保存前先看看整体阅读效果。"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached images"
+msgstr ""
 
 #: src/routes/_layout.discover.tsx
 #~ msgid "Find your corner"
@@ -5073,6 +5097,10 @@ msgstr "打开第 {position} 张图片"
 
 #: src/components/labeler-detail-view.tsx
 msgid "Not responding"
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Cached pages"
 msgstr ""
 
 #: src/components/docs/api-docs-intro.tsx

--- a/apps/standard-reader/src/pwa/offline-cache.ts
+++ b/apps/standard-reader/src/pwa/offline-cache.ts
@@ -206,6 +206,58 @@ export async function clearPersonalOfflineData(): Promise<void> {
   await deleteCaches(PERSONAL_CACHE_NAMES);
 }
 
+/** Entries held in each Workbox bucket, or `null` where the bucket is absent. */
+export interface OfflineCacheCounts {
+  /** `/_serverFn` responses — feeds, article bodies, publication pages. */
+  data: number | null;
+  /** Article and avatar images. */
+  images: number | null;
+  /** Rendered documents, which is what a cold offline launch boots from. */
+  pages: number | null;
+  /** Hashed JS/CSS, including the code-split route chunks. */
+  assets: number | null;
+}
+
+/**
+ * How much is on the device, counted from Cache Storage itself.
+ *
+ * The per-pass counters answer "what did the last run do", which is zero for
+ * every category once a reader is fully synced — a top-up that finds nothing
+ * new is a success that looks identical to sync never having worked. These
+ * numbers answer "what do I have", so they stay meaningful when there is
+ * nothing left to fetch.
+ */
+export async function offlineCacheCounts(): Promise<OfflineCacheCounts> {
+  const empty: OfflineCacheCounts = {
+    assets: null,
+    data: null,
+    images: null,
+    pages: null,
+  };
+  if (globalThis.caches === undefined) return empty;
+
+  const names = ["data", "images", "pages", "assets"] as const;
+  const counted = await Promise.all(
+    names.map(async (name) => {
+      try {
+        if (!(await globalThis.caches.has(name))) return null;
+        const cache = await globalThis.caches.open(name);
+        const keys = await cache.keys();
+        return keys.length;
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  return {
+    assets: counted[3] ?? null,
+    data: counted[0] ?? null,
+    images: counted[1] ?? null,
+    pages: counted[2] ?? null,
+  };
+}
+
 export interface OfflineStorageUsage {
   /** Bytes this origin is using, across all caches — not just ours. */
   usage: number;


### PR DESCRIPTION
Follow-up to #151.

Every counter in the offline troubleshooting panel described a single pass. So a
reader who is fully synced saw a column of zeroes — and "sync is broken" and
"there was nothing left to do" produced an identical screenshot. That is
backwards for the state you most want to be able to confirm.

## What changed

The panel now opens with what is actually on the device, counted from Cache
Storage itself:

| Row | What it counts |
| --- | --- |
| Cached responses | `/_serverFn` entries — feeds, article bodies, publication pages |
| Cached images | article and avatar images |
| Cached pages | rendered documents, which is what a cold offline launch boots from |
| Cached app files | hashed JS/CSS, including the code-split route chunks |

These are facts about the device rather than about a run, so they stay true when
a pass fetches nothing. A bucket that does not exist yet renders as `—` rather
than `0`: "the worker has never handled this kind of request" is a different
diagnosis from "it handled some and kept none".

Two more lines come from the persisted plan added in #151 — how far each feed
tab's walk has reached while the initial fill is still running, and when the
followed-page fan-out last completed. Together they answer *is it stuck, or just
done?*

The per-pass counters remain, now under a heading that says what they count, so
zeroes there read as "nothing new this pass".

## Verification

`typecheck`, `lint`, `format:check`, 913 tests and `build` (service-worker gate
included) all pass, re-run after rebasing onto the squashed #151.

In a browser against the built server the counts climb while browsing and
survive a reload that fetches nothing new — `images 29, pages 3, assets 141`
before and after — instead of resetting. The panel itself is behind sign-in, so
the rendered layout still wants a look on a real device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
