### PR TITLE
Don't treat a site root as an article's discussion target

### DIFF
--- a/apps/standard-reader/src/integrations/tanstack-query/api-publication.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-publication.functions.ts
@@ -11,6 +11,7 @@ import { uriAuthorityDid } from "#/lib/blocks";
 import type { CollectionManifest } from "#/lib/collections/manifest";
 import type { CollectionTheme } from "#/lib/collections/theme";
 import type { InlineMentionRefs } from "#/lib/leaflet/publication-mentions";
+import { articleLinkTarget } from "#/lib/link-target-variants";
 import type { ArchiveOrder } from "#/lib/publication/archive-order";
 import {
   ARCHIVE_ORDER_COOKIE,
@@ -936,8 +937,9 @@ const getArticleExtras = createServerFn({ method: "GET" })
         }
         span.set("found", true);
 
-        const canonicalUrl =
-          row.canonicalUrl ?? buildCanonicalUrl(row.publicationUrl, row.path);
+        const canonicalUrl = articleLinkTarget(
+          row.canonicalUrl ?? buildCanonicalUrl(row.publicationUrl, row.path),
+        );
         const linkUrls = canonicalUrl ? [canonicalUrl] : [];
 
         const readerDid = await getReaderDidForRequest(getRequest());

--- a/apps/standard-reader/src/lib/link-target-variants.test.ts
+++ b/apps/standard-reader/src/lib/link-target-variants.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { articleLinkTarget } from "./link-target-variants";
+
+describe("articleLinkTarget", () => {
+  it("keeps article-page URLs", () => {
+    expect(articleLinkTarget("https://blog.example/some-article")).toBe(
+      "https://blog.example/some-article",
+    );
+  });
+
+  it("rejects bare site roots, with and without the trailing slash", () => {
+    expect(articleLinkTarget("https://standard-reader.app")).toBeNull();
+    expect(articleLinkTarget("https://standard-reader.app/")).toBeNull();
+  });
+
+  it("keeps roots that carry a query or fragment", () => {
+    expect(articleLinkTarget("https://blog.example/?p=42")).toBe(
+      "https://blog.example/?p=42",
+    );
+    expect(articleLinkTarget("https://blog.example/#section")).toBe(
+      "https://blog.example/#section",
+    );
+  });
+
+  it("passes through non-absolute URLs untouched", () => {
+    expect(articleLinkTarget("blog.example/some-article")).toBe(
+      "blog.example/some-article",
+    );
+  });
+
+  it("returns null for null and blank input", () => {
+    expect(articleLinkTarget(null)).toBeNull();
+    expect(articleLinkTarget("   ")).toBeNull();
+  });
+});

--- a/apps/standard-reader/src/lib/link-target-variants.ts
+++ b/apps/standard-reader/src/lib/link-target-variants.ts
@@ -1,3 +1,27 @@
+/**
+ * A URL only works as an article-level backlink target when it points at the
+ * article's own page. A path-less document inherits its publication's bare
+ * root as `canonicalUrl` — collection documents most of all, since collections
+ * publications use the app origin itself as their `url` — and a backlink
+ * lookup against a site root matches every post that links to the site, not
+ * discussion of the article. Returns null for bare origins so those lookups
+ * are skipped entirely.
+ */
+export function articleLinkTarget(url: string | null): string | null {
+  if (!url) return null;
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.pathname === "/" && !parsed.search && !parsed.hash) {
+      return null;
+    }
+  } catch {
+    // Not a parseable absolute URL — it can't be a site root; keep it.
+  }
+  return trimmed;
+}
+
 /** URL normalization for canonical link matching (trailing slash variants). */
 export function linkTargetVariants(url: string): Array<string> {
   const trimmed = url.trim();

--- a/apps/standard-reader/src/server/extension/discussion.server.ts
+++ b/apps/standard-reader/src/server/extension/discussion.server.ts
@@ -4,6 +4,7 @@ import { documentLinkParams } from "#/components/reader/format";
 import type { db } from "#/db/index.server";
 import type * as schema from "#/db/schema";
 import type { ArticleCard } from "#/integrations/tanstack-query/api-shapes";
+import { articleLinkTarget } from "#/lib/link-target-variants";
 import { getPublicUrl } from "#/lib/public-url";
 import { blockFilterDid, filterBlockedCards } from "#/server/blocks/blocks";
 import { buildCanonicalUrl } from "#/server/ingest/mappers";
@@ -131,8 +132,9 @@ export async function resolveDiscussion(
     };
   }
 
-  const canonicalUrl =
-    row.canonicalUrl ?? buildCanonicalUrl(row.publicationUrl, row.path);
+  const canonicalUrl = articleLinkTarget(
+    row.canonicalUrl ?? buildCanonicalUrl(row.publicationUrl, row.path),
+  );
   const linkUrls = canonicalUrl ? [canonicalUrl] : [];
 
   const blockDid = await blockFilterDid(dbClient, schemaModule, viewerDid);

--- a/apps/standard-reader/src/server/reader/document-comments.test.ts
+++ b/apps/standard-reader/src/server/reader/document-comments.test.ts
@@ -282,6 +282,35 @@ describe("document comment counts", () => {
     expect(getPosts.mock.calls).toHaveLength(buildsAfterSection);
   });
 
+  /**
+   * Regression test: a collection document carries no `path`, so its stored
+   * canonicalUrl falls back to the publication root — which for collections is
+   * the app origin itself. Looking that root up on Constellation returned
+   * every post that links standard-reader.app as "discussion" of the
+   * collection.
+   */
+  it("never queries a bare site root as a discussion target", async () => {
+    getPostBacklinksForTarget.mockResolvedValue([]);
+    getPosts.mockResolvedValue([]);
+
+    const { fetchDocumentComments } = await importModule();
+    const dbClient = fakeDb({
+      ...documentRow,
+      path: null,
+      canonicalUrl: "https://standard-reader.app",
+      publicationUrl: "https://standard-reader.app",
+    });
+
+    await fetchDocumentComments(dbClient, fakeSchema, DOCUMENT_URI);
+
+    const targets = getPostBacklinksForTarget.mock.calls.map(
+      ([target]) => target as string,
+    );
+    expect(targets).toContain(APP_URL);
+    expect(targets).not.toContain("https://standard-reader.app");
+    expect(targets).not.toContain("https://standard-reader.app/");
+  });
+
   it("reports 0 for a document with no discussion", async () => {
     getPostBacklinksForTarget.mockResolvedValue([]);
     getPosts.mockResolvedValue([]);

--- a/apps/standard-reader/src/server/reader/document-comments.ts
+++ b/apps/standard-reader/src/server/reader/document-comments.ts
@@ -9,6 +9,7 @@ import type {
 import { bskyPostUrl } from "#/lib/leaflet/bsky";
 import { shiftFacets } from "#/lib/leaflet/facets";
 import { utf8ByteLength } from "#/lib/leaflet/utf8";
+import { articleLinkTarget } from "#/lib/link-target-variants";
 import { getCanonicalPublicUrl } from "#/lib/public-url";
 import {
   articleSharePath,
@@ -477,7 +478,7 @@ async function loadDocumentCommentTargets(
   const targets = buildCommentTargets(
     doc.did,
     doc.rkey,
-    canonicalUrl,
+    articleLinkTarget(canonicalUrl),
     quoteShares,
     baseUrl,
   );


### PR DESCRIPTION
## Bug

[userinput.app report](https://userinput.app/d/did:plc:bpotnohnlgcj3fbmp7ugx4en/3msutnusf2z2c): viewing a collection in Reader mode shows every Bluesky post about **Standard Reader itself** in the Discussions section, instead of discussion of the collection.

## Root cause

The Discussions section looks up comments by exact-URL backlink on Constellation, and one of its targets is the document's `canonicalUrl`. A collection's paired `site.standard.document` carries no `path`, and collections publications are written with `url: getPublicUrl()`, so `buildCanonicalUrl` falls back to the bare publication root — `https://standard-reader.app` itself. Constellation then returns every `app.bsky.feed.post` linking the app's homepage.

Verified against the reporter's live records: their collection doc ("We are humans too", publication "The Spectrum ♾️") has no `path` and its publication `url` is literally `https://standard-reader.app`.

## Fix

A site root can never identify a specific article, so `articleLinkTarget()` (new, in `lib/link-target-variants.ts`) rejects bare origins (pathname `/`, no query/fragment), and is applied everywhere `canonicalUrl` becomes a backlink target:

- `server/reader/document-comments.ts` — the Discussions section (the reported bug; also keeps the inferred announcement-post lookup from matching homepage links)
- `integrations/tanstack-query/api-publication.functions.ts` — article extras, where "Cited in" / Margin connections had the same exposure
- `server/extension/discussion.server.ts` — the extension's discussion popup

Mirrors the existing `articleSourceUrl` precedent (`components/reader/format.ts`), which already refuses the root fallback for `rel=canonical` for the same reason.

Ingest is deliberately untouched: the stored root `canonicalUrl` is still the right fallback for "open this on the author's site", and the read-time guard neutralizes existing bad rows without a backfill.

## Testing

- New regression test reproduces the collection shape (no `path`, root canonical) and asserts the root is never queried as a target
- Unit tests for `articleLinkTarget` (roots with/without trailing slash, query/fragment roots kept, non-absolute URLs passed through)
- 11/11 tests pass; `tsc --noEmit`, oxlint, and oxfmt clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)