### PR TITLE
Resume where you left off (+ Continue reading on /history)

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -576,6 +576,10 @@ comic issue with no pages falls back to it outright.
 
 - Signed-in reader's **reading history** (`app.standard-reader.read`), newest first — every
   article opened while signed in.
+- Opens with a **Continue reading** shelf: up to six articles the reader is partway through,
+  most recently touched first, each with a percentage-read meter. Short on purpose — it is a
+  prompt to pick something back up, not another backlog. It is an extra on this page, never
+  fatal: offline (or on any error) it simply doesn't render and the cached history still does.
 - Route `/history`; linked from the user menu. Requires auth (redirects to login).
 
 ### Reader profile (saved for later)
@@ -742,6 +746,20 @@ source of truth; Neon holds a derived view for speed and cross-network querying.
   `/saved`, distinct from likes.
 - **Read / unread:** an `app.standard-reader.read` record per article; opening an article
   marks it read. **Reading history** at `/history` lists these newest-first.
+- **Reading position (deliberately not a record):** reopening an article puts the reader back
+  where they stopped, and `/history` opens with a **Continue reading** shelf of the articles they
+  are partway through. This is the one piece of personal state that is **not** written to the
+  repo. Reads and bookmarks being public is a fair trade — they say what you read. A position
+  says how far you got and where you gave up, which is a running commentary on attention that
+  nobody opts into by opening an article. So it lives in a private, app-local Neon table
+  (`reading_progress`, keyed by `(owner_did, document_uri)`) that the tap never writes, mirrored
+  into `localStorage` per device. The local copy is what restores the scroll — it is readable
+  before first paint, where a Neon round trip is an order of magnitude too slow — and it is what
+  keeps position working offline in the installed PWA; the server copy is what carries the
+  position from phone to laptop, and only wins when it is newer and the reader has not already
+  started scrolling. Rows exist only between 2% and 95%, so the table *is* the shelf and never
+  needs sweeping, and clearing reading history clears positions with it. Gated on the same
+  "Track reading history" setting: position is reading history at a finer grain.
 - **The write path mirrors personal state into Neon itself**
   (`src/server/reader/personal-state-mirror.ts`) — reads, bookmarks, and likes — rather than
   waiting for the tap to replay them. These are the toggles a reader watches change in the moment

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -1103,6 +1103,26 @@ Backend/API exists; UI or copy is missing.
 
 ## 9. Post-v1 — reader polish (Tier 2)
 
+- [x] **Resume where you left off** — reopening an article restores the reader's position, and
+      `/history` opens with a **Continue reading** shelf (six most-recent in-progress articles,
+      each with a percent-read meter). Position is the one bit of personal state kept **off**
+      the protocol: reads are public records, and how far you got is a different kind of fact.
+      A private app-local table ([`reading-progress.ts`](src/db/schema/reading-progress.ts),
+      `drizzle/0037_*`, keyed `(owner_did, document_uri)`, never touched by the tap) plus a
+      per-device `localStorage` mirror ([`reading-progress.ts`](src/lib/reading-progress.ts)).
+      Local drives the restore because it can be read before first paint and works offline;
+      the server copy carries position across devices and only wins when it is newer and the
+      reader hasn't already scrolled. Rows live only between 2% and 95%, so the table *is* the
+      shelf. All of it in [`use-reading-progress.ts`](src/components/reader/use-reading-progress.ts),
+      which also owns the sticky-chrome progress bar it replaced.
+      Gated on "Track reading history"; clearing history clears positions too.
+      **Before deploy:** run `pnpm db:migrate` (migration `0037`) — the shelf query 500s without
+      the table.
+      Known gaps, deliberately deferred: `/history` is still not in `OFFLINE_ROUTES`, so the shelf
+      is unavailable offline (it degrades to absent, never to an error); and an offline
+      "Start from top" is a paused mutation, so killing the PWA before reconnect leaves the server
+      row and the position comes back. Both want the durable write outbox the app doesn't have yet.
+
 - [x] **Web push notifications (v1)** — a bell on a publication page
       ([`publication-actions.tsx`](src/components/reader/publication-actions.tsx)) and an author
       page ([`author-actions.tsx`](src/components/reader/author-actions.tsx)) that notifies you when

--- a/apps/standard-reader/drizzle/0037_burly_magus.sql
+++ b/apps/standard-reader/drizzle/0037_burly_magus.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "reading_progress" (
+	"owner_did" text NOT NULL,
+	"document_uri" text NOT NULL,
+	"progress" real NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "reading_progress_owner_did_document_uri_pk" PRIMARY KEY("owner_did","document_uri")
+);
+--> statement-breakpoint
+CREATE INDEX "reading_progress_owner_idx" ON "reading_progress" USING btree ("owner_did","updated_at" DESC NULLS LAST);

--- a/apps/standard-reader/drizzle/meta/0037_snapshot.json
+++ b/apps/standard-reader/drizzle/meta/0037_snapshot.json
@@ -1,0 +1,5523 @@
+{
+  "id": "6695349a-63f5-4a0b-afed-822ba5ff6ffe",
+  "prevId": "7ad10254-71c4-4ff2-b003-e79a5f292d33",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_mode": {
+          "name": "theme_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appearance": {
+          "name": "appearance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale_hint_seen": {
+          "name": "locale_hint_seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reader_voice": {
+          "name": "reader_voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_links_externally": {
+          "name": "open_links_externally",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_collections_in_magazine": {
+          "name": "open_collections_in_magazine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reading_typography": {
+          "name": "reading_typography",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_reading_history": {
+          "name": "track_reading_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count_old_posts_as_unread": {
+          "name": "count_old_posts_as_unread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclude_web_bridge": {
+          "name": "exclude_web_bridge",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_publication_theme": {
+          "name": "use_publication_theme",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hide_feed_metrics": {
+          "name": "hide_feed_metrics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feed_pagination": {
+          "name": "feed_pagination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_scope": {
+          "name": "home_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_hidden_tabs": {
+          "name": "profile_hidden_tabs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_show_likes": {
+          "name": "profile_show_likes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_authoring_enabled": {
+          "name": "collections_authoring_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userinput_feedback_enabled": {
+          "name": "userinput_feedback_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "margin_save_enabled": {
+          "name": "margin_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semble_save_enabled": {
+          "name": "semble_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocking_enabled": {
+          "name": "blocking_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "atstore_review_prompt_dismissed": {
+          "name": "atstore_review_prompt_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_enabled": {
+          "name": "weekly_digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_subscriptions": {
+          "name": "weekly_digest_section_subscriptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_network": {
+          "name": "weekly_digest_section_network",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_saved": {
+          "name": "weekly_digest_section_saved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_recommendations": {
+          "name": "weekly_digest_section_recommendations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_last_sent_at": {
+          "name": "weekly_digest_last_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_welcome_sent_at": {
+          "name": "weekly_digest_welcome_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_labelers_imported_at": {
+          "name": "bsky_labelers_imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_did_unique": {
+          "name": "user_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "did"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pds": {
+          "name": "pds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_url": {
+          "name": "banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_uri": {
+          "name": "bsky_profile_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_cid": {
+          "name": "bsky_profile_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_fetched_at": {
+          "name": "profile_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_handle_idx": {
+          "name": "profiles_handle_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_handle_trgm_idx": {
+          "name": "profiles_handle_trgm_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "profiles_display_name_trgm_idx": {
+          "name": "profiles_display_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publications": {
+      "name": "publications",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_cid": {
+          "name": "icon_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_mime": {
+          "name": "icon_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent": {
+          "name": "theme_accent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_background": {
+          "name": "theme_background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_foreground": {
+          "name": "theme_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent_foreground": {
+          "name": "theme_accent_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_json": {
+          "name": "theme_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_in_discover": {
+          "name": "show_in_discover",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "prev_next_direction": {
+          "name": "prev_next_direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_kind": {
+          "name": "serial_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_publication": {
+          "name": "collections_publication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_checked_at": {
+          "name": "verification_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(name, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(topic, '')), 'B')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publications_did_idx": {
+          "name": "publications_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_name_idx": {
+          "name": "publications_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_discover_idx": {
+          "name": "publications_discover_idx",
+          "columns": [
+            {
+              "expression": "show_in_discover",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_topic_idx": {
+          "name": "publications_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_url_idx": {
+          "name": "publications_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_serial_idx": {
+          "name": "publications_serial_idx",
+          "columns": [
+            {
+              "expression": "prev_next_direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_search_idx": {
+          "name": "publications_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_contributors": {
+      "name": "document_contributors",
+      "schema": "",
+      "columns": {
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "document_contributors_did_idx": {
+          "name": "document_contributors_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_contributors_document_uri_documents_uri_fk": {
+          "name": "document_contributors_document_uri_documents_uri_fk",
+          "tableFrom": "document_contributors",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_contributors_document_uri_did_pk": {
+          "name": "document_contributors_document_uri_did_pk",
+          "columns": [
+            "document_uri",
+            "did"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_uri": {
+          "name": "site_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_json": {
+          "name": "collection_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_renderable_body": {
+          "name": "has_renderable_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "body_image_count": {
+          "name": "body_image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_cid": {
+          "name": "cover_image_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_mime": {
+          "name": "cover_image_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backlink_count": {
+          "name": "backlink_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_count_prev": {
+          "name": "backlink_count_prev",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_synced_at": {
+          "name": "backlink_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_recomputed_at": {
+          "name": "trending_recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_recommender_count": {
+          "name": "distinct_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bsky_post_uri": {
+          "name": "bsky_post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_post_cid": {
+          "name": "bsky_post_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_updated_at": {
+          "name": "record_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(title, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(immutable_array_to_string(tags), '')), 'B') || setweight(to_tsvector('english', coalesce(text_content, '')), 'C')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documents_did_idx": {
+          "name": "documents_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_did_published_idx": {
+          "name": "documents_did_published_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"published_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_publication_published_idx": {
+          "name": "documents_publication_published_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_published_idx": {
+          "name": "documents_published_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_featured_idx": {
+          "name": "documents_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_site_idx": {
+          "name": "documents_site_idx",
+          "columns": [
+            {
+              "expression": "site_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_search_idx": {
+          "name": "documents_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "documents_trending_idx": {
+          "name": "documents_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_idx": {
+          "name": "documents_canonical_url_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_trgm_idx": {
+          "name": "documents_canonical_url_trgm_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommends": {
+      "name": "recommends",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommender_did": {
+          "name": "recommender_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recommends_document_idx": {
+          "name": "recommends_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_recommender_idx": {
+          "name": "recommends_recommender_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_edge_idx": {
+          "name": "recommends_edge_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_doc_recommender_created_idx": {
+          "name": "recommends_doc_recommender_created_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recommends\".\"deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_did": {
+          "name": "publication_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_publication_idx": {
+          "name": "subscriptions_publication_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_subscriber_idx": {
+          "name": "subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_edge_idx": {
+          "name": "subscriptions_edge_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follower_did": {
+          "name": "follower_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excluded_publications": {
+          "name": "excluded_publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_subject_idx": {
+          "name": "user_follows_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_edge_idx": {
+          "name": "user_follows_edge_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_owner_idx": {
+          "name": "bookmarks_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_document_idx": {
+          "name": "bookmarks_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_edge_idx": {
+          "name": "bookmarks_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reads": {
+      "name": "reads",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reads_owner_idx": {
+          "name": "reads_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_document_idx": {
+          "name": "reads_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_edge_idx": {
+          "name": "reads_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidebar_prefs": {
+      "name": "sidebar_prefs",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_order": {
+          "name": "list_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "tree_order": {
+          "name": "tree_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "subscription_sort": {
+          "name": "subscription_sort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customize_nav": {
+          "name": "customize_nav",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_nav": {
+          "name": "hidden_nav",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reading_progress": {
+      "name": "reading_progress",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reading_progress_owner_idx": {
+          "name": "reading_progress_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "reading_progress_owner_did_document_uri_pk": {
+          "name": "reading_progress_owner_did_document_uri_pk",
+          "columns": [
+            "owner_did",
+            "document_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_push_queue": {
+      "name": "document_push_queue",
+      "schema": "",
+      "columns": {
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_push_queue_claim_idx": {
+          "name": "document_push_queue_claim_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_push_queue_author_idx": {
+          "name": "document_push_queue_author_idx",
+          "columns": [
+            {
+              "expression": "author_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_devices": {
+      "name": "push_devices",
+      "schema": "",
+      "columns": {
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_devices_owner_idx": {
+          "name": "push_devices_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_topics": {
+      "name": "push_topics",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_topics_subject_idx": {
+          "name": "push_topics_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "push_topics_owner_did_subject_type_subject_pk": {
+          "name": "push_topics_owner_did_subject_type_subject_pk",
+          "columns": [
+            "owner_did",
+            "subject_type",
+            "subject"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_saves": {
+      "name": "list_saves",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saver_did": {
+          "name": "saver_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_owner_did": {
+          "name": "list_owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "list_saves_saver_idx": {
+          "name": "list_saves_saver_idx",
+          "columns": [
+            {
+              "expression": "saver_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "list_saves_list_uri_idx": {
+          "name": "list_saves_list_uri_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lists": {
+      "name": "lists",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publications": {
+          "name": "publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "users": {
+          "name": "users",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lists_owner_idx": {
+          "name": "lists_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rkey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_corecommends": {
+      "name": "publication_corecommends",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_recommender_count": {
+          "name": "co_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_corecomm_rank_idx": {
+          "name": "publication_corecomm_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_corecommends_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_corecommends_related_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_corecommends_publication_uri_related_publication_uri_pk": {
+          "name": "publication_corecommends_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_cosubscriptions": {
+      "name": "publication_cosubscriptions",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_subscriber_count": {
+          "name": "co_subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_cosub_rank_idx": {
+          "name": "publication_cosub_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_cosubscriptions_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_cosubscriptions_related_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_cosubscriptions_publication_uri_related_publication_uri_pk": {
+          "name": "publication_cosubscriptions_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_stats": {
+      "name": "publication_stats",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommend_count": {
+          "name": "recommend_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_document_at": {
+          "name": "last_document_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documents_7d": {
+          "name": "documents_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_7d": {
+          "name": "subscribers_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_7d": {
+          "name": "recommends_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "documents_prev_7d": {
+          "name": "documents_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_prev_7d": {
+          "name": "subscribers_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_prev_7d": {
+          "name": "recommends_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlinks_7d": {
+          "name": "backlinks_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_velocity": {
+          "name": "trending_velocity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_window_start": {
+          "name": "trending_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_stats_subscribers_idx": {
+          "name": "publication_stats_subscribers_idx",
+          "columns": [
+            {
+              "expression": "subscriber_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_active_idx": {
+          "name": "publication_stats_active_idx",
+          "columns": [
+            {
+              "expression": "last_document_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_trending_idx": {
+          "name": "publication_stats_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_stats_publication_uri_publications_uri_fk": {
+          "name": "publication_stats_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_stats",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_stats": {
+      "name": "network_stats",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discover_topic_counts": {
+      "name": "discover_topic_counts",
+      "schema": "",
+      "columns": {
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discover_topic_counts_count_idx": {
+          "name": "discover_topic_counts_count_idx",
+          "columns": [
+            {
+              "expression": "publication_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discover_topic_counts_topic_trgm_idx": {
+          "name": "discover_topic_counts_topic_trgm_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag_embeddings": {
+      "name": "tag_embeddings",
+      "schema": "",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "double precision[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_publications": {
+      "name": "topic_publications",
+      "schema": "",
+      "columns": {
+        "topic_slug": {
+          "name": "topic_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "matched_tag_count": {
+          "name": "matched_tag_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "topic_publications_rank_idx": {
+          "name": "topic_publications_rank_idx",
+          "columns": [
+            {
+              "expression": "topic_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_publications_pub_idx": {
+          "name": "topic_publications_pub_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_publications_topic_slug_topics_slug_fk": {
+          "name": "topic_publications_topic_slug_topics_slug_fk",
+          "tableFrom": "topic_publications",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "topic_publications_publication_uri_publications_uri_fk": {
+          "name": "topic_publications_publication_uri_publications_uri_fk",
+          "tableFrom": "topic_publications",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_publications_topic_slug_publication_uri_pk": {
+          "name": "topic_publications_topic_slug_publication_uri_pk",
+          "columns": [
+            "topic_slug",
+            "publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_tags": {
+      "name": "topic_tags",
+      "schema": "",
+      "columns": {
+        "topic_slug": {
+          "name": "topic_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "topic_tags_tag_idx": {
+          "name": "topic_tags_tag_idx",
+          "columns": [
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_tags_weight_idx": {
+          "name": "topic_tags_weight_idx",
+          "columns": [
+            {
+              "expression": "topic_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weight",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_tags_topic_slug_topics_slug_fk": {
+          "name": "topic_tags_topic_slug_topics_slug_fk",
+          "tableFrom": "topic_tags",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_tags_topic_slug_tag_pk": {
+          "name": "topic_tags_topic_slug_tag_pk",
+          "columns": [
+            "topic_slug",
+            "tag"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_tags": {
+          "name": "signature_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_count": {
+          "name": "tag_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author_count": {
+          "name": "author_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_model": {
+          "name": "name_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "named_at": {
+          "name": "named_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topics_published_score_idx": {
+          "name": "topics_published_score_idx",
+          "columns": [
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topics_superseded_by_topics_slug_fk": {
+          "name": "topics_superseded_by_topics_slug_fk",
+          "tableFrom": "topics",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "superseded_by"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_dead_letter": {
+      "name": "ingest_dead_letter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retries": {
+          "name": "retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingest_dead_letter_collection_idx": {
+          "name": "ingest_dead_letter_collection_idx",
+          "columns": [
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_state": {
+      "name": "ingest_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_processed": {
+          "name": "events_processed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_repos": {
+      "name": "tracked_repos",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_to_tap_at": {
+          "name": "added_to_tap_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_state": {
+          "name": "backfill_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_seen_rev": {
+          "name": "last_seen_rev",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_fail_count": {
+          "name": "reconcile_fail_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconcile_retry_after": {
+          "name": "reconcile_retry_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tracked_repos_state_idx": {
+          "name": "tracked_repos_state_idx",
+          "columns": [
+            {
+              "expression": "backfill_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_labels": {
+      "name": "document_labels",
+      "schema": "",
+      "columns": {
+        "src": {
+          "name": "src",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "val": {
+          "name": "val",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cts": {
+          "name": "cts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_labels_uri_idx": {
+          "name": "document_labels_uri_idx",
+          "columns": [
+            {
+              "expression": "uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_labels_src_idx": {
+          "name": "document_labels_src_idx",
+          "columns": [
+            {
+              "expression": "src",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "document_labels_src_uri_val_pk": {
+          "name": "document_labels_src_uri_val_pk",
+          "columns": [
+            "src",
+            "uri",
+            "val"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_sync_state": {
+      "name": "label_sync_state",
+      "schema": "",
+      "columns": {
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_count": {
+          "name": "stored_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rejected_count": {
+          "name": "rejected_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_services": {
+      "name": "labeler_services",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_endpoint": {
+          "name": "service_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels_standard_site": {
+          "name": "labels_standard_site",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels_probed_at": {
+          "name": "labels_probed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reachable": {
+          "name": "reachable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_value_definitions": {
+          "name": "label_value_definitions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_services_labeler_idx": {
+          "name": "labeler_services_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_subscriptions": {
+      "name": "labeler_subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefs": {
+          "name": "prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_subscriptions_subscriber_idx": {
+          "name": "labeler_subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labeler_subscriptions_labeler_idx": {
+          "name": "labeler_subscriptions_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_list_items": {
+      "name": "block_list_items",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "block_list_items_list_idx": {
+          "name": "block_list_items_list_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_list_items_subject_idx": {
+          "name": "block_list_items_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_list_items_list_subject_idx": {
+          "name": "block_list_items_list_subject_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_list_sync_state": {
+      "name": "block_list_sync_state",
+      "schema": "",
+      "columns": {
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_count": {
+          "name": "item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "truncated": {
+          "name": "truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_lists": {
+      "name": "block_lists",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocker_did": {
+          "name": "blocker_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "block_lists_blocker_idx": {
+          "name": "block_lists_blocker_idx",
+          "columns": [
+            {
+              "expression": "blocker_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_lists_list_idx": {
+          "name": "block_lists_list_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_sync_state": {
+      "name": "block_sync_state",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "outgoing_count": {
+          "name": "outgoing_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "incoming_count": {
+          "name": "incoming_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "list_count": {
+          "name": "list_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocker_did": {
+          "name": "blocker_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocks_subject_idx": {
+          "name": "blocks_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocks_edge_idx": {
+          "name": "blocks_edge_idx",
+          "columns": [
+            {
+              "expression": "blocker_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_auth_code": {
+      "name": "mcp_auth_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_auth_code_expires_at_idx": {
+          "name": "mcp_auth_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_auth_code_client_id_mcp_client_id_fk": {
+          "name": "mcp_auth_code_client_id_mcp_client_id_fk",
+          "tableFrom": "mcp_auth_code",
+          "tableTo": "mcp_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_auth_code_user_id_user_id_fk": {
+          "name": "mcp_auth_code_user_id_user_id_fk",
+          "tableFrom": "mcp_auth_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_client": {
+      "name": "mcp_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_uri": {
+          "name": "client_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_uri": {
+          "name": "logo_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_token": {
+      "name": "mcp_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_token_user_id_idx": {
+          "name": "mcp_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_expires_at_idx": {
+          "name": "mcp_token_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_client_id_mcp_client_id_fk": {
+          "name": "mcp_token_client_id_mcp_client_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "mcp_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_user_id_user_id_fk": {
+          "name": "mcp_token_user_id_user_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_token_access_token_hash_unique": {
+          "name": "mcp_token_access_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token_hash"
+          ]
+        },
+        "mcp_token_refresh_token_hash_unique": {
+          "name": "mcp_token_refresh_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_shares": {
+      "name": "quote_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_text": {
+          "name": "quote_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quote_shares_document_uri_idx": {
+          "name": "quote_shares_document_uri_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_draft": {
+      "name": "feedback_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feedback_draft_user_idx": {
+          "name": "feedback_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_draft_expires_idx": {
+          "name": "feedback_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_draft_user_id_user_id_fk": {
+          "name": "feedback_draft_user_id_user_id_fk",
+          "tableFrom": "feedback_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upvote_draft": {
+      "name": "upvote_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "upvote_draft_user_idx": {
+          "name": "upvote_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upvote_draft_expires_idx": {
+          "name": "upvote_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upvote_draft_user_id_user_id_fk": {
+          "name": "upvote_draft_user_id_user_id_fk",
+          "tableFrom": "upvote_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.save_draft": {
+      "name": "save_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_app": {
+          "name": "target_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_uri": {
+          "name": "collection_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_cid": {
+          "name": "collection_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_collection_name": {
+          "name": "new_collection_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motivation": {
+          "name": "motivation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passage": {
+          "name": "passage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "save_draft_user_idx": {
+          "name": "save_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "save_draft_expires_idx": {
+          "name": "save_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "save_draft_user_id_user_id_fk": {
+          "name": "save_draft_user_id_user_id_fk",
+          "tableFrom": "save_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/standard-reader/drizzle/meta/_journal.json
+++ b/apps/standard-reader/drizzle/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1786344772815,
       "tag": "0036_acoustic_zemo",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1786555171840,
+      "tag": "0037_burly_magus",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/standard-reader/src/components/reader/article-view.tsx
+++ b/apps/standard-reader/src/components/reader/article-view.tsx
@@ -29,6 +29,7 @@ import {
   horizontalSpace,
   verticalSpace,
 } from "@standard-reader/design-system/theme/semantic-spacing.stylex";
+import { shadow } from "@standard-reader/design-system/theme/shadow.stylex";
 import { spacing } from "@standard-reader/design-system/theme/spacing.stylex";
 import {
   fontFamily,
@@ -62,7 +63,6 @@ import {
   Fragment,
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -126,20 +126,7 @@ import { SaveDraftConsumer } from "./save-draft-consumer";
 import { useArticleBookmark } from "./use-article-bookmark";
 import { useArticleReadToggle } from "./use-article-read-toggle";
 import { useArticleRecommend } from "./use-article-recommend";
-
-/** Reading progress of the article content within the document scroll. */
-function articleReadingProgress(content: HTMLElement): number {
-  const viewport = globalThis.innerHeight;
-  const scrollY = globalThis.scrollY;
-  const contentTop = content.getBoundingClientRect().top + scrollY;
-  const contentBottom = contentTop + content.offsetHeight;
-  const endScroll = Math.max(contentBottom - viewport, contentTop);
-  const range = endScroll - contentTop;
-  if (range <= 0) {
-    return scrollY >= contentTop ? 1 : 0;
-  }
-  return Math.min(1, Math.max(0, (scrollY - contentTop) / range));
-}
+import { useReadingProgress } from "./use-reading-progress";
 
 /**
  * How tall the article's own top bar is, measured rather than assumed — it wraps
@@ -277,6 +264,39 @@ const styles = stylex.create({
     position: "relative",
     height: spacing["1"],
     width: "100%",
+  },
+  resumedNotice: {
+    alignItems: "center",
+    backgroundColor: uiColor.bg,
+    borderColor: uiColor.border1,
+    borderRadius: radius.full,
+    borderStyle: "solid",
+    borderWidth: 1,
+    boxShadow: shadow.lg,
+    columnGap: gap.md,
+    display: "flex",
+    // Clears the floating page-reader bar and the home indicator, so the two
+    // never stack on top of each other on a phone.
+    bottom: `calc(env(safe-area-inset-bottom, 0px) + ${spacing["6"]})`,
+    // Centred with auto margins rather than a 50% inset + translate: the
+    // translate would push the pill off-centre the moment the locale is RTL.
+    insetInline: 0,
+    marginInline: "auto",
+    maxWidth: `calc(100% - ${spacing["8"]})`,
+    paddingBottom: verticalSpace.xs,
+    paddingInlineEnd: horizontalSpace.xs,
+    paddingInlineStart: horizontalSpace.md,
+    paddingTop: verticalSpace.xs,
+    position: "fixed",
+    width: "fit-content",
+    zIndex: 30,
+  },
+  resumedText: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.sm,
+    lineHeight: lineHeight.sm,
+    whiteSpace: "nowrap",
   },
   topLeft: {
     alignItems: "center",
@@ -964,6 +984,50 @@ function ReaderProgress({ progress }: { progress: number }) {
   );
 }
 
+/** How long the resume notice stays up before it gets out of the way. */
+const RESUMED_NOTICE_MS = 6000;
+
+/**
+ * Says what just happened, and offers the way back.
+ *
+ * Landing mid-article is ambiguous on its own — a reader can't tell whether we
+ * resumed them or whether the piece simply opens that way, and the doubt is
+ * enough to make them scroll up to check. One line removes the doubt, and the
+ * button makes the jump reversible for the case where they did want the top.
+ */
+function ResumedNotice({ onStartFromTop }: { onStartFromTop: () => void }) {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const timer = globalThis.setTimeout(
+      () => setVisible(false),
+      RESUMED_NOTICE_MS,
+    );
+    return () => globalThis.clearTimeout(timer);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    // `status` rather than `alert`: worth mentioning, never worth interrupting.
+    <div {...stylex.props(styles.resumedNotice)} role="status">
+      <span {...stylex.props(styles.resumedText)}>
+        <Trans>Picked up where you left off</Trans>
+      </span>
+      <Button
+        variant="tertiary"
+        size="sm"
+        onPress={() => {
+          onStartFromTop();
+          setVisible(false);
+        }}
+      >
+        <Trans>Start from top</Trans>
+      </Button>
+    </div>
+  );
+}
+
 const COLLECTION_MAGAZINE_INTRO_KEY = "collection-magazine-intro:v1";
 
 function CollectionColophon({ body }: { body: string }) {
@@ -1011,7 +1075,6 @@ function ArticleViewBody({
   // reader is moving forward, leaving only the progress track on screen.
   const stickyChromeRef = useRef<HTMLDivElement>(null);
   const setTopBarNode = useTopBarHeight(stickyChromeRef);
-  const [progress, setProgress] = useState(0);
   const [showMagazineIntro, setShowMagazineIntro] = useState(
     () => Boolean(article.collection) && !hasSeenCollectionMagazineIntro(),
   );
@@ -1172,37 +1235,19 @@ function ArticleViewBody({
     return () => globalThis.clearTimeout(timeout);
   }, [article.collection, article.uri, linkParams, queryClient, router]);
 
-  useLayoutEffect(() => {
-    // Measure the <article> only — progress should hit 100% at the end of the
-    // article body, not after the "More from" / comments sections below it.
-    const articleEl = articleRef.current;
-    if (!articleEl) return;
-
-    const sync = () => {
-      setProgress(articleReadingProgress(articleEl));
-    };
-
-    if (!sharedQuote?.trim()) {
-      globalThis.scrollTo(0, 0);
-    }
-    sync();
-
-    // The page (document) is the scroller, so its scroll event fires on window.
-    globalThis.addEventListener("scroll", sync, { passive: true });
-    const resizeObserver = new ResizeObserver(() => sync());
-    resizeObserver.observe(articleEl);
-
-    return () => {
-      globalThis.removeEventListener("scroll", sync);
-      resizeObserver.disconnect();
-    };
-  }, [article.uri, sharedQuote]);
+  const { progress, resumed, startFromTop } = useReadingProgress({
+    articleRef,
+    documentUri: article.uri,
+    enabled: trackReading,
+    skipRestore: Boolean(sharedQuote?.trim()),
+  });
 
   return (
     <div
       data-unclipped-sticky
       {...stylex.props(styles.root, readerActive && styles.rootReader)}
     >
+      {resumed ? <ResumedNotice onStartFromTop={startFromTop} /> : null}
       <div ref={stickyChromeRef} {...stylex.props(styles.stickyChrome)}>
         <div ref={setTopBarNode} {...stylex.props(styles.topBar)}>
           <div {...stylex.props(styles.topLeft)}>

--- a/apps/standard-reader/src/components/reader/continue-reading.tsx
+++ b/apps/standard-reader/src/components/reader/continue-reading.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { Trans, useLingui } from "@lingui/react/macro";
+import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
+import { radius } from "@standard-reader/design-system/theme/radius.stylex";
+import { gap } from "@standard-reader/design-system/theme/semantic-spacing.stylex";
+import { spacing } from "@standard-reader/design-system/theme/spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+} from "@standard-reader/design-system/theme/typography.stylex";
+import * as stylex from "@stylexjs/stylex";
+
+import type { UnfinishedReadingItem } from "#/integrations/tanstack-query/api-reader.functions";
+
+import { ArticleRow } from "./cards";
+import { SectionHead } from "./primitives";
+
+const styles = stylex.create({
+  row: {
+    display: "flex",
+    flexDirection: "column",
+    rowGap: gap.sm,
+  },
+  meter: {
+    alignItems: "center",
+    columnGap: gap.sm,
+    display: "flex",
+    paddingBottom: spacing["4"],
+  },
+  track: {
+    backgroundColor: uiColor.component2,
+    borderRadius: radius.full,
+    flexGrow: 1,
+    height: spacing["1"],
+    minWidth: 0,
+    overflow: "hidden",
+  },
+  fill: {
+    backgroundColor: uiColor.text1,
+    borderRadius: radius.full,
+    height: "100%",
+  },
+  percent: {
+    color: uiColor.text1,
+    flexShrink: 0,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.xs,
+    fontVariantNumeric: "tabular-nums",
+    fontWeight: fontWeight.medium,
+    lineHeight: lineHeight.sm,
+  },
+});
+
+/**
+ * The shelf of articles this reader is in the middle of.
+ *
+ * It sits above the history list rather than inside it because the two answer
+ * different questions — history is "what have I read", this is "what am I still
+ * reading" — and only one of them is actionable.
+ */
+export function ContinueReading({
+  items,
+}: {
+  items: Array<UnfinishedReadingItem>;
+}) {
+  const { t, i18n } = useLingui();
+
+  // An article can drop out of the read-model (deleted, or never mirrored);
+  // there is nothing to continue in that case, so it just isn't on the shelf.
+  // `flatMap` rather than `filter` so the narrowed `article` survives.
+  const readable = items.flatMap((item) =>
+    item.article ? [{ ...item, article: item.article }] : [],
+  );
+  if (readable.length === 0) return null;
+
+  return (
+    <>
+      <SectionHead
+        kicker={t`Still open`}
+        title={t`Continue reading`}
+        size="md"
+      />
+      {readable.map((item, index) => {
+        // Round toward the middle: never 0% on an article they've started, and
+        // never 100% on one they haven't finished.
+        const percent = Math.min(
+          99,
+          Math.max(1, Math.round(item.progress * 100)),
+        );
+        const label = i18n.number(item.progress, { style: "percent" });
+
+        return (
+          <div key={item.documentUri} {...stylex.props(styles.row)}>
+            <ArticleRow
+              article={item.article}
+              isFirstInSection={index === 0}
+              showSaveButton={false}
+            />
+            <div {...stylex.props(styles.meter)}>
+              <div
+                {...stylex.props(styles.track)}
+                role="progressbar"
+                aria-valuenow={percent}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label={t`Reading progress`}
+              >
+                <div
+                  {...stylex.props(styles.fill)}
+                  style={{ width: `${percent}%` }}
+                />
+              </div>
+              <span {...stylex.props(styles.percent)}>
+                <Trans>{label} read</Trans>
+              </span>
+            </div>
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/standard-reader/src/components/reader/use-reading-progress.ts
+++ b/apps/standard-reader/src/components/reader/use-reading-progress.ts
@@ -1,0 +1,355 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+
+import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
+import {
+  clearLocalProgress,
+  isResumableProgress,
+  READING_PROGRESS_EPSILON,
+  readLocalProgress,
+  writeLocalProgress,
+} from "#/lib/reading-progress";
+
+/**
+ * How long after landing we keep pulling the reader back to their saved spot.
+ *
+ * Restoring by fraction assumes the article is as tall as it was last time, and
+ * for a few hundred milliseconds it isn't: images have reserved no space yet, so
+ * the target offset drifts as they load. Re-applying across a short window is
+ * what makes the difference between landing where you left off and landing two
+ * screens early. Any real input ends it immediately — nothing yanks the page out
+ * from under someone who has started reading.
+ */
+const RESTORE_SETTLE_MS = 3000;
+
+/** Debounce on writes. Long enough that a flick through doesn't write a row. */
+const SAVE_DEBOUNCE_MS = 1000;
+
+/** Input that means the reader is driving, not us. */
+const USER_INTENT_EVENTS = [
+  "wheel",
+  "touchstart",
+  "keydown",
+  "pointerdown",
+] as const;
+
+/** Scroll offsets mapping the article body onto a 0–1 fraction. */
+function progressGeometry(content: HTMLElement) {
+  const viewport = globalThis.innerHeight;
+  const contentTop = content.getBoundingClientRect().top + globalThis.scrollY;
+  const contentBottom = contentTop + content.offsetHeight;
+  const endScroll = Math.max(contentBottom - viewport, contentTop);
+  return { contentTop, range: endScroll - contentTop };
+}
+
+/** How far through the article body the reader currently is, 0–1. */
+function measureProgress(content: HTMLElement): number {
+  const { contentTop, range } = progressGeometry(content);
+  const scrollY = globalThis.scrollY;
+  if (range <= 0) return scrollY >= contentTop ? 1 : 0;
+  return Math.min(1, Math.max(0, (scrollY - contentTop) / range));
+}
+
+/** The inverse: the scroll offset that puts the reader at `progress`. */
+function offsetForProgress(content: HTMLElement, progress: number): number {
+  const { contentTop, range } = progressGeometry(content);
+  return contentTop + progress * Math.max(0, range);
+}
+
+export interface UseReadingProgressResult {
+  /** Live 0–1 fraction, for the progress track in the sticky chrome. */
+  progress: number;
+  /** Whether we opened this article somewhere other than the top. */
+  resumed: boolean;
+  /** Send the reader back to the top and forget the saved position. */
+  startFromTop: () => void;
+}
+
+/**
+ * Keeps an article open at the place the reader left it, and remembers the
+ * place they leave it at.
+ *
+ * Position is stored twice on purpose — see `#/lib/reading-progress`. The local
+ * copy is read synchronously here so the restore happens in the same frame as
+ * the first paint (a visible scroll jump is worse than no restore at all); the
+ * server copy arrives a beat later and only wins if the reader got further on
+ * another device and hasn't touched this one yet.
+ */
+export function useReadingProgress({
+  documentUri,
+  articleRef,
+  enabled,
+  skipRestore,
+}: {
+  documentUri: string;
+  articleRef: React.RefObject<HTMLElement | null>;
+  /** False when the reader has reading history turned off. */
+  enabled: boolean;
+  /** True when something else owns the landing position (a shared quote). */
+  skipRestore: boolean;
+}): UseReadingProgressResult {
+  const queryClient = useQueryClient();
+  const [progress, setProgress] = useState(0);
+  const [resumed, setResumed] = useState(false);
+
+  const progressRef = useRef(0);
+  const savedRef = useRef<number | null>(null);
+  const userDroveRef = useRef(false);
+  /** Re-applies the saved position; live only during the settle window. */
+  const applyRestoreRef = useRef<((progress: number) => void) | null>(null);
+  /**
+   * `enabled` and `save` are read through refs so the restore effect can depend
+   * on the article alone. The preference arrives from a query and flips from its
+   * default a moment after mount — as a dependency it would re-run the effect
+   * and scroll a reader who had already started reading back to the saved spot.
+   */
+  const enabledRef = useRef(enabled);
+  const saveRef = useRef<(next: number) => void>(() => {});
+
+  const { mutate: persist } = useMutation({
+    mutationKey: ["reader", "setReadingProgress"] as const,
+    mutationFn: async (next: number) =>
+      readerApi.setReadingProgress({
+        data: { documentUri, progress: next },
+      }),
+    // Fail fast offline instead of taking React Query's default, which *pauses*
+    // the mutation and replays it on reconnect. Scrolling emits one of these
+    // every second or so, so a subway ride would queue dozens of writes that
+    // all replay to say what the last one says. The local copy is the durable
+    // record; the reconnect flush below sends the one value that matters.
+    networkMode: "offlineFirst",
+    onError: () => {},
+    retry: false,
+  });
+
+  const save = useCallback(
+    (next: number) => {
+      if (!enabled) return;
+
+      const previous = savedRef.current;
+      if (
+        previous !== null &&
+        Math.abs(next - previous) < READING_PROGRESS_EPSILON
+      ) {
+        return;
+      }
+      savedRef.current = next;
+
+      writeLocalProgress(documentUri, next);
+      persist(next);
+
+      // The shelf only changes when an article joins or leaves it — not on
+      // every scroll — so this refetch stays rare.
+      if (
+        previous === null ||
+        isResumableProgress(previous) !== isResumableProgress(next)
+      ) {
+        void queryClient.invalidateQueries({
+          queryKey: ["reader", "unfinished"],
+        });
+      }
+    },
+    [documentUri, enabled, persist, queryClient],
+  );
+
+  // Runs before the restore effect below on every commit, so that effect always
+  // reads the current preference without listing it as a dependency.
+  useLayoutEffect(() => {
+    enabledRef.current = enabled;
+    saveRef.current = save;
+  }, [enabled, save]);
+
+  // Coming back online, send where the reader actually got to while offline —
+  // one write, deliberately bypassing `save`'s "has it moved enough" guard,
+  // because what changed is our ability to reach the server, not the position.
+  useEffect(() => {
+    if (!enabled) return;
+
+    const flushOnReconnect = () => {
+      persist(progressRef.current);
+      void queryClient.invalidateQueries({
+        queryKey: ["reader", "unfinished"],
+      });
+    };
+
+    globalThis.addEventListener("online", flushOnReconnect);
+    return () => globalThis.removeEventListener("online", flushOnReconnect);
+  }, [enabled, persist, queryClient]);
+
+  const { mutate: forget } = useMutation({
+    mutationKey: ["reader", "clearReadingProgress"] as const,
+    mutationFn: async () =>
+      readerApi.clearReadingProgress({ data: { documentUri } }),
+    // Unlike the position writes above, this one keeps React Query's default
+    // network mode so an offline clear is paused and replayed on reconnect.
+    // It is a single deliberate action, not a stream, and dropping it would let
+    // the server position come back and undo what the reader just asked for.
+    onSettled: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["reader", "unfinished"],
+      });
+    },
+  });
+
+  const startFromTop = useCallback(() => {
+    userDroveRef.current = true;
+    applyRestoreRef.current = null;
+    globalThis.scrollTo(0, 0);
+    setResumed(false);
+    savedRef.current = 0;
+    clearLocalProgress(documentUri);
+    // Drop the cached server answer too, so nothing re-reads the position we
+    // just cleared before the mutation lands.
+    queryClient.setQueryData(
+      readerApi.getReadingProgressQueryOptions(documentUri).queryKey,
+      null,
+    );
+    if (enabled) forget();
+  }, [documentUri, enabled, forget, queryClient]);
+
+  useLayoutEffect(() => {
+    const articleEl = articleRef.current;
+    if (!articleEl) return;
+
+    progressRef.current = 0;
+    savedRef.current = null;
+    userDroveRef.current = false;
+    setResumed(false);
+
+    let restoreTarget: number | null = null;
+    let settleTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
+    let saveTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
+
+    const endRestore = () => {
+      userDroveRef.current = true;
+      restoreTarget = null;
+      applyRestoreRef.current = null;
+      if (settleTimer !== undefined) globalThis.clearTimeout(settleTimer);
+      for (const event of USER_INTENT_EVENTS) {
+        globalThis.removeEventListener(event, endRestore);
+      }
+    };
+
+    const applyRestore = (target: number) => {
+      restoreTarget = target;
+      globalThis.scrollTo(0, offsetForProgress(articleEl, target));
+      setResumed(true);
+    };
+
+    const sync = () => {
+      const next = measureProgress(articleEl);
+      progressRef.current = next;
+      setProgress(next);
+    };
+
+    const scheduleSave = () => {
+      if (!enabledRef.current) return;
+      if (saveTimer !== undefined) globalThis.clearTimeout(saveTimer);
+      saveTimer = globalThis.setTimeout(() => {
+        saveRef.current(progressRef.current);
+      }, SAVE_DEBOUNCE_MS);
+    };
+
+    // Measure the <article> only — progress should hit 100% at the end of the
+    // article body, not after the "More from" / comments sections below it.
+    const stored =
+      enabledRef.current && !skipRestore
+        ? readLocalProgress(documentUri)
+        : null;
+
+    if (stored && isResumableProgress(stored.progress)) {
+      savedRef.current = stored.progress;
+      applyRestore(stored.progress);
+      applyRestoreRef.current = applyRestore;
+      for (const event of USER_INTENT_EVENTS) {
+        globalThis.addEventListener(event, endRestore, {
+          passive: true,
+          once: true,
+        });
+      }
+      settleTimer = globalThis.setTimeout(endRestore, RESTORE_SETTLE_MS);
+    } else if (!skipRestore) {
+      globalThis.scrollTo(0, 0);
+    }
+
+    sync();
+
+    // The page (document) is the scroller, so its scroll event fires on window.
+    const onScroll = () => {
+      sync();
+      scheduleSave();
+    };
+    globalThis.addEventListener("scroll", onScroll, { passive: true });
+
+    const resizeObserver = new ResizeObserver(() => {
+      // Late-loading media moved the target out from under us.
+      if (restoreTarget !== null) {
+        globalThis.scrollTo(0, offsetForProgress(articleEl, restoreTarget));
+      }
+      sync();
+    });
+    resizeObserver.observe(articleEl);
+
+    // Closing the tab is the most common way to leave an article part-read, and
+    // it is the one moment a debounce would lose. `pagehide` also covers the
+    // iOS back-forward cache, where `beforeunload` never fires.
+    const flush = () => {
+      if (saveTimer !== undefined) globalThis.clearTimeout(saveTimer);
+      saveRef.current(progressRef.current);
+    };
+    const onPageHide = () => flush();
+    const onVisibility = () => {
+      if (globalThis.document.visibilityState === "hidden") flush();
+    };
+    globalThis.addEventListener("pagehide", onPageHide);
+    globalThis.document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      flush();
+      endRestore();
+      if (saveTimer !== undefined) globalThis.clearTimeout(saveTimer);
+      globalThis.removeEventListener("scroll", onScroll);
+      globalThis.removeEventListener("pagehide", onPageHide);
+      globalThis.document.removeEventListener("visibilitychange", onVisibility);
+      resizeObserver.disconnect();
+    };
+    // Deliberately keyed on the article alone — see `enabledRef` above.
+  }, [articleRef, documentUri, skipRestore]);
+
+  // The other-device correction. Deliberately not awaited anywhere on the
+  // critical path — it lands late and only matters when it disagrees.
+  const { data: remote } = useQuery({
+    ...readerApi.getReadingProgressQueryOptions(documentUri),
+    enabled: enabled && !skipRestore,
+  });
+
+  useEffect(() => {
+    if (!remote || userDroveRef.current) return;
+    const applyRestore = applyRestoreRef.current;
+    if (!applyRestore) return;
+    if (!isResumableProgress(remote.progress)) return;
+
+    const local = readLocalProgress(documentUri);
+    // This device already knows at least as much — leave the reader alone.
+    if (local && local.updatedAt >= remote.updatedAt) return;
+    if (
+      Math.abs(remote.progress - progressRef.current) < READING_PROGRESS_EPSILON
+    ) {
+      return;
+    }
+
+    savedRef.current = remote.progress;
+    writeLocalProgress(documentUri, remote.progress, remote.updatedAt);
+    applyRestore(remote.progress);
+  }, [documentUri, remote]);
+
+  return { progress, resumed, startFromTop };
+}

--- a/apps/standard-reader/src/components/user-settings-view.tsx
+++ b/apps/standard-reader/src/components/user-settings-view.tsx
@@ -82,6 +82,7 @@ import type { Locale } from "#/lib/locale";
 import { LOCALE_LABELS, LOCALES, PSEUDO_LOCALE, isLocale } from "#/lib/locale";
 import { AMERICAN_ENGLISH_VOICES } from "#/lib/page-reader/voice-catalog";
 import { isReaderVoicePreference } from "#/lib/reader-voice";
+import { clearAllLocalProgress } from "#/lib/reading-progress";
 import type { ReadingTypographyPreference } from "#/lib/reading-typography";
 import {
   READING_BODY_FONTS,
@@ -485,9 +486,17 @@ export function UserSettingsView() {
   const signedIn = Boolean(session?.user);
   const sidebarPref = useSidebarPref(signedIn);
 
-  const deleteHistoryMutation = useMutation(
-    readerApi.deleteAllReadHistoryMutationOptions(),
-  );
+  const deleteHistoryMutation = useMutation({
+    ...readerApi.deleteAllReadHistoryMutationOptions(),
+    onSuccess: () => {
+      // The server rows are gone; drop this device's copy too, or the next
+      // article the reader opens resumes from a position they just erased.
+      clearAllLocalProgress();
+      void queryClient.invalidateQueries({
+        queryKey: ["reader", "unfinished"],
+      });
+    },
+  });
   const deleteBookmarksMutation = useMutation(
     readerApi.deleteAllBookmarksMutationOptions(),
   );

--- a/apps/standard-reader/src/db/schema.ts
+++ b/apps/standard-reader/src/db/schema.ts
@@ -17,6 +17,7 @@ export * from "./schema/publications.ts";
 export * from "./schema/documents.ts";
 export * from "./schema/graph.ts";
 export * from "./schema/personal.ts";
+export * from "./schema/reading-progress.ts";
 export * from "./schema/push.ts";
 export * from "./schema/lists.ts";
 export * from "./schema/stats.ts";

--- a/apps/standard-reader/src/db/schema/reading-progress.ts
+++ b/apps/standard-reader/src/db/schema/reading-progress.ts
@@ -1,0 +1,58 @@
+import {
+  index,
+  pgTable,
+  primaryKey,
+  real,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core";
+
+/**
+ * How far a reader got through an article — deliberately **not** an AT Proto
+ * record.
+ *
+ * Every other personal-state table in `./personal.ts` mirrors a record in the
+ * reader's own repo, and those records are public (`APP_VISION.md` §5): anyone
+ * can see what you read. Position is a different kind of fact. "I stopped 20%
+ * into this" is a running commentary on attention, and publishing it to the
+ * firehose is not something a reader opted into by opening an article. So this
+ * lives only here, private to the app, and the tap never writes it.
+ *
+ * The trade is that progress is app-local rather than portable — it follows the
+ * reader across their devices (it is keyed by DID, not by browser) but does not
+ * travel with the repo to another client.
+ */
+export const readingProgress = pgTable(
+  "reading_progress",
+  {
+    /** DID of the reader. No FK to `user`: the DID outlives any one session
+     * row, matching `push_devices` / `push_topics`. */
+    ownerDid: text("owner_did").notNull(),
+    /** AT-URI of the `site.standard.document` being read. */
+    documentUri: text("document_uri").notNull(),
+
+    /**
+     * Fraction of the article body scrolled past, 0–1. A fraction rather than a
+     * pixel offset because the same reader's phone and laptop disagree on every
+     * pixel — column width, text-size dial, and font all differ — but they
+     * agree on "a third of the way in".
+     */
+    progress: real("progress").notNull(),
+
+    /** When the reader was last at this position. */
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.ownerDid, table.documentUri] }),
+    // "Continue reading" — a reader's in-progress articles, most recent first.
+    index("reading_progress_owner_idx").on(
+      table.ownerDid,
+      table.updatedAt.desc(),
+    ),
+  ],
+);
+
+export type ReadingProgress = typeof readingProgress.$inferSelect;
+export type NewReadingProgress = typeof readingProgress.$inferInsert;

--- a/apps/standard-reader/src/integrations/tanstack-query/api-reader.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-reader.functions.ts
@@ -11,6 +11,11 @@ import { alias } from "drizzle-orm/pg-core";
 import { z } from "zod";
 
 import {
+  isResumableProgress,
+  READING_PROGRESS_DONE,
+  READING_PROGRESS_MIN,
+} from "#/lib/reading-progress";
+import {
   getAtprotoSessionForRequest,
   getReaderDidForRequest,
 } from "#/middleware/auth-session.server";
@@ -94,6 +99,13 @@ const documentsInput = z.object({
 
 /** Default page size for likes / saved / history infinite scroll. */
 export const READER_QUEUE_PAGE_SIZE = 20;
+
+/**
+ * How many in-progress articles the "Continue reading" shelf holds. Short on
+ * purpose: it is a prompt to pick something back up, and a long one reads as
+ * another backlog to feel behind on.
+ */
+export const UNFINISHED_SHELF_SIZE = 6;
 
 const readerListInput = z.object({
   limit: z.number().int().min(1).max(100).default(READER_QUEUE_PAGE_SIZE),
@@ -442,6 +454,20 @@ export interface SavedListPage extends ReaderListPage<SavedArticleItem> {
 export interface ReadHistoryItem {
   readUri: string;
   readAt: string | null;
+  documentUri: string;
+  /** Null when the document is no longer in the read-model. */
+  article: ArticleCard | null;
+}
+
+/** Where a reader stopped in one article, as the server knows it. */
+export interface ReadingPosition {
+  /** Fraction of the article body scrolled past, 0–1. */
+  progress: number;
+  updatedAt: string;
+}
+
+/** An article the reader is partway through, with hydrated card data. */
+export interface UnfinishedReadingItem extends ReadingPosition {
   documentUri: string;
   /** Null when the document is no longer in the read-model. */
   article: ArticleCard | null;
@@ -1152,6 +1178,174 @@ const getReadingHistory = createServerFn({ method: "GET" })
     }),
   );
 
+// ── Reading position (app-local; deliberately not a repo record) ────────────
+
+const readingProgressInput = z.object({
+  documentUri: z.string().min(1),
+  /** Fraction of the article body scrolled past. */
+  progress: z.number().min(0).max(1),
+});
+
+const unfinishedInput = z.object({
+  limit: z.number().int().min(1).max(50).default(UNFINISHED_SHELF_SIZE),
+});
+
+/**
+ * Remember where the reader stopped — or forget it, once they finish. Rows are
+ * only kept while {@link isResumableProgress} holds, so `reading_progress` is
+ * exactly the set of articles "Continue reading" should show and never needs a
+ * sweep to stay that way.
+ */
+const setReadingProgress = createServerFn({ method: "POST" })
+  .middleware([dbMiddleware])
+  .validator(readingProgressInput)
+  .handler(
+    observe("reader.setReadingProgress", async ({ data, context }, span) => {
+      span.set("documentUri", data.documentUri);
+      span.set("progress", data.progress);
+      const did = await getReaderDidForRequest(getRequest());
+      if (!did) return { ok: true as const };
+      span.set("did", did);
+
+      // Position is reading history by another name — a reader who turned that
+      // off did not ask us to keep a finer-grained version of it.
+      if (!context.trackReadingEnabled) return { ok: true as const };
+
+      const rp = context.schema.readingProgress;
+      const where = and(
+        eq(rp.ownerDid, did),
+        eq(rp.documentUri, data.documentUri),
+      );
+
+      if (!isResumableProgress(data.progress)) {
+        await context.db.delete(rp).where(where);
+        span.set("cleared", true);
+        return { ok: true as const };
+      }
+
+      await context.db
+        .insert(rp)
+        .values({
+          documentUri: data.documentUri,
+          ownerDid: did,
+          progress: data.progress,
+          updatedAt: new Date(),
+        })
+        .onConflictDoUpdate({
+          target: [rp.ownerDid, rp.documentUri],
+          set: { progress: data.progress, updatedAt: new Date() },
+        });
+
+      return { ok: true as const };
+    }),
+  );
+
+/** Drop a remembered position (the reader chose to start from the top). */
+const clearReadingProgress = createServerFn({ method: "POST" })
+  .middleware([dbMiddleware])
+  .validator(documentInput)
+  .handler(
+    observe("reader.clearReadingProgress", async ({ data, context }, span) => {
+      span.set("documentUri", data.documentUri);
+      const did = await getReaderDidForRequest(getRequest());
+      if (!did) return { ok: true as const };
+      span.set("did", did);
+
+      const rp = context.schema.readingProgress;
+      await context.db
+        .delete(rp)
+        .where(and(eq(rp.ownerDid, did), eq(rp.documentUri, data.documentUri)));
+      return { ok: true as const };
+    }),
+  );
+
+/**
+ * The position this reader's *other* devices know about. The local copy drives
+ * the initial scroll (it is available before first paint); this is what corrects
+ * it when the reader got further on their phone.
+ */
+const getReadingProgress = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware])
+  .validator(documentInput)
+  .handler(
+    observe("reader.getReadingProgress", async ({ data, context }, span) => {
+      span.set("documentUri", data.documentUri);
+      const did = await getReaderDidForRequest(getRequest());
+      if (!did) return null satisfies ReadingPosition | null;
+      span.set("did", did);
+
+      const rp = context.schema.readingProgress;
+      const rows = await context.db
+        .select({ progress: rp.progress, updatedAt: rp.updatedAt })
+        .from(rp)
+        .where(and(eq(rp.ownerDid, did), eq(rp.documentUri, data.documentUri)))
+        .limit(1);
+
+      const row = rows[0];
+      if (!row) return null;
+      return {
+        progress: row.progress,
+        updatedAt: row.updatedAt.toISOString(),
+      } satisfies ReadingPosition;
+    }),
+  );
+
+/** Articles the reader is partway through, most recently touched first. */
+const getUnfinishedReading = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware])
+  .validator(unfinishedInput)
+  .handler(
+    observe("reader.getUnfinishedReading", async ({ data, context }, span) => {
+      const did = await getReaderDidForRequest(getRequest());
+      if (!did) return [] satisfies Array<UnfinishedReadingItem>;
+      span.set("did", did);
+      span.set("limit", data.limit);
+
+      const rp = context.schema.readingProgress;
+      const d = context.schema.documents;
+      const p = context.schema.publications;
+      const pr = context.schema.profiles;
+      const pa = alias(context.schema.profiles, "pa");
+      const cols = articleQueueCardColumns(context.schema);
+
+      const rows = await context.db
+        .select({
+          documentUri: rp.documentUri,
+          progress: rp.progress,
+          updatedAt: rp.updatedAt,
+          ...cols,
+        })
+        .from(rp)
+        .leftJoin(d, eq(d.uri, rp.documentUri))
+        .leftJoin(p, eq(p.uri, d.publicationUri))
+        .leftJoin(pr, eq(pr.did, p.did))
+        .leftJoin(pa, eq(pa.did, d.did))
+        .where(
+          and(
+            eq(rp.ownerDid, did),
+            // Writes already hold this invariant; the filter keeps a stale row
+            // from an older threshold out of the shelf.
+            sql`${rp.progress} >= ${READING_PROGRESS_MIN}`,
+            sql`${rp.progress} < ${READING_PROGRESS_DONE}`,
+          ),
+        )
+        // Matches `reading_progress_owner_idx` (owner_did, updated_at DESC).
+        .orderBy(desc(rp.updatedAt))
+        .limit(data.limit);
+
+      span.set("count", rows.length);
+
+      const items = rows.map((row) => ({
+        documentUri: row.documentUri,
+        progress: row.progress,
+        updatedAt: row.updatedAt.toISOString(),
+        article: hydrateArticleFromRow(row, { isRead: true }),
+      })) satisfies Array<UnfinishedReadingItem>;
+
+      return flagViewerRecommendedItems(context.db, context.schema, did, items);
+    }),
+  );
+
 // ── Save for later (app.standard-reader.bookmark) ───────────────────────────
 
 const getBookmarkStatus = createServerFn({ method: "GET" })
@@ -1445,6 +1639,12 @@ const deleteAllReadHistory = createServerFn({ method: "POST" })
         .delete(context.schema.reads)
         .where(eq(context.schema.reads.ownerDid, session.did));
 
+      // Positions are reading history at a finer grain. Someone clearing the
+      // one and being left with the other would reasonably call that a bug.
+      await context.db
+        .delete(context.schema.readingProgress)
+        .where(eq(context.schema.readingProgress.ownerDid, session.did));
+
       await trackReaderRepo(session.did);
       span.set("deleted", readRows.length);
       return { ok: true as const, deleted: readRows.length };
@@ -1736,6 +1936,25 @@ function getReadingHistoryInfiniteQueryOptions({
   });
 }
 
+function getReadingProgressQueryOptions(documentUri: string) {
+  return queryOptions({
+    queryKey: ["reader", "readingProgress", documentUri] as const,
+    queryFn: async () => getReadingProgress({ data: { documentUri } }),
+    // The reader is looking at the article right now; their own scrolling is
+    // the authority here, not a refetch.
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+function getUnfinishedReadingQueryOptions({
+  limit = UNFINISHED_SHELF_SIZE,
+}: { limit?: number } = {}) {
+  return queryOptions({
+    queryKey: ["reader", "unfinished", limit] as const,
+    queryFn: async () => getUnfinishedReading({ data: { limit } }),
+  });
+}
+
 function getReadDocumentsQueryOptions(documentUris: Array<string>) {
   return queryOptions({
     queryKey: ["reader", "readDocuments", documentUris.toSorted()] as const,
@@ -1916,6 +2135,13 @@ export const readerApi = {
   markUnreadMutationOptions,
   getReadingHistory,
   getReadingHistoryInfiniteQueryOptions,
+  // reading position (app-local, not a repo record)
+  getReadingProgress,
+  getReadingProgressQueryOptions,
+  setReadingProgress,
+  clearReadingProgress,
+  getUnfinishedReading,
+  getUnfinishedReadingQueryOptions,
   // save for later (app.standard-reader.bookmark)
   getBookmarkStatus,
   getBookmarkStatusQueryOptions,

--- a/apps/standard-reader/src/lib/reading-progress.test.ts
+++ b/apps/standard-reader/src/lib/reading-progress.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  clearAllLocalProgress,
+  clearLocalProgress,
+  isResumableProgress,
+  READING_PROGRESS_DONE,
+  READING_PROGRESS_MIN,
+  readLocalProgress,
+  writeLocalProgress,
+} from "./reading-progress";
+
+const URI = "at://did:plc:author/site.standard.document/aaa";
+
+beforeEach(() => {
+  globalThis.localStorage.clear();
+});
+
+describe("isResumableProgress", () => {
+  it("ignores an article the reader barely opened", () => {
+    expect(isResumableProgress(0)).toBe(false);
+    expect(isResumableProgress(READING_PROGRESS_MIN / 2)).toBe(false);
+  });
+
+  it("ignores an article the reader finished", () => {
+    expect(isResumableProgress(READING_PROGRESS_DONE)).toBe(false);
+    expect(isResumableProgress(1)).toBe(false);
+  });
+
+  it("resumes everything in between", () => {
+    expect(isResumableProgress(READING_PROGRESS_MIN)).toBe(true);
+    expect(isResumableProgress(0.5)).toBe(true);
+  });
+});
+
+describe("writeLocalProgress", () => {
+  it("round-trips a mid-article position", () => {
+    writeLocalProgress(URI, 0.42, "2026-08-12T10:00:00.000Z");
+    expect(readLocalProgress(URI)).toEqual({
+      progress: 0.42,
+      updatedAt: "2026-08-12T10:00:00.000Z",
+    });
+  });
+
+  it("forgets the article once the reader reaches the end", () => {
+    writeLocalProgress(URI, 0.42);
+    writeLocalProgress(URI, 0.99);
+    expect(readLocalProgress(URI)).toBeNull();
+  });
+
+  it("forgets the article when the reader scrolls back to the top", () => {
+    writeLocalProgress(URI, 0.42);
+    writeLocalProgress(URI, 0);
+    expect(readLocalProgress(URI)).toBeNull();
+  });
+
+  it("never stores an article that was only glanced at", () => {
+    writeLocalProgress(URI, 0.001);
+    expect(readLocalProgress(URI)).toBeNull();
+  });
+
+  it("keeps articles apart", () => {
+    const other = "at://did:plc:author/site.standard.document/bbb";
+    writeLocalProgress(URI, 0.2);
+    writeLocalProgress(other, 0.8);
+    expect(readLocalProgress(URI)?.progress).toBe(0.2);
+    expect(readLocalProgress(other)?.progress).toBe(0.8);
+  });
+
+  it("evicts the oldest positions past the cap, keeping the newest", () => {
+    // 120 articles, oldest first, one minute apart — the cap is 100.
+    const base = Date.UTC(2026, 0, 1);
+    for (let index = 0; index < 120; index++) {
+      writeLocalProgress(
+        `at://did:plc:author/site.standard.document/${index}`,
+        0.5,
+        new Date(base + index * 60_000).toISOString(),
+      );
+    }
+
+    // The most recent write survives; the very first one does not.
+    expect(
+      readLocalProgress("at://did:plc:author/site.standard.document/119"),
+    ).not.toBeNull();
+    expect(
+      readLocalProgress("at://did:plc:author/site.standard.document/0"),
+    ).toBeNull();
+  });
+});
+
+describe("clearing", () => {
+  it("forgets one article", () => {
+    writeLocalProgress(URI, 0.42);
+    clearLocalProgress(URI);
+    expect(readLocalProgress(URI)).toBeNull();
+  });
+
+  it("forgets everything", () => {
+    writeLocalProgress(URI, 0.42);
+    writeLocalProgress("at://did:plc:author/site.standard.document/bbb", 0.6);
+    clearAllLocalProgress();
+    expect(readLocalProgress(URI)).toBeNull();
+  });
+
+  it("survives a corrupt stored value", () => {
+    globalThis.localStorage.setItem(
+      "standard-reader:reading-progress",
+      "not json",
+    );
+    expect(readLocalProgress(URI)).toBeNull();
+    expect(() => writeLocalProgress(URI, 0.42)).not.toThrow();
+    expect(readLocalProgress(URI)?.progress).toBe(0.42);
+  });
+});

--- a/apps/standard-reader/src/lib/reading-progress.ts
+++ b/apps/standard-reader/src/lib/reading-progress.ts
@@ -1,0 +1,141 @@
+/**
+ * Where a reader stopped in an article, and the rules for when that is worth
+ * remembering.
+ *
+ * Two stores back this, and they answer different questions. The server
+ * (`reading_progress`) is the one that follows a reader from phone to laptop.
+ * `localStorage` is the one that can answer *before the first paint* — restoring
+ * position has to happen in a layout effect, and a round trip to Neon is an
+ * order of magnitude too slow for that, so the local copy drives the scroll and
+ * the server copy corrects it if the reader's other device got further.
+ *
+ * The local copy is also what keeps this working in the installed PWA with no
+ * network: the write is best-effort against the server, always durable locally.
+ */
+
+/**
+ * Below this the reader has barely started — a glance at the top, a bounce.
+ * Resuming there would scroll them roughly nowhere, and listing it under
+ * "Continue reading" would fill the shelf with articles nobody started.
+ */
+export const READING_PROGRESS_MIN = 0.02;
+
+/**
+ * At or above this, treat the article as finished. The tail of an article is
+ * footnotes and author bio, and holding someone at 97% forever means the shelf
+ * never empties — which is the failure that makes people stop trusting it.
+ */
+export const READING_PROGRESS_DONE = 0.95;
+
+/** Whether a stored position is worth restoring / listing. */
+export function isResumableProgress(progress: number): boolean {
+  return progress >= READING_PROGRESS_MIN && progress < READING_PROGRESS_DONE;
+}
+
+/** How much scrolling has to happen before another write is worth it. */
+export const READING_PROGRESS_EPSILON = 0.01;
+
+const STORAGE_KEY = "standard-reader:reading-progress";
+
+/**
+ * Cap on remembered articles. Position is only interesting for what a reader is
+ * currently in the middle of, and an unbounded map in `localStorage` is a slow
+ * leak in a store the whole app shares.
+ */
+const LOCAL_LIMIT = 100;
+
+export interface LocalReadingProgress {
+  progress: number;
+  /** ISO timestamp, used to decide whether the server knows something newer. */
+  updatedAt: string;
+}
+
+type LocalMap = Map<string, LocalReadingProgress>;
+
+function readMap(): LocalMap {
+  if (globalThis.localStorage === undefined) return new Map();
+  try {
+    const raw = globalThis.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return new Map();
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return new Map();
+    return new Map(
+      Object.entries(parsed as Record<string, LocalReadingProgress>),
+    );
+  } catch {
+    // Private browsing, disabled storage, or a value from an older shape.
+    return new Map();
+  }
+}
+
+function writeMap(map: LocalMap): void {
+  if (globalThis.localStorage === undefined) return;
+  try {
+    globalThis.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify(Object.fromEntries(map)),
+    );
+  } catch {
+    // Quota or private browsing — position is a convenience, never a failure.
+  }
+}
+
+/** The locally-remembered position for an article, if any. */
+export function readLocalProgress(
+  documentUri: string,
+): LocalReadingProgress | null {
+  const entry = readMap().get(documentUri);
+  if (!entry || typeof entry.progress !== "number") return null;
+  return entry;
+}
+
+/**
+ * Remember (or forget) a position locally. Writing a finished / barely-started
+ * value forgets it instead, so the local map holds exactly the articles that
+ * would show under "Continue reading".
+ */
+export function writeLocalProgress(
+  documentUri: string,
+  progress: number,
+  updatedAt: string = new Date().toISOString(),
+): void {
+  const map = readMap();
+
+  if (isResumableProgress(progress)) {
+    map.set(documentUri, { progress, updatedAt });
+  } else if (!map.delete(documentUri)) {
+    // Nothing stored and nothing worth storing — don't rewrite the store.
+    return;
+  }
+
+  if (map.size > LOCAL_LIMIT) {
+    const kept = [...map.entries()]
+      .toSorted((a, b) => b[1].updatedAt.localeCompare(a[1].updatedAt))
+      .slice(0, LOCAL_LIMIT);
+    writeMap(new Map(kept));
+    return;
+  }
+
+  writeMap(map);
+}
+
+/** Forget an article's position locally (finished, or reset to the top). */
+export function clearLocalProgress(documentUri: string): void {
+  const map = readMap();
+  if (!map.delete(documentUri)) return;
+  writeMap(map);
+}
+
+/**
+ * Forget every position on this device. Pairs with clearing reading history:
+ * the server rows go with it, and leaving the local copy behind would resurrect
+ * positions the reader just asked us to drop.
+ */
+export function clearAllLocalProgress(): void {
+  if (globalThis.localStorage === undefined) return;
+  try {
+    globalThis.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Nothing to do — the store is unavailable, so nothing is stored.
+  }
+}

--- a/apps/standard-reader/src/routes/_layout.history.tsx
+++ b/apps/standard-reader/src/routes/_layout.history.tsx
@@ -12,7 +12,7 @@ import {
   lineHeight,
 } from "@standard-reader/design-system/theme/typography.stylex";
 import * as stylex from "@stylexjs/stylex";
-import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
+import { useQuery, useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useCallback } from "react";
 
@@ -24,8 +24,13 @@ import { getPublicUrlClient } from "#/lib/public-url";
 import { pageSocialMeta } from "#/lib/site-metadata";
 import { buildAuthRedirectPath } from "#/utils/auth-redirect";
 
+import { ContinueReading } from "../components/reader/continue-reading";
 import { FeedLoadMore } from "../components/reader/feed-load-more";
-import { Masthead, ReaderContent } from "../components/reader/primitives";
+import {
+  Masthead,
+  ReaderContent,
+  SectionHead,
+} from "../components/reader/primitives";
 import { ReaderQueueRows } from "../components/reader/reader-queue-rows";
 
 export const Route = createFileRoute("/_layout/history")({
@@ -41,9 +46,19 @@ export const Route = createFileRoute("/_layout/history")({
     }
   },
   loader: async ({ context }) => {
-    await context.queryClient.ensureInfiniteQueryData(
-      readerApi.getReadingHistoryInfiniteQueryOptions(),
-    );
+    await Promise.all([
+      context.queryClient.ensureInfiniteQueryData(
+        readerApi.getReadingHistoryInfiniteQueryOptions(),
+      ),
+      // The shelf rides along so it paints with the list, but it must never be
+      // what fails the page: offline (or on any server hiccup) a rejection here
+      // would throw the whole route to the error component and cost the reader
+      // their cached history over a six-row extra. The component treats a
+      // missing result as an empty shelf.
+      context.queryClient
+        .ensureQueryData(readerApi.getUnfinishedReadingQueryOptions())
+        .catch(() => null),
+    ]);
   },
   head: () => ({
     meta: pageSocialMeta("history", getPublicUrlClient()),
@@ -105,9 +120,17 @@ function ReaderHistory() {
   const { t } = useLingui();
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useSuspenseInfiniteQuery(readerApi.getReadingHistoryInfiniteQueryOptions());
+  // `useQuery`, not `useSuspenseQuery`: the shelf is an extra on this page, and
+  // suspending (or throwing) on it would take the reading history down with it
+  // when the reader is offline.
+  const { data: unfinished } = useQuery(
+    readerApi.getUnfinishedReadingQueryOptions(),
+  );
 
   const history = data.pages.flatMap((page) => page.items);
   const total = data.pages[0]?.total ?? 0;
+  const unfinishedItems = unfinished ?? [];
+  const hasUnfinished = unfinishedItems.some((item) => item.article != null);
 
   const loadMore = useCallback(() => {
     if (hasNextPage && !isFetchingNextPage) {
@@ -161,6 +184,12 @@ function ReaderHistory() {
         </div>
       ) : (
         <>
+          <ContinueReading items={unfinishedItems} />
+          {/* Only once the shelf is above it does the list below need naming —
+              on its own it is the page, and the masthead already said so. */}
+          {hasUnfinished ? (
+            <SectionHead title={t`Everything you've read`} size="md" />
+          ) : null}
           <ReaderQueueRows
             items={queueRows}
             showSaveButton={false}


### PR DESCRIPTION
Reopening an article puts you back where you stopped, and `/history` opens with a shelf of what you're partway through.

## Why this isn't a record

Every other piece of personal state in the app is an AT Proto record in the reader's repo. This one deliberately isn't.

Reads and bookmarks being public is a fair trade — they say *what* you read. A position says how far you got and where you gave up, which is a running commentary on attention that nobody opts into by opening an article. So it lives in a private app-local Neon table (`reading_progress`, keyed `(owner_did, document_uri)`) that the tap never writes, mirrored to `localStorage` per device.

## Two stores, on purpose

They answer different questions:

- **`localStorage`** can be read *before first paint*, which is the only place a scroll restore can happen without a visible jump. It's also what keeps this working offline in the installed PWA.
- **The server row** carries position from phone to laptop. It only wins when it's newer than the local copy *and* the reader hasn't already started scrolling.

## The settle window

Restoring by fraction assumes the article is as tall as it was last time, and for a few hundred milliseconds it isn't — images haven't reserved space yet, so the target offset drifts as they load. The target is re-applied across a 3s window, ended immediately by any real input (`wheel`, `touchstart`, `keydown`, `pointerdown`). Nothing yanks the page out from under someone who has started reading.

A pill names the jump and offers "Start from top", because landing mid-article with no explanation reads as a bug rather than a feature.

## Invariants

Rows exist only between 2% and 95% — below that you didn't start, above it you finished and holding you at 97% forever means the shelf never empties. Writes enforce the band by deleting outside it, so **the table *is* the shelf** and never needs sweeping.

Clearing reading history clears positions (server rows and the local mirror). The whole feature is gated on the existing **Track reading history** setting: position is reading history at a finer grain, and someone who turned that off didn't ask for a more detailed version of it.

## Offline

- Position writes use `networkMode: "offlineFirst"` + `retry: false` rather than React Query's default. The default *pauses* mutations and replays them on reconnect — scrolling emits one write per second, so a subway ride would queue dozens that all replay to say what the last one says. The local copy is the durable record; a single flush on the `online` event sends the value that matters.
- "Start from top" *keeps* the default network mode — it's one deliberate action, not a stream, and dropping it would let the server position come back and undo what the reader asked for.
- The shelf query is **non-fatal** on `/history`: caught in the loader and a plain `useQuery` (not `useSuspenseQuery`) in the component. Offline it doesn't render, rather than taking the reader's cached history down with it.
- The shelf reuses `ArticleRow`, so it inherits the existing offline dimming for articles whose bodies aren't on device.

## Also

Replaces the ad-hoc scroll effect in `article-view.tsx` — the new hook owns the sticky-chrome progress bar it used to compute.

## Before deploy

`pnpm db:migrate` (migration `0037`) — the shelf query 500s without the table.

## Testing

- 12 new unit tests over the local store (band enforcement, LRU eviction at the 100-entry cap, corrupt-value recovery).
- Full suite: 925 passed / 9 skipped. `pnpm lint`, `pnpm typecheck`, `pnpm build` all clean.
- **Not verified in a browser.** The worktree has no `.env` and migration `0037` isn't applied to any database yet, so there was nothing to run against — and scroll-position behaviour is the case where driving Safari from a script reliably lies. Worth a manual pass on: the restore landing point on an image-heavy article, and the cross-device correction.

## Known gaps (deliberate)

- `/history` still isn't in `OFFLINE_ROUTES`, so the shelf is unavailable offline. It degrades to absent, never to an error. Expanding offline route coverage felt out of scope here.
- An offline "Start from top" is a paused mutation, so killing the PWA before reconnect leaves the server row and the position comes back. Same durability level as `markRead`/bookmark today; both want the write outbox the app doesn't have yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
