### PR TITLE
Clarify mute vs block dialog copy: both are public records, block is cross-app, mute is Standard Reader only

### DIFF
--- a/apps/standard-reader/src/components/muted-settings-view.tsx
+++ b/apps/standard-reader/src/components/muted-settings-view.tsx
@@ -181,7 +181,7 @@ export function MutedSettingsView() {
       <Masthead
         kicker={t`Moderation`}
         title={t`Muted`}
-        dek={t`Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices.`}
+        dek={t`Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work.`}
         metaLabel={t`Muted`}
         metaValue={
           settings.isLoading ? (

--- a/apps/standard-reader/src/components/reader/block-user-menu-item.tsx
+++ b/apps/standard-reader/src/components/reader/block-user-menu-item.tsx
@@ -152,10 +152,11 @@ export function BlockUserDialog({
       </AlertDialogHeader>
       <AlertDialogDescription>
         <Trans>
-          This writes a block to your Bluesky account, so it applies here and
-          anywhere else you use it. Their writing disappears from your feeds,
-          search and discussion, and they can't see yours. You can undo it in
-          Settings → Blocked accounts.
+          This writes a public block record to your atproto account, so it
+          applies everywhere that respects blocks — Standard Reader, Bluesky,
+          and other apps. Their writing and replies are hidden from your feeds
+          and search, and they can't see your writing. Undo in Settings →
+          Blocked accounts.
         </Trans>
       </AlertDialogDescription>
       <AlertDialogFooter>

--- a/apps/standard-reader/src/components/reader/mute-menu-item.tsx
+++ b/apps/standard-reader/src/components/reader/mute-menu-item.tsx
@@ -193,20 +193,19 @@ export function MuteDialog({
         {kind === "publication" ? (
           <Trans>
             This publication's articles are hidden from your feeds, search and
-            discovery — but only in Standard Reader. This writes a public
-            record to your atproto account, but unlike a block, Bluesky and
-            other apps don't enforce it. Your subscription is untouched and you
-            can still visit the publication directly. Undo in Settings →
-            Muted.
+            discovery — but only in Standard Reader. This writes a public record
+            to your atproto account, but unlike a block, Bluesky and other apps
+            don't enforce it. Your subscription is untouched and you can still
+            visit the publication directly. Undo in Settings → Muted.
           </Trans>
         ) : (
           <Trans>
             Their articles, publications and recommendations are hidden from
-            your feeds, search and discovery — but only in Standard Reader.
-            This writes a public record to your atproto account, but unlike a
-            block, Bluesky and other apps don't enforce it. Your subscriptions
-            are untouched and you can still visit their pages directly. Undo
-            in Settings → Muted.
+            your feeds, search and discovery — but only in Standard Reader. This
+            writes a public record to your atproto account, but unlike a block,
+            Bluesky and other apps don't enforce it. Your subscriptions are
+            untouched and you can still visit their pages directly. Undo in
+            Settings → Muted.
           </Trans>
         )}
       </AlertDialogDescription>

--- a/apps/standard-reader/src/components/reader/mute-menu-item.tsx
+++ b/apps/standard-reader/src/components/reader/mute-menu-item.tsx
@@ -193,10 +193,11 @@ export function MuteDialog({
         {kind === "publication" ? (
           <Trans>
             This publication's articles are hidden from your feeds, search and
-            discovery — but only in Standard Reader. This writes a public record
-            to your atproto account, but unlike a block, Bluesky and other apps
-            don't enforce it. Your subscription is untouched and you can still
-            visit the publication directly. Undo in Settings → Muted.
+            discovery — but only in Standard Reader. This writes a public
+            record to your atproto account, but unlike a block, Bluesky and
+            other apps don't enforce it. Your subscription is untouched and you
+            can still visit the publication directly. Undo in Settings →
+            Muted.
           </Trans>
         ) : (
           <Trans>
@@ -204,8 +205,8 @@ export function MuteDialog({
             your feeds, search and discovery — but only in Standard Reader.
             This writes a public record to your atproto account, but unlike a
             block, Bluesky and other apps don't enforce it. Your subscriptions
-            are untouched and you can still visit their pages directly. Undo in
-            Settings → Muted.
+            are untouched and you can still visit their pages directly. Undo
+            in Settings → Muted.
           </Trans>
         )}
       </AlertDialogDescription>

--- a/apps/standard-reader/src/components/reader/mute-menu-item.tsx
+++ b/apps/standard-reader/src/components/reader/mute-menu-item.tsx
@@ -192,15 +192,19 @@ export function MuteDialog({
       <AlertDialogDescription>
         {kind === "publication" ? (
           <Trans>
-            This publication's articles disappear from your feeds, search and
-            discovery. Your subscription is untouched, and you can still visit
-            the publication directly. You can undo this in Settings → Muted.
+            This publication's articles are hidden from your feeds, search and
+            discovery — but only in Standard Reader. This writes a public record
+            to your atproto account, but unlike a block, Bluesky and other apps
+            don't enforce it. Your subscription is untouched and you can still
+            visit the publication directly. Undo in Settings → Muted.
           </Trans>
         ) : (
           <Trans>
-            Their articles, publications and recommendations disappear from your
-            feeds, search and discovery. Your subscriptions are untouched, and
-            you can still visit their pages directly. You can undo this in
+            Their articles, publications and recommendations are hidden from
+            your feeds, search and discovery — but only in Standard Reader.
+            This writes a public record to your atproto account, but unlike a
+            block, Bluesky and other apps don't enforce it. Your subscriptions
+            are untouched and you can still visit their pages directly. Undo in
             Settings → Muted.
           </Trans>
         )}

--- a/apps/standard-reader/src/components/reader/muted-pill.tsx
+++ b/apps/standard-reader/src/components/reader/muted-pill.tsx
@@ -113,14 +113,15 @@ export function MutedPill({
           <p {...stylex.props(styles.desc)}>
             {kind === "publication" ? (
               <Trans>
-                Its articles are hidden from your feeds, search and discovery.
-                Your subscription is untouched, and this page still works.
+                Its articles are hidden from your feeds, search and discovery in
+                Standard Reader. Your subscription is untouched, and this page
+                still works.
               </Trans>
             ) : (
               <Trans>
                 Their articles, publications and recommendations are hidden from
-                your feeds, search and discovery. Your subscriptions are
-                untouched, and this page still works.
+                your feeds, search and discovery in Standard Reader. Your
+                subscriptions are untouched, and this page still works.
               </Trans>
             )}
           </p>

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -353,7 +353,7 @@ msgid "There’s an MCP server on the same host, so you can point an agent at th
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
-msgid "This publication's articles disappear from your feeds, search and discovery. Your subscription is untouched, and you can still visit the publication directly. You can undo this in Settings → Muted."
+msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
@@ -3157,7 +3157,7 @@ msgid "Uploading…"
 msgstr "جارٍ الرفع…"
 
 #: src/components/muted-settings-view.tsx
-msgid "Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices."
+msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
 msgstr ""
 
 #: src/routes/_layout.latest.tsx
@@ -3617,7 +3617,7 @@ msgid "Read and unread"
 msgstr ""
 
 #: src/components/reader/block-user-menu-item.tsx
-msgid "This writes a block to your Bluesky account, so it applies here and anywhere else you use it. Their writing disappears from your feeds, search and discussion, and they can't see yours. You can undo it in Settings → Blocked accounts."
+msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4510,7 +4510,7 @@ msgid "If notifications aren’t working, this is what your browser reports. Sha
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
-msgid "Their articles, publications and recommendations disappear from your feeds, search and discovery. Your subscriptions are untouched, and you can still visit their pages directly. You can undo this in Settings → Muted."
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -7120,7 +7120,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/muted-pill.tsx
-msgid "Its articles are hidden from your feeds, search and discovery. Your subscription is untouched, and this page still works."
+msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
 msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
@@ -7128,7 +7128,7 @@ msgid "Tag"
 msgstr "وسم"
 
 #: src/components/reader/muted-pill.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery. Your subscriptions are untouched, and this page still works."
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
 msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -352,10 +352,6 @@ msgstr "يرجى إضافة عنوان."
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
 msgstr ""
 
-#: src/components/reader/mute-menu-item.tsx
-msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
-msgstr ""
-
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -1208,6 +1204,10 @@ msgstr "تم النسخ"
 #~ msgid "The shelf"
 #~ msgstr ""
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "See collections"
 msgstr "عرض المجموعات"
@@ -1536,6 +1536,10 @@ msgstr ""
 msgid "Select <0>Listen</0> in the top bar and the article is read aloud. The first time takes a few seconds to warm up; after that it starts straight away."
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Paste that link anywhere that unfurls a preview — Bluesky, a chat, a document — and the passage itself is the preview:"
 msgstr ""
@@ -1813,6 +1817,10 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Browse your feed"
 msgstr "تصفّح تغذيتك"
+
+#: src/components/reader/muted-pill.tsx
+msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
+msgstr ""
 
 #: src/components/muted-settings-view.tsx
 msgid "Your mutes are enforced here already. To add or remove one, you'll be asked to re-authorize the first time you try."
@@ -3156,10 +3164,6 @@ msgstr ""
 msgid "Uploading…"
 msgstr "جارٍ الرفع…"
 
-#: src/components/muted-settings-view.tsx
-msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
-msgstr ""
-
 #: src/routes/_layout.latest.tsx
 msgid "No articles are trending across the network right now. Check back soon."
 msgstr "لا توجد مقالات رائجة عبر الشبكة الآن. عد قريبًا."
@@ -3614,10 +3618,6 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Read and unread"
-msgstr ""
-
-#: src/components/reader/block-user-menu-item.tsx
-msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4509,10 +4509,6 @@ msgstr ""
 msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 msgstr ""
 
-#: src/components/reader/mute-menu-item.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
-msgstr ""
-
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "We couldn’t find that publication."
 msgstr "تعذّر العثور على تلك المنشورة."
@@ -4746,6 +4742,10 @@ msgstr ""
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Collections you have made, grouped into a series."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
@@ -6690,6 +6690,10 @@ msgstr "قراءات ذات صلة"
 msgid "operational"
 msgstr "يعمل"
 
+#: src/components/reader/muted-pill.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Top on the network"
 msgstr ""
@@ -6729,6 +6733,10 @@ msgstr "{0, plural, zero {لا قرّاء} one {قارئ واحد} two {قارئ
 
 #: src/components/reader/terms-view.tsx
 msgid "We may change, suspend, or discontinue any part of the service at any time. Because {SITE_NAME} indexes a decentralized network, the availability of specific publications is outside our control."
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
 msgstr ""
 
 #: src/components/guide/pages/everywhere-guide-page.tsx
@@ -7119,17 +7127,9 @@ msgstr ""
 #~ msgid "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 #~ msgstr ""
 
-#: src/components/reader/muted-pill.tsx
-msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
-msgstr ""
-
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag"
 msgstr "وسم"
-
-#: src/components/reader/muted-pill.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
-msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "The React package, for example. With no <0>components</0> prop, a document renders as unstyled semantic HTML."

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -353,7 +353,7 @@ msgid "There’s an MCP server on the same host, so you can point an agent at th
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
-msgid "This publication's articles disappear from your feeds, search and discovery. Your subscription is untouched, and you can still visit the publication directly. You can undo this in Settings → Muted."
+msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
@@ -3157,7 +3157,7 @@ msgid "Uploading…"
 msgstr "Wird hochgeladen…"
 
 #: src/components/muted-settings-view.tsx
-msgid "Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices."
+msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
 msgstr ""
 
 #: src/routes/_layout.latest.tsx
@@ -3617,7 +3617,7 @@ msgid "Read and unread"
 msgstr ""
 
 #: src/components/reader/block-user-menu-item.tsx
-msgid "This writes a block to your Bluesky account, so it applies here and anywhere else you use it. Their writing disappears from your feeds, search and discussion, and they can't see yours. You can undo it in Settings → Blocked accounts."
+msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4510,7 +4510,7 @@ msgid "If notifications aren’t working, this is what your browser reports. Sha
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
-msgid "Their articles, publications and recommendations disappear from your feeds, search and discovery. Your subscriptions are untouched, and you can still visit their pages directly. You can undo this in Settings → Muted."
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -7120,7 +7120,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/muted-pill.tsx
-msgid "Its articles are hidden from your feeds, search and discovery. Your subscription is untouched, and this page still works."
+msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
 msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
@@ -7128,7 +7128,7 @@ msgid "Tag"
 msgstr "Tag"
 
 #: src/components/reader/muted-pill.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery. Your subscriptions are untouched, and this page still works."
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
 msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -352,10 +352,6 @@ msgstr "Bitte fügen Sie einen Titel hinzu."
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
 msgstr ""
 
-#: src/components/reader/mute-menu-item.tsx
-msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
-msgstr ""
-
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -1208,6 +1204,10 @@ msgstr "Kopiert"
 #~ msgid "The shelf"
 #~ msgstr ""
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "See collections"
 msgstr "Sammlungen ansehen"
@@ -1536,6 +1536,10 @@ msgstr ""
 msgid "Select <0>Listen</0> in the top bar and the article is read aloud. The first time takes a few seconds to warm up; after that it starts straight away."
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Paste that link anywhere that unfurls a preview — Bluesky, a chat, a document — and the passage itself is the preview:"
 msgstr ""
@@ -1813,6 +1817,10 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Browse your feed"
 msgstr "Feed durchstöbern"
+
+#: src/components/reader/muted-pill.tsx
+msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
+msgstr ""
 
 #: src/components/muted-settings-view.tsx
 msgid "Your mutes are enforced here already. To add or remove one, you'll be asked to re-authorize the first time you try."
@@ -3156,10 +3164,6 @@ msgstr ""
 msgid "Uploading…"
 msgstr "Wird hochgeladen…"
 
-#: src/components/muted-settings-view.tsx
-msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
-msgstr ""
-
 #: src/routes/_layout.latest.tsx
 msgid "No articles are trending across the network right now. Check back soon."
 msgstr "Derzeit sind keine Artikel im Netzwerk im Trend. Schauen Sie bald wieder vorbei."
@@ -3614,10 +3618,6 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Read and unread"
-msgstr ""
-
-#: src/components/reader/block-user-menu-item.tsx
-msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4509,10 +4509,6 @@ msgstr ""
 msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 msgstr ""
 
-#: src/components/reader/mute-menu-item.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
-msgstr ""
-
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "We couldn’t find that publication."
 msgstr "Diese Publikation konnten wir nicht finden."
@@ -4746,6 +4742,10 @@ msgstr ""
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Collections you have made, grouped into a series."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
@@ -6690,6 +6690,10 @@ msgstr "Passend dazu"
 msgid "operational"
 msgstr "betriebsbereit"
 
+#: src/components/reader/muted-pill.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Top on the network"
 msgstr ""
@@ -6729,6 +6733,10 @@ msgstr "{0, plural, one {# Leser} other {{subscriberLabel} Leser}}"
 
 #: src/components/reader/terms-view.tsx
 msgid "We may change, suspend, or discontinue any part of the service at any time. Because {SITE_NAME} indexes a decentralized network, the availability of specific publications is outside our control."
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
 msgstr ""
 
 #: src/components/guide/pages/everywhere-guide-page.tsx
@@ -7119,17 +7127,9 @@ msgstr ""
 #~ msgid "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 #~ msgstr ""
 
-#: src/components/reader/muted-pill.tsx
-msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
-msgstr ""
-
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag"
 msgstr "Tag"
-
-#: src/components/reader/muted-pill.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
-msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "The React package, for example. With no <0>components</0> prop, a document renders as unstyled semantic HTML."

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -352,10 +352,6 @@ msgstr ""
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
 msgstr ""
 
-#: src/components/reader/mute-menu-item.tsx
-msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
-msgstr ""
-
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -1208,6 +1204,10 @@ msgstr ""
 #~ msgid "The shelf"
 #~ msgstr ""
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "See collections"
 msgstr ""
@@ -1536,6 +1536,10 @@ msgstr ""
 msgid "Select <0>Listen</0> in the top bar and the article is read aloud. The first time takes a few seconds to warm up; after that it starts straight away."
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Paste that link anywhere that unfurls a preview — Bluesky, a chat, a document — and the passage itself is the preview:"
 msgstr ""
@@ -1812,6 +1816,10 @@ msgstr ""
 #: src/routes/_layout.saved.tsx
 #: src/routes/_layout.u.$did.tsx
 msgid "Browse your feed"
+msgstr ""
+
+#: src/components/reader/muted-pill.tsx
+msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
 msgstr ""
 
 #: src/components/muted-settings-view.tsx
@@ -3156,10 +3164,6 @@ msgstr ""
 msgid "Uploading…"
 msgstr ""
 
-#: src/components/muted-settings-view.tsx
-msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
-msgstr ""
-
 #: src/routes/_layout.latest.tsx
 msgid "No articles are trending across the network right now. Check back soon."
 msgstr ""
@@ -3614,10 +3618,6 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Read and unread"
-msgstr ""
-
-#: src/components/reader/block-user-menu-item.tsx
-msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4509,10 +4509,6 @@ msgstr ""
 msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 msgstr ""
 
-#: src/components/reader/mute-menu-item.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
-msgstr ""
-
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "We couldn’t find that publication."
 msgstr ""
@@ -4746,6 +4742,10 @@ msgstr ""
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Collections you have made, grouped into a series."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
@@ -6690,6 +6690,10 @@ msgstr ""
 msgid "operational"
 msgstr ""
 
+#: src/components/reader/muted-pill.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Top on the network"
 msgstr ""
@@ -6729,6 +6733,10 @@ msgstr ""
 
 #: src/components/reader/terms-view.tsx
 msgid "We may change, suspend, or discontinue any part of the service at any time. Because {SITE_NAME} indexes a decentralized network, the availability of specific publications is outside our control."
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
 msgstr ""
 
 #: src/components/guide/pages/everywhere-guide-page.tsx
@@ -7119,16 +7127,8 @@ msgstr ""
 #~ msgid "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 #~ msgstr ""
 
-#: src/components/reader/muted-pill.tsx
-msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
-msgstr ""
-
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag"
-msgstr ""
-
-#: src/components/reader/muted-pill.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
 msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -353,7 +353,7 @@ msgid "There’s an MCP server on the same host, so you can point an agent at th
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
-msgid "This publication's articles disappear from your feeds, search and discovery. Your subscription is untouched, and you can still visit the publication directly. You can undo this in Settings → Muted."
+msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
@@ -3157,7 +3157,7 @@ msgid "Uploading…"
 msgstr ""
 
 #: src/components/muted-settings-view.tsx
-msgid "Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices."
+msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
 msgstr ""
 
 #: src/routes/_layout.latest.tsx
@@ -3617,7 +3617,7 @@ msgid "Read and unread"
 msgstr ""
 
 #: src/components/reader/block-user-menu-item.tsx
-msgid "This writes a block to your Bluesky account, so it applies here and anywhere else you use it. Their writing disappears from your feeds, search and discussion, and they can't see yours. You can undo it in Settings → Blocked accounts."
+msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4510,7 +4510,7 @@ msgid "If notifications aren’t working, this is what your browser reports. Sha
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
-msgid "Their articles, publications and recommendations disappear from your feeds, search and discovery. Your subscriptions are untouched, and you can still visit their pages directly. You can undo this in Settings → Muted."
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -7120,7 +7120,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/muted-pill.tsx
-msgid "Its articles are hidden from your feeds, search and discovery. Your subscription is untouched, and this page still works."
+msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
 msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
@@ -7128,7 +7128,7 @@ msgid "Tag"
 msgstr ""
 
 #: src/components/reader/muted-pill.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery. Your subscriptions are untouched, and this page still works."
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
 msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -352,10 +352,6 @@ msgstr "Please add a title."
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
 msgstr "There’s an MCP server on the same host, so you can point an agent at the network too."
 
-#: src/components/reader/mute-menu-item.tsx
-msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
-msgstr "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
-
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr "Filter by name, handle, or topic"
@@ -1208,6 +1204,10 @@ msgstr "Copied"
 #~ msgid "The shelf"
 #~ msgstr "The shelf"
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
+msgstr "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
+
 #: src/components/reader/about-view.tsx
 msgid "See collections"
 msgstr "See collections"
@@ -1536,6 +1536,10 @@ msgstr "No saved articles match"
 msgid "Select <0>Listen</0> in the top bar and the article is read aloud. The first time takes a few seconds to warm up; after that it starts straight away."
 msgstr "Select <0>Listen</0> in the top bar and the article is read aloud. The first time takes a few seconds to warm up; after that it starts straight away."
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
+msgstr "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
+
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Paste that link anywhere that unfurls a preview — Bluesky, a chat, a document — and the passage itself is the preview:"
 msgstr "Paste that link anywhere that unfurls a preview — Bluesky, a chat, a document — and the passage itself is the preview:"
@@ -1813,6 +1817,10 @@ msgstr "Relaxed"
 #: src/routes/_layout.u.$did.tsx
 msgid "Browse your feed"
 msgstr "Browse your feed"
+
+#: src/components/reader/muted-pill.tsx
+msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
+msgstr "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
 
 #: src/components/muted-settings-view.tsx
 msgid "Your mutes are enforced here already. To add or remove one, you'll be asked to re-authorize the first time you try."
@@ -3156,10 +3164,6 @@ msgstr "<0>Hide recommend and comment counts</0> removes the numbers from articl
 msgid "Uploading…"
 msgstr "Uploading…"
 
-#: src/components/muted-settings-view.tsx
-msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
-msgstr "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
-
 #: src/routes/_layout.latest.tsx
 msgid "No articles are trending across the network right now. Check back soon."
 msgstr "No articles are trending across the network right now. Check back soon."
@@ -3615,10 +3619,6 @@ msgstr "Prefer a typed client? The whole API ships as codegen'd AT Protocol lexi
 #: src/lib/guide/navigation.ts
 msgid "Read and unread"
 msgstr "Read and unread"
-
-#: src/components/reader/block-user-menu-item.tsx
-msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
-msgstr "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.u.$did.tsx
@@ -4509,10 +4509,6 @@ msgstr "Pasting a handle works even for publications the network has not indexed
 msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 msgstr "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 
-#: src/components/reader/mute-menu-item.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
-msgstr "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
-
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "We couldn’t find that publication."
 msgstr "We couldn’t find that publication."
@@ -4747,6 +4743,10 @@ msgstr "Every column sorts, and the filter box narrows by name, handle, or topic
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Collections you have made, grouped into a series."
 msgstr "Collections you have made, grouped into a series."
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
+msgstr "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
 
 #: src/components/guide/pages/extension-guide-page.tsx
 #: src/lib/guide/navigation.ts
@@ -6690,6 +6690,10 @@ msgstr "Related reading"
 msgid "operational"
 msgstr "operational"
 
+#: src/components/reader/muted-pill.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
+msgstr "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
+
 #: src/components/user-settings-view.tsx
 msgid "Top on the network"
 msgstr "Top on the network"
@@ -6730,6 +6734,10 @@ msgstr "{0, plural, one {# reader} other {{subscriberLabel} readers}}"
 #: src/components/reader/terms-view.tsx
 msgid "We may change, suspend, or discontinue any part of the service at any time. Because {SITE_NAME} indexes a decentralized network, the availability of specific publications is outside our control."
 msgstr "We may change, suspend, or discontinue any part of the service at any time. Because {SITE_NAME} indexes a decentralized network, the availability of specific publications is outside our control."
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
+msgstr "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
 
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "Standard Reader is a reader, not a publishing tool — you write wherever you already write. If your site publishes in the same open format, it turns up in the directory on its own, and readers can follow it here."
@@ -7119,17 +7127,9 @@ msgstr "It follows you"
 #~ msgid "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 #~ msgstr "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 
-#: src/components/reader/muted-pill.tsx
-msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
-msgstr "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
-
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag"
 msgstr "Tag"
-
-#: src/components/reader/muted-pill.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
-msgstr "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "The React package, for example. With no <0>components</0> prop, a document renders as unstyled semantic HTML."

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -353,8 +353,8 @@ msgid "There’s an MCP server on the same host, so you can point an agent at th
 msgstr "There’s an MCP server on the same host, so you can point an agent at the network too."
 
 #: src/components/reader/mute-menu-item.tsx
-msgid "This publication's articles disappear from your feeds, search and discovery. Your subscription is untouched, and you can still visit the publication directly. You can undo this in Settings → Muted."
-msgstr "This publication's articles disappear from your feeds, search and discovery. Your subscription is untouched, and you can still visit the publication directly. You can undo this in Settings → Muted."
+msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
+msgstr "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
@@ -3157,8 +3157,8 @@ msgid "Uploading…"
 msgstr "Uploading…"
 
 #: src/components/muted-settings-view.tsx
-msgid "Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices."
-msgstr "Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices."
+msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
+msgstr "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
 
 #: src/routes/_layout.latest.tsx
 msgid "No articles are trending across the network right now. Check back soon."
@@ -3617,8 +3617,8 @@ msgid "Read and unread"
 msgstr "Read and unread"
 
 #: src/components/reader/block-user-menu-item.tsx
-msgid "This writes a block to your Bluesky account, so it applies here and anywhere else you use it. Their writing disappears from your feeds, search and discussion, and they can't see yours. You can undo it in Settings → Blocked accounts."
-msgstr "This writes a block to your Bluesky account, so it applies here and anywhere else you use it. Their writing disappears from your feeds, search and discussion, and they can't see yours. You can undo it in Settings → Blocked accounts."
+msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
+msgstr "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 #: src/routes/_layout.u.$did.tsx
@@ -4510,8 +4510,8 @@ msgid "If notifications aren’t working, this is what your browser reports. Sha
 msgstr "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 
 #: src/components/reader/mute-menu-item.tsx
-msgid "Their articles, publications and recommendations disappear from your feeds, search and discovery. Your subscriptions are untouched, and you can still visit their pages directly. You can undo this in Settings → Muted."
-msgstr "Their articles, publications and recommendations disappear from your feeds, search and discovery. Your subscriptions are untouched, and you can still visit their pages directly. You can undo this in Settings → Muted."
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
+msgstr "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "We couldn’t find that publication."
@@ -7120,16 +7120,16 @@ msgstr "It follows you"
 #~ msgstr "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 
 #: src/components/reader/muted-pill.tsx
-msgid "Its articles are hidden from your feeds, search and discovery. Your subscription is untouched, and this page still works."
-msgstr "Its articles are hidden from your feeds, search and discovery. Your subscription is untouched, and this page still works."
+msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
+msgstr "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
 
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag"
 msgstr "Tag"
 
 #: src/components/reader/muted-pill.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery. Your subscriptions are untouched, and this page still works."
-msgstr "Their articles, publications and recommendations are hidden from your feeds, search and discovery. Your subscriptions are untouched, and this page still works."
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
+msgstr "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "The React package, for example. With no <0>components</0> prop, a document renders as unstyled semantic HTML."

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -353,7 +353,7 @@ msgid "There’s an MCP server on the same host, so you can point an agent at th
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
-msgid "This publication's articles disappear from your feeds, search and discovery. Your subscription is untouched, and you can still visit the publication directly. You can undo this in Settings → Muted."
+msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
@@ -3157,7 +3157,7 @@ msgid "Uploading…"
 msgstr "Subiendo…"
 
 #: src/components/muted-settings-view.tsx
-msgid "Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices."
+msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
 msgstr ""
 
 #: src/routes/_layout.latest.tsx
@@ -3617,7 +3617,7 @@ msgid "Read and unread"
 msgstr ""
 
 #: src/components/reader/block-user-menu-item.tsx
-msgid "This writes a block to your Bluesky account, so it applies here and anywhere else you use it. Their writing disappears from your feeds, search and discussion, and they can't see yours. You can undo it in Settings → Blocked accounts."
+msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4510,7 +4510,7 @@ msgid "If notifications aren’t working, this is what your browser reports. Sha
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
-msgid "Their articles, publications and recommendations disappear from your feeds, search and discovery. Your subscriptions are untouched, and you can still visit their pages directly. You can undo this in Settings → Muted."
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -7120,7 +7120,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/muted-pill.tsx
-msgid "Its articles are hidden from your feeds, search and discovery. Your subscription is untouched, and this page still works."
+msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
 msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
@@ -7128,7 +7128,7 @@ msgid "Tag"
 msgstr "Etiqueta"
 
 #: src/components/reader/muted-pill.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery. Your subscriptions are untouched, and this page still works."
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
 msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -352,10 +352,6 @@ msgstr "Añada un título."
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
 msgstr ""
 
-#: src/components/reader/mute-menu-item.tsx
-msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
-msgstr ""
-
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -1208,6 +1204,10 @@ msgstr "Copiado"
 #~ msgid "The shelf"
 #~ msgstr ""
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "See collections"
 msgstr "Ver colecciones"
@@ -1536,6 +1536,10 @@ msgstr ""
 msgid "Select <0>Listen</0> in the top bar and the article is read aloud. The first time takes a few seconds to warm up; after that it starts straight away."
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Paste that link anywhere that unfurls a preview — Bluesky, a chat, a document — and the passage itself is the preview:"
 msgstr ""
@@ -1813,6 +1817,10 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Browse your feed"
 msgstr "Explorar su feed"
+
+#: src/components/reader/muted-pill.tsx
+msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
+msgstr ""
 
 #: src/components/muted-settings-view.tsx
 msgid "Your mutes are enforced here already. To add or remove one, you'll be asked to re-authorize the first time you try."
@@ -3156,10 +3164,6 @@ msgstr ""
 msgid "Uploading…"
 msgstr "Subiendo…"
 
-#: src/components/muted-settings-view.tsx
-msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
-msgstr ""
-
 #: src/routes/_layout.latest.tsx
 msgid "No articles are trending across the network right now. Check back soon."
 msgstr "Ahora mismo no hay artículos en tendencia en la red. Vuelva pronto."
@@ -3614,10 +3618,6 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Read and unread"
-msgstr ""
-
-#: src/components/reader/block-user-menu-item.tsx
-msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4509,10 +4509,6 @@ msgstr ""
 msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 msgstr ""
 
-#: src/components/reader/mute-menu-item.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
-msgstr ""
-
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "We couldn’t find that publication."
 msgstr "No encontramos esa publicación."
@@ -4746,6 +4742,10 @@ msgstr ""
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Collections you have made, grouped into a series."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
@@ -6690,6 +6690,10 @@ msgstr "Lecturas relacionadas"
 msgid "operational"
 msgstr "operativo"
 
+#: src/components/reader/muted-pill.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Top on the network"
 msgstr ""
@@ -6729,6 +6733,10 @@ msgstr "{0, plural, one {# lector} other {{subscriberLabel} lectores}}"
 
 #: src/components/reader/terms-view.tsx
 msgid "We may change, suspend, or discontinue any part of the service at any time. Because {SITE_NAME} indexes a decentralized network, the availability of specific publications is outside our control."
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
 msgstr ""
 
 #: src/components/guide/pages/everywhere-guide-page.tsx
@@ -7119,17 +7127,9 @@ msgstr ""
 #~ msgid "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 #~ msgstr ""
 
-#: src/components/reader/muted-pill.tsx
-msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
-msgstr ""
-
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag"
 msgstr "Etiqueta"
-
-#: src/components/reader/muted-pill.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
-msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "The React package, for example. With no <0>components</0> prop, a document renders as unstyled semantic HTML."

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -353,7 +353,7 @@ msgid "There’s an MCP server on the same host, so you can point an agent at th
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
-msgid "This publication's articles disappear from your feeds, search and discovery. Your subscription is untouched, and you can still visit the publication directly. You can undo this in Settings → Muted."
+msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
@@ -3157,7 +3157,7 @@ msgid "Uploading…"
 msgstr "Envoi en cours…"
 
 #: src/components/muted-settings-view.tsx
-msgid "Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices."
+msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
 msgstr ""
 
 #: src/routes/_layout.latest.tsx
@@ -3617,7 +3617,7 @@ msgid "Read and unread"
 msgstr ""
 
 #: src/components/reader/block-user-menu-item.tsx
-msgid "This writes a block to your Bluesky account, so it applies here and anywhere else you use it. Their writing disappears from your feeds, search and discussion, and they can't see yours. You can undo it in Settings → Blocked accounts."
+msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4510,7 +4510,7 @@ msgid "If notifications aren’t working, this is what your browser reports. Sha
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
-msgid "Their articles, publications and recommendations disappear from your feeds, search and discovery. Your subscriptions are untouched, and you can still visit their pages directly. You can undo this in Settings → Muted."
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -7120,7 +7120,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/muted-pill.tsx
-msgid "Its articles are hidden from your feeds, search and discovery. Your subscription is untouched, and this page still works."
+msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
 msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
@@ -7128,7 +7128,7 @@ msgid "Tag"
 msgstr "Mot-clé"
 
 #: src/components/reader/muted-pill.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery. Your subscriptions are untouched, and this page still works."
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
 msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -352,10 +352,6 @@ msgstr "Veuillez ajouter un titre."
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
 msgstr ""
 
-#: src/components/reader/mute-menu-item.tsx
-msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
-msgstr ""
-
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -1208,6 +1204,10 @@ msgstr "Copié"
 #~ msgid "The shelf"
 #~ msgstr ""
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "See collections"
 msgstr "Voir les collections"
@@ -1536,6 +1536,10 @@ msgstr ""
 msgid "Select <0>Listen</0> in the top bar and the article is read aloud. The first time takes a few seconds to warm up; after that it starts straight away."
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Paste that link anywhere that unfurls a preview — Bluesky, a chat, a document — and the passage itself is the preview:"
 msgstr ""
@@ -1813,6 +1817,10 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Browse your feed"
 msgstr "Parcourir votre flux"
+
+#: src/components/reader/muted-pill.tsx
+msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
+msgstr ""
 
 #: src/components/muted-settings-view.tsx
 msgid "Your mutes are enforced here already. To add or remove one, you'll be asked to re-authorize the first time you try."
@@ -3156,10 +3164,6 @@ msgstr ""
 msgid "Uploading…"
 msgstr "Envoi en cours…"
 
-#: src/components/muted-settings-view.tsx
-msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
-msgstr ""
-
 #: src/routes/_layout.latest.tsx
 msgid "No articles are trending across the network right now. Check back soon."
 msgstr "Aucun article ne fait l'actualité sur le réseau en ce moment. Revenez bientôt."
@@ -3614,10 +3618,6 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Read and unread"
-msgstr ""
-
-#: src/components/reader/block-user-menu-item.tsx
-msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4509,10 +4509,6 @@ msgstr ""
 msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 msgstr ""
 
-#: src/components/reader/mute-menu-item.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
-msgstr ""
-
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "We couldn’t find that publication."
 msgstr "Publication introuvable."
@@ -4746,6 +4742,10 @@ msgstr ""
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Collections you have made, grouped into a series."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
@@ -6690,6 +6690,10 @@ msgstr "Lectures associées"
 msgid "operational"
 msgstr "opérationnel"
 
+#: src/components/reader/muted-pill.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Top on the network"
 msgstr ""
@@ -6729,6 +6733,10 @@ msgstr "{0, plural, one {# lecteur} other {{subscriberLabel} lecteurs}}"
 
 #: src/components/reader/terms-view.tsx
 msgid "We may change, suspend, or discontinue any part of the service at any time. Because {SITE_NAME} indexes a decentralized network, the availability of specific publications is outside our control."
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
 msgstr ""
 
 #: src/components/guide/pages/everywhere-guide-page.tsx
@@ -7119,17 +7127,9 @@ msgstr ""
 #~ msgid "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 #~ msgstr ""
 
-#: src/components/reader/muted-pill.tsx
-msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
-msgstr ""
-
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag"
 msgstr "Mot-clé"
-
-#: src/components/reader/muted-pill.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
-msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "The React package, for example. With no <0>components</0> prop, a document renders as unstyled semantic HTML."

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -352,10 +352,6 @@ msgstr "タイトルを入力してください。"
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
 msgstr ""
 
-#: src/components/reader/mute-menu-item.tsx
-msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
-msgstr ""
-
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -1208,6 +1204,10 @@ msgstr "コピーしました"
 #~ msgid "The shelf"
 #~ msgstr ""
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "See collections"
 msgstr "コレクションを見る"
@@ -1536,6 +1536,10 @@ msgstr ""
 msgid "Select <0>Listen</0> in the top bar and the article is read aloud. The first time takes a few seconds to warm up; after that it starts straight away."
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Paste that link anywhere that unfurls a preview — Bluesky, a chat, a document — and the passage itself is the preview:"
 msgstr ""
@@ -1813,6 +1817,10 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Browse your feed"
 msgstr "フィードを見る"
+
+#: src/components/reader/muted-pill.tsx
+msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
+msgstr ""
 
 #: src/components/muted-settings-view.tsx
 msgid "Your mutes are enforced here already. To add or remove one, you'll be asked to re-authorize the first time you try."
@@ -3156,10 +3164,6 @@ msgstr ""
 msgid "Uploading…"
 msgstr "アップロード中…"
 
-#: src/components/muted-settings-view.tsx
-msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
-msgstr ""
-
 #: src/routes/_layout.latest.tsx
 msgid "No articles are trending across the network right now. Check back soon."
 msgstr "現在、ネットワーク全体で話題になっている記事はありません。しばらくしてからご確認ください。"
@@ -3614,10 +3618,6 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Read and unread"
-msgstr ""
-
-#: src/components/reader/block-user-menu-item.tsx
-msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4509,10 +4509,6 @@ msgstr ""
 msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 msgstr ""
 
-#: src/components/reader/mute-menu-item.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
-msgstr ""
-
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "We couldn’t find that publication."
 msgstr "その発行物は見つかりませんでした。"
@@ -4746,6 +4742,10 @@ msgstr ""
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Collections you have made, grouped into a series."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
@@ -6690,6 +6690,10 @@ msgstr "関連する記事"
 msgid "operational"
 msgstr "稼働中"
 
+#: src/components/reader/muted-pill.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Top on the network"
 msgstr ""
@@ -6729,6 +6733,10 @@ msgstr "{0, plural, one {読者 # 人} other {読者 {subscriberLabel} 人}}"
 
 #: src/components/reader/terms-view.tsx
 msgid "We may change, suspend, or discontinue any part of the service at any time. Because {SITE_NAME} indexes a decentralized network, the availability of specific publications is outside our control."
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
 msgstr ""
 
 #: src/components/guide/pages/everywhere-guide-page.tsx
@@ -7119,17 +7127,9 @@ msgstr ""
 #~ msgid "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 #~ msgstr ""
 
-#: src/components/reader/muted-pill.tsx
-msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
-msgstr ""
-
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag"
 msgstr "タグ"
-
-#: src/components/reader/muted-pill.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
-msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "The React package, for example. With no <0>components</0> prop, a document renders as unstyled semantic HTML."

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -353,7 +353,7 @@ msgid "There’s an MCP server on the same host, so you can point an agent at th
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
-msgid "This publication's articles disappear from your feeds, search and discovery. Your subscription is untouched, and you can still visit the publication directly. You can undo this in Settings → Muted."
+msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
@@ -3157,7 +3157,7 @@ msgid "Uploading…"
 msgstr "アップロード中…"
 
 #: src/components/muted-settings-view.tsx
-msgid "Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices."
+msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
 msgstr ""
 
 #: src/routes/_layout.latest.tsx
@@ -3617,7 +3617,7 @@ msgid "Read and unread"
 msgstr ""
 
 #: src/components/reader/block-user-menu-item.tsx
-msgid "This writes a block to your Bluesky account, so it applies here and anywhere else you use it. Their writing disappears from your feeds, search and discussion, and they can't see yours. You can undo it in Settings → Blocked accounts."
+msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4510,7 +4510,7 @@ msgid "If notifications aren’t working, this is what your browser reports. Sha
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
-msgid "Their articles, publications and recommendations disappear from your feeds, search and discovery. Your subscriptions are untouched, and you can still visit their pages directly. You can undo this in Settings → Muted."
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -7120,7 +7120,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/muted-pill.tsx
-msgid "Its articles are hidden from your feeds, search and discovery. Your subscription is untouched, and this page still works."
+msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
 msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
@@ -7128,7 +7128,7 @@ msgid "Tag"
 msgstr "タグ"
 
 #: src/components/reader/muted-pill.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery. Your subscriptions are untouched, and this page still works."
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
 msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -353,7 +353,7 @@ msgid "There’s an MCP server on the same host, so you can point an agent at th
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
-msgid "This publication's articles disappear from your feeds, search and discovery. Your subscription is untouched, and you can still visit the publication directly. You can undo this in Settings → Muted."
+msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
@@ -3157,7 +3157,7 @@ msgid "Uploading…"
 msgstr "업로드 중…"
 
 #: src/components/muted-settings-view.tsx
-msgid "Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices."
+msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
 msgstr ""
 
 #: src/routes/_layout.latest.tsx
@@ -3617,7 +3617,7 @@ msgid "Read and unread"
 msgstr ""
 
 #: src/components/reader/block-user-menu-item.tsx
-msgid "This writes a block to your Bluesky account, so it applies here and anywhere else you use it. Their writing disappears from your feeds, search and discussion, and they can't see yours. You can undo it in Settings → Blocked accounts."
+msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4510,7 +4510,7 @@ msgid "If notifications aren’t working, this is what your browser reports. Sha
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
-msgid "Their articles, publications and recommendations disappear from your feeds, search and discovery. Your subscriptions are untouched, and you can still visit their pages directly. You can undo this in Settings → Muted."
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -7120,7 +7120,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/muted-pill.tsx
-msgid "Its articles are hidden from your feeds, search and discovery. Your subscription is untouched, and this page still works."
+msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
 msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
@@ -7128,7 +7128,7 @@ msgid "Tag"
 msgstr "태그"
 
 #: src/components/reader/muted-pill.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery. Your subscriptions are untouched, and this page still works."
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
 msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -352,10 +352,6 @@ msgstr "제목을 입력하세요."
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
 msgstr ""
 
-#: src/components/reader/mute-menu-item.tsx
-msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
-msgstr ""
-
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -1208,6 +1204,10 @@ msgstr "복사됨"
 #~ msgid "The shelf"
 #~ msgstr ""
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "See collections"
 msgstr "컬렉션 보기"
@@ -1536,6 +1536,10 @@ msgstr ""
 msgid "Select <0>Listen</0> in the top bar and the article is read aloud. The first time takes a few seconds to warm up; after that it starts straight away."
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Paste that link anywhere that unfurls a preview — Bluesky, a chat, a document — and the passage itself is the preview:"
 msgstr ""
@@ -1813,6 +1817,10 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Browse your feed"
 msgstr "내 피드 둘러보기"
+
+#: src/components/reader/muted-pill.tsx
+msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
+msgstr ""
 
 #: src/components/muted-settings-view.tsx
 msgid "Your mutes are enforced here already. To add or remove one, you'll be asked to re-authorize the first time you try."
@@ -3156,10 +3164,6 @@ msgstr ""
 msgid "Uploading…"
 msgstr "업로드 중…"
 
-#: src/components/muted-settings-view.tsx
-msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
-msgstr ""
-
 #: src/routes/_layout.latest.tsx
 msgid "No articles are trending across the network right now. Check back soon."
 msgstr "지금은 네트워크에서 인기 있는 아티클이 없습니다. 잠시 후 다시 확인해 주세요."
@@ -3614,10 +3618,6 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Read and unread"
-msgstr ""
-
-#: src/components/reader/block-user-menu-item.tsx
-msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4509,10 +4509,6 @@ msgstr ""
 msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 msgstr ""
 
-#: src/components/reader/mute-menu-item.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
-msgstr ""
-
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "We couldn’t find that publication."
 msgstr "해당 발행물을 찾을 수 없습니다."
@@ -4746,6 +4742,10 @@ msgstr ""
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Collections you have made, grouped into a series."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
@@ -6690,6 +6690,10 @@ msgstr "함께 읽기"
 msgid "operational"
 msgstr "정상"
 
+#: src/components/reader/muted-pill.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Top on the network"
 msgstr ""
@@ -6729,6 +6733,10 @@ msgstr "{0, plural, one {독자 #명} other {독자 {subscriberLabel}명}}"
 
 #: src/components/reader/terms-view.tsx
 msgid "We may change, suspend, or discontinue any part of the service at any time. Because {SITE_NAME} indexes a decentralized network, the availability of specific publications is outside our control."
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
 msgstr ""
 
 #: src/components/guide/pages/everywhere-guide-page.tsx
@@ -7119,17 +7127,9 @@ msgstr ""
 #~ msgid "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 #~ msgstr ""
 
-#: src/components/reader/muted-pill.tsx
-msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
-msgstr ""
-
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag"
 msgstr "태그"
-
-#: src/components/reader/muted-pill.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
-msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "The React package, for example. With no <0>components</0> prop, a document renders as unstyled semantic HTML."

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -352,10 +352,6 @@ msgstr "Adicione um título."
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
 msgstr ""
 
-#: src/components/reader/mute-menu-item.tsx
-msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
-msgstr ""
-
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr "Filtrar por nome, nome de usuário, ou tema"
@@ -1208,6 +1204,10 @@ msgstr "Copiado"
 #~ msgid "The shelf"
 #~ msgstr ""
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "See collections"
 msgstr "Ver coleções"
@@ -1536,6 +1536,10 @@ msgstr ""
 msgid "Select <0>Listen</0> in the top bar and the article is read aloud. The first time takes a few seconds to warm up; after that it starts straight away."
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Paste that link anywhere that unfurls a preview — Bluesky, a chat, a document — and the passage itself is the preview:"
 msgstr ""
@@ -1813,6 +1817,10 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Browse your feed"
 msgstr "Explorar o seu feed"
+
+#: src/components/reader/muted-pill.tsx
+msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
+msgstr ""
 
 #: src/components/muted-settings-view.tsx
 msgid "Your mutes are enforced here already. To add or remove one, you'll be asked to re-authorize the first time you try."
@@ -3156,10 +3164,6 @@ msgstr ""
 msgid "Uploading…"
 msgstr "Enviando…"
 
-#: src/components/muted-settings-view.tsx
-msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
-msgstr ""
-
 #: src/routes/_layout.latest.tsx
 msgid "No articles are trending across the network right now. Check back soon."
 msgstr "Não há artigos em alta na rede neste momento. Volte em breve."
@@ -3614,10 +3618,6 @@ msgstr "Prefere um cliente tipificado? Toda a API é fornecida na forma de esque
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Read and unread"
-msgstr ""
-
-#: src/components/reader/block-user-menu-item.tsx
-msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4509,10 +4509,6 @@ msgstr ""
 msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 msgstr ""
 
-#: src/components/reader/mute-menu-item.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
-msgstr ""
-
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "We couldn’t find that publication."
 msgstr "Não foi possível encontrar essa publicação."
@@ -4746,6 +4742,10 @@ msgstr ""
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Collections you have made, grouped into a series."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
@@ -6690,6 +6690,10 @@ msgstr "Leituras relacionadas"
 msgid "operational"
 msgstr "operacional"
 
+#: src/components/reader/muted-pill.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Top on the network"
 msgstr "Os mais populares da rede"
@@ -6730,6 +6734,10 @@ msgstr "{0, plural, one {# leitor} other {{subscriberLabel} leitores}}"
 #: src/components/reader/terms-view.tsx
 msgid "We may change, suspend, or discontinue any part of the service at any time. Because {SITE_NAME} indexes a decentralized network, the availability of specific publications is outside our control."
 msgstr "Podemos alterar, suspender ou descontinuar qualquer parte do serviço a qualquer momento. Como o {SITE_NAME} indexa uma rede descentralizada, a disponibilidade de publicações específicas está fora de nosso controle."
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
+msgstr ""
 
 #: src/components/guide/pages/everywhere-guide-page.tsx
 #~ msgid "Standard Reader is a reader, not a publishing tool — you write wherever you already write. If your site publishes in the same open format, it turns up in the directory on its own, and readers can follow it here."
@@ -7119,17 +7127,9 @@ msgstr ""
 #~ msgid "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 #~ msgstr "Cada renderizador recebe uma entrada para o documento — o conteúdo de um <0>site.standard.document</0>. O formato é detectado a partir do <1>$type</1> do conteúdo."
 
-#: src/components/reader/muted-pill.tsx
-msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
-msgstr ""
-
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag"
 msgstr "Etiqueta"
-
-#: src/components/reader/muted-pill.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
-msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "The React package, for example. With no <0>components</0> prop, a document renders as unstyled semantic HTML."

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -353,7 +353,7 @@ msgid "There’s an MCP server on the same host, so you can point an agent at th
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
-msgid "This publication's articles disappear from your feeds, search and discovery. Your subscription is untouched, and you can still visit the publication directly. You can undo this in Settings → Muted."
+msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
@@ -3157,7 +3157,7 @@ msgid "Uploading…"
 msgstr "Enviando…"
 
 #: src/components/muted-settings-view.tsx
-msgid "Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices."
+msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
 msgstr ""
 
 #: src/routes/_layout.latest.tsx
@@ -3617,7 +3617,7 @@ msgid "Read and unread"
 msgstr ""
 
 #: src/components/reader/block-user-menu-item.tsx
-msgid "This writes a block to your Bluesky account, so it applies here and anywhere else you use it. Their writing disappears from your feeds, search and discussion, and they can't see yours. You can undo it in Settings → Blocked accounts."
+msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4510,7 +4510,7 @@ msgid "If notifications aren’t working, this is what your browser reports. Sha
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
-msgid "Their articles, publications and recommendations disappear from your feeds, search and discovery. Your subscriptions are untouched, and you can still visit their pages directly. You can undo this in Settings → Muted."
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -7120,7 +7120,7 @@ msgstr ""
 #~ msgstr "Cada renderizador recebe uma entrada para o documento — o conteúdo de um <0>site.standard.document</0>. O formato é detectado a partir do <1>$type</1> do conteúdo."
 
 #: src/components/reader/muted-pill.tsx
-msgid "Its articles are hidden from your feeds, search and discovery. Your subscription is untouched, and this page still works."
+msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
 msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
@@ -7128,7 +7128,7 @@ msgid "Tag"
 msgstr "Etiqueta"
 
 #: src/components/reader/muted-pill.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery. Your subscriptions are untouched, and this page still works."
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
 msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -352,10 +352,6 @@ msgstr "请添加标题。"
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
 msgstr ""
 
-#: src/components/reader/mute-menu-item.tsx
-msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
-msgstr ""
-
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter by name, handle, or topic"
 msgstr ""
@@ -1208,6 +1204,10 @@ msgstr "已复制"
 #~ msgid "The shelf"
 #~ msgstr ""
 
+#: src/components/reader/block-user-menu-item.tsx
+msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
+msgstr ""
+
 #: src/components/reader/about-view.tsx
 msgid "See collections"
 msgstr "查看合集"
@@ -1536,6 +1536,10 @@ msgstr ""
 msgid "Select <0>Listen</0> in the top bar and the article is read aloud. The first time takes a few seconds to warm up; after that it starts straight away."
 msgstr ""
 
+#: src/components/reader/mute-menu-item.tsx
+msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
+msgstr ""
+
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "Paste that link anywhere that unfurls a preview — Bluesky, a chat, a document — and the passage itself is the preview:"
 msgstr ""
@@ -1813,6 +1817,10 @@ msgstr ""
 #: src/routes/_layout.u.$did.tsx
 msgid "Browse your feed"
 msgstr "浏览你的信息流"
+
+#: src/components/reader/muted-pill.tsx
+msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
+msgstr ""
 
 #: src/components/muted-settings-view.tsx
 msgid "Your mutes are enforced here already. To add or remove one, you'll be asked to re-authorize the first time you try."
@@ -3156,10 +3164,6 @@ msgstr ""
 msgid "Uploading…"
 msgstr "正在上传…"
 
-#: src/components/muted-settings-view.tsx
-msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
-msgstr ""
-
 #: src/routes/_layout.latest.tsx
 msgid "No articles are trending across the network right now. Check back soon."
 msgstr "目前全网没有热门文章。请稍后再来看看。"
@@ -3614,10 +3618,6 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Read and unread"
-msgstr ""
-
-#: src/components/reader/block-user-menu-item.tsx
-msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4509,10 +4509,6 @@ msgstr ""
 msgid "If notifications aren’t working, this is what your browser reports. Sharing a screenshot of it is the fastest way to get it fixed."
 msgstr ""
 
-#: src/components/reader/mute-menu-item.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
-msgstr ""
-
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "We couldn’t find that publication."
 msgstr "找不到该刊物。"
@@ -4746,6 +4742,10 @@ msgstr ""
 
 #: src/components/guide/pages/collections-guide-page.tsx
 msgid "Collections you have made, grouped into a series."
+msgstr ""
+
+#: src/components/reader/mute-menu-item.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/components/guide/pages/extension-guide-page.tsx
@@ -6690,6 +6690,10 @@ msgstr "相关阅读"
 msgid "operational"
 msgstr "运行正常"
 
+#: src/components/reader/muted-pill.tsx
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Top on the network"
 msgstr ""
@@ -6729,6 +6733,10 @@ msgstr "{0, plural, one {# 位读者} other {{subscriberLabel} 位读者}}"
 
 #: src/components/reader/terms-view.tsx
 msgid "We may change, suspend, or discontinue any part of the service at any time. Because {SITE_NAME} indexes a decentralized network, the availability of specific publications is outside our control."
+msgstr ""
+
+#: src/components/muted-settings-view.tsx
+msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
 msgstr ""
 
 #: src/components/guide/pages/everywhere-guide-page.tsx
@@ -7119,17 +7127,9 @@ msgstr ""
 #~ msgid "Every renderer takes one input for the document — the content payload of a <0>site.standard.document</0>. The format is detected from the payload's <1>$type</1>."
 #~ msgstr ""
 
-#: src/components/reader/muted-pill.tsx
-msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
-msgstr ""
-
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Tag"
 msgstr "标签"
-
-#: src/components/reader/muted-pill.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
-msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "The React package, for example. With no <0>components</0> prop, a document renders as unstyled semantic HTML."

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -353,7 +353,7 @@ msgid "There’s an MCP server on the same host, so you can point an agent at th
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
-msgid "This publication's articles disappear from your feeds, search and discovery. Your subscription is untouched, and you can still visit the publication directly. You can undo this in Settings → Muted."
+msgid "This publication's articles are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscription is untouched and you can still visit the publication directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
@@ -3157,7 +3157,7 @@ msgid "Uploading…"
 msgstr "正在上传…"
 
 #: src/components/muted-settings-view.tsx
-msgid "Muted people and publications disappear from your feeds, search, and discovery — quietly. Your subscriptions stay intact, direct links still work, and nobody is told. Mutes live in your own repo as records, so they follow you across devices."
+msgid "Muted people and publications disappear from your feeds, search, and discovery — but only in Standard Reader. Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them. Your subscriptions stay intact and direct links still work."
 msgstr ""
 
 #: src/routes/_layout.latest.tsx
@@ -3617,7 +3617,7 @@ msgid "Read and unread"
 msgstr ""
 
 #: src/components/reader/block-user-menu-item.tsx
-msgid "This writes a block to your Bluesky account, so it applies here and anywhere else you use it. Their writing disappears from your feeds, search and discussion, and they can't see yours. You can undo it in Settings → Blocked accounts."
+msgid "This writes a public block record to your atproto account, so it applies everywhere that respects blocks — Standard Reader, Bluesky, and other apps. Their writing and replies are hidden from your feeds and search, and they can't see your writing. Undo in Settings → Blocked accounts."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -4510,7 +4510,7 @@ msgid "If notifications aren’t working, this is what your browser reports. Sha
 msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
-msgid "Their articles, publications and recommendations disappear from your feeds, search and discovery. Your subscriptions are untouched, and you can still visit their pages directly. You can undo this in Settings → Muted."
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery — but only in Standard Reader. This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it. Your subscriptions are untouched and you can still visit their pages directly. Undo in Settings → Muted."
 msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
@@ -7120,7 +7120,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/reader/muted-pill.tsx
-msgid "Its articles are hidden from your feeds, search and discovery. Your subscription is untouched, and this page still works."
+msgid "Its articles are hidden from your feeds, search and discovery in Standard Reader. Your subscription is untouched, and this page still works."
 msgstr ""
 
 #: src/routes/_layout.tag.$tag.tsx
@@ -7128,7 +7128,7 @@ msgid "Tag"
 msgstr "标签"
 
 #: src/components/reader/muted-pill.tsx
-msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery. Your subscriptions are untouched, and this page still works."
+msgid "Their articles, publications and recommendations are hidden from your feeds, search and discovery in Standard Reader. Your subscriptions are untouched, and this page still works."
 msgstr ""
 
 #: src/components/docs/renderers-docs-page.tsx


### PR DESCRIPTION
Feedback from a reader: both mute and block feel "nuclear" because the dialog copy doesn't explain how limited a mute actually is on atproto — or that both actions write **public records** to your repo.

## What changed

### Block confirmation dialog
- "your Bluesky account" → "your atproto account" (it's not a Bluesky-specific account)
- Now says "public block record" and explicitly lists "Standard Reader, Bluesky, and other apps" as enforcing it

### Mute confirmation dialog (user + publication)
- Adds "but only in Standard Reader" to the scope description
- Adds: "This writes a public record to your atproto account, but unlike a block, Bluesky and other apps don't enforce it"
- This directly addresses the feedback: now it's clear a mute is **not** cross-app

### Muted settings page masthead
- "Mutes live in your own repo as records, so they follow you across devices" → "Mutes are public records in your repo, but unlike a block, Bluesky and other apps don't enforce them"

### Muted pill hover card
- Both user and publication descriptions now say "in Standard Reader" for consistency

## The core distinction now communicated everywhere

| | Block | Mute |
|---|---|---|
| Record type | Standard `app.bsky.graph.block` | App-specific `app.standard-reader.graph.mute` |
| Enforced by | All atproto apps | Standard Reader only |
| The other person... | Knows they're blocked | Doesn't know |
| Writing visibility | Bidirectional (neither sees the other) | One-directional (only hides them from you) |
