### PR TITLE
Mute publications and users

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -1366,6 +1366,11 @@ reversibly.
 - **UI**: Mute/Unmute in the author and publication overflow menus (next to Block; mute confirms,
   unmute is immediate), and **Settings → Muted** lists both kinds with unmute — every row still
   links to the page it hides, because muting never takes those pages away.
+- **A muted page says so.** Because muting leaves the profile readable, a muted author or
+  publication page would otherwise look identical to an unmuted one. A "Muted" pill renders on the
+  header in the same visual register as a labeler label (`MutedPill`, next to `AccountLabels`) —
+  it's the reader's own statement about the account — with a hover card explaining the scope and
+  carrying the Unmute action and a link to Settings → Muted.
 
 ---
 

--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -892,7 +892,7 @@ upstream `site.standard.auth*` sets (published by standard.site — see
 
 | Tier                                | App-owned set (we publish)                      | site.standard set (we reference)         | Covers                                                                               |
 | ----------------------------------- | ----------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------ |
-| **Basic** (default sign-in)         | `include:app.standard-reader.authBasicFeatures` | `include:site.standard.authSocial`       | bookmark, read, list, listSave, labelerSubscription + follows + likes                |
+| **Basic** (default sign-in)         | `include:app.standard-reader.authBasicFeatures` | `include:site.standard.authSocial`       | bookmark, read, list, listSave, labelerSubscription, graph.mute + follows + likes    |
 | **Collections authoring** (upgrade) | `+ include:app.standard-reader.authCollections` | swap to `include:site.standard.authFull` | collection, collectionsPublication, publicationTheme + publication + document writes |
 | **Subscribe embed**                 | —                                               | `include:site.standard.authSocial`       | subscription write (also covers recommend)                                           |
 
@@ -1000,6 +1000,10 @@ re-auth because `prompt: consent` re-consent isn't reliable across PDS providers
     `publications` at-uris of `site.standard.publication` records + `createdAt`; tid rkey).
   - `app.standard-reader.listSave` — another reader's list saved into this app (`list` at-uri +
     `createdAt`; deterministic rkey so save/unsave/status address one record).
+  - `app.standard-reader.graph.mute` — a muted subject: a user DID **or** a
+    `site.standard.publication` at-uri in one format-less `subject` string (the lexicon has no
+    did-or-at-uri format; app code classifies). Presence means muted; deterministic rkey via
+    `subjectRkey`. One direction, feeds + discovery only — see "Muting" below.
   - `app.standard-reader.collection` — curated magazine manifest for a
     `site.standard.document` (same rkey sidecar: editorial, colophon, ordered items).
     Editorial body, colophon, and per-item notes are stored as `at.markpub.markdown`.
@@ -1324,6 +1328,44 @@ A reader's blocks follow them here, in both directions, with no setup and no imp
 - **A hidden reply is explained, not just missing.** The Discussion badge is the cached, unfiltered
   count (a per-reader count would need a per-reader cache), so the section reports how many replies
   the reader's blocks removed instead of showing "No discussion yet" under a badge reading 6.
+
+### Muting
+
+The lighter-weight "stop showing me this": a reader mutes a **publication** or a **user**, and the
+muted subject disappears from their feeds and discovery — quietly, one-directionally, and
+reversibly.
+
+- **Muting vs blocking.** A block is a portable Bluesky record, bidirectional, and absolute — it
+  hides pages, discussion, everything, in both directions. A mute is an **app-local visibility
+  record** (`app.standard-reader.graph.mute` in the muter's repo), one direction only, and scoped:
+  muted content vanishes from home, latest, discover, trending, tag, search and the recommendation
+  rails, but **direct navigation still works and subscriptions stay intact**. Nobody is notified,
+  nothing is hidden from the muted side. (Note the record itself is public in the reader's repo,
+  unlike Bluesky's server-side private mutes — the _effect_ is private, the record is not.)
+- **One record, two subject kinds.** `subject` is a format-less string holding either a user DID or
+  a publication at-uri (the lexicon has no did-or-at-uri format; ingest classifies into
+  discriminated `subject_did` / `subject_uri` columns). Muting a **user** hides everything they
+  touch: documents they authored, documents from publications they own, and their recommends
+  (removed by dropping the muted DID from the follow-feed's source sets, which also keeps badge
+  counts honest). Muting a **publication** hides its documents and the publication card itself from
+  discovery.
+- **Rides the firehose, unlike blocks.** The record lives in the reader's own repo — a repo we
+  already track — so the tap/Jetstream stream mirrors it into the `mutes` table (migration `0039`)
+  with no per-reader sweep. Writes eagerly mirror the row (`subjectRkey` addressing) so the mute
+  takes effect on the next page; repo-sync repairs cover the cold-start/backfill path.
+- **Enforced like blocks, gated like blocks.** SQL `NOT (EXISTS …)` (`notMutedByViewer` in
+  `server/mutes/mutes.ts`) on paginated feeds — author DID, publication-owner DID, and a
+  publication-URI branch blocks don't have — and JS post-filters (`filterMutedCards`) on rails.
+  Reached only through `muteFilterDid`, the same has-any gate + in-process cache pattern as
+  `blockFilterDid`, so readers who mute nothing pay nothing. `queries.explain.test.ts` asserts the
+  filtered plan keeps its index scans.
+- **Scope rides the basic tier.** The collection is in the republished `authBasicFeatures`
+  permission set, so fresh logins can write mutes with no upgrade. Sessions from before the
+  republish may hold a frozen expansion; the write path maps a PDS scope rejection to a
+  `needs-mute-scope` re-auth (`upgradeToMuting` — plain basic scope, no flag, no new consent tier).
+- **UI**: Mute/Unmute in the author and publication overflow menus (next to Block; mute confirms,
+  unmute is immediate), and **Settings → Muted** lists both kinds with unmute — every row still
+  links to the page it hides, because muting never takes those pages away.
 
 ---
 

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -2042,6 +2042,9 @@ unfollowing, blocking, or telling anyone. See [`APP_VISION.md` §"Muting"](./APP
 - [x] **UI** — Mute/Unmute in author + publication overflow menus (sibling-dialog pattern; mute
       confirms, unmute is immediate), Settings → Muted management page (`/settings/muted`), Muted
       row in settings index.
+- [x] **Muted pill on profile headers** — labeler-label-style "Muted" badge (`MutedPill`) on the
+      author and publication heroes next to `AccountLabels`, with a hover card explaining scope +
+      Unmute action; the only visible trace of a mute on pages muting leaves readable.
 - [ ] **Scrub "Recommended by X" bylines** — a card that survives via a non-muted source can still
       credit a muted recommender in its byline; the entries themselves are filtered, the
       attribution string is not.

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -2016,6 +2016,40 @@ A reader's Bluesky blocks apply here, in both directions, with no setup. See
       within one process, which is enough for the single web service today. A second instance can
       still sweep the same reader concurrently; an advisory lock would make the guard cluster-wide.
 
+### Muting
+
+The lighter-weight moderation control: hide a publication or user from feeds + discovery without
+unfollowing, blocking, or telling anyone. See [`APP_VISION.md` §"Muting"](./APP_VISION.md#muting).
+
+- [x] **`app.standard-reader.graph.mute` lexicon** — one record for both subject kinds (user DID or
+      `site.standard.publication` at-uri in a format-less `subject`), deterministic `subjectRkey`,
+      added to the `authBasicFeatures` permission set. ⚠️ Publish the new lexicon **and** the
+      updated permission set (`pnpm atproto:publish-lexicons`) before deploying.
+- [x] **Read-model mirror** (migration `0039`) — `mutes` table with discriminated
+      `subject_did`/`subject_uri` columns + muter/edge indexes; firehose ingest (`upsertMute` +
+      delete case), repo-sync repair registration, tap collection filters (a no-op once the
+      Jetstream `app.standard-reader.*` wildcard lands). ⚠️ Pre-Jetstream deploys must also update
+      the live `TAP_COLLECTION_FILTERS` env override on Railway.
+- [x] **Write path** — `putMuteRecord`/`deleteMuteRecords` + `mutesApi`
+      (`api-mutes.functions.ts`): eager DB mirror on write, `needs-mute-scope` → `upgradeToMuting`
+      re-auth for pre-republish sessions (PDS 401/403 on the write is the fallback detector).
+- [x] **Enforcement** — SQL `notMutedByViewer` (author + publication-owner + publication-URI
+      branches) behind the `muteFilterDid` has-any gate on home, latest, trending, tag, search,
+      topics, discover directory + XRPC feeds; JS `filterMutedCards` on rails; muted DIDs/URIs
+      dropped from follow-feed source sets (kills recommend-sourced entries + keeps counts honest).
+      Deliberately **not** applied to direct navigation (publication/author/article pages), lists,
+      or subscriptions. Gated EXPLAIN coverage in `queries.explain.test.ts`.
+- [x] **UI** — Mute/Unmute in author + publication overflow menus (sibling-dialog pattern; mute
+      confirms, unmute is immediate), Settings → Muted management page (`/settings/muted`), Muted
+      row in settings index.
+- [ ] **Scrub "Recommended by X" bylines** — a card that survives via a non-muted source can still
+      credit a muted recommender in its byline; the entries themselves are filtered, the
+      attribution string is not.
+- [ ] **Translate the mutes UI** — strings need `pnpm i18n:extract` + a translation pass; they
+      render in English outside `en` until then.
+- [ ] **Digest / push / RSS parity** — blocks filter the weekly digest, push notifications and
+      per-reader RSS; mutes should too (same "arrives uninvited" argument).
+
 ---
 
 ## 15. Format conversion (`@standard-reader/converter` + CLI)

--- a/apps/standard-reader/drizzle/0039_glamorous_martin_li.sql
+++ b/apps/standard-reader/drizzle/0039_glamorous_martin_li.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "mutes" (
+	"uri" text PRIMARY KEY NOT NULL,
+	"cid" text,
+	"muter_did" text NOT NULL,
+	"rkey" text NOT NULL,
+	"subject" text NOT NULL,
+	"subject_did" text,
+	"subject_uri" text,
+	"created_at" timestamp with time zone,
+	"deleted" boolean DEFAULT false NOT NULL,
+	"indexed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "mutes_muter_idx" ON "mutes" USING btree ("muter_did");--> statement-breakpoint
+CREATE INDEX "mutes_user_edge_idx" ON "mutes" USING btree ("muter_did","subject_did");--> statement-breakpoint
+CREATE INDEX "mutes_pub_edge_idx" ON "mutes" USING btree ("muter_did","subject_uri");

--- a/apps/standard-reader/drizzle/meta/0039_snapshot.json
+++ b/apps/standard-reader/drizzle/meta/0039_snapshot.json
@@ -1,0 +1,5736 @@
+{
+  "id": "040d9ce8-4be5-456a-ada0-fef1f52b1e3d",
+  "prevId": "c38ed39a-2954-4326-ba7c-8807a722c373",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_mode": {
+          "name": "theme_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appearance": {
+          "name": "appearance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale_hint_seen": {
+          "name": "locale_hint_seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reader_voice": {
+          "name": "reader_voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_links_externally": {
+          "name": "open_links_externally",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_collections_in_magazine": {
+          "name": "open_collections_in_magazine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reading_typography": {
+          "name": "reading_typography",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_reading_history": {
+          "name": "track_reading_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count_old_posts_as_unread": {
+          "name": "count_old_posts_as_unread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclude_web_bridge": {
+          "name": "exclude_web_bridge",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_publication_theme": {
+          "name": "use_publication_theme",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hide_feed_metrics": {
+          "name": "hide_feed_metrics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feed_pagination": {
+          "name": "feed_pagination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_scope": {
+          "name": "home_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_hidden_tabs": {
+          "name": "profile_hidden_tabs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_show_likes": {
+          "name": "profile_show_likes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_authoring_enabled": {
+          "name": "collections_authoring_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userinput_feedback_enabled": {
+          "name": "userinput_feedback_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "margin_save_enabled": {
+          "name": "margin_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semble_save_enabled": {
+          "name": "semble_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocking_enabled": {
+          "name": "blocking_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "atstore_review_prompt_dismissed": {
+          "name": "atstore_review_prompt_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_enabled": {
+          "name": "weekly_digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_subscriptions": {
+          "name": "weekly_digest_section_subscriptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_network": {
+          "name": "weekly_digest_section_network",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_saved": {
+          "name": "weekly_digest_section_saved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_recommendations": {
+          "name": "weekly_digest_section_recommendations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_last_sent_at": {
+          "name": "weekly_digest_last_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_welcome_sent_at": {
+          "name": "weekly_digest_welcome_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_labelers_imported_at": {
+          "name": "bsky_labelers_imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_did_unique": {
+          "name": "user_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "did"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pds": {
+          "name": "pds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_url": {
+          "name": "banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_uri": {
+          "name": "bsky_profile_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_cid": {
+          "name": "bsky_profile_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_fetched_at": {
+          "name": "profile_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_handle_idx": {
+          "name": "profiles_handle_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_handle_trgm_idx": {
+          "name": "profiles_handle_trgm_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "profiles_display_name_trgm_idx": {
+          "name": "profiles_display_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publications": {
+      "name": "publications",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_cid": {
+          "name": "icon_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_mime": {
+          "name": "icon_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent": {
+          "name": "theme_accent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_background": {
+          "name": "theme_background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_foreground": {
+          "name": "theme_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent_foreground": {
+          "name": "theme_accent_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_json": {
+          "name": "theme_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_in_discover": {
+          "name": "show_in_discover",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "prev_next_direction": {
+          "name": "prev_next_direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_kind": {
+          "name": "serial_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_publication": {
+          "name": "collections_publication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_checked_at": {
+          "name": "verification_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(name, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(topic, '')), 'B')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publications_did_idx": {
+          "name": "publications_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_name_idx": {
+          "name": "publications_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_discover_idx": {
+          "name": "publications_discover_idx",
+          "columns": [
+            {
+              "expression": "show_in_discover",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_topic_idx": {
+          "name": "publications_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_url_idx": {
+          "name": "publications_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_serial_idx": {
+          "name": "publications_serial_idx",
+          "columns": [
+            {
+              "expression": "prev_next_direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_search_idx": {
+          "name": "publications_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_contributors": {
+      "name": "document_contributors",
+      "schema": "",
+      "columns": {
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "document_contributors_did_idx": {
+          "name": "document_contributors_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_contributors_document_uri_documents_uri_fk": {
+          "name": "document_contributors_document_uri_documents_uri_fk",
+          "tableFrom": "document_contributors",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_contributors_document_uri_did_pk": {
+          "name": "document_contributors_document_uri_did_pk",
+          "columns": [
+            "document_uri",
+            "did"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_uri": {
+          "name": "site_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_json": {
+          "name": "collection_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_renderable_body": {
+          "name": "has_renderable_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "body_image_count": {
+          "name": "body_image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_cid": {
+          "name": "cover_image_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_mime": {
+          "name": "cover_image_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backlink_count": {
+          "name": "backlink_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_count_prev": {
+          "name": "backlink_count_prev",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_synced_at": {
+          "name": "backlink_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_recomputed_at": {
+          "name": "trending_recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_recommender_count": {
+          "name": "distinct_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bsky_post_uri": {
+          "name": "bsky_post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_post_cid": {
+          "name": "bsky_post_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_updated_at": {
+          "name": "record_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(title, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(immutable_array_to_string(tags), '')), 'B') || setweight(to_tsvector('english', coalesce(text_content, '')), 'C')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documents_did_idx": {
+          "name": "documents_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_did_published_idx": {
+          "name": "documents_did_published_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"published_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_publication_published_idx": {
+          "name": "documents_publication_published_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_published_idx": {
+          "name": "documents_published_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_featured_idx": {
+          "name": "documents_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_site_idx": {
+          "name": "documents_site_idx",
+          "columns": [
+            {
+              "expression": "site_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_search_idx": {
+          "name": "documents_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "documents_trending_idx": {
+          "name": "documents_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_idx": {
+          "name": "documents_canonical_url_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_trgm_idx": {
+          "name": "documents_canonical_url_trgm_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommends": {
+      "name": "recommends",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommender_did": {
+          "name": "recommender_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recommends_document_idx": {
+          "name": "recommends_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_recommender_idx": {
+          "name": "recommends_recommender_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_edge_idx": {
+          "name": "recommends_edge_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_doc_recommender_created_idx": {
+          "name": "recommends_doc_recommender_created_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recommends\".\"deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_did": {
+          "name": "publication_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_publication_idx": {
+          "name": "subscriptions_publication_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_subscriber_idx": {
+          "name": "subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_edge_idx": {
+          "name": "subscriptions_edge_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follower_did": {
+          "name": "follower_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excluded_publications": {
+          "name": "excluded_publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_subject_idx": {
+          "name": "user_follows_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_edge_idx": {
+          "name": "user_follows_edge_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_owner_idx": {
+          "name": "bookmarks_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_document_idx": {
+          "name": "bookmarks_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_edge_idx": {
+          "name": "bookmarks_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reads": {
+      "name": "reads",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reads_owner_idx": {
+          "name": "reads_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_document_idx": {
+          "name": "reads_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_edge_idx": {
+          "name": "reads_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidebar_prefs": {
+      "name": "sidebar_prefs",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_order": {
+          "name": "list_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "tree_order": {
+          "name": "tree_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "subscription_sort": {
+          "name": "subscription_sort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customize_nav": {
+          "name": "customize_nav",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_nav": {
+          "name": "hidden_nav",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reading_progress": {
+      "name": "reading_progress",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reading_progress_owner_idx": {
+          "name": "reading_progress_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "reading_progress_owner_did_document_uri_pk": {
+          "name": "reading_progress_owner_did_document_uri_pk",
+          "columns": [
+            "owner_did",
+            "document_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_push_queue": {
+      "name": "document_push_queue",
+      "schema": "",
+      "columns": {
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_push_queue_claim_idx": {
+          "name": "document_push_queue_claim_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_push_queue_author_idx": {
+          "name": "document_push_queue_author_idx",
+          "columns": [
+            {
+              "expression": "author_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_devices": {
+      "name": "push_devices",
+      "schema": "",
+      "columns": {
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_devices_owner_idx": {
+          "name": "push_devices_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_topics": {
+      "name": "push_topics",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_topics_subject_idx": {
+          "name": "push_topics_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "push_topics_owner_did_subject_type_subject_pk": {
+          "name": "push_topics_owner_did_subject_type_subject_pk",
+          "columns": [
+            "owner_did",
+            "subject_type",
+            "subject"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_saves": {
+      "name": "list_saves",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saver_did": {
+          "name": "saver_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_owner_did": {
+          "name": "list_owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "list_saves_saver_idx": {
+          "name": "list_saves_saver_idx",
+          "columns": [
+            {
+              "expression": "saver_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "list_saves_list_uri_idx": {
+          "name": "list_saves_list_uri_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lists": {
+      "name": "lists",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publications": {
+          "name": "publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "users": {
+          "name": "users",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lists_owner_idx": {
+          "name": "lists_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rkey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_corecommends": {
+      "name": "publication_corecommends",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_recommender_count": {
+          "name": "co_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_corecomm_rank_idx": {
+          "name": "publication_corecomm_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_corecommends_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_corecommends_related_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_corecommends_publication_uri_related_publication_uri_pk": {
+          "name": "publication_corecommends_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_cosubscriptions": {
+      "name": "publication_cosubscriptions",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_subscriber_count": {
+          "name": "co_subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_cosub_rank_idx": {
+          "name": "publication_cosub_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_cosubscriptions_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_cosubscriptions_related_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_cosubscriptions_publication_uri_related_publication_uri_pk": {
+          "name": "publication_cosubscriptions_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_stats": {
+      "name": "publication_stats",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommend_count": {
+          "name": "recommend_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_document_at": {
+          "name": "last_document_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documents_7d": {
+          "name": "documents_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_7d": {
+          "name": "subscribers_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_7d": {
+          "name": "recommends_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "documents_prev_7d": {
+          "name": "documents_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_prev_7d": {
+          "name": "subscribers_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_prev_7d": {
+          "name": "recommends_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlinks_7d": {
+          "name": "backlinks_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_velocity": {
+          "name": "trending_velocity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_window_start": {
+          "name": "trending_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_stats_subscribers_idx": {
+          "name": "publication_stats_subscribers_idx",
+          "columns": [
+            {
+              "expression": "subscriber_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_active_idx": {
+          "name": "publication_stats_active_idx",
+          "columns": [
+            {
+              "expression": "last_document_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_trending_idx": {
+          "name": "publication_stats_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_stats_publication_uri_publications_uri_fk": {
+          "name": "publication_stats_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_stats",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_stats": {
+      "name": "network_stats",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discover_topic_counts": {
+      "name": "discover_topic_counts",
+      "schema": "",
+      "columns": {
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discover_topic_counts_count_idx": {
+          "name": "discover_topic_counts_count_idx",
+          "columns": [
+            {
+              "expression": "publication_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discover_topic_counts_topic_trgm_idx": {
+          "name": "discover_topic_counts_topic_trgm_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag_embeddings": {
+      "name": "tag_embeddings",
+      "schema": "",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "double precision[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_publications": {
+      "name": "topic_publications",
+      "schema": "",
+      "columns": {
+        "topic_slug": {
+          "name": "topic_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "matched_tag_count": {
+          "name": "matched_tag_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "topic_publications_rank_idx": {
+          "name": "topic_publications_rank_idx",
+          "columns": [
+            {
+              "expression": "topic_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_publications_pub_idx": {
+          "name": "topic_publications_pub_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_publications_topic_slug_topics_slug_fk": {
+          "name": "topic_publications_topic_slug_topics_slug_fk",
+          "tableFrom": "topic_publications",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "topic_publications_publication_uri_publications_uri_fk": {
+          "name": "topic_publications_publication_uri_publications_uri_fk",
+          "tableFrom": "topic_publications",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_publications_topic_slug_publication_uri_pk": {
+          "name": "topic_publications_topic_slug_publication_uri_pk",
+          "columns": [
+            "topic_slug",
+            "publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_tags": {
+      "name": "topic_tags",
+      "schema": "",
+      "columns": {
+        "topic_slug": {
+          "name": "topic_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "topic_tags_tag_idx": {
+          "name": "topic_tags_tag_idx",
+          "columns": [
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_tags_weight_idx": {
+          "name": "topic_tags_weight_idx",
+          "columns": [
+            {
+              "expression": "topic_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weight",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_tags_topic_slug_topics_slug_fk": {
+          "name": "topic_tags_topic_slug_topics_slug_fk",
+          "tableFrom": "topic_tags",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_tags_topic_slug_tag_pk": {
+          "name": "topic_tags_topic_slug_tag_pk",
+          "columns": [
+            "topic_slug",
+            "tag"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_tags": {
+          "name": "signature_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_count": {
+          "name": "tag_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author_count": {
+          "name": "author_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_model": {
+          "name": "name_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "named_at": {
+          "name": "named_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topics_published_score_idx": {
+          "name": "topics_published_score_idx",
+          "columns": [
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topics_superseded_by_topics_slug_fk": {
+          "name": "topics_superseded_by_topics_slug_fk",
+          "tableFrom": "topics",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "superseded_by"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_dead_letter": {
+      "name": "ingest_dead_letter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retries": {
+          "name": "retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingest_dead_letter_collection_idx": {
+          "name": "ingest_dead_letter_collection_idx",
+          "columns": [
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_state": {
+      "name": "ingest_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_processed": {
+          "name": "events_processed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_repos": {
+      "name": "tracked_repos",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_to_tap_at": {
+          "name": "added_to_tap_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_state": {
+          "name": "backfill_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_seen_rev": {
+          "name": "last_seen_rev",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_fail_count": {
+          "name": "reconcile_fail_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconcile_retry_after": {
+          "name": "reconcile_retry_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tracked_repos_state_idx": {
+          "name": "tracked_repos_state_idx",
+          "columns": [
+            {
+              "expression": "backfill_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_labels": {
+      "name": "document_labels",
+      "schema": "",
+      "columns": {
+        "src": {
+          "name": "src",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "val": {
+          "name": "val",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cts": {
+          "name": "cts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_labels_uri_idx": {
+          "name": "document_labels_uri_idx",
+          "columns": [
+            {
+              "expression": "uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_labels_src_idx": {
+          "name": "document_labels_src_idx",
+          "columns": [
+            {
+              "expression": "src",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "document_labels_src_uri_val_pk": {
+          "name": "document_labels_src_uri_val_pk",
+          "columns": [
+            "src",
+            "uri",
+            "val"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_sync_state": {
+      "name": "label_sync_state",
+      "schema": "",
+      "columns": {
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_count": {
+          "name": "stored_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rejected_count": {
+          "name": "rejected_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_services": {
+      "name": "labeler_services",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_endpoint": {
+          "name": "service_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels_standard_site": {
+          "name": "labels_standard_site",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels_probed_at": {
+          "name": "labels_probed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reachable": {
+          "name": "reachable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_value_definitions": {
+          "name": "label_value_definitions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_services_labeler_idx": {
+          "name": "labeler_services_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_subscriptions": {
+      "name": "labeler_subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefs": {
+          "name": "prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_subscriptions_subscriber_idx": {
+          "name": "labeler_subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labeler_subscriptions_labeler_idx": {
+          "name": "labeler_subscriptions_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_list_items": {
+      "name": "block_list_items",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "block_list_items_list_idx": {
+          "name": "block_list_items_list_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_list_items_subject_idx": {
+          "name": "block_list_items_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_list_items_list_subject_idx": {
+          "name": "block_list_items_list_subject_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_list_sync_state": {
+      "name": "block_list_sync_state",
+      "schema": "",
+      "columns": {
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_count": {
+          "name": "item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "truncated": {
+          "name": "truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_lists": {
+      "name": "block_lists",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocker_did": {
+          "name": "blocker_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "block_lists_blocker_idx": {
+          "name": "block_lists_blocker_idx",
+          "columns": [
+            {
+              "expression": "blocker_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_lists_list_idx": {
+          "name": "block_lists_list_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_sync_state": {
+      "name": "block_sync_state",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "outgoing_count": {
+          "name": "outgoing_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "incoming_count": {
+          "name": "incoming_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "list_count": {
+          "name": "list_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocker_did": {
+          "name": "blocker_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocks_subject_idx": {
+          "name": "blocks_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocks_edge_idx": {
+          "name": "blocks_edge_idx",
+          "columns": [
+            {
+              "expression": "blocker_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mutes": {
+      "name": "mutes",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "muter_did": {
+          "name": "muter_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mutes_muter_idx": {
+          "name": "mutes_muter_idx",
+          "columns": [
+            {
+              "expression": "muter_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mutes_user_edge_idx": {
+          "name": "mutes_user_edge_idx",
+          "columns": [
+            {
+              "expression": "muter_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mutes_pub_edge_idx": {
+          "name": "mutes_pub_edge_idx",
+          "columns": [
+            {
+              "expression": "muter_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_auth_code": {
+      "name": "mcp_auth_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_auth_code_expires_at_idx": {
+          "name": "mcp_auth_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_auth_code_client_id_mcp_client_id_fk": {
+          "name": "mcp_auth_code_client_id_mcp_client_id_fk",
+          "tableFrom": "mcp_auth_code",
+          "tableTo": "mcp_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_auth_code_user_id_user_id_fk": {
+          "name": "mcp_auth_code_user_id_user_id_fk",
+          "tableFrom": "mcp_auth_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_client": {
+      "name": "mcp_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_uri": {
+          "name": "client_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_uri": {
+          "name": "logo_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_token": {
+      "name": "mcp_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_token_user_id_idx": {
+          "name": "mcp_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_expires_at_idx": {
+          "name": "mcp_token_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_client_id_mcp_client_id_fk": {
+          "name": "mcp_token_client_id_mcp_client_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "mcp_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_user_id_user_id_fk": {
+          "name": "mcp_token_user_id_user_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_token_access_token_hash_unique": {
+          "name": "mcp_token_access_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token_hash"
+          ]
+        },
+        "mcp_token_refresh_token_hash_unique": {
+          "name": "mcp_token_refresh_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_shares": {
+      "name": "quote_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_text": {
+          "name": "quote_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quote_shares_document_uri_idx": {
+          "name": "quote_shares_document_uri_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_draft": {
+      "name": "feedback_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feedback_draft_user_idx": {
+          "name": "feedback_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_draft_expires_idx": {
+          "name": "feedback_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_draft_user_id_user_id_fk": {
+          "name": "feedback_draft_user_id_user_id_fk",
+          "tableFrom": "feedback_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upvote_draft": {
+      "name": "upvote_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "upvote_draft_user_idx": {
+          "name": "upvote_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upvote_draft_expires_idx": {
+          "name": "upvote_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upvote_draft_user_id_user_id_fk": {
+          "name": "upvote_draft_user_id_user_id_fk",
+          "tableFrom": "upvote_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.save_draft": {
+      "name": "save_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_app": {
+          "name": "target_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_uri": {
+          "name": "collection_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_cid": {
+          "name": "collection_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_collection_name": {
+          "name": "new_collection_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motivation": {
+          "name": "motivation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passage": {
+          "name": "passage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "save_draft_user_idx": {
+          "name": "save_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "save_draft_expires_idx": {
+          "name": "save_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "save_draft_user_id_user_id_fk": {
+          "name": "save_draft_user_id_user_id_fk",
+          "tableFrom": "save_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_thread_runs": {
+      "name": "weekly_thread_runs",
+      "schema": "",
+      "columns": {
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "root_uri": {
+          "name": "root_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/standard-reader/drizzle/meta/_journal.json
+++ b/apps/standard-reader/drizzle/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1786724326958,
       "tag": "0038_weekly_thread_runs",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1786744115710,
+      "tag": "0039_glamorous_martin_li",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/standard-reader/lexicons/app/standard-reader/authBasicFeatures.json
+++ b/apps/standard-reader/lexicons/app/standard-reader/authBasicFeatures.json
@@ -13,6 +13,7 @@
           "collection": [
             "app.standard-reader.bookmark",
             "app.standard-reader.graph.follow",
+            "app.standard-reader.graph.mute",
             "app.standard-reader.labelerSubscription",
             "app.standard-reader.labeler.subscription",
             "app.standard-reader.list",

--- a/apps/standard-reader/lexicons/app/standard-reader/graph.mute.json
+++ b/apps/standard-reader/lexicons/app/standard-reader/graph.mute.json
@@ -1,0 +1,27 @@
+{
+  "lexicon": 1,
+  "id": "app.standard-reader.graph.mute",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Mutes a subject for this reader: either a user (a DID) or a publication (the AT-URI of its site.standard.publication record). Presence of the record means muted; deleting it unmutes. The rkey is derived from the subject so each subject maps to a single record. Muted subjects are hidden from the reader's feeds and discovery surfaces, but direct navigation still works and subscriptions are untouched.",
+      "key": "any",
+      "record": {
+        "type": "object",
+        "required": ["subject", "createdAt"],
+        "properties": {
+          "subject": {
+            "type": "string",
+            "maxLength": 2048,
+            "description": "The muted subject: a user DID (did:...) or the AT-URI of a site.standard.publication record (at://...)."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "When the reader muted the subject."
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/standard-reader/src/components/muted-settings-view.tsx
+++ b/apps/standard-reader/src/components/muted-settings-view.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import { Trans, useLingui } from "@lingui/react/macro";
+import { Avatar } from "@standard-reader/design-system/avatar";
+import { Button } from "@standard-reader/design-system/button";
+import { Skeleton } from "@standard-reader/design-system/skeleton";
+import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
+import { radius } from "@standard-reader/design-system/theme/radius.stylex";
+import {
+  gap,
+  verticalSpace,
+} from "@standard-reader/design-system/theme/semantic-spacing.stylex";
+import { spacing } from "@standard-reader/design-system/theme/spacing.stylex";
+import {
+  fontSize,
+  fontWeight,
+} from "@standard-reader/design-system/theme/typography.stylex";
+import { toasts } from "@standard-reader/design-system/toast";
+import * as stylex from "@stylexjs/stylex";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+
+import type {
+  MutedPublicationItem,
+  MutedUserRow,
+} from "#/integrations/tanstack-query/api-mutes.functions";
+import { mutesApi } from "#/integrations/tanstack-query/api-mutes.functions";
+
+import { publicationLinkParams } from "./reader/format";
+import { Masthead, ReaderContent } from "./reader/primitives";
+
+function userLabel(row: MutedUserRow): string {
+  return row.displayName ?? row.handle ?? row.did;
+}
+
+function initials(label: string): string {
+  return label
+    .replace(/^did:\w+:/, "")
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+/** One muted user, with the control to undo it. */
+function MutedUserItem({
+  row,
+  canWrite,
+  onUnmute,
+  pending,
+}: {
+  row: MutedUserRow;
+  canWrite: boolean;
+  onUnmute: (subject: string) => void;
+  pending: boolean;
+}) {
+  const label = userLabel(row);
+  return (
+    <li {...stylex.props(styles.row)}>
+      <Link
+        to="/u/$did"
+        params={{ did: row.handle ?? row.did }}
+        {...stylex.props(styles.rowMain)}
+      >
+        <Avatar
+          size="sm"
+          src={row.avatarUrl ?? undefined}
+          fallback={initials(label)}
+          alt={label}
+        />
+        <span {...stylex.props(styles.rowText)}>
+          <span {...stylex.props(styles.rowName)}>{label}</span>
+          {row.handle ? (
+            <span {...stylex.props(styles.rowMeta)}>@{row.handle}</span>
+          ) : null}
+        </span>
+      </Link>
+      {canWrite ? (
+        <Button
+          variant="secondary"
+          size="sm"
+          isPending={pending}
+          onPress={() => onUnmute(row.did)}
+        >
+          <Trans>Unmute</Trans>
+        </Button>
+      ) : null}
+    </li>
+  );
+}
+
+/** One muted publication, with the control to undo it. */
+function MutedPublicationItemRow({
+  row,
+  canWrite,
+  onUnmute,
+  pending,
+}: {
+  row: MutedPublicationItem;
+  canWrite: boolean;
+  onUnmute: (subject: string) => void;
+  pending: boolean;
+}) {
+  const label = row.name ?? row.subjectUri;
+  const params = publicationLinkParams(row.subjectUri);
+  const main = (
+    <>
+      <Avatar
+        size="sm"
+        src={row.iconUrl ?? undefined}
+        fallback={initials(label)}
+        alt={label}
+      />
+      <span {...stylex.props(styles.rowText)}>
+        <span {...stylex.props(styles.rowName)}>{label}</span>
+        {row.url ? (
+          <span {...stylex.props(styles.rowMeta)}>{row.url}</span>
+        ) : null}
+      </span>
+    </>
+  );
+  return (
+    <li {...stylex.props(styles.row)}>
+      {params ? (
+        <Link
+          to="/p/$did/$rkey"
+          params={params}
+          {...stylex.props(styles.rowMain)}
+        >
+          {main}
+        </Link>
+      ) : (
+        <span {...stylex.props(styles.rowMain)}>{main}</span>
+      )}
+      {canWrite ? (
+        <Button
+          variant="secondary"
+          size="sm"
+          isPending={pending}
+          onPress={() => onUnmute(row.subjectUri)}
+        >
+          <Trans>Unmute</Trans>
+        </Button>
+      ) : null}
+    </li>
+  );
+}
+
+/**
+ * Muted people and publications.
+ *
+ * Reads the reader's `app.standard-reader.graph.mute` records. Unlike blocks
+ * these are one-directional and scoped: muted subjects disappear from feeds
+ * and discovery only, subscriptions stay intact, and their pages stay
+ * reachable — which is why every row here still links to the page it hides.
+ */
+export function MutedSettingsView() {
+  const { t } = useLingui();
+  const queryClient = useQueryClient();
+  const settings = useQuery(mutesApi.getMutedSettingsQueryOptions());
+
+  const onMutationError = () => {
+    toasts.add({
+      description: t`We couldn't reach your account to change that. Try again?`,
+      title: t`Something went wrong`,
+    });
+  };
+  const unmute = useMutation({
+    mutationFn: async (subject: string) =>
+      mutesApi.unmuteSubject({ data: { subject } }),
+    // An unmute changes every feed and discovery surface, not just this list.
+    onSuccess: () => void queryClient.invalidateQueries(),
+    onError: onMutationError,
+  });
+
+  const data = settings.data ?? null;
+  const users = data?.users ?? [];
+  const publications = data?.publications ?? [];
+  const canWrite = data?.canWrite ?? false;
+
+  return (
+    <ReaderContent>
+      <Masthead
+        kicker={t`Moderation`}
+        title={t`Muted`}
+        dek={t`Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices.`}
+        metaLabel={t`Muted`}
+        metaValue={
+          settings.isLoading ? (
+            <Skeleton variant="rectangle" height="2rem" width="3.5rem" />
+          ) : (
+            String(data?.count ?? 0)
+          )
+        }
+      />
+
+      {data && !canWrite ? (
+        <p {...stylex.props(styles.note)}>
+          <Trans>
+            Your mutes are enforced here already. To add or remove one, you'll
+            be asked to re-authorize the first time you try.
+          </Trans>
+        </p>
+      ) : null}
+
+      <section {...stylex.props(styles.section)}>
+        <h2 {...stylex.props(styles.sectionHeading)}>
+          <Trans>Muted people</Trans>
+        </h2>
+        {settings.isLoading ? (
+          <div aria-busy="true" aria-label={t`Loading muted people`}>
+            <Skeleton variant="rectangle" height="3rem" width="100%" />
+          </div>
+        ) : users.length === 0 ? (
+          <p {...stylex.props(styles.note)}>
+            <Trans>
+              You haven't muted anyone. Mute someone from the menu on their page
+              to hide everything they write — and everything they recommend —
+              without unfollowing.
+            </Trans>
+          </p>
+        ) : (
+          <ul {...stylex.props(styles.list)}>
+            {users.map((row) => (
+              <MutedUserItem
+                key={row.did}
+                row={row}
+                canWrite={canWrite}
+                pending={unmute.isPending && unmute.variables === row.did}
+                onUnmute={(subject) => unmute.mutate(subject)}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section {...stylex.props(styles.section)}>
+        <h2 {...stylex.props(styles.sectionHeading)}>
+          <Trans>Muted publications</Trans>
+        </h2>
+        {settings.isLoading ? (
+          <div aria-busy="true" aria-label={t`Loading muted publications`}>
+            <Skeleton variant="rectangle" height="3rem" width="100%" />
+          </div>
+        ) : publications.length === 0 ? (
+          <p {...stylex.props(styles.note)}>
+            <Trans>
+              You haven't muted any publications. Mute one from the menu on its
+              page to hide its articles from your feeds while staying
+              subscribed.
+            </Trans>
+          </p>
+        ) : (
+          <ul {...stylex.props(styles.list)}>
+            {publications.map((row) => (
+              <MutedPublicationItemRow
+                key={row.subjectUri}
+                row={row}
+                canWrite={canWrite}
+                pending={
+                  unmute.isPending && unmute.variables === row.subjectUri
+                }
+                onUnmute={(subject) => unmute.mutate(subject)}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+    </ReaderContent>
+  );
+}
+
+const styles = stylex.create({
+  section: {
+    marginBlockEnd: verticalSpace["2xl"],
+  },
+  sectionHeading: {
+    fontSize: fontSize.lg,
+    fontWeight: fontWeight.semibold,
+    marginBlock: spacing["0"],
+  },
+  list: {
+    gap: gap.xs,
+    display: "flex",
+    flexDirection: "column",
+    listStyle: "none",
+    marginBlock: verticalSpace.md,
+    paddingInline: spacing["0"],
+  },
+  row: {
+    gap: gap.md,
+    alignItems: "center",
+    borderRadius: radius.md,
+    display: "flex",
+    justifyContent: "space-between",
+    paddingBlock: verticalSpace.sm,
+    paddingInline: spacing["0"],
+  },
+  rowMain: {
+    gap: gap.sm,
+    alignItems: "center",
+    color: "inherit",
+    display: "flex",
+    minWidth: spacing["0"],
+    textDecoration: "none",
+  },
+  rowText: {
+    gap: gap.xxs,
+    display: "flex",
+    flexDirection: "column",
+    minWidth: spacing["0"],
+  },
+  rowName: {
+    fontSize: fontSize.sm,
+    fontWeight: fontWeight.medium,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  rowMeta: {
+    color: uiColor.text2,
+    fontSize: fontSize.xs,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  note: {
+    color: uiColor.text2,
+    fontSize: fontSize.sm,
+    marginBlock: verticalSpace.md,
+  },
+});

--- a/apps/standard-reader/src/components/reader/author-actions.tsx
+++ b/apps/standard-reader/src/components/reader/author-actions.tsx
@@ -36,6 +36,7 @@ import { useLoginSearch } from "#/utils/use-login-search";
 
 import { BlockUserDialog, BlockUserMenuItem } from "./block-user-menu-item";
 import { FollowUserButton } from "./follow-user-button";
+import { MuteDialog, MuteMenuItem } from "./mute-menu-item";
 import { NotifyButton } from "./notify-button";
 import { RssFeedDialog } from "./rss-feed-button";
 import { ShareMenuItems, useShareActions } from "./share-menu";
@@ -188,6 +189,7 @@ export function AuthorActions({
   const share = useShareActions({ pageUrl });
   const [rssOpen, setRssOpen] = useState(false);
   const [blockOpen, setBlockOpen] = useState(false);
+  const [muteOpen, setMuteOpen] = useState(false);
 
   const { data: followStatus } = useQuery({
     ...readerApi.getUserFollowStatusQueryOptions(did),
@@ -317,11 +319,18 @@ export function AuthorActions({
                 <Trans>Resume</Trans>
               </MenuItem>
             ) : null}
-            {/* Last, and behind its own separator: blocking is the one item
-                here that hides things rather than opening them. */}
+            {/* Last, and behind their own separator: muting and blocking are
+                the items here that hide things rather than opening them. Mute
+                first — it's the reversible, lighter-weight of the two. */}
             {isOwnProfile || !signedIn ? null : (
               <>
                 <MenuSeparator />
+                <MuteMenuItem
+                  subject={did}
+                  name={user.displayName ?? handle}
+                  iconSize={MENU_ICON}
+                  onOpenDialog={() => setMuteOpen(true)}
+                />
                 <BlockUserMenuItem
                   name={user.displayName ?? handle}
                   iconSize={MENU_ICON}
@@ -354,12 +363,21 @@ export function AuthorActions({
       {/* Outside `<Menu>`, like the RSS dialog above: a dialog rendered inside
           the menu unmounts with the popover the moment the item is pressed. */}
       {isOwnProfile || !signedIn ? null : (
-        <BlockUserDialog
-          did={did}
-          name={user.displayName ?? handle}
-          isOpen={blockOpen}
-          onOpenChange={setBlockOpen}
-        />
+        <>
+          <MuteDialog
+            subject={did}
+            kind="user"
+            name={user.displayName ?? handle}
+            isOpen={muteOpen}
+            onOpenChange={setMuteOpen}
+          />
+          <BlockUserDialog
+            did={did}
+            name={user.displayName ?? handle}
+            isOpen={blockOpen}
+            onOpenChange={setBlockOpen}
+          />
+        </>
       )}
     </>
   );

--- a/apps/standard-reader/src/components/reader/mute-menu-item.tsx
+++ b/apps/standard-reader/src/components/reader/mute-menu-item.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { Trans, useLingui } from "@lingui/react/macro";
+import {
+  AlertDialog,
+  AlertDialogActionButton,
+  AlertDialogCancelButton,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+} from "@standard-reader/design-system/alert-dialog";
+import { MenuItem } from "@standard-reader/design-system/menu";
+import { toasts } from "@standard-reader/design-system/toast";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Volume2, VolumeX } from "lucide-react";
+
+import { auth } from "#/integrations/tanstack-query/api-auth.functions";
+import {
+  NEEDS_MUTE_SCOPE,
+  mutesApi,
+} from "#/integrations/tanstack-query/api-mutes.functions";
+
+/** What kind of subject the mute targets — labels and copy differ. */
+export type MuteSubjectKind = "user" | "publication";
+
+/**
+ * "Mute" / "Unmute" in the author and publication overflow menus, and the
+ * confirmation the mute direction opens.
+ *
+ * Writes an `app.standard-reader.graph.mute` record to the reader's own repo.
+ * A mute hides the subject from the reader's feeds and discovery only — direct
+ * navigation still works and subscriptions are untouched — which is why, unlike
+ * blocking, the same menu can offer the undo: the page it lives on stays
+ * reachable.
+ *
+ * Muting confirms first (it's one press away from Share in the same menu and
+ * quietly rewrites every feed); unmuting is a pure restore, so it runs
+ * immediately.
+ *
+ * Writing may need a re-auth for sessions that predate the mute collection in
+ * the `authBasicFeatures` permission set. Rather than gate the item, the first
+ * press runs the progressive upgrade and returns here (the `BlockUserMenuItem`
+ * pattern).
+ *
+ * **The item and the dialog are two components on purpose.** `Menu` renders its
+ * children inside the trigger's `Popover`, so a dialog returned alongside the
+ * `MenuItem` mounts *inside* the menu — and pressing the item closes the menu,
+ * which unmounts the dialog in the same frame. The dialog has to be a sibling
+ * of `<Menu>` (see `BlockUserDialog`).
+ */
+export function MuteMenuItem({
+  subject,
+  name,
+  iconSize = 14,
+  onOpenDialog,
+}: {
+  /** A user DID or a publication AT-URI — the mute record's subject. */
+  subject: string;
+  name?: string | null;
+  iconSize?: number;
+  /** Opens {@link MuteDialog}, which the menu's parent renders as a sibling. */
+  onOpenDialog: () => void;
+}) {
+  const { t } = useLingui();
+  const queryClient = useQueryClient();
+  const { data: state } = useQuery(mutesApi.getMuteStateQueryOptions(subject));
+  const isMuted = state?.muted ?? false;
+
+  const unmute = useMutation({
+    mutationFn: async () => mutesApi.unmuteSubject({ data: { subject } }),
+    onSuccess: () => {
+      toasts.add({
+        description: name
+          ? t`${name} will show up in your feeds again.`
+          : t`They'll show up in your feeds again.`,
+        title: t`Unmuted`,
+      });
+      // A mute changes every feed and discovery surface — no narrower key.
+      void queryClient.invalidateQueries();
+    },
+    onError: () => {
+      toasts.add({
+        description: t`We couldn't remove the mute from your account. Try again?`,
+        title: t`Something went wrong`,
+      });
+    },
+  });
+
+  if (isMuted) {
+    return (
+      <MenuItem
+        onPress={() => unmute.mutate()}
+        suffix={<Volume2 size={iconSize} />}
+        textValue={name ? t`Unmute ${name}` : t`Unmute`}
+      >
+        <Trans>Unmute</Trans>
+      </MenuItem>
+    );
+  }
+  return (
+    <MenuItem
+      onPress={onOpenDialog}
+      suffix={<VolumeX size={iconSize} />}
+      textValue={name ? t`Mute ${name}` : t`Mute`}
+    >
+      <Trans>Mute</Trans>
+    </MenuItem>
+  );
+}
+
+/**
+ * The confirmation for {@link MuteMenuItem}'s mute direction. Render outside
+ * `<Menu>`.
+ */
+export function MuteDialog({
+  subject,
+  kind,
+  name,
+  isOpen,
+  onOpenChange,
+}: {
+  subject: string;
+  kind: MuteSubjectKind;
+  name?: string | null;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { t } = useLingui();
+  const queryClient = useQueryClient();
+
+  const mute = useMutation({
+    mutationFn: async () => {
+      try {
+        await mutesApi.muteSubject({ data: { subject } });
+        return { muted: true as const };
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message.includes(NEEDS_MUTE_SCOPE)
+        ) {
+          const here = new URL(globalThis.location.href);
+          const result = await auth.upgradeToMuting({
+            data: {
+              redirect: `${here.pathname}${here.search}${here.hash}`,
+            },
+          });
+          return { authorizationUrl: result.authorizationUrl };
+        }
+        throw error;
+      }
+    },
+    onSuccess: (result) => {
+      if ("authorizationUrl" in result && result.authorizationUrl) {
+        globalThis.location.href = result.authorizationUrl;
+        return;
+      }
+      onOpenChange(false);
+      // Muting is scoped, and the copy must say so: subscriptions and direct
+      // links keep working, and the undo lives in Settings → Muted.
+      toasts.add({
+        description: name
+          ? t`${name} is hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted.`
+          : t`It's hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted.`,
+        title: t`Muted`,
+      });
+      // A mute changes every feed and discovery surface — no narrower key.
+      void queryClient.invalidateQueries();
+    },
+    // Without this a failed write is indistinguishable from a successful one.
+    onError: () => {
+      onOpenChange(false);
+      toasts.add({
+        description: t`We couldn't write the mute to your account. Try again?`,
+        title: t`Something went wrong`,
+      });
+    },
+  });
+
+  return (
+    <AlertDialog
+      trigger={null}
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        // Never yank the dialog out from under a write already in flight.
+        if (!open && mute.isPending) return;
+        onOpenChange(open);
+      }}
+    >
+      <AlertDialogHeader>
+        {name ? <Trans>Mute {name}?</Trans> : <Trans>Mute?</Trans>}
+      </AlertDialogHeader>
+      <AlertDialogDescription>
+        {kind === "publication" ? (
+          <Trans>
+            This publication's articles disappear from your feeds, search and
+            discovery. Your subscription is untouched, and you can still visit
+            the publication directly. You can undo this in Settings → Muted.
+          </Trans>
+        ) : (
+          <Trans>
+            Their articles, publications and recommendations disappear from your
+            feeds, search and discovery. Your subscriptions are untouched, and
+            you can still visit their pages directly. You can undo this in
+            Settings → Muted.
+          </Trans>
+        )}
+      </AlertDialogDescription>
+      <AlertDialogFooter>
+        <AlertDialogCancelButton>
+          <Trans>Cancel</Trans>
+        </AlertDialogCancelButton>
+        <AlertDialogActionButton
+          closeOnPress={false}
+          isPending={mute.isPending}
+          onPress={() => mute.mutate()}
+        >
+          <Trans>Mute</Trans>
+        </AlertDialogActionButton>
+      </AlertDialogFooter>
+    </AlertDialog>
+  );
+}

--- a/apps/standard-reader/src/components/reader/muted-pill.tsx
+++ b/apps/standard-reader/src/components/reader/muted-pill.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { Trans, useLingui } from "@lingui/react/macro";
+import { Badge } from "@standard-reader/design-system/badge";
+import { Button } from "@standard-reader/design-system/button";
+import { HoverCard } from "@standard-reader/design-system/hover-card";
+import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
+import { radius } from "@standard-reader/design-system/theme/radius.stylex";
+import {
+  gap,
+  horizontalSpace,
+  verticalSpace,
+} from "@standard-reader/design-system/theme/semantic-spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+  tracking,
+} from "@standard-reader/design-system/theme/typography.stylex";
+import { toasts } from "@standard-reader/design-system/toast";
+import * as stylex from "@stylexjs/stylex";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { VolumeX } from "lucide-react";
+
+import { mutesApi } from "#/integrations/tanstack-query/api-mutes.functions";
+
+import type { MuteSubjectKind } from "./mute-menu-item";
+import { Kicker } from "./primitives";
+
+/**
+ * A "Muted" pill on the author / publication header, in the same visual
+ * register as a labeler label ({@link LabelerPill}) — because that's what it
+ * is: a statement about this account, sitting after the account's own words.
+ * The difference is who's speaking: a label comes from a labeler, this comes
+ * from the reader themself, so instead of linking to a labeler's page the
+ * hover card carries the undo.
+ *
+ * Muting leaves the page fully readable (that's the point — feeds and
+ * discovery only), so without this pill a muted profile looks identical to an
+ * unmuted one and the mute state is invisible until a feed is missing
+ * something. The pill is that feedback.
+ *
+ * Renders nothing for guests, unmuted subjects, or while the state query is in
+ * flight — a pill that pops in late is better than a layout that reserves
+ * space for a state that's almost always absent.
+ */
+export function MutedPill({
+  subject,
+  kind,
+  signedIn,
+}: {
+  /** A user DID or a publication AT-URI — the mute record's subject. */
+  subject: string;
+  kind: MuteSubjectKind;
+  signedIn: boolean;
+}) {
+  const { t } = useLingui();
+  const queryClient = useQueryClient();
+  const { data } = useQuery({
+    ...mutesApi.getMuteStateQueryOptions(subject),
+    enabled: signedIn,
+  });
+
+  const unmute = useMutation({
+    mutationFn: async () => mutesApi.unmuteSubject({ data: { subject } }),
+    onSuccess: () => {
+      toasts.add({
+        description:
+          kind === "publication"
+            ? t`This publication will show up in your feeds again.`
+            : t`They'll show up in your feeds again.`,
+        title: t`Unmuted`,
+      });
+      // A mute changes every feed and discovery surface — no narrower key.
+      void queryClient.invalidateQueries();
+    },
+    onError: () => {
+      toasts.add({
+        description: t`We couldn't remove the mute from your account. Try again?`,
+        title: t`Something went wrong`,
+      });
+    },
+  });
+
+  if (!signedIn || !data?.muted) return null;
+
+  return (
+    <div {...stylex.props(styles.row)}>
+      <HoverCard
+        placement="top"
+        trigger={
+          <Badge variant="default" size="sm" style={styles.pill}>
+            <VolumeX size={12} aria-hidden />
+            <Trans>Muted</Trans>
+          </Badge>
+        }
+      >
+        <div {...stylex.props(styles.card)}>
+          <div {...stylex.props(styles.meta)}>
+            <Kicker muted>
+              <Trans>Muted by you</Trans>
+            </Kicker>
+            <span {...stylex.props(styles.title)}>
+              {kind === "publication" ? (
+                <Trans>This publication is muted</Trans>
+              ) : (
+                <Trans>This person is muted</Trans>
+              )}
+            </span>
+          </div>
+          <p {...stylex.props(styles.desc)}>
+            {kind === "publication" ? (
+              <Trans>
+                Its articles are hidden from your feeds, search and discovery.
+                Your subscription is untouched, and this page still works.
+              </Trans>
+            ) : (
+              <Trans>
+                Their articles, publications and recommendations are hidden from
+                your feeds, search and discovery. Your subscriptions are
+                untouched, and this page still works.
+              </Trans>
+            )}
+          </p>
+          <div {...stylex.props(styles.foot)}>
+            <Link to="/settings/muted" {...stylex.props(styles.manage)}>
+              <Trans>Manage mutes</Trans>
+            </Link>
+            <Button
+              variant="secondary"
+              size="sm"
+              isPending={unmute.isPending}
+              onPress={() => unmute.mutate()}
+            >
+              <Trans>Unmute</Trans>
+            </Button>
+          </div>
+        </div>
+      </HoverCard>
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  row: {
+    alignItems: "center",
+    display: "flex",
+  },
+  pill: {
+    // A leading icon wants less space before it than a bare word does —
+    // matches `LabelerPill`'s avatar treatment.
+    paddingInlineStart: horizontalSpace.sm,
+  },
+  card: {
+    display: "flex",
+    flexDirection: "column",
+    rowGap: gap.md,
+    width: "20rem",
+  },
+  meta: {
+    display: "flex",
+    flexDirection: "column",
+    rowGap: verticalSpace.sm,
+    minWidth: 0,
+  },
+  title: {
+    overflow: "hidden",
+    color: uiColor.text2,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.lg,
+    fontWeight: fontWeight.bold,
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  desc: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.sm,
+    lineHeight: lineHeight.base,
+    marginBottom: 0,
+    marginTop: 0,
+  },
+  foot: {
+    alignItems: "center",
+    display: "flex",
+    justifyContent: "space-between",
+    marginInlineEnd: `calc(-1 * ${horizontalSpace.md})`,
+    // Full-bleed footer, matching `LabelerPill`: the popover content pads with
+    // `horizontalSpace.md`, so negate it so the divider spans edge to edge.
+    marginInlineStart: `calc(-1 * ${horizontalSpace.md})`,
+    paddingInlineEnd: horizontalSpace.md,
+    paddingInlineStart: horizontalSpace.md,
+    borderTopColor: uiColor.border1,
+    borderTopStyle: "solid",
+    borderTopWidth: 1,
+    paddingTop: verticalSpace.sm,
+  },
+  manage: {
+    borderRadius: radius.sm,
+    color: uiColor.text1,
+    fontFamily: fontFamily.mono,
+    fontSize: fontSize.xs,
+    fontWeight: fontWeight.medium,
+    letterSpacing: tracking.wide,
+    textDecoration: "none",
+    textTransform: "uppercase",
+  },
+});

--- a/apps/standard-reader/src/components/reader/publication-actions.tsx
+++ b/apps/standard-reader/src/components/reader/publication-actions.tsx
@@ -45,6 +45,7 @@ import { useLoginSearch } from "#/utils/use-login-search";
 import type { PublicationCard } from "../../integrations/tanstack-query/api-shapes";
 import { AddToListModal } from "./add-to-list-modal";
 import { FollowButton } from "./cards";
+import { MuteDialog, MuteMenuItem } from "./mute-menu-item";
 import { NotifyButton } from "./notify-button";
 import { RssFeedDialog } from "./rss-feed-button";
 import { ShareMenuItems, useShareActions } from "./share-menu";
@@ -249,6 +250,7 @@ export function PublicationActions({
   const [listOpen, setListOpen] = useState(false);
   const [rssOpen, setRssOpen] = useState(false);
   const [markAllReadOpen, setMarkAllReadOpen] = useState(false);
+  const [muteOpen, setMuteOpen] = useState(false);
 
   const { data: followStatus } = useQuery({
     ...readerApi.getFollowStatusQueryOptions(pub.uri),
@@ -353,6 +355,19 @@ export function PublicationActions({
                 <Trans>Visit publication site</Trans>
               </MenuItem>
             ) : null}
+            {/* Last, behind its own separator: the one item here that hides
+                things rather than opening them. */}
+            {signedIn ? (
+              <>
+                <MenuSeparator />
+                <MuteMenuItem
+                  subject={pub.uri}
+                  name={pub.name}
+                  iconSize={MENU_ICON}
+                  onOpenDialog={() => setMuteOpen(true)}
+                />
+              </>
+            ) : null}
           </Menu>
         </ButtonGroup>
         <NotifyButton
@@ -375,6 +390,18 @@ export function PublicationActions({
         isOpen={rssOpen}
         onOpenChange={setRssOpen}
       />
+
+      {/* Outside `<Menu>`, like the RSS dialog above: a dialog rendered inside
+          the menu unmounts with the popover the moment the item is pressed. */}
+      {signedIn ? (
+        <MuteDialog
+          subject={pub.uri}
+          kind="publication"
+          name={pub.name}
+          isOpen={muteOpen}
+          onOpenChange={setMuteOpen}
+        />
+      ) : null}
 
       {signedIn ? (
         <AddToListModal

--- a/apps/standard-reader/src/components/user-settings-view.tsx
+++ b/apps/standard-reader/src/components/user-settings-view.tsx
@@ -73,6 +73,7 @@ import { feedApi } from "#/integrations/tanstack-query/api-feed.functions";
 import { labelerApi } from "#/integrations/tanstack-query/api-labelers.functions";
 import { listApi } from "#/integrations/tanstack-query/api-lists.functions";
 import { mcpApi } from "#/integrations/tanstack-query/api-mcp.functions";
+import { mutesApi } from "#/integrations/tanstack-query/api-mutes.functions";
 import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
 import type { DigestSectionKey } from "#/integrations/tanstack-query/api-user.functions";
 import { user } from "#/integrations/tanstack-query/api-user.functions";
@@ -420,6 +421,8 @@ export function UserSettingsView() {
   // Just the headline count — the list itself lives on `/settings/blocks`.
   const blocks = useQuery(blocksApi.getBlockCapabilityQueryOptions());
   const blockCount = blocks.data?.accountCount ?? null;
+  const mutes = useQuery(mutesApi.getMuteCapabilityQueryOptions());
+  const muteCount = mutes.data?.count ?? null;
   const connections = useQuery(mcpApi.listConnectionsQueryOptions());
   const fmt = useFormatters();
   const revokeConnectionMutation = useMutation({
@@ -1214,6 +1217,19 @@ export function UserSettingsView() {
                 <Trans>Manage blocks</Trans>
               ) : (
                 <Trans>Manage {blockCount} blocks</Trans>
+              )}
+            </ButtonLink>
+          </SettingRow>
+          <Separator />
+          <SettingRow
+            label={t`Muted`}
+            description={t`Muted people and publications stay subscribed but disappear from your feeds, search, and discovery. Only you can see your mutes' effect — nobody is notified.`}
+          >
+            <ButtonLink to="/settings/muted" variant="secondary" size="sm">
+              {muteCount == null ? (
+                <Trans>Manage mutes</Trans>
+              ) : (
+                <Trans>Manage {muteCount} mutes</Trans>
               )}
             </ButtonLink>
           </SettingRow>

--- a/apps/standard-reader/src/db/schema.ts
+++ b/apps/standard-reader/src/db/schema.ts
@@ -27,6 +27,7 @@ export * from "./schema/topics.ts";
 export * from "./schema/ingest.ts";
 export * from "./schema/labels.ts";
 export * from "./schema/blocks.ts";
+export * from "./schema/mutes.ts";
 export * from "./schema/mcp.ts";
 export * from "./schema/quote-shares.ts";
 export * from "./schema/relations.ts";

--- a/apps/standard-reader/src/db/schema/mutes.ts
+++ b/apps/standard-reader/src/db/schema/mutes.ts
@@ -1,0 +1,59 @@
+import { boolean, index, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+/**
+ * Mutes — mirrored `app.standard-reader.graph.mute` records.
+ *
+ * One row per record in the muter's repo. A mute hides the subject from the
+ * reader's feeds and discovery surfaces only: direct navigation still works and
+ * subscriptions are untouched. Unlike {@link blocks} it is strictly
+ * one-directional — being muted by someone never hides *their* content from
+ * you — so there is no incoming half to mirror.
+ *
+ * The record's `subject` is either a user DID or the AT-URI of a
+ * `site.standard.publication`. The raw value is kept in `subject`, and ingest
+ * classifies it into exactly one of `subjectDid` / `subjectUri` so feed SQL
+ * correlates on an indexed column instead of a string-prefix test.
+ */
+export const mutes = pgTable(
+  "mutes",
+  {
+    /** AT-URI of the `app.standard-reader.graph.mute` record. */
+    uri: text("uri").primaryKey(),
+    cid: text("cid"),
+    /** DID of the muter (the repo that holds this record). */
+    muterDid: text("muter_did").notNull(),
+    rkey: text("rkey").notNull(),
+
+    /** The record's raw `subject` — a user DID or a publication AT-URI. */
+    subject: text("subject").notNull(),
+    /** DID of the muted user; set iff this is a user mute. */
+    subjectDid: text("subject_did"),
+    /** AT-URI of the muted publication; set iff this is a publication mute. */
+    subjectUri: text("subject_uri"),
+
+    /** `createdAt` from the record. */
+    createdAt: timestamp("created_at", { withTimezone: true }),
+
+    deleted: boolean("deleted").notNull().default(false),
+
+    indexedAt: timestamp("indexed_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    // "does this reader have any mutes" gate + the settings listing.
+    index("mutes_muter_idx").on(table.muterDid),
+    // Per-candidate probe: is this author / publication owner muted by the
+    // viewer. Serves the user-mute `NOT EXISTS` branches in feed queries and
+    // the single-edge mute-state lookup.
+    index("mutes_user_edge_idx").on(table.muterDid, table.subjectDid),
+    // Per-candidate probe: is this publication muted by the viewer.
+    index("mutes_pub_edge_idx").on(table.muterDid, table.subjectUri),
+  ],
+);
+
+export type Mute = typeof mutes.$inferSelect;
+export type NewMute = typeof mutes.$inferInsert;

--- a/apps/standard-reader/src/integrations/auth/scope.test.ts
+++ b/apps/standard-reader/src/integrations/auth/scope.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { hasMuteWriteScope } from "./scope";
+
+const MUTE = "app.standard-reader.graph.mute";
+
+describe("hasMuteWriteScope", () => {
+  it("accepts the verbatim authBasicFeatures set token", () => {
+    expect(
+      hasMuteWriteScope(
+        "atproto include:app.standard-reader.authBasicFeatures",
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts a PDS-expanded repo?collection token", () => {
+    expect(
+      hasMuteWriteScope(`atproto repo?collection=${MUTE}&action=create`),
+    ).toBe(true);
+    // Several collections in one token.
+    expect(
+      hasMuteWriteScope(
+        `atproto repo?collection=app.standard-reader.bookmark&collection=${MUTE}`,
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts the action-less repo: form", () => {
+    expect(hasMuteWriteScope(`atproto repo:${MUTE}`)).toBe(true);
+  });
+
+  it("rejects tokens granting other collections only", () => {
+    expect(
+      hasMuteWriteScope(
+        "atproto repo?collection=app.standard-reader.bookmark&action=create",
+      ),
+    ).toBe(false);
+    expect(hasMuteWriteScope("atproto repo:app.standard-reader.read")).toBe(
+      false,
+    );
+  });
+
+  it("rejects a mute token whose actions exclude create", () => {
+    expect(
+      hasMuteWriteScope(`atproto repo?collection=${MUTE}&action=delete`),
+    ).toBe(false);
+  });
+
+  it("rejects empty and absent scopes", () => {
+    expect(hasMuteWriteScope(null)).toBe(false);
+    expect(hasMuteWriteScope("")).toBe(false);
+    expect(hasMuteWriteScope("atproto")).toBe(false);
+  });
+});

--- a/apps/standard-reader/src/integrations/auth/scope.ts
+++ b/apps/standard-reader/src/integrations/auth/scope.ts
@@ -427,6 +427,32 @@ export function hasUserinputUpvoteScope(
 }
 
 /**
+ * Detect whether the granted scope includes the mute writer tier
+ * (`app.standard-reader.graph.mute`, part of the `authBasicFeatures` set).
+ * Accepts the `include:app.standard-reader.authBasicFeatures` set token
+ * verbatim, or (if the PDS expanded the set) a granular
+ * `repo?collection=app.standard-reader.graph.mute` token — with or without
+ * `action=create` — or the action-less `repo:` form.
+ *
+ * The verbatim `include:` check is optimistic for sessions granted *before*
+ * the set was republished with the mute collection: whether such a grant
+ * covers the new NSID depends on whether the PDS resolves sets at token-use
+ * time or froze the expansion at grant. The mute write path treats a PDS
+ * scope rejection as the truth and maps it to a re-auth prompt, so this
+ * helper only needs to be right for the common case.
+ */
+export function hasMuteWriteScope(
+  grantedScope: string | null | undefined,
+): boolean {
+  if (!grantedScope) return false;
+  const tokens = grantedScope.split(/\s+/);
+  if (tokens.includes(AUTH_BASIC_FEATURES)) return true;
+  return tokens.some((token) =>
+    repoScopeAllowsCreateForCollection(token, APP_NSID.graphMute),
+  );
+}
+
+/**
  * Detect whether the granted scope includes the Margin save writer tier.
  * Accepts the `include:at.margin.authFull` set token verbatim, or (if the PDS
  * expanded the set) a granular `repo?collection=at.margin.note` token — with

--- a/apps/standard-reader/src/integrations/tanstack-query/api-auth.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-auth.functions.ts
@@ -780,6 +780,59 @@ const upgradeToBlocking = createServerFn({ method: "POST" })
   });
 
 /**
+ * Scope refresh for mute writes: re-authorize the signed-in reader so their
+ * session picks up the republished `authBasicFeatures` set, whose collection
+ * list now includes `app.standard-reader.graph.mute`.
+ *
+ * Unlike {@link upgradeToBlocking} there is no opt-in flag to persist and no
+ * extra scope to request — mute lives inside the basic set every login already
+ * asks for, so the plain resolved scope is the right request. This exists only
+ * for sessions granted before the set was republished, whose tokens may not
+ * cover the new collection (the write path detects that and routes here).
+ */
+const upgradeToMuting = createServerFn({ method: "POST" })
+  .validator(upgradeToCollectionsInputSchema)
+  .handler(async ({ data }) => {
+    const request = getRequest();
+    const { getReaderContextForRequest } =
+      await import("#/middleware/auth-session.server");
+
+    const reader = await getReaderContextForRequest(request);
+    if (!reader) {
+      throw new Error("Unauthorized");
+    }
+
+    try {
+      await revokeAtprotoSession(
+        reader.did as Parameters<typeof revokeAtprotoSession>[0],
+      );
+    } catch (error) {
+      console.warn(
+        "Failed to revoke Atproto session during muting upgrade:",
+        error,
+      );
+    }
+
+    const redirectTarget = sanitizeAuthRedirectTarget(
+      data.redirect,
+      request.url,
+    );
+
+    const { url } = await atprotoOAuth.authorize({
+      target: {
+        type: "account",
+        identifier: reader.did as ActorIdentifier,
+      },
+      scope: await resolveUpgradeScope(reader.userId, {}),
+      state: {
+        redirect: redirectTarget,
+      },
+    });
+
+    return { authorizationUrl: url.toString() };
+  });
+
+/**
  * Progressive scope upgrade: opt the signed-in reader into saving articles to
  * their Semble collections. Mirrors {@link upgradeToMargin} for
  * `SEMBLE_FULL_SCOPE` / `user.sembleSaveEnabled`.
@@ -936,6 +989,7 @@ export const auth = {
   upgradeToMargin,
   upgradeToSemble,
   upgradeToBlocking,
+  upgradeToMuting,
   upgradeToWeeklyDigest,
   disableWeeklyDigest,
   getSavedHandles: getSavedHandlesServer,

--- a/apps/standard-reader/src/integrations/tanstack-query/api-discover.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-discover.functions.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 import { getAtprotoSessionForRequest } from "#/middleware/auth-session.server";
 import { blockFilterDid, filterBlockedCards } from "#/server/blocks/blocks";
+import { filterMutedCards, muteFilterDid } from "#/server/mutes/mutes";
 import type { Span } from "#/server/observability/log";
 import { observe } from "#/server/observability/log";
 import { attachReaderSpanContext } from "#/server/observability/span-context.ts";
@@ -135,7 +136,12 @@ async function loadRecommendedRail(
           followUris,
           seed: rotationSeed("discover", did),
         });
-  const visible = await filterBlockedCards(db, schema, did, items);
+  const visible = await filterMutedCards(
+    db,
+    schema,
+    did,
+    await filterBlockedCards(db, schema, did, items),
+  );
   return visible.filter((pub) => pub.documentCount > 0);
 }
 
@@ -177,7 +183,9 @@ async function loadDiscoverExtras(
           excludeWebBridge,
           followUris,
           seed: rotationSeed("discover-followed-by", did),
-        }).then((rows) => filterBlockedCards(db, schema, did, rows))
+        })
+          .then((rows) => filterBlockedCards(db, schema, did, rows))
+          .then((rows) => filterMutedCards(db, schema, did, rows))
       : Promise.resolve([]),
   ]);
 
@@ -377,6 +385,7 @@ const getPublications = createServerFn({ method: "GET" })
       const items = await discoverDirectoryPublications(db, schema, {
         topic: data.topic ?? null,
         viewerDid: await blockFilterDid(db, schema, session?.did),
+        muterDid: await muteFilterDid(db, schema, session?.did),
         // The topic chips now surface the full document-tag vocabulary, so a
         // selected chip must match any document tag — not only a publication's
         // single effective topic — or tags past the dominant one return empty.
@@ -406,13 +415,18 @@ const getTrendingPublications = createServerFn({ method: "GET" })
       async ({ data, context }, span) => {
         const { db, schema } = context;
         const session = await getAtprotoSessionForRequest(getRequest());
-        const items = await filterBlockedCards(
+        const items = await filterMutedCards(
           db,
           schema,
           session?.did,
-          await trendingPublications(db, schema, data.limit, {
-            excludeWebBridge: context.excludeWebBridgeEnabled,
-          }),
+          await filterBlockedCards(
+            db,
+            schema,
+            session?.did,
+            await trendingPublications(db, schema, data.limit, {
+              excludeWebBridge: context.excludeWebBridgeEnabled,
+            }),
+          ),
         );
         span.set("count", items.length);
         return items;
@@ -587,9 +601,9 @@ const getOnboardingSuggestions = createServerFn({ method: "GET" })
           : [];
 
         const [trending, topicGroups] = await Promise.all([
-          trendingPublications(db, schema, 6, { excludeWebBridge }).then(
-            (rows) => filterBlockedCards(db, schema, did, rows),
-          ),
+          trendingPublications(db, schema, 6, { excludeWebBridge })
+            .then((rows) => filterBlockedCards(db, schema, did, rows))
+            .then((rows) => filterMutedCards(db, schema, did, rows)),
           Promise.all(
             topics.map(async (topic) => ({
               topic,
@@ -600,23 +614,29 @@ const getOnboardingSuggestions = createServerFn({ method: "GET" })
                 offset: 0,
                 excludeWebBridge,
                 viewerDid: await blockFilterDid(db, schema, did),
+                muterDid: await muteFilterDid(db, schema, did),
               }),
             })),
           ),
         ]);
 
         const trendingUris = trending.map((pub) => pub.uri);
-        const popular = await filterBlockedCards(
+        const popular = await filterMutedCards(
           db,
           schema,
           did,
-          await popularPublications(
+          await filterBlockedCards(
             db,
             schema,
-            data.limit,
-            [...new Set([...followUris, ...trendingUris])],
-            rotationSeed("onboarding", did ?? "anon"),
-            { excludeWebBridge },
+            did,
+            await popularPublications(
+              db,
+              schema,
+              data.limit,
+              [...new Set([...followUris, ...trendingUris])],
+              rotationSeed("onboarding", did ?? "anon"),
+              { excludeWebBridge },
+            ),
           ),
         );
 
@@ -692,11 +712,11 @@ const getFollowedByPeopleYouFollow = createServerFn({ method: "GET" })
             seed: rotationSeed("discover-followed-by", session.did),
           },
         );
-        const visible = await filterBlockedCards(
+        const visible = await filterMutedCards(
           db,
           schema,
           session.did,
-          items,
+          await filterBlockedCards(db, schema, session.did, items),
         );
         span.set("count", visible.length);
         return visible;

--- a/apps/standard-reader/src/integrations/tanstack-query/api-feed.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-feed.functions.ts
@@ -24,6 +24,11 @@ import {
   labelSubjects,
   readLabelsForSubjects,
 } from "#/server/labeler/labels.server";
+import {
+  filterMutedCards,
+  muteFilterDid,
+  mutedSubjectsAmong,
+} from "#/server/mutes/mutes";
 import type { Span } from "#/server/observability/log";
 import { observe } from "#/server/observability/log";
 import { attachReaderSpanContext } from "#/server/observability/span-context.ts";
@@ -281,14 +286,35 @@ async function resolveHomeFeedContext(
   const excludeWebBridge = did ? (excludeWebBridgeEnabled ?? false) : false;
 
   const [
-    { publicationUris: followUris, userDids: followedUserDids },
+    { publicationUris: rawFollowUris, userDids: rawFollowedUserDids },
     blockDid,
+    muteDid,
   ] = await Promise.all([
     did
       ? effectiveFollowSets(db, schema, did)
       : Promise.resolve({ publicationUris: [], userDids: [] }),
     blockFilterDid(db, schema, did),
+    muteFilterDid(db, schema, did),
   ]);
+  // Pre-filter the follow sets rather than relying on the SQL predicate alone:
+  // removing a muted user here is what removes their *recommend*-sourced
+  // entries (the recommend union branch keys off `followedUserDids`), and
+  // removing a muted publication keeps its whole branch out of the union. The
+  // `muterDid` predicate below still catches what pre-filtering can't see —
+  // e.g. a guest post by a muted author inside a followed publication.
+  const muted =
+    muteDid && (rawFollowedUserDids.length > 0 || rawFollowUris.length > 0)
+      ? await mutedSubjectsAmong(db, schema, muteDid, {
+          dids: rawFollowedUserDids,
+          uris: rawFollowUris,
+        })
+      : null;
+  const followUris = muted
+    ? rawFollowUris.filter((uri) => !muted.uris.has(uri))
+    : rawFollowUris;
+  const followedUserDids = muted
+    ? rawFollowedUserDids.filter((mutedDid) => !muted.dids.has(mutedDid))
+    : rawFollowedUserDids;
   const hasFollows = followUris.length > 0 || followedUserDids.length > 0;
   const isTrending = scope === "trending";
   const personalized = hasFollows && scope === "follows";
@@ -303,17 +329,20 @@ async function resolveHomeFeedContext(
         followedUserDids,
         countOldPostsAsUnread,
         ...(blockDid ? { viewerDid: blockDid } : {}),
+        ...(muteDid ? { muterDid: muteDid } : {}),
         ...(trackReading && did ? { readForDid: did, unreadForDid: did } : {}),
       }
     : {
         discoverOnly: true,
         excludeWebBridge,
         ...(blockDid ? { viewerDid: blockDid } : {}),
+        ...(muteDid ? { muterDid: muteDid } : {}),
       };
 
   return {
     did,
     blockDid,
+    muteDid,
     followUris,
     followedUserDids,
     trackReading,
@@ -348,16 +377,17 @@ async function buildHomeFeedCritical(
         readForDid: trackReading && ctx.did ? ctx.did : undefined,
         excludeWebBridge: ctx.excludeWebBridge,
         viewerDid: ctx.blockDid,
+        muterDid: ctx.muteDid,
       }),
     ]);
-    // Publication rails aren't paginated, so blocked owners are dropped from
-    // the page rather than excluded in SQL — a shorter rail is fine where a
-    // shorter *feed* page would strand results behind the offset.
-    const trendingPubs = await filterBlockedCards(
+    // Publication rails aren't paginated, so blocked/muted owners are dropped
+    // from the page rather than excluded in SQL — a shorter rail is fine where
+    // a shorter *feed* page would strand results behind the offset.
+    const trendingPubs = await filterMutedCards(
       db,
       schema,
       ctx.did,
-      trendingPubsRaw,
+      await filterBlockedCards(db, schema, ctx.did, trendingPubsRaw),
     );
     span.set("trendingPublications", trendingPubs.length);
 
@@ -417,11 +447,11 @@ async function buildHomeFeedCritical(
       limit: HOME_ROW_LIMIT + 1,
     }),
   ]);
-  const trendingPubs = await filterBlockedCards(
+  const trendingPubs = await filterMutedCards(
     db,
     schema,
     ctx.did,
-    trendingPubsRaw,
+    await filterBlockedCards(db, schema, ctx.did, trendingPubsRaw),
   );
   span.set("trendingPublications", trendingPubs.length);
 
@@ -533,13 +563,14 @@ async function buildHomeFeedExtras(
           rotationSeed("home", did ?? "anon"),
           { excludeWebBridge },
         );
-  // Never recommend a publication whose owner the reader is blocked from —
-  // "you might follow" is the one rail where that would read as an endorsement.
-  const youMightFollow = await filterBlockedCards(
+  // Never recommend a publication whose owner the reader is blocked from or
+  // has muted — "you might follow" is the one rail where that would read as an
+  // endorsement.
+  const youMightFollow = await filterMutedCards(
     db,
     schema,
     did,
-    youMightFollowRaw,
+    await filterBlockedCards(db, schema, did, youMightFollowRaw),
   );
 
   span.set("youMightFollow", youMightFollow.length);
@@ -710,14 +741,32 @@ async function loadLatestFeedCritical(
   span.set("offset", data.offset);
 
   const [
-    { publicationUris: followUris, userDids: followedUserDids },
+    { publicationUris: rawFollowUris, userDids: rawFollowedUserDids },
     blockDid,
+    muteDid,
   ] = await Promise.all([
     did
       ? effectiveFollowSets(db, schema, did)
       : Promise.resolve({ publicationUris: [], userDids: [] }),
     blockFilterDid(db, schema, did),
+    muteFilterDid(db, schema, did),
   ]);
+  // Same pre-filter as the home feed: dropping muted sources from the input
+  // sets removes their recommend-sourced entries; the `muterDid` predicate
+  // catches guest posts by muted authors inside followed publications.
+  const muted =
+    muteDid && (rawFollowedUserDids.length > 0 || rawFollowUris.length > 0)
+      ? await mutedSubjectsAmong(db, schema, muteDid, {
+          dids: rawFollowedUserDids,
+          uris: rawFollowUris,
+        })
+      : null;
+  const followUris = muted
+    ? rawFollowUris.filter((uri) => !muted.uris.has(uri))
+    : rawFollowUris;
+  const followedUserDids = muted
+    ? rawFollowedUserDids.filter((mutedDid) => !muted.dids.has(mutedDid))
+    : rawFollowedUserDids;
   span.set("follows", followUris.length);
   span.set("followedUsers", followedUserDids.length);
   const trackReading = did == null ? false : trackReadingEnabled;
@@ -739,6 +788,7 @@ async function loadLatestFeedCritical(
             scope: "page",
             excludeWebBridge,
             viewerDid: blockDid,
+            muterDid: muteDid,
           })
         : []
       : await selectArticleCards(db, schema, {
@@ -753,6 +803,7 @@ async function loadLatestFeedCritical(
           readForDid: trackReading && did ? did : undefined,
           countOldPostsAsUnread,
           viewerDid: blockDid,
+          muterDid: muteDid,
           limit: data.limit,
           offset: data.offset,
         });
@@ -816,9 +867,32 @@ async function loadLatestFeedCounts(
   countOldPostsAsUnreadEnabled = true,
   excludeWebBridgeEnabled = false,
 ): Promise<LatestFeedCounts> {
-  const { publicationUris: followUris, userDids: followedUserDids } = did
-    ? await effectiveFollowSets(db, schema, did)
-    : { publicationUris: [], userDids: [] };
+  const [
+    { publicationUris: rawFollowUris, userDids: rawFollowedUserDids },
+    muteDid,
+  ] = await Promise.all([
+    did
+      ? effectiveFollowSets(db, schema, did)
+      : Promise.resolve({ publicationUris: [], userDids: [] }),
+    muteFilterDid(db, schema, did),
+  ]);
+  // Counts must agree with the rows: the feed pre-filters muted sources out of
+  // its input sets, so the badge totals drop them the same way. (Blocks skip
+  // counts entirely — the correlated predicate is too expensive for a badge —
+  // and the same goes for muted guest posts inside followed publications.)
+  const muted =
+    muteDid && (rawFollowedUserDids.length > 0 || rawFollowUris.length > 0)
+      ? await mutedSubjectsAmong(db, schema, muteDid, {
+          dids: rawFollowedUserDids,
+          uris: rawFollowUris,
+        })
+      : null;
+  const followUris = muted
+    ? rawFollowUris.filter((uri) => !muted.uris.has(uri))
+    : rawFollowUris;
+  const followedUserDids = muted
+    ? rawFollowedUserDids.filter((mutedDid) => !muted.dids.has(mutedDid))
+    : rawFollowedUserDids;
   span.set("follows", followUris.length);
   span.set("followedUsers", followedUserDids.length);
   const trackReading = did == null ? false : trackReadingEnabled;

--- a/apps/standard-reader/src/integrations/tanstack-query/api-mutes.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-mutes.functions.ts
@@ -1,0 +1,375 @@
+import { ClientResponseError } from "@atcute/client";
+import { queryOptions } from "@tanstack/react-query";
+import { createServerFn } from "@tanstack/react-start";
+import { getRequest } from "@tanstack/react-start/server";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { hasMuteWriteScope } from "#/integrations/auth/scope";
+import { classifyMuteSubject } from "#/lib/mutes";
+import {
+  getAtprotoSessionForRequest,
+  getReaderContextForRequest,
+} from "#/middleware/auth-session.server";
+import { cdnImageUrl } from "#/server/atproto/blob";
+import {
+  deleteMuteRecords,
+  putMuteRecord,
+  subjectRkey,
+} from "#/server/atproto/repo-records";
+import { upsertMute } from "#/server/ingest/handlers";
+import { ensureTracked } from "#/server/ingest/tap-client";
+import type { MutedPublicationRow, MutedUserRow } from "#/server/mutes/mutes";
+import {
+  countReaderMutes,
+  invalidateMuteCache,
+  isMutedForViewer,
+  readerMutedPublications,
+  readerMutedUsers,
+} from "#/server/mutes/mutes";
+import { observe } from "#/server/observability/log";
+
+import { dbMiddleware } from "./db-middleware";
+
+export type { MutedUserRow };
+
+/** {@link MutedPublicationRow} with the icon blob resolved to a browser URL. */
+export interface MutedPublicationItem extends Omit<
+  MutedPublicationRow,
+  "iconCid"
+> {
+  iconUrl: string | null;
+}
+
+/**
+ * Mutes — reading and writing the reader's `app.standard-reader.graph.mute`
+ * records.
+ *
+ * Writes go to the reader's repo, never to our tables directly: the record is
+ * the mute, and the read-model is a mirror. Unlike blocks (arbitrary repos,
+ * refreshed by re-reading the PDS), a mute is our own record with a
+ * deterministic rkey, so every write here eagerly mirrors the row it just
+ * wrote — the mute takes effect on the very next page, and the firehose upsert
+ * that follows is a no-op.
+ */
+
+const muteInput = z.object({
+  /** A user DID (`did:...`) or a publication AT-URI (`at://...`). */
+  subject: z
+    .string()
+    .min(1)
+    .max(2048)
+    .refine((value) => classifyMuteSubject(value) !== null, {
+      message: "Subject must be a user DID or a publication AT-URI.",
+    }),
+});
+
+const mutedSettingsInput = z.object({
+  limit: z.number().int().min(1).max(100).default(50),
+});
+
+/** The reader's mutes, as the settings page renders them. */
+export interface MutedSettings {
+  /** Users the reader mutes, newest first. */
+  users: Array<MutedUserRow>;
+  /** Publications the reader mutes, newest first. */
+  publications: Array<MutedPublicationItem>;
+  /** Total mutes across both kinds. */
+  count: number;
+  /**
+   * Whether the reader has granted write access to their mute records. When
+   * false the page is read-only: their mutes are still enforced, they just
+   * can't add or remove one without re-authorizing.
+   */
+  canWrite: boolean;
+}
+
+const getMutedSettings = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware])
+  .validator(mutedSettingsInput)
+  .handler(
+    observe(
+      "mutes.getSettings",
+      async ({ data, context }, span): Promise<MutedSettings | null> => {
+        const { db, schema } = context;
+        const reader = await getReaderContextForRequest(getRequest());
+        if (!reader) return null;
+        span.set("did", reader.did);
+
+        const [users, publications, count, account] = await Promise.all([
+          readerMutedUsers(db, schema, reader.did, { limit: data.limit }),
+          readerMutedPublications(db, schema, reader.did, {
+            limit: data.limit,
+          }),
+          countReaderMutes(db, schema, reader.did),
+          db.query.account.findFirst({
+            where: and(
+              eq(schema.account.userId, reader.userId),
+              eq(schema.account.providerId, "atproto"),
+            ),
+            columns: { scope: true },
+          }),
+        ]);
+
+        span.set("count", count);
+        return {
+          users,
+          publications: publications.map(
+            ({ iconCid, ...row }): MutedPublicationItem => ({
+              ...row,
+              iconUrl:
+                iconCid && row.ownerDid
+                  ? cdnImageUrl(row.ownerDid, iconCid, "png")
+                  : null,
+            }),
+          ),
+          count,
+          canWrite: hasMuteWriteScope(account?.scope),
+        };
+      },
+    ),
+  );
+
+/**
+ * The two facts surfaces outside `/settings/muted` want: whether a Mute button
+ * would work, and the headline count for the settings row. Mirrors
+ * `getBlockCapability`.
+ */
+export interface MuteCapability {
+  canWrite: boolean;
+  count: number;
+}
+
+const getMuteCapability = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware])
+  .handler(
+    observe(
+      "mutes.getCapability",
+      async ({ context }, span): Promise<MuteCapability | null> => {
+        const { db, schema } = context;
+        const reader = await getReaderContextForRequest(getRequest());
+        if (!reader) return null;
+
+        const [account, count] = await Promise.all([
+          db.query.account.findFirst({
+            where: and(
+              eq(schema.account.userId, reader.userId),
+              eq(schema.account.providerId, "atproto"),
+            ),
+            columns: { scope: true },
+          }),
+          countReaderMutes(db, schema, reader.did),
+        ]);
+        span.set("count", count);
+        return { canWrite: hasMuteWriteScope(account?.scope), count };
+      },
+    ),
+  );
+
+/** Whether one subject is muted by the reader, for the menu items. */
+const getMuteState = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware])
+  .validator(muteInput)
+  .handler(
+    observe(
+      "mutes.getMuteState",
+      async ({ data, context }, span): Promise<{ muted: boolean }> => {
+        const reader = await getReaderContextForRequest(getRequest());
+        if (!reader) return { muted: false };
+        const muted = await isMutedForViewer(
+          context.db,
+          context.schema,
+          reader.did,
+          data.subject,
+        );
+        span.set("muted", muted);
+        return { muted };
+      },
+    ),
+  );
+
+/**
+ * Thrown when the reader hasn't granted mute-write access yet, so the UI can
+ * offer the re-authorize flow instead of surfacing a raw PDS rejection.
+ *
+ * Two paths throw it: the optimistic scope-string check below, and a 401/403
+ * from the PDS on the write itself — the latter catches sessions whose
+ * `include:authBasicFeatures` grant predates the set being republished with
+ * the mute collection and wasn't re-expanded (PDS-dependent behavior).
+ */
+const NEEDS_MUTE_SCOPE = "needs-mute-scope";
+
+/** The reader's authenticated PDS client, once we know they can write mutes. */
+async function requireMuteWriter() {
+  const session = await getAtprotoSessionForRequest(getRequest());
+  if (!session) {
+    throw new Error("Unauthorized");
+  }
+  const [{ db }, schema] = await Promise.all([
+    import("#/db/index.server"),
+    import("#/db/schema"),
+  ]);
+  const account = await db.query.account.findFirst({
+    where: and(
+      eq(schema.account.userId, session.session.user.id),
+      eq(schema.account.providerId, "atproto"),
+    ),
+    columns: { scope: true },
+  });
+  if (!hasMuteWriteScope(account?.scope)) {
+    throw new Error(NEEDS_MUTE_SCOPE);
+  }
+  return session;
+}
+
+/**
+ * Re-throw a PDS rejection of a mute write as {@link NEEDS_MUTE_SCOPE} when it
+ * looks like a scope problem. After a successful session resume, a 401/403 on
+ * a write to the reader's *own* repo means the token doesn't cover the
+ * collection — the pre-republish-grant case the optimistic check can't see.
+ */
+function rethrowMuteScopeRejection(error: unknown): never {
+  if (
+    error instanceof ClientResponseError &&
+    (error.status === 401 || error.status === 403)
+  ) {
+    throw new Error(NEEDS_MUTE_SCOPE);
+  }
+  throw error;
+}
+
+const muteSubject = createServerFn({ method: "POST" })
+  .validator(muteInput)
+  .handler(
+    observe("mutes.mute", async ({ data }, span) => {
+      const session = await requireMuteWriter();
+      span.set("did", session.did);
+      const classified = classifyMuteSubject(data.subject);
+      if (!classified) {
+        throw new Error("Subject must be a user DID or a publication AT-URI.");
+      }
+      if (classified.kind === "user" && classified.did === session.did) {
+        throw new Error("You can't mute yourself.");
+      }
+
+      const createdAt = new Date().toISOString();
+      let written: { uri: string; cid: string };
+      try {
+        written = await putMuteRecord(
+          session.client,
+          session.did,
+          data.subject,
+          createdAt,
+        );
+      } catch (error) {
+        rethrowMuteScopeRejection(error);
+      }
+      // Eagerly mirror the record we just wrote so the mute takes effect on
+      // the next page instead of at firehose latency.
+      await upsertMute(
+        written.uri,
+        session.did,
+        subjectRkey(data.subject),
+        written.cid,
+        { subject: data.subject, createdAt },
+      );
+      invalidateMuteCache(session.did);
+      await trackReaderRepo(session.did);
+      return { muted: true as const };
+    }),
+  );
+
+const unmuteSubject = createServerFn({ method: "POST" })
+  .validator(muteInput)
+  .handler(
+    observe("mutes.unmute", async ({ data }, span) => {
+      const session = await requireMuteWriter();
+      span.set("did", session.did);
+
+      // Other clients may have written TID-rkey mute records for the same
+      // subject; the mirror's rkeys make unmuting cover those too.
+      const [{ db }, schema] = await Promise.all([
+        import("#/db/index.server"),
+        import("#/db/schema"),
+      ]);
+      const rows = await db
+        .select({ rkey: schema.mutes.rkey, uri: schema.mutes.uri })
+        .from(schema.mutes)
+        .where(
+          and(
+            eq(schema.mutes.muterDid, session.did),
+            eq(schema.mutes.subject, data.subject),
+            eq(schema.mutes.deleted, false),
+          ),
+        );
+
+      try {
+        await deleteMuteRecords(
+          session.client,
+          session.did,
+          data.subject,
+          rows.map((row) => row.rkey),
+        );
+      } catch (error) {
+        rethrowMuteScopeRejection(error);
+      }
+      // Eagerly drop the mirror rows; the firehose delete that follows is a
+      // no-op. Hard delete to match the ingest delete path.
+      const uris = rows.map((row) => row.uri);
+      if (uris.length > 0) {
+        const { inArray } = await import("drizzle-orm");
+        await db.delete(schema.mutes).where(inArray(schema.mutes.uri, uris));
+      }
+      invalidateMuteCache(session.did);
+      return { muted: false as const };
+    }),
+  );
+
+/**
+ * Register the reader's own repo with tap (best-effort) so their mute records
+ * flow back into the read-model. Idempotent; never fails the request.
+ */
+async function trackReaderRepo(did: string): Promise<void> {
+  try {
+    await ensureTracked(did, "reader");
+  } catch (error) {
+    console.warn("[mutes] failed to track reader repo", did, error);
+  }
+}
+
+function getMutedSettingsQueryOptions({ limit = 50 }: { limit?: number } = {}) {
+  return queryOptions({
+    queryKey: ["mutes", "settings", limit] as const,
+    queryFn: async () => getMutedSettings({ data: { limit } }),
+    staleTime: 30_000,
+  });
+}
+
+function getMuteCapabilityQueryOptions() {
+  return queryOptions({
+    queryKey: ["mutes", "capability"] as const,
+    queryFn: async () => getMuteCapability(),
+    staleTime: 30_000,
+  });
+}
+
+function getMuteStateQueryOptions(subject: string) {
+  return queryOptions({
+    queryKey: ["mutes", "state", subject] as const,
+    queryFn: async () => getMuteState({ data: { subject } }),
+    staleTime: 30_000,
+  });
+}
+
+export { NEEDS_MUTE_SCOPE };
+
+export const mutesApi = {
+  getMutedSettings,
+  getMutedSettingsQueryOptions,
+  getMuteCapability,
+  getMuteCapabilityQueryOptions,
+  getMuteState,
+  getMuteStateQueryOptions,
+  muteSubject,
+  unmuteSubject,
+};

--- a/apps/standard-reader/src/integrations/tanstack-query/api-search.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-search.functions.ts
@@ -22,6 +22,11 @@ import {
   notBlockedByViewer,
 } from "#/server/blocks/blocks";
 import { ensureTracked } from "#/server/ingest/tap-client";
+import {
+  filterMutedCards,
+  muteFilterDid,
+  notMutedByViewer,
+} from "#/server/mutes/mutes";
 import { observe } from "#/server/observability/log";
 import { attachReaderSpanContext } from "#/server/observability/span-context.ts";
 import { attachCommentCountsToArticles } from "#/server/reader/document-comments";
@@ -139,7 +144,12 @@ const searchPublications = createServerFn({ method: "GET" })
         total = items.length;
       }
 
-      const visible = await filterBlockedCards(db, schema, did, items);
+      const visible = await filterMutedCards(
+        db,
+        schema,
+        did,
+        await filterBlockedCards(db, schema, did, items),
+      );
       if (visible.length !== items.length) {
         total = Math.max(0, total - (items.length - visible.length));
         items = visible;
@@ -188,7 +198,10 @@ const searchArticles = createServerFn({ method: "GET" })
         hints,
       );
       const matchClause = documentMatchSql(d, tsq, hints, authorMatch);
-      const blockDid = await blockFilterDid(db, schema, did);
+      const [blockDid, muteDid] = await Promise.all([
+        blockFilterDid(db, schema, did),
+        muteFilterDid(db, schema, did),
+      ]);
       const articleWhere = and(
         eq(d.deleted, false),
         matchClause,
@@ -204,6 +217,15 @@ const searchArticles = createServerFn({ method: "GET" })
                 sql`${d.did}`,
                 atUriAuthoritySql(sql`${d.publicationUri}`),
               ),
+            ]
+          : []),
+        ...(muteDid
+          ? [
+              notMutedByViewer(schema, muteDid, {
+                authorDidExpr: sql`${d.did}`,
+                ownerDidExpr: atUriAuthoritySql(sql`${d.publicationUri}`),
+                pubUriExpr: sql`${d.publicationUri}`,
+              }),
             ]
           : []),
       );

--- a/apps/standard-reader/src/integrations/tanstack-query/api-tag.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-tag.functions.ts
@@ -13,6 +13,7 @@ import { blockFilterDid } from "#/server/blocks/blocks";
 import { upsertSubscription } from "#/server/ingest/handlers";
 import { ensureTracked } from "#/server/ingest/tap-client";
 import { attachSubscribedLabels } from "#/server/labeler/labels.server";
+import { muteFilterDid } from "#/server/mutes/mutes";
 import { observe } from "#/server/observability/log";
 import { attachReaderSpanContext } from "#/server/observability/span-context.ts";
 import { attachCommentCountsToArticles } from "#/server/reader/document-comments";
@@ -130,7 +131,10 @@ const getArticles = createServerFn({ method: "GET" })
 
       // The tag rows and the reader's follow set are independent reads (the
       // follow set only needs `did`), so resolve them in one wave.
-      const blockDid = await blockFilterDid(db, schema, did);
+      const [blockDid, muteDid] = await Promise.all([
+        blockFilterDid(db, schema, did),
+        muteFilterDid(db, schema, did),
+      ]);
       const [rows, followSets] = await Promise.all([
         selectArticleCards(db, schema, {
           tag: data.tag,
@@ -142,6 +146,7 @@ const getArticles = createServerFn({ method: "GET" })
           readForDid: trackReading && did ? did : undefined,
           countOldPostsAsUnread,
           viewerDid: blockDid,
+          muterDid: muteDid,
         }),
         did ? effectiveFollowSets(db, schema, did) : Promise.resolve(null),
       ]);
@@ -194,6 +199,7 @@ const getPublications = createServerFn({ method: "GET" })
         offset: data.offset,
         excludeWebBridge: excludeWebBridgeEnabled,
         viewerDid: await blockFilterDid(db, schema, did),
+        muterDid: await muteFilterDid(db, schema, did),
       });
 
       span.set("count", items.length);
@@ -259,7 +265,10 @@ const getTagPage = createServerFn({ method: "GET" })
         did == null ? true : countOldPostsAsUnreadEnabled;
       const excludeWebBridge = did == null ? false : excludeWebBridgeEnabled;
 
-      const blockDid = await blockFilterDid(db, schema, did);
+      const [blockDid, muteDid] = await Promise.all([
+        blockFilterDid(db, schema, did),
+        muteFilterDid(db, schema, did),
+      ]);
       const [articleCount, publicationCount, content, followSets] =
         await Promise.all([
           countTagArticles(db, schema, data.tag, { excludeWebBridge }),
@@ -275,6 +284,7 @@ const getTagPage = createServerFn({ method: "GET" })
                 readForDid: trackReading && did ? did : undefined,
                 countOldPostsAsUnread,
                 viewerDid: blockDid,
+                muterDid: muteDid,
               }).then((rows) => attachCommentCountsToArticles(db, schema, rows))
             : tagDirectoryPublications(db, schema, {
                 tag: data.tag,
@@ -283,6 +293,7 @@ const getTagPage = createServerFn({ method: "GET" })
                 offset: data.offset,
                 excludeWebBridge,
                 viewerDid: blockDid,
+                muterDid: muteDid,
               }),
           data.view === "feed" && did
             ? effectiveFollowSets(db, schema, did)

--- a/apps/standard-reader/src/integrations/tanstack-query/api-topics.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-topics.functions.ts
@@ -5,6 +5,7 @@ import { getRequest } from "@tanstack/react-start/server";
 import { z } from "zod";
 
 import { blockFilterDid } from "#/server/blocks/blocks";
+import { muteFilterDid } from "#/server/mutes/mutes";
 import { observe } from "#/server/observability/log";
 import { attachReaderSpanContext } from "#/server/observability/span-context.ts";
 import { attachCommentCountsToArticles } from "#/server/reader/document-comments";
@@ -182,6 +183,7 @@ async function loadTopicArticles(
     readForDid: trackReading && did ? did : undefined,
     countOldPostsAsUnread,
     viewerDid: await blockFilterDid(db, schema, did),
+    muterDid: await muteFilterDid(db, schema, did),
   });
 
   const withComments = await attachCommentCountsToArticles(db, schema, rows);

--- a/apps/standard-reader/src/lib/atproto/nsids.ts
+++ b/apps/standard-reader/src/lib/atproto/nsids.ts
@@ -33,6 +33,7 @@ export const APP_NSID = {
   labelerSubscription: "app.standard-reader.labelerSubscription",
   labelerSubscriptionV2: "app.standard-reader.labeler.subscription",
   graphFollow: "app.standard-reader.graph.follow",
+  graphMute: "app.standard-reader.graph.mute",
 } as const;
 
 /**

--- a/apps/standard-reader/src/lib/mutes.test.ts
+++ b/apps/standard-reader/src/lib/mutes.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+
+import type { MutedSubjects } from "./mutes";
+import {
+  classifyMuteSubject,
+  isCardMuted,
+  muteCandidateKeys,
+  rejectMutedCards,
+} from "./mutes";
+
+const PUB_URI = "at://did:plc:owner/site.standard.publication/3kabc";
+
+const muted = (
+  dids: Array<string> = [],
+  uris: Array<string> = [],
+): MutedSubjects => ({ dids: new Set(dids), uris: new Set(uris) });
+
+describe("classifyMuteSubject", () => {
+  it("classifies a DID as a user mute", () => {
+    expect(classifyMuteSubject("did:plc:abc123")).toEqual({
+      kind: "user",
+      did: "did:plc:abc123",
+    });
+  });
+
+  it("classifies a publication AT-URI as a publication mute", () => {
+    expect(classifyMuteSubject(PUB_URI)).toEqual({
+      kind: "publication",
+      uri: PUB_URI,
+    });
+  });
+
+  it("rejects AT-URIs of other collections", () => {
+    expect(
+      classifyMuteSubject("at://did:plc:owner/site.standard.document/3kabc"),
+    ).toBeNull();
+    expect(
+      classifyMuteSubject("at://did:plc:owner/app.bsky.graph.block/3kabc"),
+    ).toBeNull();
+  });
+
+  it("rejects malformed subjects", () => {
+    expect(classifyMuteSubject("")).toBeNull();
+    expect(classifyMuteSubject("https://example.com")).toBeNull();
+    expect(classifyMuteSubject("at://did:plc:owner")).toBeNull();
+    // Missing rkey.
+    expect(
+      classifyMuteSubject("at://did:plc:owner/site.standard.publication"),
+    ).toBeNull();
+    expect(
+      classifyMuteSubject("at://did:plc:owner/site.standard.publication/"),
+    ).toBeNull();
+    // Trailing path segment.
+    expect(classifyMuteSubject(`${PUB_URI}/extra`)).toBeNull();
+    // Handle authority — tap always emits DIDs, so anything else is malformed.
+    expect(
+      classifyMuteSubject("at://alice.test/site.standard.publication/3kabc"),
+    ).toBeNull();
+    expect(classifyMuteSubject(42)).toBeNull();
+    expect(classifyMuteSubject(null)).toBeNull();
+  });
+});
+
+describe("muteCandidateKeys", () => {
+  it("collects every DID and URI a card set renders, deduped", () => {
+    expect(
+      muteCandidateKeys([
+        {
+          did: "did:plc:author",
+          publicationOwnerDid: "did:plc:owner",
+          publicationUri: PUB_URI,
+        },
+        { did: "did:plc:author", uri: PUB_URI },
+        { did: null, publicationUri: null },
+      ]),
+    ).toEqual({
+      dids: ["did:plc:author", "did:plc:owner"],
+      uris: [PUB_URI],
+    });
+  });
+});
+
+describe("isCardMuted", () => {
+  it("matches the author DID", () => {
+    expect(
+      isCardMuted({ did: "did:plc:author" }, muted(["did:plc:author"])),
+    ).toBe(true);
+  });
+
+  it("matches the publication owner DID (guest posts)", () => {
+    expect(
+      isCardMuted(
+        { did: "did:plc:guest", publicationOwnerDid: "did:plc:owner" },
+        muted(["did:plc:owner"]),
+      ),
+    ).toBe(true);
+  });
+
+  it("matches the document's publication URI", () => {
+    expect(
+      isCardMuted(
+        { did: "did:plc:author", publicationUri: PUB_URI },
+        muted([], [PUB_URI]),
+      ),
+    ).toBe(true);
+  });
+
+  it("matches a publication card's own URI", () => {
+    expect(
+      isCardMuted({ did: "did:plc:owner", uri: PUB_URI }, muted([], [PUB_URI])),
+    ).toBe(true);
+  });
+
+  it("passes an unmuted card through", () => {
+    expect(
+      isCardMuted(
+        { did: "did:plc:author", publicationUri: PUB_URI },
+        muted(
+          ["did:plc:other"],
+          ["at://did:plc:x/site.standard.publication/y"],
+        ),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("rejectMutedCards", () => {
+  const cards = [
+    { id: 1, did: "did:plc:author" },
+    { id: 2, did: "did:plc:guest", publicationOwnerDid: "did:plc:owner" },
+    { id: 3, did: "did:plc:fine", publicationUri: PUB_URI },
+    { id: 4, did: "did:plc:fine" },
+  ];
+
+  it("drops cards muted through any surface", () => {
+    expect(
+      rejectMutedCards(
+        cards,
+        muted(["did:plc:author", "did:plc:owner"], [PUB_URI]),
+      ),
+    ).toEqual([{ id: 4, did: "did:plc:fine" }]);
+  });
+
+  it("returns the same array when nothing is muted", () => {
+    expect(rejectMutedCards(cards, muted())).toBe(cards);
+  });
+});

--- a/apps/standard-reader/src/lib/mutes.ts
+++ b/apps/standard-reader/src/lib/mutes.ts
@@ -1,0 +1,110 @@
+/**
+ * Pure mute logic, split out from `server/mutes/mutes.ts` so it carries no
+ * database import and can be unit-tested directly (mirrors `lib/blocks.ts`).
+ *
+ * A mute subject is either a **user** (a DID — hides everything they touch:
+ * documents they authored, documents from publications they own, their
+ * recommends) or a **publication** (the AT-URI of its
+ * `site.standard.publication` record — hides that publication's documents and
+ * the publication itself from discovery). Unlike blocks, mutes are strictly
+ * one-directional and only affect feeds + discovery, never direct navigation.
+ */
+
+import { STANDARD_NSID } from "#/lib/atproto/nsids";
+
+/** A mute record subject, classified. */
+export type MuteSubject =
+  | { kind: "user"; did: string }
+  | { kind: "publication"; uri: string };
+
+/**
+ * Classify a raw mute-record `subject` into a user or publication mute.
+ * Returns null for anything else (malformed strings, at-uris of other
+ * collections), which callers skip rather than guess at.
+ */
+export function classifyMuteSubject(subject: unknown): MuteSubject | null {
+  if (typeof subject !== "string" || subject.length === 0) return null;
+  if (subject.startsWith("did:")) {
+    return { kind: "user", did: subject };
+  }
+  if (!subject.startsWith("at://")) return null;
+  const [authority, collection, rkey, ...rest] = subject
+    .slice("at://".length)
+    .split("/");
+  if (
+    !authority?.startsWith("did:") ||
+    collection !== STANDARD_NSID.publication ||
+    !rkey ||
+    rest.length > 0
+  ) {
+    return null;
+  }
+  return { kind: "publication", uri: subject };
+}
+
+/**
+ * A card that may be hidden by a mute. Extends the blockable shape with the
+ * publication facts mutes match on: the card's publication URI (documents) or
+ * its own URI (publication cards, where the card *is* the mute subject).
+ */
+export interface MutableCard {
+  /** Author DID (documents) or owner DID (publications, profiles). */
+  did?: string | null;
+  /** Owner of the card's publication, when it differs from `did`. */
+  publicationOwnerDid?: string | null;
+  /** AT-URI of the publication a document card belongs to. */
+  publicationUri?: string | null;
+  /** The card's own AT-URI — matched for publication cards. */
+  uri?: string | null;
+}
+
+/** The muted subjects resolved for a viewer, split by kind. */
+export interface MutedSubjects {
+  dids: ReadonlySet<string>;
+  uris: ReadonlySet<string>;
+}
+
+/** Every candidate mute subject a set of cards renders, deduped. */
+export function muteCandidateKeys(cards: ReadonlyArray<MutableCard>): {
+  dids: Array<string>;
+  uris: Array<string>;
+} {
+  const dids = new Set<string>();
+  const uris = new Set<string>();
+  for (const card of cards) {
+    if (card.did) dids.add(card.did);
+    if (card.publicationOwnerDid) dids.add(card.publicationOwnerDid);
+    if (card.publicationUri) uris.add(card.publicationUri);
+    if (card.uri) uris.add(card.uri);
+  }
+  return { dids: [...dids], uris: [...uris] };
+}
+
+/** Whether a card renders any muted user or publication. */
+export function isCardMuted(card: MutableCard, muted: MutedSubjects): boolean {
+  if (muted.dids.size > 0) {
+    if (card.did != null && muted.dids.has(card.did)) return true;
+    if (
+      card.publicationOwnerDid != null &&
+      muted.dids.has(card.publicationOwnerDid)
+    ) {
+      return true;
+    }
+  }
+  if (muted.uris.size > 0) {
+    if (card.publicationUri != null && muted.uris.has(card.publicationUri)) {
+      return true;
+    }
+    if (card.uri != null && muted.uris.has(card.uri)) return true;
+  }
+  return false;
+}
+
+/** Drop every card that renders a muted user or publication. */
+export function rejectMutedCards<T extends MutableCard>(
+  cards: Array<T>,
+  muted: MutedSubjects,
+): Array<T> {
+  if (muted.dids.size === 0 && muted.uris.size === 0) return cards;
+  return cards.filter((card) => !isCardMuted(card, muted));
+}

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -222,6 +222,7 @@ msgstr ""
 #: src/components/labelers-settings-view.tsx
 #: src/components/muted-settings-view.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 #: src/components/user-settings-view.tsx
 msgid "Muted"
 msgstr ""
@@ -3083,6 +3084,10 @@ msgstr "تحذير"
 msgid "What it does"
 msgstr ""
 
+#: src/components/reader/muted-pill.tsx
+msgid "Muted by you"
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 #: src/components/reader/save-to-collection-dialog.tsx
 #: src/components/reader/subscriptions-table.tsx
@@ -3395,6 +3400,10 @@ msgstr ""
 #: src/routes/_layout.collections.index.tsx
 msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, zero {متابع} one {متابع} two {متابعان} few {متابعين} many {متابعًا} other {متابع}}"
+
+#: src/components/reader/muted-pill.tsx
+msgid "This publication is muted"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 #~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
@@ -4369,6 +4378,7 @@ msgstr "مقارنة الصور قبل وبعد"
 msgid "No matching people."
 msgstr "لا يوجد أشخاص مطابقون."
 
+#: src/components/reader/muted-pill.tsx
 #: src/components/user-settings-view.tsx
 msgid "Manage mutes"
 msgstr ""
@@ -4676,6 +4686,7 @@ msgid "{days}d ago"
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "Unmuted"
 msgstr ""
 
@@ -5281,6 +5292,7 @@ msgstr ""
 #: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/blocked-notice.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 #: src/components/route-error.tsx
@@ -6050,6 +6062,7 @@ msgid "No lists yet — switch to New list to create one."
 msgstr "لا توجد قوائم بعد — بدّل إلى «قائمة جديدة» لإنشاء واحدة."
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "We couldn't remove the mute from your account. Try again?"
 msgstr ""
 
@@ -6293,6 +6306,7 @@ msgstr ""
 
 #: src/components/muted-settings-view.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "Unmute"
 msgstr ""
 
@@ -6383,6 +6397,10 @@ msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the queue of articles you put aside. A badge shows how many are waiting."
+msgstr ""
+
+#: src/components/reader/muted-pill.tsx
+msgid "This publication will show up in your feeds again."
 msgstr ""
 
 #: src/routes/_layout.recommended.tsx
@@ -7093,9 +7111,17 @@ msgstr ""
 #~ msgid "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 #~ msgstr ""
 
+#: src/components/reader/muted-pill.tsx
+msgid "Its articles are hidden from your feeds, search and discovery. Your subscription is untouched, and this page still works."
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag"
 msgstr "وسم"
+
+#: src/components/reader/muted-pill.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery. Your subscriptions are untouched, and this page still works."
+msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "The React package, for example. With no <0>components</0> prop, a document renders as unstyled semantic HTML."
@@ -7180,6 +7206,7 @@ msgid "Muted here"
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "They'll show up in your feeds again."
 msgstr ""
 
@@ -8153,6 +8180,10 @@ msgstr ""
 #. placeholder {0}: fmt.relativeTime(connection.lastUsedAt)
 #: src/components/user-settings-view.tsx
 msgid "Last used {0}"
+msgstr ""
+
+#: src/components/reader/muted-pill.tsx
+msgid "This person is muted"
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -105,6 +105,10 @@ msgstr "جرّب \"المناخ\"، أو وسمًا مثل #essay، أو معر�
 msgid "Thanks for taking the time to help us improve Standard Reader."
 msgstr "شكرًا لتخصيصك الوقت لمساعدتنا في تحسين Standard Reader."
 
+#: src/components/user-settings-view.tsx
+msgid "Manage {muteCount} mutes"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Articles and publications carry topic tags. Select one anywhere you see it — under a headline, on a publication card, in Discover — and you get everything filed under it: an <0>Articles</0> tab you can sort by recent, trending, or most popular, and a <1>Publications</1> tab of everyone who writes about it."
 msgstr ""
@@ -216,11 +220,18 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/labelers-settings-view.tsx
+#: src/components/muted-settings-view.tsx
+#: src/components/reader/mute-menu-item.tsx
+#: src/components/user-settings-view.tsx
 msgid "Muted"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Content and intellectual property"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute {name}?"
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -340,6 +351,10 @@ msgstr "يرجى إضافة عنوان."
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "This publication's articles disappear from your feeds, search and discovery. Your subscription is untouched, and you can still visit the publication directly. You can undo this in Settings → Muted."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -366,6 +381,10 @@ msgstr "ابحث بالعنوان أو الكاتب، أو الصق عنوان U
 
 #: src/components/user-settings-view.tsx
 msgid "Show {itemLabel} in the sidebar"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "We couldn't write the mute to your account. Try again?"
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
@@ -1024,6 +1043,10 @@ msgstr "بالنقر على «إنشاء» سيُطلب أولًا الإذن ب
 msgid "Extension privacy"
 msgstr "خصوصية الإضافة"
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "It's hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Signing in"
@@ -1031,6 +1054,10 @@ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Public API — no key required"
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people"
 msgstr ""
 
 #: src/components/reading-settings-preview.tsx
@@ -1688,6 +1715,10 @@ msgstr "محتوى مضمَّن"
 msgid "Account"
 msgstr "الحساب"
 
+#: src/components/muted-settings-view.tsx
+msgid "Loading muted publications"
+msgstr ""
+
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "There is no “this is a comic” switch anywhere on the network, and nothing to set on Standard Reader — we do not host your publication. Two things have to be true instead."
 msgstr ""
@@ -1777,6 +1808,10 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Browse your feed"
 msgstr "تصفّح تغذيتك"
+
+#: src/components/muted-settings-view.tsx
+msgid "Your mutes are enforced here already. To add or remove one, you'll be asked to re-authorize the first time you try."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Scales every size in the app, article text included — from 13px up to 22px of interface text."
@@ -2136,6 +2171,10 @@ msgstr ""
 msgid "Loading page"
 msgstr "جارٍ تحميل الصفحة"
 
+#: src/components/muted-settings-view.tsx
+msgid "You haven't muted any publications. Mute one from the menu on its page to hide its articles from your feeds while staying subscribed."
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "The button sits next to a publication's name wherever you meet it — a card in a feed, the top of an article, the publication's own page. Select it again to unsubscribe."
 msgstr ""
@@ -2435,6 +2474,7 @@ msgstr "المقالات التي فتحتها — سجلات عامة في مس
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-publication-editor.tsx
 #: src/components/reader/collection-theme-editor.tsx
+#: src/components/reader/mute-menu-item.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 #: src/components/user-settings-view.tsx
 #: src/routes/_layout.collections.new.tsx
@@ -2599,6 +2639,7 @@ msgstr "اقرأ المزيد للكاتب"
 
 #: src/components/blocks-settings-view.tsx
 #: src/components/labelers-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 #: src/components/user-settings-view.tsx
 msgid "Moderation"
 msgstr "الإشراف"
@@ -2689,6 +2730,10 @@ msgstr "تعيين العدد"
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Feed preferences"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "{name} will show up in your feeds again."
 msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx
@@ -3097,6 +3142,10 @@ msgstr ""
 #: src/components/reader/collection-publication-editor.tsx
 msgid "Uploading…"
 msgstr "جارٍ الرفع…"
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices."
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "No articles are trending across the network right now. Check back soon."
@@ -3523,6 +3572,7 @@ msgid "Publications to explore"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 msgid "We couldn't reach your account to change that. Try again?"
 msgstr ""
 
@@ -3680,6 +3730,10 @@ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Muted people and publications stay subscribed but disappear from your feeds, search, and discovery. Only you can see your mutes' effect — nobody is notified."
 msgstr ""
 
 #: src/components/push-diagnostics.tsx
@@ -4315,6 +4369,10 @@ msgstr "مقارنة الصور قبل وبعد"
 msgid "No matching people."
 msgstr "لا يوجد أشخاص مطابقون."
 
+#: src/components/user-settings-view.tsx
+msgid "Manage mutes"
+msgstr ""
+
 #: src/components/reader/subscriptions-tree.tsx
 msgid "Empty list."
 msgstr "قائمة فارغة."
@@ -4431,6 +4489,10 @@ msgstr ""
 
 #: src/components/push-diagnostics.tsx
 msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Their articles, publications and recommendations disappear from your feeds, search and discovery. Your subscriptions are untouched, and you can still visit their pages directly. You can undo this in Settings → Muted."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4611,6 +4673,10 @@ msgstr "لم ينشر هذا المصنِّف أي تعريفات للتصنيف
 
 #: src/components/reader/format-i18n.ts
 msgid "{days}d ago"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmuted"
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -5211,8 +5277,10 @@ msgid "Not in the directory yet?"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 #: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/blocked-notice.tsx
+#: src/components/reader/mute-menu-item.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 #: src/components/route-error.tsx
@@ -5692,6 +5760,10 @@ msgstr "لا توجد جهات تصنيف معروفة بعد."
 msgid "You're all caught up"
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "{name} is hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "All publication lists you created in this app."
 msgstr "جميع قوائم المنشورات التي أنشأتها في هذا التطبيق."
@@ -5977,6 +6049,10 @@ msgstr ""
 msgid "No lists yet — switch to New list to create one."
 msgstr "لا توجد قوائم بعد — بدّل إلى «قائمة جديدة» لإنشاء واحدة."
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "We couldn't remove the mute from your account. Try again?"
+msgstr ""
+
 #: src/components/reader/terms-view.tsx
 msgid "{SITE_NAME} is provided “as is” and “as available,” without warranties of any kind, whether express or implied. We do not guarantee that the service will be uninterrupted, error-free, or that the index will always be complete or current. To the fullest extent permitted by law, the operator of this deployment is not liable for any indirect, incidental, or consequential damages arising from your use of the site."
 msgstr ""
@@ -6059,6 +6135,10 @@ msgstr "إغلاق التبويب"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Groups collapse and expand, so you can keep the sidebar short and open only what you are reading today. <0>Collapse all lists</0> and <1>Expand all lists</1> do it in one go."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute"
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
@@ -6211,6 +6291,11 @@ msgstr ""
 msgid "Unfollow?"
 msgstr ""
 
+#: src/components/muted-settings-view.tsx
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmute"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Listen to anything"
 msgstr "استمع إلى أي شيء"
@@ -6327,6 +6412,10 @@ msgstr ""
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Type size, shape, and density"
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Loading muted people"
 msgstr ""
 
 #: src/routes/_layout.latest.tsx
@@ -7034,6 +7123,10 @@ msgstr "عرض على Bluesky"
 msgid "Paused"
 msgstr "متوقف مؤقتًا"
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute?"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Reading without an account"
@@ -7084,6 +7177,10 @@ msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Muted here"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "They'll show up in your feeds again."
 msgstr ""
 
 #: src/components/reader/privacy-view.tsx
@@ -7187,6 +7284,10 @@ msgstr "نشر التشغيل ومشاركته"
 #: src/components/reader/collection-builder.tsx
 msgid "Editorial"
 msgstr "تحريري"
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted publications"
+msgstr ""
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Click Run example to fetch a live response with your session."
@@ -7662,6 +7763,10 @@ msgstr ""
 msgid "Read aloud"
 msgstr "قراءة بصوت مسموع"
 
+#: src/components/muted-settings-view.tsx
+msgid "You haven't muted anyone. Mute someone from the menu on their page to hide everything they write — and everything they recommend — without unfollowing."
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "المقالات التي حفظتها لوقت لاحق — في مستودعك، ومُزامَنة عبر أجهزتك."
@@ -7826,6 +7931,10 @@ msgstr ""
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Filter by topic"
 msgstr "تصفية حسب الموضوع"
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmute {name}"
+msgstr ""
 
 #. placeholder {0}: image.file.name
 #: src/components/feedback/feedback-image-picker.tsx
@@ -8337,6 +8446,10 @@ msgstr ""
 
 #: src/components/reader/saved-filters.tsx
 msgid "Filter saved articles"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute {name}"
 msgstr ""
 
 #: src/components/reader/series-up-next.tsx

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -105,6 +105,10 @@ msgstr "Versuchen Sie „Klima“, ein #Tag wie #essay oder ein Handle wie stdou
 msgid "Thanks for taking the time to help us improve Standard Reader."
 msgstr "Danke, dass Sie sich die Zeit nehmen, Standard Reader zu verbessern."
 
+#: src/components/user-settings-view.tsx
+msgid "Manage {muteCount} mutes"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Articles and publications carry topic tags. Select one anywhere you see it — under a headline, on a publication card, in Discover — and you get everything filed under it: an <0>Articles</0> tab you can sort by recent, trending, or most popular, and a <1>Publications</1> tab of everyone who writes about it."
 msgstr ""
@@ -216,11 +220,18 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/labelers-settings-view.tsx
+#: src/components/muted-settings-view.tsx
+#: src/components/reader/mute-menu-item.tsx
+#: src/components/user-settings-view.tsx
 msgid "Muted"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Content and intellectual property"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute {name}?"
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -340,6 +351,10 @@ msgstr "Bitte fügen Sie einen Titel hinzu."
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "This publication's articles disappear from your feeds, search and discovery. Your subscription is untouched, and you can still visit the publication directly. You can undo this in Settings → Muted."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -366,6 +381,10 @@ msgstr "Nach Titel oder Autor suchen oder eine URL bzw. at://-URI einfügen"
 
 #: src/components/user-settings-view.tsx
 msgid "Show {itemLabel} in the sidebar"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "We couldn't write the mute to your account. Try again?"
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
@@ -1024,6 +1043,10 @@ msgstr "Beim Klick auf „Erstellen“ werden zuerst Berechtigungen für eine Re
 msgid "Extension privacy"
 msgstr "Datenschutz der Erweiterung"
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "It's hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Signing in"
@@ -1031,6 +1054,10 @@ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Public API — no key required"
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people"
 msgstr ""
 
 #: src/components/reading-settings-preview.tsx
@@ -1688,6 +1715,10 @@ msgstr "Eingebettete Inhalte"
 msgid "Account"
 msgstr "Konto"
 
+#: src/components/muted-settings-view.tsx
+msgid "Loading muted publications"
+msgstr ""
+
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "There is no “this is a comic” switch anywhere on the network, and nothing to set on Standard Reader — we do not host your publication. Two things have to be true instead."
 msgstr ""
@@ -1777,6 +1808,10 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Browse your feed"
 msgstr "Feed durchstöbern"
+
+#: src/components/muted-settings-view.tsx
+msgid "Your mutes are enforced here already. To add or remove one, you'll be asked to re-authorize the first time you try."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Scales every size in the app, article text included — from 13px up to 22px of interface text."
@@ -2136,6 +2171,10 @@ msgstr ""
 msgid "Loading page"
 msgstr "Seite wird geladen"
 
+#: src/components/muted-settings-view.tsx
+msgid "You haven't muted any publications. Mute one from the menu on its page to hide its articles from your feeds while staying subscribed."
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "The button sits next to a publication's name wherever you meet it — a card in a feed, the top of an article, the publication's own page. Select it again to unsubscribe."
 msgstr ""
@@ -2435,6 +2474,7 @@ msgstr "Von Ihnen geöffnete Artikel – öffentliche Records in Ihrem Repo, ger
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-publication-editor.tsx
 #: src/components/reader/collection-theme-editor.tsx
+#: src/components/reader/mute-menu-item.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 #: src/components/user-settings-view.tsx
 #: src/routes/_layout.collections.new.tsx
@@ -2599,6 +2639,7 @@ msgstr "Mehr von diesem Autor lesen"
 
 #: src/components/blocks-settings-view.tsx
 #: src/components/labelers-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 #: src/components/user-settings-view.tsx
 msgid "Moderation"
 msgstr "Moderation"
@@ -2689,6 +2730,10 @@ msgstr "Ausgabe wird gesetzt"
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Feed preferences"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "{name} will show up in your feeds again."
 msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx
@@ -3097,6 +3142,10 @@ msgstr ""
 #: src/components/reader/collection-publication-editor.tsx
 msgid "Uploading…"
 msgstr "Wird hochgeladen…"
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices."
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "No articles are trending across the network right now. Check back soon."
@@ -3523,6 +3572,7 @@ msgid "Publications to explore"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 msgid "We couldn't reach your account to change that. Try again?"
 msgstr ""
 
@@ -3680,6 +3730,10 @@ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Muted people and publications stay subscribed but disappear from your feeds, search, and discovery. Only you can see your mutes' effect — nobody is notified."
 msgstr ""
 
 #: src/components/push-diagnostics.tsx
@@ -4315,6 +4369,10 @@ msgstr "Bilder vorher und nachher vergleichen"
 msgid "No matching people."
 msgstr "Keine passenden Personen."
 
+#: src/components/user-settings-view.tsx
+msgid "Manage mutes"
+msgstr ""
+
 #: src/components/reader/subscriptions-tree.tsx
 msgid "Empty list."
 msgstr "Leere Liste."
@@ -4431,6 +4489,10 @@ msgstr ""
 
 #: src/components/push-diagnostics.tsx
 msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Their articles, publications and recommendations disappear from your feeds, search and discovery. Your subscriptions are untouched, and you can still visit their pages directly. You can undo this in Settings → Muted."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4611,6 +4673,10 @@ msgstr "Dieser Labeler hat keine Label-Definitionen veröffentlicht."
 
 #: src/components/reader/format-i18n.ts
 msgid "{days}d ago"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmuted"
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -5211,8 +5277,10 @@ msgid "Not in the directory yet?"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 #: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/blocked-notice.tsx
+#: src/components/reader/mute-menu-item.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 #: src/components/route-error.tsx
@@ -5692,6 +5760,10 @@ msgstr "Noch keine bekannten Labeler."
 msgid "You're all caught up"
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "{name} is hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "All publication lists you created in this app."
 msgstr "Alle Publikationslisten, die Sie in dieser App erstellt haben."
@@ -5977,6 +6049,10 @@ msgstr ""
 msgid "No lists yet — switch to New list to create one."
 msgstr "Noch keine Listen – wechseln Sie zu „Neue Liste“, um eine anzulegen."
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "We couldn't remove the mute from your account. Try again?"
+msgstr ""
+
 #: src/components/reader/terms-view.tsx
 msgid "{SITE_NAME} is provided “as is” and “as available,” without warranties of any kind, whether express or implied. We do not guarantee that the service will be uninterrupted, error-free, or that the index will always be complete or current. To the fullest extent permitted by law, the operator of this deployment is not liable for any indirect, incidental, or consequential damages arising from your use of the site."
 msgstr ""
@@ -6059,6 +6135,10 @@ msgstr "Tab schließen"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Groups collapse and expand, so you can keep the sidebar short and open only what you are reading today. <0>Collapse all lists</0> and <1>Expand all lists</1> do it in one go."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute"
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
@@ -6211,6 +6291,11 @@ msgstr ""
 msgid "Unfollow?"
 msgstr ""
 
+#: src/components/muted-settings-view.tsx
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmute"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Listen to anything"
 msgstr "Alles anhören"
@@ -6327,6 +6412,10 @@ msgstr ""
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Type size, shape, and density"
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Loading muted people"
 msgstr ""
 
 #: src/routes/_layout.latest.tsx
@@ -7034,6 +7123,10 @@ msgstr "Auf Bluesky ansehen"
 msgid "Paused"
 msgstr "Pausiert"
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute?"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Reading without an account"
@@ -7084,6 +7177,10 @@ msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Muted here"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "They'll show up in your feeds again."
 msgstr ""
 
 #: src/components/reader/privacy-view.tsx
@@ -7187,6 +7284,10 @@ msgstr "Lauf veröffentlichen & teilen"
 #: src/components/reader/collection-builder.tsx
 msgid "Editorial"
 msgstr "Redaktionell"
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted publications"
+msgstr ""
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Click Run example to fetch a live response with your session."
@@ -7662,6 +7763,10 @@ msgstr ""
 msgid "Read aloud"
 msgstr "Vorlesen"
 
+#: src/components/muted-settings-view.tsx
+msgid "You haven't muted anyone. Mute someone from the menu on their page to hide everything they write — and everything they recommend — without unfollowing."
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "Artikel, die Sie für später gespeichert haben — in Ihrem Repo, geräteübergreifend synchronisiert."
@@ -7826,6 +7931,10 @@ msgstr ""
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Filter by topic"
 msgstr "Nach Thema filtern"
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmute {name}"
+msgstr ""
 
 #. placeholder {0}: image.file.name
 #: src/components/feedback/feedback-image-picker.tsx
@@ -8337,6 +8446,10 @@ msgstr ""
 
 #: src/components/reader/saved-filters.tsx
 msgid "Filter saved articles"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute {name}"
 msgstr ""
 
 #: src/components/reader/series-up-next.tsx

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -222,6 +222,7 @@ msgstr ""
 #: src/components/labelers-settings-view.tsx
 #: src/components/muted-settings-view.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 #: src/components/user-settings-view.tsx
 msgid "Muted"
 msgstr ""
@@ -3083,6 +3084,10 @@ msgstr "Warnen"
 msgid "What it does"
 msgstr ""
 
+#: src/components/reader/muted-pill.tsx
+msgid "Muted by you"
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 #: src/components/reader/save-to-collection-dialog.tsx
 #: src/components/reader/subscriptions-table.tsx
@@ -3395,6 +3400,10 @@ msgstr ""
 #: src/routes/_layout.collections.index.tsx
 msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {Follower} other {Follower}}"
+
+#: src/components/reader/muted-pill.tsx
+msgid "This publication is muted"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 #~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
@@ -4369,6 +4378,7 @@ msgstr "Bilder vorher und nachher vergleichen"
 msgid "No matching people."
 msgstr "Keine passenden Personen."
 
+#: src/components/reader/muted-pill.tsx
 #: src/components/user-settings-view.tsx
 msgid "Manage mutes"
 msgstr ""
@@ -4676,6 +4686,7 @@ msgid "{days}d ago"
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "Unmuted"
 msgstr ""
 
@@ -5281,6 +5292,7 @@ msgstr ""
 #: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/blocked-notice.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 #: src/components/route-error.tsx
@@ -6050,6 +6062,7 @@ msgid "No lists yet — switch to New list to create one."
 msgstr "Noch keine Listen – wechseln Sie zu „Neue Liste“, um eine anzulegen."
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "We couldn't remove the mute from your account. Try again?"
 msgstr ""
 
@@ -6293,6 +6306,7 @@ msgstr ""
 
 #: src/components/muted-settings-view.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "Unmute"
 msgstr ""
 
@@ -6383,6 +6397,10 @@ msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the queue of articles you put aside. A badge shows how many are waiting."
+msgstr ""
+
+#: src/components/reader/muted-pill.tsx
+msgid "This publication will show up in your feeds again."
 msgstr ""
 
 #: src/routes/_layout.recommended.tsx
@@ -7093,9 +7111,17 @@ msgstr ""
 #~ msgid "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 #~ msgstr ""
 
+#: src/components/reader/muted-pill.tsx
+msgid "Its articles are hidden from your feeds, search and discovery. Your subscription is untouched, and this page still works."
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag"
 msgstr "Tag"
+
+#: src/components/reader/muted-pill.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery. Your subscriptions are untouched, and this page still works."
+msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "The React package, for example. With no <0>components</0> prop, a document renders as unstyled semantic HTML."
@@ -7180,6 +7206,7 @@ msgid "Muted here"
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "They'll show up in your feeds again."
 msgstr ""
 
@@ -8153,6 +8180,10 @@ msgstr ""
 #. placeholder {0}: fmt.relativeTime(connection.lastUsedAt)
 #: src/components/user-settings-view.tsx
 msgid "Last used {0}"
+msgstr ""
+
+#: src/components/reader/muted-pill.tsx
+msgid "This person is muted"
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -105,6 +105,10 @@ msgstr ""
 msgid "Thanks for taking the time to help us improve Standard Reader."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Manage {muteCount} mutes"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Articles and publications carry topic tags. Select one anywhere you see it — under a headline, on a publication card, in Discover — and you get everything filed under it: an <0>Articles</0> tab you can sort by recent, trending, or most popular, and a <1>Publications</1> tab of everyone who writes about it."
 msgstr ""
@@ -216,11 +220,18 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/labelers-settings-view.tsx
+#: src/components/muted-settings-view.tsx
+#: src/components/reader/mute-menu-item.tsx
+#: src/components/user-settings-view.tsx
 msgid "Muted"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Content and intellectual property"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute {name}?"
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -340,6 +351,10 @@ msgstr ""
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "This publication's articles disappear from your feeds, search and discovery. Your subscription is untouched, and you can still visit the publication directly. You can undo this in Settings → Muted."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -366,6 +381,10 @@ msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Show {itemLabel} in the sidebar"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "We couldn't write the mute to your account. Try again?"
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
@@ -1024,6 +1043,10 @@ msgstr ""
 msgid "Extension privacy"
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "It's hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Signing in"
@@ -1031,6 +1054,10 @@ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Public API — no key required"
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people"
 msgstr ""
 
 #: src/components/reading-settings-preview.tsx
@@ -1688,6 +1715,10 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
+#: src/components/muted-settings-view.tsx
+msgid "Loading muted publications"
+msgstr ""
+
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "There is no “this is a comic” switch anywhere on the network, and nothing to set on Standard Reader — we do not host your publication. Two things have to be true instead."
 msgstr ""
@@ -1776,6 +1807,10 @@ msgstr ""
 #: src/routes/_layout.saved.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Browse your feed"
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Your mutes are enforced here already. To add or remove one, you'll be asked to re-authorize the first time you try."
 msgstr ""
 
 #: src/components/appearance-settings.tsx
@@ -2136,6 +2171,10 @@ msgstr ""
 msgid "Loading page"
 msgstr ""
 
+#: src/components/muted-settings-view.tsx
+msgid "You haven't muted any publications. Mute one from the menu on its page to hide its articles from your feeds while staying subscribed."
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "The button sits next to a publication's name wherever you meet it — a card in a feed, the top of an article, the publication's own page. Select it again to unsubscribe."
 msgstr ""
@@ -2435,6 +2474,7 @@ msgstr ""
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-publication-editor.tsx
 #: src/components/reader/collection-theme-editor.tsx
+#: src/components/reader/mute-menu-item.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 #: src/components/user-settings-view.tsx
 #: src/routes/_layout.collections.new.tsx
@@ -2599,6 +2639,7 @@ msgstr ""
 
 #: src/components/blocks-settings-view.tsx
 #: src/components/labelers-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 #: src/components/user-settings-view.tsx
 msgid "Moderation"
 msgstr ""
@@ -2689,6 +2730,10 @@ msgstr ""
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Feed preferences"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "{name} will show up in your feeds again."
 msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx
@@ -3096,6 +3141,10 @@ msgstr ""
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-publication-editor.tsx
 msgid "Uploading…"
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices."
 msgstr ""
 
 #: src/routes/_layout.latest.tsx
@@ -3523,6 +3572,7 @@ msgid "Publications to explore"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 msgid "We couldn't reach your account to change that. Try again?"
 msgstr ""
 
@@ -3680,6 +3730,10 @@ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Muted people and publications stay subscribed but disappear from your feeds, search, and discovery. Only you can see your mutes' effect — nobody is notified."
 msgstr ""
 
 #: src/components/push-diagnostics.tsx
@@ -4315,6 +4369,10 @@ msgstr ""
 msgid "No matching people."
 msgstr ""
 
+#: src/components/user-settings-view.tsx
+msgid "Manage mutes"
+msgstr ""
+
 #: src/components/reader/subscriptions-tree.tsx
 msgid "Empty list."
 msgstr ""
@@ -4431,6 +4489,10 @@ msgstr ""
 
 #: src/components/push-diagnostics.tsx
 msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Their articles, publications and recommendations disappear from your feeds, search and discovery. Your subscriptions are untouched, and you can still visit their pages directly. You can undo this in Settings → Muted."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4611,6 +4673,10 @@ msgstr ""
 
 #: src/components/reader/format-i18n.ts
 msgid "{days}d ago"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmuted"
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -5211,8 +5277,10 @@ msgid "Not in the directory yet?"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 #: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/blocked-notice.tsx
+#: src/components/reader/mute-menu-item.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 #: src/components/route-error.tsx
@@ -5692,6 +5760,10 @@ msgstr ""
 msgid "You're all caught up"
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "{name} is hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "All publication lists you created in this app."
 msgstr ""
@@ -5977,6 +6049,10 @@ msgstr ""
 msgid "No lists yet — switch to New list to create one."
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "We couldn't remove the mute from your account. Try again?"
+msgstr ""
+
 #: src/components/reader/terms-view.tsx
 msgid "{SITE_NAME} is provided “as is” and “as available,” without warranties of any kind, whether express or implied. We do not guarantee that the service will be uninterrupted, error-free, or that the index will always be complete or current. To the fullest extent permitted by law, the operator of this deployment is not liable for any indirect, incidental, or consequential damages arising from your use of the site."
 msgstr ""
@@ -6059,6 +6135,10 @@ msgstr ""
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Groups collapse and expand, so you can keep the sidebar short and open only what you are reading today. <0>Collapse all lists</0> and <1>Expand all lists</1> do it in one go."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute"
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
@@ -6211,6 +6291,11 @@ msgstr ""
 msgid "Unfollow?"
 msgstr ""
 
+#: src/components/muted-settings-view.tsx
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmute"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Listen to anything"
 msgstr ""
@@ -6327,6 +6412,10 @@ msgstr ""
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Type size, shape, and density"
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Loading muted people"
 msgstr ""
 
 #: src/routes/_layout.latest.tsx
@@ -7034,6 +7123,10 @@ msgstr ""
 msgid "Paused"
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute?"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Reading without an account"
@@ -7084,6 +7177,10 @@ msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Muted here"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "They'll show up in your feeds again."
 msgstr ""
 
 #: src/components/reader/privacy-view.tsx
@@ -7186,6 +7283,10 @@ msgstr ""
 #: src/components/appearance-settings.tsx
 #: src/components/reader/collection-builder.tsx
 msgid "Editorial"
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted publications"
 msgstr ""
 
 #: src/components/docs/api-docs-request-panel.tsx
@@ -7662,6 +7763,10 @@ msgstr ""
 msgid "Read aloud"
 msgstr ""
 
+#: src/components/muted-settings-view.tsx
+msgid "You haven't muted anyone. Mute someone from the menu on their page to hide everything they write — and everything they recommend — without unfollowing."
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr ""
@@ -7825,6 +7930,10 @@ msgstr ""
 
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Filter by topic"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmute {name}"
 msgstr ""
 
 #. placeholder {0}: image.file.name
@@ -8337,6 +8446,10 @@ msgstr ""
 
 #: src/components/reader/saved-filters.tsx
 msgid "Filter saved articles"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute {name}"
 msgstr ""
 
 #: src/components/reader/series-up-next.tsx

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -222,6 +222,7 @@ msgstr ""
 #: src/components/labelers-settings-view.tsx
 #: src/components/muted-settings-view.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 #: src/components/user-settings-view.tsx
 msgid "Muted"
 msgstr ""
@@ -3083,6 +3084,10 @@ msgstr ""
 msgid "What it does"
 msgstr ""
 
+#: src/components/reader/muted-pill.tsx
+msgid "Muted by you"
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 #: src/components/reader/save-to-collection-dialog.tsx
 #: src/components/reader/subscriptions-table.tsx
@@ -3394,6 +3399,10 @@ msgstr ""
 #. placeholder {0}: publication.subscriberCount
 #: src/routes/_layout.collections.index.tsx
 msgid "{0, plural, one {follower} other {followers}}"
+msgstr ""
+
+#: src/components/reader/muted-pill.tsx
+msgid "This publication is muted"
 msgstr ""
 
 #: src/components/reader/about-view.tsx
@@ -4369,6 +4378,7 @@ msgstr ""
 msgid "No matching people."
 msgstr ""
 
+#: src/components/reader/muted-pill.tsx
 #: src/components/user-settings-view.tsx
 msgid "Manage mutes"
 msgstr ""
@@ -4676,6 +4686,7 @@ msgid "{days}d ago"
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "Unmuted"
 msgstr ""
 
@@ -5281,6 +5292,7 @@ msgstr ""
 #: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/blocked-notice.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 #: src/components/route-error.tsx
@@ -6050,6 +6062,7 @@ msgid "No lists yet — switch to New list to create one."
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "We couldn't remove the mute from your account. Try again?"
 msgstr ""
 
@@ -6293,6 +6306,7 @@ msgstr ""
 
 #: src/components/muted-settings-view.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "Unmute"
 msgstr ""
 
@@ -6383,6 +6397,10 @@ msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the queue of articles you put aside. A badge shows how many are waiting."
+msgstr ""
+
+#: src/components/reader/muted-pill.tsx
+msgid "This publication will show up in your feeds again."
 msgstr ""
 
 #: src/routes/_layout.recommended.tsx
@@ -7093,8 +7111,16 @@ msgstr ""
 #~ msgid "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 #~ msgstr ""
 
+#: src/components/reader/muted-pill.tsx
+msgid "Its articles are hidden from your feeds, search and discovery. Your subscription is untouched, and this page still works."
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag"
+msgstr ""
+
+#: src/components/reader/muted-pill.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery. Your subscriptions are untouched, and this page still works."
 msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
@@ -7180,6 +7206,7 @@ msgid "Muted here"
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "They'll show up in your feeds again."
 msgstr ""
 
@@ -8153,6 +8180,10 @@ msgstr ""
 #. placeholder {0}: fmt.relativeTime(connection.lastUsedAt)
 #: src/components/user-settings-view.tsx
 msgid "Last used {0}"
+msgstr ""
+
+#: src/components/reader/muted-pill.tsx
+msgid "This person is muted"
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -105,6 +105,10 @@ msgstr "Try \"climate\", a #tag like #essay, or a handle like stdout.dev"
 msgid "Thanks for taking the time to help us improve Standard Reader."
 msgstr "Thanks for taking the time to help us improve Standard Reader."
 
+#: src/components/user-settings-view.tsx
+msgid "Manage {muteCount} mutes"
+msgstr "Manage {muteCount} mutes"
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Articles and publications carry topic tags. Select one anywhere you see it — under a headline, on a publication card, in Discover — and you get everything filed under it: an <0>Articles</0> tab you can sort by recent, trending, or most popular, and a <1>Publications</1> tab of everyone who writes about it."
 msgstr "Articles and publications carry topic tags. Select one anywhere you see it — under a headline, on a publication card, in Discover — and you get everything filed under it: an <0>Articles</0> tab you can sort by recent, trending, or most popular, and a <1>Publications</1> tab of everyone who writes about it."
@@ -216,12 +220,19 @@ msgstr "That means you can build in whichever direction you need — read the in
 #~ msgstr "Standard Reader works the other way round. You sign in with a Bluesky account, and the things you do here — what you follow, save, recommend, and read — are written into your own account's storage, the same place your Bluesky posts live. We keep a copy so the app is fast, but the original is yours. Another app built on the same network can read it, and if you stop using Standard Reader, none of it disappears."
 
 #: src/components/labelers-settings-view.tsx
+#: src/components/muted-settings-view.tsx
+#: src/components/reader/mute-menu-item.tsx
+#: src/components/user-settings-view.tsx
 msgid "Muted"
 msgstr "Muted"
 
 #: src/components/reader/terms-view.tsx
 msgid "Content and intellectual property"
 msgstr "Content and intellectual property"
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute {name}?"
+msgstr "Mute {name}?"
 
 #: src/components/user-settings-view.tsx
 msgid "Disconnect"
@@ -340,6 +351,10 @@ msgstr "Please add a title."
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
 msgstr "There’s an MCP server on the same host, so you can point an agent at the network too."
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "This publication's articles disappear from your feeds, search and discovery. Your subscription is untouched, and you can still visit the publication directly. You can undo this in Settings → Muted."
+msgstr "This publication's articles disappear from your feeds, search and discovery. Your subscription is untouched, and you can still visit the publication directly. You can undo this in Settings → Muted."
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr "Filter by name, handle, or topic"
@@ -367,6 +382,10 @@ msgstr "Search by title or author, or paste a URL or at:// URI"
 #: src/components/user-settings-view.tsx
 msgid "Show {itemLabel} in the sidebar"
 msgstr "Show {itemLabel} in the sidebar"
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "We couldn't write the mute to your account. Try again?"
+msgstr "We couldn't write the mute to your account. Try again?"
 
 #: src/components/reader/continue-reading.tsx
 #~ msgid "Still open"
@@ -1024,6 +1043,10 @@ msgstr "Clicking Create will first request permissions to create a review."
 msgid "Extension privacy"
 msgstr "Extension privacy"
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "It's hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted."
+msgstr "It's hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted."
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Signing in"
@@ -1032,6 +1055,10 @@ msgstr "Signing in"
 #: src/components/reader/about-view.tsx
 msgid "Public API — no key required"
 msgstr "Public API — no key required"
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people"
+msgstr "Muted people"
 
 #: src/components/reading-settings-preview.tsx
 msgid "Loading voice sample"
@@ -1688,6 +1715,10 @@ msgstr "Embedded content"
 msgid "Account"
 msgstr "Account"
 
+#: src/components/muted-settings-view.tsx
+msgid "Loading muted publications"
+msgstr "Loading muted publications"
+
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "There is no “this is a comic” switch anywhere on the network, and nothing to set on Standard Reader — we do not host your publication. Two things have to be true instead."
 msgstr "There is no “this is a comic” switch anywhere on the network, and nothing to set on Standard Reader — we do not host your publication. Two things have to be true instead."
@@ -1777,6 +1808,10 @@ msgstr "Relaxed"
 #: src/routes/_layout.u.$did.tsx
 msgid "Browse your feed"
 msgstr "Browse your feed"
+
+#: src/components/muted-settings-view.tsx
+msgid "Your mutes are enforced here already. To add or remove one, you'll be asked to re-authorize the first time you try."
+msgstr "Your mutes are enforced here already. To add or remove one, you'll be asked to re-authorize the first time you try."
 
 #: src/components/appearance-settings.tsx
 msgid "Scales every size in the app, article text included — from 13px up to 22px of interface text."
@@ -2136,6 +2171,10 @@ msgstr "Notifications aren’t available here"
 msgid "Loading page"
 msgstr "Loading page"
 
+#: src/components/muted-settings-view.tsx
+msgid "You haven't muted any publications. Mute one from the menu on its page to hide its articles from your feeds while staying subscribed."
+msgstr "You haven't muted any publications. Mute one from the menu on its page to hide its articles from your feeds while staying subscribed."
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "The button sits next to a publication's name wherever you meet it — a card in a feed, the top of an article, the publication's own page. Select it again to unsubscribe."
 msgstr "The button sits next to a publication's name wherever you meet it — a card in a feed, the top of an article, the publication's own page. Select it again to unsubscribe."
@@ -2435,6 +2474,7 @@ msgstr "Articles you've opened — public records in your repo, synced across de
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-publication-editor.tsx
 #: src/components/reader/collection-theme-editor.tsx
+#: src/components/reader/mute-menu-item.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 #: src/components/user-settings-view.tsx
 #: src/routes/_layout.collections.new.tsx
@@ -2599,6 +2639,7 @@ msgstr "Read more from the author"
 
 #: src/components/blocks-settings-view.tsx
 #: src/components/labelers-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 #: src/components/user-settings-view.tsx
 msgid "Moderation"
 msgstr "Moderation"
@@ -2690,6 +2731,10 @@ msgstr "Setting the issue"
 #: src/lib/guide/navigation.ts
 msgid "Feed preferences"
 msgstr "Feed preferences"
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "{name} will show up in your feeds again."
+msgstr "{name} will show up in your feeds again."
 
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "A single post whose title breaks the pattern does not split an issue in two. An interstitial in the middle of issue 3 joins issue 3, and a one-off announcement will not start a phantom issue of its own."
@@ -3097,6 +3142,10 @@ msgstr "<0>Hide recommend and comment counts</0> removes the numbers from articl
 #: src/components/reader/collection-publication-editor.tsx
 msgid "Uploading…"
 msgstr "Uploading…"
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices."
+msgstr "Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices."
 
 #: src/routes/_layout.latest.tsx
 msgid "No articles are trending across the network right now. Check back soon."
@@ -3523,6 +3572,7 @@ msgid "Publications to explore"
 msgstr "Publications to explore"
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 msgid "We couldn't reach your account to change that. Try again?"
 msgstr "We couldn't reach your account to change that. Try again?"
 
@@ -3681,6 +3731,10 @@ msgstr "This API is also served as a <0>Model Context Protocol</0> server at <1>
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
 msgstr "Reset filters"
+
+#: src/components/user-settings-view.tsx
+msgid "Muted people and publications stay subscribed but disappear from your feeds, search, and discovery. Only you can see your mutes' effect — nobody is notified."
+msgstr "Muted people and publications stay subscribed but disappear from your feeds, search, and discovery. Only you can see your mutes' effect — nobody is notified."
 
 #: src/components/push-diagnostics.tsx
 msgid "Service worker"
@@ -4315,6 +4369,10 @@ msgstr "Compare before and after images"
 msgid "No matching people."
 msgstr "No matching people."
 
+#: src/components/user-settings-view.tsx
+msgid "Manage mutes"
+msgstr "Manage mutes"
+
 #: src/components/reader/subscriptions-tree.tsx
 msgid "Empty list."
 msgstr "Empty list."
@@ -4432,6 +4490,10 @@ msgstr "Pasting a handle works even for publications the network has not indexed
 #: src/components/push-diagnostics.tsx
 msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 msgstr "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Their articles, publications and recommendations disappear from your feeds, search and discovery. Your subscriptions are untouched, and you can still visit their pages directly. You can undo this in Settings → Muted."
+msgstr "Their articles, publications and recommendations disappear from your feeds, search and discovery. Your subscriptions are untouched, and you can still visit their pages directly. You can undo this in Settings → Muted."
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "We couldn’t find that publication."
@@ -4612,6 +4674,10 @@ msgstr "This labeler didn’t publish any label definitions."
 #: src/components/reader/format-i18n.ts
 msgid "{days}d ago"
 msgstr "{days}d ago"
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmuted"
+msgstr "Unmuted"
 
 #: src/components/user-settings-view.tsx
 msgid "Continue to approve"
@@ -5211,8 +5277,10 @@ msgid "Not in the directory yet?"
 msgstr "Not in the directory yet?"
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 #: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/blocked-notice.tsx
+#: src/components/reader/mute-menu-item.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 #: src/components/route-error.tsx
@@ -5692,6 +5760,10 @@ msgstr "No known labelers yet."
 msgid "You're all caught up"
 msgstr "You're all caught up"
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "{name} is hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted."
+msgstr "{name} is hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted."
+
 #: src/components/user-settings-view.tsx
 msgid "All publication lists you created in this app."
 msgstr "All publication lists you created in this app."
@@ -5977,6 +6049,10 @@ msgstr "On Bluesky"
 msgid "No lists yet — switch to New list to create one."
 msgstr "No lists yet — switch to New list to create one."
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "We couldn't remove the mute from your account. Try again?"
+msgstr "We couldn't remove the mute from your account. Try again?"
+
 #: src/components/reader/terms-view.tsx
 msgid "{SITE_NAME} is provided “as is” and “as available,” without warranties of any kind, whether express or implied. We do not guarantee that the service will be uninterrupted, error-free, or that the index will always be complete or current. To the fullest extent permitted by law, the operator of this deployment is not liable for any indirect, incidental, or consequential damages arising from your use of the site."
 msgstr "{SITE_NAME} is provided “as is” and “as available,” without warranties of any kind, whether express or implied. We do not guarantee that the service will be uninterrupted, error-free, or that the index will always be complete or current. To the fullest extent permitted by law, the operator of this deployment is not liable for any indirect, incidental, or consequential damages arising from your use of the site."
@@ -6060,6 +6136,10 @@ msgstr "Close tab"
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Groups collapse and expand, so you can keep the sidebar short and open only what you are reading today. <0>Collapse all lists</0> and <1>Expand all lists</1> do it in one go."
 msgstr "Groups collapse and expand, so you can keep the sidebar short and open only what you are reading today. <0>Collapse all lists</0> and <1>Expand all lists</1> do it in one go."
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute"
+msgstr "Mute"
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 #~ msgid "When you follow a publication, save an article, recommend one, or open one, that fact is written into <0>your own account's storage</0> — the same place your Bluesky profile and posts are kept, run by whoever hosts your account."
@@ -6211,6 +6291,11 @@ msgstr "<0>Loading more</0> chooses between infinite scroll and a <1>Load more</
 msgid "Unfollow?"
 msgstr "Unfollow?"
 
+#: src/components/muted-settings-view.tsx
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmute"
+msgstr "Unmute"
+
 #: src/components/reader/about-view.tsx
 msgid "Listen to anything"
 msgstr "Listen to anything"
@@ -6328,6 +6413,10 @@ msgstr "Being in a list does not change your feeds. Everything you subscribe to 
 #: src/lib/guide/navigation.ts
 msgid "Type size, shape, and density"
 msgstr "Type size, shape, and density"
+
+#: src/components/muted-settings-view.tsx
+msgid "Loading muted people"
+msgstr "Loading muted people"
 
 #: src/routes/_layout.latest.tsx
 msgid "All caught up"
@@ -7034,6 +7123,10 @@ msgstr "View on Bluesky"
 msgid "Paused"
 msgstr "Paused"
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute?"
+msgstr "Mute?"
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Reading without an account"
@@ -7085,6 +7178,10 @@ msgstr "Order"
 #: src/components/labeler-detail-view.tsx
 msgid "Muted here"
 msgstr "Muted here"
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "They'll show up in your feeds again."
+msgstr "They'll show up in your feeds again."
 
 #: src/components/reader/privacy-view.tsx
 msgid "Sign-in and record access go through your Personal Data Server and the wider AT Protocol network. Infrastructure providers (such as our database host) process data on our behalf under their own terms. Embedded media, fonts, or links on article pages may load resources from other sites when you open them."
@@ -7187,6 +7284,10 @@ msgstr "Publish & share the run"
 #: src/components/reader/collection-builder.tsx
 msgid "Editorial"
 msgstr "Editorial"
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted publications"
+msgstr "Muted publications"
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Click Run example to fetch a live response with your session."
@@ -7662,6 +7763,10 @@ msgstr "Most cartoonists write a line or two under the page — a caption, a pro
 msgid "Read aloud"
 msgstr "Read aloud"
 
+#: src/components/muted-settings-view.tsx
+msgid "You haven't muted anyone. Mute someone from the menu on their page to hide everything they write — and everything they recommend — without unfollowing."
+msgstr "You haven't muted anyone. Mute someone from the menu on their page to hide everything they write — and everything they recommend — without unfollowing."
+
 #: src/routes/_layout.saved.tsx
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "Articles you've saved for later — in your repo, synced across devices."
@@ -7826,6 +7931,10 @@ msgstr "This is the part that makes Standard Reader different from a normal app,
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Filter by topic"
 msgstr "Filter by topic"
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmute {name}"
+msgstr "Unmute {name}"
 
 #. placeholder {0}: image.file.name
 #: src/components/feedback/feedback-image-picker.tsx
@@ -8338,6 +8447,10 @@ msgstr "Your day: a featured lead and the latest from your subscriptions."
 #: src/components/reader/saved-filters.tsx
 msgid "Filter saved articles"
 msgstr "Filter saved articles"
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute {name}"
+msgstr "Mute {name}"
 
 #: src/components/reader/series-up-next.tsx
 msgid "You’ve read every issue published so far."

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -222,6 +222,7 @@ msgstr "That means you can build in whichever direction you need — read the in
 #: src/components/labelers-settings-view.tsx
 #: src/components/muted-settings-view.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 #: src/components/user-settings-view.tsx
 msgid "Muted"
 msgstr "Muted"
@@ -3083,6 +3084,10 @@ msgstr "Warn"
 msgid "What it does"
 msgstr "What it does"
 
+#: src/components/reader/muted-pill.tsx
+msgid "Muted by you"
+msgstr "Muted by you"
+
 #: src/components/feedback/feedback-dialog.tsx
 #: src/components/reader/save-to-collection-dialog.tsx
 #: src/components/reader/subscriptions-table.tsx
@@ -3395,6 +3400,10 @@ msgstr "Select any image in an article to open it full size. If the article has 
 #: src/routes/_layout.collections.index.tsx
 msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {follower} other {followers}}"
+
+#: src/components/reader/muted-pill.tsx
+msgid "This publication is muted"
+msgstr "This publication is muted"
 
 #: src/components/reader/about-view.tsx
 #~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
@@ -4369,6 +4378,7 @@ msgstr "Compare before and after images"
 msgid "No matching people."
 msgstr "No matching people."
 
+#: src/components/reader/muted-pill.tsx
 #: src/components/user-settings-view.tsx
 msgid "Manage mutes"
 msgstr "Manage mutes"
@@ -4676,6 +4686,7 @@ msgid "{days}d ago"
 msgstr "{days}d ago"
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "Unmuted"
 msgstr "Unmuted"
 
@@ -5281,6 +5292,7 @@ msgstr "Not in the directory yet?"
 #: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/blocked-notice.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 #: src/components/route-error.tsx
@@ -6050,6 +6062,7 @@ msgid "No lists yet — switch to New list to create one."
 msgstr "No lists yet — switch to New list to create one."
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "We couldn't remove the mute from your account. Try again?"
 msgstr "We couldn't remove the mute from your account. Try again?"
 
@@ -6293,6 +6306,7 @@ msgstr "Unfollow?"
 
 #: src/components/muted-settings-view.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "Unmute"
 msgstr "Unmute"
 
@@ -6384,6 +6398,10 @@ msgstr "Labels articles here"
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the queue of articles you put aside. A badge shows how many are waiting."
 msgstr "the queue of articles you put aside. A badge shows how many are waiting."
+
+#: src/components/reader/muted-pill.tsx
+msgid "This publication will show up in your feeds again."
+msgstr "This publication will show up in your feeds again."
 
 #: src/routes/_layout.recommended.tsx
 msgid "Articles you've recommended across the network."
@@ -7093,9 +7111,17 @@ msgstr "It follows you"
 #~ msgid "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 #~ msgstr "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 
+#: src/components/reader/muted-pill.tsx
+msgid "Its articles are hidden from your feeds, search and discovery. Your subscription is untouched, and this page still works."
+msgstr "Its articles are hidden from your feeds, search and discovery. Your subscription is untouched, and this page still works."
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag"
 msgstr "Tag"
+
+#: src/components/reader/muted-pill.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery. Your subscriptions are untouched, and this page still works."
+msgstr "Their articles, publications and recommendations are hidden from your feeds, search and discovery. Your subscriptions are untouched, and this page still works."
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "The React package, for example. With no <0>components</0> prop, a document renders as unstyled semantic HTML."
@@ -7180,6 +7206,7 @@ msgid "Muted here"
 msgstr "Muted here"
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "They'll show up in your feeds again."
 msgstr "They'll show up in your feeds again."
 
@@ -8154,6 +8181,10 @@ msgstr "Semble"
 #: src/components/user-settings-view.tsx
 msgid "Last used {0}"
 msgstr "Last used {0}"
+
+#: src/components/reader/muted-pill.tsx
+msgid "This person is muted"
+msgstr "This person is muted"
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "No feedback matches your filters."

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -105,6 +105,10 @@ msgstr "Pruebe \"clima\", una #etiqueta como #ensayo o un handle como stdout.dev
 msgid "Thanks for taking the time to help us improve Standard Reader."
 msgstr "Gracias por dedicar tiempo a ayudarnos a mejorar Standard Reader."
 
+#: src/components/user-settings-view.tsx
+msgid "Manage {muteCount} mutes"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Articles and publications carry topic tags. Select one anywhere you see it — under a headline, on a publication card, in Discover — and you get everything filed under it: an <0>Articles</0> tab you can sort by recent, trending, or most popular, and a <1>Publications</1> tab of everyone who writes about it."
 msgstr ""
@@ -216,11 +220,18 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/labelers-settings-view.tsx
+#: src/components/muted-settings-view.tsx
+#: src/components/reader/mute-menu-item.tsx
+#: src/components/user-settings-view.tsx
 msgid "Muted"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Content and intellectual property"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute {name}?"
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -340,6 +351,10 @@ msgstr "Añada un título."
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "This publication's articles disappear from your feeds, search and discovery. Your subscription is untouched, and you can still visit the publication directly. You can undo this in Settings → Muted."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -366,6 +381,10 @@ msgstr "Busque por título o autor, o pegue una URL o un URI at://"
 
 #: src/components/user-settings-view.tsx
 msgid "Show {itemLabel} in the sidebar"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "We couldn't write the mute to your account. Try again?"
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
@@ -1024,6 +1043,10 @@ msgstr "Al pulsar Crear se solicitarán primero los permisos para crear una rese
 msgid "Extension privacy"
 msgstr "Privacidad de la extensión"
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "It's hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Signing in"
@@ -1031,6 +1054,10 @@ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Public API — no key required"
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people"
 msgstr ""
 
 #: src/components/reading-settings-preview.tsx
@@ -1688,6 +1715,10 @@ msgstr "Contenido incrustado"
 msgid "Account"
 msgstr "Cuenta"
 
+#: src/components/muted-settings-view.tsx
+msgid "Loading muted publications"
+msgstr ""
+
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "There is no “this is a comic” switch anywhere on the network, and nothing to set on Standard Reader — we do not host your publication. Two things have to be true instead."
 msgstr ""
@@ -1777,6 +1808,10 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Browse your feed"
 msgstr "Explorar su feed"
+
+#: src/components/muted-settings-view.tsx
+msgid "Your mutes are enforced here already. To add or remove one, you'll be asked to re-authorize the first time you try."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Scales every size in the app, article text included — from 13px up to 22px of interface text."
@@ -2136,6 +2171,10 @@ msgstr ""
 msgid "Loading page"
 msgstr "Cargando página"
 
+#: src/components/muted-settings-view.tsx
+msgid "You haven't muted any publications. Mute one from the menu on its page to hide its articles from your feeds while staying subscribed."
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "The button sits next to a publication's name wherever you meet it — a card in a feed, the top of an article, the publication's own page. Select it again to unsubscribe."
 msgstr ""
@@ -2435,6 +2474,7 @@ msgstr "Artículos que ha abierto: registros públicos en su repositorio, sincro
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-publication-editor.tsx
 #: src/components/reader/collection-theme-editor.tsx
+#: src/components/reader/mute-menu-item.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 #: src/components/user-settings-view.tsx
 #: src/routes/_layout.collections.new.tsx
@@ -2599,6 +2639,7 @@ msgstr "Leer más del autor"
 
 #: src/components/blocks-settings-view.tsx
 #: src/components/labelers-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 #: src/components/user-settings-view.tsx
 msgid "Moderation"
 msgstr "Moderación"
@@ -2689,6 +2730,10 @@ msgstr "Estableciendo el número"
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Feed preferences"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "{name} will show up in your feeds again."
 msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx
@@ -3097,6 +3142,10 @@ msgstr ""
 #: src/components/reader/collection-publication-editor.tsx
 msgid "Uploading…"
 msgstr "Subiendo…"
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices."
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "No articles are trending across the network right now. Check back soon."
@@ -3523,6 +3572,7 @@ msgid "Publications to explore"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 msgid "We couldn't reach your account to change that. Try again?"
 msgstr ""
 
@@ -3680,6 +3730,10 @@ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Muted people and publications stay subscribed but disappear from your feeds, search, and discovery. Only you can see your mutes' effect — nobody is notified."
 msgstr ""
 
 #: src/components/push-diagnostics.tsx
@@ -4315,6 +4369,10 @@ msgstr "Comparar las imágenes de antes y después"
 msgid "No matching people."
 msgstr "No hay personas coincidentes."
 
+#: src/components/user-settings-view.tsx
+msgid "Manage mutes"
+msgstr ""
+
 #: src/components/reader/subscriptions-tree.tsx
 msgid "Empty list."
 msgstr "Lista vacía."
@@ -4431,6 +4489,10 @@ msgstr ""
 
 #: src/components/push-diagnostics.tsx
 msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Their articles, publications and recommendations disappear from your feeds, search and discovery. Your subscriptions are untouched, and you can still visit their pages directly. You can undo this in Settings → Muted."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4611,6 +4673,10 @@ msgstr "Este etiquetador no publicó ninguna definición de etiqueta."
 
 #: src/components/reader/format-i18n.ts
 msgid "{days}d ago"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmuted"
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -5211,8 +5277,10 @@ msgid "Not in the directory yet?"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 #: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/blocked-notice.tsx
+#: src/components/reader/mute-menu-item.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 #: src/components/route-error.tsx
@@ -5692,6 +5760,10 @@ msgstr "Todavía no hay etiquetadores conocidos."
 msgid "You're all caught up"
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "{name} is hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "All publication lists you created in this app."
 msgstr "Todas las listas de publicaciones que creó en esta app."
@@ -5977,6 +6049,10 @@ msgstr ""
 msgid "No lists yet — switch to New list to create one."
 msgstr "Aún no hay listas — cambie a Nueva lista para crear una."
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "We couldn't remove the mute from your account. Try again?"
+msgstr ""
+
 #: src/components/reader/terms-view.tsx
 msgid "{SITE_NAME} is provided “as is” and “as available,” without warranties of any kind, whether express or implied. We do not guarantee that the service will be uninterrupted, error-free, or that the index will always be complete or current. To the fullest extent permitted by law, the operator of this deployment is not liable for any indirect, incidental, or consequential damages arising from your use of the site."
 msgstr ""
@@ -6059,6 +6135,10 @@ msgstr "Cerrar pestaña"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Groups collapse and expand, so you can keep the sidebar short and open only what you are reading today. <0>Collapse all lists</0> and <1>Expand all lists</1> do it in one go."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute"
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
@@ -6211,6 +6291,11 @@ msgstr ""
 msgid "Unfollow?"
 msgstr ""
 
+#: src/components/muted-settings-view.tsx
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmute"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Listen to anything"
 msgstr "Escuche lo que sea"
@@ -6327,6 +6412,10 @@ msgstr ""
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Type size, shape, and density"
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Loading muted people"
 msgstr ""
 
 #: src/routes/_layout.latest.tsx
@@ -7034,6 +7123,10 @@ msgstr "Ver en Bluesky"
 msgid "Paused"
 msgstr "En pausa"
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute?"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Reading without an account"
@@ -7084,6 +7177,10 @@ msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Muted here"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "They'll show up in your feeds again."
 msgstr ""
 
 #: src/components/reader/privacy-view.tsx
@@ -7187,6 +7284,10 @@ msgstr "Publicar y compartir la ejecución"
 #: src/components/reader/collection-builder.tsx
 msgid "Editorial"
 msgstr "Editorial"
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted publications"
+msgstr ""
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Click Run example to fetch a live response with your session."
@@ -7662,6 +7763,10 @@ msgstr ""
 msgid "Read aloud"
 msgstr "Leer en voz alta"
 
+#: src/components/muted-settings-view.tsx
+msgid "You haven't muted anyone. Mute someone from the menu on their page to hide everything they write — and everything they recommend — without unfollowing."
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "Artículos que guardó para después: en su repositorio y sincronizados entre dispositivos."
@@ -7826,6 +7931,10 @@ msgstr ""
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Filter by topic"
 msgstr "Filtrar por tema"
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmute {name}"
+msgstr ""
 
 #. placeholder {0}: image.file.name
 #: src/components/feedback/feedback-image-picker.tsx
@@ -8337,6 +8446,10 @@ msgstr ""
 
 #: src/components/reader/saved-filters.tsx
 msgid "Filter saved articles"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute {name}"
 msgstr ""
 
 #: src/components/reader/series-up-next.tsx

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -222,6 +222,7 @@ msgstr ""
 #: src/components/labelers-settings-view.tsx
 #: src/components/muted-settings-view.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 #: src/components/user-settings-view.tsx
 msgid "Muted"
 msgstr ""
@@ -3083,6 +3084,10 @@ msgstr "Advertir"
 msgid "What it does"
 msgstr ""
 
+#: src/components/reader/muted-pill.tsx
+msgid "Muted by you"
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 #: src/components/reader/save-to-collection-dialog.tsx
 #: src/components/reader/subscriptions-table.tsx
@@ -3395,6 +3400,10 @@ msgstr ""
 #: src/routes/_layout.collections.index.tsx
 msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {seguidor} other {seguidores}}"
+
+#: src/components/reader/muted-pill.tsx
+msgid "This publication is muted"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 #~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
@@ -4369,6 +4378,7 @@ msgstr "Comparar las imágenes de antes y después"
 msgid "No matching people."
 msgstr "No hay personas coincidentes."
 
+#: src/components/reader/muted-pill.tsx
 #: src/components/user-settings-view.tsx
 msgid "Manage mutes"
 msgstr ""
@@ -4676,6 +4686,7 @@ msgid "{days}d ago"
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "Unmuted"
 msgstr ""
 
@@ -5281,6 +5292,7 @@ msgstr ""
 #: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/blocked-notice.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 #: src/components/route-error.tsx
@@ -6050,6 +6062,7 @@ msgid "No lists yet — switch to New list to create one."
 msgstr "Aún no hay listas — cambie a Nueva lista para crear una."
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "We couldn't remove the mute from your account. Try again?"
 msgstr ""
 
@@ -6293,6 +6306,7 @@ msgstr ""
 
 #: src/components/muted-settings-view.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "Unmute"
 msgstr ""
 
@@ -6383,6 +6397,10 @@ msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the queue of articles you put aside. A badge shows how many are waiting."
+msgstr ""
+
+#: src/components/reader/muted-pill.tsx
+msgid "This publication will show up in your feeds again."
 msgstr ""
 
 #: src/routes/_layout.recommended.tsx
@@ -7093,9 +7111,17 @@ msgstr ""
 #~ msgid "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 #~ msgstr ""
 
+#: src/components/reader/muted-pill.tsx
+msgid "Its articles are hidden from your feeds, search and discovery. Your subscription is untouched, and this page still works."
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag"
 msgstr "Etiqueta"
+
+#: src/components/reader/muted-pill.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery. Your subscriptions are untouched, and this page still works."
+msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "The React package, for example. With no <0>components</0> prop, a document renders as unstyled semantic HTML."
@@ -7180,6 +7206,7 @@ msgid "Muted here"
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "They'll show up in your feeds again."
 msgstr ""
 
@@ -8153,6 +8180,10 @@ msgstr ""
 #. placeholder {0}: fmt.relativeTime(connection.lastUsedAt)
 #: src/components/user-settings-view.tsx
 msgid "Last used {0}"
+msgstr ""
+
+#: src/components/reader/muted-pill.tsx
+msgid "This person is muted"
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -105,6 +105,10 @@ msgstr "Essayez « climat », un #tag comme #essai, ou un identifiant comme stdo
 msgid "Thanks for taking the time to help us improve Standard Reader."
 msgstr "Merci d’avoir pris le temps de nous aider à améliorer Standard Reader."
 
+#: src/components/user-settings-view.tsx
+msgid "Manage {muteCount} mutes"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Articles and publications carry topic tags. Select one anywhere you see it — under a headline, on a publication card, in Discover — and you get everything filed under it: an <0>Articles</0> tab you can sort by recent, trending, or most popular, and a <1>Publications</1> tab of everyone who writes about it."
 msgstr ""
@@ -216,11 +220,18 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/labelers-settings-view.tsx
+#: src/components/muted-settings-view.tsx
+#: src/components/reader/mute-menu-item.tsx
+#: src/components/user-settings-view.tsx
 msgid "Muted"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Content and intellectual property"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute {name}?"
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -340,6 +351,10 @@ msgstr "Veuillez ajouter un titre."
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "This publication's articles disappear from your feeds, search and discovery. Your subscription is untouched, and you can still visit the publication directly. You can undo this in Settings → Muted."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -366,6 +381,10 @@ msgstr "Recherchez par titre ou auteur, ou collez une URL ou une URI at://"
 
 #: src/components/user-settings-view.tsx
 msgid "Show {itemLabel} in the sidebar"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "We couldn't write the mute to your account. Try again?"
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
@@ -1024,6 +1043,10 @@ msgstr "Cliquer sur Créer demandera d’abord les autorisations nécessaires po
 msgid "Extension privacy"
 msgstr "Confidentialité de l’extension"
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "It's hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Signing in"
@@ -1031,6 +1054,10 @@ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Public API — no key required"
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people"
 msgstr ""
 
 #: src/components/reading-settings-preview.tsx
@@ -1688,6 +1715,10 @@ msgstr "Contenu intégré"
 msgid "Account"
 msgstr "Compte"
 
+#: src/components/muted-settings-view.tsx
+msgid "Loading muted publications"
+msgstr ""
+
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "There is no “this is a comic” switch anywhere on the network, and nothing to set on Standard Reader — we do not host your publication. Two things have to be true instead."
 msgstr ""
@@ -1777,6 +1808,10 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Browse your feed"
 msgstr "Parcourir votre flux"
+
+#: src/components/muted-settings-view.tsx
+msgid "Your mutes are enforced here already. To add or remove one, you'll be asked to re-authorize the first time you try."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Scales every size in the app, article text included — from 13px up to 22px of interface text."
@@ -2136,6 +2171,10 @@ msgstr ""
 msgid "Loading page"
 msgstr "Chargement de la page"
 
+#: src/components/muted-settings-view.tsx
+msgid "You haven't muted any publications. Mute one from the menu on its page to hide its articles from your feeds while staying subscribed."
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "The button sits next to a publication's name wherever you meet it — a card in a feed, the top of an article, the publication's own page. Select it again to unsubscribe."
 msgstr ""
@@ -2435,6 +2474,7 @@ msgstr "Les articles que vous avez ouverts — des enregistrements publics dans 
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-publication-editor.tsx
 #: src/components/reader/collection-theme-editor.tsx
+#: src/components/reader/mute-menu-item.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 #: src/components/user-settings-view.tsx
 #: src/routes/_layout.collections.new.tsx
@@ -2599,6 +2639,7 @@ msgstr "Lire d'autres articles de l'auteur"
 
 #: src/components/blocks-settings-view.tsx
 #: src/components/labelers-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 #: src/components/user-settings-view.tsx
 msgid "Moderation"
 msgstr "Modération"
@@ -2689,6 +2730,10 @@ msgstr "Composition du numéro"
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Feed preferences"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "{name} will show up in your feeds again."
 msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx
@@ -3097,6 +3142,10 @@ msgstr ""
 #: src/components/reader/collection-publication-editor.tsx
 msgid "Uploading…"
 msgstr "Envoi en cours…"
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices."
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "No articles are trending across the network right now. Check back soon."
@@ -3523,6 +3572,7 @@ msgid "Publications to explore"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 msgid "We couldn't reach your account to change that. Try again?"
 msgstr ""
 
@@ -3680,6 +3730,10 @@ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Muted people and publications stay subscribed but disappear from your feeds, search, and discovery. Only you can see your mutes' effect — nobody is notified."
 msgstr ""
 
 #: src/components/push-diagnostics.tsx
@@ -4315,6 +4369,10 @@ msgstr "Comparer les images avant et après"
 msgid "No matching people."
 msgstr "Aucune personne correspondante."
 
+#: src/components/user-settings-view.tsx
+msgid "Manage mutes"
+msgstr ""
+
 #: src/components/reader/subscriptions-tree.tsx
 msgid "Empty list."
 msgstr "Liste vide."
@@ -4431,6 +4489,10 @@ msgstr ""
 
 #: src/components/push-diagnostics.tsx
 msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Their articles, publications and recommendations disappear from your feeds, search and discovery. Your subscriptions are untouched, and you can still visit their pages directly. You can undo this in Settings → Muted."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4611,6 +4673,10 @@ msgstr "Ce service d’étiquetage n’a publié aucune définition d’étiquet
 
 #: src/components/reader/format-i18n.ts
 msgid "{days}d ago"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmuted"
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -5211,8 +5277,10 @@ msgid "Not in the directory yet?"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 #: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/blocked-notice.tsx
+#: src/components/reader/mute-menu-item.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 #: src/components/route-error.tsx
@@ -5692,6 +5760,10 @@ msgstr "Aucun service d'étiquetage connu pour l'instant."
 msgid "You're all caught up"
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "{name} is hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "All publication lists you created in this app."
 msgstr "Toutes les listes de publications que vous avez créées dans cette application."
@@ -5977,6 +6049,10 @@ msgstr ""
 msgid "No lists yet — switch to New list to create one."
 msgstr "Aucune liste pour l'instant — passez à Nouvelle liste pour en créer une."
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "We couldn't remove the mute from your account. Try again?"
+msgstr ""
+
 #: src/components/reader/terms-view.tsx
 msgid "{SITE_NAME} is provided “as is” and “as available,” without warranties of any kind, whether express or implied. We do not guarantee that the service will be uninterrupted, error-free, or that the index will always be complete or current. To the fullest extent permitted by law, the operator of this deployment is not liable for any indirect, incidental, or consequential damages arising from your use of the site."
 msgstr ""
@@ -6059,6 +6135,10 @@ msgstr "Fermer l'onglet"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Groups collapse and expand, so you can keep the sidebar short and open only what you are reading today. <0>Collapse all lists</0> and <1>Expand all lists</1> do it in one go."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute"
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
@@ -6211,6 +6291,11 @@ msgstr ""
 msgid "Unfollow?"
 msgstr ""
 
+#: src/components/muted-settings-view.tsx
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmute"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Listen to anything"
 msgstr "Écouter n'importe quoi"
@@ -6327,6 +6412,10 @@ msgstr ""
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Type size, shape, and density"
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Loading muted people"
 msgstr ""
 
 #: src/routes/_layout.latest.tsx
@@ -7034,6 +7123,10 @@ msgstr "Voir sur Bluesky"
 msgid "Paused"
 msgstr "En pause"
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute?"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Reading without an account"
@@ -7084,6 +7177,10 @@ msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Muted here"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "They'll show up in your feeds again."
 msgstr ""
 
 #: src/components/reader/privacy-view.tsx
@@ -7187,6 +7284,10 @@ msgstr "Publier et partager l'exécution"
 #: src/components/reader/collection-builder.tsx
 msgid "Editorial"
 msgstr "Éditorial"
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted publications"
+msgstr ""
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Click Run example to fetch a live response with your session."
@@ -7662,6 +7763,10 @@ msgstr ""
 msgid "Read aloud"
 msgstr "Lire à voix haute"
 
+#: src/components/muted-settings-view.tsx
+msgid "You haven't muted anyone. Mute someone from the menu on their page to hide everything they write — and everything they recommend — without unfollowing."
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "Les articles que vous avez enregistrés pour plus tard — dans votre dépôt, synchronisés entre vos appareils."
@@ -7826,6 +7931,10 @@ msgstr ""
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Filter by topic"
 msgstr "Filtrer par sujet"
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmute {name}"
+msgstr ""
 
 #. placeholder {0}: image.file.name
 #: src/components/feedback/feedback-image-picker.tsx
@@ -8337,6 +8446,10 @@ msgstr ""
 
 #: src/components/reader/saved-filters.tsx
 msgid "Filter saved articles"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute {name}"
 msgstr ""
 
 #: src/components/reader/series-up-next.tsx

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -222,6 +222,7 @@ msgstr ""
 #: src/components/labelers-settings-view.tsx
 #: src/components/muted-settings-view.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 #: src/components/user-settings-view.tsx
 msgid "Muted"
 msgstr ""
@@ -3083,6 +3084,10 @@ msgstr "Avertir"
 msgid "What it does"
 msgstr ""
 
+#: src/components/reader/muted-pill.tsx
+msgid "Muted by you"
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 #: src/components/reader/save-to-collection-dialog.tsx
 #: src/components/reader/subscriptions-table.tsx
@@ -3395,6 +3400,10 @@ msgstr ""
 #: src/routes/_layout.collections.index.tsx
 msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {abonné} other {abonnés}}"
+
+#: src/components/reader/muted-pill.tsx
+msgid "This publication is muted"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 #~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
@@ -4369,6 +4378,7 @@ msgstr "Comparer les images avant et après"
 msgid "No matching people."
 msgstr "Aucune personne correspondante."
 
+#: src/components/reader/muted-pill.tsx
 #: src/components/user-settings-view.tsx
 msgid "Manage mutes"
 msgstr ""
@@ -4676,6 +4686,7 @@ msgid "{days}d ago"
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "Unmuted"
 msgstr ""
 
@@ -5281,6 +5292,7 @@ msgstr ""
 #: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/blocked-notice.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 #: src/components/route-error.tsx
@@ -6050,6 +6062,7 @@ msgid "No lists yet — switch to New list to create one."
 msgstr "Aucune liste pour l'instant — passez à Nouvelle liste pour en créer une."
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "We couldn't remove the mute from your account. Try again?"
 msgstr ""
 
@@ -6293,6 +6306,7 @@ msgstr ""
 
 #: src/components/muted-settings-view.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "Unmute"
 msgstr ""
 
@@ -6383,6 +6397,10 @@ msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the queue of articles you put aside. A badge shows how many are waiting."
+msgstr ""
+
+#: src/components/reader/muted-pill.tsx
+msgid "This publication will show up in your feeds again."
 msgstr ""
 
 #: src/routes/_layout.recommended.tsx
@@ -7093,9 +7111,17 @@ msgstr ""
 #~ msgid "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 #~ msgstr ""
 
+#: src/components/reader/muted-pill.tsx
+msgid "Its articles are hidden from your feeds, search and discovery. Your subscription is untouched, and this page still works."
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag"
 msgstr "Mot-clé"
+
+#: src/components/reader/muted-pill.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery. Your subscriptions are untouched, and this page still works."
+msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "The React package, for example. With no <0>components</0> prop, a document renders as unstyled semantic HTML."
@@ -7180,6 +7206,7 @@ msgid "Muted here"
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "They'll show up in your feeds again."
 msgstr ""
 
@@ -8153,6 +8180,10 @@ msgstr ""
 #. placeholder {0}: fmt.relativeTime(connection.lastUsedAt)
 #: src/components/user-settings-view.tsx
 msgid "Last used {0}"
+msgstr ""
+
+#: src/components/reader/muted-pill.tsx
+msgid "This person is muted"
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -105,6 +105,10 @@ msgstr "「climate」、#essay のようなタグ、stdout.dev のようなハ�
 msgid "Thanks for taking the time to help us improve Standard Reader."
 msgstr "Standard Reader の改善にご協力いただきありがとうございます。"
 
+#: src/components/user-settings-view.tsx
+msgid "Manage {muteCount} mutes"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Articles and publications carry topic tags. Select one anywhere you see it — under a headline, on a publication card, in Discover — and you get everything filed under it: an <0>Articles</0> tab you can sort by recent, trending, or most popular, and a <1>Publications</1> tab of everyone who writes about it."
 msgstr ""
@@ -216,11 +220,18 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/labelers-settings-view.tsx
+#: src/components/muted-settings-view.tsx
+#: src/components/reader/mute-menu-item.tsx
+#: src/components/user-settings-view.tsx
 msgid "Muted"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Content and intellectual property"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute {name}?"
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -340,6 +351,10 @@ msgstr "タイトルを入力してください。"
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "This publication's articles disappear from your feeds, search and discovery. Your subscription is untouched, and you can still visit the publication directly. You can undo this in Settings → Muted."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -366,6 +381,10 @@ msgstr "タイトルや著者で検索、または URL や at:// URI を貼り�
 
 #: src/components/user-settings-view.tsx
 msgid "Show {itemLabel} in the sidebar"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "We couldn't write the mute to your account. Try again?"
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
@@ -1024,6 +1043,10 @@ msgstr "「作成」を押すと、まずレビュー作成の権限を求めま
 msgid "Extension privacy"
 msgstr "拡張機能のプライバシー"
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "It's hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Signing in"
@@ -1031,6 +1054,10 @@ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Public API — no key required"
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people"
 msgstr ""
 
 #: src/components/reading-settings-preview.tsx
@@ -1688,6 +1715,10 @@ msgstr "埋め込みコンテンツ"
 msgid "Account"
 msgstr "アカウント"
 
+#: src/components/muted-settings-view.tsx
+msgid "Loading muted publications"
+msgstr ""
+
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "There is no “this is a comic” switch anywhere on the network, and nothing to set on Standard Reader — we do not host your publication. Two things have to be true instead."
 msgstr ""
@@ -1777,6 +1808,10 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Browse your feed"
 msgstr "フィードを見る"
+
+#: src/components/muted-settings-view.tsx
+msgid "Your mutes are enforced here already. To add or remove one, you'll be asked to re-authorize the first time you try."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Scales every size in the app, article text included — from 13px up to 22px of interface text."
@@ -2136,6 +2171,10 @@ msgstr ""
 msgid "Loading page"
 msgstr "ページを読み込み中"
 
+#: src/components/muted-settings-view.tsx
+msgid "You haven't muted any publications. Mute one from the menu on its page to hide its articles from your feeds while staying subscribed."
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "The button sits next to a publication's name wherever you meet it — a card in a feed, the top of an article, the publication's own page. Select it again to unsubscribe."
 msgstr ""
@@ -2435,6 +2474,7 @@ msgstr "開いたことのある記事です。リポジトリ内の公開レコ
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-publication-editor.tsx
 #: src/components/reader/collection-theme-editor.tsx
+#: src/components/reader/mute-menu-item.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 #: src/components/user-settings-view.tsx
 #: src/routes/_layout.collections.new.tsx
@@ -2599,6 +2639,7 @@ msgstr "この著者の他の記事を読む"
 
 #: src/components/blocks-settings-view.tsx
 #: src/components/labelers-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 #: src/components/user-settings-view.tsx
 msgid "Moderation"
 msgstr "モデレーション"
@@ -2689,6 +2730,10 @@ msgstr "号を設定"
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Feed preferences"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "{name} will show up in your feeds again."
 msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx
@@ -3097,6 +3142,10 @@ msgstr ""
 #: src/components/reader/collection-publication-editor.tsx
 msgid "Uploading…"
 msgstr "アップロード中…"
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices."
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "No articles are trending across the network right now. Check back soon."
@@ -3523,6 +3572,7 @@ msgid "Publications to explore"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 msgid "We couldn't reach your account to change that. Try again?"
 msgstr ""
 
@@ -3680,6 +3730,10 @@ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Muted people and publications stay subscribed but disappear from your feeds, search, and discovery. Only you can see your mutes' effect — nobody is notified."
 msgstr ""
 
 #: src/components/push-diagnostics.tsx
@@ -4315,6 +4369,10 @@ msgstr "ビフォーとアフターの画像を比較"
 msgid "No matching people."
 msgstr "一致するユーザーはいません。"
 
+#: src/components/user-settings-view.tsx
+msgid "Manage mutes"
+msgstr ""
+
 #: src/components/reader/subscriptions-tree.tsx
 msgid "Empty list."
 msgstr "リストは空です。"
@@ -4431,6 +4489,10 @@ msgstr ""
 
 #: src/components/push-diagnostics.tsx
 msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Their articles, publications and recommendations disappear from your feeds, search and discovery. Your subscriptions are untouched, and you can still visit their pages directly. You can undo this in Settings → Muted."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4611,6 +4673,10 @@ msgstr "このラベラーはラベル定義を公開していません。"
 
 #: src/components/reader/format-i18n.ts
 msgid "{days}d ago"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmuted"
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -5211,8 +5277,10 @@ msgid "Not in the directory yet?"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 #: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/blocked-notice.tsx
+#: src/components/reader/mute-menu-item.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 #: src/components/route-error.tsx
@@ -5692,6 +5760,10 @@ msgstr "既知のラベラーはまだありません。"
 msgid "You're all caught up"
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "{name} is hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "All publication lists you created in this app."
 msgstr "このアプリで作成したすべての発行物リストです。"
@@ -5977,6 +6049,10 @@ msgstr ""
 msgid "No lists yet — switch to New list to create one."
 msgstr "リストはまだありません。「新しいリスト」に切り替えて作成してください。"
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "We couldn't remove the mute from your account. Try again?"
+msgstr ""
+
 #: src/components/reader/terms-view.tsx
 msgid "{SITE_NAME} is provided “as is” and “as available,” without warranties of any kind, whether express or implied. We do not guarantee that the service will be uninterrupted, error-free, or that the index will always be complete or current. To the fullest extent permitted by law, the operator of this deployment is not liable for any indirect, incidental, or consequential damages arising from your use of the site."
 msgstr ""
@@ -6059,6 +6135,10 @@ msgstr "タブを閉じる"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Groups collapse and expand, so you can keep the sidebar short and open only what you are reading today. <0>Collapse all lists</0> and <1>Expand all lists</1> do it in one go."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute"
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
@@ -6211,6 +6291,11 @@ msgstr ""
 msgid "Unfollow?"
 msgstr ""
 
+#: src/components/muted-settings-view.tsx
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmute"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Listen to anything"
 msgstr "何でも聴く"
@@ -6327,6 +6412,10 @@ msgstr ""
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Type size, shape, and density"
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Loading muted people"
 msgstr ""
 
 #: src/routes/_layout.latest.tsx
@@ -7034,6 +7123,10 @@ msgstr "Bluesky で見る"
 msgid "Paused"
 msgstr "一時停止中"
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute?"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Reading without an account"
@@ -7084,6 +7177,10 @@ msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Muted here"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "They'll show up in your feeds again."
 msgstr ""
 
 #: src/components/reader/privacy-view.tsx
@@ -7187,6 +7284,10 @@ msgstr "公開して共有"
 #: src/components/reader/collection-builder.tsx
 msgid "Editorial"
 msgstr "編集部"
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted publications"
+msgstr ""
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Click Run example to fetch a live response with your session."
@@ -7662,6 +7763,10 @@ msgstr ""
 msgid "Read aloud"
 msgstr "読み上げ"
 
+#: src/components/muted-settings-view.tsx
+msgid "You haven't muted anyone. Mute someone from the menu on their page to hide everything they write — and everything they recommend — without unfollowing."
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "あとで読むために保存した記事です。リポジトリに保存され、デバイス間で同期されます。"
@@ -7826,6 +7931,10 @@ msgstr ""
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Filter by topic"
 msgstr "トピックで絞り込む"
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmute {name}"
+msgstr ""
 
 #. placeholder {0}: image.file.name
 #: src/components/feedback/feedback-image-picker.tsx
@@ -8337,6 +8446,10 @@ msgstr ""
 
 #: src/components/reader/saved-filters.tsx
 msgid "Filter saved articles"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute {name}"
 msgstr ""
 
 #: src/components/reader/series-up-next.tsx

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -222,6 +222,7 @@ msgstr ""
 #: src/components/labelers-settings-view.tsx
 #: src/components/muted-settings-view.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 #: src/components/user-settings-view.tsx
 msgid "Muted"
 msgstr ""
@@ -3083,6 +3084,10 @@ msgstr "警告"
 msgid "What it does"
 msgstr ""
 
+#: src/components/reader/muted-pill.tsx
+msgid "Muted by you"
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 #: src/components/reader/save-to-collection-dialog.tsx
 #: src/components/reader/subscriptions-table.tsx
@@ -3395,6 +3400,10 @@ msgstr ""
 #: src/routes/_layout.collections.index.tsx
 msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {フォロワー} other {フォロワー}}"
+
+#: src/components/reader/muted-pill.tsx
+msgid "This publication is muted"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 #~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
@@ -4369,6 +4378,7 @@ msgstr "ビフォーとアフターの画像を比較"
 msgid "No matching people."
 msgstr "一致するユーザーはいません。"
 
+#: src/components/reader/muted-pill.tsx
 #: src/components/user-settings-view.tsx
 msgid "Manage mutes"
 msgstr ""
@@ -4676,6 +4686,7 @@ msgid "{days}d ago"
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "Unmuted"
 msgstr ""
 
@@ -5281,6 +5292,7 @@ msgstr ""
 #: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/blocked-notice.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 #: src/components/route-error.tsx
@@ -6050,6 +6062,7 @@ msgid "No lists yet — switch to New list to create one."
 msgstr "リストはまだありません。「新しいリスト」に切り替えて作成してください。"
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "We couldn't remove the mute from your account. Try again?"
 msgstr ""
 
@@ -6293,6 +6306,7 @@ msgstr ""
 
 #: src/components/muted-settings-view.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "Unmute"
 msgstr ""
 
@@ -6383,6 +6397,10 @@ msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the queue of articles you put aside. A badge shows how many are waiting."
+msgstr ""
+
+#: src/components/reader/muted-pill.tsx
+msgid "This publication will show up in your feeds again."
 msgstr ""
 
 #: src/routes/_layout.recommended.tsx
@@ -7093,9 +7111,17 @@ msgstr ""
 #~ msgid "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 #~ msgstr ""
 
+#: src/components/reader/muted-pill.tsx
+msgid "Its articles are hidden from your feeds, search and discovery. Your subscription is untouched, and this page still works."
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag"
 msgstr "タグ"
+
+#: src/components/reader/muted-pill.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery. Your subscriptions are untouched, and this page still works."
+msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "The React package, for example. With no <0>components</0> prop, a document renders as unstyled semantic HTML."
@@ -7180,6 +7206,7 @@ msgid "Muted here"
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "They'll show up in your feeds again."
 msgstr ""
 
@@ -8153,6 +8180,10 @@ msgstr ""
 #. placeholder {0}: fmt.relativeTime(connection.lastUsedAt)
 #: src/components/user-settings-view.tsx
 msgid "Last used {0}"
+msgstr ""
+
+#: src/components/reader/muted-pill.tsx
+msgid "This person is muted"
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -105,6 +105,10 @@ msgstr "\"기후\", #에세이 같은 #태그, 또는 stdout.dev 같은 핸들�
 msgid "Thanks for taking the time to help us improve Standard Reader."
 msgstr "시간을 내어 Standard Reader 개선에 도움을 주셔서 감사합니다."
 
+#: src/components/user-settings-view.tsx
+msgid "Manage {muteCount} mutes"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Articles and publications carry topic tags. Select one anywhere you see it — under a headline, on a publication card, in Discover — and you get everything filed under it: an <0>Articles</0> tab you can sort by recent, trending, or most popular, and a <1>Publications</1> tab of everyone who writes about it."
 msgstr ""
@@ -216,11 +220,18 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/labelers-settings-view.tsx
+#: src/components/muted-settings-view.tsx
+#: src/components/reader/mute-menu-item.tsx
+#: src/components/user-settings-view.tsx
 msgid "Muted"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Content and intellectual property"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute {name}?"
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -340,6 +351,10 @@ msgstr "제목을 입력하세요."
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "This publication's articles disappear from your feeds, search and discovery. Your subscription is untouched, and you can still visit the publication directly. You can undo this in Settings → Muted."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -366,6 +381,10 @@ msgstr "제목이나 저자로 검색하거나 URL 또는 at:// URI를 붙여넣
 
 #: src/components/user-settings-view.tsx
 msgid "Show {itemLabel} in the sidebar"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "We couldn't write the mute to your account. Try again?"
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
@@ -1024,6 +1043,10 @@ msgstr "만들기를 누르면 먼저 리뷰 작성 권한을 요청합니다."
 msgid "Extension privacy"
 msgstr "확장 프로그램 개인정보 보호"
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "It's hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Signing in"
@@ -1031,6 +1054,10 @@ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Public API — no key required"
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people"
 msgstr ""
 
 #: src/components/reading-settings-preview.tsx
@@ -1688,6 +1715,10 @@ msgstr "임베드된 콘텐츠"
 msgid "Account"
 msgstr "계정"
 
+#: src/components/muted-settings-view.tsx
+msgid "Loading muted publications"
+msgstr ""
+
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "There is no “this is a comic” switch anywhere on the network, and nothing to set on Standard Reader — we do not host your publication. Two things have to be true instead."
 msgstr ""
@@ -1777,6 +1808,10 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Browse your feed"
 msgstr "내 피드 둘러보기"
+
+#: src/components/muted-settings-view.tsx
+msgid "Your mutes are enforced here already. To add or remove one, you'll be asked to re-authorize the first time you try."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Scales every size in the app, article text included — from 13px up to 22px of interface text."
@@ -2136,6 +2171,10 @@ msgstr ""
 msgid "Loading page"
 msgstr "페이지 불러오는 중"
 
+#: src/components/muted-settings-view.tsx
+msgid "You haven't muted any publications. Mute one from the menu on its page to hide its articles from your feeds while staying subscribed."
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "The button sits next to a publication's name wherever you meet it — a card in a feed, the top of an article, the publication's own page. Select it again to unsubscribe."
 msgstr ""
@@ -2435,6 +2474,7 @@ msgstr "열어본 아티클입니다. 내 저장소의 공개 레코드로, 여�
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-publication-editor.tsx
 #: src/components/reader/collection-theme-editor.tsx
+#: src/components/reader/mute-menu-item.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 #: src/components/user-settings-view.tsx
 #: src/routes/_layout.collections.new.tsx
@@ -2599,6 +2639,7 @@ msgstr "이 작가의 다른 글 보기"
 
 #: src/components/blocks-settings-view.tsx
 #: src/components/labelers-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 #: src/components/user-settings-view.tsx
 msgid "Moderation"
 msgstr "모더레이션"
@@ -2689,6 +2730,10 @@ msgstr "호 설정 중"
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Feed preferences"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "{name} will show up in your feeds again."
 msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx
@@ -3097,6 +3142,10 @@ msgstr ""
 #: src/components/reader/collection-publication-editor.tsx
 msgid "Uploading…"
 msgstr "업로드 중…"
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices."
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "No articles are trending across the network right now. Check back soon."
@@ -3523,6 +3572,7 @@ msgid "Publications to explore"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 msgid "We couldn't reach your account to change that. Try again?"
 msgstr ""
 
@@ -3680,6 +3730,10 @@ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Muted people and publications stay subscribed but disappear from your feeds, search, and discovery. Only you can see your mutes' effect — nobody is notified."
 msgstr ""
 
 #: src/components/push-diagnostics.tsx
@@ -4315,6 +4369,10 @@ msgstr "이전과 이후 이미지 비교"
 msgid "No matching people."
 msgstr "일치하는 사람이 없습니다."
 
+#: src/components/user-settings-view.tsx
+msgid "Manage mutes"
+msgstr ""
+
 #: src/components/reader/subscriptions-tree.tsx
 msgid "Empty list."
 msgstr "빈 목록입니다."
@@ -4431,6 +4489,10 @@ msgstr ""
 
 #: src/components/push-diagnostics.tsx
 msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Their articles, publications and recommendations disappear from your feeds, search and discovery. Your subscriptions are untouched, and you can still visit their pages directly. You can undo this in Settings → Muted."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4611,6 +4673,10 @@ msgstr "이 레이블러는 레이블 정의를 게시하지 않았습니다."
 
 #: src/components/reader/format-i18n.ts
 msgid "{days}d ago"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmuted"
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -5211,8 +5277,10 @@ msgid "Not in the directory yet?"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 #: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/blocked-notice.tsx
+#: src/components/reader/mute-menu-item.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 #: src/components/route-error.tsx
@@ -5692,6 +5760,10 @@ msgstr "아직 알려진 라벨러가 없습니다."
 msgid "You're all caught up"
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "{name} is hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "All publication lists you created in this app."
 msgstr "이 앱에서 만든 모든 발행물 목록입니다."
@@ -5977,6 +6049,10 @@ msgstr ""
 msgid "No lists yet — switch to New list to create one."
 msgstr "아직 목록이 없습니다. 새 목록으로 전환해 만들어 보세요."
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "We couldn't remove the mute from your account. Try again?"
+msgstr ""
+
 #: src/components/reader/terms-view.tsx
 msgid "{SITE_NAME} is provided “as is” and “as available,” without warranties of any kind, whether express or implied. We do not guarantee that the service will be uninterrupted, error-free, or that the index will always be complete or current. To the fullest extent permitted by law, the operator of this deployment is not liable for any indirect, incidental, or consequential damages arising from your use of the site."
 msgstr ""
@@ -6059,6 +6135,10 @@ msgstr "탭 닫기"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Groups collapse and expand, so you can keep the sidebar short and open only what you are reading today. <0>Collapse all lists</0> and <1>Expand all lists</1> do it in one go."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute"
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
@@ -6211,6 +6291,11 @@ msgstr ""
 msgid "Unfollow?"
 msgstr ""
 
+#: src/components/muted-settings-view.tsx
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmute"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Listen to anything"
 msgstr "무엇이든 들어보세요"
@@ -6327,6 +6412,10 @@ msgstr ""
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Type size, shape, and density"
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Loading muted people"
 msgstr ""
 
 #: src/routes/_layout.latest.tsx
@@ -7034,6 +7123,10 @@ msgstr "Bluesky에서 보기"
 msgid "Paused"
 msgstr "일시정지됨"
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute?"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Reading without an account"
@@ -7084,6 +7177,10 @@ msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Muted here"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "They'll show up in your feeds again."
 msgstr ""
 
 #: src/components/reader/privacy-view.tsx
@@ -7187,6 +7284,10 @@ msgstr "실행 결과 게시 및 공유"
 #: src/components/reader/collection-builder.tsx
 msgid "Editorial"
 msgstr "에디토리얼"
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted publications"
+msgstr ""
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Click Run example to fetch a live response with your session."
@@ -7662,6 +7763,10 @@ msgstr ""
 msgid "Read aloud"
 msgstr "소리내어 읽기"
 
+#: src/components/muted-settings-view.tsx
+msgid "You haven't muted anyone. Mute someone from the menu on their page to hide everything they write — and everything they recommend — without unfollowing."
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "나중에 읽으려고 저장한 글 — 내 저장소에 보관되어 기기 간에 동기화됩니다."
@@ -7826,6 +7931,10 @@ msgstr ""
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Filter by topic"
 msgstr "주제로 필터"
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmute {name}"
+msgstr ""
 
 #. placeholder {0}: image.file.name
 #: src/components/feedback/feedback-image-picker.tsx
@@ -8337,6 +8446,10 @@ msgstr ""
 
 #: src/components/reader/saved-filters.tsx
 msgid "Filter saved articles"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute {name}"
 msgstr ""
 
 #: src/components/reader/series-up-next.tsx

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -222,6 +222,7 @@ msgstr ""
 #: src/components/labelers-settings-view.tsx
 #: src/components/muted-settings-view.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 #: src/components/user-settings-view.tsx
 msgid "Muted"
 msgstr ""
@@ -3083,6 +3084,10 @@ msgstr "경고"
 msgid "What it does"
 msgstr ""
 
+#: src/components/reader/muted-pill.tsx
+msgid "Muted by you"
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 #: src/components/reader/save-to-collection-dialog.tsx
 #: src/components/reader/subscriptions-table.tsx
@@ -3395,6 +3400,10 @@ msgstr ""
 #: src/routes/_layout.collections.index.tsx
 msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {팔로워} other {팔로워}}"
+
+#: src/components/reader/muted-pill.tsx
+msgid "This publication is muted"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 #~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
@@ -4369,6 +4378,7 @@ msgstr "이전과 이후 이미지 비교"
 msgid "No matching people."
 msgstr "일치하는 사람이 없습니다."
 
+#: src/components/reader/muted-pill.tsx
 #: src/components/user-settings-view.tsx
 msgid "Manage mutes"
 msgstr ""
@@ -4676,6 +4686,7 @@ msgid "{days}d ago"
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "Unmuted"
 msgstr ""
 
@@ -5281,6 +5292,7 @@ msgstr ""
 #: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/blocked-notice.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 #: src/components/route-error.tsx
@@ -6050,6 +6062,7 @@ msgid "No lists yet — switch to New list to create one."
 msgstr "아직 목록이 없습니다. 새 목록으로 전환해 만들어 보세요."
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "We couldn't remove the mute from your account. Try again?"
 msgstr ""
 
@@ -6293,6 +6306,7 @@ msgstr ""
 
 #: src/components/muted-settings-view.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "Unmute"
 msgstr ""
 
@@ -6383,6 +6397,10 @@ msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the queue of articles you put aside. A badge shows how many are waiting."
+msgstr ""
+
+#: src/components/reader/muted-pill.tsx
+msgid "This publication will show up in your feeds again."
 msgstr ""
 
 #: src/routes/_layout.recommended.tsx
@@ -7093,9 +7111,17 @@ msgstr ""
 #~ msgid "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 #~ msgstr ""
 
+#: src/components/reader/muted-pill.tsx
+msgid "Its articles are hidden from your feeds, search and discovery. Your subscription is untouched, and this page still works."
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag"
 msgstr "태그"
+
+#: src/components/reader/muted-pill.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery. Your subscriptions are untouched, and this page still works."
+msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "The React package, for example. With no <0>components</0> prop, a document renders as unstyled semantic HTML."
@@ -7180,6 +7206,7 @@ msgid "Muted here"
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "They'll show up in your feeds again."
 msgstr ""
 
@@ -8153,6 +8180,10 @@ msgstr ""
 #. placeholder {0}: fmt.relativeTime(connection.lastUsedAt)
 #: src/components/user-settings-view.tsx
 msgid "Last used {0}"
+msgstr ""
+
+#: src/components/reader/muted-pill.tsx
+msgid "This person is muted"
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -222,6 +222,7 @@ msgstr "Isso significa que você pode desenvolver na direção que precisar: ler
 #: src/components/labelers-settings-view.tsx
 #: src/components/muted-settings-view.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 #: src/components/user-settings-view.tsx
 msgid "Muted"
 msgstr ""
@@ -3083,6 +3084,10 @@ msgstr "Avisar"
 msgid "What it does"
 msgstr ""
 
+#: src/components/reader/muted-pill.tsx
+msgid "Muted by you"
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 #: src/components/reader/save-to-collection-dialog.tsx
 #: src/components/reader/subscriptions-table.tsx
@@ -3395,6 +3400,10 @@ msgstr ""
 #: src/routes/_layout.collections.index.tsx
 msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {seguidor} other {seguidores}}"
+
+#: src/components/reader/muted-pill.tsx
+msgid "This publication is muted"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 #~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
@@ -4369,6 +4378,7 @@ msgstr "Comparar imagens antes e depois"
 msgid "No matching people."
 msgstr "Sem pessoas correspondentes."
 
+#: src/components/reader/muted-pill.tsx
 #: src/components/user-settings-view.tsx
 msgid "Manage mutes"
 msgstr ""
@@ -4676,6 +4686,7 @@ msgid "{days}d ago"
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "Unmuted"
 msgstr ""
 
@@ -5281,6 +5292,7 @@ msgstr ""
 #: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/blocked-notice.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 #: src/components/route-error.tsx
@@ -6050,6 +6062,7 @@ msgid "No lists yet — switch to New list to create one."
 msgstr "Ainda não há listas — mude para Nova lista para criar uma."
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "We couldn't remove the mute from your account. Try again?"
 msgstr ""
 
@@ -6293,6 +6306,7 @@ msgstr "Deixar de seguir?"
 
 #: src/components/muted-settings-view.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "Unmute"
 msgstr ""
 
@@ -6383,6 +6397,10 @@ msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the queue of articles you put aside. A badge shows how many are waiting."
+msgstr ""
+
+#: src/components/reader/muted-pill.tsx
+msgid "This publication will show up in your feeds again."
 msgstr ""
 
 #: src/routes/_layout.recommended.tsx
@@ -7093,9 +7111,17 @@ msgstr ""
 #~ msgid "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 #~ msgstr "Cada renderizador recebe uma entrada para o documento — o conteúdo de um <0>site.standard.document</0>. O formato é detectado a partir do <1>$type</1> do conteúdo."
 
+#: src/components/reader/muted-pill.tsx
+msgid "Its articles are hidden from your feeds, search and discovery. Your subscription is untouched, and this page still works."
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag"
 msgstr "Etiqueta"
+
+#: src/components/reader/muted-pill.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery. Your subscriptions are untouched, and this page still works."
+msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "The React package, for example. With no <0>components</0> prop, a document renders as unstyled semantic HTML."
@@ -7180,6 +7206,7 @@ msgid "Muted here"
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "They'll show up in your feeds again."
 msgstr ""
 
@@ -8153,6 +8180,10 @@ msgstr ""
 #. placeholder {0}: fmt.relativeTime(connection.lastUsedAt)
 #: src/components/user-settings-view.tsx
 msgid "Last used {0}"
+msgstr ""
+
+#: src/components/reader/muted-pill.tsx
+msgid "This person is muted"
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -105,6 +105,10 @@ msgstr "Experimente \"clima\", uma #etiqueta como #ensaio ou um nome de usuário
 msgid "Thanks for taking the time to help us improve Standard Reader."
 msgstr "Obrigado por dedicar o seu tempo a ajudar-nos a melhorar o Standard Reader."
 
+#: src/components/user-settings-view.tsx
+msgid "Manage {muteCount} mutes"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Articles and publications carry topic tags. Select one anywhere you see it — under a headline, on a publication card, in Discover — and you get everything filed under it: an <0>Articles</0> tab you can sort by recent, trending, or most popular, and a <1>Publications</1> tab of everyone who writes about it."
 msgstr ""
@@ -216,12 +220,19 @@ msgstr "Isso significa que você pode desenvolver na direção que precisar: ler
 #~ msgstr ""
 
 #: src/components/labelers-settings-view.tsx
+#: src/components/muted-settings-view.tsx
+#: src/components/reader/mute-menu-item.tsx
+#: src/components/user-settings-view.tsx
 msgid "Muted"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Content and intellectual property"
 msgstr "Conteúdo e propriedade intelectual"
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute {name}?"
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Disconnect"
@@ -340,6 +351,10 @@ msgstr "Adicione um título."
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "This publication's articles disappear from your feeds, search and discovery. Your subscription is untouched, and you can still visit the publication directly. You can undo this in Settings → Muted."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr "Filtrar por nome, nome de usuário, ou tema"
@@ -366,6 +381,10 @@ msgstr "Pesquise por título ou autor, ou cole um URL ou URI at://"
 
 #: src/components/user-settings-view.tsx
 msgid "Show {itemLabel} in the sidebar"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "We couldn't write the mute to your account. Try again?"
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
@@ -1024,6 +1043,10 @@ msgstr "Ao clicar em Criar, primeiro serão pedidas permissões para criar uma a
 msgid "Extension privacy"
 msgstr "Privacidade da extensão"
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "It's hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Signing in"
@@ -1031,6 +1054,10 @@ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Public API — no key required"
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people"
 msgstr ""
 
 #: src/components/reading-settings-preview.tsx
@@ -1688,6 +1715,10 @@ msgstr "Conteúdo incorporado"
 msgid "Account"
 msgstr "Conta"
 
+#: src/components/muted-settings-view.tsx
+msgid "Loading muted publications"
+msgstr ""
+
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "There is no “this is a comic” switch anywhere on the network, and nothing to set on Standard Reader — we do not host your publication. Two things have to be true instead."
 msgstr ""
@@ -1777,6 +1808,10 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Browse your feed"
 msgstr "Explorar o seu feed"
+
+#: src/components/muted-settings-view.tsx
+msgid "Your mutes are enforced here already. To add or remove one, you'll be asked to re-authorize the first time you try."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Scales every size in the app, article text included — from 13px up to 22px of interface text."
@@ -2136,6 +2171,10 @@ msgstr ""
 msgid "Loading page"
 msgstr "Carregando página"
 
+#: src/components/muted-settings-view.tsx
+msgid "You haven't muted any publications. Mute one from the menu on its page to hide its articles from your feeds while staying subscribed."
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "The button sits next to a publication's name wherever you meet it — a card in a feed, the top of an article, the publication's own page. Select it again to unsubscribe."
 msgstr ""
@@ -2435,6 +2474,7 @@ msgstr "Artigos que abriu — registos públicos no seu repositório, sincroniza
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-publication-editor.tsx
 #: src/components/reader/collection-theme-editor.tsx
+#: src/components/reader/mute-menu-item.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 #: src/components/user-settings-view.tsx
 #: src/routes/_layout.collections.new.tsx
@@ -2599,6 +2639,7 @@ msgstr "Ler mais do autor"
 
 #: src/components/blocks-settings-view.tsx
 #: src/components/labelers-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 #: src/components/user-settings-view.tsx
 msgid "Moderation"
 msgstr "Moderação"
@@ -2689,6 +2730,10 @@ msgstr "Configurando a edição"
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Feed preferences"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "{name} will show up in your feeds again."
 msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx
@@ -3097,6 +3142,10 @@ msgstr ""
 #: src/components/reader/collection-publication-editor.tsx
 msgid "Uploading…"
 msgstr "Enviando…"
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices."
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "No articles are trending across the network right now. Check back soon."
@@ -3523,6 +3572,7 @@ msgid "Publications to explore"
 msgstr "Publicações para explorar"
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 msgid "We couldn't reach your account to change that. Try again?"
 msgstr ""
 
@@ -3680,6 +3730,10 @@ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Muted people and publications stay subscribed but disappear from your feeds, search, and discovery. Only you can see your mutes' effect — nobody is notified."
 msgstr ""
 
 #: src/components/push-diagnostics.tsx
@@ -4315,6 +4369,10 @@ msgstr "Comparar imagens antes e depois"
 msgid "No matching people."
 msgstr "Sem pessoas correspondentes."
 
+#: src/components/user-settings-view.tsx
+msgid "Manage mutes"
+msgstr ""
+
 #: src/components/reader/subscriptions-tree.tsx
 msgid "Empty list."
 msgstr "Lista vazia."
@@ -4431,6 +4489,10 @@ msgstr ""
 
 #: src/components/push-diagnostics.tsx
 msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Their articles, publications and recommendations disappear from your feeds, search and discovery. Your subscriptions are untouched, and you can still visit their pages directly. You can undo this in Settings → Muted."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4611,6 +4673,10 @@ msgstr "Este rotulador não publicou nenhuma definição de rótulos."
 
 #: src/components/reader/format-i18n.ts
 msgid "{days}d ago"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmuted"
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -5211,8 +5277,10 @@ msgid "Not in the directory yet?"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 #: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/blocked-notice.tsx
+#: src/components/reader/mute-menu-item.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 #: src/components/route-error.tsx
@@ -5692,6 +5760,10 @@ msgstr "Ainda não há rotuladores conhecidos."
 msgid "You're all caught up"
 msgstr "Você está em dia"
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "{name} is hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "All publication lists you created in this app."
 msgstr "Todas as listas de publicações que criou nesta aplicação."
@@ -5977,6 +6049,10 @@ msgstr ""
 msgid "No lists yet — switch to New list to create one."
 msgstr "Ainda não há listas — mude para Nova lista para criar uma."
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "We couldn't remove the mute from your account. Try again?"
+msgstr ""
+
 #: src/components/reader/terms-view.tsx
 msgid "{SITE_NAME} is provided “as is” and “as available,” without warranties of any kind, whether express or implied. We do not guarantee that the service will be uninterrupted, error-free, or that the index will always be complete or current. To the fullest extent permitted by law, the operator of this deployment is not liable for any indirect, incidental, or consequential damages arising from your use of the site."
 msgstr "O {SITE_NAME} é disponibilizado \"no “estado em que se encontra” e “conforme a disponibilidade”, sem garantias de qualquer tipo, sejam elas expressas ou implícitas. Não garantimos que o serviço será ininterrupto ou livre de erros, nem que o índice estará sempre completo ou atualizado. Na máxima extensão permitida por lei, o operador desta implementação não se responsabiliza por quaisquer danos indiretos, incidentais ou consequenciais decorrentes do seu uso do site."
@@ -6059,6 +6135,10 @@ msgstr "Fechar aba"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Groups collapse and expand, so you can keep the sidebar short and open only what you are reading today. <0>Collapse all lists</0> and <1>Expand all lists</1> do it in one go."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute"
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
@@ -6211,6 +6291,11 @@ msgstr ""
 msgid "Unfollow?"
 msgstr "Deixar de seguir?"
 
+#: src/components/muted-settings-view.tsx
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmute"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Listen to anything"
 msgstr "Ouvir seja o que for"
@@ -6327,6 +6412,10 @@ msgstr ""
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Type size, shape, and density"
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Loading muted people"
 msgstr ""
 
 #: src/routes/_layout.latest.tsx
@@ -7034,6 +7123,10 @@ msgstr "Ver no Bluesky"
 msgid "Paused"
 msgstr "Em pausa"
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute?"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Reading without an account"
@@ -7084,6 +7177,10 @@ msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Muted here"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "They'll show up in your feeds again."
 msgstr ""
 
 #: src/components/reader/privacy-view.tsx
@@ -7187,6 +7284,10 @@ msgstr "Publicar e compartilhar a edição"
 #: src/components/reader/collection-builder.tsx
 msgid "Editorial"
 msgstr "Editorial"
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted publications"
+msgstr ""
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Click Run example to fetch a live response with your session."
@@ -7662,6 +7763,10 @@ msgstr ""
 msgid "Read aloud"
 msgstr "Ler em voz alta"
 
+#: src/components/muted-settings-view.tsx
+msgid "You haven't muted anyone. Mute someone from the menu on their page to hide everything they write — and everything they recommend — without unfollowing."
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "Artigos que salvou para mais tarde — no seu repositório, sincronizados entre dispositivos."
@@ -7826,6 +7931,10 @@ msgstr ""
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Filter by topic"
 msgstr "Filtrar por tópico"
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmute {name}"
+msgstr ""
 
 #. placeholder {0}: image.file.name
 #: src/components/feedback/feedback-image-picker.tsx
@@ -8337,6 +8446,10 @@ msgstr ""
 
 #: src/components/reader/saved-filters.tsx
 msgid "Filter saved articles"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute {name}"
 msgstr ""
 
 #: src/components/reader/series-up-next.tsx

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -222,6 +222,7 @@ msgstr ""
 #: src/components/labelers-settings-view.tsx
 #: src/components/muted-settings-view.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 #: src/components/user-settings-view.tsx
 msgid "Muted"
 msgstr ""
@@ -3083,6 +3084,10 @@ msgstr "警告"
 msgid "What it does"
 msgstr ""
 
+#: src/components/reader/muted-pill.tsx
+msgid "Muted by you"
+msgstr ""
+
 #: src/components/feedback/feedback-dialog.tsx
 #: src/components/reader/save-to-collection-dialog.tsx
 #: src/components/reader/subscriptions-table.tsx
@@ -3395,6 +3400,10 @@ msgstr ""
 #: src/routes/_layout.collections.index.tsx
 msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {位关注者} other {位关注者}}"
+
+#: src/components/reader/muted-pill.tsx
+msgid "This publication is muted"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 #~ msgid "Most readers stop at what you already subscribe to. Standard Reader treats finding your next favourite as part of the job. Browse all {countLabel} publications on the network — not just the handful you've heard of."
@@ -4369,6 +4378,7 @@ msgstr "对比处理前后的图片"
 msgid "No matching people."
 msgstr "没有匹配的人。"
 
+#: src/components/reader/muted-pill.tsx
 #: src/components/user-settings-view.tsx
 msgid "Manage mutes"
 msgstr ""
@@ -4676,6 +4686,7 @@ msgid "{days}d ago"
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "Unmuted"
 msgstr ""
 
@@ -5281,6 +5292,7 @@ msgstr ""
 #: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/blocked-notice.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 #: src/components/route-error.tsx
@@ -6050,6 +6062,7 @@ msgid "No lists yet — switch to New list to create one."
 msgstr "还没有列表——切换到「新建列表」来创建一个。"
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "We couldn't remove the mute from your account. Try again?"
 msgstr ""
 
@@ -6293,6 +6306,7 @@ msgstr ""
 
 #: src/components/muted-settings-view.tsx
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "Unmute"
 msgstr ""
 
@@ -6383,6 +6397,10 @@ msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "the queue of articles you put aside. A badge shows how many are waiting."
+msgstr ""
+
+#: src/components/reader/muted-pill.tsx
+msgid "This publication will show up in your feeds again."
 msgstr ""
 
 #: src/routes/_layout.recommended.tsx
@@ -7093,9 +7111,17 @@ msgstr ""
 #~ msgid "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 #~ msgstr ""
 
+#: src/components/reader/muted-pill.tsx
+msgid "Its articles are hidden from your feeds, search and discovery. Your subscription is untouched, and this page still works."
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag"
 msgstr "标签"
+
+#: src/components/reader/muted-pill.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery. Your subscriptions are untouched, and this page still works."
+msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "The React package, for example. With no <0>components</0> prop, a document renders as unstyled semantic HTML."
@@ -7180,6 +7206,7 @@ msgid "Muted here"
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
+#: src/components/reader/muted-pill.tsx
 msgid "They'll show up in your feeds again."
 msgstr ""
 
@@ -8153,6 +8180,10 @@ msgstr ""
 #. placeholder {0}: fmt.relativeTime(connection.lastUsedAt)
 #: src/components/user-settings-view.tsx
 msgid "Last used {0}"
+msgstr ""
+
+#: src/components/reader/muted-pill.tsx
+msgid "This person is muted"
 msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -105,6 +105,10 @@ msgstr "试试「climate」、#essay 这样的 #标签，或 stdout.dev 这样�
 msgid "Thanks for taking the time to help us improve Standard Reader."
 msgstr "感谢你抽出时间帮助我们改进 Standard Reader。"
 
+#: src/components/user-settings-view.tsx
+msgid "Manage {muteCount} mutes"
+msgstr ""
+
 #: src/components/guide/pages/finding-guide-page.tsx
 msgid "Articles and publications carry topic tags. Select one anywhere you see it — under a headline, on a publication card, in Discover — and you get everything filed under it: an <0>Articles</0> tab you can sort by recent, trending, or most popular, and a <1>Publications</1> tab of everyone who writes about it."
 msgstr ""
@@ -216,11 +220,18 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/labelers-settings-view.tsx
+#: src/components/muted-settings-view.tsx
+#: src/components/reader/mute-menu-item.tsx
+#: src/components/user-settings-view.tsx
 msgid "Muted"
 msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "Content and intellectual property"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute {name}?"
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -340,6 +351,10 @@ msgstr "请添加标题。"
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "This publication's articles disappear from your feeds, search and discovery. Your subscription is untouched, and you can still visit the publication directly. You can undo this in Settings → Muted."
+msgstr ""
+
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -366,6 +381,10 @@ msgstr "按标题或作者搜索，或粘贴 URL、at:// URI"
 
 #: src/components/user-settings-view.tsx
 msgid "Show {itemLabel} in the sidebar"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "We couldn't write the mute to your account. Try again?"
 msgstr ""
 
 #: src/components/reader/continue-reading.tsx
@@ -1024,6 +1043,10 @@ msgstr "点击「创建」会先请求创建评价所需的权限。"
 msgid "Extension privacy"
 msgstr "扩展隐私"
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "It's hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Signing in"
@@ -1031,6 +1054,10 @@ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "Public API — no key required"
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people"
 msgstr ""
 
 #: src/components/reading-settings-preview.tsx
@@ -1688,6 +1715,10 @@ msgstr "嵌入内容"
 msgid "Account"
 msgstr "账户"
 
+#: src/components/muted-settings-view.tsx
+msgid "Loading muted publications"
+msgstr ""
+
 #: src/components/guide/pages/comics-guide-page.tsx
 msgid "There is no “this is a comic” switch anywhere on the network, and nothing to set on Standard Reader — we do not host your publication. Two things have to be true instead."
 msgstr ""
@@ -1777,6 +1808,10 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Browse your feed"
 msgstr "浏览你的信息流"
+
+#: src/components/muted-settings-view.tsx
+msgid "Your mutes are enforced here already. To add or remove one, you'll be asked to re-authorize the first time you try."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Scales every size in the app, article text included — from 13px up to 22px of interface text."
@@ -2136,6 +2171,10 @@ msgstr ""
 msgid "Loading page"
 msgstr "正在加载页面"
 
+#: src/components/muted-settings-view.tsx
+msgid "You haven't muted any publications. Mute one from the menu on its page to hide its articles from your feeds while staying subscribed."
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "The button sits next to a publication's name wherever you meet it — a card in a feed, the top of an article, the publication's own page. Select it again to unsubscribe."
 msgstr ""
@@ -2435,6 +2474,7 @@ msgstr "你打开过的文章——存为你仓库中的公开记录，跨设备
 #: src/components/reader/collection-builder.tsx
 #: src/components/reader/collection-publication-editor.tsx
 #: src/components/reader/collection-theme-editor.tsx
+#: src/components/reader/mute-menu-item.tsx
 #: src/components/reader/subscriptions-unsubscribe-dialog.tsx
 #: src/components/user-settings-view.tsx
 #: src/routes/_layout.collections.new.tsx
@@ -2599,6 +2639,7 @@ msgstr "阅读该作者的更多文章"
 
 #: src/components/blocks-settings-view.tsx
 #: src/components/labelers-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 #: src/components/user-settings-view.tsx
 msgid "Moderation"
 msgstr "审核"
@@ -2689,6 +2730,10 @@ msgstr "正在设置该期"
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Feed preferences"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "{name} will show up in your feeds again."
 msgstr ""
 
 #: src/components/guide/pages/comics-guide-page.tsx
@@ -3097,6 +3142,10 @@ msgstr ""
 #: src/components/reader/collection-publication-editor.tsx
 msgid "Uploading…"
 msgstr "正在上传…"
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices."
+msgstr ""
 
 #: src/routes/_layout.latest.tsx
 msgid "No articles are trending across the network right now. Check back soon."
@@ -3523,6 +3572,7 @@ msgid "Publications to explore"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 msgid "We couldn't reach your account to change that. Try again?"
 msgstr ""
 
@@ -3680,6 +3730,10 @@ msgstr ""
 
 #: src/routes/_layout.feedback.index.tsx
 msgid "Reset filters"
+msgstr ""
+
+#: src/components/user-settings-view.tsx
+msgid "Muted people and publications stay subscribed but disappear from your feeds, search, and discovery. Only you can see your mutes' effect — nobody is notified."
 msgstr ""
 
 #: src/components/push-diagnostics.tsx
@@ -4315,6 +4369,10 @@ msgstr "对比处理前后的图片"
 msgid "No matching people."
 msgstr "没有匹配的人。"
 
+#: src/components/user-settings-view.tsx
+msgid "Manage mutes"
+msgstr ""
+
 #: src/components/reader/subscriptions-tree.tsx
 msgid "Empty list."
 msgstr "空列表。"
@@ -4431,6 +4489,10 @@ msgstr ""
 
 #: src/components/push-diagnostics.tsx
 msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Their articles, publications and recommendations disappear from your feeds, search and discovery. Your subscriptions are untouched, and you can still visit their pages directly. You can undo this in Settings → Muted."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4611,6 +4673,10 @@ msgstr "该标注服务未发布任何标签定义。"
 
 #: src/components/reader/format-i18n.ts
 msgid "{days}d ago"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmuted"
 msgstr ""
 
 #: src/components/user-settings-view.tsx
@@ -5211,8 +5277,10 @@ msgid "Not in the directory yet?"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
+#: src/components/muted-settings-view.tsx
 #: src/components/reader/block-user-menu-item.tsx
 #: src/components/reader/blocked-notice.tsx
+#: src/components/reader/mute-menu-item.tsx
 #: src/components/reader/notify-button.tsx
 #: src/components/reader/page-reader-bar.tsx
 #: src/components/route-error.tsx
@@ -5692,6 +5760,10 @@ msgstr "暂无已知的标注服务。"
 msgid "You're all caught up"
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "{name} is hidden from your feeds and discovery. Subscriptions and direct links still work. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "All publication lists you created in this app."
 msgstr "你在本应用中创建的所有刊物列表。"
@@ -5977,6 +6049,10 @@ msgstr ""
 msgid "No lists yet — switch to New list to create one."
 msgstr "还没有列表——切换到「新建列表」来创建一个。"
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "We couldn't remove the mute from your account. Try again?"
+msgstr ""
+
 #: src/components/reader/terms-view.tsx
 msgid "{SITE_NAME} is provided “as is” and “as available,” without warranties of any kind, whether express or implied. We do not guarantee that the service will be uninterrupted, error-free, or that the index will always be complete or current. To the fullest extent permitted by law, the operator of this deployment is not liable for any indirect, incidental, or consequential damages arising from your use of the site."
 msgstr ""
@@ -6059,6 +6135,10 @@ msgstr "关闭标签页"
 
 #: src/components/guide/pages/lists-guide-page.tsx
 msgid "Groups collapse and expand, so you can keep the sidebar short and open only what you are reading today. <0>Collapse all lists</0> and <1>Expand all lists</1> do it in one go."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute"
 msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
@@ -6211,6 +6291,11 @@ msgstr ""
 msgid "Unfollow?"
 msgstr ""
 
+#: src/components/muted-settings-view.tsx
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmute"
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "Listen to anything"
 msgstr "任意内容都能听"
@@ -6327,6 +6412,10 @@ msgstr ""
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Type size, shape, and density"
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Loading muted people"
 msgstr ""
 
 #: src/routes/_layout.latest.tsx
@@ -7034,6 +7123,10 @@ msgstr "在 Bluesky 上查看"
 msgid "Paused"
 msgstr "已暂停"
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute?"
+msgstr ""
+
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Reading without an account"
@@ -7084,6 +7177,10 @@ msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 msgid "Muted here"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "They'll show up in your feeds again."
 msgstr ""
 
 #: src/components/reader/privacy-view.tsx
@@ -7187,6 +7284,10 @@ msgstr "发布并分享此次运行"
 #: src/components/reader/collection-builder.tsx
 msgid "Editorial"
 msgstr "编辑部"
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted publications"
+msgstr ""
 
 #: src/components/docs/api-docs-request-panel.tsx
 msgid "Click Run example to fetch a live response with your session."
@@ -7662,6 +7763,10 @@ msgstr ""
 msgid "Read aloud"
 msgstr "朗读"
 
+#: src/components/muted-settings-view.tsx
+msgid "You haven't muted anyone. Mute someone from the menu on their page to hide everything they write — and everything they recommend — without unfollowing."
+msgstr ""
+
 #: src/routes/_layout.saved.tsx
 msgid "Articles you've saved for later — in your repo, synced across devices."
 msgstr "你稍后再读的文章——存放在你的仓库中，跨设备同步。"
@@ -7826,6 +7931,10 @@ msgstr ""
 #: src/components/reader/discover-topic-filters.tsx
 msgid "Filter by topic"
 msgstr "按话题筛选"
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Unmute {name}"
+msgstr ""
 
 #. placeholder {0}: image.file.name
 #: src/components/feedback/feedback-image-picker.tsx
@@ -8337,6 +8446,10 @@ msgstr ""
 
 #: src/components/reader/saved-filters.tsx
 msgid "Filter saved articles"
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Mute {name}"
 msgstr ""
 
 #: src/components/reader/series-up-next.tsx

--- a/apps/standard-reader/src/routeTree.gen.ts
+++ b/apps/standard-reader/src/routeTree.gen.ts
@@ -67,6 +67,7 @@ import { Route as LayoutLabelersDidRouteImport } from './routes/_layout.labelers
 import { Route as LayoutPrivacyExtensionRouteImport } from './routes/_layout.privacy.extension'
 import { Route as LayoutSettingsIndexRouteImport } from './routes/_layout.settings.index'
 import { Route as LayoutSettingsBlocksRouteImport } from './routes/_layout.settings.blocks'
+import { Route as LayoutSettingsMutedRouteImport } from './routes/_layout.settings.muted'
 import { Route as LayoutTagTagRouteImport } from './routes/_layout.tag.$tag'
 import { Route as LayoutTopicsIndexRouteImport } from './routes/_layout.topics.index'
 import { Route as LayoutTopicsSlugRouteImport } from './routes/_layout.topics.$slug'
@@ -420,6 +421,11 @@ const LayoutSettingsBlocksRoute = LayoutSettingsBlocksRouteImport.update({
   path: '/settings/blocks',
   getParentRoute: () => LayoutRoute,
 } as any)
+const LayoutSettingsMutedRoute = LayoutSettingsMutedRouteImport.update({
+  id: '/settings/muted',
+  path: '/settings/muted',
+  getParentRoute: () => LayoutRoute,
+} as any)
 const LayoutTagTagRoute = LayoutTagTagRouteImport.update({
   id: '/tag/$tag',
   path: '/tag/$tag',
@@ -727,6 +733,7 @@ export interface FileRoutesByFullPath {
   '/labelers/$did': typeof LayoutLabelersDidRoute
   '/privacy/extension': typeof LayoutPrivacyExtensionRoute
   '/settings/blocks': typeof LayoutSettingsBlocksRoute
+  '/settings/muted': typeof LayoutSettingsMutedRoute
   '/tag/$tag': typeof LayoutTagTagRoute
   '/topics/$slug': typeof LayoutTopicsSlugRoute
   '/u/$did': typeof LayoutUDidRoute
@@ -833,6 +840,7 @@ export interface FileRoutesByTo {
   '/labelers/$did': typeof LayoutLabelersDidRoute
   '/privacy/extension': typeof LayoutPrivacyExtensionRoute
   '/settings/blocks': typeof LayoutSettingsBlocksRoute
+  '/settings/muted': typeof LayoutSettingsMutedRoute
   '/tag/$tag': typeof LayoutTagTagRoute
   '/topics/$slug': typeof LayoutTopicsSlugRoute
   '/u/$did': typeof LayoutUDidRoute
@@ -944,6 +952,7 @@ export interface FileRoutesById {
   '/_layout/labelers/$did': typeof LayoutLabelersDidRoute
   '/_layout/privacy/extension': typeof LayoutPrivacyExtensionRoute
   '/_layout/settings/blocks': typeof LayoutSettingsBlocksRoute
+  '/_layout/settings/muted': typeof LayoutSettingsMutedRoute
   '/_layout/tag/$tag': typeof LayoutTagTagRoute
   '/_layout/topics/$slug': typeof LayoutTopicsSlugRoute
   '/_layout/u/$did': typeof LayoutUDidRoute
@@ -1053,6 +1062,7 @@ export interface FileRouteTypes {
     | '/labelers/$did'
     | '/privacy/extension'
     | '/settings/blocks'
+    | '/settings/muted'
     | '/tag/$tag'
     | '/topics/$slug'
     | '/u/$did'
@@ -1159,6 +1169,7 @@ export interface FileRouteTypes {
     | '/labelers/$did'
     | '/privacy/extension'
     | '/settings/blocks'
+    | '/settings/muted'
     | '/tag/$tag'
     | '/topics/$slug'
     | '/u/$did'
@@ -1269,6 +1280,7 @@ export interface FileRouteTypes {
     | '/_layout/labelers/$did'
     | '/_layout/privacy/extension'
     | '/_layout/settings/blocks'
+    | '/_layout/settings/muted'
     | '/_layout/tag/$tag'
     | '/_layout/topics/$slug'
     | '/_layout/u/$did'
@@ -1796,6 +1808,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutSettingsBlocksRouteImport
       parentRoute: typeof LayoutRoute
     }
+    '/_layout/settings/muted': {
+      id: '/_layout/settings/muted'
+      path: '/settings/muted'
+      fullPath: '/settings/muted'
+      preLoaderRoute: typeof LayoutSettingsMutedRouteImport
+      parentRoute: typeof LayoutRoute
+    }
     '/_layout/tag/$tag': {
       id: '/_layout/tag/$tag'
       path: '/tag/$tag'
@@ -2249,6 +2268,7 @@ interface LayoutRouteChildren {
   LayoutFeedbackReturnRoute: typeof LayoutFeedbackReturnRoute
   LayoutLabelersDidRoute: typeof LayoutLabelersDidRoute
   LayoutSettingsBlocksRoute: typeof LayoutSettingsBlocksRoute
+  LayoutSettingsMutedRoute: typeof LayoutSettingsMutedRoute
   LayoutTagTagRoute: typeof LayoutTagTagRoute
   LayoutTopicsSlugRoute: typeof LayoutTopicsSlugRoute
   LayoutUDidRoute: typeof LayoutUDidRoute
@@ -2279,6 +2299,7 @@ const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutFeedbackReturnRoute: LayoutFeedbackReturnRoute,
   LayoutLabelersDidRoute: LayoutLabelersDidRoute,
   LayoutSettingsBlocksRoute: LayoutSettingsBlocksRoute,
+  LayoutSettingsMutedRoute: LayoutSettingsMutedRoute,
   LayoutTagTagRoute: LayoutTagTagRoute,
   LayoutTopicsSlugRoute: LayoutTopicsSlugRoute,
   LayoutUDidRoute: LayoutUDidRoute,

--- a/apps/standard-reader/src/routes/_layout.p.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/_layout.p.$did.$rkey.tsx
@@ -61,6 +61,7 @@ import {
   publicationUriFromParams,
 } from "../components/reader/format";
 import { formatLastActive } from "../components/reader/format-i18n";
+import { MutedPill } from "../components/reader/muted-pill";
 import {
   Handle,
   PublicationAvatar,
@@ -842,7 +843,10 @@ function PublicationProfileContent({
 
           {/* Below the description, matching the author profile: a label is a
               third party's statement about this account, so it reads after the
-              publication's own words rather than interrupting its identity line. */}
+              publication's own words rather than interrupting its identity line.
+              The muted pill sits with them — the reader's own label, and the
+              only visible trace of a mute on a page muting leaves readable. */}
+          <MutedPill subject={pub.uri} kind="publication" signedIn={signedIn} />
           <AccountLabelsForDid did={pub.did} readerScope={readerScope} />
 
           <div {...stylex.props(styles.statStrip)}>

--- a/apps/standard-reader/src/routes/_layout.settings.muted.tsx
+++ b/apps/standard-reader/src/routes/_layout.settings.muted.tsx
@@ -1,0 +1,35 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+import { MutedSettingsView } from "#/components/muted-settings-view";
+import { mutesApi } from "#/integrations/tanstack-query/api-mutes.functions";
+import { user } from "#/integrations/tanstack-query/api-user.functions";
+import { getPublicUrlClient } from "#/lib/public-url";
+import { pageSocialMeta } from "#/lib/site-metadata";
+import { buildAuthRedirectPath } from "#/utils/auth-redirect";
+
+export const Route = createFileRoute("/_layout/settings/muted")({
+  beforeLoad: async ({ context }) => {
+    const session = await context.queryClient.ensureQueryData(
+      user.getSessionQueryOptions,
+    );
+    if (!session?.user) {
+      throw redirect({
+        to: "/login",
+        search: { redirect: buildAuthRedirectPath("/settings/muted") },
+      });
+    }
+  },
+  loader: async ({ context }) => {
+    await context.queryClient.ensureQueryData(
+      mutesApi.getMutedSettingsQueryOptions(),
+    );
+  },
+  head: () => ({
+    meta: pageSocialMeta("settings", getPublicUrlClient()),
+  }),
+  component: MutedPage,
+});
+
+function MutedPage() {
+  return <MutedSettingsView />;
+}

--- a/apps/standard-reader/src/routes/_layout.u.$did.tsx
+++ b/apps/standard-reader/src/routes/_layout.u.$did.tsx
@@ -75,6 +75,7 @@ import { BlockedNotice } from "../components/reader/blocked-notice";
 import { ArticleRow, PubDirectoryRow } from "../components/reader/cards";
 import { FeedLoadMore } from "../components/reader/feed-load-more";
 import { LinkifiedText } from "../components/reader/linkified-text";
+import { MutedPill } from "../components/reader/muted-pill";
 import {
   Handle,
   Kicker,
@@ -773,7 +774,17 @@ function AuthorProfileContent({
 
           {/* Below the bio rather than beside the handle: a label is something a
               third party says about this account, so it reads after the account's
-              own words instead of interrupting its identity line. */}
+              own words instead of interrupting its identity line. The muted
+              pill sits with them — it's the reader's own label on this account,
+              and without it a muted profile would look identical to an unmuted
+              one (muting deliberately leaves this page readable). */}
+          {isOwnProfile ? null : (
+            <MutedPill
+              subject={did}
+              kind="user"
+              signedIn={session?.user?.did != null}
+            />
+          )}
           <AccountLabels labels={accountLabels} />
         </div>
       </div>

--- a/apps/standard-reader/src/server/atproto/repo-records.ts
+++ b/apps/standard-reader/src/server/atproto/repo-records.ts
@@ -356,6 +356,52 @@ export async function deleteUserFollowRecords(
   );
 }
 
+/**
+ * Write an `app.standard-reader.graph.mute` for `subject` — a user DID or the
+ * AT-URI of a `site.standard.publication`. Keyed by {@link subjectRkey} so
+ * muting twice is the same record.
+ */
+export async function putMuteRecord(
+  client: Client,
+  repo: string,
+  subject: string,
+  createdAt: string,
+): Promise<{ uri: string; cid: string }> {
+  return repoPutRecord(client, {
+    repo,
+    collection: COLLECTION.graphMute,
+    rkey: subjectRkey(subject),
+    record: {
+      $type: COLLECTION.graphMute,
+      subject,
+      createdAt,
+    },
+  });
+}
+
+/**
+ * Delete every mute record for `subject` — the deterministic `subjectRkey`
+ * plus any TID-rkey records other clients may have written for the same
+ * subject (mirrors {@link deleteUserFollowRecords}).
+ */
+export async function deleteMuteRecords(
+  client: Client,
+  repo: string,
+  subject: string,
+  knownRkeys: Array<string> = [],
+): Promise<void> {
+  const rkeys = new Set([subjectRkey(subject), ...knownRkeys]);
+  await Promise.all(
+    [...rkeys].map((rkey) =>
+      repoDeleteRecord(client, {
+        repo,
+        collection: COLLECTION.graphMute,
+        rkey,
+      }),
+    ),
+  );
+}
+
 // ── Bluesky blocks ──────────────────────────────────────────────────────────
 //
 // A block is a portable `app.bsky.graph.block` record in the reader's own repo,

--- a/apps/standard-reader/src/server/atproto/types.ts
+++ b/apps/standard-reader/src/server/atproto/types.ts
@@ -177,6 +177,19 @@ export interface UserFollowRecord {
   createdAt?: string;
 }
 
+/**
+ * `app.standard-reader.graph.mute` — mutes a subject for this reader: either a
+ * user (a DID) or a publication (the AT-URI of its `site.standard.publication`
+ * record). Presence means muted; deleting unmutes. Hidden from the reader's
+ * feeds and discovery only — direct navigation and subscriptions are untouched.
+ */
+export interface MuteRecord {
+  $type?: string;
+  /** A user DID (`did:...`) or a publication AT-URI (`at://...`). */
+  subject: string;
+  createdAt?: string;
+}
+
 /** `app.standard-reader.read` — an article the reader has read. */
 export interface ReadRecord {
   $type?: string;

--- a/apps/standard-reader/src/server/atproto/uri.ts
+++ b/apps/standard-reader/src/server/atproto/uri.ts
@@ -37,6 +37,7 @@ export const Collections = {
   listSave: APP_NSID.listSave,
   sidebarPref: APP_NSID.sidebarPref,
   userFollow: APP_NSID.graphFollow,
+  mute: APP_NSID.graphMute,
 } as const;
 
 export type KnownCollection = (typeof Collections)[keyof typeof Collections];

--- a/apps/standard-reader/src/server/ingest/consumer.ts
+++ b/apps/standard-reader/src/server/ingest/consumer.ts
@@ -12,6 +12,7 @@ import type {
   ListRecord,
   ListSaveRecord,
   MochottArticleRecord,
+  MuteRecord,
   PublicationRecord,
   PublicationThemeRecord,
   ReadRecord,
@@ -40,6 +41,7 @@ import {
   upsertList,
   upsertListSave,
   upsertMochottArticle,
+  upsertMute,
   upsertPublication,
   upsertPublicationTheme,
   upsertRead,
@@ -211,6 +213,10 @@ export async function handleRecord(payload: TapRecordPayload): Promise<void> {
         cid,
         record as unknown as UserFollowRecord,
       );
+      return;
+    }
+    case Collections.mute: {
+      await upsertMute(uri, did, rkey, cid, record as unknown as MuteRecord);
       return;
     }
     case Collections.labelerSubscription:

--- a/apps/standard-reader/src/server/ingest/handlers.ts
+++ b/apps/standard-reader/src/server/ingest/handlers.ts
@@ -10,6 +10,7 @@ import { hasRenderableArticleBody } from "#/lib/document/renderable";
 import { documentSearchText } from "#/lib/document/search-text";
 import { labelerSubscriptionEnabled } from "#/lib/labeler-subscription";
 import { MOCHOTT_ARTICLE, mochottArticleContent } from "#/lib/mochott/types";
+import { classifyMuteSubject } from "#/lib/mutes";
 import { isExcludedPublicationUrl } from "#/lib/publication/exclusions";
 import {
   BLOG_DIRECTION,
@@ -22,6 +23,7 @@ import {
 } from "#/server/content/resolve";
 import { resolveLeafletContent } from "#/server/leaflet/resolve";
 import { fetchMochottArticleContent } from "#/server/mochott/resolve";
+import { invalidateMuteCache } from "#/server/mutes/mutes";
 import { resolvePcktContent } from "#/server/pckt/resolve";
 
 import { db } from "../../db/index.ts";
@@ -32,6 +34,7 @@ import {
   labelerSubscriptions,
   listSaves,
   lists,
+  mutes,
   profiles,
   publicationStats,
   publications,
@@ -62,6 +65,7 @@ import type {
   ListRecord,
   ListSaveRecord,
   MochottArticleRecord,
+  MuteRecord,
   PublicationRecord,
   PublicationThemeRecord,
   ReadRecord,
@@ -642,6 +646,52 @@ export async function upsertUserFollow(
   await ensureTracked(record.subject, "followed");
 }
 
+/**
+ * Mirror an `app.standard-reader.graph.mute` record — the muter (`did`) hides
+ * a user (DID subject) or a publication (AT-URI subject) from their own feeds
+ * and discovery. The subject is classified into exactly one of `subjectDid` /
+ * `subjectUri` so feed SQL correlates on an indexed column; malformed subjects
+ * are skipped. Unlike a follow, a mute must not enrol the subject into the
+ * read-model, so only the muter's repo is tracked.
+ */
+export async function upsertMute(
+  uri: string,
+  did: string,
+  rkey: string,
+  cid: string | undefined,
+  record: MuteRecord,
+): Promise<void> {
+  const subject = classifyMuteSubject(record.subject);
+  // Skip malformed records and defensive self-mutes.
+  if (!subject || (subject.kind === "user" && subject.did === did)) {
+    return;
+  }
+
+  const values = {
+    uri,
+    cid: cid ?? null,
+    muterDid: did,
+    rkey,
+    subject: record.subject,
+    subjectDid: subject.kind === "user" ? subject.did : null,
+    subjectUri: subject.kind === "publication" ? subject.uri : null,
+    createdAt: parseDate(record.createdAt),
+    deleted: false,
+    updatedAt: sql`now()`,
+  };
+
+  await db
+    .insert(mutes)
+    .values(values)
+    .onConflictDoUpdate({ target: mutes.uri, set: values });
+
+  // A mute made in another client must take effect here without waiting out
+  // the has-mutes TTL (no-op across processes, where the TTL covers it).
+  invalidateMuteCache(did);
+
+  await ensureTracked(did, "reader");
+}
+
 export async function upsertLabelerSubscription(
   uri: string,
   did: string,
@@ -1155,6 +1205,12 @@ export async function deleteRecord(
     }
     case Collections.userFollow: {
       await db.delete(userFollows).where(eq(userFollows.uri, uri));
+      return;
+    }
+    case Collections.mute: {
+      const parsed = parseAtUri(uri);
+      if (parsed) invalidateMuteCache(parsed.did);
+      await db.delete(mutes).where(eq(mutes.uri, uri));
       return;
     }
     case Collections.labelerSubscription:

--- a/apps/standard-reader/src/server/ingest/repo-sync.ts
+++ b/apps/standard-reader/src/server/ingest/repo-sync.ts
@@ -21,6 +21,7 @@ import {
   labelerSubscriptions,
   listSaves,
   lists,
+  mutes,
   profiles,
   publications,
   reads,
@@ -283,6 +284,7 @@ const REPAIRABLE_COLLECTIONS: ReadonlyArray<{
   },
   { collection: Collections.sidebarPref, table: sidebarPrefs },
   { collection: Collections.userFollow, table: userFollows },
+  { collection: Collections.mute, table: mutes },
 ];
 
 /**

--- a/apps/standard-reader/src/server/mutes/mutes.ts
+++ b/apps/standard-reader/src/server/mutes/mutes.ts
@@ -1,0 +1,453 @@
+/**
+ * Resolve a reader's mutes from the read-model.
+ *
+ * Mutes are mirrored `app.standard-reader.graph.mute` records (see
+ * `db/schema/mutes.ts`); the ingester and the mute write path keep the mirror
+ * current, and every request path reads them from here in SQL — rendering a
+ * feed never costs a network call to work out what the reader muted.
+ *
+ * No `.server` suffix, deliberately: `reader/queries.ts` needs
+ * {@link notMutedByViewer} and is itself reachable from the client bundle, so
+ * a server-only module here would fail import protection at build time. Nothing
+ * in this file is server-only — the Drizzle client is threaded in by the
+ * caller, exactly as in `blocks/blocks.ts`.
+ *
+ * Mutes differ from blocks in two ways that shape everything here:
+ *
+ *  - **One direction only.** A mute lives in the muter's repo and hides content
+ *    *from the muter*. Being muted hides nothing from you, so there is no
+ *    incoming half to resolve.
+ *  - **Two subject kinds.** A muted *user* (DID) hides everything they touch —
+ *    documents they authored, documents from publications they own, their
+ *    recommends. A muted *publication* (AT-URI) hides that publication's
+ *    documents and the publication itself from discovery.
+ *
+ * Scope is feeds + discovery only: direct navigation to a muted publication,
+ * author, or article keeps working, and subscriptions are untouched.
+ *
+ * **Bounded by the candidate set, never by the mute set.** Every helper takes
+ * the DIDs/URIs a page is about to render and asks which of *those* are muted,
+ * so the cost stays an index probe regardless of how much a reader mutes.
+ */
+
+import { inArray, sql } from "drizzle-orm";
+import { cache as reactCache } from "react";
+
+import type { Db, Schema } from "#/integrations/tanstack-query/api-shapes";
+import type { MutableCard, MutedSubjects } from "#/lib/mutes";
+import { muteCandidateKeys, rejectMutedCards } from "#/lib/mutes";
+
+/** Read rows off a drizzle `db.execute` result (array or `{ rows }`). */
+function executeRows<T>(result: unknown): Array<T> {
+  if (Array.isArray(result)) return result as Array<T>;
+  return ((result as { rows?: Array<T> }).rows ?? []) as Array<T>;
+}
+
+/**
+ * How long "does this reader mute anything?" is trusted in-process.
+ *
+ * Short, because the answer flipping false→true is a reader who just muted
+ * something and expects it gone. Every write path calls
+ * {@link invalidateMuteCache} anyway, so the TTL only covers mutes made in
+ * another client and picked up by the firehose.
+ */
+const HAS_MUTES_TTL_MS = 60_000;
+
+/**
+ * Bound on the cache — same rationale as the blocks gate: a single boolean per
+ * signed-in reader, dropped wholesale rather than evicted, re-earned by one
+ * indexed `EXISTS`.
+ */
+const HAS_MUTES_CACHE_MAX = 10_000;
+
+const hasMutesCache = new Map<string, { value: boolean; expires: number }>();
+
+/** Drop a reader's cached answer, after they mute or unmute anything. */
+export function invalidateMuteCache(did: string): void {
+  hasMutesCache.delete(did);
+}
+
+/**
+ * Whether this viewer has any mutes at all.
+ *
+ * The guard in front of every other helper here, and in front of every SQL
+ * predicate {@link notMutedByViewer} would otherwise add — and the
+ * overwhelmingly common answer is "no". Cached per-request via
+ * {@link reactCache} and across requests in-process for
+ * {@link HAS_MUTES_TTL_MS}, so a reader who mutes nothing costs nothing on the
+ * steady path.
+ */
+export const readerHasMutes = reactCache(readerHasMutesImpl);
+
+async function readerHasMutesImpl(
+  db: Db,
+  schema: Schema,
+  viewerDid: string,
+): Promise<boolean> {
+  const cached = hasMutesCache.get(viewerDid);
+  if (cached && cached.expires > Date.now()) return cached.value;
+
+  const m = schema.mutes;
+  const result = await db.execute(sql`
+    select exists(
+      select 1 from ${m}
+      where ${m.muterDid} = ${viewerDid} and ${m.deleted} = false
+    ) as has
+  `);
+  const value = executeRows<{ has: boolean }>(result)[0]?.has ?? false;
+
+  if (hasMutesCache.size >= HAS_MUTES_CACHE_MAX) hasMutesCache.clear();
+  hasMutesCache.set(viewerDid, {
+    value,
+    expires: Date.now() + HAS_MUTES_TTL_MS,
+  });
+  return value;
+}
+
+/**
+ * The DID to hand a query builder's `muterDid`, or `undefined` to leave the
+ * query alone.
+ *
+ * **The only supported way to reach {@link notMutedByViewer} from a feed** —
+ * the same contract as `blockFilterDid`: the predicate is up to three
+ * correlated `NOT EXISTS` per candidate row, and paying that for the majority
+ * of readers who mute nothing would regress every feed to serve empty result
+ * sets. The predicate is added only once the cached {@link readerHasMutes}
+ * says it can match.
+ */
+export async function muteFilterDid(
+  db: Db,
+  schema: Schema,
+  viewerDid: string | null | undefined,
+): Promise<string | undefined> {
+  if (!viewerDid) return undefined;
+  return (await readerHasMutes(db, schema, viewerDid)) ? viewerDid : undefined;
+}
+
+/**
+ * `NOT EXISTS` predicate excluding muted subjects for `viewerDid`, for use
+ * inside a paginated query — post-filtering a page is fine for a rail (see
+ * {@link filterMutedCards}) but drops rows after `LIMIT` on a feed.
+ *
+ * Callers pass whichever expressions the row can supply:
+ *
+ *  - `authorDidExpr` — the row's author DID (user mutes).
+ *  - `ownerDidExpr` — the owner of the row's publication, usually
+ *    `atUriAuthoritySql(publicationUri)` (user mutes reach guest posts in a
+ *    muted user's publication). NULL for a loose document never matches.
+ *  - `pubUriExpr` — the row's publication AT-URI for documents, or the row's
+ *    own URI for publication-shaped rows (publication mutes).
+ *
+ * Each branch is one index probe on `mutes_user_edge_idx` /
+ * `mutes_pub_edge_idx`.
+ *
+ * **Never pass a raw session DID here.** Resolve it through
+ * {@link muteFilterDid} first.
+ */
+export function notMutedByViewer(
+  schema: Schema,
+  viewerDid: string,
+  exprs: {
+    authorDidExpr?: ReturnType<typeof sql>;
+    ownerDidExpr?: ReturnType<typeof sql>;
+    pubUriExpr?: ReturnType<typeof sql>;
+  },
+): ReturnType<typeof sql> {
+  const m = schema.mutes;
+  const branches: Array<ReturnType<typeof sql>> = [];
+  for (const didExpr of [exprs.authorDidExpr, exprs.ownerDidExpr]) {
+    if (didExpr) {
+      branches.push(sql`exists(
+        select 1 from ${m}
+        where ${m.muterDid} = ${viewerDid}
+          and ${m.deleted} = false
+          and ${m.subjectDid} = ${didExpr}
+      )`);
+    }
+  }
+  if (exprs.pubUriExpr) {
+    branches.push(sql`exists(
+      select 1 from ${m}
+      where ${m.muterDid} = ${viewerDid}
+        and ${m.deleted} = false
+        and ${m.subjectUri} = ${exprs.pubUriExpr}
+    )`);
+  }
+  if (branches.length === 0) return sql`true`;
+  return sql`not (${sql.join(branches, sql` or `)})`;
+}
+
+/**
+ * Which of the candidate subjects are muted for `viewerDid`, split by kind.
+ *
+ * The post-filter workhorse for rails and for pre-filtering query inputs (the
+ * follow feed drops muted DIDs/publication URIs from its source sets before
+ * the query runs). Gated on {@link readerHasMutes} and narrowed to the
+ * candidates, so it stays an index probe.
+ */
+export async function mutedSubjectsAmong(
+  db: Db,
+  schema: Schema,
+  viewerDid: string | null | undefined,
+  candidates: { dids?: ReadonlyArray<string>; uris?: ReadonlyArray<string> },
+): Promise<MutedSubjects> {
+  const empty: MutedSubjects = { dids: new Set(), uris: new Set() };
+  if (!viewerDid) return empty;
+  const dids = [...new Set(candidates.dids ?? [])].filter(
+    (did) => did.startsWith("did:") && did !== viewerDid,
+  );
+  const uris = [...new Set(candidates.uris ?? [])].filter((uri) =>
+    uri.startsWith("at://"),
+  );
+  if (dids.length === 0 && uris.length === 0) return empty;
+  if (!(await readerHasMutes(db, schema, viewerDid))) return empty;
+
+  const m = schema.mutes;
+  const parts: Array<ReturnType<typeof sql>> = [];
+  if (dids.length > 0) {
+    parts.push(sql`
+      select ${m.subjectDid} as did, null as uri from ${m}
+      where ${m.muterDid} = ${viewerDid}
+        and ${m.deleted} = false
+        and ${inArray(m.subjectDid, dids)}
+    `);
+  }
+  if (uris.length > 0) {
+    parts.push(sql`
+      select null as did, ${m.subjectUri} as uri from ${m}
+      where ${m.muterDid} = ${viewerDid}
+        and ${m.deleted} = false
+        and ${inArray(m.subjectUri, uris)}
+    `);
+  }
+  const result = await db.execute(sql.join(parts, sql` union all `));
+  const rows = executeRows<{ did: string | null; uri: string | null }>(result);
+  const mutedDids = new Set<string>();
+  const mutedUris = new Set<string>();
+  for (const row of rows) {
+    if (row.did) mutedDids.add(row.did);
+    if (row.uri) mutedUris.add(row.uri);
+  }
+  return { dids: mutedDids, uris: mutedUris };
+}
+
+/** Which of `dids` are muted users for `viewerDid`. */
+export async function mutedDidsAmong(
+  db: Db,
+  schema: Schema,
+  viewerDid: string | null | undefined,
+  dids: ReadonlyArray<string>,
+): Promise<Set<string>> {
+  const muted = await mutedSubjectsAmong(db, schema, viewerDid, { dids });
+  return new Set(muted.dids);
+}
+
+/** Whether one subject (a DID or publication AT-URI) is muted by the viewer. */
+export async function isMutedForViewer(
+  db: Db,
+  schema: Schema,
+  viewerDid: string | null | undefined,
+  subject: string | null | undefined,
+): Promise<boolean> {
+  if (!subject) return false;
+  const candidates = subject.startsWith("did:")
+    ? { dids: [subject] }
+    : { uris: [subject] };
+  const muted = await mutedSubjectsAmong(db, schema, viewerDid, candidates);
+  return muted.dids.size > 0 || muted.uris.size > 0;
+}
+
+/**
+ * Drop every card that renders a muted user or publication. The rail filter:
+ * pair it with {@link notMutedByViewer} on paginated feeds, and use it alone
+ * for rails and third-party content.
+ */
+export async function filterMutedCards<T extends MutableCard>(
+  db: Db,
+  schema: Schema,
+  viewerDid: string | null | undefined,
+  cards: Array<T>,
+): Promise<Array<T>> {
+  if (!viewerDid || cards.length === 0) return cards;
+  const muted = await mutedSubjectsAmong(
+    db,
+    schema,
+    viewerDid,
+    muteCandidateKeys(cards),
+  );
+  return rejectMutedCards(cards, muted);
+}
+
+// ── Settings surfaces ───────────────────────────────────────────────────────
+
+/** A muted user as rendered in the settings list. */
+export interface MutedUserRow {
+  did: string;
+  handle: string | null;
+  displayName: string | null;
+  avatarUrl: string | null;
+  /** The mute record's AT-URI. */
+  uri: string;
+  createdAt: string | null;
+}
+
+/** A muted publication as rendered in the settings list. */
+export interface MutedPublicationRow {
+  /** AT-URI of the muted `site.standard.publication`. */
+  subjectUri: string;
+  name: string | null;
+  url: string | null;
+  ownerDid: string | null;
+  iconCid: string | null;
+  /** The mute record's AT-URI. */
+  uri: string;
+  createdAt: string | null;
+}
+
+/**
+ * The reader's muted users, newest first, joined to whatever profile we have
+ * mirrored. Anything the mirror can't name is resolved from the public
+ * AppView in one batched call — merged at read time, never written back, so a
+ * mute doesn't quietly enrol an account into the read-model.
+ */
+export async function readerMutedUsers(
+  db: Db,
+  schema: Schema,
+  viewerDid: string,
+  opts: { limit: number; offset?: number },
+): Promise<Array<MutedUserRow>> {
+  const m = schema.mutes;
+  const p = schema.profiles;
+  const result = await db.execute(sql`
+    select
+      ${m.subjectDid} as did,
+      ${m.uri} as uri,
+      ${m.createdAt} as created_at,
+      ${p.handle} as handle,
+      ${p.displayName} as display_name,
+      ${p.avatarUrl} as avatar_url
+    from ${m}
+    left join ${p} on ${p.did} = ${m.subjectDid}
+    where ${m.muterDid} = ${viewerDid}
+      and ${m.deleted} = false
+      and ${m.subjectDid} is not null
+    order by ${m.createdAt} desc nulls last, ${m.uri} desc
+    limit ${opts.limit} offset ${opts.offset ?? 0}
+  `);
+  const rows = executeRows<{
+    did: string;
+    uri: string;
+    created_at: Date | string | null;
+    handle: string | null;
+    display_name: string | null;
+    avatar_url: string | null;
+  }>(result).map((row) => ({
+    did: row.did,
+    uri: row.uri,
+    handle: row.handle,
+    displayName: row.display_name,
+    avatarUrl: row.avatar_url,
+    createdAt: toIso(row.created_at),
+  }));
+
+  return hydrateMutedUsers(rows);
+}
+
+/**
+ * Fill in identity for muted users the read-model has never seen — same
+ * rationale and mechanics as `hydrateBlockedAccounts` in `blocks/blocks.ts`.
+ */
+async function hydrateMutedUsers(
+  rows: Array<MutedUserRow>,
+): Promise<Array<MutedUserRow>> {
+  const missing = rows.filter(
+    (row) => !row.handle && !row.displayName && !row.avatarUrl,
+  );
+  if (missing.length === 0) return rows;
+
+  const { fetchBlueskyPublicProfiles } =
+    await import("#/lib/bluesky-public-profile");
+  const fetched = await fetchBlueskyPublicProfiles(
+    missing.map((row) => row.did),
+  );
+  if (fetched.size === 0) return rows;
+
+  return rows.map((row) => {
+    const profile = fetched.get(row.did);
+    if (!profile) return row;
+    return {
+      ...row,
+      handle: row.handle ?? profile.handle,
+      displayName: row.displayName ?? profile.displayName,
+      avatarUrl: row.avatarUrl ?? profile.avatarUrl,
+    };
+  });
+}
+
+/**
+ * The reader's muted publications, newest first, joined to the mirrored
+ * publication for a name/icon. A muted publication we've never mirrored still
+ * renders — just as its bare AT-URI.
+ */
+export async function readerMutedPublications(
+  db: Db,
+  schema: Schema,
+  viewerDid: string,
+  opts: { limit: number; offset?: number },
+): Promise<Array<MutedPublicationRow>> {
+  const m = schema.mutes;
+  const pub = schema.publications;
+  const result = await db.execute(sql`
+    select
+      ${m.subjectUri} as subject_uri,
+      ${m.uri} as uri,
+      ${m.createdAt} as created_at,
+      ${pub.name} as name,
+      ${pub.url} as url,
+      ${pub.did} as owner_did,
+      ${pub.iconCid} as icon_cid
+    from ${m}
+    left join ${pub} on ${pub.uri} = ${m.subjectUri}
+    where ${m.muterDid} = ${viewerDid}
+      and ${m.deleted} = false
+      and ${m.subjectUri} is not null
+    order by ${m.createdAt} desc nulls last, ${m.uri} desc
+    limit ${opts.limit} offset ${opts.offset ?? 0}
+  `);
+  return executeRows<{
+    subject_uri: string;
+    uri: string;
+    created_at: Date | string | null;
+    name: string | null;
+    url: string | null;
+    owner_did: string | null;
+    icon_cid: string | null;
+  }>(result).map((row) => ({
+    subjectUri: row.subject_uri,
+    uri: row.uri,
+    name: row.name,
+    url: row.url,
+    ownerDid: row.owner_did,
+    iconCid: row.icon_cid,
+    createdAt: toIso(row.created_at),
+  }));
+}
+
+/** How many subjects the reader mutes (both kinds). */
+export async function countReaderMutes(
+  db: Db,
+  schema: Schema,
+  viewerDid: string,
+): Promise<number> {
+  const m = schema.mutes;
+  const result = await db.execute(sql`
+    select count(*)::int as count from ${m}
+    where ${m.muterDid} = ${viewerDid} and ${m.deleted} = false
+  `);
+  return executeRows<{ count: number }>(result)[0]?.count ?? 0;
+}
+
+function toIso(value: Date | string | null): string | null {
+  if (value == null) return null;
+  return value instanceof Date ? value.toISOString() : value;
+}

--- a/apps/standard-reader/src/server/reader/queries.explain.test.ts
+++ b/apps/standard-reader/src/server/reader/queries.explain.test.ts
@@ -141,6 +141,41 @@ describe.skipIf(!RUN)("follow-feed block filter — EXPLAIN", () => {
 });
 
 /**
+ * The mute filter on the follow feed — same shape and same hazard as the block
+ * filter above: `notMutedByViewer` is up to three correlated `NOT EXISTS`
+ * inside `baseWhere`, and it must not push the per-source laterals off their
+ * `ORDER BY published_at DESC LIMIT k` index scans. As with blocks this is the
+ * worst case by construction — `muteFilterDid` keeps the predicate out of the
+ * query for readers who mute nothing.
+ */
+describe.skipIf(!RUN)("follow-feed mute filter — EXPLAIN", () => {
+  test("mute filter does not defeat the per-source index scans", async () => {
+    const plan = await explainCandidate({
+      unreadForDid: READER_DID,
+      countOldPostsAsUnread: true,
+      muterDid: READER_DID,
+    });
+
+    assertNoSeqScanOnDocuments(plan);
+    assertPerSourceIndexScans(plan);
+    assertExecTimeUnder(plan, BLOCK_FILTER_BUDGET_MS);
+  }, 30_000);
+
+  test("block + mute filters together stay on the index scans", async () => {
+    const plan = await explainCandidate({
+      unreadForDid: READER_DID,
+      countOldPostsAsUnread: true,
+      viewerDid: READER_DID,
+      muterDid: READER_DID,
+    });
+
+    assertNoSeqScanOnDocuments(plan);
+    assertPerSourceIndexScans(plan);
+    assertExecTimeUnder(plan, BLOCK_FILTER_BUDGET_MS);
+  }, 30_000);
+});
+
+/**
  * The Latest "All" tab badge. This was a ~1.08s parallel seq scan over every
  * `documents` row on `/latest`'s blocking route loader before it moved to the
  * `network_stats` scalar (`recomputeNetworkStats()`).
@@ -238,11 +273,14 @@ async function explainCandidate({
   unreadForDid,
   countOldPostsAsUnread,
   viewerDid,
+  muterDid,
 }: {
   unreadForDid: string;
   countOldPostsAsUnread: boolean | undefined;
   /** Set to force the block predicate on — see the block-filter describe. */
   viewerDid?: string;
+  /** Set to force the mute predicate on — see the mute-filter describe. */
+  muterDid?: string;
 }): Promise<string> {
   const [publicationUris, followedUserDids] = await Promise.all([
     selectFollowUris(db, schema, READER_DID),
@@ -264,6 +302,7 @@ async function explainCandidate({
     unreadForDid,
     countOldPostsAsUnread,
     viewerDid,
+    muterDid,
     limit: PAGE_LIMIT,
     offset: PAGE_OFFSET,
   });

--- a/apps/standard-reader/src/server/reader/queries.ts
+++ b/apps/standard-reader/src/server/reader/queries.ts
@@ -57,6 +57,7 @@ import {
 } from "#/lib/atproto/bridged-repo";
 import { EXCLUDED_PUBLICATION_URL_PATTERN } from "#/lib/publication/exclusions";
 import { atUriAuthoritySql, notBlockedByViewer } from "#/server/blocks/blocks";
+import { notMutedByViewer } from "#/server/mutes/mutes";
 import { documentPublishedNotInFuture } from "#/server/reader/document-filters";
 import {
   discoverEligibleArticleWhere,
@@ -175,6 +176,17 @@ export interface ArticleCardQuery {
    * readers on discover surfaces where the other two are unset.
    */
   viewerDid?: string;
+  /**
+   * The reader this page is being rendered for, for mute filtering. Documents
+   * by a muted user, from a publication a muted user owns, or in a muted
+   * publication are excluded in SQL for the same reason as `viewerDid`.
+   *
+   * **Resolve through `muteFilterDid`, never a raw session DID** — the
+   * predicate is correlated subqueries per candidate row, and the gate is what
+   * keeps readers who mute nothing from paying for it. See
+   * {@link notMutedByViewer}.
+   */
+  muterDid?: string;
   limit: number;
   offset?: number;
 }
@@ -461,6 +473,8 @@ async function selectFollowFeedCandidateUris(
     countOldPostsAsUnread?: boolean;
     /** See {@link ArticleCardQuery.viewerDid}. */
     viewerDid?: string;
+    /** See {@link ArticleCardQuery.muterDid}. */
+    muterDid?: string;
     limit: number;
     offset: number;
   },
@@ -487,6 +501,8 @@ export function buildFollowFeedCandidateSql(
     countOldPostsAsUnread?: boolean;
     /** See {@link ArticleCardQuery.viewerDid}. */
     viewerDid?: string;
+    /** See {@link ArticleCardQuery.muterDid}. */
+    muterDid?: string;
     limit: number;
     offset: number;
   },
@@ -530,6 +546,18 @@ export function buildFollowFeedCandidateSql(
         sql`${d.did}`,
         atUriAuthoritySql(sql`${d.publicationUri}`),
       ),
+    );
+  }
+  // Same union-branch reasoning as blocks: a followed publication can carry a
+  // guest post by a muted author, and a followed user can recommend into a
+  // muted publication. Reached only through `muteFilterDid`.
+  if (opts.muterDid) {
+    base.push(
+      notMutedByViewer(schema, opts.muterDid, {
+        authorDidExpr: sql`${d.did}`,
+        ownerDidExpr: atUriAuthoritySql(sql`${d.publicationUri}`),
+        pubUriExpr: sql`${d.publicationUri}`,
+      }),
     );
   }
   const baseWhere = and(...base) ?? sql`true`;
@@ -760,6 +788,7 @@ export async function selectArticleCards(
       unreadForDid: opts.unreadForDid,
       countOldPostsAsUnread: opts.countOldPostsAsUnread,
       viewerDid: opts.viewerDid,
+      muterDid: opts.muterDid,
       limit: opts.limit,
       offset: opts.offset ?? 0,
     });
@@ -768,6 +797,7 @@ export async function selectArticleCards(
       readForDid: opts.readForDid,
       countOldPostsAsUnread: opts.countOldPostsAsUnread,
       viewerDid: opts.viewerDid,
+      muterDid: opts.muterDid,
     });
   }
 
@@ -822,6 +852,15 @@ export async function selectArticleCards(
         sql`${d.did}`,
         atUriAuthoritySql(sql`${d.publicationUri}`),
       ),
+    );
+  }
+  if (opts.muterDid) {
+    conds.push(
+      notMutedByViewer(schema, opts.muterDid, {
+        authorDidExpr: sql`${d.did}`,
+        ownerDidExpr: atUriAuthoritySql(sql`${d.publicationUri}`),
+        pubUriExpr: sql`${d.publicationUri}`,
+      }),
     );
   }
 
@@ -1678,6 +1717,8 @@ export interface TrendingArticlesQuery {
   excludeWebBridge?: boolean;
   /** See {@link ArticleCardQuery.viewerDid}. */
   viewerDid?: string;
+  /** See {@link ArticleCardQuery.muterDid}. */
+  muterDid?: string;
 }
 
 function trendingArticleWhere(
@@ -1686,6 +1727,7 @@ function trendingArticleWhere(
   excludeUris: Array<string> = [],
   excludeWebBridge = false,
   viewerDid?: string,
+  muterDid?: string,
 ) {
   const d = schema.documents;
   const p = schema.publications;
@@ -1726,6 +1768,16 @@ function trendingArticleWhere(
     );
   }
 
+  if (muterDid) {
+    conds.push(
+      notMutedByViewer(schema, muterDid, {
+        authorDidExpr: sql`${d.did}`,
+        ownerDidExpr: atUriAuthoritySql(sql`${d.publicationUri}`),
+        pubUriExpr: sql`${d.publicationUri}`,
+      }),
+    );
+  }
+
   return conds;
 }
 
@@ -1751,6 +1803,7 @@ export async function trendingArticles(
     readForDid,
     scope = "rail",
     viewerDid,
+    muterDid,
   }: TrendingArticlesQuery = {},
 ): Promise<Array<ArticleCard>> {
   const d = schema.documents;
@@ -1773,6 +1826,7 @@ export async function trendingArticles(
             excludeUris,
             excludeWebBridge,
             viewerDid,
+            muterDid,
           ),
         ),
       )
@@ -1800,6 +1854,7 @@ export async function trendingArticles(
           excludeUris,
           excludeWebBridge,
           viewerDid,
+          muterDid,
         ),
       ),
     )
@@ -2313,6 +2368,7 @@ export async function discoverDirectoryPublications(
     query = null,
     excludeWebBridge = false,
     viewerDid,
+    muterDid,
   }: {
     topic?: string | null;
     /** `effective` = publication topic only; `document` = topic or any document tag. */
@@ -2325,6 +2381,8 @@ export async function discoverDirectoryPublications(
     excludeWebBridge?: boolean;
     /** See {@link ArticleCardQuery.viewerDid}. */
     viewerDid?: string;
+    /** See {@link ArticleCardQuery.muterDid}. */
+    muterDid?: string;
   },
 ): Promise<Array<PublicationCard>> {
   const p = schema.publications;
@@ -2339,6 +2397,14 @@ export async function discoverDirectoryPublications(
   }
   if (viewerDid) {
     conds.push(notBlockedByViewer(schema, viewerDid, sql`${p.did}`));
+  }
+  if (muterDid) {
+    conds.push(
+      notMutedByViewer(schema, muterDid, {
+        authorDidExpr: sql`${p.did}`,
+        pubUriExpr: sql`${p.uri}`,
+      }),
+    );
   }
   if (topic) {
     conds.push(
@@ -2668,6 +2734,7 @@ export async function tagDirectoryPublications(
     offset,
     excludeWebBridge = false,
     viewerDid,
+    muterDid,
   }: {
     tag: string;
     sort: TagDirectorySort;
@@ -2677,6 +2744,8 @@ export async function tagDirectoryPublications(
     excludeWebBridge?: boolean;
     /** See {@link ArticleCardQuery.viewerDid}. */
     viewerDid?: string;
+    /** See {@link ArticleCardQuery.muterDid}. */
+    muterDid?: string;
   },
 ): Promise<Array<TagPublicationCard>> {
   const p = schema.publications;
@@ -2694,6 +2763,14 @@ export async function tagDirectoryPublications(
   ];
   if (viewerDid) {
     conds.push(notBlockedByViewer(schema, viewerDid, sql`${p.did}`));
+  }
+  if (muterDid) {
+    conds.push(
+      notMutedByViewer(schema, muterDid, {
+        authorDidExpr: sql`${p.did}`,
+        pubUriExpr: sql`${p.uri}`,
+      }),
+    );
   }
 
   const sortName = publicationSortNameSql(p.name, p.url);
@@ -3452,6 +3529,8 @@ export async function selectArticleCardsByUris(
     countOldPostsAsUnread?: boolean;
     /** See {@link ArticleCardQuery.viewerDid}. */
     viewerDid?: string;
+    /** See {@link ArticleCardQuery.muterDid}. */
+    muterDid?: string;
   },
 ): Promise<Array<ArticleCard>> {
   if (uris.length === 0) {
@@ -3492,6 +3571,15 @@ export async function selectArticleCardsByUris(
                 sql`${d.did}`,
                 atUriAuthoritySql(sql`${d.publicationUri}`),
               ),
+            ]
+          : []),
+        ...(opts?.muterDid
+          ? [
+              notMutedByViewer(schema, opts.muterDid, {
+                authorDidExpr: sql`${d.did}`,
+                ownerDidExpr: atUriAuthoritySql(sql`${d.publicationUri}`),
+                pubUriExpr: sql`${d.publicationUri}`,
+              }),
             ]
           : []),
       ),

--- a/apps/standard-reader/src/server/xrpc/handlers/catalog.ts
+++ b/apps/standard-reader/src/server/xrpc/handlers/catalog.ts
@@ -10,6 +10,7 @@ import {
   resolvePageUrl,
   resolvePageUrls,
 } from "#/server/extension/resolve-page-url.server";
+import { muteFilterDid } from "#/server/mutes/mutes";
 import { selectPublicationHeader } from "#/server/reader/publication-header";
 import {
   discoverDirectoryPublications,
@@ -223,6 +224,7 @@ export async function handleGetPublications(ctx: XrpcRequestContext) {
     query: q ?? undefined,
     excludeWebBridge: ctx.excludeWebBridgeEnabled,
     viewerDid: await blockFilterDid(ctx.db, ctx.schema, ctx.auth?.did),
+    muterDid: await muteFilterDid(ctx.db, ctx.schema, ctx.auth?.did),
   });
 
   const total =
@@ -330,6 +332,8 @@ export async function handleGetPublicationDocuments(ctx: XrpcRequestContext) {
     offset,
     readForDid,
     countOldPostsAsUnread: ctx.auth ? ctx.countOldPostsAsUnreadEnabled : true,
+    // No mute filter: this is the publication's own document list, and muting
+    // only hides content from feeds + discovery — direct navigation still works.
     viewerDid: await blockFilterDid(ctx.db, ctx.schema, ctx.auth?.did),
   });
   const items = await enrichDocuments(ctx, rows, readForDid);

--- a/apps/standard-reader/src/server/xrpc/handlers/feeds.ts
+++ b/apps/standard-reader/src/server/xrpc/handlers/feeds.ts
@@ -3,6 +3,7 @@ import { articleCardsAsAllRead } from "#/lib/track-reading-history";
 import { resolveAuthorDid } from "#/server/atproto/resolve-author-ref";
 import { parseAtUri } from "#/server/atproto/uri";
 import { blockFilterDid, filterBlockedCards } from "#/server/blocks/blocks";
+import { filterMutedCards, muteFilterDid } from "#/server/mutes/mutes";
 import {
   followedPublications,
   selectArticleCards,
@@ -53,6 +54,7 @@ export async function handleGetLatestFeed(ctx: XrpcRequestContext) {
             scope: "page",
             excludeWebBridge,
             viewerDid: await blockFilterDid(ctx.db, ctx.schema, ctx.auth?.did),
+            muterDid: await muteFilterDid(ctx.db, ctx.schema, ctx.auth?.did),
           })
         : []
       : await selectArticleCards(ctx.db, ctx.schema, {
@@ -66,6 +68,7 @@ export async function handleGetLatestFeed(ctx: XrpcRequestContext) {
           readForDid: trackReading && subjectDid ? subjectDid : undefined,
           countOldPostsAsUnread,
           viewerDid: await blockFilterDid(ctx.db, ctx.schema, ctx.auth?.did),
+          muterDid: await muteFilterDid(ctx.db, ctx.schema, ctx.auth?.did),
           limit,
           offset,
         });
@@ -91,13 +94,18 @@ export async function handleGetLatestFeed(ctx: XrpcRequestContext) {
 
 export async function handleGetTrendingPublications(ctx: XrpcRequestContext) {
   const limit = intParam(ctx.params, "limit", 12, { min: 1, max: 100 });
-  const items = await filterBlockedCards(
+  const items = await filterMutedCards(
     ctx.db,
     ctx.schema,
     ctx.auth?.did,
-    await trendingPublications(ctx.db, ctx.schema, limit, {
-      excludeWebBridge: ctx.excludeWebBridgeEnabled,
-    }),
+    await filterBlockedCards(
+      ctx.db,
+      ctx.schema,
+      ctx.auth?.did,
+      await trendingPublications(ctx.db, ctx.schema, limit, {
+        excludeWebBridge: ctx.excludeWebBridgeEnabled,
+      }),
+    ),
   );
   return { items: items.map((item) => toPublicationView(item)) };
 }
@@ -112,6 +120,7 @@ export async function handleGetTrendingDocuments(ctx: XrpcRequestContext) {
     readForDid,
     excludeWebBridge: ctx.excludeWebBridgeEnabled,
     viewerDid: await blockFilterDid(ctx.db, ctx.schema, ctx.auth?.did),
+    muterDid: await muteFilterDid(ctx.db, ctx.schema, ctx.auth?.did),
   });
   const enriched = await enrichDocuments(ctx, items, readForDid);
   return { items: enriched.map((item) => toDocumentView(item)) };
@@ -131,6 +140,7 @@ export async function handleGetTagFeed(ctx: XrpcRequestContext) {
       offset,
       excludeWebBridge: ctx.excludeWebBridgeEnabled,
       viewerDid: await blockFilterDid(ctx.db, ctx.schema, ctx.auth?.did),
+      muterDid: await muteFilterDid(ctx.db, ctx.schema, ctx.auth?.did),
     });
     return {
       view: "publications" as const,
@@ -153,6 +163,7 @@ export async function handleGetTagFeed(ctx: XrpcRequestContext) {
     readForDid,
     countOldPostsAsUnread: ctx.auth ? ctx.countOldPostsAsUnreadEnabled : true,
     viewerDid: await blockFilterDid(ctx.db, ctx.schema, ctx.auth?.did),
+    muterDid: await muteFilterDid(ctx.db, ctx.schema, ctx.auth?.did),
   });
   const items = await enrichDocuments(ctx, rows, readForDid);
   return {
@@ -244,6 +255,8 @@ export async function handleGetListFeed(ctx: XrpcRequestContext) {
     publicationUris: list.publications,
     readForDid,
     countOldPostsAsUnread: ctx.auth ? ctx.countOldPostsAsUnreadEnabled : true,
+    // No mute filter: a curated list the reader opened deliberately is direct
+    // navigation, not a feed — its publications render even when muted.
     viewerDid: await blockFilterDid(ctx.db, ctx.schema, ctx.auth?.did),
     limit,
     offset,

--- a/apps/standard-reader/src/server/xrpc/handlers/reader.ts
+++ b/apps/standard-reader/src/server/xrpc/handlers/reader.ts
@@ -7,6 +7,7 @@ import {
   toArticleCard,
 } from "#/integrations/tanstack-query/api-shapes";
 import { blockFilterDid } from "#/server/blocks/blocks";
+import { muteFilterDid, mutedSubjectsAmong } from "#/server/mutes/mutes";
 import {
   followedByPeopleYouFollow,
   recommendedPublications,
@@ -37,22 +38,37 @@ export async function handleGetHomeFeed(ctx: XrpcRequestContext) {
   const scope = homeScopeFromParam(optionalParam(ctx.params, "scope"));
   const did = ctx.auth.did;
   const trackReading = ctx.trackReadingEnabled;
-  const followUris = await effectiveFollowUris(ctx.db, ctx.schema, did);
+  const rawFollowUris = await effectiveFollowUris(ctx.db, ctx.schema, did);
+
+  const [blockDid, muteDid] = await Promise.all([
+    blockFilterDid(ctx.db, ctx.schema, did),
+    muteFilterDid(ctx.db, ctx.schema, did),
+  ]);
+  // Drop muted publications from the follow set (same pre-filter as the app's
+  // home feed); the `muterDid` predicate catches muted guest authors inside
+  // the remaining publications.
+  const followUris =
+    muteDid && rawFollowUris.length > 0
+      ? await mutedSubjectsAmong(ctx.db, ctx.schema, muteDid, {
+          uris: rawFollowUris,
+        }).then((muted) => rawFollowUris.filter((uri) => !muted.uris.has(uri)))
+      : rawFollowUris;
   const hasFollows = followUris.length > 0;
   const personalized = hasFollows && scope === "follows";
 
-  const blockDid = await blockFilterDid(ctx.db, ctx.schema, did);
   const rowQuery = personalized
     ? {
         publicationUris: followUris,
         countOldPostsAsUnread: ctx.countOldPostsAsUnreadEnabled,
         viewerDid: blockDid,
+        muterDid: muteDid,
         ...(trackReading ? { readForDid: did, unreadForDid: did } : {}),
       }
     : {
         discoverOnly: true as const,
         excludeWebBridge: ctx.excludeWebBridgeEnabled,
         viewerDid: blockDid,
+        muterDid: muteDid,
       };
 
   const [featuredLead, rows] = await Promise.all([

--- a/apps/standard-reader/src/server/xrpc/registry.test.ts
+++ b/apps/standard-reader/src/server/xrpc/registry.test.ts
@@ -18,6 +18,7 @@ const NON_XRPC_LEXICON_STEMS = new Set([
   "collectionsPublication",
   "defs",
   "graph.follow",
+  "graph.mute",
   "labeler.defs",
   "labeler.subscription",
   "labelerSubscription",

--- a/apps/standard-reader/tap/.env.example
+++ b/apps/standard-reader/tap/.env.example
@@ -7,7 +7,7 @@ TAP_PLC_URL="https://plc.directory"
 
 # Network boundary + record filtering (defaults set in docker-compose.yml).
 # TAP_SIGNAL_COLLECTION="site.standard.publication"
-# TAP_COLLECTION_FILTERS="site.standard.publication,site.standard.document,site.standard.graph.subscription,site.standard.graph.recommend,app.standard-reader.graph.follow,app.bsky.actor.profile,app.standard-reader.read,app.standard-reader.bookmark,app.standard-reader.collection,app.standard-reader.collectionsPublication,app.standard-reader.publicationTheme,app.standard-reader.labelerSubscription,app.standard-reader.labeler.subscription"
+# TAP_COLLECTION_FILTERS="site.standard.publication,site.standard.document,site.standard.graph.subscription,site.standard.graph.recommend,app.standard-reader.graph.follow,app.standard-reader.graph.mute,app.bsky.actor.profile,app.standard-reader.read,app.standard-reader.bookmark,app.standard-reader.collection,app.standard-reader.collectionsPublication,app.standard-reader.publicationTheme,app.standard-reader.labelerSubscription,app.standard-reader.labeler.subscription"
 
 # worker so it consumes that channel too.
 

--- a/apps/standard-reader/tap/docker-compose.yml
+++ b/apps/standard-reader/tap/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       # our own app-owned reader records (read, bookmark, list, listSave, etc.)
       # written back by the app. Must stay in sync with the `Collections` enum in
       # src/server/atproto/uri.ts and the dispatch in src/server/ingest/consumer.ts.
-      TAP_COLLECTION_FILTERS: "${TAP_COLLECTION_FILTERS:-site.standard.publication,site.standard.document,site.standard.graph.subscription,site.standard.graph.recommend,app.standard-reader.graph.follow,app.bsky.actor.profile,app.standard-reader.read,app.standard-reader.bookmark,app.standard-reader.list,app.standard-reader.listSave,site.mochott.article,app.standard-reader.collection,app.standard-reader.collectionsPublication,app.standard-reader.publicationTheme,app.standard-reader.labelerSubscription,app.standard-reader.labeler.subscription}"
+      TAP_COLLECTION_FILTERS: "${TAP_COLLECTION_FILTERS:-site.standard.publication,site.standard.document,site.standard.graph.subscription,site.standard.graph.recommend,app.standard-reader.graph.follow,app.standard-reader.graph.mute,app.bsky.actor.profile,app.standard-reader.read,app.standard-reader.bookmark,app.standard-reader.list,app.standard-reader.listSave,site.mochott.article,app.standard-reader.collection,app.standard-reader.collectionsPublication,app.standard-reader.publicationTheme,app.standard-reader.labelerSubscription,app.standard-reader.labeler.subscription}"
 
       # Basic-auth credential for tap's admin API + WebSocket channel (user is
       # always `admin`). The ingest worker uses the same value to connect.
@@ -67,7 +67,7 @@ services:
       TAP_SIGNAL_COLLECTION: "site.standard.document"
       # Deliver the same collections as the primary tap (publishers often own
       # loose docs too, plus their profile/subscriptions/recommends/lists).
-      TAP_COLLECTION_FILTERS: "${TAP_COLLECTION_FILTERS:-site.standard.publication,site.standard.document,site.standard.graph.subscription,site.standard.graph.recommend,app.standard-reader.graph.follow,app.bsky.actor.profile,app.standard-reader.read,app.standard-reader.bookmark,app.standard-reader.list,app.standard-reader.listSave,site.mochott.article,app.standard-reader.collection,app.standard-reader.collectionsPublication,app.standard-reader.publicationTheme,app.standard-reader.labelerSubscription,app.standard-reader.labeler.subscription}"
+      TAP_COLLECTION_FILTERS: "${TAP_COLLECTION_FILTERS:-site.standard.publication,site.standard.document,site.standard.graph.subscription,site.standard.graph.recommend,app.standard-reader.graph.follow,app.standard-reader.graph.mute,app.bsky.actor.profile,app.standard-reader.read,app.standard-reader.bookmark,app.standard-reader.list,app.standard-reader.listSave,site.mochott.article,app.standard-reader.collection,app.standard-reader.collectionsPublication,app.standard-reader.publicationTheme,app.standard-reader.labelerSubscription,app.standard-reader.labeler.subscription}"
       TAP_ADMIN_PASSWORD: "${TAP_ADMIN_PASSWORD:?set TAP_ADMIN_PASSWORD in .env}"
       TAP_LOG_LEVEL: "${TAP_LOG_LEVEL:-info}"
     volumes:


### PR DESCRIPTION
> Recreates #160 after rebasing past #159 so the migration state is unambiguous.

## What

A reader can now **mute a publication or a user**. The muted subject disappears from feeds and discovery — home, latest, discover, trending, tag, search, and the recommendation rails — while **direct navigation still works and subscriptions stay intact**. Muting a user hides everything they touch: documents they authored, documents from publications they own, and their recommends. One direction only; nobody is notified.

Backed by one new repo record, **`app.standard-reader.graph.mute`**: `subject` is a format-less string holding either a user DID or a `site.standard.publication` AT-URI (the lexicon has no did-or-at-uri format; app code classifies), keyed by the deterministic `subjectRkey` so mute ⇄ unmute address one record. Note the record is public in the reader's repo — the *effect* is private, the record is not (unlike Bluesky's server-side mutes).

## Database (the reason for the recreate)

- Mutes migration is **`drizzle/0039_glamorous_martin_li.sql`** — regenerated on top of #159's `0038_weekly_thread_runs` after the rebase, snapshot chain verified (`0039.prevId` = `0038.id`), **`drizzle-kit check` passes**.
- **`0039` is already applied to prod** (via `pnpm db:migrate`, recorded in the drizzle ledger) — the deploy's pre-deploy migrate will see it as applied and no-op. Table + 3 indexes verified live.
- #158 (Jetstream) still claims a `0038` against the old parent — it regenerates when it rebases.

## How

- **Lexicon + scope** — `lexicons/app/standard-reader/graph.mute.json` (reuses the published `graph` NSID authority) and the collection added to the `authBasicFeatures` permission set. `hasMuteWriteScope` accepts the verbatim `include:` token or a PDS-expanded `repo` token; the write path additionally maps a PDS 401/403 to `needs-mute-scope` → `upgradeToMuting` re-auth. **Verified against a real prod grant**: existing sessions store the *expanded* collection list (frozen at grant time), so every pre-republish session goes through one re-auth on first mute — and that re-auth only helps once the republished set is live (see blocker below).
- **Read-model** — `mutes` table with discriminated `subject_did` / `subject_uri` columns and muter/edge indexes; firehose ingest (`upsertMute` + delete case), repo-sync repair registration, tap collection filters. Writes eagerly mirror the row so a mute takes effect on the very next page.
- **Enforcement** — new `src/server/mutes/mutes.ts`, mirroring the blocks architecture (no `.server` suffix, bounded by the candidate set): `muteFilterDid` has-any gate (readers who mute nothing pay zero), `notMutedByViewer` correlated `NOT (EXISTS …)` with author-DID + publication-owner-DID + a publication-URI branch, threaded as a parallel `muterDid` option through `queries.ts`; `filterMutedCards` post-filter on rails; the home/latest follow feeds **pre-filter muted sources out of their input sets** (removes recommend-sourced entries, keeps badge counts honest). Deliberately **not** applied to publication/author/article pages, curated lists, or subscriptions.
- **UI**
  - Mute/Unmute in the author + publication overflow menus next to Block (sibling-dialog pattern; mute confirms, unmute is immediate).
  - **"Muted" pill on the author and publication heroes**, in the same visual register as a labeler label, sitting next to `AccountLabels` — since muting leaves these pages readable, the pill is the visible trace of the mute. Hover card explains the scope and carries Unmute + a Settings → Muted link.
  - **Settings → Muted** management page (`/settings/muted`) + a Muted row in the settings index.
  - Strings extracted into all ten Lingui catalogs.
- **Tests** — subject classification + card-rejection matrix, `hasMuteWriteScope` token forms, and `muterDid` variants in the gated EXPLAIN perf suite.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm lex:lint`, `pnpm build`, `drizzle-kit check` all pass; all unit tests pass.
- **Perf verified against prod-scale data** on a throwaway Neon branch (migration applied + mutes seeded for the heaviest perf reader): the mute-filter EXPLAIN variants keep the follow-feed candidate query on its per-source index scans — no `Seq Scan on documents`, exec time within the block filter's budget, alone and with both filters stacked. The two pre-existing perf-spec budget failures reproduce identically from a clean `origin/main` checkout on the same database.

## ⚠️ Remaining blocker for end-to-end testing

**`pnpm atproto:publish-lexicons` has not run** — it needs `LEXICON_PUBLISH_IDENTIFIER` / `LEXICON_PUBLISH_APP_PASSWORD`, which aren't in `.env`. Until the `graph.mute` schema record and the republished `authBasicFeatures` set are published, **no session (new or re-authed) can be granted the mute collection, and every mute write 403s at the PDS** (surfaced in-app as the re-auth loop). Publish, then re-auth via the in-app prompt on first mute.

Other deploy notes: pre-Jetstream deploys need `app.standard-reader.graph.mute` appended to the live `TAP_COLLECTION_FILTERS` env override on Railway (no-op after #158). Follow-ups tracked in TODO.md: recommend-byline scrubbing, translation pass, digest/push/RSS parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)