### PR TITLE
Resume where you left off (+ Continue reading on /history)

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -757,7 +757,7 @@ source of truth; Neon holds a derived view for speed and cross-network querying.
   before first paint, where a Neon round trip is an order of magnitude too slow — and it is what
   keeps position working offline in the installed PWA; the server copy is what carries the
   position from phone to laptop, and only wins when it is newer and the reader has not already
-  started scrolling. Rows exist only between 2% and 95%, so the table *is* the shelf and never
+  started scrolling. Rows exist only between 2% and 95%, so the table _is_ the shelf and never
   needs sweeping, and clearing reading history clears positions with it. Gated on the same
   "Track reading history" setting: position is reading history at a finer grain.
 - **The write path mirrors personal state into Neon itself**
@@ -1552,8 +1552,10 @@ publication list looked clean.
 - Network-powered recommendations & trending (initial heuristics, tunable).
 - **Offline reading in the installed app** — the service worker caches read server functions
   (`/_serverFn` GETs), and `src/pwa/offline-sync.ts` pre-downloads every unread body and its
-  images so the backlog opens with no connection. Reaching for something never downloaded shows
-  an offline state rather than an error.
+  images so the backlog opens with no connection. The surfaces that must survive a dead
+  connection are warmed by name — home, `/latest`, `/saved`, `/subscriptions`, and `/history`
+  (its list and its **Continue reading** shelf, whose part-read bodies no unread walk would
+  reach). Reaching for something never downloaded shows an offline state rather than an error.
 
 ### Later
 

--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -580,6 +580,12 @@ comic issue with no pages falls back to it outright.
   most recently touched first. Short on purpose — it is a prompt to pick something back up,
   not another backlog. It is an extra on this page, never fatal: offline (or on any error) it
   simply doesn't render and the cached history still does.
+- **No article appears twice on the page.** An in-progress article is claimed by the shelf and
+  filtered out of the list beneath, which is why that list is titled "Everything else" rather
+  than "Everything you've read". (Only the ones the shelf actually renders are claimed — an
+  item whose document has dropped out of the read-model isn't shown up there, so it stays in
+  the list.) The masthead's `Read` count is unaffected: it counts read records for all time,
+  and an article you're partway through is still one you opened.
 - The shelf's rows are the **same rows as the list below it**; what separates the two sections
   is the heading plus the one fact these rows carry and those don't. That fact — how far in the
   reader got — leads each row's existing meta line, as a 56px camel meter and a percentage, so

--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -1553,9 +1553,10 @@ publication list looked clean.
 - **Offline reading in the installed app** — the service worker caches read server functions
   (`/_serverFn` GETs), and `src/pwa/offline-sync.ts` pre-downloads every unread body and its
   images so the backlog opens with no connection. The surfaces that must survive a dead
-  connection are warmed by name — home, `/latest`, `/saved`, `/subscriptions`, and `/history`
-  (its list and its **Continue reading** shelf, whose part-read bodies no unread walk would
-  reach). Reaching for something never downloaded shows an offline state rather than an error.
+  connection are warmed by name — home, `/latest`, `/saved`, `/subscriptions`, and everything
+  behind the avatar menu: `/history` (its list and its **Continue reading** shelf, whose
+  part-read bodies no unread walk would reach), `/recommended`, and the reader's own profile.
+  Reaching for something never downloaded shows an offline state rather than an error.
 
 ### Later
 

--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -577,9 +577,17 @@ comic issue with no pages falls back to it outright.
 - Signed-in reader's **reading history** (`app.standard-reader.read`), newest first — every
   article opened while signed in.
 - Opens with a **Continue reading** shelf: up to six articles the reader is partway through,
-  most recently touched first, each with a percentage-read meter. Short on purpose — it is a
-  prompt to pick something back up, not another backlog. It is an extra on this page, never
-  fatal: offline (or on any error) it simply doesn't render and the cached history still does.
+  most recently touched first. Short on purpose — it is a prompt to pick something back up,
+  not another backlog. It is an extra on this page, never fatal: offline (or on any error) it
+  simply doesn't render and the cached history still does.
+- The shelf's rows are the **same rows as the list below it**; what separates the two sections
+  is the heading plus the one fact these rows carry and those don't. That fact — how far in the
+  reader got — leads each row's existing meta line, as a 56px camel meter and a percentage, so
+  the number sits beside the title it describes. It is deliberately not a full-width bar under
+  the row: at page width it outweighed the headline it annotated, and below the row's closing
+  rule it read as a divider belonging to the next section. Camel because the accent is this
+  app's state-indicator colour and progress is a state; near-ink made it the heaviest element
+  on the page, which inverts "the reading leads; the UI recedes".
 - Route `/history`; linked from the user menu. Requires auth (redirects to login).
 
 ### Reader profile (saved for later)

--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -576,6 +576,10 @@ comic issue with no pages falls back to it outright.
 
 - Signed-in reader's **reading history** (`app.standard-reader.read`), newest first — every
   article opened while signed in.
+- Opens with a **Continue reading** shelf: up to six articles the reader is partway through,
+  most recently touched first, each with a percentage-read meter. Short on purpose — it is a
+  prompt to pick something back up, not another backlog. It is an extra on this page, never
+  fatal: offline (or on any error) it simply doesn't render and the cached history still does.
 - Route `/history`; linked from the user menu. Requires auth (redirects to login).
 
 ### Reader profile (saved for later)
@@ -742,6 +746,20 @@ source of truth; Neon holds a derived view for speed and cross-network querying.
   `/saved`, distinct from likes.
 - **Read / unread:** an `app.standard-reader.read` record per article; opening an article
   marks it read. **Reading history** at `/history` lists these newest-first.
+- **Reading position (deliberately not a record):** reopening an article puts the reader back
+  where they stopped, and `/history` opens with a **Continue reading** shelf of the articles they
+  are partway through. This is the one piece of personal state that is **not** written to the
+  repo. Reads and bookmarks being public is a fair trade — they say what you read. A position
+  says how far you got and where you gave up, which is a running commentary on attention that
+  nobody opts into by opening an article. So it lives in a private, app-local Neon table
+  (`reading_progress`, keyed by `(owner_did, document_uri)`) that the tap never writes, mirrored
+  into `localStorage` per device. The local copy is what restores the scroll — it is readable
+  before first paint, where a Neon round trip is an order of magnitude too slow — and it is what
+  keeps position working offline in the installed PWA; the server copy is what carries the
+  position from phone to laptop, and only wins when it is newer and the reader has not already
+  started scrolling. Rows exist only between 2% and 95%, so the table *is* the shelf and never
+  needs sweeping, and clearing reading history clears positions with it. Gated on the same
+  "Track reading history" setting: position is reading history at a finer grain.
 - **The write path mirrors personal state into Neon itself**
   (`src/server/reader/personal-state-mirror.ts`) — reads, bookmarks, and likes — rather than
   waiting for the tap to replay them. These are the toggles a reader watches change in the moment

--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -580,6 +580,14 @@ comic issue with no pages falls back to it outright.
   most recently touched first. Short on purpose — it is a prompt to pick something back up,
   not another backlog. It is an extra on this page, never fatal: offline (or on any error) it
   simply doesn't render and the cached history still does.
+- Each shelf row carries a **Mark as finished** control, in the same slot the history rows use
+  for their unread toggle (the two never appear together). It forgets the saved position —
+  which is the whole of what puts an article on the shelf — and re-stamps the read record, so
+  the article leaves the shelf and arrives at the _top_ of the list below rather than back at
+  the date it was first opened. Re-stamping is not a special case: `markRead` re-stamps on
+  every open, so history is already ordered by when a reader last read something, and finishing
+  is reading. No confirmation and no undo — the row leaving is the feedback, and what's lost is
+  a scroll position on an article the reader just declared themselves done with.
 - **No article appears twice on the page.** An in-progress article is claimed by the shelf and
   filtered out of the list beneath, which is why that list is titled "Everything else" rather
   than "Everything you've read". (Only the ones the shelf actually renders are claimed — an

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -1115,6 +1115,15 @@ Backend/API exists; UI or copy is missing.
       reader hasn't already scrolled. Rows live only between 2% and 95%, so the table _is_ the
       shelf. All of it in [`use-reading-progress.ts`](src/components/reader/use-reading-progress.ts),
       which also owns the sticky-chrome progress bar it replaced.
+      The settle window **corrects** scrolls it didn't ask for and never saves one, because the
+      router's own `scrollRestoration` runs on `onRendered` from a layout effect mounted after
+      the route's tree — so every in-app navigation scrolled a freshly-restored article back to
+      the top a beat later, and the 0 that measured was written a second after that. Writes
+      outside the band delete, so one clobbered restore erased the position from the device, the
+      server and the shelf: the feature appeared to work exactly once. Covered by
+      [`use-reading-progress.test.ts`](src/components/reader/use-reading-progress.test.ts).
+      A `#hash` in the URL now opts out of the restore entirely — an anchor the reader asked for
+      out loud outranks a position we remembered for them.
       Gated on "Track reading history"; clearing history clears positions too.
       **Before deploy:** run `pnpm db:migrate` (migration `0037`) — the shelf query 500s without
       the table.

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -1124,14 +1124,26 @@ Backend/API exists; UI or copy is missing.
       outside the band delete, so one clobbered restore erased the position from the device, the
       server and the shelf: the feature appeared to work exactly once. Covered by
       [`use-reading-progress.test.ts`](src/components/reader/use-reading-progress.test.ts).
-      **Input alone does not end that window** — inertial scrolling doesn't stop because the page
-      changed, so momentum from the feed kept arriving on the article, ended the window early, and
-      handed the router's reset the same clobber by another door (reported as "restores, then
-      jumps back to the top", and permanent for the same reason). The window is given up to a
-      scroll a hand could plausibly have made; a single discrete jump to the top from more than a
-      screen away is the router's and gets corrected. The unmount flush is guarded the same way,
-      so leaving fast can't write the reset on the way out. The rule throughout: losing the
-      landing is a nuisance, losing the position is data loss, so ambiguity keeps the stored value.
+      **The router is switched off for this route rather than raced** —
+      [`routerOwnsScroll`](src/lib/router-scroll.ts), passed to `scrollRestoration` as a function.
+      Correcting after the fact meant racing three separate actors (the `onRendered` handler, the
+      inline `<script>` Start injects into the SSR'd HTML, and the `sessionStorage` cache they
+      share), and the race was lost often enough to look random. The function form guards all
+      three — including whether the inline script is emitted at all. A `#hash` keeps the router,
+      since on a hard load that script is what scrolls the anchor into view and the article view
+      declines to restore over one. Verified in a browser both ways: with restoration on, the
+      router's `scrollTo({top:0})` lands right after ours and the position is deleted; with the
+      opt-out, the only scroll calls on the page come from this hook.
+      The in-hook settle window stays as a **backstop** for anything else that scrolls unasked.
+      Input alone does not end it — inertial scrolling doesn't stop because the page changed, so
+      momentum from the feed keeps arriving here. What ends it is a scroll a hand could plausibly
+      have made; landing at the very top _without having passed through anywhere else_ is a
+      teleport and gets corrected. Deliberately not a distance test: measured in the running app,
+      a 1498px article on a 664px viewport restores to ~417px, so "was the jump taller than a
+      screen" is dead code at the size articles actually are. The unmount flush is guarded the
+      same way, so leaving fast can't write a reset on the way out. The rule throughout: losing
+      the landing is a nuisance, losing the position is data loss, so ambiguity keeps the stored
+      value.
       A `#hash` in the URL now opts out of the restore entirely — an anchor the reader asked for
       out loud outranks a position we remembered for them.
       Gated on "Track reading history"; clearing history clears positions too.

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -1112,7 +1112,9 @@ Backend/API exists; UI or copy is missing.
       per-device `localStorage` mirror ([`reading-progress.ts`](src/lib/reading-progress.ts)).
       Local drives the restore because it can be read before first paint and works offline;
       the server copy carries position across devices and only wins when it is newer and the
-      reader hasn't already scrolled. Rows live only between 2% and 95%, so the table _is_ the
+      reader hasn't already scrolled. That correction is armed whether or not this device
+      remembers anything — gating it on a local copy meant a device that had never seen the
+      article, the one case cross-device sync exists for, was the one case it couldn't serve. Rows live only between 2% and 95%, so the table _is_ the
       shelf. All of it in [`use-reading-progress.ts`](src/components/reader/use-reading-progress.ts),
       which also owns the sticky-chrome progress bar it replaced.
       The settle window **corrects** scrolls it didn't ask for and never saves one, because the
@@ -1122,6 +1124,14 @@ Backend/API exists; UI or copy is missing.
       outside the band delete, so one clobbered restore erased the position from the device, the
       server and the shelf: the feature appeared to work exactly once. Covered by
       [`use-reading-progress.test.ts`](src/components/reader/use-reading-progress.test.ts).
+      **Input alone does not end that window** — inertial scrolling doesn't stop because the page
+      changed, so momentum from the feed kept arriving on the article, ended the window early, and
+      handed the router's reset the same clobber by another door (reported as "restores, then
+      jumps back to the top", and permanent for the same reason). The window is given up to a
+      scroll a hand could plausibly have made; a single discrete jump to the top from more than a
+      screen away is the router's and gets corrected. The unmount flush is guarded the same way,
+      so leaving fast can't write the reset on the way out. The rule throughout: losing the
+      landing is a nuisance, losing the position is data loss, so ambiguity keeps the stored value.
       A `#hash` in the URL now opts out of the restore entirely — an anchor the reader asked for
       out loud outranks a position we remembered for them.
       Gated on "Track reading history"; clearing history clears positions too.

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -1103,6 +1103,26 @@ Backend/API exists; UI or copy is missing.
 
 ## 9. Post-v1 — reader polish (Tier 2)
 
+- [x] **Resume where you left off** — reopening an article restores the reader's position, and
+      `/history` opens with a **Continue reading** shelf (six most-recent in-progress articles,
+      each with a percent-read meter). Position is the one bit of personal state kept **off**
+      the protocol: reads are public records, and how far you got is a different kind of fact.
+      A private app-local table ([`reading-progress.ts`](src/db/schema/reading-progress.ts),
+      `drizzle/0037_*`, keyed `(owner_did, document_uri)`, never touched by the tap) plus a
+      per-device `localStorage` mirror ([`reading-progress.ts`](src/lib/reading-progress.ts)).
+      Local drives the restore because it can be read before first paint and works offline;
+      the server copy carries position across devices and only wins when it is newer and the
+      reader hasn't already scrolled. Rows live only between 2% and 95%, so the table *is* the
+      shelf. All of it in [`use-reading-progress.ts`](src/components/reader/use-reading-progress.ts),
+      which also owns the sticky-chrome progress bar it replaced.
+      Gated on "Track reading history"; clearing history clears positions too.
+      **Before deploy:** run `pnpm db:migrate` (migration `0037`) — the shelf query 500s without
+      the table.
+      Known gaps, deliberately deferred: `/history` is still not in `OFFLINE_ROUTES`, so the shelf
+      is unavailable offline (it degrades to absent, never to an error); and an offline
+      "Start from top" is a paused mutation, so killing the PWA before reconnect leaves the server
+      row and the position comes back. Both want the durable write outbox the app doesn't have yet.
+
 - [x] **Web push notifications (v1)** — a bell on a publication page
       ([`publication-actions.tsx`](src/components/reader/publication-actions.tsx)) and an author
       page ([`author-actions.tsx`](src/components/reader/author-actions.tsx)) that notifies you when

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -1183,13 +1183,17 @@ Backend/API exists; UI or copy is missing.
       real `Image` elements (a `fetch` sets no `destination: "image"`, so the Workbox rule would
       miss it). Gated on the installed app + a device-scoped toggle; stops at 80% of storage
       quota; personal caches are dropped on sign-out.
-      `/history` is warmed like the feeds: five pages of the reading list (100 rows, re-walked
-      every pass because the head changes every time an article is opened) plus the
-      **Continue reading** shelf, whose six bodies are queued _ahead_ of the unread backlog —
-      a half-read article is already marked read, so no unread walk would ever reach it, and it
-      is the likeliest thing the reader opens next. Read history rows are not queued: those
-      bodies are unbounded and the storage budget belongs to the backlog, so a row without a
-      body dims instead.
+      Every surface behind the avatar menu is warmed like the feeds rather than left to
+      `preloadRoute`: `/history` (five pages, 100 rows) plus the **Continue reading** shelf,
+      `/recommended` (five pages of likes), and the reader's own `/u/$did` — the one profile
+      `warmFollowedUsers` misses, because nobody follows themselves. All re-walked every pass:
+      their heads move whenever the reader opens or likes something, so they can't hide behind
+      the daily surface timestamp.
+      Only the shelf's six bodies are queued, and they go _ahead_ of the unread backlog — a
+      half-read article is already marked read, so no unread walk would ever reach it, and it is
+      the likeliest thing the reader opens next. History and likes rows are not queued: those
+      bodies are already-read and unbounded, and the storage budget belongs to the backlog, so a
+      row without a body dims instead.
       [`RouteError`](src/components/route-error.tsx) is the app-wide `defaultErrorComponent`.
 - [x] **Content rendering gaps** — PCKT gallery renderer (`blog.pckt.block.gallery`); prod scan
       found 54 documents — implemented grid/list/carousel/masonry layouts via

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -1112,16 +1112,17 @@ Backend/API exists; UI or copy is missing.
       per-device `localStorage` mirror ([`reading-progress.ts`](src/lib/reading-progress.ts)).
       Local drives the restore because it can be read before first paint and works offline;
       the server copy carries position across devices and only wins when it is newer and the
-      reader hasn't already scrolled. Rows live only between 2% and 95%, so the table *is* the
+      reader hasn't already scrolled. Rows live only between 2% and 95%, so the table _is_ the
       shelf. All of it in [`use-reading-progress.ts`](src/components/reader/use-reading-progress.ts),
       which also owns the sticky-chrome progress bar it replaced.
       Gated on "Track reading history"; clearing history clears positions too.
       **Before deploy:** run `pnpm db:migrate` (migration `0037`) — the shelf query 500s without
       the table.
-      Known gaps, deliberately deferred: `/history` is still not in `OFFLINE_ROUTES`, so the shelf
-      is unavailable offline (it degrades to absent, never to an error); and an offline
-      "Start from top" is a paused mutation, so killing the PWA before reconnect leaves the server
-      row and the position comes back. Both want the durable write outbox the app doesn't have yet.
+      `/history` is in `OFFLINE_ROUTES` (see **Offline reading** below), so the list and the shelf
+      both survive a dead connection.
+      Known gap, deliberately deferred: an offline "Start from top" is a paused mutation, so killing
+      the PWA before reconnect leaves the server row and the position comes back. It wants the
+      durable write outbox the app doesn't have yet.
 
 - [x] **Web push notifications (v1)** — a bell on a publication page
       ([`publication-actions.tsx`](src/components/reader/publication-actions.tsx)) and an author
@@ -1182,6 +1183,13 @@ Backend/API exists; UI or copy is missing.
       real `Image` elements (a `fetch` sets no `destination: "image"`, so the Workbox rule would
       miss it). Gated on the installed app + a device-scoped toggle; stops at 80% of storage
       quota; personal caches are dropped on sign-out.
+      `/history` is warmed like the feeds: five pages of the reading list (100 rows, re-walked
+      every pass because the head changes every time an article is opened) plus the
+      **Continue reading** shelf, whose six bodies are queued _ahead_ of the unread backlog —
+      a half-read article is already marked read, so no unread walk would ever reach it, and it
+      is the likeliest thing the reader opens next. Read history rows are not queued: those
+      bodies are unbounded and the storage budget belongs to the backlog, so a row without a
+      body dims instead.
       [`RouteError`](src/components/route-error.tsx) is the app-wide `defaultErrorComponent`.
 - [x] **Content rendering gaps** — PCKT gallery renderer (`blog.pckt.block.gallery`); prod scan
       found 54 documents — implemented grid/list/carousel/masonry layouts via

--- a/apps/standard-reader/drizzle/0037_burly_magus.sql
+++ b/apps/standard-reader/drizzle/0037_burly_magus.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "reading_progress" (
+	"owner_did" text NOT NULL,
+	"document_uri" text NOT NULL,
+	"progress" real NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "reading_progress_owner_did_document_uri_pk" PRIMARY KEY("owner_did","document_uri")
+);
+--> statement-breakpoint
+CREATE INDEX "reading_progress_owner_idx" ON "reading_progress" USING btree ("owner_did","updated_at" DESC NULLS LAST);

--- a/apps/standard-reader/drizzle/meta/0037_snapshot.json
+++ b/apps/standard-reader/drizzle/meta/0037_snapshot.json
@@ -1,0 +1,5523 @@
+{
+  "id": "6695349a-63f5-4a0b-afed-822ba5ff6ffe",
+  "prevId": "7ad10254-71c4-4ff2-b003-e79a5f292d33",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_mode": {
+          "name": "theme_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appearance": {
+          "name": "appearance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale_hint_seen": {
+          "name": "locale_hint_seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reader_voice": {
+          "name": "reader_voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_links_externally": {
+          "name": "open_links_externally",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_collections_in_magazine": {
+          "name": "open_collections_in_magazine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reading_typography": {
+          "name": "reading_typography",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_reading_history": {
+          "name": "track_reading_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count_old_posts_as_unread": {
+          "name": "count_old_posts_as_unread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclude_web_bridge": {
+          "name": "exclude_web_bridge",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_publication_theme": {
+          "name": "use_publication_theme",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hide_feed_metrics": {
+          "name": "hide_feed_metrics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feed_pagination": {
+          "name": "feed_pagination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_scope": {
+          "name": "home_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_hidden_tabs": {
+          "name": "profile_hidden_tabs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_show_likes": {
+          "name": "profile_show_likes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_authoring_enabled": {
+          "name": "collections_authoring_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userinput_feedback_enabled": {
+          "name": "userinput_feedback_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "margin_save_enabled": {
+          "name": "margin_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semble_save_enabled": {
+          "name": "semble_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocking_enabled": {
+          "name": "blocking_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "atstore_review_prompt_dismissed": {
+          "name": "atstore_review_prompt_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_enabled": {
+          "name": "weekly_digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_subscriptions": {
+          "name": "weekly_digest_section_subscriptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_network": {
+          "name": "weekly_digest_section_network",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_saved": {
+          "name": "weekly_digest_section_saved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_recommendations": {
+          "name": "weekly_digest_section_recommendations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_last_sent_at": {
+          "name": "weekly_digest_last_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_welcome_sent_at": {
+          "name": "weekly_digest_welcome_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_labelers_imported_at": {
+          "name": "bsky_labelers_imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_did_unique": {
+          "name": "user_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "did"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pds": {
+          "name": "pds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_url": {
+          "name": "banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_uri": {
+          "name": "bsky_profile_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_cid": {
+          "name": "bsky_profile_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_fetched_at": {
+          "name": "profile_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_handle_idx": {
+          "name": "profiles_handle_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_handle_trgm_idx": {
+          "name": "profiles_handle_trgm_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "profiles_display_name_trgm_idx": {
+          "name": "profiles_display_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publications": {
+      "name": "publications",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_cid": {
+          "name": "icon_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_mime": {
+          "name": "icon_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent": {
+          "name": "theme_accent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_background": {
+          "name": "theme_background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_foreground": {
+          "name": "theme_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent_foreground": {
+          "name": "theme_accent_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_json": {
+          "name": "theme_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_in_discover": {
+          "name": "show_in_discover",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "prev_next_direction": {
+          "name": "prev_next_direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_kind": {
+          "name": "serial_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_publication": {
+          "name": "collections_publication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_checked_at": {
+          "name": "verification_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(name, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(topic, '')), 'B')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publications_did_idx": {
+          "name": "publications_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_name_idx": {
+          "name": "publications_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_discover_idx": {
+          "name": "publications_discover_idx",
+          "columns": [
+            {
+              "expression": "show_in_discover",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_topic_idx": {
+          "name": "publications_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_url_idx": {
+          "name": "publications_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_serial_idx": {
+          "name": "publications_serial_idx",
+          "columns": [
+            {
+              "expression": "prev_next_direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_search_idx": {
+          "name": "publications_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_contributors": {
+      "name": "document_contributors",
+      "schema": "",
+      "columns": {
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "document_contributors_did_idx": {
+          "name": "document_contributors_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_contributors_document_uri_documents_uri_fk": {
+          "name": "document_contributors_document_uri_documents_uri_fk",
+          "tableFrom": "document_contributors",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_contributors_document_uri_did_pk": {
+          "name": "document_contributors_document_uri_did_pk",
+          "columns": [
+            "document_uri",
+            "did"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_uri": {
+          "name": "site_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_json": {
+          "name": "collection_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_renderable_body": {
+          "name": "has_renderable_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "body_image_count": {
+          "name": "body_image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_cid": {
+          "name": "cover_image_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_mime": {
+          "name": "cover_image_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backlink_count": {
+          "name": "backlink_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_count_prev": {
+          "name": "backlink_count_prev",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_synced_at": {
+          "name": "backlink_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_recomputed_at": {
+          "name": "trending_recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_recommender_count": {
+          "name": "distinct_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bsky_post_uri": {
+          "name": "bsky_post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_post_cid": {
+          "name": "bsky_post_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_updated_at": {
+          "name": "record_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(title, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(immutable_array_to_string(tags), '')), 'B') || setweight(to_tsvector('english', coalesce(text_content, '')), 'C')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documents_did_idx": {
+          "name": "documents_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_did_published_idx": {
+          "name": "documents_did_published_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"published_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_publication_published_idx": {
+          "name": "documents_publication_published_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_published_idx": {
+          "name": "documents_published_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_featured_idx": {
+          "name": "documents_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_site_idx": {
+          "name": "documents_site_idx",
+          "columns": [
+            {
+              "expression": "site_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_search_idx": {
+          "name": "documents_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "documents_trending_idx": {
+          "name": "documents_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_idx": {
+          "name": "documents_canonical_url_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_trgm_idx": {
+          "name": "documents_canonical_url_trgm_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommends": {
+      "name": "recommends",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommender_did": {
+          "name": "recommender_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recommends_document_idx": {
+          "name": "recommends_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_recommender_idx": {
+          "name": "recommends_recommender_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_edge_idx": {
+          "name": "recommends_edge_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_doc_recommender_created_idx": {
+          "name": "recommends_doc_recommender_created_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recommends\".\"deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_did": {
+          "name": "publication_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_publication_idx": {
+          "name": "subscriptions_publication_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_subscriber_idx": {
+          "name": "subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_edge_idx": {
+          "name": "subscriptions_edge_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follower_did": {
+          "name": "follower_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excluded_publications": {
+          "name": "excluded_publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_subject_idx": {
+          "name": "user_follows_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_edge_idx": {
+          "name": "user_follows_edge_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_owner_idx": {
+          "name": "bookmarks_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_document_idx": {
+          "name": "bookmarks_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_edge_idx": {
+          "name": "bookmarks_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reads": {
+      "name": "reads",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reads_owner_idx": {
+          "name": "reads_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_document_idx": {
+          "name": "reads_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_edge_idx": {
+          "name": "reads_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidebar_prefs": {
+      "name": "sidebar_prefs",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_order": {
+          "name": "list_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "tree_order": {
+          "name": "tree_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "subscription_sort": {
+          "name": "subscription_sort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customize_nav": {
+          "name": "customize_nav",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_nav": {
+          "name": "hidden_nav",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reading_progress": {
+      "name": "reading_progress",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reading_progress_owner_idx": {
+          "name": "reading_progress_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "reading_progress_owner_did_document_uri_pk": {
+          "name": "reading_progress_owner_did_document_uri_pk",
+          "columns": [
+            "owner_did",
+            "document_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_push_queue": {
+      "name": "document_push_queue",
+      "schema": "",
+      "columns": {
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_push_queue_claim_idx": {
+          "name": "document_push_queue_claim_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_push_queue_author_idx": {
+          "name": "document_push_queue_author_idx",
+          "columns": [
+            {
+              "expression": "author_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_devices": {
+      "name": "push_devices",
+      "schema": "",
+      "columns": {
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_devices_owner_idx": {
+          "name": "push_devices_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_topics": {
+      "name": "push_topics",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_topics_subject_idx": {
+          "name": "push_topics_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "push_topics_owner_did_subject_type_subject_pk": {
+          "name": "push_topics_owner_did_subject_type_subject_pk",
+          "columns": [
+            "owner_did",
+            "subject_type",
+            "subject"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_saves": {
+      "name": "list_saves",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saver_did": {
+          "name": "saver_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_owner_did": {
+          "name": "list_owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "list_saves_saver_idx": {
+          "name": "list_saves_saver_idx",
+          "columns": [
+            {
+              "expression": "saver_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "list_saves_list_uri_idx": {
+          "name": "list_saves_list_uri_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lists": {
+      "name": "lists",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publications": {
+          "name": "publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "users": {
+          "name": "users",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lists_owner_idx": {
+          "name": "lists_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rkey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_corecommends": {
+      "name": "publication_corecommends",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_recommender_count": {
+          "name": "co_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_corecomm_rank_idx": {
+          "name": "publication_corecomm_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_corecommends_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_corecommends_related_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_corecommends_publication_uri_related_publication_uri_pk": {
+          "name": "publication_corecommends_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_cosubscriptions": {
+      "name": "publication_cosubscriptions",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_subscriber_count": {
+          "name": "co_subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_cosub_rank_idx": {
+          "name": "publication_cosub_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_cosubscriptions_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_cosubscriptions_related_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_cosubscriptions_publication_uri_related_publication_uri_pk": {
+          "name": "publication_cosubscriptions_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_stats": {
+      "name": "publication_stats",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommend_count": {
+          "name": "recommend_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_document_at": {
+          "name": "last_document_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documents_7d": {
+          "name": "documents_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_7d": {
+          "name": "subscribers_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_7d": {
+          "name": "recommends_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "documents_prev_7d": {
+          "name": "documents_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_prev_7d": {
+          "name": "subscribers_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_prev_7d": {
+          "name": "recommends_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlinks_7d": {
+          "name": "backlinks_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_velocity": {
+          "name": "trending_velocity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_window_start": {
+          "name": "trending_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_stats_subscribers_idx": {
+          "name": "publication_stats_subscribers_idx",
+          "columns": [
+            {
+              "expression": "subscriber_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_active_idx": {
+          "name": "publication_stats_active_idx",
+          "columns": [
+            {
+              "expression": "last_document_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_trending_idx": {
+          "name": "publication_stats_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_stats_publication_uri_publications_uri_fk": {
+          "name": "publication_stats_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_stats",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_stats": {
+      "name": "network_stats",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discover_topic_counts": {
+      "name": "discover_topic_counts",
+      "schema": "",
+      "columns": {
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discover_topic_counts_count_idx": {
+          "name": "discover_topic_counts_count_idx",
+          "columns": [
+            {
+              "expression": "publication_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discover_topic_counts_topic_trgm_idx": {
+          "name": "discover_topic_counts_topic_trgm_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag_embeddings": {
+      "name": "tag_embeddings",
+      "schema": "",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "double precision[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_publications": {
+      "name": "topic_publications",
+      "schema": "",
+      "columns": {
+        "topic_slug": {
+          "name": "topic_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "matched_tag_count": {
+          "name": "matched_tag_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "topic_publications_rank_idx": {
+          "name": "topic_publications_rank_idx",
+          "columns": [
+            {
+              "expression": "topic_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_publications_pub_idx": {
+          "name": "topic_publications_pub_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_publications_topic_slug_topics_slug_fk": {
+          "name": "topic_publications_topic_slug_topics_slug_fk",
+          "tableFrom": "topic_publications",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "topic_publications_publication_uri_publications_uri_fk": {
+          "name": "topic_publications_publication_uri_publications_uri_fk",
+          "tableFrom": "topic_publications",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_publications_topic_slug_publication_uri_pk": {
+          "name": "topic_publications_topic_slug_publication_uri_pk",
+          "columns": [
+            "topic_slug",
+            "publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_tags": {
+      "name": "topic_tags",
+      "schema": "",
+      "columns": {
+        "topic_slug": {
+          "name": "topic_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "topic_tags_tag_idx": {
+          "name": "topic_tags_tag_idx",
+          "columns": [
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_tags_weight_idx": {
+          "name": "topic_tags_weight_idx",
+          "columns": [
+            {
+              "expression": "topic_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weight",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_tags_topic_slug_topics_slug_fk": {
+          "name": "topic_tags_topic_slug_topics_slug_fk",
+          "tableFrom": "topic_tags",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_tags_topic_slug_tag_pk": {
+          "name": "topic_tags_topic_slug_tag_pk",
+          "columns": [
+            "topic_slug",
+            "tag"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_tags": {
+          "name": "signature_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_count": {
+          "name": "tag_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author_count": {
+          "name": "author_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_model": {
+          "name": "name_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "named_at": {
+          "name": "named_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topics_published_score_idx": {
+          "name": "topics_published_score_idx",
+          "columns": [
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topics_superseded_by_topics_slug_fk": {
+          "name": "topics_superseded_by_topics_slug_fk",
+          "tableFrom": "topics",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "superseded_by"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_dead_letter": {
+      "name": "ingest_dead_letter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retries": {
+          "name": "retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingest_dead_letter_collection_idx": {
+          "name": "ingest_dead_letter_collection_idx",
+          "columns": [
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_state": {
+      "name": "ingest_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_processed": {
+          "name": "events_processed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_repos": {
+      "name": "tracked_repos",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_to_tap_at": {
+          "name": "added_to_tap_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_state": {
+          "name": "backfill_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_seen_rev": {
+          "name": "last_seen_rev",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_fail_count": {
+          "name": "reconcile_fail_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconcile_retry_after": {
+          "name": "reconcile_retry_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tracked_repos_state_idx": {
+          "name": "tracked_repos_state_idx",
+          "columns": [
+            {
+              "expression": "backfill_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_labels": {
+      "name": "document_labels",
+      "schema": "",
+      "columns": {
+        "src": {
+          "name": "src",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "val": {
+          "name": "val",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cts": {
+          "name": "cts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_labels_uri_idx": {
+          "name": "document_labels_uri_idx",
+          "columns": [
+            {
+              "expression": "uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_labels_src_idx": {
+          "name": "document_labels_src_idx",
+          "columns": [
+            {
+              "expression": "src",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "document_labels_src_uri_val_pk": {
+          "name": "document_labels_src_uri_val_pk",
+          "columns": [
+            "src",
+            "uri",
+            "val"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_sync_state": {
+      "name": "label_sync_state",
+      "schema": "",
+      "columns": {
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_count": {
+          "name": "stored_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rejected_count": {
+          "name": "rejected_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_services": {
+      "name": "labeler_services",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_endpoint": {
+          "name": "service_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels_standard_site": {
+          "name": "labels_standard_site",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels_probed_at": {
+          "name": "labels_probed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reachable": {
+          "name": "reachable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_value_definitions": {
+          "name": "label_value_definitions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_services_labeler_idx": {
+          "name": "labeler_services_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_subscriptions": {
+      "name": "labeler_subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefs": {
+          "name": "prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_subscriptions_subscriber_idx": {
+          "name": "labeler_subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labeler_subscriptions_labeler_idx": {
+          "name": "labeler_subscriptions_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_list_items": {
+      "name": "block_list_items",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "block_list_items_list_idx": {
+          "name": "block_list_items_list_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_list_items_subject_idx": {
+          "name": "block_list_items_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_list_items_list_subject_idx": {
+          "name": "block_list_items_list_subject_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_list_sync_state": {
+      "name": "block_list_sync_state",
+      "schema": "",
+      "columns": {
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_count": {
+          "name": "item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "truncated": {
+          "name": "truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_lists": {
+      "name": "block_lists",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocker_did": {
+          "name": "blocker_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "block_lists_blocker_idx": {
+          "name": "block_lists_blocker_idx",
+          "columns": [
+            {
+              "expression": "blocker_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_lists_list_idx": {
+          "name": "block_lists_list_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_sync_state": {
+      "name": "block_sync_state",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "outgoing_count": {
+          "name": "outgoing_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "incoming_count": {
+          "name": "incoming_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "list_count": {
+          "name": "list_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocker_did": {
+          "name": "blocker_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocks_subject_idx": {
+          "name": "blocks_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocks_edge_idx": {
+          "name": "blocks_edge_idx",
+          "columns": [
+            {
+              "expression": "blocker_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_auth_code": {
+      "name": "mcp_auth_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_auth_code_expires_at_idx": {
+          "name": "mcp_auth_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_auth_code_client_id_mcp_client_id_fk": {
+          "name": "mcp_auth_code_client_id_mcp_client_id_fk",
+          "tableFrom": "mcp_auth_code",
+          "tableTo": "mcp_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_auth_code_user_id_user_id_fk": {
+          "name": "mcp_auth_code_user_id_user_id_fk",
+          "tableFrom": "mcp_auth_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_client": {
+      "name": "mcp_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_uri": {
+          "name": "client_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_uri": {
+          "name": "logo_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_token": {
+      "name": "mcp_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_token_user_id_idx": {
+          "name": "mcp_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_expires_at_idx": {
+          "name": "mcp_token_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_client_id_mcp_client_id_fk": {
+          "name": "mcp_token_client_id_mcp_client_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "mcp_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_user_id_user_id_fk": {
+          "name": "mcp_token_user_id_user_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_token_access_token_hash_unique": {
+          "name": "mcp_token_access_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token_hash"
+          ]
+        },
+        "mcp_token_refresh_token_hash_unique": {
+          "name": "mcp_token_refresh_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_shares": {
+      "name": "quote_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_text": {
+          "name": "quote_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quote_shares_document_uri_idx": {
+          "name": "quote_shares_document_uri_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_draft": {
+      "name": "feedback_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feedback_draft_user_idx": {
+          "name": "feedback_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_draft_expires_idx": {
+          "name": "feedback_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_draft_user_id_user_id_fk": {
+          "name": "feedback_draft_user_id_user_id_fk",
+          "tableFrom": "feedback_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upvote_draft": {
+      "name": "upvote_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "upvote_draft_user_idx": {
+          "name": "upvote_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upvote_draft_expires_idx": {
+          "name": "upvote_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upvote_draft_user_id_user_id_fk": {
+          "name": "upvote_draft_user_id_user_id_fk",
+          "tableFrom": "upvote_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.save_draft": {
+      "name": "save_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_app": {
+          "name": "target_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_uri": {
+          "name": "collection_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_cid": {
+          "name": "collection_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_collection_name": {
+          "name": "new_collection_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motivation": {
+          "name": "motivation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passage": {
+          "name": "passage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "save_draft_user_idx": {
+          "name": "save_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "save_draft_expires_idx": {
+          "name": "save_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "save_draft_user_id_user_id_fk": {
+          "name": "save_draft_user_id_user_id_fk",
+          "tableFrom": "save_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/standard-reader/drizzle/meta/_journal.json
+++ b/apps/standard-reader/drizzle/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1786344772815,
       "tag": "0036_acoustic_zemo",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1786555171840,
+      "tag": "0037_burly_magus",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/standard-reader/src/components/offline-sync-debug.tsx
+++ b/apps/standard-reader/src/components/offline-sync-debug.tsx
@@ -310,6 +310,14 @@ export function OfflineSyncDebugPanel() {
         value={String(counts.unfinishedListed)}
       />
       <Row
+        label={<Trans>Liked pages</Trans>}
+        value={String(counts.likesPages)}
+      />
+      <Row
+        label={<Trans>Your profile</Trans>}
+        value={counts.ownProfile > 0 ? "cached" : "not this pass"}
+      />
+      <Row
         label={<Trans>Publications</Trans>}
         value={String(counts.publications)}
       />

--- a/apps/standard-reader/src/components/offline-sync-debug.tsx
+++ b/apps/standard-reader/src/components/offline-sync-debug.tsx
@@ -302,6 +302,14 @@ export function OfflineSyncDebugPanel() {
         value={String(counts.unreadListed)}
       />
       <Row
+        label={<Trans>History pages</Trans>}
+        value={String(counts.historyPages)}
+      />
+      <Row
+        label={<Trans>Unfinished listed</Trans>}
+        value={String(counts.unfinishedListed)}
+      />
+      <Row
         label={<Trans>Publications</Trans>}
         value={String(counts.publications)}
       />

--- a/apps/standard-reader/src/components/reader/article-view.tsx
+++ b/apps/standard-reader/src/components/reader/article-view.tsx
@@ -29,6 +29,7 @@ import {
   horizontalSpace,
   verticalSpace,
 } from "@standard-reader/design-system/theme/semantic-spacing.stylex";
+import { shadow } from "@standard-reader/design-system/theme/shadow.stylex";
 import { spacing } from "@standard-reader/design-system/theme/spacing.stylex";
 import {
   fontFamily,
@@ -62,7 +63,6 @@ import {
   Fragment,
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -126,20 +126,7 @@ import { SaveDraftConsumer } from "./save-draft-consumer";
 import { useArticleBookmark } from "./use-article-bookmark";
 import { useArticleReadToggle } from "./use-article-read-toggle";
 import { useArticleRecommend } from "./use-article-recommend";
-
-/** Reading progress of the article content within the document scroll. */
-function articleReadingProgress(content: HTMLElement): number {
-  const viewport = globalThis.innerHeight;
-  const scrollY = globalThis.scrollY;
-  const contentTop = content.getBoundingClientRect().top + scrollY;
-  const contentBottom = contentTop + content.offsetHeight;
-  const endScroll = Math.max(contentBottom - viewport, contentTop);
-  const range = endScroll - contentTop;
-  if (range <= 0) {
-    return scrollY >= contentTop ? 1 : 0;
-  }
-  return Math.min(1, Math.max(0, (scrollY - contentTop) / range));
-}
+import { useReadingProgress } from "./use-reading-progress";
 
 /**
  * How tall the article's own top bar is, measured rather than assumed — it wraps
@@ -277,6 +264,39 @@ const styles = stylex.create({
     position: "relative",
     height: spacing["1"],
     width: "100%",
+  },
+  resumedNotice: {
+    alignItems: "center",
+    backgroundColor: uiColor.bg,
+    borderColor: uiColor.border1,
+    borderRadius: radius.full,
+    borderStyle: "solid",
+    borderWidth: 1,
+    boxShadow: shadow.lg,
+    columnGap: gap.md,
+    display: "flex",
+    // Clears the floating page-reader bar and the home indicator, so the two
+    // never stack on top of each other on a phone.
+    bottom: `calc(env(safe-area-inset-bottom, 0px) + ${spacing["6"]})`,
+    // Centred with auto margins rather than a 50% inset + translate: the
+    // translate would push the pill off-centre the moment the locale is RTL.
+    insetInline: 0,
+    marginInline: "auto",
+    maxWidth: `calc(100% - ${spacing["8"]})`,
+    paddingBottom: verticalSpace.xs,
+    paddingInlineEnd: horizontalSpace.xs,
+    paddingInlineStart: horizontalSpace.md,
+    paddingTop: verticalSpace.xs,
+    position: "fixed",
+    width: "fit-content",
+    zIndex: 30,
+  },
+  resumedText: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.sm,
+    lineHeight: lineHeight.sm,
+    whiteSpace: "nowrap",
   },
   topLeft: {
     alignItems: "center",
@@ -964,6 +984,50 @@ function ReaderProgress({ progress }: { progress: number }) {
   );
 }
 
+/** How long the resume notice stays up before it gets out of the way. */
+const RESUMED_NOTICE_MS = 6000;
+
+/**
+ * Says what just happened, and offers the way back.
+ *
+ * Landing mid-article is ambiguous on its own — a reader can't tell whether we
+ * resumed them or whether the piece simply opens that way, and the doubt is
+ * enough to make them scroll up to check. One line removes the doubt, and the
+ * button makes the jump reversible for the case where they did want the top.
+ */
+function ResumedNotice({ onStartFromTop }: { onStartFromTop: () => void }) {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const timer = globalThis.setTimeout(
+      () => setVisible(false),
+      RESUMED_NOTICE_MS,
+    );
+    return () => globalThis.clearTimeout(timer);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    // `status` rather than `alert`: worth mentioning, never worth interrupting.
+    <div {...stylex.props(styles.resumedNotice)} role="status">
+      <span {...stylex.props(styles.resumedText)}>
+        <Trans>Picked up where you left off</Trans>
+      </span>
+      <Button
+        variant="tertiary"
+        size="sm"
+        onPress={() => {
+          onStartFromTop();
+          setVisible(false);
+        }}
+      >
+        <Trans>Start from top</Trans>
+      </Button>
+    </div>
+  );
+}
+
 const COLLECTION_MAGAZINE_INTRO_KEY = "collection-magazine-intro:v1";
 
 function CollectionColophon({ body }: { body: string }) {
@@ -1011,7 +1075,6 @@ function ArticleViewBody({
   // reader is moving forward, leaving only the progress track on screen.
   const stickyChromeRef = useRef<HTMLDivElement>(null);
   const setTopBarNode = useTopBarHeight(stickyChromeRef);
-  const [progress, setProgress] = useState(0);
   const [showMagazineIntro, setShowMagazineIntro] = useState(
     () => Boolean(article.collection) && !hasSeenCollectionMagazineIntro(),
   );
@@ -1172,37 +1235,19 @@ function ArticleViewBody({
     return () => globalThis.clearTimeout(timeout);
   }, [article.collection, article.uri, linkParams, queryClient, router]);
 
-  useLayoutEffect(() => {
-    // Measure the <article> only — progress should hit 100% at the end of the
-    // article body, not after the "More from" / comments sections below it.
-    const articleEl = articleRef.current;
-    if (!articleEl) return;
-
-    const sync = () => {
-      setProgress(articleReadingProgress(articleEl));
-    };
-
-    if (!sharedQuote?.trim()) {
-      globalThis.scrollTo(0, 0);
-    }
-    sync();
-
-    // The page (document) is the scroller, so its scroll event fires on window.
-    globalThis.addEventListener("scroll", sync, { passive: true });
-    const resizeObserver = new ResizeObserver(() => sync());
-    resizeObserver.observe(articleEl);
-
-    return () => {
-      globalThis.removeEventListener("scroll", sync);
-      resizeObserver.disconnect();
-    };
-  }, [article.uri, sharedQuote]);
+  const { progress, resumed, startFromTop } = useReadingProgress({
+    articleRef,
+    documentUri: article.uri,
+    enabled: trackReading,
+    skipRestore: Boolean(sharedQuote?.trim()),
+  });
 
   return (
     <div
       data-unclipped-sticky
       {...stylex.props(styles.root, readerActive && styles.rootReader)}
     >
+      {resumed ? <ResumedNotice onStartFromTop={startFromTop} /> : null}
       <div ref={stickyChromeRef} {...stylex.props(styles.stickyChrome)}>
         <div ref={setTopBarNode} {...stylex.props(styles.topBar)}>
           <div {...stylex.props(styles.topLeft)}>

--- a/apps/standard-reader/src/components/reader/cards.tsx
+++ b/apps/standard-reader/src/components/reader/cards.tsx
@@ -34,6 +34,7 @@ import { Link } from "@tanstack/react-router";
 import {
   ArrowRight,
   BookOpen,
+  BookOpenCheck,
   Bookmark,
   Bot,
   Check,
@@ -49,10 +50,14 @@ import { FollowUserButton } from "#/components/reader/follow-user-button";
 import { PublicationNameLink } from "#/components/reader/publication-name-link";
 import { SearchHeadline } from "#/components/reader/search-headline";
 import { ButtonLink } from "#/components/router-links";
-import type { FollowStatus } from "#/integrations/tanstack-query/api-reader.functions";
+import type {
+  FollowStatus,
+  UnfinishedReadingItem,
+} from "#/integrations/tanstack-query/api-reader.functions";
 import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
 import { user } from "#/integrations/tanstack-query/api-user.functions";
 import { parseInternalRoute } from "#/lib/internal-route";
+import { clearLocalProgress } from "#/lib/reading-progress";
 import { tsHeadlineHasMatch } from "#/lib/search-headline";
 import { useFormatters } from "#/lib/use-formatters";
 import { useOfflineCachedUris } from "#/lib/use-offline-cached-uris";
@@ -1903,6 +1908,68 @@ export function MarkUnreadButton({
   );
 }
 
+/**
+ * "I'm done with this" for a row on the Continue reading shelf.
+ *
+ * It forgets the saved position, which is the whole of what puts an article on
+ * the shelf — so the row leaves and settles into the list below, where it was
+ * always going to end up.
+ *
+ * It also re-stamps the read record, which is what lands the article at the top
+ * of history rather than back at whatever date it was first opened. That isn't
+ * a special case: `markRead` re-stamps on every open too, so history is already
+ * ordered by when you last read something, and finishing is reading.
+ *
+ * No confirmation and no undo. The row visibly leaving is the feedback, and
+ * what's lost is a scroll position on an article the reader just said they're
+ * finished with — the recovery is to open it and scroll.
+ */
+export function FinishReadingButton({ documentUri }: { documentUri: string }) {
+  const { t } = useLingui();
+  const queryClient = useQueryClient();
+  const { mutate: finish, isPending } = useMutation({
+    mutationKey: ["reader", "finishReading"] as const,
+    mutationFn: async () => {
+      await readerApi.clearReadingProgress({ data: { documentUri } });
+      await readerApi.markRead({ data: { documentUri } });
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["reader", "unfinished"],
+      });
+      // The read record moved, so the list's order did too.
+      void queryClient.invalidateQueries({ queryKey: ["reader", "history"] });
+    },
+  });
+
+  const onPress = () => {
+    // Drop it from the shelf now rather than after the round trip; the refetch
+    // in `onSettled` is what makes it stick, or puts it back if the write lost.
+    queryClient.setQueriesData<Array<UnfinishedReadingItem>>(
+      { queryKey: ["reader", "unfinished"] },
+      (current) =>
+        current?.filter((item) => item.documentUri !== documentUri) ?? current,
+    );
+    // The device-local mirror is the copy that restores scroll, so it has to go
+    // too — otherwise the next visit resumes a position we just cleared.
+    clearLocalProgress(documentUri);
+    finish();
+  };
+
+  return (
+    <IconButton
+      variant="secondary"
+      size="sm"
+      label={t`Mark as finished`}
+      isDisabled={isPending}
+      onPress={onPress}
+      onClick={stopSaveClick}
+    >
+      <BookOpenCheck size={16} aria-hidden />
+    </IconButton>
+  );
+}
+
 /* ── Article row (list) ─────────────────────────────────────────────────── */
 
 /**
@@ -1931,6 +1998,7 @@ export function ArticleRow({
   showSaveButton = true,
   saveButtonPlacement = "header",
   showMarkUnreadButton = false,
+  showFinishButton = false,
   isFirstInSection = false,
   assumeBookmarked,
   metaLabels,
@@ -1944,6 +2012,9 @@ export function ArticleRow({
   saveButtonPlacement?: "header" | "besideMedia";
   /** Show a "mark as unread" control in the row header (reading-history list). */
   showMarkUnreadButton?: boolean;
+  /** Show a "mark as finished" control (Continue reading shelf). Shares the
+   * unread toggle's slot; set one or the other, never both. */
+  showFinishButton?: boolean;
   /** Drop top padding when the section head already provides spacing above. */
   isFirstInSection?: boolean;
   /** Skip per-row bookmark status fetches when the list is already the save queue. */
@@ -1972,12 +2043,18 @@ export function ArticleRow({
       publicationUri={article.publicationUri}
     />
   ) : null;
+  const finishButton = showFinishButton ? (
+    <FinishReadingButton documentUri={article.uri} />
+  ) : null;
   // The save toggle sits in the header by default; `besideMedia` pins it to the
   // row's right edge instead. The unread toggle always pins to the right edge so
-  // it lines up across rows regardless of whether a cover image is present.
+  // it lines up across rows regardless of whether a cover image is present. The
+  // finish toggle rides in that same slot — the two never appear together, since
+  // one belongs to the history list and the other to the shelf above it.
   const asideSaveButton = saveBesideMedia ? saveButton : null;
   const headerSaveButton = saveBesideMedia ? null : saveButton;
-  const hasAside = Boolean(markUnreadButton || asideSaveButton);
+  const asideAction = markUnreadButton ?? finishButton;
+  const hasAside = Boolean(asideAction || asideSaveButton);
 
   const gridStyles: Array<stylex.StyleXStyles | false | undefined> = [
     showByline ? styles.rowGrid : styles.row,
@@ -2033,7 +2110,7 @@ export function ArticleRow({
       {hasAside ? (
         <div {...stylex.props(styles.rowSaveAside)}>
           <Flex align="center" gap="sm">
-            {markUnreadButton}
+            {asideAction}
             {asideSaveButton}
           </Flex>
         </div>

--- a/apps/standard-reader/src/components/reader/cards.tsx
+++ b/apps/standard-reader/src/components/reader/cards.tsx
@@ -452,6 +452,29 @@ const styles = stylex.create({
   metaDot: {
     color: uiColor.text1,
   },
+  progressMeta: {
+    alignItems: "center",
+    columnGap: gap.sm,
+    display: "inline-flex",
+    // Digits change width as the number climbs; without this the bar beside
+    // them twitches left and right between 9% and 10%.
+    fontVariantNumeric: "tabular-nums",
+  },
+  progressTrack: {
+    backgroundColor: uiColor.component2,
+    borderRadius: radius.full,
+    display: "block",
+    flexShrink: 0,
+    height: spacing["1"],
+    overflow: "hidden",
+    width: spacing["14"],
+  },
+  progressFill: {
+    backgroundColor: primaryColor.solid1,
+    borderRadius: radius.full,
+    display: "block",
+    height: "100%",
+  },
   botByline: {
     alignItems: "center",
     color: uiColor.text1,
@@ -1284,13 +1307,52 @@ function CollectionMagazineMeta() {
   );
 }
 
+/**
+ * How far into an article the reader got — the Continue reading shelf's one
+ * extra fact.
+ *
+ * It leads the meta line rather than sitting under the row, so the number lands
+ * beside the title it describes; a full-width bar below the row's closing rule
+ * read as a page divider belonging to whatever came next. Camel rather than
+ * ink, because the accent is this app's state-indicator colour and progress is
+ * a state — an ink bar outweighed the headline it was annotating.
+ */
+function ReadingProgressMeta({ progress }: { progress: number }) {
+  const { t, i18n } = useLingui();
+  // Round toward the middle: never 0% on something started, never 100% on
+  // something unfinished.
+  const percent = Math.min(99, Math.max(1, Math.round(progress * 100)));
+  const formatted = i18n.number(progress, { style: "percent" });
+
+  return (
+    // One `img` with a full label: sighted readers get the compact "37%" beside
+    // the bar, screen readers get "37% read" instead of a bare number.
+    <span
+      {...stylex.props(styles.progressMeta)}
+      role="img"
+      aria-label={t`${formatted} read`}
+    >
+      <span aria-hidden {...stylex.props(styles.progressTrack)}>
+        <span
+          {...stylex.props(styles.progressFill)}
+          style={{ width: `${percent}%` }}
+        />
+      </span>
+      <span aria-hidden>{formatted}</span>
+    </span>
+  );
+}
+
 function ArticleMetaLine({
   article,
   metaLabels,
+  progress,
 }: {
   article: ArticleCard;
   /** When set, replaces article tags in the meta line (e.g. labeler label values). */
   metaLabels?: Array<{ src: string; val: string }>;
+  /** 0–1 reading position; leads the line on the Continue reading shelf. */
+  progress?: number | null;
 }) {
   const metricsVisible = useEngagementCountsVisible();
   const hasEngagement =
@@ -1317,10 +1379,19 @@ function ArticleMetaLine({
   const hasCardLabels = cardLabelVals.length > 0;
   const hasMetaLabels = metaLabels != null && metaLabels.length > 0;
   const hasTrailing = hasTopics || hasCardLabels || hasMetaLabels;
-  if (!showCollection && !hasEngagement && !hasTrailing) return null;
+  const hasProgress = progress != null;
+  if (!hasProgress && !showCollection && !hasEngagement && !hasTrailing) {
+    return null;
+  }
 
   return (
     <MetaLine>
+      {hasProgress ? <ReadingProgressMeta progress={progress} /> : null}
+      {hasProgress && (showCollection || hasEngagement || hasTrailing) ? (
+        <span aria-hidden {...stylex.props(styles.metaDot)}>
+          ·
+        </span>
+      ) : null}
       {showCollection ? <CollectionMagazineMeta /> : null}
       {showCollection && (hasEngagement || hasTrailing) ? (
         <span aria-hidden {...stylex.props(styles.metaDot)}>
@@ -1863,6 +1934,7 @@ export function ArticleRow({
   isFirstInSection = false,
   assumeBookmarked,
   metaLabels,
+  progress,
 }: {
   article: ArticleCard;
   unread?: boolean;
@@ -1876,6 +1948,8 @@ export function ArticleRow({
   isFirstInSection?: boolean;
   /** Skip per-row bookmark status fetches when the list is already the save queue. */
   assumeBookmarked?: boolean;
+  /** 0–1 reading position, shown leading the meta line (Continue reading). */
+  progress?: number | null;
   /** When set, replaces article tags in the meta line (e.g. labeler label values). */
   metaLabels?: Array<{ src: string; val: string }>;
 }) {
@@ -1941,7 +2015,11 @@ export function ArticleRow({
           unreadDotStyle={styles.unreadDotRow}
         />
         <ArticleSearchDek article={article} style={styles.rowDek} />
-        <ArticleMetaLine article={article} metaLabels={metaLabels} />
+        <ArticleMetaLine
+          article={article}
+          metaLabels={metaLabels}
+          progress={progress}
+        />
       </Flex>
       {cover ? (
         <AspectRatio

--- a/apps/standard-reader/src/components/reader/continue-reading.tsx
+++ b/apps/standard-reader/src/components/reader/continue-reading.tsx
@@ -1,58 +1,11 @@
 "use client";
 
-import { Trans, useLingui } from "@lingui/react/macro";
-import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
-import { radius } from "@standard-reader/design-system/theme/radius.stylex";
-import { gap } from "@standard-reader/design-system/theme/semantic-spacing.stylex";
-import { spacing } from "@standard-reader/design-system/theme/spacing.stylex";
-import {
-  fontFamily,
-  fontSize,
-  fontWeight,
-  lineHeight,
-} from "@standard-reader/design-system/theme/typography.stylex";
-import * as stylex from "@stylexjs/stylex";
+import { useLingui } from "@lingui/react/macro";
 
 import type { UnfinishedReadingItem } from "#/integrations/tanstack-query/api-reader.functions";
 
 import { ArticleRow } from "./cards";
 import { SectionHead } from "./primitives";
-
-const styles = stylex.create({
-  row: {
-    display: "flex",
-    flexDirection: "column",
-    rowGap: gap.sm,
-  },
-  meter: {
-    alignItems: "center",
-    columnGap: gap.sm,
-    display: "flex",
-    paddingBottom: spacing["4"],
-  },
-  track: {
-    backgroundColor: uiColor.component2,
-    borderRadius: radius.full,
-    flexGrow: 1,
-    height: spacing["1"],
-    minWidth: 0,
-    overflow: "hidden",
-  },
-  fill: {
-    backgroundColor: uiColor.text1,
-    borderRadius: radius.full,
-    height: "100%",
-  },
-  percent: {
-    color: uiColor.text1,
-    flexShrink: 0,
-    fontFamily: fontFamily.sans,
-    fontSize: fontSize.xs,
-    fontVariantNumeric: "tabular-nums",
-    fontWeight: fontWeight.medium,
-    lineHeight: lineHeight.sm,
-  },
-});
 
 /**
  * The shelf of articles this reader is in the middle of.
@@ -60,13 +13,19 @@ const styles = stylex.create({
  * It sits above the history list rather than inside it because the two answer
  * different questions — history is "what have I read", this is "what am I still
  * reading" — and only one of them is actionable.
+ *
+ * The rows are deliberately the same rows as the list below. What separates the
+ * sections is the heading plus the one fact these rows carry and those don't
+ * (how far in the reader got, leading each meta line). Giving the shelf its own
+ * surface or bracketing rules would add chrome to a page that has none, and the
+ * page already uses rules to separate rows.
  */
 export function ContinueReading({
   items,
 }: {
   items: Array<UnfinishedReadingItem>;
 }) {
-  const { t, i18n } = useLingui();
+  const { t } = useLingui();
 
   // An article can drop out of the read-model (deleted, or never mirrored);
   // there is nothing to continue in that case, so it just isn't on the shelf.
@@ -78,48 +37,16 @@ export function ContinueReading({
 
   return (
     <>
-      <SectionHead
-        kicker={t`Still open`}
-        title={t`Continue reading`}
-        size="md"
-      />
-      {readable.map((item, index) => {
-        // Round toward the middle: never 0% on an article they've started, and
-        // never 100% on one they haven't finished.
-        const percent = Math.min(
-          99,
-          Math.max(1, Math.round(item.progress * 100)),
-        );
-        const label = i18n.number(item.progress, { style: "percent" });
-
-        return (
-          <div key={item.documentUri} {...stylex.props(styles.row)}>
-            <ArticleRow
-              article={item.article}
-              isFirstInSection={index === 0}
-              showSaveButton={false}
-            />
-            <div {...stylex.props(styles.meter)}>
-              <div
-                {...stylex.props(styles.track)}
-                role="progressbar"
-                aria-valuenow={percent}
-                aria-valuemin={0}
-                aria-valuemax={100}
-                aria-label={t`Reading progress`}
-              >
-                <div
-                  {...stylex.props(styles.fill)}
-                  style={{ width: `${percent}%` }}
-                />
-              </div>
-              <span {...stylex.props(styles.percent)}>
-                <Trans>{label} read</Trans>
-              </span>
-            </div>
-          </div>
-        );
-      })}
+      <SectionHead title={t`Continue reading`} size="md" />
+      {readable.map((item, index) => (
+        <ArticleRow
+          key={item.documentUri}
+          article={item.article}
+          isFirstInSection={index === 0}
+          showSaveButton={false}
+          progress={item.progress}
+        />
+      ))}
     </>
   );
 }

--- a/apps/standard-reader/src/components/reader/continue-reading.tsx
+++ b/apps/standard-reader/src/components/reader/continue-reading.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { Trans, useLingui } from "@lingui/react/macro";
+import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
+import { radius } from "@standard-reader/design-system/theme/radius.stylex";
+import { gap } from "@standard-reader/design-system/theme/semantic-spacing.stylex";
+import { spacing } from "@standard-reader/design-system/theme/spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+} from "@standard-reader/design-system/theme/typography.stylex";
+import * as stylex from "@stylexjs/stylex";
+
+import type { UnfinishedReadingItem } from "#/integrations/tanstack-query/api-reader.functions";
+
+import { ArticleRow } from "./cards";
+import { SectionHead } from "./primitives";
+
+const styles = stylex.create({
+  row: {
+    display: "flex",
+    flexDirection: "column",
+    rowGap: gap.sm,
+  },
+  meter: {
+    alignItems: "center",
+    columnGap: gap.sm,
+    display: "flex",
+    paddingBottom: spacing["4"],
+  },
+  track: {
+    backgroundColor: uiColor.component2,
+    borderRadius: radius.full,
+    flexGrow: 1,
+    height: spacing["1"],
+    minWidth: 0,
+    overflow: "hidden",
+  },
+  fill: {
+    backgroundColor: uiColor.text1,
+    borderRadius: radius.full,
+    height: "100%",
+  },
+  percent: {
+    color: uiColor.text1,
+    flexShrink: 0,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.xs,
+    fontVariantNumeric: "tabular-nums",
+    fontWeight: fontWeight.medium,
+    lineHeight: lineHeight.sm,
+  },
+});
+
+/**
+ * The shelf of articles this reader is in the middle of.
+ *
+ * It sits above the history list rather than inside it because the two answer
+ * different questions — history is "what have I read", this is "what am I still
+ * reading" — and only one of them is actionable.
+ */
+export function ContinueReading({
+  items,
+}: {
+  items: Array<UnfinishedReadingItem>;
+}) {
+  const { t, i18n } = useLingui();
+
+  // An article can drop out of the read-model (deleted, or never mirrored);
+  // there is nothing to continue in that case, so it just isn't on the shelf.
+  // `flatMap` rather than `filter` so the narrowed `article` survives.
+  const readable = items.flatMap((item) =>
+    item.article ? [{ ...item, article: item.article }] : [],
+  );
+  if (readable.length === 0) return null;
+
+  return (
+    <>
+      <SectionHead
+        kicker={t`Still open`}
+        title={t`Continue reading`}
+        size="md"
+      />
+      {readable.map((item, index) => {
+        // Round toward the middle: never 0% on an article they've started, and
+        // never 100% on one they haven't finished.
+        const percent = Math.min(
+          99,
+          Math.max(1, Math.round(item.progress * 100)),
+        );
+        const label = i18n.number(item.progress, { style: "percent" });
+
+        return (
+          <div key={item.documentUri} {...stylex.props(styles.row)}>
+            <ArticleRow
+              article={item.article}
+              isFirstInSection={index === 0}
+              showSaveButton={false}
+            />
+            <div {...stylex.props(styles.meter)}>
+              <div
+                {...stylex.props(styles.track)}
+                role="progressbar"
+                aria-valuenow={percent}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label={t`Reading progress`}
+              >
+                <div
+                  {...stylex.props(styles.fill)}
+                  style={{ width: `${percent}%` }}
+                />
+              </div>
+              <span {...stylex.props(styles.percent)}>
+                <Trans>{label} read</Trans>
+              </span>
+            </div>
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/standard-reader/src/components/reader/continue-reading.tsx
+++ b/apps/standard-reader/src/components/reader/continue-reading.tsx
@@ -44,6 +44,7 @@ export function ContinueReading({
           article={item.article}
           isFirstInSection={index === 0}
           showSaveButton={false}
+          showFinishButton
           progress={item.progress}
         />
       ))}

--- a/apps/standard-reader/src/components/reader/primitives.tsx
+++ b/apps/standard-reader/src/components/reader/primitives.tsx
@@ -212,6 +212,12 @@ const styles = stylex.create({
     marginBottom: spacing["5"],
     marginTop: spacing["2"],
   },
+  // Enough of a beat that the eye reads "different list", not "next row". The
+  // preceding row contributes its own bottom padding and rule, so this lands
+  // at roughly the same air the masthead leaves above the first section.
+  sectionHeadFollowing: {
+    marginTop: spacing["10"],
+  },
   sectionHeadRow: {
     alignItems: "flex-end",
     flexDirection: "row",
@@ -438,6 +444,7 @@ export function SectionHead({
   icon,
   stackOnMobile = true,
   size = "lg",
+  followsSection = false,
 }: {
   kicker?: React.ReactNode;
   title: React.ReactNode;
@@ -451,11 +458,19 @@ export function SectionHead({
    * ranks below that title instead of tying with it.
    */
   size?: "lg" | "md";
+  /**
+   * Set when this head opens a section that follows another section's rows.
+   * The default top margin assumes the head starts a page, where the space
+   * above it is already the masthead's; landing it straight after a row gives
+   * the reader no signal that one list ended and a different one began.
+   */
+  followsSection?: boolean;
 }) {
   return (
     <div
       {...stylex.props(
         styles.sectionHead,
+        followsSection && styles.sectionHeadFollowing,
         !stackOnMobile && styles.sectionHeadRow,
       )}
     >

--- a/apps/standard-reader/src/components/reader/use-reading-progress.test.ts
+++ b/apps/standard-reader/src/components/reader/use-reading-progress.test.ts
@@ -7,10 +7,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { readLocalProgress, writeLocalProgress } from "#/lib/reading-progress";
 
-import { useReadingProgress } from "./use-reading-progress";
+import { RESTORE_SETTLE_MS, useReadingProgress } from "./use-reading-progress";
 
 const setReadingProgress = vi.fn(async () => ({ ok: true as const }));
 const clearReadingProgress = vi.fn(async () => ({ ok: true as const }));
+
+/** What the server says this reader's position is. Null in most tests. */
+let remotePosition: { progress: number; updatedAt: string } | null = null;
 
 vi.mock("#/integrations/tanstack-query/api-reader.functions", () => ({
   readerApi: {
@@ -18,9 +21,9 @@ vi.mock("#/integrations/tanstack-query/api-reader.functions", () => ({
       clearReadingProgress(...(args as [])),
     getReadingProgressQueryOptions: (documentUri: string) => ({
       queryKey: ["reader", "readingProgress", documentUri] as const,
-      // The other-device correction. Absent in these tests: what is under test
-      // is what the *local* copy does on landing.
-      queryFn: async () => null,
+      // The other-device correction. Null in most tests: what is under test
+      // there is what the *local* copy does on landing.
+      queryFn: async () => remotePosition,
     }),
     setReadingProgress: (...args: Array<unknown>) =>
       setReadingProgress(...(args as [])),
@@ -110,6 +113,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  remotePosition = null;
   localStorage.clear();
   setReadingProgress.mockClear();
   clearReadingProgress.mockClear();
@@ -183,6 +187,10 @@ describe("useReadingProgress", () => {
 
     setup();
 
+    // Past the landing window, so this is unambiguously the reader's doing.
+    act(() => {
+      vi.advanceTimersByTime(RESTORE_SETTLE_MS);
+    });
     act(() => {
       globalThis.dispatchEvent(new Event("wheel"));
     });
@@ -192,6 +200,65 @@ describe("useReadingProgress", () => {
     });
 
     expect(readLocalProgress(DOCUMENT_URI)).toBeNull();
+  });
+
+  /**
+   * The reported failure, and the reason it was permanent.
+   *
+   * Inertial scrolling does not stop because the page changed: flick the feed,
+   * open an article, and the momentum `wheel` events keep arriving for a while
+   * on the article. That ended the settle window, so the router's reset — which
+   * lands a beat later on every in-app navigation — was no longer corrected.
+   * The reader saw the restore undone, which is the visible half.
+   *
+   * The invisible half is what made it permanent: with the window closed, that
+   * reset measured 0 and was saved as the reader's own position a second later,
+   * and a write outside the 2–95% band deletes. One stray wheel event and the
+   * position was gone from the device, the server, and the shelf — so it worked
+   * once and never again.
+   */
+  it("survives momentum still arriving from the page we came from", () => {
+    writeLocalProgress(DOCUMENT_URI, 0.5);
+
+    setup();
+    expect(globalThis.scrollY).toBe(offsetFor(0.5));
+
+    // Momentum from the feed, still in flight after the navigation.
+    act(() => {
+      globalThis.dispatchEvent(new Event("wheel"));
+    });
+    // The router's scroll reset, arriving on `onRendered` as it always does.
+    scrollTo(0);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(globalThis.scrollY).toBe(offsetFor(0.5));
+    expect(readLocalProgress(DOCUMENT_URI)?.progress).toBe(0.5);
+    expect(setReadingProgress).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Cross-device restore. The server copy exists precisely for the device that
+   * has never seen this article, so gating it on a local copy already being
+   * there defeats the only thing it is for.
+   */
+  it("adopts a position from another device when this one has none", async () => {
+    remotePosition = { progress: 0.5, updatedAt: new Date().toISOString() };
+
+    const { result } = setup();
+
+    // Nothing stored locally, so the landing is the top — until the server answers.
+    expect(globalThis.scrollY).toBe(0);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(globalThis.scrollY).toBe(offsetFor(0.5));
+    expect(result.current.resumed).toBe(true);
+    expect(readLocalProgress(DOCUMENT_URI)?.progress).toBe(0.5);
   });
 
   it("leaves the landing position alone when the URL names an anchor", () => {

--- a/apps/standard-reader/src/components/reader/use-reading-progress.test.ts
+++ b/apps/standard-reader/src/components/reader/use-reading-progress.test.ts
@@ -35,21 +35,21 @@ const DOCUMENT_URI = "at://did:plc:reader/site.standard.document/abc";
 /** Tall enough that a fraction maps to a distinctive offset. */
 const ARTICLE_HEIGHT = 5000;
 
-/** `progressGeometry`'s range for the article below: height − viewport. */
-const RANGE = ARTICLE_HEIGHT - 768;
+const VIEWPORT = 768;
 
-function offsetFor(progress: number): number {
-  return Math.round(progress * RANGE);
+/** `progressGeometry`'s range is height − viewport, so a fraction maps onto it. */
+function offsetFor(progress: number, height = ARTICLE_HEIGHT): number {
+  return Math.round(progress * (height - VIEWPORT));
 }
 
 /**
  * An `<article>` with real geometry. jsdom lays nothing out, so the two
  * measurements the hook takes are supplied by hand: the element starts at the
- * top of the document and is `ARTICLE_HEIGHT` tall.
+ * top of the document and is `height` tall.
  */
-function articleElement(): HTMLElement {
+function articleElement(height = ARTICLE_HEIGHT): HTMLElement {
   const element = document.createElement("article");
-  Object.defineProperty(element, "offsetHeight", { value: ARTICLE_HEIGHT });
+  Object.defineProperty(element, "offsetHeight", { value: height });
   element.getBoundingClientRect = () =>
     ({ top: -globalThis.scrollY }) as DOMRect;
   document.body.append(element);
@@ -78,8 +78,11 @@ function scrollTo(y: number) {
   });
 }
 
-function setup({ enabled = true }: { enabled?: boolean } = {}) {
-  const articleRef = { current: articleElement() };
+function setup({
+  enabled = true,
+  height = ARTICLE_HEIGHT,
+}: { enabled?: boolean; height?: number } = {}) {
+  const articleRef = { current: articleElement(height) };
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -235,6 +238,39 @@ describe("useReadingProgress", () => {
     });
 
     expect(globalThis.scrollY).toBe(offsetFor(0.5));
+    expect(readLocalProgress(DOCUMENT_URI)?.progress).toBe(0.5);
+    expect(setReadingProgress).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The same defence, at the size articles actually are.
+   *
+   * Measured in the running app: a 1498px article on a 664px viewport restores
+   * to ~417px — the whole offset is smaller than one screen. Any "was this jump
+   * bigger than a viewport" test is dead code at that size, which is why the
+   * first attempt at this guard passed its own test and changed nothing in the
+   * browser. Landing at the top without having passed through anywhere else is
+   * the tell, and it doesn't care how tall the article is.
+   */
+  it("survives momentum on an ordinary-length article", () => {
+    writeLocalProgress(DOCUMENT_URI, 0.5);
+
+    const height = 1498;
+    setup({ height });
+    expect(globalThis.scrollY).toBe(offsetFor(0.5, height));
+    // The restore offset really is under one screen — the premise of the test.
+    expect(offsetFor(0.5, height)).toBeLessThan(VIEWPORT);
+
+    act(() => {
+      globalThis.dispatchEvent(new Event("wheel"));
+    });
+    scrollTo(0);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(globalThis.scrollY).toBe(offsetFor(0.5, height));
     expect(readLocalProgress(DOCUMENT_URI)?.progress).toBe(0.5);
     expect(setReadingProgress).not.toHaveBeenCalled();
   });

--- a/apps/standard-reader/src/components/reader/use-reading-progress.test.ts
+++ b/apps/standard-reader/src/components/reader/use-reading-progress.test.ts
@@ -1,0 +1,208 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { createElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { readLocalProgress, writeLocalProgress } from "#/lib/reading-progress";
+
+import { useReadingProgress } from "./use-reading-progress";
+
+const setReadingProgress = vi.fn(async () => ({ ok: true as const }));
+const clearReadingProgress = vi.fn(async () => ({ ok: true as const }));
+
+vi.mock("#/integrations/tanstack-query/api-reader.functions", () => ({
+  readerApi: {
+    clearReadingProgress: (...args: Array<unknown>) =>
+      clearReadingProgress(...(args as [])),
+    getReadingProgressQueryOptions: (documentUri: string) => ({
+      queryKey: ["reader", "readingProgress", documentUri] as const,
+      // The other-device correction. Absent in these tests: what is under test
+      // is what the *local* copy does on landing.
+      queryFn: async () => null,
+    }),
+    setReadingProgress: (...args: Array<unknown>) =>
+      setReadingProgress(...(args as [])),
+  },
+}));
+
+const DOCUMENT_URI = "at://did:plc:reader/site.standard.document/abc";
+
+/** Tall enough that a fraction maps to a distinctive offset. */
+const ARTICLE_HEIGHT = 5000;
+
+/** `progressGeometry`'s range for the article below: height − viewport. */
+const RANGE = ARTICLE_HEIGHT - 768;
+
+function offsetFor(progress: number): number {
+  return Math.round(progress * RANGE);
+}
+
+/**
+ * An `<article>` with real geometry. jsdom lays nothing out, so the two
+ * measurements the hook takes are supplied by hand: the element starts at the
+ * top of the document and is `ARTICLE_HEIGHT` tall.
+ */
+function articleElement(): HTMLElement {
+  const element = document.createElement("article");
+  Object.defineProperty(element, "offsetHeight", { value: ARTICLE_HEIGHT });
+  element.getBoundingClientRect = () =>
+    ({ top: -globalThis.scrollY }) as DOMRect;
+  document.body.append(element);
+  return element;
+}
+
+/** `scrollY` is read-only on a real window; jsdom lays out nothing anyway. */
+function setScrollY(y: number) {
+  Object.defineProperty(globalThis, "scrollY", {
+    configurable: true,
+    value: y,
+    writable: true,
+  });
+}
+
+/** What a browser does on `scrollTo`, minus the asynchronous scroll event. */
+function stubScrollTo() {
+  vi.stubGlobal("scrollTo", (_x: number, y: number) => setScrollY(y));
+}
+
+/** A scroll this hook did not ask for — the router's, or the reader's. */
+function scrollTo(y: number) {
+  act(() => {
+    setScrollY(y);
+    globalThis.dispatchEvent(new Event("scroll"));
+  });
+}
+
+function setup({ enabled = true }: { enabled?: boolean } = {}) {
+  const articleRef = { current: articleElement() };
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return renderHook(
+    () =>
+      useReadingProgress({
+        articleRef,
+        documentUri: DOCUMENT_URI,
+        enabled,
+        skipRestore: false,
+      }),
+    {
+      wrapper: ({ children }: { children: ReactNode }) =>
+        createElement(QueryClientProvider, { client: queryClient }, children),
+    },
+  );
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  stubScrollTo();
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      disconnect() {}
+    },
+  );
+  setScrollY(0);
+});
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  setReadingProgress.mockClear();
+  clearReadingProgress.mockClear();
+  document.body.replaceChildren();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  setScrollY(0);
+});
+
+describe("useReadingProgress", () => {
+  it("lands on the remembered position", () => {
+    writeLocalProgress(DOCUMENT_URI, 0.5);
+
+    const { result } = setup();
+
+    expect(globalThis.scrollY).toBe(offsetFor(0.5));
+    expect(result.current.resumed).toBe(true);
+  });
+
+  /**
+   * The regression: the router's `scrollRestoration` runs on `onRendered`, from
+   * a layout effect mounted after the route's own tree, so on every in-app
+   * navigation it scrolls a freshly-restored article back to the top a beat
+   * after the restore. Landing at the top was the visible half; the invisible
+   * half was worse — the 0 that scroll measured was saved a second later, and a
+   * write outside the 2–95% band *deletes*, so one clobbered restore took the
+   * position off this device, off the server, and off the shelf. Which is why
+   * it appeared to work exactly once.
+   */
+  it("corrects a scroll it did not ask for, and never saves one", () => {
+    writeLocalProgress(DOCUMENT_URI, 0.5);
+
+    setup();
+    expect(globalThis.scrollY).toBe(offsetFor(0.5));
+
+    scrollTo(0);
+
+    expect(globalThis.scrollY).toBe(offsetFor(0.5));
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(setReadingProgress).not.toHaveBeenCalled();
+    expect(readLocalProgress(DOCUMENT_URI)?.progress).toBe(0.5);
+  });
+
+  it("hands the page back the moment the reader touches it", async () => {
+    writeLocalProgress(DOCUMENT_URI, 0.5);
+
+    setup();
+
+    act(() => {
+      globalThis.dispatchEvent(new Event("wheel"));
+    });
+
+    // No longer ours to steer: the reader's scroll stands, and is recorded.
+    scrollTo(offsetFor(0.25));
+    expect(globalThis.scrollY).toBe(offsetFor(0.25));
+
+    // Async: the local write is synchronous, but the server write goes through
+    // React Query's mutation queue, which settles on a microtask.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(readLocalProgress(DOCUMENT_URI)?.progress).toBeCloseTo(0.25, 2);
+    expect(setReadingProgress).toHaveBeenCalledTimes(1);
+  });
+
+  it("forgets the position when the reader scrolls back to the top", () => {
+    writeLocalProgress(DOCUMENT_URI, 0.5);
+
+    setup();
+
+    act(() => {
+      globalThis.dispatchEvent(new Event("wheel"));
+    });
+    scrollTo(0);
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(readLocalProgress(DOCUMENT_URI)).toBeNull();
+  });
+
+  it("leaves the landing position alone when the URL names an anchor", () => {
+    writeLocalProgress(DOCUMENT_URI, 0.5);
+    globalThis.history.replaceState(null, "", "/a/did/rkey#footnote-3");
+
+    const { result } = setup();
+
+    expect(globalThis.scrollY).toBe(0);
+    expect(result.current.resumed).toBe(false);
+
+    globalThis.history.replaceState(null, "", "/");
+  });
+});

--- a/apps/standard-reader/src/components/reader/use-reading-progress.ts
+++ b/apps/standard-reader/src/components/reader/use-reading-progress.ts
@@ -1,0 +1,355 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+
+import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
+import {
+  clearLocalProgress,
+  isResumableProgress,
+  READING_PROGRESS_EPSILON,
+  readLocalProgress,
+  writeLocalProgress,
+} from "#/lib/reading-progress";
+
+/**
+ * How long after landing we keep pulling the reader back to their saved spot.
+ *
+ * Restoring by fraction assumes the article is as tall as it was last time, and
+ * for a few hundred milliseconds it isn't: images have reserved no space yet, so
+ * the target offset drifts as they load. Re-applying across a short window is
+ * what makes the difference between landing where you left off and landing two
+ * screens early. Any real input ends it immediately — nothing yanks the page out
+ * from under someone who has started reading.
+ */
+const RESTORE_SETTLE_MS = 3000;
+
+/** Debounce on writes. Long enough that a flick through doesn't write a row. */
+const SAVE_DEBOUNCE_MS = 1000;
+
+/** Input that means the reader is driving, not us. */
+const USER_INTENT_EVENTS = [
+  "wheel",
+  "touchstart",
+  "keydown",
+  "pointerdown",
+] as const;
+
+/** Scroll offsets mapping the article body onto a 0–1 fraction. */
+function progressGeometry(content: HTMLElement) {
+  const viewport = globalThis.innerHeight;
+  const contentTop = content.getBoundingClientRect().top + globalThis.scrollY;
+  const contentBottom = contentTop + content.offsetHeight;
+  const endScroll = Math.max(contentBottom - viewport, contentTop);
+  return { contentTop, range: endScroll - contentTop };
+}
+
+/** How far through the article body the reader currently is, 0–1. */
+function measureProgress(content: HTMLElement): number {
+  const { contentTop, range } = progressGeometry(content);
+  const scrollY = globalThis.scrollY;
+  if (range <= 0) return scrollY >= contentTop ? 1 : 0;
+  return Math.min(1, Math.max(0, (scrollY - contentTop) / range));
+}
+
+/** The inverse: the scroll offset that puts the reader at `progress`. */
+function offsetForProgress(content: HTMLElement, progress: number): number {
+  const { contentTop, range } = progressGeometry(content);
+  return contentTop + progress * Math.max(0, range);
+}
+
+export interface UseReadingProgressResult {
+  /** Live 0–1 fraction, for the progress track in the sticky chrome. */
+  progress: number;
+  /** Whether we opened this article somewhere other than the top. */
+  resumed: boolean;
+  /** Send the reader back to the top and forget the saved position. */
+  startFromTop: () => void;
+}
+
+/**
+ * Keeps an article open at the place the reader left it, and remembers the
+ * place they leave it at.
+ *
+ * Position is stored twice on purpose — see `#/lib/reading-progress`. The local
+ * copy is read synchronously here so the restore happens in the same frame as
+ * the first paint (a visible scroll jump is worse than no restore at all); the
+ * server copy arrives a beat later and only wins if the reader got further on
+ * another device and hasn't touched this one yet.
+ */
+export function useReadingProgress({
+  documentUri,
+  articleRef,
+  enabled,
+  skipRestore,
+}: {
+  documentUri: string;
+  articleRef: React.RefObject<HTMLElement | null>;
+  /** False when the reader has reading history turned off. */
+  enabled: boolean;
+  /** True when something else owns the landing position (a shared quote). */
+  skipRestore: boolean;
+}): UseReadingProgressResult {
+  const queryClient = useQueryClient();
+  const [progress, setProgress] = useState(0);
+  const [resumed, setResumed] = useState(false);
+
+  const progressRef = useRef(0);
+  const savedRef = useRef<number | null>(null);
+  const userDroveRef = useRef(false);
+  /** Re-applies the saved position; live only during the settle window. */
+  const applyRestoreRef = useRef<((progress: number) => void) | null>(null);
+  /**
+   * `enabled` and `save` are read through refs so the restore effect can depend
+   * on the article alone. The preference arrives from a query and flips from its
+   * default a moment after mount — as a dependency it would re-run the effect
+   * and scroll a reader who had already started reading back to the saved spot.
+   */
+  const enabledRef = useRef(enabled);
+  const saveRef = useRef<(next: number) => void>(() => {});
+
+  const { mutate: persist } = useMutation({
+    mutationKey: ["reader", "setReadingProgress"] as const,
+    mutationFn: async (next: number) =>
+      readerApi.setReadingProgress({
+        data: { documentUri, progress: next },
+      }),
+    // Fail fast offline instead of taking React Query's default, which *pauses*
+    // the mutation and replays it on reconnect. Scrolling emits one of these
+    // every second or so, so a subway ride would queue dozens of writes that
+    // all replay to say what the last one says. The local copy is the durable
+    // record; the reconnect flush below sends the one value that matters.
+    networkMode: "offlineFirst",
+    onError: () => {},
+    retry: false,
+  });
+
+  const save = useCallback(
+    (next: number) => {
+      if (!enabled) return;
+
+      const previous = savedRef.current;
+      if (
+        previous !== null &&
+        Math.abs(next - previous) < READING_PROGRESS_EPSILON
+      ) {
+        return;
+      }
+      savedRef.current = next;
+
+      writeLocalProgress(documentUri, next);
+      persist(next);
+
+      // The shelf only changes when an article joins or leaves it — not on
+      // every scroll — so this refetch stays rare.
+      if (
+        previous === null ||
+        isResumableProgress(previous) !== isResumableProgress(next)
+      ) {
+        void queryClient.invalidateQueries({
+          queryKey: ["reader", "unfinished"],
+        });
+      }
+    },
+    [documentUri, enabled, persist, queryClient],
+  );
+
+  // Runs before the restore effect below on every commit, so that effect always
+  // reads the current preference without listing it as a dependency.
+  useLayoutEffect(() => {
+    enabledRef.current = enabled;
+    saveRef.current = save;
+  }, [enabled, save]);
+
+  // Coming back online, send where the reader actually got to while offline —
+  // one write, deliberately bypassing `save`'s "has it moved enough" guard,
+  // because what changed is our ability to reach the server, not the position.
+  useEffect(() => {
+    if (!enabled) return;
+
+    const flushOnReconnect = () => {
+      persist(progressRef.current);
+      void queryClient.invalidateQueries({
+        queryKey: ["reader", "unfinished"],
+      });
+    };
+
+    globalThis.addEventListener("online", flushOnReconnect);
+    return () => globalThis.removeEventListener("online", flushOnReconnect);
+  }, [enabled, persist, queryClient]);
+
+  const { mutate: forget } = useMutation({
+    mutationKey: ["reader", "clearReadingProgress"] as const,
+    mutationFn: async () =>
+      readerApi.clearReadingProgress({ data: { documentUri } }),
+    // Unlike the position writes above, this one keeps React Query's default
+    // network mode so an offline clear is paused and replayed on reconnect.
+    // It is a single deliberate action, not a stream, and dropping it would let
+    // the server position come back and undo what the reader just asked for.
+    onSettled: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["reader", "unfinished"],
+      });
+    },
+  });
+
+  const startFromTop = useCallback(() => {
+    userDroveRef.current = true;
+    applyRestoreRef.current = null;
+    globalThis.scrollTo(0, 0);
+    setResumed(false);
+    savedRef.current = 0;
+    clearLocalProgress(documentUri);
+    // Drop the cached server answer too, so nothing re-reads the position we
+    // just cleared before the mutation lands.
+    queryClient.setQueryData(
+      readerApi.getReadingProgressQueryOptions(documentUri).queryKey,
+      null,
+    );
+    if (enabled) forget();
+  }, [documentUri, enabled, forget, queryClient]);
+
+  useLayoutEffect(() => {
+    const articleEl = articleRef.current;
+    if (!articleEl) return;
+
+    progressRef.current = 0;
+    savedRef.current = null;
+    userDroveRef.current = false;
+    setResumed(false);
+
+    let restoreTarget: number | null = null;
+    let settleTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
+    let saveTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
+
+    const endRestore = () => {
+      userDroveRef.current = true;
+      restoreTarget = null;
+      applyRestoreRef.current = null;
+      if (settleTimer !== undefined) globalThis.clearTimeout(settleTimer);
+      for (const event of USER_INTENT_EVENTS) {
+        globalThis.removeEventListener(event, endRestore);
+      }
+    };
+
+    const applyRestore = (target: number) => {
+      restoreTarget = target;
+      globalThis.scrollTo(0, offsetForProgress(articleEl, target));
+      setResumed(true);
+    };
+
+    const sync = () => {
+      const next = measureProgress(articleEl);
+      progressRef.current = next;
+      setProgress(next);
+    };
+
+    const scheduleSave = () => {
+      if (!enabledRef.current) return;
+      if (saveTimer !== undefined) globalThis.clearTimeout(saveTimer);
+      saveTimer = globalThis.setTimeout(() => {
+        saveRef.current(progressRef.current);
+      }, SAVE_DEBOUNCE_MS);
+    };
+
+    // Measure the <article> only — progress should hit 100% at the end of the
+    // article body, not after the "More from" / comments sections below it.
+    const stored =
+      enabledRef.current && !skipRestore
+        ? readLocalProgress(documentUri)
+        : null;
+
+    if (stored && isResumableProgress(stored.progress)) {
+      savedRef.current = stored.progress;
+      applyRestore(stored.progress);
+      applyRestoreRef.current = applyRestore;
+      for (const event of USER_INTENT_EVENTS) {
+        globalThis.addEventListener(event, endRestore, {
+          passive: true,
+          once: true,
+        });
+      }
+      settleTimer = globalThis.setTimeout(endRestore, RESTORE_SETTLE_MS);
+    } else if (!skipRestore) {
+      globalThis.scrollTo(0, 0);
+    }
+
+    sync();
+
+    // The page (document) is the scroller, so its scroll event fires on window.
+    const onScroll = () => {
+      sync();
+      scheduleSave();
+    };
+    globalThis.addEventListener("scroll", onScroll, { passive: true });
+
+    const resizeObserver = new ResizeObserver(() => {
+      // Late-loading media moved the target out from under us.
+      if (restoreTarget !== null) {
+        globalThis.scrollTo(0, offsetForProgress(articleEl, restoreTarget));
+      }
+      sync();
+    });
+    resizeObserver.observe(articleEl);
+
+    // Closing the tab is the most common way to leave an article part-read, and
+    // it is the one moment a debounce would lose. `pagehide` also covers the
+    // iOS back-forward cache, where `beforeunload` never fires.
+    const flush = () => {
+      if (saveTimer !== undefined) globalThis.clearTimeout(saveTimer);
+      saveRef.current(progressRef.current);
+    };
+    const onPageHide = () => flush();
+    const onVisibility = () => {
+      if (globalThis.document.visibilityState === "hidden") flush();
+    };
+    globalThis.addEventListener("pagehide", onPageHide);
+    globalThis.document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      flush();
+      endRestore();
+      if (saveTimer !== undefined) globalThis.clearTimeout(saveTimer);
+      globalThis.removeEventListener("scroll", onScroll);
+      globalThis.removeEventListener("pagehide", onPageHide);
+      globalThis.document.removeEventListener("visibilitychange", onVisibility);
+      resizeObserver.disconnect();
+    };
+    // Deliberately keyed on the article alone — see `enabledRef` above.
+  }, [articleRef, documentUri, skipRestore]);
+
+  // The other-device correction. Deliberately not awaited anywhere on the
+  // critical path — it lands late and only matters when it disagrees.
+  const { data: remote } = useQuery({
+    ...readerApi.getReadingProgressQueryOptions(documentUri),
+    enabled: enabled && !skipRestore,
+  });
+
+  useEffect(() => {
+    if (!remote || userDroveRef.current) return;
+    const applyRestore = applyRestoreRef.current;
+    if (!applyRestore) return;
+    if (!isResumableProgress(remote.progress)) return;
+
+    const local = readLocalProgress(documentUri);
+    // This device already knows at least as much — leave the reader alone.
+    if (local && local.updatedAt >= remote.updatedAt) return;
+    if (
+      Math.abs(remote.progress - progressRef.current) < READING_PROGRESS_EPSILON
+    ) {
+      return;
+    }
+
+    savedRef.current = remote.progress;
+    writeLocalProgress(documentUri, remote.progress, remote.updatedAt);
+    applyRestore(remote.progress);
+  }, [documentUri, remote]);
+
+  return { progress, resumed, startFromTop };
+}

--- a/apps/standard-reader/src/components/reader/use-reading-progress.ts
+++ b/apps/standard-reader/src/components/reader/use-reading-progress.ts
@@ -28,7 +28,7 @@ import {
  * screens early. Any real input ends it immediately — nothing yanks the page out
  * from under someone who has started reading.
  */
-const RESTORE_SETTLE_MS = 3000;
+export const RESTORE_SETTLE_MS = 3000;
 
 /**
  * How far the page may drift from the target before the settle window pulls it
@@ -151,6 +151,14 @@ export function useReadingProgress({
       ) {
         return;
       }
+      // Nothing known this session and nothing worth keeping: there is no row
+      // to delete, so this would be a POST per article open that does nothing.
+      // (`previous` is only null when neither a local nor a remote position was
+      // adopted, so this can't swallow a real clear.)
+      if (previous === null && !isResumableProgress(next)) {
+        savedRef.current = next;
+        return;
+      }
       savedRef.current = next;
 
       writeLocalProgress(documentUri, next);
@@ -237,6 +245,19 @@ export function useReadingProgress({
     let restoreTarget: number | null = null;
     let settleTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
     let saveTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
+    /**
+     * Whether the reader has touched the input devices since we landed. On its
+     * own this does not mean they are steering — inertial scrolling does not
+     * stop because the page changed, so momentum from the feed keeps arriving
+     * here for a while after the navigation. It takes a *scroll* that a hand
+     * could plausibly have produced to hand the page over.
+     */
+    let sawUserIntent = false;
+    let lastScrollY = globalThis.scrollY;
+
+    const noteUserIntent = () => {
+      sawUserIntent = true;
+    };
 
     const endRestore = () => {
       userDroveRef.current = true;
@@ -244,15 +265,32 @@ export function useReadingProgress({
       applyRestoreRef.current = null;
       if (settleTimer !== undefined) globalThis.clearTimeout(settleTimer);
       for (const event of USER_INTENT_EVENTS) {
-        globalThis.removeEventListener(event, endRestore);
+        globalThis.removeEventListener(event, noteUserIntent);
       }
     };
 
     const applyRestore = (target: number) => {
       restoreTarget = target;
+      // A restore landing now invalidates anything queued from before it — in
+      // particular the router's reset, which would otherwise save a 0 over the
+      // position we just adopted and delete it.
+      if (saveTimer !== undefined) globalThis.clearTimeout(saveTimer);
+      if (settleTimer !== undefined) globalThis.clearTimeout(settleTimer);
+      settleTimer = globalThis.setTimeout(endRestore, RESTORE_SETTLE_MS);
       globalThis.scrollTo(0, offsetForProgress(articleEl, target));
+      lastScrollY = globalThis.scrollY;
       setResumed(true);
     };
+
+    /**
+     * Whether a scroll is one no hand produced: a single discrete jump to the
+     * very top, from somewhere more than a screen away. That is the shape of
+     * the router's `onRendered` reset. A reader arrives at the top the long
+     * way, through a run of small deltas, and is handed the page at the first
+     * of them.
+     */
+    const isProgrammaticReset = (from: number, to: number) =>
+      to <= RESTORE_TOLERANCE_PX && from - to > globalThis.innerHeight;
 
     const sync = () => {
       const next = measureProgress(articleEl);
@@ -278,19 +316,27 @@ export function useReadingProgress({
     const stored =
       enabledRef.current && ownsLanding ? readLocalProgress(documentUri) : null;
 
-    if (stored && isResumableProgress(stored.progress)) {
-      savedRef.current = stored.progress;
-      applyRestore(stored.progress);
+    if (ownsLanding) {
+      // Armed whether or not this device remembers anything: the server copy
+      // exists precisely for the device that has never seen this article, and
+      // gating the machinery on a local copy meant the only case cross-device
+      // sync is *for* was the one case it could never serve.
       applyRestoreRef.current = applyRestore;
       for (const event of USER_INTENT_EVENTS) {
-        globalThis.addEventListener(event, endRestore, {
+        globalThis.addEventListener(event, noteUserIntent, {
           passive: true,
           once: true,
         });
       }
       settleTimer = globalThis.setTimeout(endRestore, RESTORE_SETTLE_MS);
-    } else if (ownsLanding) {
-      globalThis.scrollTo(0, 0);
+
+      if (stored && isResumableProgress(stored.progress)) {
+        savedRef.current = stored.progress;
+        applyRestore(stored.progress);
+      } else {
+        globalThis.scrollTo(0, 0);
+        lastScrollY = globalThis.scrollY;
+      }
     }
 
     sync();
@@ -306,14 +352,29 @@ export function useReadingProgress({
     // after the restore. Saving that would be worse than losing the landing:
     // a measured 0 is written straight through to both stores, and writes
     // outside the 2–95% band delete — one clobbered restore and the position
-    // is gone from this device, the server, and the shelf. Hence: correct, and
-    // never save from inside the window. Real input ends it (`endRestore`)
-    // before any scroll it causes is dispatched.
+    // is gone from this device, the server, and the shelf.
+    //
+    // So the window is given up to a scroll the reader plausibly made, and
+    // never to the router's reset — input alone is not enough to end it,
+    // because momentum from the previous page is input the reader is no longer
+    // making.
     const onScroll = () => {
+      const from = lastScrollY;
+      const to = globalThis.scrollY;
+      lastScrollY = to;
+
       if (restoreTarget !== null) {
+        if (sawUserIntent && !isProgrammaticReset(from, to)) {
+          endRestore();
+          sync();
+          scheduleSave();
+          return;
+        }
+
         const target = offsetForProgress(articleEl, restoreTarget);
-        if (Math.abs(globalThis.scrollY - target) > RESTORE_TOLERANCE_PX) {
+        if (Math.abs(to - target) > RESTORE_TOLERANCE_PX) {
           globalThis.scrollTo(0, target);
+          lastScrollY = globalThis.scrollY;
         }
         sync();
         return;
@@ -337,6 +398,11 @@ export function useReadingProgress({
     // iOS back-forward cache, where `beforeunload` never fires.
     const flush = () => {
       if (saveTimer !== undefined) globalThis.clearTimeout(saveTimer);
+      // Inside the settle window the position on screen is one we chose, or one
+      // we are about to correct — never the reader's. Leaving fast (a glance,
+      // then straight back) would otherwise write the router's reset on the way
+      // out, which is the one write that deletes.
+      if (restoreTarget !== null) return;
       saveRef.current(progressRef.current);
     };
     const onPageHide = () => flush();

--- a/apps/standard-reader/src/components/reader/use-reading-progress.ts
+++ b/apps/standard-reader/src/components/reader/use-reading-progress.ts
@@ -253,7 +253,6 @@ export function useReadingProgress({
      * could plausibly have produced to hand the page over.
      */
     let sawUserIntent = false;
-    let lastScrollY = globalThis.scrollY;
 
     const noteUserIntent = () => {
       sawUserIntent = true;
@@ -278,19 +277,26 @@ export function useReadingProgress({
       if (settleTimer !== undefined) globalThis.clearTimeout(settleTimer);
       settleTimer = globalThis.setTimeout(endRestore, RESTORE_SETTLE_MS);
       globalThis.scrollTo(0, offsetForProgress(articleEl, target));
-      lastScrollY = globalThis.scrollY;
       setResumed(true);
     };
 
+    /** Set once a scroll lands somewhere that isn't the very top. */
+    let sawIncrementalScroll = false;
+
     /**
-     * Whether a scroll is one no hand produced: a single discrete jump to the
-     * very top, from somewhere more than a screen away. That is the shape of
-     * the router's `onRendered` reset. A reader arrives at the top the long
-     * way, through a run of small deltas, and is handed the page at the first
-     * of them.
+     * Whether a scroll is one no hand produced: it arrives at the very top,
+     * and it is the first scroll since we landed. A reader cannot get from
+     * mid-article to the top without passing through it — wheel and touch both
+     * emit a run of intermediate events, and the first of those hands the page
+     * over. Only a programmatic `scrollTo` teleports.
+     *
+     * Deliberately not a distance test. The obvious version — "a jump of more
+     * than a screen" — silently does nothing on ordinary articles, where the
+     * whole restore offset is smaller than the viewport (a 1500px article on a
+     * 660px screen restores to ~420px, so the jump is never a screen tall).
      */
-    const isProgrammaticReset = (from: number, to: number) =>
-      to <= RESTORE_TOLERANCE_PX && from - to > globalThis.innerHeight;
+    const isProgrammaticReset = (to: number) =>
+      to <= RESTORE_TOLERANCE_PX && !sawIncrementalScroll;
 
     const sync = () => {
       const next = measureProgress(articleEl);
@@ -335,7 +341,6 @@ export function useReadingProgress({
         applyRestore(stored.progress);
       } else {
         globalThis.scrollTo(0, 0);
-        lastScrollY = globalThis.scrollY;
       }
     }
 
@@ -345,26 +350,26 @@ export function useReadingProgress({
     //
     // While the settle window is live, *we* are the one steering — so a scroll
     // we didn't ask for is something else's, and gets corrected rather than
-    // recorded. The router is the one that always does this: its
-    // `scrollRestoration` handler runs on `onRendered`, from a layout effect
-    // mounted as a sibling *after* the route's own tree, so on every in-app
-    // navigation it scrolls a freshly-restored article back to the top a beat
-    // after the restore. Saving that would be worse than losing the landing:
-    // a measured 0 is written straight through to both stores, and writes
-    // outside the 2–95% band delete — one clobbered restore and the position
-    // is gone from this device, the server, and the shelf.
+    // recorded. This is now a backstop rather than the mechanism: the router
+    // used to be the reliable offender — its handler runs on `onRendered`, from
+    // a layout effect mounted as a sibling *after* the route's own tree, so on
+    // every in-app navigation it scrolled a freshly-restored article back to the
+    // top a beat later — and it is switched off for this route outright (see
+    // `routerOwnsScroll`). What remains is defence against anything else that
+    // scrolls without asking, because the cost is asymmetric: a measured 0 is
+    // written straight through to both stores, and writes outside the 2–95%
+    // band delete, so one clobbered restore takes the position off this device,
+    // off the server, and off the shelf.
     //
     // So the window is given up to a scroll the reader plausibly made, and
-    // never to the router's reset — input alone is not enough to end it,
-    // because momentum from the previous page is input the reader is no longer
-    // making.
+    // never to a teleport — input alone is not enough to end it, because
+    // momentum from the previous page is input the reader is no longer making.
     const onScroll = () => {
-      const from = lastScrollY;
       const to = globalThis.scrollY;
-      lastScrollY = to;
+      if (to > RESTORE_TOLERANCE_PX) sawIncrementalScroll = true;
 
       if (restoreTarget !== null) {
-        if (sawUserIntent && !isProgrammaticReset(from, to)) {
+        if (sawUserIntent && !isProgrammaticReset(to)) {
           endRestore();
           sync();
           scheduleSave();
@@ -374,7 +379,6 @@ export function useReadingProgress({
         const target = offsetForProgress(articleEl, restoreTarget);
         if (Math.abs(to - target) > RESTORE_TOLERANCE_PX) {
           globalThis.scrollTo(0, target);
-          lastScrollY = globalThis.scrollY;
         }
         sync();
         return;

--- a/apps/standard-reader/src/components/reader/use-reading-progress.ts
+++ b/apps/standard-reader/src/components/reader/use-reading-progress.ts
@@ -30,6 +30,16 @@ import {
  */
 const RESTORE_SETTLE_MS = 3000;
 
+/**
+ * How far the page may drift from the target before the settle window pulls it
+ * back.
+ *
+ * Wide enough that `scrollTo` landing a pixel or two off (or bottoming out
+ * against the end of the document) doesn't bounce, narrow enough that a
+ * scroll-to-top is always corrected.
+ */
+const RESTORE_TOLERANCE_PX = 8;
+
 /** Debounce on writes. Long enough that a flick through doesn't write a row. */
 const SAVE_DEBOUNCE_MS = 1000;
 
@@ -258,12 +268,15 @@ export function useReadingProgress({
       }, SAVE_DEBOUNCE_MS);
     };
 
+    // Whether the landing position is ours to choose. A shared quote owns it,
+    // and so does a `#hash` — an anchor in the URL is a destination the reader
+    // asked for out loud, which outranks one we remembered for them.
+    const ownsLanding = !skipRestore && !globalThis.location.hash;
+
     // Measure the <article> only — progress should hit 100% at the end of the
     // article body, not after the "More from" / comments sections below it.
     const stored =
-      enabledRef.current && !skipRestore
-        ? readLocalProgress(documentUri)
-        : null;
+      enabledRef.current && ownsLanding ? readLocalProgress(documentUri) : null;
 
     if (stored && isResumableProgress(stored.progress)) {
       savedRef.current = stored.progress;
@@ -276,14 +289,35 @@ export function useReadingProgress({
         });
       }
       settleTimer = globalThis.setTimeout(endRestore, RESTORE_SETTLE_MS);
-    } else if (!skipRestore) {
+    } else if (ownsLanding) {
       globalThis.scrollTo(0, 0);
     }
 
     sync();
 
     // The page (document) is the scroller, so its scroll event fires on window.
+    //
+    // While the settle window is live, *we* are the one steering — so a scroll
+    // we didn't ask for is something else's, and gets corrected rather than
+    // recorded. The router is the one that always does this: its
+    // `scrollRestoration` handler runs on `onRendered`, from a layout effect
+    // mounted as a sibling *after* the route's own tree, so on every in-app
+    // navigation it scrolls a freshly-restored article back to the top a beat
+    // after the restore. Saving that would be worse than losing the landing:
+    // a measured 0 is written straight through to both stores, and writes
+    // outside the 2–95% band delete — one clobbered restore and the position
+    // is gone from this device, the server, and the shelf. Hence: correct, and
+    // never save from inside the window. Real input ends it (`endRestore`)
+    // before any scroll it causes is dispatched.
     const onScroll = () => {
+      if (restoreTarget !== null) {
+        const target = offsetForProgress(articleEl, restoreTarget);
+        if (Math.abs(globalThis.scrollY - target) > RESTORE_TOLERANCE_PX) {
+          globalThis.scrollTo(0, target);
+        }
+        sync();
+        return;
+      }
       sync();
       scheduleSave();
     };

--- a/apps/standard-reader/src/components/user-settings-view.tsx
+++ b/apps/standard-reader/src/components/user-settings-view.tsx
@@ -82,6 +82,7 @@ import type { Locale } from "#/lib/locale";
 import { LOCALE_LABELS, LOCALES, PSEUDO_LOCALE, isLocale } from "#/lib/locale";
 import { AMERICAN_ENGLISH_VOICES } from "#/lib/page-reader/voice-catalog";
 import { isReaderVoicePreference } from "#/lib/reader-voice";
+import { clearAllLocalProgress } from "#/lib/reading-progress";
 import type { ReadingTypographyPreference } from "#/lib/reading-typography";
 import {
   READING_BODY_FONTS,
@@ -485,9 +486,17 @@ export function UserSettingsView() {
   const signedIn = Boolean(session?.user);
   const sidebarPref = useSidebarPref(signedIn);
 
-  const deleteHistoryMutation = useMutation(
-    readerApi.deleteAllReadHistoryMutationOptions(),
-  );
+  const deleteHistoryMutation = useMutation({
+    ...readerApi.deleteAllReadHistoryMutationOptions(),
+    onSuccess: () => {
+      // The server rows are gone; drop this device's copy too, or the next
+      // article the reader opens resumes from a position they just erased.
+      clearAllLocalProgress();
+      void queryClient.invalidateQueries({
+        queryKey: ["reader", "unfinished"],
+      });
+    },
+  });
   const deleteBookmarksMutation = useMutation(
     readerApi.deleteAllBookmarksMutationOptions(),
   );

--- a/apps/standard-reader/src/db/schema.ts
+++ b/apps/standard-reader/src/db/schema.ts
@@ -17,6 +17,7 @@ export * from "./schema/publications.ts";
 export * from "./schema/documents.ts";
 export * from "./schema/graph.ts";
 export * from "./schema/personal.ts";
+export * from "./schema/reading-progress.ts";
 export * from "./schema/push.ts";
 export * from "./schema/lists.ts";
 export * from "./schema/stats.ts";

--- a/apps/standard-reader/src/db/schema/reading-progress.ts
+++ b/apps/standard-reader/src/db/schema/reading-progress.ts
@@ -1,0 +1,58 @@
+import {
+  index,
+  pgTable,
+  primaryKey,
+  real,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core";
+
+/**
+ * How far a reader got through an article — deliberately **not** an AT Proto
+ * record.
+ *
+ * Every other personal-state table in `./personal.ts` mirrors a record in the
+ * reader's own repo, and those records are public (`APP_VISION.md` §5): anyone
+ * can see what you read. Position is a different kind of fact. "I stopped 20%
+ * into this" is a running commentary on attention, and publishing it to the
+ * firehose is not something a reader opted into by opening an article. So this
+ * lives only here, private to the app, and the tap never writes it.
+ *
+ * The trade is that progress is app-local rather than portable — it follows the
+ * reader across their devices (it is keyed by DID, not by browser) but does not
+ * travel with the repo to another client.
+ */
+export const readingProgress = pgTable(
+  "reading_progress",
+  {
+    /** DID of the reader. No FK to `user`: the DID outlives any one session
+     * row, matching `push_devices` / `push_topics`. */
+    ownerDid: text("owner_did").notNull(),
+    /** AT-URI of the `site.standard.document` being read. */
+    documentUri: text("document_uri").notNull(),
+
+    /**
+     * Fraction of the article body scrolled past, 0–1. A fraction rather than a
+     * pixel offset because the same reader's phone and laptop disagree on every
+     * pixel — column width, text-size dial, and font all differ — but they
+     * agree on "a third of the way in".
+     */
+    progress: real("progress").notNull(),
+
+    /** When the reader was last at this position. */
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.ownerDid, table.documentUri] }),
+    // "Continue reading" — a reader's in-progress articles, most recent first.
+    index("reading_progress_owner_idx").on(
+      table.ownerDid,
+      table.updatedAt.desc(),
+    ),
+  ],
+);
+
+export type ReadingProgress = typeof readingProgress.$inferSelect;
+export type NewReadingProgress = typeof readingProgress.$inferInsert;

--- a/apps/standard-reader/src/integrations/tanstack-query/api-reader.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-reader.functions.ts
@@ -1932,7 +1932,12 @@ function getReadingHistoryInfiniteQueryOptions({
     queryFn: async ({ pageParam }) =>
       getReadingHistory({ data: { limit, offset: pageParam } }),
     initialPageParam: 0,
-    getNextPageParam: (lastPage) => lastPage.nextOffset ?? undefined,
+    // `lastPage?` rather than `lastPage.`: a page can be missing when a fetch
+    // resolved without one (seen against a database that was erroring), and an
+    // unguarded read throws out of render — taking down a `/history` whose own
+    // rows loaded fine. The same unguarded shape is on every other infinite
+    // query in the app; this is the one observed to crash.
+    getNextPageParam: (lastPage) => lastPage?.nextOffset ?? undefined,
   });
 }
 

--- a/apps/standard-reader/src/integrations/tanstack-query/api-reader.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-reader.functions.ts
@@ -11,6 +11,11 @@ import { alias } from "drizzle-orm/pg-core";
 import { z } from "zod";
 
 import {
+  isResumableProgress,
+  READING_PROGRESS_DONE,
+  READING_PROGRESS_MIN,
+} from "#/lib/reading-progress";
+import {
   getAtprotoSessionForRequest,
   getReaderDidForRequest,
 } from "#/middleware/auth-session.server";
@@ -94,6 +99,13 @@ const documentsInput = z.object({
 
 /** Default page size for likes / saved / history infinite scroll. */
 export const READER_QUEUE_PAGE_SIZE = 20;
+
+/**
+ * How many in-progress articles the "Continue reading" shelf holds. Short on
+ * purpose: it is a prompt to pick something back up, and a long one reads as
+ * another backlog to feel behind on.
+ */
+export const UNFINISHED_SHELF_SIZE = 6;
 
 const readerListInput = z.object({
   limit: z.number().int().min(1).max(100).default(READER_QUEUE_PAGE_SIZE),
@@ -442,6 +454,20 @@ export interface SavedListPage extends ReaderListPage<SavedArticleItem> {
 export interface ReadHistoryItem {
   readUri: string;
   readAt: string | null;
+  documentUri: string;
+  /** Null when the document is no longer in the read-model. */
+  article: ArticleCard | null;
+}
+
+/** Where a reader stopped in one article, as the server knows it. */
+export interface ReadingPosition {
+  /** Fraction of the article body scrolled past, 0–1. */
+  progress: number;
+  updatedAt: string;
+}
+
+/** An article the reader is partway through, with hydrated card data. */
+export interface UnfinishedReadingItem extends ReadingPosition {
   documentUri: string;
   /** Null when the document is no longer in the read-model. */
   article: ArticleCard | null;
@@ -1152,6 +1178,174 @@ const getReadingHistory = createServerFn({ method: "GET" })
     }),
   );
 
+// ── Reading position (app-local; deliberately not a repo record) ────────────
+
+const readingProgressInput = z.object({
+  documentUri: z.string().min(1),
+  /** Fraction of the article body scrolled past. */
+  progress: z.number().min(0).max(1),
+});
+
+const unfinishedInput = z.object({
+  limit: z.number().int().min(1).max(50).default(UNFINISHED_SHELF_SIZE),
+});
+
+/**
+ * Remember where the reader stopped — or forget it, once they finish. Rows are
+ * only kept while {@link isResumableProgress} holds, so `reading_progress` is
+ * exactly the set of articles "Continue reading" should show and never needs a
+ * sweep to stay that way.
+ */
+const setReadingProgress = createServerFn({ method: "POST" })
+  .middleware([dbMiddleware])
+  .validator(readingProgressInput)
+  .handler(
+    observe("reader.setReadingProgress", async ({ data, context }, span) => {
+      span.set("documentUri", data.documentUri);
+      span.set("progress", data.progress);
+      const did = await getReaderDidForRequest(getRequest());
+      if (!did) return { ok: true as const };
+      span.set("did", did);
+
+      // Position is reading history by another name — a reader who turned that
+      // off did not ask us to keep a finer-grained version of it.
+      if (!context.trackReadingEnabled) return { ok: true as const };
+
+      const rp = context.schema.readingProgress;
+      const where = and(
+        eq(rp.ownerDid, did),
+        eq(rp.documentUri, data.documentUri),
+      );
+
+      if (!isResumableProgress(data.progress)) {
+        await context.db.delete(rp).where(where);
+        span.set("cleared", true);
+        return { ok: true as const };
+      }
+
+      await context.db
+        .insert(rp)
+        .values({
+          documentUri: data.documentUri,
+          ownerDid: did,
+          progress: data.progress,
+          updatedAt: new Date(),
+        })
+        .onConflictDoUpdate({
+          target: [rp.ownerDid, rp.documentUri],
+          set: { progress: data.progress, updatedAt: new Date() },
+        });
+
+      return { ok: true as const };
+    }),
+  );
+
+/** Drop a remembered position (the reader chose to start from the top). */
+const clearReadingProgress = createServerFn({ method: "POST" })
+  .middleware([dbMiddleware])
+  .validator(documentInput)
+  .handler(
+    observe("reader.clearReadingProgress", async ({ data, context }, span) => {
+      span.set("documentUri", data.documentUri);
+      const did = await getReaderDidForRequest(getRequest());
+      if (!did) return { ok: true as const };
+      span.set("did", did);
+
+      const rp = context.schema.readingProgress;
+      await context.db
+        .delete(rp)
+        .where(and(eq(rp.ownerDid, did), eq(rp.documentUri, data.documentUri)));
+      return { ok: true as const };
+    }),
+  );
+
+/**
+ * The position this reader's *other* devices know about. The local copy drives
+ * the initial scroll (it is available before first paint); this is what corrects
+ * it when the reader got further on their phone.
+ */
+const getReadingProgress = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware])
+  .validator(documentInput)
+  .handler(
+    observe("reader.getReadingProgress", async ({ data, context }, span) => {
+      span.set("documentUri", data.documentUri);
+      const did = await getReaderDidForRequest(getRequest());
+      if (!did) return null satisfies ReadingPosition | null;
+      span.set("did", did);
+
+      const rp = context.schema.readingProgress;
+      const rows = await context.db
+        .select({ progress: rp.progress, updatedAt: rp.updatedAt })
+        .from(rp)
+        .where(and(eq(rp.ownerDid, did), eq(rp.documentUri, data.documentUri)))
+        .limit(1);
+
+      const row = rows[0];
+      if (!row) return null;
+      return {
+        progress: row.progress,
+        updatedAt: row.updatedAt.toISOString(),
+      } satisfies ReadingPosition;
+    }),
+  );
+
+/** Articles the reader is partway through, most recently touched first. */
+const getUnfinishedReading = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware])
+  .validator(unfinishedInput)
+  .handler(
+    observe("reader.getUnfinishedReading", async ({ data, context }, span) => {
+      const did = await getReaderDidForRequest(getRequest());
+      if (!did) return [] satisfies Array<UnfinishedReadingItem>;
+      span.set("did", did);
+      span.set("limit", data.limit);
+
+      const rp = context.schema.readingProgress;
+      const d = context.schema.documents;
+      const p = context.schema.publications;
+      const pr = context.schema.profiles;
+      const pa = alias(context.schema.profiles, "pa");
+      const cols = articleQueueCardColumns(context.schema);
+
+      const rows = await context.db
+        .select({
+          documentUri: rp.documentUri,
+          progress: rp.progress,
+          updatedAt: rp.updatedAt,
+          ...cols,
+        })
+        .from(rp)
+        .leftJoin(d, eq(d.uri, rp.documentUri))
+        .leftJoin(p, eq(p.uri, d.publicationUri))
+        .leftJoin(pr, eq(pr.did, p.did))
+        .leftJoin(pa, eq(pa.did, d.did))
+        .where(
+          and(
+            eq(rp.ownerDid, did),
+            // Writes already hold this invariant; the filter keeps a stale row
+            // from an older threshold out of the shelf.
+            sql`${rp.progress} >= ${READING_PROGRESS_MIN}`,
+            sql`${rp.progress} < ${READING_PROGRESS_DONE}`,
+          ),
+        )
+        // Matches `reading_progress_owner_idx` (owner_did, updated_at DESC).
+        .orderBy(desc(rp.updatedAt))
+        .limit(data.limit);
+
+      span.set("count", rows.length);
+
+      const items = rows.map((row) => ({
+        documentUri: row.documentUri,
+        progress: row.progress,
+        updatedAt: row.updatedAt.toISOString(),
+        article: hydrateArticleFromRow(row, { isRead: true }),
+      })) satisfies Array<UnfinishedReadingItem>;
+
+      return flagViewerRecommendedItems(context.db, context.schema, did, items);
+    }),
+  );
+
 // ── Save for later (app.standard-reader.bookmark) ───────────────────────────
 
 const getBookmarkStatus = createServerFn({ method: "GET" })
@@ -1445,6 +1639,12 @@ const deleteAllReadHistory = createServerFn({ method: "POST" })
         .delete(context.schema.reads)
         .where(eq(context.schema.reads.ownerDid, session.did));
 
+      // Positions are reading history at a finer grain. Someone clearing the
+      // one and being left with the other would reasonably call that a bug.
+      await context.db
+        .delete(context.schema.readingProgress)
+        .where(eq(context.schema.readingProgress.ownerDid, session.did));
+
       await trackReaderRepo(session.did);
       span.set("deleted", readRows.length);
       return { ok: true as const, deleted: readRows.length };
@@ -1736,6 +1936,25 @@ function getReadingHistoryInfiniteQueryOptions({
   });
 }
 
+function getReadingProgressQueryOptions(documentUri: string) {
+  return queryOptions({
+    queryKey: ["reader", "readingProgress", documentUri] as const,
+    queryFn: async () => getReadingProgress({ data: { documentUri } }),
+    // The reader is looking at the article right now; their own scrolling is
+    // the authority here, not a refetch.
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+function getUnfinishedReadingQueryOptions({
+  limit = UNFINISHED_SHELF_SIZE,
+}: { limit?: number } = {}) {
+  return queryOptions({
+    queryKey: ["reader", "unfinished", limit] as const,
+    queryFn: async () => getUnfinishedReading({ data: { limit } }),
+  });
+}
+
 function getReadDocumentsQueryOptions(documentUris: Array<string>) {
   return queryOptions({
     queryKey: ["reader", "readDocuments", documentUris.toSorted()] as const,
@@ -1916,6 +2135,13 @@ export const readerApi = {
   markUnreadMutationOptions,
   getReadingHistory,
   getReadingHistoryInfiniteQueryOptions,
+  // reading position (app-local, not a repo record)
+  getReadingProgress,
+  getReadingProgressQueryOptions,
+  setReadingProgress,
+  clearReadingProgress,
+  getUnfinishedReading,
+  getUnfinishedReadingQueryOptions,
   // save for later (app.standard-reader.bookmark)
   getBookmarkStatus,
   getBookmarkStatusQueryOptions,

--- a/apps/standard-reader/src/lib/reading-progress.test.ts
+++ b/apps/standard-reader/src/lib/reading-progress.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  clearAllLocalProgress,
+  clearLocalProgress,
+  isResumableProgress,
+  READING_PROGRESS_DONE,
+  READING_PROGRESS_MIN,
+  readLocalProgress,
+  writeLocalProgress,
+} from "./reading-progress";
+
+const URI = "at://did:plc:author/site.standard.document/aaa";
+
+beforeEach(() => {
+  globalThis.localStorage.clear();
+});
+
+describe("isResumableProgress", () => {
+  it("ignores an article the reader barely opened", () => {
+    expect(isResumableProgress(0)).toBe(false);
+    expect(isResumableProgress(READING_PROGRESS_MIN / 2)).toBe(false);
+  });
+
+  it("ignores an article the reader finished", () => {
+    expect(isResumableProgress(READING_PROGRESS_DONE)).toBe(false);
+    expect(isResumableProgress(1)).toBe(false);
+  });
+
+  it("resumes everything in between", () => {
+    expect(isResumableProgress(READING_PROGRESS_MIN)).toBe(true);
+    expect(isResumableProgress(0.5)).toBe(true);
+  });
+});
+
+describe("writeLocalProgress", () => {
+  it("round-trips a mid-article position", () => {
+    writeLocalProgress(URI, 0.42, "2026-08-12T10:00:00.000Z");
+    expect(readLocalProgress(URI)).toEqual({
+      progress: 0.42,
+      updatedAt: "2026-08-12T10:00:00.000Z",
+    });
+  });
+
+  it("forgets the article once the reader reaches the end", () => {
+    writeLocalProgress(URI, 0.42);
+    writeLocalProgress(URI, 0.99);
+    expect(readLocalProgress(URI)).toBeNull();
+  });
+
+  it("forgets the article when the reader scrolls back to the top", () => {
+    writeLocalProgress(URI, 0.42);
+    writeLocalProgress(URI, 0);
+    expect(readLocalProgress(URI)).toBeNull();
+  });
+
+  it("never stores an article that was only glanced at", () => {
+    writeLocalProgress(URI, 0.001);
+    expect(readLocalProgress(URI)).toBeNull();
+  });
+
+  it("keeps articles apart", () => {
+    const other = "at://did:plc:author/site.standard.document/bbb";
+    writeLocalProgress(URI, 0.2);
+    writeLocalProgress(other, 0.8);
+    expect(readLocalProgress(URI)?.progress).toBe(0.2);
+    expect(readLocalProgress(other)?.progress).toBe(0.8);
+  });
+
+  it("evicts the oldest positions past the cap, keeping the newest", () => {
+    // 120 articles, oldest first, one minute apart — the cap is 100.
+    const base = Date.UTC(2026, 0, 1);
+    for (let index = 0; index < 120; index++) {
+      writeLocalProgress(
+        `at://did:plc:author/site.standard.document/${index}`,
+        0.5,
+        new Date(base + index * 60_000).toISOString(),
+      );
+    }
+
+    // The most recent write survives; the very first one does not.
+    expect(
+      readLocalProgress("at://did:plc:author/site.standard.document/119"),
+    ).not.toBeNull();
+    expect(
+      readLocalProgress("at://did:plc:author/site.standard.document/0"),
+    ).toBeNull();
+  });
+});
+
+describe("clearing", () => {
+  it("forgets one article", () => {
+    writeLocalProgress(URI, 0.42);
+    clearLocalProgress(URI);
+    expect(readLocalProgress(URI)).toBeNull();
+  });
+
+  it("forgets everything", () => {
+    writeLocalProgress(URI, 0.42);
+    writeLocalProgress("at://did:plc:author/site.standard.document/bbb", 0.6);
+    clearAllLocalProgress();
+    expect(readLocalProgress(URI)).toBeNull();
+  });
+
+  it("survives a corrupt stored value", () => {
+    globalThis.localStorage.setItem(
+      "standard-reader:reading-progress",
+      "not json",
+    );
+    expect(readLocalProgress(URI)).toBeNull();
+    expect(() => writeLocalProgress(URI, 0.42)).not.toThrow();
+    expect(readLocalProgress(URI)?.progress).toBe(0.42);
+  });
+});

--- a/apps/standard-reader/src/lib/reading-progress.ts
+++ b/apps/standard-reader/src/lib/reading-progress.ts
@@ -1,0 +1,141 @@
+/**
+ * Where a reader stopped in an article, and the rules for when that is worth
+ * remembering.
+ *
+ * Two stores back this, and they answer different questions. The server
+ * (`reading_progress`) is the one that follows a reader from phone to laptop.
+ * `localStorage` is the one that can answer *before the first paint* — restoring
+ * position has to happen in a layout effect, and a round trip to Neon is an
+ * order of magnitude too slow for that, so the local copy drives the scroll and
+ * the server copy corrects it if the reader's other device got further.
+ *
+ * The local copy is also what keeps this working in the installed PWA with no
+ * network: the write is best-effort against the server, always durable locally.
+ */
+
+/**
+ * Below this the reader has barely started — a glance at the top, a bounce.
+ * Resuming there would scroll them roughly nowhere, and listing it under
+ * "Continue reading" would fill the shelf with articles nobody started.
+ */
+export const READING_PROGRESS_MIN = 0.02;
+
+/**
+ * At or above this, treat the article as finished. The tail of an article is
+ * footnotes and author bio, and holding someone at 97% forever means the shelf
+ * never empties — which is the failure that makes people stop trusting it.
+ */
+export const READING_PROGRESS_DONE = 0.95;
+
+/** Whether a stored position is worth restoring / listing. */
+export function isResumableProgress(progress: number): boolean {
+  return progress >= READING_PROGRESS_MIN && progress < READING_PROGRESS_DONE;
+}
+
+/** How much scrolling has to happen before another write is worth it. */
+export const READING_PROGRESS_EPSILON = 0.01;
+
+const STORAGE_KEY = "standard-reader:reading-progress";
+
+/**
+ * Cap on remembered articles. Position is only interesting for what a reader is
+ * currently in the middle of, and an unbounded map in `localStorage` is a slow
+ * leak in a store the whole app shares.
+ */
+const LOCAL_LIMIT = 100;
+
+export interface LocalReadingProgress {
+  progress: number;
+  /** ISO timestamp, used to decide whether the server knows something newer. */
+  updatedAt: string;
+}
+
+type LocalMap = Map<string, LocalReadingProgress>;
+
+function readMap(): LocalMap {
+  if (globalThis.localStorage === undefined) return new Map();
+  try {
+    const raw = globalThis.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return new Map();
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return new Map();
+    return new Map(
+      Object.entries(parsed as Record<string, LocalReadingProgress>),
+    );
+  } catch {
+    // Private browsing, disabled storage, or a value from an older shape.
+    return new Map();
+  }
+}
+
+function writeMap(map: LocalMap): void {
+  if (globalThis.localStorage === undefined) return;
+  try {
+    globalThis.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify(Object.fromEntries(map)),
+    );
+  } catch {
+    // Quota or private browsing — position is a convenience, never a failure.
+  }
+}
+
+/** The locally-remembered position for an article, if any. */
+export function readLocalProgress(
+  documentUri: string,
+): LocalReadingProgress | null {
+  const entry = readMap().get(documentUri);
+  if (!entry || typeof entry.progress !== "number") return null;
+  return entry;
+}
+
+/**
+ * Remember (or forget) a position locally. Writing a finished / barely-started
+ * value forgets it instead, so the local map holds exactly the articles that
+ * would show under "Continue reading".
+ */
+export function writeLocalProgress(
+  documentUri: string,
+  progress: number,
+  updatedAt: string = new Date().toISOString(),
+): void {
+  const map = readMap();
+
+  if (isResumableProgress(progress)) {
+    map.set(documentUri, { progress, updatedAt });
+  } else if (!map.delete(documentUri)) {
+    // Nothing stored and nothing worth storing — don't rewrite the store.
+    return;
+  }
+
+  if (map.size > LOCAL_LIMIT) {
+    const kept = [...map.entries()]
+      .toSorted((a, b) => b[1].updatedAt.localeCompare(a[1].updatedAt))
+      .slice(0, LOCAL_LIMIT);
+    writeMap(new Map(kept));
+    return;
+  }
+
+  writeMap(map);
+}
+
+/** Forget an article's position locally (finished, or reset to the top). */
+export function clearLocalProgress(documentUri: string): void {
+  const map = readMap();
+  if (!map.delete(documentUri)) return;
+  writeMap(map);
+}
+
+/**
+ * Forget every position on this device. Pairs with clearing reading history:
+ * the server rows go with it, and leaving the local copy behind would resurrect
+ * positions the reader just asked us to drop.
+ */
+export function clearAllLocalProgress(): void {
+  if (globalThis.localStorage === undefined) return;
+  try {
+    globalThis.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Nothing to do — the store is unavailable, so nothing is stored.
+  }
+}

--- a/apps/standard-reader/src/lib/router-scroll.test.ts
+++ b/apps/standard-reader/src/lib/router-scroll.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { routerOwnsScroll } from "./router-scroll";
+
+const ARTICLE = "/a/did:plc:abc/my-post";
+
+describe("routerOwnsScroll", () => {
+  it("keeps the router in charge everywhere but the reader", () => {
+    for (const pathname of [
+      "/",
+      "/latest",
+      "/saved",
+      "/history",
+      "/discover",
+      "/p/did:plc:abc/pub",
+      "/collection/did:plc:abc/rkey",
+      "/comic/did:plc:abc/rkey",
+    ]) {
+      expect(routerOwnsScroll({ hash: "", pathname })).toBe(true);
+    }
+  });
+
+  it("hands the article reader its own scroll", () => {
+    expect(routerOwnsScroll({ hash: "", pathname: ARTICLE })).toBe(false);
+  });
+
+  /**
+   * The anchor is the reader naming a destination out loud. The article view
+   * declines to restore over one, and on a hard load the router's inline script
+   * is what scrolls it into view before hydration — so this is the one case on
+   * the reader route where switching the router off would leave nobody holding
+   * the scroll.
+   */
+  it("leaves an anchored article to the router", () => {
+    expect(routerOwnsScroll({ hash: "footnote-3", pathname: ARTICLE })).toBe(
+      true,
+    );
+    expect(routerOwnsScroll({ hash: "#footnote-3", pathname: ARTICLE })).toBe(
+      true,
+    );
+  });
+
+  it("does not mistake a path that merely starts with an a", () => {
+    for (const pathname of ["/about", "/authors", "/a", "/archive"]) {
+      expect(routerOwnsScroll({ hash: "", pathname })).toBe(true);
+    }
+  });
+});

--- a/apps/standard-reader/src/lib/router-scroll.ts
+++ b/apps/standard-reader/src/lib/router-scroll.ts
@@ -1,0 +1,43 @@
+/**
+ * Which routes the router is allowed to position the scroll on.
+ *
+ * The article reader restores the reader's saved position itself
+ * (`use-reading-progress.ts`), and the router has three separate ways of
+ * undoing that, all of which run outside the route's own tree:
+ *
+ *  1. the `onRendered` subscription, from a layout effect mounted as a sibling
+ *     *after* the route — so it lands a beat after the route's own restore;
+ *  2. an inline `<script>` Start injects into the SSR'd HTML, which runs at
+ *     parse time on every hard load and ends in `scrollTo(0, 0)`;
+ *  3. the `sessionStorage` cache the first two share, which is keyed per
+ *     history entry and so misses on every fresh navigation to the same
+ *     article — meaning the fallback (the top) is what a reader normally gets.
+ *
+ * Correcting after the fact means racing all three forever. Handing the router
+ * a function instead turns every one of them off for the locations it returns
+ * false for — the check guards the `onRendered` body *and*
+ * `getScrollRestorationScriptForRouter`, so the inline script isn't even
+ * emitted. One switch, no race.
+ *
+ * Everything else on the site keeps the router's restoration untouched.
+ */
+
+/** Article reader route: `/a/$did/$rkey`. */
+const ARTICLE_PATH_PREFIX = "/a/";
+
+export function routerOwnsScroll({
+  pathname,
+  hash,
+}: {
+  pathname: string;
+  hash: string;
+}): boolean {
+  // A `#hash` stays the router's business even here. It is the one case the
+  // reader named a destination out loud, the article view deliberately declines
+  // to restore over it, and on a hard load the router's inline script is what
+  // scrolls the anchor into view before hydration — so switching it off would
+  // leave the anchor unhandled entirely.
+  if (hash) return true;
+
+  return !pathname.startsWith(ARTICLE_PATH_PREFIX);
+}

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -368,6 +368,10 @@ msgstr "ابحث بالعنوان أو الكاتب، أو الصق عنوان U
 msgid "Show {itemLabel} in the sidebar"
 msgstr ""
 
+#: src/components/reader/continue-reading.tsx
+msgid "Still open"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Each tab carries a count, and <0>Mark all as read</0> clears the backlog when a week gets away from you."
 msgstr ""
@@ -1290,6 +1294,10 @@ msgstr ""
 msgid "Followed pages warmed"
 msgstr ""
 
+#: src/routes/_layout.history.tsx
+msgid "Everything you've read"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
 msgstr ""
@@ -1782,6 +1790,10 @@ msgstr ""
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
+#: src/components/reader/continue-reading.tsx
+msgid "Reading progress"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "So subscribe to the publication when you want that particular thing, and follow the person when you want the writer — and their reading. In the sidebar and in Subscriptions the two are listed together, with a <0>Type</0> column telling them apart."
 msgstr ""
@@ -1875,6 +1887,10 @@ msgstr ""
 msgid "Notifications aren’t available"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "History pages"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "اسم المجموعة"
@@ -1904,6 +1920,10 @@ msgstr ""
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Publishing your site"
+msgstr ""
+
+#: src/components/reader/continue-reading.tsx
+msgid "Continue reading"
 msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
@@ -3754,6 +3774,10 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Share elsewhere"
 msgstr "المشاركة في مكان آخر"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Unfinished listed"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "Signing in asks for permission to write only the kinds of records the app actually needs — follows, saves, recommendations, read records, and lists. It cannot post to Bluesky as you."
@@ -6304,6 +6328,10 @@ msgstr ""
 #~ msgid "Reorder subscriptions"
 #~ msgstr ""
 
+#: src/components/reader/article-view.tsx
+msgid "Picked up where you left off"
+msgstr ""
+
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Light, dark, and custom colors"
@@ -6840,6 +6868,10 @@ msgstr "نحن لا نبيع بيانات الامتداد ولا نشاركها
 #: src/routes/_layout.latest.tsx
 msgid "Explore the directory"
 msgstr "استكشف الدليل"
+
+#: src/components/reader/article-view.tsx
+msgid "Start from top"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "How requests are handled"
@@ -8152,6 +8184,10 @@ msgstr ""
 #: src/components/TrackReadingHistoryMenuItem.tsx
 msgid "On"
 msgstr "مفعّل"
+
+#: src/components/reader/continue-reading.tsx
+msgid "{label} read"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -1070,6 +1070,10 @@ msgstr ""
 msgid "These are separate from the app-wide appearance settings, which is deliberate: you can have compact, small interface text and large, wide-set article text at the same time. <0>Making it yours</0> covers the rest."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Liked pages"
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Nothing saved yet"
 msgstr "لا شيء محفوظ بعد"
@@ -5370,6 +5374,7 @@ msgstr "تتبّع سجل القراءة"
 msgid "{readCount, plural, one {# read} other {{value} reads}}"
 msgstr "{readCount, plural, zero {لا قراءات} one {قراءة واحدة} two {قراءتان} few {# قراءات} many {# قراءةً} other {{value} قراءة}}"
 
+#: src/components/offline-sync-debug.tsx
 #: src/routes/_layout.collections.index.tsx
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.recommended.tsx

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -369,8 +369,8 @@ msgid "Show {itemLabel} in the sidebar"
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
-msgid "Still open"
-msgstr ""
+#~ msgid "Still open"
+#~ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Each tab carries a count, and <0>Mark all as read</0> clears the backlog when a week gets away from you."
@@ -1299,8 +1299,8 @@ msgid "Followed pages warmed"
 msgstr ""
 
 #: src/routes/_layout.history.tsx
-msgid "Everything you've read"
-msgstr ""
+#~ msgid "Everything you've read"
+#~ msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
@@ -1795,8 +1795,8 @@ msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
-msgid "Reading progress"
-msgstr ""
+#~ msgid "Reading progress"
+#~ msgstr ""
 
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "So subscribe to the publication when you want that particular thing, and follow the person when you want the writer — and their reading. In the sidebar and in Subscriptions the two are listed together, with a <0>Type</0> column telling them apart."
@@ -4945,6 +4945,10 @@ msgstr "انتهت صلاحية ذلك الرابط."
 msgid "Lists in the sidebar"
 msgstr ""
 
+#: src/routes/_layout.history.tsx
+msgid "Everything else"
+msgstr ""
+
 #: src/components/reader/blocked-notice.tsx
 msgid "You blocked {who}, so their writing is hidden everywhere you read."
 msgstr ""
@@ -5562,6 +5566,10 @@ msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "You haven’t read anything here yet."
+msgstr ""
+
+#: src/components/reader/cards.tsx
+msgid "Mark as finished"
 msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
@@ -6984,6 +6992,10 @@ msgstr ""
 msgid "Filter and sort — {activeFilters, plural, one {# filter active} other {# filters active}}"
 msgstr ""
 
+#: src/components/reader/cards.tsx
+msgid "{formatted} read"
+msgstr ""
+
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "It follows you"
 msgstr ""
@@ -8191,8 +8203,8 @@ msgid "On"
 msgstr "مفعّل"
 
 #: src/components/reader/continue-reading.tsx
-msgid "{label} read"
-msgstr ""
+#~ msgid "{label} read"
+#~ msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -1070,6 +1070,10 @@ msgstr ""
 msgid "These are separate from the app-wide appearance settings, which is deliberate: you can have compact, small interface text and large, wide-set article text at the same time. <0>Making it yours</0> covers the rest."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Liked pages"
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Nothing saved yet"
 msgstr "Noch nichts gespeichert"
@@ -5370,6 +5374,7 @@ msgstr "Leseverlauf speichern"
 msgid "{readCount, plural, one {# read} other {{value} reads}}"
 msgstr "{readCount, plural, one {# gelesen} other {{value} gelesen}}"
 
+#: src/components/offline-sync-debug.tsx
 #: src/routes/_layout.collections.index.tsx
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.recommended.tsx

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -368,6 +368,10 @@ msgstr "Nach Titel oder Autor suchen oder eine URL bzw. at://-URI einfügen"
 msgid "Show {itemLabel} in the sidebar"
 msgstr ""
 
+#: src/components/reader/continue-reading.tsx
+msgid "Still open"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Each tab carries a count, and <0>Mark all as read</0> clears the backlog when a week gets away from you."
 msgstr ""
@@ -1290,6 +1294,10 @@ msgstr ""
 msgid "Followed pages warmed"
 msgstr ""
 
+#: src/routes/_layout.history.tsx
+msgid "Everything you've read"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
 msgstr ""
@@ -1782,6 +1790,10 @@ msgstr ""
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
+#: src/components/reader/continue-reading.tsx
+msgid "Reading progress"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "So subscribe to the publication when you want that particular thing, and follow the person when you want the writer — and their reading. In the sidebar and in Subscriptions the two are listed together, with a <0>Type</0> column telling them apart."
 msgstr ""
@@ -1875,6 +1887,10 @@ msgstr ""
 msgid "Notifications aren’t available"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "History pages"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "Name der Sammlung"
@@ -1904,6 +1920,10 @@ msgstr ""
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Publishing your site"
+msgstr ""
+
+#: src/components/reader/continue-reading.tsx
+msgid "Continue reading"
 msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
@@ -3754,6 +3774,10 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Share elsewhere"
 msgstr "Woanders teilen"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Unfinished listed"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "Signing in asks for permission to write only the kinds of records the app actually needs — follows, saves, recommendations, read records, and lists. It cannot post to Bluesky as you."
@@ -6304,6 +6328,10 @@ msgstr ""
 #~ msgid "Reorder subscriptions"
 #~ msgstr ""
 
+#: src/components/reader/article-view.tsx
+msgid "Picked up where you left off"
+msgstr ""
+
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Light, dark, and custom colors"
@@ -6840,6 +6868,10 @@ msgstr "Wir verkaufen die Daten der Erweiterung nicht und geben sie nicht an Dri
 #: src/routes/_layout.latest.tsx
 msgid "Explore the directory"
 msgstr "Verzeichnis erkunden"
+
+#: src/components/reader/article-view.tsx
+msgid "Start from top"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "How requests are handled"
@@ -8152,6 +8184,10 @@ msgstr ""
 #: src/components/TrackReadingHistoryMenuItem.tsx
 msgid "On"
 msgstr "An"
+
+#: src/components/reader/continue-reading.tsx
+msgid "{label} read"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -369,8 +369,8 @@ msgid "Show {itemLabel} in the sidebar"
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
-msgid "Still open"
-msgstr ""
+#~ msgid "Still open"
+#~ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Each tab carries a count, and <0>Mark all as read</0> clears the backlog when a week gets away from you."
@@ -1299,8 +1299,8 @@ msgid "Followed pages warmed"
 msgstr ""
 
 #: src/routes/_layout.history.tsx
-msgid "Everything you've read"
-msgstr ""
+#~ msgid "Everything you've read"
+#~ msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
@@ -1795,8 +1795,8 @@ msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
-msgid "Reading progress"
-msgstr ""
+#~ msgid "Reading progress"
+#~ msgstr ""
 
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "So subscribe to the publication when you want that particular thing, and follow the person when you want the writer — and their reading. In the sidebar and in Subscriptions the two are listed together, with a <0>Type</0> column telling them apart."
@@ -4945,6 +4945,10 @@ msgstr "Dieser Link ist abgelaufen."
 msgid "Lists in the sidebar"
 msgstr ""
 
+#: src/routes/_layout.history.tsx
+msgid "Everything else"
+msgstr ""
+
 #: src/components/reader/blocked-notice.tsx
 msgid "You blocked {who}, so their writing is hidden everywhere you read."
 msgstr ""
@@ -5562,6 +5566,10 @@ msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "You haven’t read anything here yet."
+msgstr ""
+
+#: src/components/reader/cards.tsx
+msgid "Mark as finished"
 msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
@@ -6984,6 +6992,10 @@ msgstr ""
 msgid "Filter and sort — {activeFilters, plural, one {# filter active} other {# filters active}}"
 msgstr ""
 
+#: src/components/reader/cards.tsx
+msgid "{formatted} read"
+msgstr ""
+
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "It follows you"
 msgstr ""
@@ -8191,8 +8203,8 @@ msgid "On"
 msgstr "An"
 
 #: src/components/reader/continue-reading.tsx
-msgid "{label} read"
-msgstr ""
+#~ msgid "{label} read"
+#~ msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -1070,6 +1070,10 @@ msgstr ""
 msgid "These are separate from the app-wide appearance settings, which is deliberate: you can have compact, small interface text and large, wide-set article text at the same time. <0>Making it yours</0> covers the rest."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Liked pages"
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Nothing saved yet"
 msgstr ""
@@ -5370,6 +5374,7 @@ msgstr ""
 msgid "{readCount, plural, one {# read} other {{value} reads}}"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
 #: src/routes/_layout.collections.index.tsx
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.recommended.tsx

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -368,6 +368,10 @@ msgstr ""
 msgid "Show {itemLabel} in the sidebar"
 msgstr ""
 
+#: src/components/reader/continue-reading.tsx
+msgid "Still open"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Each tab carries a count, and <0>Mark all as read</0> clears the backlog when a week gets away from you."
 msgstr ""
@@ -1290,6 +1294,10 @@ msgstr ""
 msgid "Followed pages warmed"
 msgstr ""
 
+#: src/routes/_layout.history.tsx
+msgid "Everything you've read"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
 msgstr ""
@@ -1782,6 +1790,10 @@ msgstr ""
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
+#: src/components/reader/continue-reading.tsx
+msgid "Reading progress"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "So subscribe to the publication when you want that particular thing, and follow the person when you want the writer — and their reading. In the sidebar and in Subscriptions the two are listed together, with a <0>Type</0> column telling them apart."
 msgstr ""
@@ -1875,6 +1887,10 @@ msgstr ""
 msgid "Notifications aren’t available"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "History pages"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr ""
@@ -1904,6 +1920,10 @@ msgstr ""
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Publishing your site"
+msgstr ""
+
+#: src/components/reader/continue-reading.tsx
+msgid "Continue reading"
 msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
@@ -3753,6 +3773,10 @@ msgstr ""
 #: src/components/reader/share-menu.tsx
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Share elsewhere"
+msgstr ""
+
+#: src/components/offline-sync-debug.tsx
+msgid "Unfinished listed"
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
@@ -6304,6 +6328,10 @@ msgstr ""
 #~ msgid "Reorder subscriptions"
 #~ msgstr ""
 
+#: src/components/reader/article-view.tsx
+msgid "Picked up where you left off"
+msgstr ""
+
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Light, dark, and custom colors"
@@ -6839,6 +6867,10 @@ msgstr ""
 #: src/routes/_layout.index.tsx
 #: src/routes/_layout.latest.tsx
 msgid "Explore the directory"
+msgstr ""
+
+#: src/components/reader/article-view.tsx
+msgid "Start from top"
 msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
@@ -8151,6 +8183,10 @@ msgstr ""
 #: src/components/OpenLinksMenuItem.tsx
 #: src/components/TrackReadingHistoryMenuItem.tsx
 msgid "On"
+msgstr ""
+
+#: src/components/reader/continue-reading.tsx
+msgid "{label} read"
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -369,8 +369,8 @@ msgid "Show {itemLabel} in the sidebar"
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
-msgid "Still open"
-msgstr ""
+#~ msgid "Still open"
+#~ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Each tab carries a count, and <0>Mark all as read</0> clears the backlog when a week gets away from you."
@@ -1299,8 +1299,8 @@ msgid "Followed pages warmed"
 msgstr ""
 
 #: src/routes/_layout.history.tsx
-msgid "Everything you've read"
-msgstr ""
+#~ msgid "Everything you've read"
+#~ msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
@@ -1795,8 +1795,8 @@ msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
-msgid "Reading progress"
-msgstr ""
+#~ msgid "Reading progress"
+#~ msgstr ""
 
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "So subscribe to the publication when you want that particular thing, and follow the person when you want the writer — and their reading. In the sidebar and in Subscriptions the two are listed together, with a <0>Type</0> column telling them apart."
@@ -4945,6 +4945,10 @@ msgstr ""
 msgid "Lists in the sidebar"
 msgstr ""
 
+#: src/routes/_layout.history.tsx
+msgid "Everything else"
+msgstr ""
+
 #: src/components/reader/blocked-notice.tsx
 msgid "You blocked {who}, so their writing is hidden everywhere you read."
 msgstr ""
@@ -5562,6 +5566,10 @@ msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "You haven’t read anything here yet."
+msgstr ""
+
+#: src/components/reader/cards.tsx
+msgid "Mark as finished"
 msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
@@ -6984,6 +6992,10 @@ msgstr ""
 msgid "Filter and sort — {activeFilters, plural, one {# filter active} other {# filters active}}"
 msgstr ""
 
+#: src/components/reader/cards.tsx
+msgid "{formatted} read"
+msgstr ""
+
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "It follows you"
 msgstr ""
@@ -8191,8 +8203,8 @@ msgid "On"
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
-msgid "{label} read"
-msgstr ""
+#~ msgid "{label} read"
+#~ msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -369,8 +369,8 @@ msgid "Show {itemLabel} in the sidebar"
 msgstr "Show {itemLabel} in the sidebar"
 
 #: src/components/reader/continue-reading.tsx
-msgid "Still open"
-msgstr "Still open"
+#~ msgid "Still open"
+#~ msgstr "Still open"
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Each tab carries a count, and <0>Mark all as read</0> clears the backlog when a week gets away from you."
@@ -1299,8 +1299,8 @@ msgid "Followed pages warmed"
 msgstr "Followed pages warmed"
 
 #: src/routes/_layout.history.tsx
-msgid "Everything you've read"
-msgstr "Everything you've read"
+#~ msgid "Everything you've read"
+#~ msgstr "Everything you've read"
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
@@ -1795,8 +1795,8 @@ msgid "No topics match “{debouncedQuery}”."
 msgstr "No topics match “{debouncedQuery}”."
 
 #: src/components/reader/continue-reading.tsx
-msgid "Reading progress"
-msgstr "Reading progress"
+#~ msgid "Reading progress"
+#~ msgstr "Reading progress"
 
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "So subscribe to the publication when you want that particular thing, and follow the person when you want the writer — and their reading. In the sidebar and in Subscriptions the two are listed together, with a <0>Type</0> column telling them apart."
@@ -4945,6 +4945,10 @@ msgstr "That link expired."
 msgid "Lists in the sidebar"
 msgstr "Lists in the sidebar"
 
+#: src/routes/_layout.history.tsx
+msgid "Everything else"
+msgstr "Everything else"
+
 #: src/components/reader/blocked-notice.tsx
 msgid "You blocked {who}, so their writing is hidden everywhere you read."
 msgstr "You blocked {who}, so their writing is hidden everywhere you read."
@@ -5563,6 +5567,10 @@ msgstr "Making it yours"
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "You haven’t read anything here yet."
 msgstr "You haven’t read anything here yet."
+
+#: src/components/reader/cards.tsx
+msgid "Mark as finished"
+msgstr "Mark as finished"
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "At the end of the article you can <0>Recommend</0> it, see more from the same publication, and find related reading from elsewhere on the network."
@@ -6984,6 +6992,10 @@ msgstr "Notifications aren’t switched on for this site yet."
 msgid "Filter and sort — {activeFilters, plural, one {# filter active} other {# filters active}}"
 msgstr "Filter and sort — {activeFilters, plural, one {# filter active} other {# filters active}}"
 
+#: src/components/reader/cards.tsx
+msgid "{formatted} read"
+msgstr "{formatted} read"
+
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "It follows you"
 msgstr "It follows you"
@@ -8191,8 +8203,8 @@ msgid "On"
 msgstr "On"
 
 #: src/components/reader/continue-reading.tsx
-msgid "{label} read"
-msgstr "{label} read"
+#~ msgid "{label} read"
+#~ msgstr "{label} read"
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -1070,6 +1070,10 @@ msgstr "Reading preferences"
 msgid "These are separate from the app-wide appearance settings, which is deliberate: you can have compact, small interface text and large, wide-set article text at the same time. <0>Making it yours</0> covers the rest."
 msgstr "These are separate from the app-wide appearance settings, which is deliberate: you can have compact, small interface text and large, wide-set article text at the same time. <0>Making it yours</0> covers the rest."
 
+#: src/components/offline-sync-debug.tsx
+msgid "Liked pages"
+msgstr "Liked pages"
+
 #: src/routes/_layout.saved.tsx
 msgid "Nothing saved yet"
 msgstr "Nothing saved yet"
@@ -5370,6 +5374,7 @@ msgstr "Track reading history"
 msgid "{readCount, plural, one {# read} other {{value} reads}}"
 msgstr "{readCount, plural, one {# read} other {{value} reads}}"
 
+#: src/components/offline-sync-debug.tsx
 #: src/routes/_layout.collections.index.tsx
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.recommended.tsx

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -368,6 +368,10 @@ msgstr "Search by title or author, or paste a URL or at:// URI"
 msgid "Show {itemLabel} in the sidebar"
 msgstr "Show {itemLabel} in the sidebar"
 
+#: src/components/reader/continue-reading.tsx
+msgid "Still open"
+msgstr "Still open"
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Each tab carries a count, and <0>Mark all as read</0> clears the backlog when a week gets away from you."
 msgstr "Each tab carries a count, and <0>Mark all as read</0> clears the backlog when a week gets away from you."
@@ -1290,6 +1294,10 @@ msgstr "{SITE_NAME} is a web reader for standard.site publications on the AT Pro
 msgid "Followed pages warmed"
 msgstr "Followed pages warmed"
 
+#: src/routes/_layout.history.tsx
+msgid "Everything you've read"
+msgstr "Everything you've read"
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
 msgstr "the directory of every publication the network knows about."
@@ -1782,6 +1790,10 @@ msgstr "Your own curated sets of articles."
 msgid "No topics match “{debouncedQuery}”."
 msgstr "No topics match “{debouncedQuery}”."
 
+#: src/components/reader/continue-reading.tsx
+msgid "Reading progress"
+msgstr "Reading progress"
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "So subscribe to the publication when you want that particular thing, and follow the person when you want the writer — and their reading. In the sidebar and in Subscriptions the two are listed together, with a <0>Type</0> column telling them apart."
 msgstr "So subscribe to the publication when you want that particular thing, and follow the person when you want the writer — and their reading. In the sidebar and in Subscriptions the two are listed together, with a <0>Type</0> column telling them apart."
@@ -1875,6 +1887,10 @@ msgstr "You blocked this account"
 msgid "Notifications aren’t available"
 msgstr "Notifications aren’t available"
 
+#: src/components/offline-sync-debug.tsx
+msgid "History pages"
+msgstr "History pages"
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "Collection name"
@@ -1905,6 +1921,10 @@ msgstr "History can be turned off in settings, and the menu entry disappears wit
 #: src/lib/guide/navigation.ts
 msgid "Publishing your site"
 msgstr "Publishing your site"
+
+#: src/components/reader/continue-reading.tsx
+msgid "Continue reading"
+msgstr "Continue reading"
 
 #: src/components/reader/list-edit-modal.tsx
 msgid "Choose an item to add to the list"
@@ -3754,6 +3774,10 @@ msgstr "None of these publications have posted anything yet. Subscribe from the 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Share elsewhere"
 msgstr "Share elsewhere"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Unfinished listed"
+msgstr "Unfinished listed"
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "Signing in asks for permission to write only the kinds of records the app actually needs — follows, saves, recommendations, read records, and lists. It cannot post to Bluesky as you."
@@ -6304,6 +6328,10 @@ msgstr "Everything here is linkable, too. Publications, lists, and collections e
 #~ msgid "Reorder subscriptions"
 #~ msgstr "Reorder subscriptions"
 
+#: src/components/reader/article-view.tsx
+msgid "Picked up where you left off"
+msgstr "Picked up where you left off"
+
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Light, dark, and custom colors"
@@ -6840,6 +6868,10 @@ msgstr "We do not sell or share extension data with third parties."
 #: src/routes/_layout.latest.tsx
 msgid "Explore the directory"
 msgstr "Explore the directory"
+
+#: src/components/reader/article-view.tsx
+msgid "Start from top"
+msgstr "Start from top"
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "How requests are handled"
@@ -8152,6 +8184,10 @@ msgstr "What Standard Reader is, and what you can do here."
 #: src/components/TrackReadingHistoryMenuItem.tsx
 msgid "On"
 msgstr "On"
+
+#: src/components/reader/continue-reading.tsx
+msgid "{label} read"
+msgstr "{label} read"
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -368,6 +368,10 @@ msgstr "Busque por título o autor, o pegue una URL o un URI at://"
 msgid "Show {itemLabel} in the sidebar"
 msgstr ""
 
+#: src/components/reader/continue-reading.tsx
+msgid "Still open"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Each tab carries a count, and <0>Mark all as read</0> clears the backlog when a week gets away from you."
 msgstr ""
@@ -1290,6 +1294,10 @@ msgstr ""
 msgid "Followed pages warmed"
 msgstr ""
 
+#: src/routes/_layout.history.tsx
+msgid "Everything you've read"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
 msgstr ""
@@ -1782,6 +1790,10 @@ msgstr ""
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
+#: src/components/reader/continue-reading.tsx
+msgid "Reading progress"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "So subscribe to the publication when you want that particular thing, and follow the person when you want the writer — and their reading. In the sidebar and in Subscriptions the two are listed together, with a <0>Type</0> column telling them apart."
 msgstr ""
@@ -1875,6 +1887,10 @@ msgstr ""
 msgid "Notifications aren’t available"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "History pages"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "Nombre de la colección"
@@ -1904,6 +1920,10 @@ msgstr ""
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Publishing your site"
+msgstr ""
+
+#: src/components/reader/continue-reading.tsx
+msgid "Continue reading"
 msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
@@ -3754,6 +3774,10 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Share elsewhere"
 msgstr "Compartir en otro sitio"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Unfinished listed"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "Signing in asks for permission to write only the kinds of records the app actually needs — follows, saves, recommendations, read records, and lists. It cannot post to Bluesky as you."
@@ -6304,6 +6328,10 @@ msgstr ""
 #~ msgid "Reorder subscriptions"
 #~ msgstr ""
 
+#: src/components/reader/article-view.tsx
+msgid "Picked up where you left off"
+msgstr ""
+
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Light, dark, and custom colors"
@@ -6840,6 +6868,10 @@ msgstr "No vendemos ni compartimos los datos de la extensión con terceros."
 #: src/routes/_layout.latest.tsx
 msgid "Explore the directory"
 msgstr "Explorar el directorio"
+
+#: src/components/reader/article-view.tsx
+msgid "Start from top"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "How requests are handled"
@@ -8152,6 +8184,10 @@ msgstr ""
 #: src/components/TrackReadingHistoryMenuItem.tsx
 msgid "On"
 msgstr "Activado"
+
+#: src/components/reader/continue-reading.tsx
+msgid "{label} read"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -1070,6 +1070,10 @@ msgstr ""
 msgid "These are separate from the app-wide appearance settings, which is deliberate: you can have compact, small interface text and large, wide-set article text at the same time. <0>Making it yours</0> covers the rest."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Liked pages"
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Nothing saved yet"
 msgstr "Todavía no hay nada guardado"
@@ -5370,6 +5374,7 @@ msgstr "Registrar el historial de lectura"
 msgid "{readCount, plural, one {# read} other {{value} reads}}"
 msgstr "{readCount, plural, one {# lectura} other {{value} lecturas}}"
 
+#: src/components/offline-sync-debug.tsx
 #: src/routes/_layout.collections.index.tsx
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.recommended.tsx

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -369,8 +369,8 @@ msgid "Show {itemLabel} in the sidebar"
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
-msgid "Still open"
-msgstr ""
+#~ msgid "Still open"
+#~ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Each tab carries a count, and <0>Mark all as read</0> clears the backlog when a week gets away from you."
@@ -1299,8 +1299,8 @@ msgid "Followed pages warmed"
 msgstr ""
 
 #: src/routes/_layout.history.tsx
-msgid "Everything you've read"
-msgstr ""
+#~ msgid "Everything you've read"
+#~ msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
@@ -1795,8 +1795,8 @@ msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
-msgid "Reading progress"
-msgstr ""
+#~ msgid "Reading progress"
+#~ msgstr ""
 
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "So subscribe to the publication when you want that particular thing, and follow the person when you want the writer — and their reading. In the sidebar and in Subscriptions the two are listed together, with a <0>Type</0> column telling them apart."
@@ -4945,6 +4945,10 @@ msgstr "Ese enlace caducó."
 msgid "Lists in the sidebar"
 msgstr ""
 
+#: src/routes/_layout.history.tsx
+msgid "Everything else"
+msgstr ""
+
 #: src/components/reader/blocked-notice.tsx
 msgid "You blocked {who}, so their writing is hidden everywhere you read."
 msgstr ""
@@ -5562,6 +5566,10 @@ msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "You haven’t read anything here yet."
+msgstr ""
+
+#: src/components/reader/cards.tsx
+msgid "Mark as finished"
 msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
@@ -6984,6 +6992,10 @@ msgstr ""
 msgid "Filter and sort — {activeFilters, plural, one {# filter active} other {# filters active}}"
 msgstr ""
 
+#: src/components/reader/cards.tsx
+msgid "{formatted} read"
+msgstr ""
+
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "It follows you"
 msgstr ""
@@ -8191,8 +8203,8 @@ msgid "On"
 msgstr "Activado"
 
 #: src/components/reader/continue-reading.tsx
-msgid "{label} read"
-msgstr ""
+#~ msgid "{label} read"
+#~ msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -1070,6 +1070,10 @@ msgstr ""
 msgid "These are separate from the app-wide appearance settings, which is deliberate: you can have compact, small interface text and large, wide-set article text at the same time. <0>Making it yours</0> covers the rest."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Liked pages"
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Nothing saved yet"
 msgstr "Rien d’enregistré pour l’instant"
@@ -5370,6 +5374,7 @@ msgstr "Suivre l'historique de lecture"
 msgid "{readCount, plural, one {# read} other {{value} reads}}"
 msgstr "{readCount, plural, one {# lecture} other {{value} lectures}}"
 
+#: src/components/offline-sync-debug.tsx
 #: src/routes/_layout.collections.index.tsx
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.recommended.tsx

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -368,6 +368,10 @@ msgstr "Recherchez par titre ou auteur, ou collez une URL ou une URI at://"
 msgid "Show {itemLabel} in the sidebar"
 msgstr ""
 
+#: src/components/reader/continue-reading.tsx
+msgid "Still open"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Each tab carries a count, and <0>Mark all as read</0> clears the backlog when a week gets away from you."
 msgstr ""
@@ -1290,6 +1294,10 @@ msgstr ""
 msgid "Followed pages warmed"
 msgstr ""
 
+#: src/routes/_layout.history.tsx
+msgid "Everything you've read"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
 msgstr ""
@@ -1782,6 +1790,10 @@ msgstr ""
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
+#: src/components/reader/continue-reading.tsx
+msgid "Reading progress"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "So subscribe to the publication when you want that particular thing, and follow the person when you want the writer — and their reading. In the sidebar and in Subscriptions the two are listed together, with a <0>Type</0> column telling them apart."
 msgstr ""
@@ -1875,6 +1887,10 @@ msgstr ""
 msgid "Notifications aren’t available"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "History pages"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "Nom de la collection"
@@ -1904,6 +1920,10 @@ msgstr ""
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Publishing your site"
+msgstr ""
+
+#: src/components/reader/continue-reading.tsx
+msgid "Continue reading"
 msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
@@ -3754,6 +3774,10 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Share elsewhere"
 msgstr "Partager ailleurs"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Unfinished listed"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "Signing in asks for permission to write only the kinds of records the app actually needs — follows, saves, recommendations, read records, and lists. It cannot post to Bluesky as you."
@@ -6304,6 +6328,10 @@ msgstr ""
 #~ msgid "Reorder subscriptions"
 #~ msgstr ""
 
+#: src/components/reader/article-view.tsx
+msgid "Picked up where you left off"
+msgstr ""
+
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Light, dark, and custom colors"
@@ -6840,6 +6868,10 @@ msgstr "Nous ne vendons ni ne partageons les données de l'extension avec des ti
 #: src/routes/_layout.latest.tsx
 msgid "Explore the directory"
 msgstr "Explorer l'annuaire"
+
+#: src/components/reader/article-view.tsx
+msgid "Start from top"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "How requests are handled"
@@ -8152,6 +8184,10 @@ msgstr ""
 #: src/components/TrackReadingHistoryMenuItem.tsx
 msgid "On"
 msgstr "Activé"
+
+#: src/components/reader/continue-reading.tsx
+msgid "{label} read"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -369,8 +369,8 @@ msgid "Show {itemLabel} in the sidebar"
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
-msgid "Still open"
-msgstr ""
+#~ msgid "Still open"
+#~ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Each tab carries a count, and <0>Mark all as read</0> clears the backlog when a week gets away from you."
@@ -1299,8 +1299,8 @@ msgid "Followed pages warmed"
 msgstr ""
 
 #: src/routes/_layout.history.tsx
-msgid "Everything you've read"
-msgstr ""
+#~ msgid "Everything you've read"
+#~ msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
@@ -1795,8 +1795,8 @@ msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
-msgid "Reading progress"
-msgstr ""
+#~ msgid "Reading progress"
+#~ msgstr ""
 
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "So subscribe to the publication when you want that particular thing, and follow the person when you want the writer — and their reading. In the sidebar and in Subscriptions the two are listed together, with a <0>Type</0> column telling them apart."
@@ -4945,6 +4945,10 @@ msgstr "Ce lien a expiré."
 msgid "Lists in the sidebar"
 msgstr ""
 
+#: src/routes/_layout.history.tsx
+msgid "Everything else"
+msgstr ""
+
 #: src/components/reader/blocked-notice.tsx
 msgid "You blocked {who}, so their writing is hidden everywhere you read."
 msgstr ""
@@ -5562,6 +5566,10 @@ msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "You haven’t read anything here yet."
+msgstr ""
+
+#: src/components/reader/cards.tsx
+msgid "Mark as finished"
 msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
@@ -6984,6 +6992,10 @@ msgstr ""
 msgid "Filter and sort — {activeFilters, plural, one {# filter active} other {# filters active}}"
 msgstr ""
 
+#: src/components/reader/cards.tsx
+msgid "{formatted} read"
+msgstr ""
+
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "It follows you"
 msgstr ""
@@ -8191,8 +8203,8 @@ msgid "On"
 msgstr "Activé"
 
 #: src/components/reader/continue-reading.tsx
-msgid "{label} read"
-msgstr ""
+#~ msgid "{label} read"
+#~ msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -369,8 +369,8 @@ msgid "Show {itemLabel} in the sidebar"
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
-msgid "Still open"
-msgstr ""
+#~ msgid "Still open"
+#~ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Each tab carries a count, and <0>Mark all as read</0> clears the backlog when a week gets away from you."
@@ -1299,8 +1299,8 @@ msgid "Followed pages warmed"
 msgstr ""
 
 #: src/routes/_layout.history.tsx
-msgid "Everything you've read"
-msgstr ""
+#~ msgid "Everything you've read"
+#~ msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
@@ -1795,8 +1795,8 @@ msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
-msgid "Reading progress"
-msgstr ""
+#~ msgid "Reading progress"
+#~ msgstr ""
 
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "So subscribe to the publication when you want that particular thing, and follow the person when you want the writer — and their reading. In the sidebar and in Subscriptions the two are listed together, with a <0>Type</0> column telling them apart."
@@ -4945,6 +4945,10 @@ msgstr "このリンクは期限切れです。"
 msgid "Lists in the sidebar"
 msgstr ""
 
+#: src/routes/_layout.history.tsx
+msgid "Everything else"
+msgstr ""
+
 #: src/components/reader/blocked-notice.tsx
 msgid "You blocked {who}, so their writing is hidden everywhere you read."
 msgstr ""
@@ -5562,6 +5566,10 @@ msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "You haven’t read anything here yet."
+msgstr ""
+
+#: src/components/reader/cards.tsx
+msgid "Mark as finished"
 msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
@@ -6984,6 +6992,10 @@ msgstr ""
 msgid "Filter and sort — {activeFilters, plural, one {# filter active} other {# filters active}}"
 msgstr ""
 
+#: src/components/reader/cards.tsx
+msgid "{formatted} read"
+msgstr ""
+
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "It follows you"
 msgstr ""
@@ -8191,8 +8203,8 @@ msgid "On"
 msgstr "オン"
 
 #: src/components/reader/continue-reading.tsx
-msgid "{label} read"
-msgstr ""
+#~ msgid "{label} read"
+#~ msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -368,6 +368,10 @@ msgstr "タイトルや著者で検索、または URL や at:// URI を貼り�
 msgid "Show {itemLabel} in the sidebar"
 msgstr ""
 
+#: src/components/reader/continue-reading.tsx
+msgid "Still open"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Each tab carries a count, and <0>Mark all as read</0> clears the backlog when a week gets away from you."
 msgstr ""
@@ -1290,6 +1294,10 @@ msgstr ""
 msgid "Followed pages warmed"
 msgstr ""
 
+#: src/routes/_layout.history.tsx
+msgid "Everything you've read"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
 msgstr ""
@@ -1782,6 +1790,10 @@ msgstr ""
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
+#: src/components/reader/continue-reading.tsx
+msgid "Reading progress"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "So subscribe to the publication when you want that particular thing, and follow the person when you want the writer — and their reading. In the sidebar and in Subscriptions the two are listed together, with a <0>Type</0> column telling them apart."
 msgstr ""
@@ -1875,6 +1887,10 @@ msgstr ""
 msgid "Notifications aren’t available"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "History pages"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "コレクション名"
@@ -1904,6 +1920,10 @@ msgstr ""
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Publishing your site"
+msgstr ""
+
+#: src/components/reader/continue-reading.tsx
+msgid "Continue reading"
 msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
@@ -3754,6 +3774,10 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Share elsewhere"
 msgstr "他のサービスで共有"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Unfinished listed"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "Signing in asks for permission to write only the kinds of records the app actually needs — follows, saves, recommendations, read records, and lists. It cannot post to Bluesky as you."
@@ -6304,6 +6328,10 @@ msgstr ""
 #~ msgid "Reorder subscriptions"
 #~ msgstr ""
 
+#: src/components/reader/article-view.tsx
+msgid "Picked up where you left off"
+msgstr ""
+
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Light, dark, and custom colors"
@@ -6840,6 +6868,10 @@ msgstr "拡張機能のデータを第三者に販売・共有することはあ
 #: src/routes/_layout.latest.tsx
 msgid "Explore the directory"
 msgstr "ディレクトリを見る"
+
+#: src/components/reader/article-view.tsx
+msgid "Start from top"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "How requests are handled"
@@ -8152,6 +8184,10 @@ msgstr ""
 #: src/components/TrackReadingHistoryMenuItem.tsx
 msgid "On"
 msgstr "オン"
+
+#: src/components/reader/continue-reading.tsx
+msgid "{label} read"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -1070,6 +1070,10 @@ msgstr ""
 msgid "These are separate from the app-wide appearance settings, which is deliberate: you can have compact, small interface text and large, wide-set article text at the same time. <0>Making it yours</0> covers the rest."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Liked pages"
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Nothing saved yet"
 msgstr "まだ何も保存されていません"
@@ -5370,6 +5374,7 @@ msgstr "閲覧履歴を記録"
 msgid "{readCount, plural, one {# read} other {{value} reads}}"
 msgstr "{readCount, plural, one {# 回読了} other {{value} 回読了}}"
 
+#: src/components/offline-sync-debug.tsx
 #: src/routes/_layout.collections.index.tsx
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.recommended.tsx

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -1070,6 +1070,10 @@ msgstr ""
 msgid "These are separate from the app-wide appearance settings, which is deliberate: you can have compact, small interface text and large, wide-set article text at the same time. <0>Making it yours</0> covers the rest."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Liked pages"
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Nothing saved yet"
 msgstr "아직 저장한 항목이 없습니다"
@@ -5370,6 +5374,7 @@ msgstr "읽기 기록 추적"
 msgid "{readCount, plural, one {# read} other {{value} reads}}"
 msgstr "{readCount, plural, one {# 읽음} other {{value} 읽음}}"
 
+#: src/components/offline-sync-debug.tsx
 #: src/routes/_layout.collections.index.tsx
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.recommended.tsx

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -369,8 +369,8 @@ msgid "Show {itemLabel} in the sidebar"
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
-msgid "Still open"
-msgstr ""
+#~ msgid "Still open"
+#~ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Each tab carries a count, and <0>Mark all as read</0> clears the backlog when a week gets away from you."
@@ -1299,8 +1299,8 @@ msgid "Followed pages warmed"
 msgstr ""
 
 #: src/routes/_layout.history.tsx
-msgid "Everything you've read"
-msgstr ""
+#~ msgid "Everything you've read"
+#~ msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
@@ -1795,8 +1795,8 @@ msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
-msgid "Reading progress"
-msgstr ""
+#~ msgid "Reading progress"
+#~ msgstr ""
 
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "So subscribe to the publication when you want that particular thing, and follow the person when you want the writer — and their reading. In the sidebar and in Subscriptions the two are listed together, with a <0>Type</0> column telling them apart."
@@ -4945,6 +4945,10 @@ msgstr "링크가 만료되었습니다."
 msgid "Lists in the sidebar"
 msgstr ""
 
+#: src/routes/_layout.history.tsx
+msgid "Everything else"
+msgstr ""
+
 #: src/components/reader/blocked-notice.tsx
 msgid "You blocked {who}, so their writing is hidden everywhere you read."
 msgstr ""
@@ -5562,6 +5566,10 @@ msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "You haven’t read anything here yet."
+msgstr ""
+
+#: src/components/reader/cards.tsx
+msgid "Mark as finished"
 msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
@@ -6984,6 +6992,10 @@ msgstr ""
 msgid "Filter and sort — {activeFilters, plural, one {# filter active} other {# filters active}}"
 msgstr ""
 
+#: src/components/reader/cards.tsx
+msgid "{formatted} read"
+msgstr ""
+
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "It follows you"
 msgstr ""
@@ -8191,8 +8203,8 @@ msgid "On"
 msgstr "켬"
 
 #: src/components/reader/continue-reading.tsx
-msgid "{label} read"
-msgstr ""
+#~ msgid "{label} read"
+#~ msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -368,6 +368,10 @@ msgstr "제목이나 저자로 검색하거나 URL 또는 at:// URI를 붙여넣
 msgid "Show {itemLabel} in the sidebar"
 msgstr ""
 
+#: src/components/reader/continue-reading.tsx
+msgid "Still open"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Each tab carries a count, and <0>Mark all as read</0> clears the backlog when a week gets away from you."
 msgstr ""
@@ -1290,6 +1294,10 @@ msgstr ""
 msgid "Followed pages warmed"
 msgstr ""
 
+#: src/routes/_layout.history.tsx
+msgid "Everything you've read"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
 msgstr ""
@@ -1782,6 +1790,10 @@ msgstr ""
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
+#: src/components/reader/continue-reading.tsx
+msgid "Reading progress"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "So subscribe to the publication when you want that particular thing, and follow the person when you want the writer — and their reading. In the sidebar and in Subscriptions the two are listed together, with a <0>Type</0> column telling them apart."
 msgstr ""
@@ -1875,6 +1887,10 @@ msgstr ""
 msgid "Notifications aren’t available"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "History pages"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "컬렉션 이름"
@@ -1904,6 +1920,10 @@ msgstr ""
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Publishing your site"
+msgstr ""
+
+#: src/components/reader/continue-reading.tsx
+msgid "Continue reading"
 msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
@@ -3754,6 +3774,10 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Share elsewhere"
 msgstr "다른 곳에 공유"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Unfinished listed"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "Signing in asks for permission to write only the kinds of records the app actually needs — follows, saves, recommendations, read records, and lists. It cannot post to Bluesky as you."
@@ -6304,6 +6328,10 @@ msgstr ""
 #~ msgid "Reorder subscriptions"
 #~ msgstr ""
 
+#: src/components/reader/article-view.tsx
+msgid "Picked up where you left off"
+msgstr ""
+
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Light, dark, and custom colors"
@@ -6840,6 +6868,10 @@ msgstr "확장 프로그램 데이터를 제3자에게 판매하거나 공유하
 #: src/routes/_layout.latest.tsx
 msgid "Explore the directory"
 msgstr "디렉터리 둘러보기"
+
+#: src/components/reader/article-view.tsx
+msgid "Start from top"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "How requests are handled"
@@ -8152,6 +8184,10 @@ msgstr ""
 #: src/components/TrackReadingHistoryMenuItem.tsx
 msgid "On"
 msgstr "켬"
+
+#: src/components/reader/continue-reading.tsx
+msgid "{label} read"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -368,6 +368,10 @@ msgstr "Pesquise por título ou autor, ou cole um URL ou URI at://"
 msgid "Show {itemLabel} in the sidebar"
 msgstr ""
 
+#: src/components/reader/continue-reading.tsx
+msgid "Still open"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Each tab carries a count, and <0>Mark all as read</0> clears the backlog when a week gets away from you."
 msgstr ""
@@ -1290,6 +1294,10 @@ msgstr "O {SITE_NAME} é um leitor web para publicações do standard.site no AT
 msgid "Followed pages warmed"
 msgstr ""
 
+#: src/routes/_layout.history.tsx
+msgid "Everything you've read"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
 msgstr ""
@@ -1782,6 +1790,10 @@ msgstr ""
 msgid "No topics match “{debouncedQuery}”."
 msgstr "Nenhum tema corresponde a “{debouncedQuery}”"
 
+#: src/components/reader/continue-reading.tsx
+msgid "Reading progress"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "So subscribe to the publication when you want that particular thing, and follow the person when you want the writer — and their reading. In the sidebar and in Subscriptions the two are listed together, with a <0>Type</0> column telling them apart."
 msgstr ""
@@ -1875,6 +1887,10 @@ msgstr ""
 msgid "Notifications aren’t available"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "History pages"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "Nome da coleção"
@@ -1904,6 +1920,10 @@ msgstr ""
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Publishing your site"
+msgstr ""
+
+#: src/components/reader/continue-reading.tsx
+msgid "Continue reading"
 msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
@@ -3754,6 +3774,10 @@ msgstr "Nenhuma destas publicações publicou algo. Inscreva-se através da aba 
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Share elsewhere"
 msgstr "Compartilhar em outro lugar"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Unfinished listed"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "Signing in asks for permission to write only the kinds of records the app actually needs — follows, saves, recommendations, read records, and lists. It cannot post to Bluesky as you."
@@ -6304,6 +6328,10 @@ msgstr ""
 #~ msgid "Reorder subscriptions"
 #~ msgstr ""
 
+#: src/components/reader/article-view.tsx
+msgid "Picked up where you left off"
+msgstr ""
+
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Light, dark, and custom colors"
@@ -6840,6 +6868,10 @@ msgstr "Não vendemos nem compartilhamos os dados da extensão com terceiros."
 #: src/routes/_layout.latest.tsx
 msgid "Explore the directory"
 msgstr "Explorar o diretório"
+
+#: src/components/reader/article-view.tsx
+msgid "Start from top"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "How requests are handled"
@@ -8152,6 +8184,10 @@ msgstr ""
 #: src/components/TrackReadingHistoryMenuItem.tsx
 msgid "On"
 msgstr "Ligado"
+
+#: src/components/reader/continue-reading.tsx
+msgid "{label} read"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -1070,6 +1070,10 @@ msgstr ""
 msgid "These are separate from the app-wide appearance settings, which is deliberate: you can have compact, small interface text and large, wide-set article text at the same time. <0>Making it yours</0> covers the rest."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Liked pages"
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Nothing saved yet"
 msgstr "Ainda não há nada salvo"
@@ -5370,6 +5374,7 @@ msgstr "Registar histórico de leitura"
 msgid "{readCount, plural, one {# read} other {{value} reads}}"
 msgstr "{readCount, plural, one {# leitura} other {{value} leituras}}"
 
+#: src/components/offline-sync-debug.tsx
 #: src/routes/_layout.collections.index.tsx
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.recommended.tsx

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -369,8 +369,8 @@ msgid "Show {itemLabel} in the sidebar"
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
-msgid "Still open"
-msgstr ""
+#~ msgid "Still open"
+#~ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Each tab carries a count, and <0>Mark all as read</0> clears the backlog when a week gets away from you."
@@ -1299,8 +1299,8 @@ msgid "Followed pages warmed"
 msgstr ""
 
 #: src/routes/_layout.history.tsx
-msgid "Everything you've read"
-msgstr ""
+#~ msgid "Everything you've read"
+#~ msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
@@ -1795,8 +1795,8 @@ msgid "No topics match “{debouncedQuery}”."
 msgstr "Nenhum tema corresponde a “{debouncedQuery}”"
 
 #: src/components/reader/continue-reading.tsx
-msgid "Reading progress"
-msgstr ""
+#~ msgid "Reading progress"
+#~ msgstr ""
 
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "So subscribe to the publication when you want that particular thing, and follow the person when you want the writer — and their reading. In the sidebar and in Subscriptions the two are listed together, with a <0>Type</0> column telling them apart."
@@ -4945,6 +4945,10 @@ msgstr "Esse link expirou."
 msgid "Lists in the sidebar"
 msgstr ""
 
+#: src/routes/_layout.history.tsx
+msgid "Everything else"
+msgstr ""
+
 #: src/components/reader/blocked-notice.tsx
 msgid "You blocked {who}, so their writing is hidden everywhere you read."
 msgstr ""
@@ -5562,6 +5566,10 @@ msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "You haven’t read anything here yet."
+msgstr ""
+
+#: src/components/reader/cards.tsx
+msgid "Mark as finished"
 msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
@@ -6984,6 +6992,10 @@ msgstr ""
 msgid "Filter and sort — {activeFilters, plural, one {# filter active} other {# filters active}}"
 msgstr ""
 
+#: src/components/reader/cards.tsx
+msgid "{formatted} read"
+msgstr ""
+
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "It follows you"
 msgstr ""
@@ -8191,8 +8203,8 @@ msgid "On"
 msgstr "Ligado"
 
 #: src/components/reader/continue-reading.tsx
-msgid "{label} read"
-msgstr ""
+#~ msgid "{label} read"
+#~ msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -368,6 +368,10 @@ msgstr "按标题或作者搜索，或粘贴 URL、at:// URI"
 msgid "Show {itemLabel} in the sidebar"
 msgstr ""
 
+#: src/components/reader/continue-reading.tsx
+msgid "Still open"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Each tab carries a count, and <0>Mark all as read</0> clears the backlog when a week gets away from you."
 msgstr ""
@@ -1290,6 +1294,10 @@ msgstr ""
 msgid "Followed pages warmed"
 msgstr ""
 
+#: src/routes/_layout.history.tsx
+msgid "Everything you've read"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
 msgstr ""
@@ -1782,6 +1790,10 @@ msgstr ""
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
+#: src/components/reader/continue-reading.tsx
+msgid "Reading progress"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "So subscribe to the publication when you want that particular thing, and follow the person when you want the writer — and their reading. In the sidebar and in Subscriptions the two are listed together, with a <0>Type</0> column telling them apart."
 msgstr ""
@@ -1875,6 +1887,10 @@ msgstr ""
 msgid "Notifications aren’t available"
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "History pages"
+msgstr ""
+
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "Collection name"
 msgstr "合集名称"
@@ -1904,6 +1920,10 @@ msgstr ""
 #: src/components/guide/pages/publishing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Publishing your site"
+msgstr ""
+
+#: src/components/reader/continue-reading.tsx
+msgid "Continue reading"
 msgstr ""
 
 #: src/components/reader/list-edit-modal.tsx
@@ -3754,6 +3774,10 @@ msgstr ""
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "Share elsewhere"
 msgstr "分享到其他平台"
+
+#: src/components/offline-sync-debug.tsx
+msgid "Unfinished listed"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "Signing in asks for permission to write only the kinds of records the app actually needs — follows, saves, recommendations, read records, and lists. It cannot post to Bluesky as you."
@@ -6304,6 +6328,10 @@ msgstr ""
 #~ msgid "Reorder subscriptions"
 #~ msgstr ""
 
+#: src/components/reader/article-view.tsx
+msgid "Picked up where you left off"
+msgstr ""
+
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Light, dark, and custom colors"
@@ -6840,6 +6868,10 @@ msgstr "我们不会向第三方出售或共享扩展数据。"
 #: src/routes/_layout.latest.tsx
 msgid "Explore the directory"
 msgstr "浏览目录"
+
+#: src/components/reader/article-view.tsx
+msgid "Start from top"
+msgstr ""
 
 #: src/components/reader/extension-privacy-view.tsx
 msgid "How requests are handled"
@@ -8152,6 +8184,10 @@ msgstr ""
 #: src/components/TrackReadingHistoryMenuItem.tsx
 msgid "On"
 msgstr "开"
+
+#: src/components/reader/continue-reading.tsx
+msgid "{label} read"
+msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -369,8 +369,8 @@ msgid "Show {itemLabel} in the sidebar"
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
-msgid "Still open"
-msgstr ""
+#~ msgid "Still open"
+#~ msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Each tab carries a count, and <0>Mark all as read</0> clears the backlog when a week gets away from you."
@@ -1299,8 +1299,8 @@ msgid "Followed pages warmed"
 msgstr ""
 
 #: src/routes/_layout.history.tsx
-msgid "Everything you've read"
-msgstr ""
+#~ msgid "Everything you've read"
+#~ msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the directory of every publication the network knows about."
@@ -1795,8 +1795,8 @@ msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
-msgid "Reading progress"
-msgstr ""
+#~ msgid "Reading progress"
+#~ msgstr ""
 
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "So subscribe to the publication when you want that particular thing, and follow the person when you want the writer — and their reading. In the sidebar and in Subscriptions the two are listed together, with a <0>Type</0> column telling them apart."
@@ -4945,6 +4945,10 @@ msgstr "该链接已过期。"
 msgid "Lists in the sidebar"
 msgstr ""
 
+#: src/routes/_layout.history.tsx
+msgid "Everything else"
+msgstr ""
+
 #: src/components/reader/blocked-notice.tsx
 msgid "You blocked {who}, so their writing is hidden everywhere you read."
 msgstr ""
@@ -5562,6 +5566,10 @@ msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "You haven’t read anything here yet."
+msgstr ""
+
+#: src/components/reader/cards.tsx
+msgid "Mark as finished"
 msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
@@ -6984,6 +6992,10 @@ msgstr ""
 msgid "Filter and sort — {activeFilters, plural, one {# filter active} other {# filters active}}"
 msgstr ""
 
+#: src/components/reader/cards.tsx
+msgid "{formatted} read"
+msgstr ""
+
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "It follows you"
 msgstr ""
@@ -8191,8 +8203,8 @@ msgid "On"
 msgstr "开"
 
 #: src/components/reader/continue-reading.tsx
-msgid "{label} read"
-msgstr ""
+#~ msgid "{label} read"
+#~ msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "We keep a copy of the public network — publications, articles, and who follows what — so the app can search, rank, and load quickly. That copy includes the records described above. It is a cache of things that are already public, not a second private profile of you."

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -1070,6 +1070,10 @@ msgstr ""
 msgid "These are separate from the app-wide appearance settings, which is deliberate: you can have compact, small interface text and large, wide-set article text at the same time. <0>Making it yours</0> covers the rest."
 msgstr ""
 
+#: src/components/offline-sync-debug.tsx
+msgid "Liked pages"
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Nothing saved yet"
 msgstr "尚未保存任何内容"
@@ -5370,6 +5374,7 @@ msgstr "记录阅读历史"
 msgid "{readCount, plural, one {# read} other {{value} reads}}"
 msgstr "{readCount, plural, one {# 次阅读} other {{value} 次阅读}}"
 
+#: src/components/offline-sync-debug.tsx
 #: src/routes/_layout.collections.index.tsx
 #: src/routes/_layout.history.tsx
 #: src/routes/_layout.recommended.tsx

--- a/apps/standard-reader/src/pwa/offline-sync-progress.ts
+++ b/apps/standard-reader/src/pwa/offline-sync-progress.ts
@@ -23,6 +23,10 @@ export interface OfflineSyncCounts {
   historyPages: number;
   /** Partly-read articles found for the "Continue reading" shelf. */
   unfinishedListed: number;
+  /** `/recommended` (liked articles) pages fetched. */
+  likesPages: number;
+  /** The reader's own profile page — 1 once warmed, 0 if it never was. */
+  ownProfile: number;
   /** Publications whose pages were warmed. */
   publications: number;
   /** Publication back-catalog pages fetched beyond each one's first. */
@@ -84,7 +88,9 @@ const INITIAL_COUNTS: OfflineSyncCounts = {
   feedPages: 0,
   historyPages: 0,
   imagesWarmed: 0,
+  likesPages: 0,
   lists: 0,
+  ownProfile: 0,
   publications: 0,
   unfinishedListed: 0,
   unreadListed: 0,

--- a/apps/standard-reader/src/pwa/offline-sync-progress.ts
+++ b/apps/standard-reader/src/pwa/offline-sync-progress.ts
@@ -19,6 +19,10 @@ export interface OfflineSyncCounts {
   feedPages: number;
   /** Unread document URIs enumerated (the list, not the bodies). */
   unreadListed: number;
+  /** `/history` pages fetched. */
+  historyPages: number;
+  /** Partly-read articles found for the "Continue reading" shelf. */
+  unfinishedListed: number;
   /** Publications whose pages were warmed. */
   publications: number;
   /** Publication back-catalog pages fetched beyond each one's first. */
@@ -78,9 +82,11 @@ const INITIAL_COUNTS: OfflineSyncCounts = {
   bodiesCached: 0,
   bodiesQueued: 0,
   feedPages: 0,
+  historyPages: 0,
   imagesWarmed: 0,
   lists: 0,
   publications: 0,
+  unfinishedListed: 0,
   unreadListed: 0,
 };
 

--- a/apps/standard-reader/src/pwa/offline-sync.ts
+++ b/apps/standard-reader/src/pwa/offline-sync.ts
@@ -42,6 +42,7 @@ import {
   readerApi,
   UNFINISHED_SHELF_SIZE,
 } from "#/integrations/tanstack-query/api-reader.functions";
+import { user } from "#/integrations/tanstack-query/api-user.functions";
 import { documentImages } from "#/lib/document/images";
 import { parseAtUri } from "#/server/atproto/uri";
 import { listRefFromUri } from "#/server/reader/saved-lists";
@@ -163,15 +164,16 @@ const AUTHOR_PAGE_SIZE = 24;
 const LIST_PAGE_SIZE = 20;
 
 /**
- * How deep to walk `/history`.
+ * How deep to walk the reader's own queues (`/history`, `/recommended`).
  *
  * Five pages is 100 rows — far enough back that the offline list scrolls like
  * the online one for anything recent, and cheap enough (five requests) to redo
- * on every pass. It has to be every pass: the head of reading history changes
- * every time the reader opens an article, so unlike the followed-publication
- * fan-out this can't hide behind the daily surface timestamp.
+ * on every pass. It has to be every pass: the head of these lists moves every
+ * time the reader opens or recommends an article, so unlike the
+ * followed-publication fan-out they can't hide behind the daily surface
+ * timestamp.
  */
-const HISTORY_WARM_MAX_PAGES = 5;
+const READER_QUEUE_WARM_MAX_PAGES = 5;
 
 let running = false;
 let controller: AbortController | null = null;
@@ -382,6 +384,7 @@ const OFFLINE_ROUTES = [
   "/saved",
   "/subscriptions",
   "/history",
+  "/recommended",
 ] as const;
 
 async function warmRouteChunks(
@@ -493,24 +496,103 @@ async function warmReadingHistory(
     // below is worth attempting either way.
   }
 
+  // Mirrors `getReadingHistoryInfiniteQueryOptions()`' queryFn: the first page
+  // is `offset: 0` and every "load more" after it uses the previous page's
+  // `nextOffset` at the same limit.
+  await warmQueuePages(signal, "historyPages", (offset) =>
+    readerApi.getReadingHistory({
+      data: { limit: READER_QUEUE_PAGE_SIZE, offset },
+    }),
+  );
+}
+
+/**
+ * Cache `/recommended` — the articles the reader has liked.
+ *
+ * A liked article is one the reader already thought worth keeping hold of, and
+ * this page is how they find it again; it is a bad one to lose on a plane.
+ * Bodies are left alone for the same reason as reading history: a like almost
+ * always follows a read, so these are already-read articles competing with a
+ * backlog that isn't read yet. Rows without a stored body dim.
+ */
+async function warmLikes(signal: AbortSignal): Promise<void> {
+  // `getLikesInfiniteQueryOptions()`' queryFn, page for page.
+  await warmQueuePages(signal, "likesPages", (offset) =>
+    readerApi.getLikes({ data: { limit: READER_QUEUE_PAGE_SIZE, offset } }),
+  );
+}
+
+/**
+ * Walk one of the reader's own paginated queues, stopping at the end of the
+ * list or {@link READER_QUEUE_WARM_MAX_PAGES}, whichever comes first.
+ *
+ * The pages are the cache entries: each `offset` is its own URL, so the only
+ * way "load more" works offline is to have requested that exact page online
+ * first.
+ */
+async function warmQueuePages(
+  signal: AbortSignal,
+  counter: "historyPages" | "likesPages",
+  fetchPage: (offset: number) => Promise<{ nextOffset: number | null }>,
+): Promise<void> {
   let offset = 0;
-  for (let page = 0; page < HISTORY_WARM_MAX_PAGES; page += 1) {
+  for (let page = 0; page < READER_QUEUE_WARM_MAX_PAGES; page += 1) {
     if (signal.aborted || isOffline()) return;
-    let historyPage: Awaited<ReturnType<typeof readerApi.getReadingHistory>>;
+    let result: { nextOffset: number | null };
     try {
-      // Mirrors `getReadingHistoryInfiniteQueryOptions()`' queryFn: the first
-      // page is `offset: 0` and every "load more" after it uses the previous
-      // page's `nextOffset` at the same limit.
-      historyPage = await readerApi.getReadingHistory({
-        data: { limit: READER_QUEUE_PAGE_SIZE, offset },
-      });
+      result = await fetchPage(offset);
     } catch {
+      // Signed out, or the surface is empty for this reader.
       return;
     }
-    progressCount("historyPages");
-    if (historyPage.nextOffset == null) return;
-    offset = historyPage.nextOffset;
+    progressCount(counter);
+    if (result.nextOffset == null) return;
+    offset = result.nextOffset;
     await whenIdle(signal);
+  }
+}
+
+/**
+ * Cache the reader's own profile page.
+ *
+ * {@link warmFollowedUsers} covers everyone the reader follows and misses the
+ * one profile reachable from every screen — the avatar menu's "View profile"
+ * — because nobody follows themselves. It also warms the `/u/$did` chunk for a
+ * reader who follows no one at all, which that pass skips.
+ *
+ * The `$did` used here is the one the menu links to (`did ?? handle`), because
+ * a profile requested by handle is a different cache entry from the same
+ * profile requested by DID.
+ */
+async function warmOwnProfile(
+  router: AnyRouter,
+  signal: AbortSignal,
+): Promise<void> {
+  let profileRef: string | null = null;
+  try {
+    const session = await user.getSession();
+    profileRef = session?.user.did ?? session?.user.handle ?? null;
+  } catch {
+    return;
+  }
+  if (!profileRef || signal.aborted || isOffline()) return;
+
+  await preloadRouteChunk(router, "/u/$did", { did: profileRef });
+  try {
+    // Same call `warmFollowedUsers` makes, and the same one
+    // `getAuthorProfileQueryOptions(did, { limit: AUTHOR_PAGE_SIZE })` sends
+    // from `/u/$did`'s loader.
+    await authorApi.getAuthorProfile({
+      data: {
+        did: profileRef,
+        limit: AUTHOR_PAGE_SIZE,
+        offset: 0,
+        activityLimit: AUTHOR_ACTIVITY_PAGE_SIZE,
+      },
+    });
+    progressCount("ownProfile");
+  } catch {
+    // Signed out, or a profile the appview can't resolve right now.
   }
 }
 
@@ -947,6 +1029,15 @@ export async function runOfflineSync(
     state.pending = bodyQueue;
     writeOfflineSyncState(state);
     publishTotals();
+
+    // The rest of "your stuff": what you liked, and the profile the avatar
+    // menu points at. Both are a handful of requests and neither can wait for
+    // the daily surface pass — a like made this morning should be there
+    // tonight.
+    progressStep("likes");
+    await warmLikes(signal);
+    progressStep("your profile");
+    await warmOwnProfile(router, signal);
 
     // The unread list — URIs only; their bodies queue for phase 2.
     progressStep("unread list");

--- a/apps/standard-reader/src/pwa/offline-sync.ts
+++ b/apps/standard-reader/src/pwa/offline-sync.ts
@@ -37,7 +37,11 @@ import {
 import { listApi } from "#/integrations/tanstack-query/api-lists.functions";
 import { notesApi } from "#/integrations/tanstack-query/api-notes.functions";
 import { publicationApi } from "#/integrations/tanstack-query/api-publication.functions";
-import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
+import {
+  READER_QUEUE_PAGE_SIZE,
+  readerApi,
+  UNFINISHED_SHELF_SIZE,
+} from "#/integrations/tanstack-query/api-reader.functions";
 import { documentImages } from "#/lib/document/images";
 import { parseAtUri } from "#/server/atproto/uri";
 import { listRefFromUri } from "#/server/reader/saved-lists";
@@ -157,6 +161,17 @@ const AUTHOR_PAGE_SIZE = 24;
 
 /** Must match `/l/$did/$rkey`'s loader (`PAGE_SIZE`), same caveat as above. */
 const LIST_PAGE_SIZE = 20;
+
+/**
+ * How deep to walk `/history`.
+ *
+ * Five pages is 100 rows — far enough back that the offline list scrolls like
+ * the online one for anything recent, and cheap enough (five requests) to redo
+ * on every pass. It has to be every pass: the head of reading history changes
+ * every time the reader opens an article, so unlike the followed-publication
+ * fan-out this can't hide behind the daily surface timestamp.
+ */
+const HISTORY_WARM_MAX_PAGES = 5;
 
 let running = false;
 let controller: AbortController | null = null;
@@ -361,7 +376,13 @@ async function warmArticleRoute(
  * under exactly the URL it will ask for. Guessing that list by hand would go
  * stale the first time a loader changed.
  */
-const OFFLINE_ROUTES = ["/", "/latest", "/saved", "/subscriptions"] as const;
+const OFFLINE_ROUTES = [
+  "/",
+  "/latest",
+  "/saved",
+  "/subscriptions",
+  "/history",
+] as const;
 
 async function warmRouteChunks(
   router: AnyRouter,
@@ -372,8 +393,8 @@ async function warmRouteChunks(
     try {
       await router.preloadRoute({ to });
     } catch {
-      // Signed-out readers have no /saved or /subscriptions, and a redirect
-      // throws here. Neither is a reason to stop warming the rest.
+      // Signed-out readers have no /saved, /subscriptions or /history, and the
+      // redirect to /login throws here. Not a reason to stop warming the rest.
     }
   }
 }
@@ -433,6 +454,63 @@ async function warmFeedData(signal: AbortSignal): Promise<void> {
     } catch {
       // Signed out, or a surface this reader does not have. Keep going.
     }
+  }
+}
+
+/**
+ * Cache `/history` — the reading list and the "Continue reading" shelf above
+ * it.
+ *
+ * Both halves are warmed by calling the same server functions the route's
+ * loader calls, in the exact argument shape its query options send, so each
+ * response lands in the `data` cache under the URL that loader will ask for.
+ *
+ * The shelf gets special treatment on bodies. Everything else offline sync
+ * stores is *unread* — but a half-read article is by definition already marked
+ * read, so it appears in no unread walk and its body would be the one thing
+ * missing from the surface built to send readers back to it. Six URIs is a
+ * rounding error against the backlog, and they are queued here, ahead of it,
+ * because "what I was in the middle of" outranks "what I have not started".
+ *
+ * The history rows themselves are deliberately **not** queued: those bodies
+ * are already-read articles, they are unbounded, and the storage budget is
+ * meant for the backlog. A row whose body isn't on device dims itself, which
+ * is the honest answer.
+ */
+async function warmReadingHistory(
+  signal: AbortSignal,
+  enqueueBody: (documentUri: string) => void,
+): Promise<void> {
+  try {
+    // `getUnfinishedReadingQueryOptions()` with its default limit.
+    const unfinished = await readerApi.getUnfinishedReading({
+      data: { limit: UNFINISHED_SHELF_SIZE },
+    });
+    for (const item of unfinished) enqueueBody(item.documentUri);
+    progressCount("unfinishedListed", unfinished.length);
+  } catch {
+    // Signed out, or the reader has reading history turned off. The list walk
+    // below is worth attempting either way.
+  }
+
+  let offset = 0;
+  for (let page = 0; page < HISTORY_WARM_MAX_PAGES; page += 1) {
+    if (signal.aborted || isOffline()) return;
+    let historyPage: Awaited<ReturnType<typeof readerApi.getReadingHistory>>;
+    try {
+      // Mirrors `getReadingHistoryInfiniteQueryOptions()`' queryFn: the first
+      // page is `offset: 0` and every "load more" after it uses the previous
+      // page's `nextOffset` at the same limit.
+      historyPage = await readerApi.getReadingHistory({
+        data: { limit: READER_QUEUE_PAGE_SIZE, offset },
+      });
+    } catch {
+      return;
+    }
+    progressCount("historyPages");
+    if (historyPage.nextOffset == null) return;
+    offset = historyPage.nextOffset;
+    await whenIdle(signal);
   }
 }
 
@@ -859,6 +937,16 @@ export async function runOfflineSync(
     await warmShell(signal);
     progressStep("feeds");
     await warmFeedData(signal);
+
+    // Before the unread walk on purpose — the shelf's bodies are few and are
+    // the ones the reader is most likely to open next (see
+    // `warmReadingHistory`), and the queue is drained in the order it is
+    // filled.
+    progressStep("history");
+    await warmReadingHistory(signal, enqueueBody);
+    state.pending = bodyQueue;
+    writeOfflineSyncState(state);
+    publishTotals();
 
     // The unread list — URIs only; their bodies queue for phase 2.
     progressStep("unread list");

--- a/apps/standard-reader/src/router.tsx
+++ b/apps/standard-reader/src/router.tsx
@@ -3,6 +3,7 @@ import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query
 
 import { RouteError } from "./components/route-error";
 import { getContext } from "./integrations/tanstack-query/root-provider";
+import { routerOwnsScroll } from "./lib/router-scroll";
 import { routeTree } from "./routeTree.gen";
 
 export function getRouter() {
@@ -11,9 +12,13 @@ export function getRouter() {
   const router = createTanStackRouter({
     routeTree,
     context,
-    // The document is the scroll container, so the router's default window
-    // scroll restoration + scroll-to-top applies (no custom selector needed).
-    scrollRestoration: true,
+    // The document is the scroll container, so the router's window scroll
+    // restoration + scroll-to-top applies (no custom selector needed) —
+    // everywhere except the article reader, which restores the reader's own
+    // saved position and would otherwise spend its life racing this. See
+    // `routerOwnsScroll`.
+    scrollRestoration: ({ location }) =>
+      routerOwnsScroll({ hash: location.hash, pathname: location.pathname }),
     defaultPreload: "intent",
     // Preloaded data stays fresh for 30s — long enough to hover→click without a
     // refetch, short enough to not serve stale data on a real navigation later.

--- a/apps/standard-reader/src/routes/_layout.history.tsx
+++ b/apps/standard-reader/src/routes/_layout.history.tsx
@@ -130,7 +130,16 @@ function ReaderHistory() {
   const history = data.pages.flatMap((page) => page.items);
   const total = data.pages[0]?.total ?? 0;
   const unfinishedItems = unfinished ?? [];
-  const hasUnfinished = unfinishedItems.some((item) => item.article != null);
+  // An in-progress article is claimed by the shelf and drops out of the list
+  // below, so no article appears twice on the page. Only the ones the shelf
+  // actually renders are claimed: an item whose document has fallen out of the
+  // read-model isn't shown up there, so it stays down here.
+  const shelved = new Set(
+    unfinishedItems
+      .filter((item) => item.article != null)
+      .map((item) => item.documentUri),
+  );
+  const hasUnfinished = shelved.size > 0;
 
   const loadMore = useCallback(() => {
     if (hasNextPage && !isFetchingNextPage) {
@@ -138,13 +147,15 @@ function ReaderHistory() {
     }
   }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
-  const queueRows = history.map((item) => ({
-    id: item.readUri,
-    documentUri: item.documentUri,
-    article: item.article,
-    timestamp: item.readAt,
-    actionLabel: t`Read`,
-  }));
+  const queueRows = history
+    .filter((item) => !shelved.has(item.documentUri))
+    .map((item) => ({
+      id: item.readUri,
+      documentUri: item.documentUri,
+      article: item.article,
+      timestamp: item.readAt,
+      actionLabel: t`Read`,
+    }));
 
   return (
     <ReaderContent>
@@ -186,9 +197,12 @@ function ReaderHistory() {
         <>
           <ContinueReading items={unfinishedItems} />
           {/* Only once the shelf is above it does the list below need naming —
-              on its own it is the page, and the masthead already said so. */}
-          {hasUnfinished ? (
-            <SectionHead title={t`Everything you've read`} size="md" />
+              on its own it is the page, and the masthead already said so.
+              "Everything else" rather than "Everything you've read": the
+              in-progress ones are up on the shelf and deliberately not repeated
+              here, so the older title would name a list this isn't. */}
+          {hasUnfinished && queueRows.length > 0 ? (
+            <SectionHead title={t`Everything else`} size="md" followsSection />
           ) : null}
           <ReaderQueueRows
             items={queueRows}
@@ -204,7 +218,9 @@ function ReaderHistory() {
             hasMore={hasNextPage}
             isLoading={isFetchingNextPage}
             onLoadMore={loadMore}
-            itemCount={history.length}
+            // The rows actually on screen, not the rows fetched: the shelf has
+            // claimed some, and this drives the "showing N" affordance.
+            itemCount={queueRows.length}
           />
         </>
       )}

--- a/apps/standard-reader/src/routes/_layout.history.tsx
+++ b/apps/standard-reader/src/routes/_layout.history.tsx
@@ -12,7 +12,7 @@ import {
   lineHeight,
 } from "@standard-reader/design-system/theme/typography.stylex";
 import * as stylex from "@stylexjs/stylex";
-import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
+import { useQuery, useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useCallback } from "react";
 
@@ -24,8 +24,13 @@ import { getPublicUrlClient } from "#/lib/public-url";
 import { pageSocialMeta } from "#/lib/site-metadata";
 import { buildAuthRedirectPath } from "#/utils/auth-redirect";
 
+import { ContinueReading } from "../components/reader/continue-reading";
 import { FeedLoadMore } from "../components/reader/feed-load-more";
-import { Masthead, ReaderContent } from "../components/reader/primitives";
+import {
+  Masthead,
+  ReaderContent,
+  SectionHead,
+} from "../components/reader/primitives";
 import { ReaderQueueRows } from "../components/reader/reader-queue-rows";
 
 export const Route = createFileRoute("/_layout/history")({
@@ -41,9 +46,19 @@ export const Route = createFileRoute("/_layout/history")({
     }
   },
   loader: async ({ context }) => {
-    await context.queryClient.ensureInfiniteQueryData(
-      readerApi.getReadingHistoryInfiniteQueryOptions(),
-    );
+    await Promise.all([
+      context.queryClient.ensureInfiniteQueryData(
+        readerApi.getReadingHistoryInfiniteQueryOptions(),
+      ),
+      // The shelf rides along so it paints with the list, but it must never be
+      // what fails the page: offline (or on any server hiccup) a rejection here
+      // would throw the whole route to the error component and cost the reader
+      // their cached history over a six-row extra. The component treats a
+      // missing result as an empty shelf.
+      context.queryClient
+        .ensureQueryData(readerApi.getUnfinishedReadingQueryOptions())
+        .catch(() => null),
+    ]);
   },
   head: () => ({
     meta: pageSocialMeta("history", getPublicUrlClient()),
@@ -105,9 +120,17 @@ function ReaderHistory() {
   const { t } = useLingui();
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useSuspenseInfiniteQuery(readerApi.getReadingHistoryInfiniteQueryOptions());
+  // `useQuery`, not `useSuspenseQuery`: the shelf is an extra on this page, and
+  // suspending (or throwing) on it would take the reading history down with it
+  // when the reader is offline.
+  const { data: unfinished } = useQuery(
+    readerApi.getUnfinishedReadingQueryOptions(),
+  );
 
   const history = data.pages.flatMap((page) => page.items);
   const total = data.pages[0]?.total ?? 0;
+  const unfinishedItems = unfinished ?? [];
+  const hasUnfinished = unfinishedItems.some((item) => item.article != null);
 
   const loadMore = useCallback(() => {
     if (hasNextPage && !isFetchingNextPage) {
@@ -161,6 +184,12 @@ function ReaderHistory() {
         </div>
       ) : (
         <>
+          <ContinueReading items={unfinishedItems} />
+          {/* Only once the shelf is above it does the list below need naming —
+              on its own it is the page, and the masthead already said so. */}
+          {hasUnfinished ? (
+            <SectionHead title={t`Everything you've read`} size="md" />
+          ) : null}
           <ReaderQueueRows
             items={queueRows}
             showSaveButton={false}


### PR DESCRIPTION
Reopening an article puts the reader back where they stopped, and /history
opens with a shelf of what they're partway through.

Position is deliberately kept off the protocol. Reads and bookmarks being
public records is a fair trade — they say what you read. How far you got, and
where you gave up, is a running commentary on attention that nobody opts into
by opening an article. So it lives in a private app-local Neon table the tap
never writes, mirrored to localStorage per device.

Two stores, because they answer different questions. localStorage can be read
before first paint, which is the only place a scroll restore can happen without
a visible jump, and it's what keeps this working offline in the installed PWA.
The server copy is what carries position from phone to laptop; it only wins
when it's newer and the reader hasn't already started scrolling.

Restoring by fraction assumes the article is as tall as it was last time, and
for a few hundred ms it isn't — images haven't reserved space yet. So the
target is re-applied across a 3s settle window, ended immediately by any real
input. A pill names the jump and offers the way back, because landing
mid-article with no explanation reads as a bug.

Rows exist only between 2% and 95%, so the table *is* the shelf and never needs
sweeping. Clearing reading history clears positions with it, and the whole
feature is gated on the "Track reading history" setting — position is reading
history at a finer grain.

Offline: position writes fail fast rather than taking React Query's default of
pausing, which would queue dozens of writes over a subway ride to say what the
last one says; a single flush on reconnect sends the value that matters. The
shelf query is non-fatal on /history — offline it doesn't render, rather than
taking the reader's cached history down with it.

Needs `pnpm db:migrate` (0037) before deploy.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>