### PR TITLE
Probe the network before declaring someone offline

### DIFF
--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -1226,6 +1226,19 @@ Backend/API exists; UI or copy is missing.
       bodies are already-read and unbounded, and the storage budget belongs to the backlog, so a
       row without a body dims instead.
       [`RouteError`](src/components/route-error.tsx) is the app-wide `defaultErrorComponent`.
+- [x] **"Offline" is probed, never asserted** — a reader on a WebView browser (Via, Android 14)
+      got the whole offline treatment on a working connection: wordmark reading "Offline Reader",
+      Discover/Search/Collections gone from the nav, `/latest` bounced off its network-wide
+      filters, pull-to-refresh disabled. Chromium's Android WebView returns
+      `navigator.onLine === false` for the life of the page unless the embedding app holds
+      `ACCESS_NETWORK_STATE`, and fires no `online` event to correct it.
+      [`online-status.ts`](src/lib/online-status.ts) is now the single verdict and treats the flag
+      as a hint: a claimed connection is believed immediately, a claimed _disconnection_ is
+      checked with one uncached same-origin request (`/robots.txt`, which no service-worker route
+      matches, so a cached answer can't fake reachability). Only a network-level failure counts as
+      offline; while offline it re-probes on an interval, on foreground, and whenever a query
+      fails. `useOnlineStatus`, `offlineAwareRetry` and `offline-sync` all read it — the last of
+      those was refusing to sync at all on those browsers.
 - [x] **Content rendering gaps** — PCKT gallery renderer (`blog.pckt.block.gallery`); prod scan
       found 54 documents — implemented grid/list/carousel/masonry layouts via
       [`pckt-gallery.tsx`](src/components/reader/content/renderers/pckt-gallery.tsx).

--- a/apps/standard-reader/src/integrations/tanstack-query/query-client.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/query-client.ts
@@ -1,6 +1,7 @@
 import { MutationCache, QueryClient, isServer } from "@tanstack/react-query";
 
 import { isAtprotoScopeMissingError } from "#/lib/atproto/scope-error";
+import { isOffline, recheckOnlineStatus } from "#/lib/online-status";
 
 const DEFAULT_QUERY_STALE_TIME_MS = 60 * 1000;
 
@@ -16,9 +17,15 @@ const DEFAULT_QUERY_RETRY_COUNT = 3;
  * reach the same answer, because nothing about being offline changes between
  * attempts. Fail on the first miss so the offline state renders immediately;
  * React Query refetches on `online` anyway.
+ *
+ * A failed request is also the best evidence there is that the connection has
+ * gone, so it re-opens the question — on a browser that misreports
+ * `navigator.onLine` (see `#/lib/online-status`) no `offline` event ever
+ * arrives, and this is the only moment anything notices.
  */
 function offlineAwareRetry(failureCount: number): boolean {
-  if (globalThis.navigator?.onLine === false) return false;
+  if (isOffline()) return false;
+  recheckOnlineStatus();
   return failureCount < DEFAULT_QUERY_RETRY_COUNT;
 }
 

--- a/apps/standard-reader/src/lib/online-status.test.ts
+++ b/apps/standard-reader/src/lib/online-status.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+/**
+ * The module keeps its verdict in module scope, so every test imports a fresh
+ * copy after `vi.resetModules()`.
+ */
+async function load() {
+  return await import("./online-status.ts");
+}
+
+function setNavigatorOnLine(value: boolean) {
+  Object.defineProperty(globalThis.navigator, "onLine", {
+    configurable: true,
+    get: () => value,
+  });
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.resetModules();
+  fetchMock.mockReset();
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  setNavigatorOnLine(true);
+});
+
+describe("online status", () => {
+  test("believes the browser when it claims a connection", async () => {
+    setNavigatorOnLine(true);
+    const { isOffline } = await load();
+    expect(isOffline()).toBe(false);
+    // Nothing to verify: a claimed connection is either true or about to fail a
+    // real request.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("stays online when the browser misreports offline but the network answers", async () => {
+    // Android WebView without `ACCESS_NETWORK_STATE`: `onLine` is `false` for
+    // the life of the page on a perfectly good connection.
+    setNavigatorOnLine(false);
+    fetchMock.mockResolvedValue({});
+    const { isOffline, subscribeToOnlineStatus } = await load();
+    const seen: Array<boolean> = [];
+    subscribeToOnlineStatus((online) => seen.push(online));
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    expect(isOffline()).toBe(false);
+    // Never flipped, so nothing rebuilt the nav or renamed the wordmark.
+    expect(seen).toEqual([]);
+  });
+
+  test("any HTTP answer counts as reachable, including an error status", async () => {
+    setNavigatorOnLine(false);
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+    const { isOffline } = await load();
+    // Reading the verdict is what wires the module up — nothing runs on import.
+    expect(isOffline()).toBe(false);
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    expect(isOffline()).toBe(false);
+  });
+
+  test("goes offline when the probe fails at the network level", async () => {
+    setNavigatorOnLine(false);
+    fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
+    const { isOffline, subscribeToOnlineStatus } = await load();
+    const seen: Array<boolean> = [];
+    subscribeToOnlineStatus((online) => seen.push(online));
+
+    await vi.waitFor(() => {
+      expect(isOffline()).toBe(true);
+    });
+    expect(seen).toEqual([false]);
+  });
+
+  test("recovers when a later probe succeeds", async () => {
+    setNavigatorOnLine(false);
+    fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
+    const { isOffline, recheckOnlineStatus } = await load();
+    await vi.waitFor(() => {
+      expect(isOffline()).toBe(true);
+    });
+
+    fetchMock.mockResolvedValue({});
+    recheckOnlineStatus();
+    await vi.waitFor(() => {
+      expect(isOffline()).toBe(false);
+    });
+  });
+
+  test("the `online` event is believed without a probe", async () => {
+    setNavigatorOnLine(false);
+    fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
+    const { isOffline } = await load();
+    await vi.waitFor(() => {
+      expect(isOffline()).toBe(true);
+    });
+
+    setNavigatorOnLine(true);
+    globalThis.dispatchEvent(new Event("online"));
+    expect(isOffline()).toBe(false);
+  });
+
+  test("probes a URL the service worker passes through, uncached", async () => {
+    setNavigatorOnLine(false);
+    fetchMock.mockResolvedValue({});
+    const { recheckOnlineStatus } = await load();
+    recheckOnlineStatus();
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/^\/robots\.txt\?online-probe=\d+$/);
+    expect(init.cache).toBe("no-store");
+  });
+});

--- a/apps/standard-reader/src/lib/online-status.ts
+++ b/apps/standard-reader/src/lib/online-status.ts
@@ -1,0 +1,174 @@
+/**
+ * Whether the app can reach the network — the one place that decides it.
+ *
+ * `navigator.onLine` is the obvious answer and it is not trustworthy in the
+ * direction the app relies on. It reports whether the browser believes a
+ * network interface exists, and some browsers get that permanently wrong:
+ * Chromium's Android WebView returns `false` for the lifetime of the page
+ * unless the embedding app holds `ACCESS_NETWORK_STATE`, and lightweight
+ * WebView browsers (Via, and others like it) do not ask for it. On those the
+ * flag never flips and no `online` event ever fires, so a reader with a working
+ * connection got the whole offline treatment — the wordmark reading "Offline
+ * Reader", Discover/Search/Collections pulled out of the nav, `/latest`
+ * redirected off its network-wide filters, pull-to-refresh disabled, and
+ * offline sync refusing to run — while articles loaded around them.
+ *
+ * So the flag is a hint, never the verdict:
+ *
+ * - `navigator.onLine !== false` is believed immediately. A browser claiming a
+ *   connection is either right or about to fail a request, and there is nothing
+ *   cheaper to consult.
+ * - `navigator.onLine === false` is *checked* — one small same-origin request.
+ *   A network-level failure is the only thing that proves offline; any HTTP
+ *   response at all (even a 500) proves the opposite.
+ *
+ * The verdict starts optimistic and is corrected asynchronously, which is also
+ * what keeps SSR honest: `navigator` does not exist on the server, and
+ * rendering an offline shell the client immediately undoes is a hydration
+ * mismatch on every request.
+ */
+
+/**
+ * Probed URL: the smallest same-origin file that is *not* precached and matches
+ * no runtime-caching route in `vite.config.ts` — a `fetch()` has
+ * `request.destination === ""` and `mode !== "navigate"`, so the service worker
+ * passes it straight through to the network. That matters: a cached answer
+ * would report "online" to a device sitting in a tunnel.
+ */
+const PROBE_PATH = "/robots.txt";
+
+/**
+ * Long enough for a slow mobile connection to answer, short enough that the
+ * offline UI is not held back by a stalled request. A genuinely disconnected
+ * device rejects in milliseconds; this bounds the case where packets leave and
+ * nothing comes back.
+ */
+const PROBE_TIMEOUT_MS = 5000;
+
+/**
+ * How often to re-probe while offline. The `online` event is the normal way
+ * back, but it is exactly what cannot be relied on here — a browser that lies
+ * about `navigator.onLine` does not fire the events either.
+ */
+const RECHECK_INTERVAL_MS = 20_000;
+
+type Listener = (online: boolean) => void;
+
+/** Optimistic until a probe proves otherwise — see the module comment. */
+let offline = false;
+let probing: Promise<boolean> | null = null;
+let recheckTimer: ReturnType<typeof setInterval> | null = null;
+let started = false;
+const listeners = new Set<Listener>();
+
+/** True only when a real request has failed at the network level. */
+export function isOffline(): boolean {
+  ensureStarted();
+  return offline;
+}
+
+export function isOnline(): boolean {
+  return !isOffline();
+}
+
+/** Subscribe to verdict changes. Returns the unsubscribe function. */
+export function subscribeToOnlineStatus(listener: Listener): () => void {
+  ensureStarted();
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Ask again, now.
+ *
+ * Called when something else has evidence worth acting on — a request that just
+ * failed, an app coming back to the foreground. Cheap by construction: it
+ * short-circuits without touching the network whenever the browser claims a
+ * connection, and only one probe is ever in flight.
+ */
+export function recheckOnlineStatus(): void {
+  ensureStarted();
+  evaluate();
+}
+
+function ensureStarted(): void {
+  if (started || globalThis.window === undefined) return;
+  started = true;
+
+  // The events are still worth listening to — they are the fast path on every
+  // browser that implements them correctly.
+  globalThis.addEventListener?.("online", evaluate);
+  globalThis.addEventListener?.("offline", evaluate);
+  // Timers are throttled or suspended while the app is backgrounded, so coming
+  // back to the foreground is the moment a stale offline verdict is most likely
+  // and least excusable.
+  globalThis.document?.addEventListener("visibilitychange", () => {
+    if (globalThis.document?.visibilityState === "visible") evaluate();
+  });
+
+  evaluate();
+}
+
+function evaluate(): void {
+  if (globalThis.window === undefined) return;
+  if (globalThis.navigator?.onLine !== false) {
+    setOffline(false);
+    return;
+  }
+  void runProbe().then((reachable) => {
+    setOffline(!reachable);
+  });
+}
+
+function runProbe(): Promise<boolean> {
+  // One in flight at a time: the interval, the events and every caller of
+  // `recheckOnlineStatus` can all land in the same beat.
+  probing ??= probe().finally(() => {
+    probing = null;
+  });
+  return probing;
+}
+
+async function probe(): Promise<boolean> {
+  const controller = new AbortController();
+  const timeout = globalThis.setTimeout(() => {
+    controller.abort();
+  }, PROBE_TIMEOUT_MS);
+  try {
+    // Any answer proves reachability, so the status is deliberately ignored —
+    // a 404 or a 500 still had to travel. `no-store` keeps the HTTP cache from
+    // answering for the network.
+    await fetch(`${PROBE_PATH}?online-probe=${Date.now()}`, {
+      cache: "no-store",
+      credentials: "omit",
+      method: "GET",
+      signal: controller.signal,
+    });
+    return true;
+  } catch {
+    return false;
+  } finally {
+    globalThis.clearTimeout(timeout);
+  }
+}
+
+function setOffline(next: boolean): void {
+  if (next !== offline) {
+    offline = next;
+    for (const listener of listeners) listener(!offline);
+  }
+  syncRecheckTimer();
+}
+
+function syncRecheckTimer(): void {
+  if (offline && recheckTimer === null) {
+    recheckTimer = globalThis.setInterval(evaluate, RECHECK_INTERVAL_MS);
+    return;
+  }
+  if (!offline && recheckTimer !== null) {
+    globalThis.clearInterval(recheckTimer);
+    recheckTimer = null;
+  }
+}

--- a/apps/standard-reader/src/lib/use-online-status.ts
+++ b/apps/standard-reader/src/lib/use-online-status.ts
@@ -1,32 +1,22 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
+
+import { isOnline, subscribeToOnlineStatus } from "#/lib/online-status";
 
 /**
- * Whether the browser currently reports a connection.
+ * Whether the app can currently reach the network.
  *
- * Starts `true` and corrects after mount on purpose: `navigator` does not exist
- * during SSR, and rendering an "offline" state into server markup that the
- * client then has to undo is a hydration mismatch on every request.
+ * Thin subscription over {@link isOnline} — see `online-status.ts` for why the
+ * verdict is a probed one rather than `navigator.onLine`, which some Android
+ * WebView browsers report as `false` forever on a working connection.
  *
- * `navigator.onLine` only knows whether there is *a* network interface, not
- * whether anything is reachable — so treat `false` as reliable ("definitely
- * offline") and `true` as optimistic. Everything here keys off the reliable
- * direction: hiding what cannot work, and explaining a failure after it happens.
+ * The server snapshot is `true` and the client's first snapshot matches it on
+ * purpose: `navigator` does not exist during SSR, and rendering an "offline"
+ * state into server markup that the client then has to undo is a hydration
+ * mismatch on every request. `false` still means "definitely offline"; it just
+ * arrives after a failed request rather than on a flag's say-so.
  */
 export function useOnlineStatus(): boolean {
-  const [online, setOnline] = useState(true);
-
-  useEffect(() => {
-    const sync = () => setOnline(globalThis.navigator?.onLine !== false);
-    sync();
-    globalThis.addEventListener?.("online", sync);
-    globalThis.addEventListener?.("offline", sync);
-    return () => {
-      globalThis.removeEventListener?.("online", sync);
-      globalThis.removeEventListener?.("offline", sync);
-    };
-  }, []);
-
-  return online;
+  return useSyncExternalStore(subscribeToOnlineStatus, isOnline, () => true);
 }

--- a/apps/standard-reader/src/pwa/offline-sync.ts
+++ b/apps/standard-reader/src/pwa/offline-sync.ts
@@ -44,6 +44,11 @@ import {
 } from "#/integrations/tanstack-query/api-reader.functions";
 import { user } from "#/integrations/tanstack-query/api-user.functions";
 import { documentImages } from "#/lib/document/images";
+// Never `navigator.onLine` directly: browsers that misreport the flag (Android
+// WebView without `ACCESS_NETWORK_STATE`) would otherwise refuse to sync
+// forever on a perfectly good connection — the one place that lie costs a
+// reader their whole offline library rather than a bit of chrome.
+import { isOffline, subscribeToOnlineStatus } from "#/lib/online-status";
 import { parseAtUri } from "#/server/atproto/uri";
 import { listRefFromUri } from "#/server/reader/saved-lists";
 
@@ -186,16 +191,6 @@ export function isOfflineReadingEnabled(): boolean {
   } catch {
     return true;
   }
-}
-
-/**
- * Read through a function rather than inline: an early
- * `if (navigator.onLine === false) return` narrows the global to `true` for the
- * rest of the enclosing function, and the loops below re-check it after
- * awaiting.
- */
-function isOffline(): boolean {
-  return globalThis.navigator?.onLine === false;
 }
 
 /** True when the reader has asked the OS to conserve data. */
@@ -1192,15 +1187,20 @@ export function startOfflineSync(router: AnyRouter): () => void {
   const onVisible = () => {
     if (globalThis.document?.visibilityState === "visible") start();
   };
-  globalThis.addEventListener?.("online", start);
-  globalThis.addEventListener?.("offline", stopOfflineSync);
+  // The shared verdict rather than the raw `online`/`offline` events: on a
+  // browser that misreports `navigator.onLine` those events never fire at all,
+  // so the connection coming back would otherwise go unnoticed until the next
+  // interval tick.
+  const unsubscribe = subscribeToOnlineStatus((online) => {
+    if (online) start();
+    else stopOfflineSync();
+  });
   globalThis.document?.addEventListener("visibilitychange", onVisible);
 
   return () => {
     globalThis.clearTimeout(timer);
     globalThis.clearInterval(interval);
-    globalThis.removeEventListener?.("online", start);
-    globalThis.removeEventListener?.("offline", stopOfflineSync);
+    unsubscribe();
     globalThis.document?.removeEventListener("visibilitychange", onVisible);
     stopOfflineSync();
   };


### PR DESCRIPTION
Fixes the report in [“The menu is getting truncated on mobile”](https://userinput.app/d/did:plc:bpotnohnlgcj3fbmp7ugx4en/3msymtgh3nz2c).

## It isn't a layout bug

The reader's sidebar was down to Home, Latest and Saved for later. That is not truncation — it is **the offline nav**, and their screenshots have the wordmark reading **“Offline Reader”** beside a feed of live articles and an unread count of 35.

Their browser is Via, one of the many Android browsers that are a thin shell around WebView. Chromium's WebView returns `navigator.onLine === false` for the life of the page unless the embedding app declares `ACCESS_NETWORK_STATE`, and fires no `online` event that would ever correct it. Everything offline keyed off that flag, so on a perfectly good connection they lost Discover, Search and Collections from the nav, had `/latest` bounced off its network-wide filters, lost pull-to-refresh — and had they installed the app, offline sync would have refused to run at all, permanently.

## The flag is a hint, not a verdict

`src/lib/online-status.ts` is now the single place that decides:

- **A claimed connection is believed immediately.** It is either true or about to fail a real request, and there is nothing cheaper to consult.
- **A claimed *disconnection* is checked** — one uncached same-origin request. Only a network-level failure counts as offline; any HTTP answer at all, even a 500, had to travel.
- **The probed URL is `/robots.txt`** precisely because no service-worker route in `vite.config.ts` matches it, so a cached answer cannot report reachability to a device sitting in a tunnel.
- **Recovery cannot lean on the `online` event either**, since a browser that lies about the flag does not fire the events. While offline it re-probes on an interval, on returning to the foreground, and whenever a query fails — that last one is the only moment anything notices on such a browser.

The verdict starts optimistic and is corrected asynchronously, which is also what keeps hydration honest: `navigator` does not exist during SSR, and rendering an offline shell the client immediately undoes is a mismatch on every request.

`useOnlineStatus`, `offlineAwareRetry` and `offline-sync` all read the shared verdict; no `navigator.onLine` reads remain outside that module.

## Verified

In a browser with `navigator.onLine` forced to `false` before any app script runs — the reporter's exact condition:

| condition | wordmark | Discover/Search in nav |
| --- | --- | --- |
| network reachable (the report) | `Standard Reader` | present |
| probe blocked as well (really offline) | `Offline Reader` | gone |

Plus seven unit tests in `online-status.test.ts` covering the misreporting browser, an error status still counting as reachable, the offline flip, recovery, and the probe's URL/`no-store`. Full app suite passes (944), typecheck, lint and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
