### PR TITLE
Serve the library: OPDS catalog, EPUB/CBZ downloads, KOReader sync

### DIFF
--- a/apps/standard-reader/.env.example
+++ b/apps/standard-reader/.env.example
@@ -360,3 +360,17 @@ CLAUDE_ROUTINE_TOKEN=""
 # READER_BOT_IDENTIFIER="your.handle.bsky.social"
 # READER_BOT_APP_PASSWORD="xxxx-xxxx-xxxx-xxxx"
 # READER_BOT_PDS_URL="https://bsky.social"  # optional, defaults to bsky.social
+
+# ──────────────────────────────────────────────────────────────────────────────
+# KOReader progress sync (kosync)
+# ──────────────────────────────────────────────────────────────────────────────
+# Server-only, `web` service. HMAC key behind each reader's e-reader sync key
+# (Settings → E-readers). The key is derived, not stored — so this secret is the
+# only thing standing between a guessed DID and someone else's reading position,
+# and rotating it invalidates every reader's key at once (they re-copy it from
+# Settings). Any long random string; generate with:
+#   node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))"
+#
+# In development it falls back to a fixed placeholder so the flow works without
+# setup; in production the app refuses to start the sync routes without it.
+# KOSYNC_SECRET=""

--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -722,7 +722,8 @@ Single search field with two modes (detected from input):
 The **non-technical** documentation, deliberately separate from the developer docs at
 `/docs/*`. Task-shaped pages under `/guide` — Welcome, Getting started, Reading an article,
 Finding things to read, Keeping track, Lists and your sidebar, Collections, Making it yours,
-The browser extension, Publishing your site, Publishing a comic, Your account and data —
+The browser extension, Reading on an e-reader, Publishing your site, Publishing a comic,
+Your account and data —
 written for someone who only wants to read, with no AT Protocol vocabulary and every feature
 named the way the UI names it. The last three are the exception the guide earns rather than
 assumes: they are for someone on the other side of the page, and they name record fields where
@@ -1057,6 +1058,43 @@ that presents no credential to itself at all:
 
 So a third-party CLI or agent that needs writes authenticates with an app password; a browser
 app that holds its own DPoP key uses OAuth and talks to the PDS directly.
+
+### OPDS catalog, downloads & KOReader sync
+
+Standard Reader is also a **library** an e-reading app can browse. Three pieces, all read-only
+against the same read-model the web app uses:
+
+- **OPDS catalog (`/opds`)** — served in both dialects from one model
+  (`src/lib/opds/`): OPDS 1.2 Atom by default (KOReader, Foliate, Marvin, Panels) and OPDS 2.0
+  JSON on `?format=json` or an `application/opds+json` `Accept` header. The format is sticky:
+  a client that entered in JSON gets JSON hrefs all the way down. Public sections are Latest,
+  Trending, Publications, Topics, Collections and OpenSearch. A reader's own shelves hang off
+  **`/opds/u/:did`** — Unread, Saved, Subscriptions, their publications and each of their lists —
+  keyed by DID with no token, exactly like the personalised RSS feeds (`/feed/latest/:did`), and
+  carrying the same block filtering.
+- **Books (`/book/...`)** — EPUB 3.2 (with EPUB 2 NCX and cover fallbacks) generated on demand
+  for one article, a publication, a collection, a list, a tag, or a reader's saved/unread shelf;
+  CBZ with a `ComicInfo.xml` sidecar for comic issues. Bodies render through
+  `@standard-reader/renderer-react` server-side, so **every** block vocabulary the app can display
+  a book can carry — not just the formats with a markdown/HTML path. Images are fetched and
+  embedded under per-image, per-book and concurrency caps; an image that fails keeps its remote
+  URL rather than failing the book. Generation is deterministic (`src/server/books/zip.ts`), which
+  is what makes `ETag`s stable and kosync hashes precomputable.
+- **KOReader progress sync (`/kosync`)** — the kosync protocol (`/users/auth`,
+  `/syncs/progress`), authenticated with a **derived** key: `HMAC(KOSYNC_SECRET, did)`, shown in
+  Settings → E-readers. No credential table, and the key grants nothing but position sync.
+  Because KOReader identifies a book by a hash of the _file_, every single-article download
+  records the digests that file will have (`kosync_documents`), which is how a position reported
+  by a device resolves back to an AT-URI.
+
+**Two deliberate limits.** Only documents with a renderable body appear in the catalog
+(`hasRenderableBody`): a catalog client renders a download button for every entry it sees, and a
+bridged link post has nothing to put behind one. And position sync is **one-way into the app** —
+`reading_progress` is updated from a device's percentage, but the app never sends a position
+_out_, because KOReader's `progress` is an xpointer into that device's own rendering and there is
+no honest way to synthesise one from a fraction.
+
+Reader-facing docs live at [`/guide/e-readers`](/guide/e-readers).
 
 ### Remote MCP server (`/mcp`)
 

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -2201,3 +2201,62 @@ Re-emit a document's content into another format by running the renderer's norma
 - [ ] **Convert a single record from the app** — the reading client stays read-first, but an
       author viewing their own document could be offered the same conversion inline. Depends on
       write scopes for `site.standard.document`.
+
+## 16. E-readers — OPDS catalog, EPUB/CBZ downloads, KOReader sync
+
+Standard Reader as a library an e-reading app can browse. See
+[`APP_VISION.md` §5](./APP_VISION.md#opds-catalog-downloads--koreader-sync).
+
+- [x] **Deterministic ZIP writer** (`src/server/books/zip.ts`) — hand-rolled, like the RSS
+      serializer, because EPUB needs `mimetype` first and STORED, and because byte-stable output
+      is what makes `ETag`s work across replicas and kosync hashes precomputable. Fixed DOS-epoch
+      timestamps; nothing reads the clock.
+- [x] **EPUB 3.2 packager** (`epub.ts`) — nav document _and_ NCX, `cover-image` property _and_
+      the legacy `<meta name="cover">`, endnote `epub:type` semantics, one small stylesheet that
+      leaves typography to the device.
+- [x] **Bodies through `renderer-react`** (`render.tsx`) — server-rendered with
+      `renderToStaticMarkup`, so every block vocabulary the app displays a book can carry. Raw
+      HTML blocks are sanitized against the article schema and re-serialized as XHTML;
+      HTML-family formats the block renderer does not know (WordPress/Gutenberg, micro.blog) fall
+      back to `documentContentHtml`.
+- [x] **Image embedding** (`assets.ts`) — two-pass render (discover → fetch → rewrite) with
+      per-image, whole-book and concurrency caps; a failed fetch keeps its remote URL.
+- [x] **CBZ for comics** (`cbz.ts`) — page images in filename order plus a `ComicInfo.xml`
+      sidecar, from the same page list the comic reader flips through.
+- [x] **Download routes** — `/book/a/:did/:rkey.epub` and `.cbz`, plus publication, collection,
+      list, tag, saved and unread anthologies. Strong `ETag` + `304`.
+- [x] **OPDS 1.2 + 2.0** (`src/lib/opds/`) — one neutral feed model, two serializers, content
+      negotiation on `Accept` with a sticky `?format=json`.
+- [x] **Catalog routes** — public (`/opds`, latest, trending, publications with sort facets,
+      topics, tags, collections, OpenSearch search) and personal (`/opds/u/:did` + unread, saved,
+      subscriptions, publications, and each list), paged, block-filtered.
+- [x] **Only what can be downloaded** — `renderableOnly` on `selectArticleCards` /
+      `selectPublicationArticleCards`, so a catalog never shows an entry whose download button
+      would 404.
+- [x] **kosync** (`/kosync/*`) — `users/auth`, `syncs/progress` GET/PUT, healthcheck, and a
+      `users/create` that refuses with a message pointing at Settings. Credentials are derived
+      (`HMAC(KOSYNC_SECRET, did)`), so there is no credential table to keep.
+- [x] **Device hash → AT-URI** — `koreaderPartialMd5` reproduces KOReader's twelve-sample walk
+      (including the LuaJIT shift overflow that puts the first sample at offset 0); every
+      single-article download records both digests in `kosync_documents`.
+- [x] **Position mirrors into the app** — a device's percentage lands in `reading_progress`, so
+      an article read half-way on a Kobo shows half-read here.
+- [x] **In-app surfacing** — `Download EPUB` / `Download CBZ` in an article's share menu,
+      `Send to e-reader…` on a publication, and a Settings → E-readers section with the catalog
+      URL, sync server, username and key.
+- [x] **Reader docs** — [`/guide/e-readers`](/guide/e-readers).
+- [ ] **Rotate a single reader's sync key** — the key is derived, so today the only revocation is
+      rotating `KOSYNC_SECRET` for everyone. A per-reader salt column would make it individual;
+      worth doing the first time someone loses a device.
+- [ ] **Anthology progress** — a shelf of forty pieces is one file to a device, so its position
+      syncs between devices but cannot mirror onto any single article. Splitting a kosync position
+      back onto a chapter would need the spine offsets, which we do not keep.
+- [ ] **`hasRenderableBody` for `blog.micro.content`** — those records carry `html` the catalog
+      could package, but the app rates them non-renderable and links out instead. Changing that is
+      an app-wide call, not an e-reader one.
+- [ ] **Cache generated books** — every download re-renders and re-fetches images. The `ETag` saves
+      the transfer, not the work. An object-store cache keyed by the deterministic bytes would, and
+      the determinism is already there for it.
+- [ ] **Kindle** — Amazon dropped personal-document EPUB conversion into Send-to-Kindle, which
+      takes EPUB directly now; a "send to Kindle" button would need an email path and their
+      allow-list, so it is its own piece of work.

--- a/apps/standard-reader/drizzle/0042_clear_chat.sql
+++ b/apps/standard-reader/drizzle/0042_clear_chat.sql
@@ -1,0 +1,20 @@
+CREATE TABLE "kosync_documents" (
+	"hash" text PRIMARY KEY NOT NULL,
+	"document_uri" text NOT NULL,
+	"method" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "kosync_progress" (
+	"owner_did" text NOT NULL,
+	"document_hash" text NOT NULL,
+	"progress" text NOT NULL,
+	"percentage" real NOT NULL,
+	"device" text,
+	"device_id" text,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "kosync_progress_owner_did_document_hash_pk" PRIMARY KEY("owner_did","document_hash")
+);
+--> statement-breakpoint
+CREATE INDEX "kosync_documents_uri_idx" ON "kosync_documents" USING btree ("document_uri");--> statement-breakpoint
+CREATE INDEX "kosync_progress_owner_idx" ON "kosync_progress" USING btree ("owner_did","updated_at" DESC NULLS LAST);

--- a/apps/standard-reader/drizzle/0043_slimy_tusk.sql
+++ b/apps/standard-reader/drizzle/0043_slimy_tusk.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "kosync_key_salt" text;

--- a/apps/standard-reader/drizzle/meta/0042_snapshot.json
+++ b/apps/standard-reader/drizzle/meta/0042_snapshot.json
@@ -1,0 +1,5870 @@
+{
+  "id": "e8c2d81b-b914-4d20-af75-c457b1e5d9dc",
+  "prevId": "0302ed25-df8a-4b62-b4d5-91e2213995c9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_mode": {
+          "name": "theme_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appearance": {
+          "name": "appearance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale_hint_seen": {
+          "name": "locale_hint_seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reader_voice": {
+          "name": "reader_voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_links_externally": {
+          "name": "open_links_externally",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_collections_in_magazine": {
+          "name": "open_collections_in_magazine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reading_typography": {
+          "name": "reading_typography",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_reading_history": {
+          "name": "track_reading_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count_old_posts_as_unread": {
+          "name": "count_old_posts_as_unread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclude_web_bridge": {
+          "name": "exclude_web_bridge",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_publication_theme": {
+          "name": "use_publication_theme",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hide_feed_metrics": {
+          "name": "hide_feed_metrics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feed_pagination": {
+          "name": "feed_pagination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_scope": {
+          "name": "home_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_hidden_tabs": {
+          "name": "profile_hidden_tabs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_show_likes": {
+          "name": "profile_show_likes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_authoring_enabled": {
+          "name": "collections_authoring_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userinput_feedback_enabled": {
+          "name": "userinput_feedback_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "margin_save_enabled": {
+          "name": "margin_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semble_save_enabled": {
+          "name": "semble_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocking_enabled": {
+          "name": "blocking_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "atstore_review_prompt_dismissed": {
+          "name": "atstore_review_prompt_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_enabled": {
+          "name": "weekly_digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_subscriptions": {
+          "name": "weekly_digest_section_subscriptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_network": {
+          "name": "weekly_digest_section_network",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_saved": {
+          "name": "weekly_digest_section_saved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_recommendations": {
+          "name": "weekly_digest_section_recommendations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_last_sent_at": {
+          "name": "weekly_digest_last_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_welcome_sent_at": {
+          "name": "weekly_digest_welcome_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_labelers_imported_at": {
+          "name": "bsky_labelers_imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_did_unique": {
+          "name": "user_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "did"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pds": {
+          "name": "pds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_url": {
+          "name": "banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_uri": {
+          "name": "bsky_profile_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_cid": {
+          "name": "bsky_profile_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_fetched_at": {
+          "name": "profile_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_handle_idx": {
+          "name": "profiles_handle_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_handle_trgm_idx": {
+          "name": "profiles_handle_trgm_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "profiles_display_name_trgm_idx": {
+          "name": "profiles_display_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publications": {
+      "name": "publications",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_cid": {
+          "name": "icon_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_mime": {
+          "name": "icon_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent": {
+          "name": "theme_accent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_background": {
+          "name": "theme_background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_foreground": {
+          "name": "theme_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent_foreground": {
+          "name": "theme_accent_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_json": {
+          "name": "theme_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_in_discover": {
+          "name": "show_in_discover",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "prev_next_direction": {
+          "name": "prev_next_direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_kind": {
+          "name": "serial_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_publication": {
+          "name": "collections_publication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_checked_at": {
+          "name": "verification_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(name, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(topic, '')), 'B')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publications_did_idx": {
+          "name": "publications_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_name_idx": {
+          "name": "publications_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_discover_idx": {
+          "name": "publications_discover_idx",
+          "columns": [
+            {
+              "expression": "show_in_discover",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_topic_idx": {
+          "name": "publications_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_url_idx": {
+          "name": "publications_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_serial_idx": {
+          "name": "publications_serial_idx",
+          "columns": [
+            {
+              "expression": "prev_next_direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_search_idx": {
+          "name": "publications_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_contributors": {
+      "name": "document_contributors",
+      "schema": "",
+      "columns": {
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "document_contributors_did_idx": {
+          "name": "document_contributors_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_contributors_document_uri_documents_uri_fk": {
+          "name": "document_contributors_document_uri_documents_uri_fk",
+          "tableFrom": "document_contributors",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_contributors_document_uri_did_pk": {
+          "name": "document_contributors_document_uri_did_pk",
+          "columns": [
+            "document_uri",
+            "did"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_uri": {
+          "name": "site_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_json": {
+          "name": "collection_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_renderable_body": {
+          "name": "has_renderable_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "body_image_count": {
+          "name": "body_image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_cid": {
+          "name": "cover_image_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_mime": {
+          "name": "cover_image_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backlink_count": {
+          "name": "backlink_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_count_prev": {
+          "name": "backlink_count_prev",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_synced_at": {
+          "name": "backlink_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_recomputed_at": {
+          "name": "trending_recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_recommender_count": {
+          "name": "distinct_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bsky_post_uri": {
+          "name": "bsky_post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_post_cid": {
+          "name": "bsky_post_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_updated_at": {
+          "name": "record_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(title, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(immutable_array_to_string(tags), '')), 'B') || setweight(to_tsvector('english', coalesce(text_content, '')), 'C')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documents_did_idx": {
+          "name": "documents_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_did_published_idx": {
+          "name": "documents_did_published_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"published_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_publication_published_idx": {
+          "name": "documents_publication_published_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_published_idx": {
+          "name": "documents_published_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_featured_idx": {
+          "name": "documents_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_site_idx": {
+          "name": "documents_site_idx",
+          "columns": [
+            {
+              "expression": "site_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_search_idx": {
+          "name": "documents_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "documents_trending_idx": {
+          "name": "documents_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_idx": {
+          "name": "documents_canonical_url_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_trgm_idx": {
+          "name": "documents_canonical_url_trgm_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommends": {
+      "name": "recommends",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommender_did": {
+          "name": "recommender_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recommends_document_idx": {
+          "name": "recommends_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_recommender_idx": {
+          "name": "recommends_recommender_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_edge_idx": {
+          "name": "recommends_edge_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_doc_recommender_created_idx": {
+          "name": "recommends_doc_recommender_created_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recommends\".\"deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_did": {
+          "name": "publication_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_publication_idx": {
+          "name": "subscriptions_publication_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_subscriber_idx": {
+          "name": "subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_edge_idx": {
+          "name": "subscriptions_edge_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follower_did": {
+          "name": "follower_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excluded_publications": {
+          "name": "excluded_publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_subject_idx": {
+          "name": "user_follows_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_edge_idx": {
+          "name": "user_follows_edge_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_owner_idx": {
+          "name": "bookmarks_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_document_idx": {
+          "name": "bookmarks_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_edge_idx": {
+          "name": "bookmarks_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reads": {
+      "name": "reads",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reads_owner_idx": {
+          "name": "reads_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_document_idx": {
+          "name": "reads_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_edge_idx": {
+          "name": "reads_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidebar_prefs": {
+      "name": "sidebar_prefs",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_order": {
+          "name": "list_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "tree_order": {
+          "name": "tree_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "subscription_sort": {
+          "name": "subscription_sort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customize_nav": {
+          "name": "customize_nav",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_nav": {
+          "name": "hidden_nav",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reading_progress": {
+      "name": "reading_progress",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reading_progress_owner_idx": {
+          "name": "reading_progress_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "reading_progress_owner_did_document_uri_pk": {
+          "name": "reading_progress_owner_did_document_uri_pk",
+          "columns": [
+            "owner_did",
+            "document_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kosync_documents": {
+      "name": "kosync_documents",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kosync_documents_uri_idx": {
+          "name": "kosync_documents_uri_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kosync_progress": {
+      "name": "kosync_progress",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_hash": {
+          "name": "document_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "percentage": {
+          "name": "percentage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device": {
+          "name": "device",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kosync_progress_owner_idx": {
+          "name": "kosync_progress_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "kosync_progress_owner_did_document_hash_pk": {
+          "name": "kosync_progress_owner_did_document_hash_pk",
+          "columns": [
+            "owner_did",
+            "document_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_push_queue": {
+      "name": "document_push_queue",
+      "schema": "",
+      "columns": {
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_push_queue_claim_idx": {
+          "name": "document_push_queue_claim_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_push_queue_author_idx": {
+          "name": "document_push_queue_author_idx",
+          "columns": [
+            {
+              "expression": "author_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_devices": {
+      "name": "push_devices",
+      "schema": "",
+      "columns": {
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_devices_owner_idx": {
+          "name": "push_devices_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_topics": {
+      "name": "push_topics",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_topics_subject_idx": {
+          "name": "push_topics_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "push_topics_owner_did_subject_type_subject_pk": {
+          "name": "push_topics_owner_did_subject_type_subject_pk",
+          "columns": [
+            "owner_did",
+            "subject_type",
+            "subject"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_saves": {
+      "name": "list_saves",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saver_did": {
+          "name": "saver_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_owner_did": {
+          "name": "list_owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "list_saves_saver_idx": {
+          "name": "list_saves_saver_idx",
+          "columns": [
+            {
+              "expression": "saver_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "list_saves_list_uri_idx": {
+          "name": "list_saves_list_uri_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lists": {
+      "name": "lists",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publications": {
+          "name": "publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "users": {
+          "name": "users",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lists_owner_idx": {
+          "name": "lists_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rkey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_corecommends": {
+      "name": "publication_corecommends",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_recommender_count": {
+          "name": "co_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_corecomm_rank_idx": {
+          "name": "publication_corecomm_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_corecommends_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_corecommends_related_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_corecommends_publication_uri_related_publication_uri_pk": {
+          "name": "publication_corecommends_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_cosubscriptions": {
+      "name": "publication_cosubscriptions",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_subscriber_count": {
+          "name": "co_subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_cosub_rank_idx": {
+          "name": "publication_cosub_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_cosubscriptions_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_cosubscriptions_related_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_cosubscriptions_publication_uri_related_publication_uri_pk": {
+          "name": "publication_cosubscriptions_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_stats": {
+      "name": "publication_stats",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommend_count": {
+          "name": "recommend_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_document_at": {
+          "name": "last_document_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documents_7d": {
+          "name": "documents_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_7d": {
+          "name": "subscribers_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_7d": {
+          "name": "recommends_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "documents_prev_7d": {
+          "name": "documents_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_prev_7d": {
+          "name": "subscribers_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_prev_7d": {
+          "name": "recommends_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlinks_7d": {
+          "name": "backlinks_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_velocity": {
+          "name": "trending_velocity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_window_start": {
+          "name": "trending_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_stats_subscribers_idx": {
+          "name": "publication_stats_subscribers_idx",
+          "columns": [
+            {
+              "expression": "subscriber_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_active_idx": {
+          "name": "publication_stats_active_idx",
+          "columns": [
+            {
+              "expression": "last_document_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_trending_idx": {
+          "name": "publication_stats_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_stats_publication_uri_publications_uri_fk": {
+          "name": "publication_stats_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_stats",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_stats": {
+      "name": "network_stats",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discover_topic_counts": {
+      "name": "discover_topic_counts",
+      "schema": "",
+      "columns": {
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discover_topic_counts_count_idx": {
+          "name": "discover_topic_counts_count_idx",
+          "columns": [
+            {
+              "expression": "publication_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discover_topic_counts_topic_trgm_idx": {
+          "name": "discover_topic_counts_topic_trgm_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag_embeddings": {
+      "name": "tag_embeddings",
+      "schema": "",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "double precision[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_publications": {
+      "name": "topic_publications",
+      "schema": "",
+      "columns": {
+        "topic_slug": {
+          "name": "topic_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "matched_tag_count": {
+          "name": "matched_tag_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "topic_publications_rank_idx": {
+          "name": "topic_publications_rank_idx",
+          "columns": [
+            {
+              "expression": "topic_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_publications_pub_idx": {
+          "name": "topic_publications_pub_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_publications_topic_slug_topics_slug_fk": {
+          "name": "topic_publications_topic_slug_topics_slug_fk",
+          "tableFrom": "topic_publications",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "topic_publications_publication_uri_publications_uri_fk": {
+          "name": "topic_publications_publication_uri_publications_uri_fk",
+          "tableFrom": "topic_publications",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_publications_topic_slug_publication_uri_pk": {
+          "name": "topic_publications_topic_slug_publication_uri_pk",
+          "columns": [
+            "topic_slug",
+            "publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_tags": {
+      "name": "topic_tags",
+      "schema": "",
+      "columns": {
+        "topic_slug": {
+          "name": "topic_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "topic_tags_tag_idx": {
+          "name": "topic_tags_tag_idx",
+          "columns": [
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_tags_weight_idx": {
+          "name": "topic_tags_weight_idx",
+          "columns": [
+            {
+              "expression": "topic_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weight",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_tags_topic_slug_topics_slug_fk": {
+          "name": "topic_tags_topic_slug_topics_slug_fk",
+          "tableFrom": "topic_tags",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_tags_topic_slug_tag_pk": {
+          "name": "topic_tags_topic_slug_tag_pk",
+          "columns": [
+            "topic_slug",
+            "tag"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_tags": {
+          "name": "signature_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_count": {
+          "name": "tag_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author_count": {
+          "name": "author_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_model": {
+          "name": "name_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "named_at": {
+          "name": "named_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topics_published_score_idx": {
+          "name": "topics_published_score_idx",
+          "columns": [
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topics_superseded_by_topics_slug_fk": {
+          "name": "topics_superseded_by_topics_slug_fk",
+          "tableFrom": "topics",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "superseded_by"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_dead_letter": {
+      "name": "ingest_dead_letter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retries": {
+          "name": "retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingest_dead_letter_collection_idx": {
+          "name": "ingest_dead_letter_collection_idx",
+          "columns": [
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_state": {
+      "name": "ingest_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_processed": {
+          "name": "events_processed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_repos": {
+      "name": "tracked_repos",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_state": {
+          "name": "backfill_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_seen_seq": {
+          "name": "last_seen_seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_fail_count": {
+          "name": "reconcile_fail_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconcile_retry_after": {
+          "name": "reconcile_retry_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tracked_repos_state_idx": {
+          "name": "tracked_repos_state_idx",
+          "columns": [
+            {
+              "expression": "backfill_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_labels": {
+      "name": "document_labels",
+      "schema": "",
+      "columns": {
+        "src": {
+          "name": "src",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "val": {
+          "name": "val",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cts": {
+          "name": "cts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_labels_uri_idx": {
+          "name": "document_labels_uri_idx",
+          "columns": [
+            {
+              "expression": "uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_labels_src_idx": {
+          "name": "document_labels_src_idx",
+          "columns": [
+            {
+              "expression": "src",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "document_labels_src_uri_val_pk": {
+          "name": "document_labels_src_uri_val_pk",
+          "columns": [
+            "src",
+            "uri",
+            "val"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_sync_state": {
+      "name": "label_sync_state",
+      "schema": "",
+      "columns": {
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_count": {
+          "name": "stored_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rejected_count": {
+          "name": "rejected_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_services": {
+      "name": "labeler_services",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_endpoint": {
+          "name": "service_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels_standard_site": {
+          "name": "labels_standard_site",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels_probed_at": {
+          "name": "labels_probed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reachable": {
+          "name": "reachable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_value_definitions": {
+          "name": "label_value_definitions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_services_labeler_idx": {
+          "name": "labeler_services_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_subscriptions": {
+      "name": "labeler_subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefs": {
+          "name": "prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_subscriptions_subscriber_idx": {
+          "name": "labeler_subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labeler_subscriptions_labeler_idx": {
+          "name": "labeler_subscriptions_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_list_items": {
+      "name": "block_list_items",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "block_list_items_list_idx": {
+          "name": "block_list_items_list_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_list_items_subject_idx": {
+          "name": "block_list_items_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_list_items_list_subject_idx": {
+          "name": "block_list_items_list_subject_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_list_sync_state": {
+      "name": "block_list_sync_state",
+      "schema": "",
+      "columns": {
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_count": {
+          "name": "item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "truncated": {
+          "name": "truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_lists": {
+      "name": "block_lists",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocker_did": {
+          "name": "blocker_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "block_lists_blocker_idx": {
+          "name": "block_lists_blocker_idx",
+          "columns": [
+            {
+              "expression": "blocker_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_lists_list_idx": {
+          "name": "block_lists_list_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_sync_state": {
+      "name": "block_sync_state",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "outgoing_count": {
+          "name": "outgoing_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "incoming_count": {
+          "name": "incoming_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "list_count": {
+          "name": "list_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocker_did": {
+          "name": "blocker_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocks_subject_idx": {
+          "name": "blocks_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocks_edge_idx": {
+          "name": "blocks_edge_idx",
+          "columns": [
+            {
+              "expression": "blocker_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mutes": {
+      "name": "mutes",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "muter_did": {
+          "name": "muter_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mutes_muter_idx": {
+          "name": "mutes_muter_idx",
+          "columns": [
+            {
+              "expression": "muter_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mutes_user_edge_idx": {
+          "name": "mutes_user_edge_idx",
+          "columns": [
+            {
+              "expression": "muter_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mutes_pub_edge_idx": {
+          "name": "mutes_pub_edge_idx",
+          "columns": [
+            {
+              "expression": "muter_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_auth_code": {
+      "name": "mcp_auth_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_auth_code_expires_at_idx": {
+          "name": "mcp_auth_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_auth_code_client_id_mcp_client_id_fk": {
+          "name": "mcp_auth_code_client_id_mcp_client_id_fk",
+          "tableFrom": "mcp_auth_code",
+          "tableTo": "mcp_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_auth_code_user_id_user_id_fk": {
+          "name": "mcp_auth_code_user_id_user_id_fk",
+          "tableFrom": "mcp_auth_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_client": {
+      "name": "mcp_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_uri": {
+          "name": "client_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_uri": {
+          "name": "logo_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_token": {
+      "name": "mcp_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_token_user_id_idx": {
+          "name": "mcp_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_expires_at_idx": {
+          "name": "mcp_token_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_client_id_mcp_client_id_fk": {
+          "name": "mcp_token_client_id_mcp_client_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "mcp_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_user_id_user_id_fk": {
+          "name": "mcp_token_user_id_user_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_token_access_token_hash_unique": {
+          "name": "mcp_token_access_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token_hash"
+          ]
+        },
+        "mcp_token_refresh_token_hash_unique": {
+          "name": "mcp_token_refresh_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_shares": {
+      "name": "quote_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_text": {
+          "name": "quote_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quote_shares_document_uri_idx": {
+          "name": "quote_shares_document_uri_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_draft": {
+      "name": "feedback_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feedback_draft_user_idx": {
+          "name": "feedback_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_draft_expires_idx": {
+          "name": "feedback_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_draft_user_id_user_id_fk": {
+          "name": "feedback_draft_user_id_user_id_fk",
+          "tableFrom": "feedback_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upvote_draft": {
+      "name": "upvote_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "upvote_draft_user_idx": {
+          "name": "upvote_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upvote_draft_expires_idx": {
+          "name": "upvote_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upvote_draft_user_id_user_id_fk": {
+          "name": "upvote_draft_user_id_user_id_fk",
+          "tableFrom": "upvote_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.save_draft": {
+      "name": "save_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_app": {
+          "name": "target_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_uri": {
+          "name": "collection_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_cid": {
+          "name": "collection_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_collection_name": {
+          "name": "new_collection_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motivation": {
+          "name": "motivation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passage": {
+          "name": "passage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "save_draft_user_idx": {
+          "name": "save_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "save_draft_expires_idx": {
+          "name": "save_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "save_draft_user_id_user_id_fk": {
+          "name": "save_draft_user_id_user_id_fk",
+          "tableFrom": "save_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_thread_runs": {
+      "name": "weekly_thread_runs",
+      "schema": "",
+      "columns": {
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "root_uri": {
+          "name": "root_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/standard-reader/drizzle/meta/0043_snapshot.json
+++ b/apps/standard-reader/drizzle/meta/0043_snapshot.json
@@ -1,0 +1,5876 @@
+{
+  "id": "4537bcbd-0818-47d7-af6d-dc74361051ea",
+  "prevId": "e8c2d81b-b914-4d20-af75-c457b1e5d9dc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_mode": {
+          "name": "theme_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appearance": {
+          "name": "appearance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale_hint_seen": {
+          "name": "locale_hint_seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reader_voice": {
+          "name": "reader_voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_links_externally": {
+          "name": "open_links_externally",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_collections_in_magazine": {
+          "name": "open_collections_in_magazine",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reading_typography": {
+          "name": "reading_typography",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_reading_history": {
+          "name": "track_reading_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kosync_key_salt": {
+          "name": "kosync_key_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count_old_posts_as_unread": {
+          "name": "count_old_posts_as_unread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclude_web_bridge": {
+          "name": "exclude_web_bridge",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_publication_theme": {
+          "name": "use_publication_theme",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hide_feed_metrics": {
+          "name": "hide_feed_metrics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feed_pagination": {
+          "name": "feed_pagination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_scope": {
+          "name": "home_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_hidden_tabs": {
+          "name": "profile_hidden_tabs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_show_likes": {
+          "name": "profile_show_likes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_authoring_enabled": {
+          "name": "collections_authoring_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userinput_feedback_enabled": {
+          "name": "userinput_feedback_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "margin_save_enabled": {
+          "name": "margin_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semble_save_enabled": {
+          "name": "semble_save_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocking_enabled": {
+          "name": "blocking_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "atstore_review_prompt_dismissed": {
+          "name": "atstore_review_prompt_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_enabled": {
+          "name": "weekly_digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_subscriptions": {
+          "name": "weekly_digest_section_subscriptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_network": {
+          "name": "weekly_digest_section_network",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_saved": {
+          "name": "weekly_digest_section_saved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_section_recommendations": {
+          "name": "weekly_digest_section_recommendations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_last_sent_at": {
+          "name": "weekly_digest_last_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_welcome_sent_at": {
+          "name": "weekly_digest_welcome_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_labelers_imported_at": {
+          "name": "bsky_labelers_imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_did_unique": {
+          "name": "user_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "did"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pds": {
+          "name": "pds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_url": {
+          "name": "banner_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_uri": {
+          "name": "bsky_profile_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_profile_cid": {
+          "name": "bsky_profile_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_fetched_at": {
+          "name": "profile_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_handle_idx": {
+          "name": "profiles_handle_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_handle_trgm_idx": {
+          "name": "profiles_handle_trgm_idx",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "profiles_display_name_trgm_idx": {
+          "name": "profiles_display_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publications": {
+      "name": "publications",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_cid": {
+          "name": "icon_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_mime": {
+          "name": "icon_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent": {
+          "name": "theme_accent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_background": {
+          "name": "theme_background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_foreground": {
+          "name": "theme_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_accent_foreground": {
+          "name": "theme_accent_foreground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_json": {
+          "name": "theme_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_in_discover": {
+          "name": "show_in_discover",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "prev_next_direction": {
+          "name": "prev_next_direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_kind": {
+          "name": "serial_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collections_publication": {
+          "name": "collections_publication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_checked_at": {
+          "name": "verification_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(name, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(topic, '')), 'B')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publications_did_idx": {
+          "name": "publications_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_name_idx": {
+          "name": "publications_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_discover_idx": {
+          "name": "publications_discover_idx",
+          "columns": [
+            {
+              "expression": "show_in_discover",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_topic_idx": {
+          "name": "publications_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_url_idx": {
+          "name": "publications_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_serial_idx": {
+          "name": "publications_serial_idx",
+          "columns": [
+            {
+              "expression": "prev_next_direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publications_search_idx": {
+          "name": "publications_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_contributors": {
+      "name": "document_contributors",
+      "schema": "",
+      "columns": {
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "document_contributors_did_idx": {
+          "name": "document_contributors_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_contributors_document_uri_documents_uri_fk": {
+          "name": "document_contributors_document_uri_documents_uri_fk",
+          "tableFrom": "document_contributors",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_contributors_document_uri_did_pk": {
+          "name": "document_contributors_document_uri_did_pk",
+          "columns": [
+            "document_uri",
+            "did"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_uri": {
+          "name": "site_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_json": {
+          "name": "content_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_json": {
+          "name": "collection_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_renderable_body": {
+          "name": "has_renderable_body",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "body_image_count": {
+          "name": "body_image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_cid": {
+          "name": "cover_image_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_mime": {
+          "name": "cover_image_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backlink_count": {
+          "name": "backlink_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_count_prev": {
+          "name": "backlink_count_prev",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlink_synced_at": {
+          "name": "backlink_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_recomputed_at": {
+          "name": "trending_recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_recommender_count": {
+          "name": "distinct_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bsky_post_uri": {
+          "name": "bsky_post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsky_post_cid": {
+          "name": "bsky_post_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_updated_at": {
+          "name": "record_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(title, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(immutable_array_to_string(tags), '')), 'B') || setweight(to_tsvector('english', coalesce(text_content, '')), 'C')",
+            "type": "stored"
+          }
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documents_did_idx": {
+          "name": "documents_did_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_did_published_idx": {
+          "name": "documents_did_published_idx",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"published_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_publication_published_idx": {
+          "name": "documents_publication_published_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_published_idx": {
+          "name": "documents_published_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_featured_idx": {
+          "name": "documents_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_site_idx": {
+          "name": "documents_site_idx",
+          "columns": [
+            {
+              "expression": "site_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_search_idx": {
+          "name": "documents_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "documents_trending_idx": {
+          "name": "documents_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_idx": {
+          "name": "documents_canonical_url_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_canonical_url_trgm_idx": {
+          "name": "documents_canonical_url_trgm_idx",
+          "columns": [
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommends": {
+      "name": "recommends",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommender_did": {
+          "name": "recommender_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recommends_document_idx": {
+          "name": "recommends_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_recommender_idx": {
+          "name": "recommends_recommender_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_edge_idx": {
+          "name": "recommends_edge_idx",
+          "columns": [
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommends_doc_recommender_created_idx": {
+          "name": "recommends_doc_recommender_created_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recommender_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"recommends\".\"deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_did": {
+          "name": "publication_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_publication_idx": {
+          "name": "subscriptions_publication_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_subscriber_idx": {
+          "name": "subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_edge_idx": {
+          "name": "subscriptions_edge_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follower_did": {
+          "name": "follower_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excluded_publications": {
+          "name": "excluded_publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_subject_idx": {
+          "name": "user_follows_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_edge_idx": {
+          "name": "user_follows_edge_idx",
+          "columns": [
+            {
+              "expression": "follower_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_owner_idx": {
+          "name": "bookmarks_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_document_idx": {
+          "name": "bookmarks_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_edge_idx": {
+          "name": "bookmarks_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reads": {
+      "name": "reads",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_did": {
+          "name": "document_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reads_owner_idx": {
+          "name": "reads_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_document_idx": {
+          "name": "reads_document_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reads_edge_idx": {
+          "name": "reads_edge_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sidebar_prefs": {
+      "name": "sidebar_prefs",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_order": {
+          "name": "list_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "tree_order": {
+          "name": "tree_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "subscription_sort": {
+          "name": "subscription_sort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customize_nav": {
+          "name": "customize_nav",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hidden_nav": {
+          "name": "hidden_nav",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reading_progress": {
+      "name": "reading_progress",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reading_progress_owner_idx": {
+          "name": "reading_progress_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "reading_progress_owner_did_document_uri_pk": {
+          "name": "reading_progress_owner_did_document_uri_pk",
+          "columns": [
+            "owner_did",
+            "document_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kosync_documents": {
+      "name": "kosync_documents",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kosync_documents_uri_idx": {
+          "name": "kosync_documents_uri_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kosync_progress": {
+      "name": "kosync_progress",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_hash": {
+          "name": "document_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "percentage": {
+          "name": "percentage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device": {
+          "name": "device",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kosync_progress_owner_idx": {
+          "name": "kosync_progress_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "kosync_progress_owner_did_document_hash_pk": {
+          "name": "kosync_progress_owner_did_document_hash_pk",
+          "columns": [
+            "owner_did",
+            "document_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_push_queue": {
+      "name": "document_push_queue",
+      "schema": "",
+      "columns": {
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_push_queue_claim_idx": {
+          "name": "document_push_queue_claim_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_push_queue_author_idx": {
+          "name": "document_push_queue_author_idx",
+          "columns": [
+            {
+              "expression": "author_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_devices": {
+      "name": "push_devices",
+      "schema": "",
+      "columns": {
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_devices_owner_idx": {
+          "name": "push_devices_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_topics": {
+      "name": "push_topics",
+      "schema": "",
+      "columns": {
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_topics_subject_idx": {
+          "name": "push_topics_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "push_topics_owner_did_subject_type_subject_pk": {
+          "name": "push_topics_owner_did_subject_type_subject_pk",
+          "columns": [
+            "owner_did",
+            "subject_type",
+            "subject"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_saves": {
+      "name": "list_saves",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saver_did": {
+          "name": "saver_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_owner_did": {
+          "name": "list_owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "list_saves_saver_idx": {
+          "name": "list_saves_saver_idx",
+          "columns": [
+            {
+              "expression": "saver_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "list_saves_list_uri_idx": {
+          "name": "list_saves_list_uri_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lists": {
+      "name": "lists",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publications": {
+          "name": "publications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "users": {
+          "name": "users",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lists_owner_idx": {
+          "name": "lists_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rkey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_corecommends": {
+      "name": "publication_corecommends",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_recommender_count": {
+          "name": "co_recommender_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_corecomm_rank_idx": {
+          "name": "publication_corecomm_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_corecommends_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_corecommends_related_publication_uri_publications_uri_fk": {
+          "name": "publication_corecommends_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_corecommends",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_corecommends_publication_uri_related_publication_uri_pk": {
+          "name": "publication_corecommends_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_cosubscriptions": {
+      "name": "publication_cosubscriptions",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_publication_uri": {
+          "name": "related_publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_subscriber_count": {
+          "name": "co_subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_cosub_rank_idx": {
+          "name": "publication_cosub_rank_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_cosubscriptions_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "publication_cosubscriptions_related_publication_uri_publications_uri_fk": {
+          "name": "publication_cosubscriptions_related_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_cosubscriptions",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "related_publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "publication_cosubscriptions_publication_uri_related_publication_uri_pk": {
+          "name": "publication_cosubscriptions_publication_uri_related_publication_uri_pk",
+          "columns": [
+            "publication_uri",
+            "related_publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publication_stats": {
+      "name": "publication_stats",
+      "schema": "",
+      "columns": {
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_count": {
+          "name": "subscriber_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommend_count": {
+          "name": "recommend_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_document_at": {
+          "name": "last_document_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documents_7d": {
+          "name": "documents_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_7d": {
+          "name": "subscribers_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_7d": {
+          "name": "recommends_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "documents_prev_7d": {
+          "name": "documents_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "subscribers_prev_7d": {
+          "name": "subscribers_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recommends_prev_7d": {
+          "name": "recommends_prev_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backlinks_7d": {
+          "name": "backlinks_7d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_velocity": {
+          "name": "trending_velocity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_score": {
+          "name": "trending_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trending_window_start": {
+          "name": "trending_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publication_stats_subscribers_idx": {
+          "name": "publication_stats_subscribers_idx",
+          "columns": [
+            {
+              "expression": "subscriber_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_active_idx": {
+          "name": "publication_stats_active_idx",
+          "columns": [
+            {
+              "expression": "last_document_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "publication_stats_trending_idx": {
+          "name": "publication_stats_trending_idx",
+          "columns": [
+            {
+              "expression": "trending_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publication_stats_publication_uri_publications_uri_fk": {
+          "name": "publication_stats_publication_uri_publications_uri_fk",
+          "tableFrom": "publication_stats",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network_stats": {
+      "name": "network_stats",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recomputed_at": {
+          "name": "recomputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discover_topic_counts": {
+      "name": "discover_topic_counts",
+      "schema": "",
+      "columns": {
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discover_topic_counts_count_idx": {
+          "name": "discover_topic_counts_count_idx",
+          "columns": [
+            {
+              "expression": "publication_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discover_topic_counts_topic_trgm_idx": {
+          "name": "discover_topic_counts_topic_trgm_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag_embeddings": {
+      "name": "tag_embeddings",
+      "schema": "",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "double precision[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_publications": {
+      "name": "topic_publications",
+      "schema": "",
+      "columns": {
+        "topic_slug": {
+          "name": "topic_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_uri": {
+          "name": "publication_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "matched_tag_count": {
+          "name": "matched_tag_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "topic_publications_rank_idx": {
+          "name": "topic_publications_rank_idx",
+          "columns": [
+            {
+              "expression": "topic_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_publications_pub_idx": {
+          "name": "topic_publications_pub_idx",
+          "columns": [
+            {
+              "expression": "publication_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_publications_topic_slug_topics_slug_fk": {
+          "name": "topic_publications_topic_slug_topics_slug_fk",
+          "tableFrom": "topic_publications",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "topic_publications_publication_uri_publications_uri_fk": {
+          "name": "topic_publications_publication_uri_publications_uri_fk",
+          "tableFrom": "topic_publications",
+          "tableTo": "publications",
+          "columnsFrom": [
+            "publication_uri"
+          ],
+          "columnsTo": [
+            "uri"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_publications_topic_slug_publication_uri_pk": {
+          "name": "topic_publications_topic_slug_publication_uri_pk",
+          "columns": [
+            "topic_slug",
+            "publication_uri"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_tags": {
+      "name": "topic_tags",
+      "schema": "",
+      "columns": {
+        "topic_slug": {
+          "name": "topic_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "topic_tags_tag_idx": {
+          "name": "topic_tags_tag_idx",
+          "columns": [
+            {
+              "expression": "tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topic_tags_weight_idx": {
+          "name": "topic_tags_weight_idx",
+          "columns": [
+            {
+              "expression": "topic_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weight",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topic_tags_topic_slug_topics_slug_fk": {
+          "name": "topic_tags_topic_slug_topics_slug_fk",
+          "tableFrom": "topic_tags",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "topic_tags_topic_slug_tag_pk": {
+          "name": "topic_tags_topic_slug_tag_pk",
+          "columns": [
+            "topic_slug",
+            "tag"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_tags": {
+          "name": "signature_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_count": {
+          "name": "tag_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "publication_count": {
+          "name": "publication_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author_count": {
+          "name": "author_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_model": {
+          "name": "name_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "named_at": {
+          "name": "named_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topics_published_score_idx": {
+          "name": "topics_published_score_idx",
+          "columns": [
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topics_superseded_by_topics_slug_fk": {
+          "name": "topics_superseded_by_topics_slug_fk",
+          "tableFrom": "topics",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "superseded_by"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_dead_letter": {
+      "name": "ingest_dead_letter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retries": {
+          "name": "retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingest_dead_letter_collection_idx": {
+          "name": "ingest_dead_letter_collection_idx",
+          "columns": [
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingest_state": {
+      "name": "ingest_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_processed": {
+          "name": "events_processed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracked_repos": {
+      "name": "tracked_repos",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backfill_state": {
+          "name": "backfill_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_seen_seq": {
+          "name": "last_seen_seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_fail_count": {
+          "name": "reconcile_fail_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconcile_retry_after": {
+          "name": "reconcile_retry_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tracked_repos_state_idx": {
+          "name": "tracked_repos_state_idx",
+          "columns": [
+            {
+              "expression": "backfill_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_labels": {
+      "name": "document_labels",
+      "schema": "",
+      "columns": {
+        "src": {
+          "name": "src",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "val": {
+          "name": "val",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cts": {
+          "name": "cts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_labels_uri_idx": {
+          "name": "document_labels_uri_idx",
+          "columns": [
+            {
+              "expression": "uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_labels_src_idx": {
+          "name": "document_labels_src_idx",
+          "columns": [
+            {
+              "expression": "src",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "document_labels_src_uri_val_pk": {
+          "name": "document_labels_src_uri_val_pk",
+          "columns": [
+            "src",
+            "uri",
+            "val"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.label_sync_state": {
+      "name": "label_sync_state",
+      "schema": "",
+      "columns": {
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_count": {
+          "name": "stored_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rejected_count": {
+          "name": "rejected_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_services": {
+      "name": "labeler_services",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_endpoint": {
+          "name": "service_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels_standard_site": {
+          "name": "labels_standard_site",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels_probed_at": {
+          "name": "labels_probed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reachable": {
+          "name": "reachable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_value_definitions": {
+          "name": "label_value_definitions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_services_labeler_idx": {
+          "name": "labeler_services_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labeler_subscriptions": {
+      "name": "labeler_subscriptions",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_did": {
+          "name": "subscriber_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labeler_did": {
+          "name": "labeler_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefs": {
+          "name": "prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labeler_subscriptions_subscriber_idx": {
+          "name": "labeler_subscriptions_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labeler_subscriptions_labeler_idx": {
+          "name": "labeler_subscriptions_labeler_idx",
+          "columns": [
+            {
+              "expression": "labeler_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_list_items": {
+      "name": "block_list_items",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "block_list_items_list_idx": {
+          "name": "block_list_items_list_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_list_items_subject_idx": {
+          "name": "block_list_items_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_list_items_list_subject_idx": {
+          "name": "block_list_items_list_subject_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_list_sync_state": {
+      "name": "block_list_sync_state",
+      "schema": "",
+      "columns": {
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_count": {
+          "name": "item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "truncated": {
+          "name": "truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_lists": {
+      "name": "block_lists",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocker_did": {
+          "name": "blocker_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_uri": {
+          "name": "list_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "block_lists_blocker_idx": {
+          "name": "block_lists_blocker_idx",
+          "columns": [
+            {
+              "expression": "blocker_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_lists_list_idx": {
+          "name": "block_lists_list_idx",
+          "columns": [
+            {
+              "expression": "list_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_sync_state": {
+      "name": "block_sync_state",
+      "schema": "",
+      "columns": {
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "outgoing_count": {
+          "name": "outgoing_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "incoming_count": {
+          "name": "incoming_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "list_count": {
+          "name": "list_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocker_did": {
+          "name": "blocker_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocks_subject_idx": {
+          "name": "blocks_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocks_edge_idx": {
+          "name": "blocks_edge_idx",
+          "columns": [
+            {
+              "expression": "blocker_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mutes": {
+      "name": "mutes",
+      "schema": "",
+      "columns": {
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "muter_did": {
+          "name": "muter_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mutes_muter_idx": {
+          "name": "mutes_muter_idx",
+          "columns": [
+            {
+              "expression": "muter_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mutes_user_edge_idx": {
+          "name": "mutes_user_edge_idx",
+          "columns": [
+            {
+              "expression": "muter_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mutes_pub_edge_idx": {
+          "name": "mutes_pub_edge_idx",
+          "columns": [
+            {
+              "expression": "muter_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_auth_code": {
+      "name": "mcp_auth_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_auth_code_expires_at_idx": {
+          "name": "mcp_auth_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_auth_code_client_id_mcp_client_id_fk": {
+          "name": "mcp_auth_code_client_id_mcp_client_id_fk",
+          "tableFrom": "mcp_auth_code",
+          "tableTo": "mcp_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_auth_code_user_id_user_id_fk": {
+          "name": "mcp_auth_code_user_id_user_id_fk",
+          "tableFrom": "mcp_auth_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_client": {
+      "name": "mcp_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_uri": {
+          "name": "client_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_uri": {
+          "name": "logo_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_token": {
+      "name": "mcp_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_token_user_id_idx": {
+          "name": "mcp_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_expires_at_idx": {
+          "name": "mcp_token_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_client_id_mcp_client_id_fk": {
+          "name": "mcp_token_client_id_mcp_client_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "mcp_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_user_id_user_id_fk": {
+          "name": "mcp_token_user_id_user_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_token_access_token_hash_unique": {
+          "name": "mcp_token_access_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token_hash"
+          ]
+        },
+        "mcp_token_refresh_token_hash_unique": {
+          "name": "mcp_token_refresh_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_shares": {
+      "name": "quote_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_uri": {
+          "name": "document_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_text": {
+          "name": "quote_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quote_shares_document_uri_idx": {
+          "name": "quote_shares_document_uri_idx",
+          "columns": [
+            {
+              "expression": "document_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_draft": {
+      "name": "feedback_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "feedback_draft_user_idx": {
+          "name": "feedback_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_draft_expires_idx": {
+          "name": "feedback_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_draft_user_id_user_id_fk": {
+          "name": "feedback_draft_user_id_user_id_fk",
+          "tableFrom": "feedback_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upvote_draft": {
+      "name": "upvote_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_uri": {
+          "name": "subject_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "upvote_draft_user_idx": {
+          "name": "upvote_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upvote_draft_expires_idx": {
+          "name": "upvote_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upvote_draft_user_id_user_id_fk": {
+          "name": "upvote_draft_user_id_user_id_fk",
+          "tableFrom": "upvote_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.save_draft": {
+      "name": "save_draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_app": {
+          "name": "target_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_uri": {
+          "name": "collection_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_cid": {
+          "name": "collection_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_collection_name": {
+          "name": "new_collection_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motivation": {
+          "name": "motivation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passage": {
+          "name": "passage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "save_draft_user_idx": {
+          "name": "save_draft_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "save_draft_expires_idx": {
+          "name": "save_draft_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "save_draft_user_id_user_id_fk": {
+          "name": "save_draft_user_id_user_id_fk",
+          "tableFrom": "save_draft",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weekly_thread_runs": {
+      "name": "weekly_thread_runs",
+      "schema": "",
+      "columns": {
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "root_uri": {
+          "name": "root_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/standard-reader/drizzle/meta/_journal.json
+++ b/apps/standard-reader/drizzle/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1787200014683,
       "tag": "0042_clear_chat",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1787207677749,
+      "tag": "0043_slimy_tusk",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/standard-reader/drizzle/meta/_journal.json
+++ b/apps/standard-reader/drizzle/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1786724706897,
       "tag": "0041_tidy_last_seen_seq",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1787200014683,
+      "tag": "0042_clear_chat",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/standard-reader/src/components/comic/comic-reader.tsx
+++ b/apps/standard-reader/src/components/comic/comic-reader.tsx
@@ -20,6 +20,7 @@ import {
 import * as stylex from "@stylexjs/stylex";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
+  BookDown,
   ChevronLeft,
   ChevronRight,
   FileText,
@@ -32,10 +33,13 @@ import type { PointerEvent as ReactPointerEvent } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
+import { comicIssueCbzUrl } from "#/lib/opds/urls";
+import { getPublicUrlClient } from "#/lib/public-url";
 import { useTrackReadingHistory } from "#/lib/use-track-reading-history";
 
 import { documentLinkParams, publicationLinkParams } from "../reader/format";
 import { applyMarkReadOptimisticUpdate } from "../reader/read-optimistic";
+import { startDownload } from "../reader/start-download";
 import { ButtonLink, IconButtonLink } from "../router-links";
 import { ComicPageNote } from "./comic-page-note";
 import { ICON_SIZE, ICON_STROKE } from "./theater-palette";
@@ -789,6 +793,17 @@ export function ComicReader({
     ? publicationLinkParams(publicationUri)
     : null;
   const notesParams = issueUri ? documentLinkParams(issueUri) : null;
+  // The theater flattens the whole publication into one run of pages, so
+  // "download" has to mean something narrower than what is on screen. Not this
+  // *document* though — a comic posts one page per document, so that would be a
+  // one-page file. `/book/i/…` resolves the page to the issue it sits in.
+  const issueCbzUrl = currentIssue
+    ? comicIssueCbzUrl(
+        getPublicUrlClient(),
+        currentIssue.did,
+        currentIssue.rkey,
+      )
+    : null;
 
   const chromeHidden = !chromeVisible;
 
@@ -954,6 +969,25 @@ export function ComicReader({
                 strokeWidth={ICON_STROKE}
               />
             </IconButtonLink>
+          ) : null}
+
+          {/* Next to the article link, for the same reason the note sits beside
+              it: these are the three things to do with the issue you are in,
+              and taking it with you should not cost a trip out to the
+              publication's overflow menu. */}
+          {issueCbzUrl ? (
+            <IconButton
+              variant="tertiary"
+              aria-label={t`Download this issue (CBZ)`}
+              onPress={() => startDownload(issueCbzUrl)}
+              style={styles.chromeControl}
+            >
+              <BookDown
+                aria-hidden
+                size={ICON_SIZE}
+                strokeWidth={ICON_STROKE}
+              />
+            </IconButton>
           ) : null}
 
           {/* Last in the bar, where a player puts it, and only where the

--- a/apps/standard-reader/src/components/ereader-settings.tsx
+++ b/apps/standard-reader/src/components/ereader-settings.tsx
@@ -159,7 +159,7 @@ export function EreaderSettings() {
               isReadOnly
               aria-label={field.label}
               disablePasswordManagers
-              size="lg"
+              size="md"
               style={styles.value}
               suffix={<CopyToClipboardButton size="sm" text={field.value} />}
               type={field.secret ? "password" : "text"}

--- a/apps/standard-reader/src/components/ereader-settings.tsx
+++ b/apps/standard-reader/src/components/ereader-settings.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import { Trans, useLingui } from "@lingui/react/macro";
-import { Button } from "@standard-reader/design-system/button";
 import { CopyToClipboardButton } from "@standard-reader/design-system/copy-to-clipboard-button";
 import { Separator } from "@standard-reader/design-system/separator";
+import { TextField } from "@standard-reader/design-system/text-field";
 import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
-import { radius } from "@standard-reader/design-system/theme/radius.stylex";
 import {
   gap,
   horizontalSpace,
@@ -18,7 +17,7 @@ import {
 } from "@standard-reader/design-system/theme/typography.stylex";
 import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
-import { Fragment, useState } from "react";
+import { Fragment } from "react";
 
 import { ereaderApi } from "#/integrations/tanstack-query/api-ereader.functions";
 
@@ -31,9 +30,11 @@ const MOBILE = "@media (max-width: 47.5rem)";
  *
  * Same two-column geometry — label and description at the start, the control at
  * the end — but that row sizes its control column to its content, which is right
- * for a switch and wrong for a URL: the field collapses to a sliver and the
- * reader cannot see what they are copying. Here the value column is the one that
- * grows.
+ * for a switch and wrong for a text field: it collapses to a sliver and the
+ * reader cannot see what they are copying. Here the value column gets the width.
+ *
+ * The field itself is the design system's `TextField`, so it looks like every
+ * other input in the app and the sync key gets a reveal toggle for free.
  */
 const styles = stylex.create({
   block: {
@@ -44,6 +45,15 @@ const styles = stylex.create({
     paddingInlineEnd: horizontalSpace["3xl"],
     paddingInlineStart: horizontalSpace["3xl"],
     paddingTop: verticalSpace["3xl"],
+  },
+  intro: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.xs,
+    lineHeight: lineHeight.base,
+    marginBottom: verticalSpace.none,
+    marginTop: verticalSpace.none,
+    maxWidth: "72ch",
   },
   row: {
     alignItems: { [MOBILE]: "stretch", default: "center" },
@@ -62,47 +72,13 @@ const styles = stylex.create({
     flexShrink: 1,
     minWidth: 0,
   },
-  field: {
-    backgroundColor: uiColor.component2,
-    borderColor: uiColor.border1,
-    borderRadius: radius.sm,
-    borderStyle: "solid",
-    borderWidth: 1,
-    boxSizing: "border-box",
-    color: uiColor.text1,
-    flexGrow: 1,
-    flexShrink: 1,
-    fontFamily: fontFamily.mono,
-    fontSize: fontSize.xs,
-    // Without this a flex item refuses to shrink below its content width, and
-    // a long URL pushes the copy button off the end of the card.
-    minWidth: 0,
-    paddingBottom: verticalSpace.sm,
-    paddingInlineEnd: horizontalSpace.md,
-    paddingInlineStart: horizontalSpace.md,
-    paddingTop: verticalSpace.sm,
-  },
-  intro: {
-    color: uiColor.text1,
-    fontFamily: fontFamily.sans,
-    fontSize: fontSize.xs,
-    lineHeight: lineHeight.base,
-    marginBottom: verticalSpace.none,
-    marginTop: verticalSpace.none,
-    maxWidth: "72ch",
-  },
   value: {
-    alignItems: "center",
-    display: "flex",
-    // Off the spacing scale on purpose: this is a text column, sized so a URL
-    // is readable rather than to any spacing step. It still shrinks — the
-    // field truncates before the copy button is pushed off the card.
-    flexBasis: "26rem",
-    flexGrow: 1,
+    flexGrow: 0,
     flexShrink: 1,
-    gap: gap.sm,
-    minWidth: 0,
-    width: { [MOBILE]: "100%", default: "auto" },
+    // Off the spacing scale on purpose: a text column is sized so its content
+    // reads, not to a spacing step. Wide enough for a handle or a host; a long
+    // URL scrolls inside the field rather than stretching the row to fit it.
+    width: { [MOBILE]: "100%", default: "20rem" },
   },
 });
 
@@ -110,37 +86,8 @@ interface ConnectionField {
   label: string;
   description: string;
   value: string;
-  /** Hide the value until the reader asks for it — the sync key. */
-  masked?: boolean;
-}
-
-function CopyField({ label, value, masked = false }: ConnectionField) {
-  const [revealed, setRevealed] = useState(false);
-  const shown = masked && !revealed ? "•".repeat(value.length) : value;
-
-  return (
-    <div {...stylex.props(styles.value)}>
-      <input
-        readOnly
-        aria-label={label}
-        onFocus={(event) => event.currentTarget.select()}
-        value={shown}
-        {...stylex.props(styles.field)}
-      />
-      {masked ? (
-        <Button
-          onPress={() => setRevealed((previous) => !previous)}
-          size="sm"
-          variant="secondary"
-        >
-          {revealed ? <Trans>Hide</Trans> : <Trans>Show</Trans>}
-        </Button>
-      ) : null}
-      {/* Copy works whether or not the value is on screen — a reader moving a
-          key to a device should not have to look at it. */}
-      <CopyToClipboardButton size="md" text={value} />
-    </div>
-  );
+  /** Masked until the reader asks to see it — the sync key. */
+  secret?: boolean;
 }
 
 /**
@@ -178,7 +125,7 @@ export function EreaderSettings() {
     {
       description: t`Use this as the password. It only carries your reading position between devices — it cannot read or change anything else.`,
       label: t`Sync key`,
-      masked: true,
+      secret: true,
       value: connection.syncKey,
     },
   ];
@@ -205,7 +152,19 @@ export function EreaderSettings() {
                 {field.description}
               </p>
             </div>
-            <CopyField {...field} />
+            {/* The row already carries the label and description, so the field
+                takes neither — printing them twice is what a `label` prop here
+                would do. */}
+            <TextField
+              isReadOnly
+              aria-label={field.label}
+              disablePasswordManagers
+              size="lg"
+              style={styles.value}
+              suffix={<CopyToClipboardButton size="sm" text={field.value} />}
+              type={field.secret ? "password" : "text"}
+              value={field.value}
+            />
           </div>
         </Fragment>
       ))}

--- a/apps/standard-reader/src/components/ereader-settings.tsx
+++ b/apps/standard-reader/src/components/ereader-settings.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { Trans, useLingui } from "@lingui/react/macro";
+import { Button } from "@standard-reader/design-system/button";
+import { CopyToClipboardButton } from "@standard-reader/design-system/copy-to-clipboard-button";
+import { Separator } from "@standard-reader/design-system/separator";
+import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
+import { radius } from "@standard-reader/design-system/theme/radius.stylex";
+import {
+  gap,
+  horizontalSpace,
+  verticalSpace,
+} from "@standard-reader/design-system/theme/semantic-spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+  lineHeight,
+} from "@standard-reader/design-system/theme/typography.stylex";
+import * as stylex from "@stylexjs/stylex";
+import { useQuery } from "@tanstack/react-query";
+import { Fragment, useState } from "react";
+
+import { ereaderApi } from "#/integrations/tanstack-query/api-ereader.functions";
+
+import { settingRowStyles } from "./settings-row-styles";
+
+const MOBILE = "@media (max-width: 47.5rem)";
+
+/**
+ * These rows are not `SettingRow`s.
+ *
+ * Same two-column geometry — label and description at the start, the control at
+ * the end — but that row sizes its control column to its content, which is right
+ * for a switch and wrong for a URL: the field collapses to a sliver and the
+ * reader cannot see what they are copying. Here the value column is the one that
+ * grows.
+ */
+const styles = stylex.create({
+  block: {
+    display: "flex",
+    flexDirection: "column",
+    gap: gap.md,
+    paddingBottom: verticalSpace["3xl"],
+    paddingInlineEnd: horizontalSpace["3xl"],
+    paddingInlineStart: horizontalSpace["3xl"],
+    paddingTop: verticalSpace["3xl"],
+  },
+  row: {
+    alignItems: { [MOBILE]: "stretch", default: "center" },
+    columnGap: gap["3xl"],
+    display: "flex",
+    flexDirection: { [MOBILE]: "column", default: "row" },
+    justifyContent: "space-between",
+    paddingBottom: verticalSpace["3xl"],
+    paddingInlineEnd: horizontalSpace["3xl"],
+    paddingInlineStart: horizontalSpace["3xl"],
+    paddingTop: verticalSpace["3xl"],
+    rowGap: gap.lg,
+  },
+  text: {
+    flexGrow: 1,
+    flexShrink: 1,
+    minWidth: 0,
+  },
+  field: {
+    backgroundColor: uiColor.component2,
+    borderColor: uiColor.border1,
+    borderRadius: radius.sm,
+    borderStyle: "solid",
+    borderWidth: 1,
+    boxSizing: "border-box",
+    color: uiColor.text1,
+    flexGrow: 1,
+    flexShrink: 1,
+    fontFamily: fontFamily.mono,
+    fontSize: fontSize.xs,
+    // Without this a flex item refuses to shrink below its content width, and
+    // a long URL pushes the copy button off the end of the card.
+    minWidth: 0,
+    paddingBottom: verticalSpace.sm,
+    paddingInlineEnd: horizontalSpace.md,
+    paddingInlineStart: horizontalSpace.md,
+    paddingTop: verticalSpace.sm,
+  },
+  intro: {
+    color: uiColor.text1,
+    fontFamily: fontFamily.sans,
+    fontSize: fontSize.xs,
+    lineHeight: lineHeight.base,
+    marginBottom: verticalSpace.none,
+    marginTop: verticalSpace.none,
+    maxWidth: "72ch",
+  },
+  value: {
+    alignItems: "center",
+    display: "flex",
+    // Off the spacing scale on purpose: this is a text column, sized so a URL
+    // is readable rather than to any spacing step. It still shrinks — the
+    // field truncates before the copy button is pushed off the card.
+    flexBasis: "26rem",
+    flexGrow: 1,
+    flexShrink: 1,
+    gap: gap.sm,
+    minWidth: 0,
+    width: { [MOBILE]: "100%", default: "auto" },
+  },
+});
+
+interface ConnectionField {
+  label: string;
+  description: string;
+  value: string;
+  /** Hide the value until the reader asks for it — the sync key. */
+  masked?: boolean;
+}
+
+function CopyField({ label, value, masked = false }: ConnectionField) {
+  const [revealed, setRevealed] = useState(false);
+  const shown = masked && !revealed ? "•".repeat(value.length) : value;
+
+  return (
+    <div {...stylex.props(styles.value)}>
+      <input
+        readOnly
+        aria-label={label}
+        onFocus={(event) => event.currentTarget.select()}
+        value={shown}
+        {...stylex.props(styles.field)}
+      />
+      {masked ? (
+        <Button
+          onPress={() => setRevealed((previous) => !previous)}
+          size="sm"
+          variant="secondary"
+        >
+          {revealed ? <Trans>Hide</Trans> : <Trans>Show</Trans>}
+        </Button>
+      ) : null}
+      {/* Copy works whether or not the value is on screen — a reader moving a
+          key to a device should not have to look at it. */}
+      <CopyToClipboardButton size="md" text={value} />
+    </div>
+  );
+}
+
+/**
+ * Connecting an e-reader.
+ *
+ * Two independent things, in the order a reader does them: the catalog their
+ * device browses, and the sync that carries their place between devices.
+ * Everything here is a value to copy — there is nothing to toggle, because
+ * there is nothing about this the app decides on their behalf.
+ */
+export function EreaderSettings() {
+  const { t } = useLingui();
+  const { data: connection } = useQuery(
+    ereaderApi.getEreaderConnectionQueryOptions(),
+  );
+
+  if (!connection) return null;
+
+  const fields: Array<ConnectionField> = [
+    {
+      description: t`Your shelves, as an OPDS catalog. Anyone with this URL can see the same public records your profile already shows.`,
+      label: t`Catalog URL`,
+      value: connection.catalogUrl,
+    },
+    {
+      description: t`In KOReader: Tools → Progress sync → Custom sync server.`,
+      label: t`Sync server`,
+      value: connection.kosyncUrl,
+    },
+    {
+      description: t`Log in with this as your username — there is no separate sync account.`,
+      label: t`Sync username`,
+      value: connection.username,
+    },
+    {
+      description: t`Use this as the password. It only carries your reading position between devices — it cannot read or change anything else.`,
+      label: t`Sync key`,
+      masked: true,
+      value: connection.syncKey,
+    },
+  ];
+
+  return (
+    <>
+      <div {...stylex.props(styles.block)}>
+        <p {...stylex.props(styles.intro)}>
+          <Trans>
+            Add your catalog to KOReader, Foliate, Marvin, Panels or any other
+            OPDS app and your unread queue, saved articles, subscriptions and
+            lists show up on the device — each one downloadable as an EPUB.
+          </Trans>
+        </p>
+      </div>
+
+      {fields.map((field) => (
+        <Fragment key={field.label}>
+          <Separator />
+          <div {...stylex.props(styles.row)}>
+            <div {...stylex.props(styles.text)}>
+              <p {...stylex.props(settingRowStyles.label)}>{field.label}</p>
+              <p {...stylex.props(settingRowStyles.description)}>
+                {field.description}
+              </p>
+            </div>
+            <CopyField {...field} />
+          </div>
+        </Fragment>
+      ))}
+    </>
+  );
+}

--- a/apps/standard-reader/src/components/ereader-settings.tsx
+++ b/apps/standard-reader/src/components/ereader-settings.tsx
@@ -1,6 +1,15 @@
 "use client";
 
 import { Trans, useLingui } from "@lingui/react/macro";
+import {
+  AlertDialog,
+  AlertDialogActionButton,
+  AlertDialogCancelButton,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+} from "@standard-reader/design-system/alert-dialog";
+import { Button } from "@standard-reader/design-system/button";
 import { CopyToClipboardButton } from "@standard-reader/design-system/copy-to-clipboard-button";
 import { Separator } from "@standard-reader/design-system/separator";
 import { TextField } from "@standard-reader/design-system/text-field";
@@ -16,8 +25,8 @@ import {
   lineHeight,
 } from "@standard-reader/design-system/theme/typography.stylex";
 import * as stylex from "@stylexjs/stylex";
-import { useQuery } from "@tanstack/react-query";
-import { Fragment } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Fragment, useState } from "react";
 
 import { ereaderApi } from "#/integrations/tanstack-query/api-ereader.functions";
 
@@ -73,12 +82,18 @@ const styles = stylex.create({
     minWidth: 0,
   },
   value: {
-    flexGrow: 0,
+    flexGrow: 1,
     flexShrink: 1,
+    minWidth: 0,
+  },
+  valueGroup: {
+    alignItems: "center",
+    display: "flex",
+    gap: gap.sm,
     // Off the spacing scale on purpose: a text column is sized so its content
     // reads, not to a spacing step. Wide enough for a handle or a host; a long
     // URL scrolls inside the field rather than stretching the row to fit it.
-    width: { [MOBILE]: "100%", default: "20rem" },
+    width: { [MOBILE]: "100%", default: "22rem" },
   },
 });
 
@@ -100,9 +115,22 @@ interface ConnectionField {
  */
 export function EreaderSettings() {
   const { t } = useLingui();
+  const queryClient = useQueryClient();
+  const [rotateOpen, setRotateOpen] = useState(false);
   const { data: connection } = useQuery(
     ereaderApi.getEreaderConnectionQueryOptions(),
   );
+  const rotate = useMutation({
+    ...ereaderApi.rotateKosyncKeyMutationOptions(),
+    onSuccess: async () => {
+      setRotateOpen(false);
+      // The key on screen is now the old one — refetch before the reader
+      // copies it onto a device that would then fail to sync.
+      await queryClient.invalidateQueries({
+        queryKey: ["reader", "ereaderConnection"],
+      });
+    },
+  });
 
   if (!connection) return null;
 
@@ -155,19 +183,58 @@ export function EreaderSettings() {
             {/* The row already carries the label and description, so the field
                 takes neither — printing them twice is what a `label` prop here
                 would do. */}
-            <TextField
-              isReadOnly
-              aria-label={field.label}
-              disablePasswordManagers
-              size="md"
-              style={styles.value}
-              suffix={<CopyToClipboardButton size="sm" text={field.value} />}
-              type={field.secret ? "password" : "text"}
-              value={field.value}
-            />
+            <div {...stylex.props(styles.valueGroup)}>
+              <TextField
+                isReadOnly
+                aria-label={field.label}
+                disablePasswordManagers
+                size="md"
+                style={styles.value}
+                suffix={<CopyToClipboardButton size="sm" text={field.value} />}
+                type={field.secret ? "password" : "text"}
+                value={field.value}
+              />
+              {field.secret ? (
+                <Button
+                  isPending={rotate.isPending}
+                  onPress={() => setRotateOpen(true)}
+                  size="sm"
+                  variant="secondary"
+                >
+                  <Trans>Rotate</Trans>
+                </Button>
+              ) : null}
+            </div>
           </div>
         </Fragment>
       ))}
+
+      <AlertDialog
+        isOpen={rotateOpen}
+        onOpenChange={setRotateOpen}
+        trigger={<span hidden aria-hidden />}
+      >
+        <AlertDialogHeader>
+          <Trans>Rotate your sync key?</Trans>
+        </AlertDialogHeader>
+        <AlertDialogDescription>
+          <Trans>
+            Every device syncing with the old key stops until you enter the new
+            one. Nothing you have already read is lost — reading positions are
+            kept against the books themselves, not the key.
+          </Trans>
+        </AlertDialogDescription>
+        <AlertDialogFooter>
+          <AlertDialogCancelButton isDisabled={rotate.isPending} />
+          <AlertDialogActionButton
+            closeOnPress={false}
+            isPending={rotate.isPending}
+            onPress={() => rotate.mutate()}
+          >
+            <Trans>Rotate key</Trans>
+          </AlertDialogActionButton>
+        </AlertDialogFooter>
+      </AlertDialog>
     </>
   );
 }

--- a/apps/standard-reader/src/components/guide/pages/e-readers-guide-page.tsx
+++ b/apps/standard-reader/src/components/guide/pages/e-readers-guide-page.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { Trans } from "@lingui/react/macro";
+import * as stylex from "@stylexjs/stylex";
+import { Link } from "@tanstack/react-router";
+
+import { docsStyles } from "../../docs/docs-page.stylex";
+import { GuideCallout, GuideSteps, UiLabel } from "../guide-primitives";
+import { GuideShell } from "../guide-shell";
+
+/**
+ * Reading Standard Reader on a device that is not a browser.
+ *
+ * Written for the reader who already owns a Kobo or a Kindle and wants their
+ * unread queue on it — not for someone shopping for a workflow. So it opens
+ * with the one thing they came for (the catalog URL), and only then explains
+ * what an OPDS catalog is.
+ *
+ * The honest limitation about progress sync is stated in its own section
+ * rather than buried: position travels device → app, and between devices, but
+ * not app → device, and a reader who expects otherwise will think it is broken.
+ */
+export function EreadersGuidePage() {
+  return (
+    <GuideShell
+      area="e-readers"
+      dek={
+        <Trans>
+          Your unread queue, your saved articles and every publication you
+          subscribe to, on a Kobo, a Kindle, a reMarkable or a phone — as real
+          EPUB files, with the images, ready to read on a plane.
+        </Trans>
+      }
+      title={<Trans>E-readers</Trans>}
+    >
+      <h2
+        {...stylex.props(docsStyles.h2, docsStyles.h2First)}
+        id="what-you-get"
+      >
+        <Trans>What you get</Trans>
+      </h2>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          Standard Reader publishes an <b>OPDS catalog</b> — the same thing a
+          library or a bookstore hands an e-reading app. Point an app at it once
+          and your shelves appear on the device: <b>Unread</b>,{" "}
+          <b>Saved for later</b>, <b>Subscriptions</b>, each of your lists, and
+          every publication you follow. Open any of them and each article has a
+          download button.
+        </Trans>
+      </p>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          The files are built when you ask for them, from the same article
+          bodies the reader shows — images pulled in, footnotes as real
+          endnotes, a link back to the original at the end of every piece.
+          Nothing is trimmed to an excerpt. A whole publication, a list or a
+          collection can also come down as one book, with a table of contents.
+        </Trans>
+      </p>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          Comics come down as <b>CBZ</b> as well, so comic apps get their page
+          turns and their scrubber instead of a reflowable book that fights
+          them.
+        </Trans>
+      </p>
+
+      <h2 {...stylex.props(docsStyles.h2)} id="setting-it-up">
+        <Trans>Setting it up</Trans>
+      </h2>
+      <GuideSteps>
+        <Trans>
+          <b>Copy your catalog URL.</b> It is in{" "}
+          <Link {...stylex.props(docsStyles.proseLink)} to="/settings">
+            Settings
+          </Link>{" "}
+          under <UiLabel>E-readers</UiLabel>. It is yours — it carries your
+          subscriptions and your saved articles.
+        </Trans>
+        <Trans>
+          <b>Add it to your reading app.</b> In KOReader that is{" "}
+          <UiLabel>Search → OPDS catalog → +</UiLabel>. Foliate, Marvin, Aldiko,
+          Thorium, Panels and Chunky all have a similar “add catalog” screen.
+          Paste the URL and leave the username and password blank.
+        </Trans>
+        <Trans>
+          <b>Browse and download.</b> Your shelves are the top level. Tap an
+          article to pull the EPUB onto the device.
+        </Trans>
+      </GuideSteps>
+      <GuideCallout title={<Trans>Who can use your catalog URL</Trans>}>
+        <Trans>
+          Your catalog URL is not a secret, but it is not a password either —
+          anyone who has it can see the same things your public profile already
+          shows: what you subscribe to and what you have saved. Treat it like a
+          share link rather than a login.
+        </Trans>
+      </GuideCallout>
+
+      <h2 {...stylex.props(docsStyles.h2)} id="one-article">
+        <Trans>Sending one article</Trans>
+      </h2>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          You do not need a catalog for a single piece. Every article's share
+          menu has <UiLabel>Download EPUB</UiLabel> — and{" "}
+          <UiLabel>Download CBZ</UiLabel> on a comic. A publication's{" "}
+          <UiLabel>…</UiLabel> menu has <UiLabel>Send to e-reader…</UiLabel>,
+          which offers its recent articles as one book and shows the catalog URL
+          for that publication on its own.
+        </Trans>
+      </p>
+
+      <h2 {...stylex.props(docsStyles.h2)} id="progress-sync">
+        <Trans>Keeping your place</Trans>
+      </h2>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          KOReader can sync your reading position through Standard Reader, so
+          picking up a book on a second device puts you where you stopped.
+          Settings → <UiLabel>E-readers</UiLabel> has the three values it wants:
+          the sync server URL, your username, and a sync key.
+        </Trans>
+      </p>
+      <GuideSteps>
+        <Trans>
+          In KOReader, open <UiLabel>Tools → Progress sync</UiLabel> and choose{" "}
+          <UiLabel>Custom sync server</UiLabel>.
+        </Trans>
+        <Trans>
+          Paste the sync server URL, then log in with your handle and the sync
+          key. There is no separate account to register.
+        </Trans>
+        <Trans>
+          Turn on <UiLabel>Sync every N pages</UiLabel> if you want it to happen
+          without asking.
+        </Trans>
+      </GuideSteps>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          Your position also flows back here: read half of something on the Kobo
+          and the article shows as half-read in the app, and in{" "}
+          <UiLabel>Continue reading</UiLabel>. That direction is one-way. A
+          position on a device is a place in <i>that device's</i> rendering of
+          the file, and there is no honest way to turn a percentage back into
+          one, so the app never sends a position out to a device that did not
+          record it.
+        </Trans>
+      </p>
+      <GuideCallout title={<Trans>What the sync key can do</Trans>}>
+        <Trans>
+          The sync key only carries your reading position. It cannot read your
+          account, post anything, or change what you subscribe to — and it is
+          not your Bluesky password. If you lose a device, ask us to rotate it.
+        </Trans>
+      </GuideCallout>
+
+      <h2 {...stylex.props(docsStyles.h2)} id="whats-missing">
+        <Trans>What will not be there</Trans>
+      </h2>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          A few articles on the network are really link posts — a headline and a
+          URL, bridged in from somewhere else, with no body to package. Those
+          are left out of the catalog rather than offered as a file that would
+          open to nothing. You will still find them in the app, where they link
+          out to the site that has the writing.
+        </Trans>
+      </p>
+      <p {...stylex.props(docsStyles.prose)}>
+        <Trans>
+          Downloading does not mark anything read, and reading on a device does
+          not remove it from your unread shelf until KOReader syncs a position
+          back. Polls, signup forms and other live embeds become links — a book
+          cannot run them.
+        </Trans>
+      </p>
+    </GuideShell>
+  );
+}

--- a/apps/standard-reader/src/components/guide/pages/e-readers-guide-page.tsx
+++ b/apps/standard-reader/src/components/guide/pages/e-readers-guide-page.tsx
@@ -89,14 +89,6 @@ export function EreadersGuidePage() {
           article to pull the EPUB onto the device.
         </Trans>
       </GuideSteps>
-      <GuideCallout title={<Trans>Who can use your catalog URL</Trans>}>
-        <Trans>
-          Your catalog URL is not a secret, but it is not a password either —
-          anyone who has it can see the same things your public profile already
-          shows: what you subscribe to and what you have saved. Treat it like a
-          share link rather than a login.
-        </Trans>
-      </GuideCallout>
 
       <h2 {...stylex.props(docsStyles.h2)} id="one-article">
         <Trans>Sending one article</Trans>

--- a/apps/standard-reader/src/components/guide/pages/e-readers-guide-page.tsx
+++ b/apps/standard-reader/src/components/guide/pages/e-readers-guide-page.tsx
@@ -144,7 +144,8 @@ export function EreadersGuidePage() {
         <Trans>
           The sync key only carries your reading position. It cannot read your
           account, post anything, or change what you subscribe to — and it is
-          not your Bluesky password. If you lose a device, ask us to rotate it.
+          not your Bluesky password. Lost a device? <UiLabel>Rotate</UiLabel> in
+          Settings issues a new key and stops the old one working.
         </Trans>
       </GuideCallout>
 

--- a/apps/standard-reader/src/components/reader/article-view.tsx
+++ b/apps/standard-reader/src/components/reader/article-view.tsx
@@ -78,7 +78,9 @@ import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
 import { user } from "#/integrations/tanstack-query/api-user.functions";
 import { documentImages } from "#/lib/document/images";
 import { resolveArticleHeroImage } from "#/lib/document/lead-image";
+import { articleCbzUrl, articleEpubUrl } from "#/lib/opds/urls";
 import { usePageReader } from "#/lib/page-reader/page-reader-context";
+import { getPublicUrlClient } from "#/lib/public-url";
 import { publishingPlatform } from "#/lib/publishing-platform";
 import { useFormatters } from "#/lib/use-formatters";
 import { useOpenCollectionsInMagazine } from "#/lib/use-open-collections-in-magazine";
@@ -1080,6 +1082,28 @@ function ArticleViewBody({
   );
   const pub = article.publication;
   const publicationName = pub?.name;
+  // File renditions of this article. Offered whenever there is a body to
+  // package — the reader is looking at it, so there is. A comic issue gets a
+  // CBZ too: comic apps have page turns and a scrubber that a reflowable EPUB
+  // cannot give them.
+  const articleDownloads = (() => {
+    const params = documentLinkParams(article.uri);
+    if (!params || article.contentJson == null) return [];
+    const baseUrl = getPublicUrlClient();
+    const files = [
+      {
+        label: "Download EPUB",
+        url: articleEpubUrl(baseUrl, params.did, params.rkey),
+      },
+    ];
+    if (pub?.serial?.kind === "comic") {
+      files.push({
+        label: "Download CBZ",
+        url: articleCbzUrl(baseUrl, params.did, params.rkey),
+      });
+    }
+    return files;
+  })();
   const pubParams = pub ? publicationLinkParams(pub.uri) : null;
   const authorName = primaryAuthor(article);
   const handle = authorHandle(article);
@@ -1373,6 +1397,7 @@ function ArticleViewBody({
               author={primaryAuthor(article)}
               siteName={pub?.name}
               imageUrl={article.coverImageUrl}
+              downloads={articleDownloads}
             />
 
             {/* Last in the row: the one action that leaves the app, and the

--- a/apps/standard-reader/src/components/reader/document-share-menu.tsx
+++ b/apps/standard-reader/src/components/reader/document-share-menu.tsx
@@ -11,6 +11,7 @@ import { buildPdslsRecordUrl } from "#/lib/quote-share";
 
 import { LinkShareMenu } from "./link-share-menu";
 import { SaveToCollectionDialog } from "./save-to-collection-dialog";
+import { startDownload } from "./start-download";
 
 function openExternal(url: string) {
   globalThis.open(url, "_blank", "noopener,noreferrer");
@@ -30,6 +31,7 @@ export function DocumentShareMenu({
   author,
   siteName,
   imageUrl,
+  downloads = [],
   size = "md",
 }: {
   /** Document AT-URI for PDSLS. */
@@ -47,6 +49,12 @@ export function DocumentShareMenu({
   siteName?: string | null;
   /** Article hero image, used as the saved Semble card's image. */
   imageUrl?: string | null;
+  /**
+   * File renditions of this article, when it has a body worth packaging. Empty
+   * for a bridged link post — there would be nothing in the file but the title
+   * and the link the reader already has.
+   */
+  downloads?: Array<{ label: string; url: string }>;
   size?: Size;
 }) {
   const { t } = useLingui();
@@ -78,6 +86,20 @@ export function DocumentShareMenu({
         >
           <Trans>Save to Semble…</Trans>
         </MenuItem>
+        {downloads.length > 0 ? (
+          <>
+            <MenuSeparator />
+            {downloads.map((download) => (
+              <MenuItem
+                key={download.url}
+                onPress={() => startDownload(download.url)}
+                textValue={download.label}
+              >
+                {download.label}
+              </MenuItem>
+            ))}
+          </>
+        ) : null}
         <MenuSeparator />
         <MenuItem
           onPress={() => {

--- a/apps/standard-reader/src/components/reader/publication-actions.tsx
+++ b/apps/standard-reader/src/components/reader/publication-actions.tsx
@@ -24,6 +24,7 @@ import { spacing } from "@standard-reader/design-system/theme/spacing.stylex";
 import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
 import {
+  BookDown,
   CheckCheck,
   ChevronDown,
   ExternalLink,
@@ -39,6 +40,8 @@ import type {
   PublicationEmbedMeta,
 } from "#/integrations/tanstack-query/api-publication.functions";
 import { readerApi } from "#/integrations/tanstack-query/api-reader.functions";
+import { opdsPublicationUrl, publicationEpubUrl } from "#/lib/opds/urls";
+import { getPublicUrlClient } from "#/lib/public-url";
 import type { ArchiveOrder } from "#/lib/publication/archive-order";
 import { useLoginSearch } from "#/utils/use-login-search";
 
@@ -48,6 +51,7 @@ import { FollowButton } from "./cards";
 import { MuteDialog, MuteMenuItem } from "./mute-menu-item";
 import { NotifyButton } from "./notify-button";
 import { RssFeedDialog } from "./rss-feed-button";
+import { SendToEreaderDialog } from "./send-to-ereader-dialog";
 import { ShareMenuItems, useShareActions } from "./share-menu";
 
 const MENU_ICON = 14;
@@ -220,6 +224,7 @@ export function PublicationActions({
   pub,
   pageUrl,
   feedUrl,
+  hasDownloadableArticles,
   signedIn,
   embed,
   markAllRead,
@@ -232,6 +237,12 @@ export function PublicationActions({
   pub: PublicationCard;
   pageUrl: string;
   feedUrl: string;
+  /**
+   * Whether any of this publication's posts has a body a book could carry.
+   * False for a bridged mirror, whose archive is all link posts — offering a
+   * download there would hand the reader a button that 404s.
+   */
+  hasDownloadableArticles: boolean;
   signedIn: boolean;
   embed: PublicationEmbedMeta | null | undefined;
   /** Present only when the reader has unread articles here. */
@@ -249,6 +260,19 @@ export function PublicationActions({
   const share = useShareActions({ pageUrl, embed: embed ?? undefined });
   const [listOpen, setListOpen] = useState(false);
   const [rssOpen, setRssOpen] = useState(false);
+  const [ereaderOpen, setEreaderOpen] = useState(false);
+
+  // The publication's own rkey, for the catalog and download URLs. A card
+  // always carries a well-formed AT-URI, so this is the last path segment.
+  const publicationRkey = pub.uri.split("/").pop() ?? "";
+  const baseUrl = getPublicUrlClient();
+  const catalogUrl = publicationRkey
+    ? opdsPublicationUrl(baseUrl, pub.did, publicationRkey)
+    : null;
+  const epubUrl =
+    publicationRkey && hasDownloadableArticles
+      ? publicationEpubUrl(baseUrl, pub.did, publicationRkey)
+      : null;
   const [markAllReadOpen, setMarkAllReadOpen] = useState(false);
   const [muteOpen, setMuteOpen] = useState(false);
 
@@ -340,6 +364,15 @@ export function PublicationActions({
             >
               <Trans>RSS feed</Trans>
             </MenuItem>
+            {/* Next to RSS because it answers the same question — "how do I
+                read this somewhere that isn't here?" */}
+            <MenuItem
+              onPress={() => setEreaderOpen(true)}
+              suffix={<BookDown size={MENU_ICON} />}
+              textValue={t`Send to e-reader…`}
+            >
+              <Trans>Send to e-reader…</Trans>
+            </MenuItem>
             {pub.url ? (
               <MenuItem
                 onPress={() => {
@@ -389,6 +422,14 @@ export function PublicationActions({
         feedUrl={feedUrl}
         isOpen={rssOpen}
         onOpenChange={setRssOpen}
+      />
+
+      <SendToEreaderDialog
+        catalogUrl={catalogUrl}
+        downloads={epubUrl ? [{ label: "EPUB", url: epubUrl }] : []}
+        isOpen={ereaderOpen}
+        name={pub.name}
+        onOpenChange={setEreaderOpen}
       />
 
       {/* Outside `<Menu>`, like the RSS dialog above: a dialog rendered inside

--- a/apps/standard-reader/src/components/reader/send-to-ereader-dialog.tsx
+++ b/apps/standard-reader/src/components/reader/send-to-ereader-dialog.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { Trans, useLingui } from "@lingui/react/macro";
+import { Button } from "@standard-reader/design-system/button";
+import { CopyToClipboardButton } from "@standard-reader/design-system/copy-to-clipboard-button";
+import {
+  Dialog,
+  DialogBody,
+  DialogFooter,
+  DialogHeader,
+} from "@standard-reader/design-system/dialog";
+import { Flex } from "@standard-reader/design-system/flex";
+import { uiColor } from "@standard-reader/design-system/theme/color.stylex";
+import { radius } from "@standard-reader/design-system/theme/radius.stylex";
+import {
+  gap,
+  verticalSpace,
+} from "@standard-reader/design-system/theme/semantic-spacing.stylex";
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  tracking,
+} from "@standard-reader/design-system/theme/typography.stylex";
+import { SmallBody } from "@standard-reader/design-system/typography";
+import * as stylex from "@stylexjs/stylex";
+import { BookDown } from "lucide-react";
+
+import { startDownload } from "./start-download";
+
+const styles = stylex.create({
+  body: {
+    display: "flex",
+    flexDirection: "column",
+    gap: gap["2xl"],
+    width: "100%",
+  },
+  dialogTitle: {
+    fontFamily: fontFamily.serif,
+    fontSize: fontSize.lg,
+    fontWeight: fontWeight.semibold,
+    letterSpacing: tracking.tight,
+  },
+  field: {
+    backgroundColor: uiColor.component2,
+    borderColor: uiColor.border1,
+    borderRadius: radius.sm,
+    borderStyle: "solid",
+    borderWidth: 1,
+    boxSizing: "border-box",
+    color: uiColor.text1,
+    flexGrow: 1,
+    fontFamily: fontFamily.mono,
+    fontSize: fontSize.xs,
+    minWidth: 0,
+    padding: verticalSpace.md,
+    width: "100%",
+  },
+  section: {
+    display: "flex",
+    flexDirection: "column",
+    gap: gap.md,
+  },
+});
+
+export interface EreaderDownload {
+  url: string;
+  label: string;
+}
+
+/**
+ * "Send to your e-reader" — the two ways a reader gets something onto a device.
+ *
+ * A one-off download for the piece in front of them, and the catalog URL for
+ * the readers who would rather have their device fetch it. Both in one dialog
+ * because they answer the same question, and a reader who wants one usually
+ * wants to know the other exists.
+ */
+export function SendToEreaderDialog({
+  isOpen,
+  onOpenChange,
+  name,
+  catalogUrl,
+  downloads = [],
+}: {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** What is being sent — a publication, an article, a list. */
+  name: string;
+  /** OPDS catalog URL for this thing, when it has one. */
+  catalogUrl?: string | null;
+  downloads?: Array<EreaderDownload>;
+}) {
+  const { t } = useLingui();
+
+  return (
+    <Dialog
+      fitContent
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      size="md"
+      trigger={<span hidden aria-hidden />}
+    >
+      <DialogHeader>
+        <span {...stylex.props(styles.dialogTitle)}>
+          <Trans>Send to your e-reader</Trans>
+        </span>
+      </DialogHeader>
+      <DialogBody style={styles.body}>
+        {downloads.length > 0 ? (
+          <div {...stylex.props(styles.section)}>
+            <SmallBody variant="secondary">
+              <Trans>
+                Download {name} as a file — images and all, ready to read
+                offline.
+              </Trans>
+            </SmallBody>
+            <Flex gap="sm" wrap>
+              {downloads.map((download) => (
+                <Button
+                  key={download.url}
+                  onPress={() => startDownload(download.url)}
+                  variant="secondary"
+                >
+                  <BookDown size={14} /> {download.label}
+                </Button>
+              ))}
+            </Flex>
+          </div>
+        ) : null}
+
+        {catalogUrl ? (
+          <div {...stylex.props(styles.section)}>
+            <SmallBody variant="secondary">
+              <Trans>
+                Or add this catalog URL to KOReader, Foliate, Marvin or any
+                other OPDS app, and browse {name} from the device itself.
+              </Trans>
+            </SmallBody>
+            <Flex align="center" gap="sm">
+              <input
+                readOnly
+                aria-label={t`OPDS catalog URL`}
+                onFocus={(event) => event.currentTarget.select()}
+                value={catalogUrl}
+                {...stylex.props(styles.field)}
+              />
+              <CopyToClipboardButton size="lg" text={catalogUrl} />
+            </Flex>
+          </div>
+        ) : null}
+      </DialogBody>
+      <DialogFooter>
+        <Button onPress={() => onOpenChange(false)} variant="secondary">
+          <Trans>Close</Trans>
+        </Button>
+      </DialogFooter>
+    </Dialog>
+  );
+}

--- a/apps/standard-reader/src/components/reader/start-download.ts
+++ b/apps/standard-reader/src/components/reader/start-download.ts
@@ -1,0 +1,25 @@
+/**
+ * Start a download without disturbing the page.
+ *
+ * A synthetic `<a download>` click rather than `location.assign`: the book
+ * routes answer with `Content-Disposition: attachment`, so either one ends up
+ * as a file, but only this one is guaranteed never to begin a navigation. That
+ * matters in the comic theater, where the reader may be in full screen — and a
+ * browser that treats an attachment as a navigation attempt drops out of it.
+ *
+ * `download` is honored same-origin, which our own book routes are. If the
+ * public URL ever differs from the serving origin (a preview deployment on its
+ * own domain), the attribute is ignored and the browser falls back to the
+ * navigation path — where `Content-Disposition` still makes it a download.
+ */
+export function startDownload(url: string): void {
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  // Empty string means "use the filename the server sent".
+  anchor.download = "";
+  anchor.rel = "noopener";
+  anchor.style.display = "none";
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+}

--- a/apps/standard-reader/src/components/user-settings-view.tsx
+++ b/apps/standard-reader/src/components/user-settings-view.tsx
@@ -118,6 +118,7 @@ import {
   AppearanceAdvancedRows,
   AppearancePalettePanel,
 } from "./appearance-settings";
+import { EreaderSettings } from "./ereader-settings";
 import { OfflineReadingSettings } from "./offline-settings";
 import { OfflineSyncDebugPanel } from "./offline-sync-debug";
 import { PushDiagnosticsPanel } from "./push-diagnostics";
@@ -1202,6 +1203,17 @@ export function UserSettingsView() {
           </div>
         </section>
       ) : null}
+
+      {/* After Offline, before Moderation: both sections are about reading
+          somewhere other than this tab. */}
+      <section {...stylex.props(styles.section)}>
+        <h2 {...stylex.props(styles.sectionHeading)}>
+          <Trans>E-readers</Trans>
+        </h2>
+        <div {...stylex.props(styles.settingGroup)}>
+          <EreaderSettings />
+        </div>
+      </section>
 
       <section {...stylex.props(styles.section)}>
         <h2 {...stylex.props(styles.sectionHeading)}>

--- a/apps/standard-reader/src/db/schema.ts
+++ b/apps/standard-reader/src/db/schema.ts
@@ -18,6 +18,7 @@ export * from "./schema/documents.ts";
 export * from "./schema/graph.ts";
 export * from "./schema/personal.ts";
 export * from "./schema/reading-progress.ts";
+export * from "./schema/kosync.ts";
 export * from "./schema/push.ts";
 export * from "./schema/lists.ts";
 export * from "./schema/stats.ts";

--- a/apps/standard-reader/src/db/schema/auth.ts
+++ b/apps/standard-reader/src/db/schema/auth.ts
@@ -59,6 +59,17 @@ export const user = pgTable("user", {
   readingTypography: text("reading_typography"),
   /** `false` disables read tracking and unread UI; `null` = on (default). */
   trackReadingHistory: boolean("track_reading_history"),
+  /**
+   * Salt behind this reader's KOReader sync key, so the key can be rotated for
+   * one reader instead of everyone.
+   *
+   * The key itself is never stored — it is `HMAC(KOSYNC_SECRET, did + salt)`
+   * (see `server/kosync/credentials.ts`). `null` means "never rotated" and
+   * derives the original key, so a reader whose device is already syncing keeps
+   * working without doing anything. Rotating writes a fresh random salt, which
+   * is what makes the old key stop working immediately.
+   */
+  kosyncKeySalt: text("kosync_key_salt"),
   /** `true` counts everything a source ever posted as unread on subscribe (dots
    * + counts); `null`/`false` = off (default for new users) — posts published
    * before you subscribed are suppressed from unread dots/counts (dots return if

--- a/apps/standard-reader/src/db/schema/kosync.ts
+++ b/apps/standard-reader/src/db/schema/kosync.ts
@@ -1,0 +1,84 @@
+import {
+  index,
+  pgTable,
+  primaryKey,
+  real,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core";
+
+/**
+ * KOReader progress sync (kosync).
+ *
+ * KOReader identifies a book by a hash of the *file*, not by any identifier we
+ * gave it — there is nowhere in the protocol to put an AT-URI. So a device
+ * reports progress for `a1b2c3…` and the server has to know what that was.
+ *
+ * That is what this table is: every time we generate a book, we record the
+ * hashes that file will have on a device. Generation is deterministic (see
+ * `server/books/zip.ts`), so the hash can be computed at download time and
+ * still match what the device computes later, on a copy of the file we no
+ * longer have.
+ *
+ * A document has more than one row because KOReader offers two matching
+ * methods — the partial MD5 of the file's contents (its default) and the MD5 of
+ * the filename — and the reader can switch between them per device.
+ */
+export const kosyncDocuments = pgTable(
+  "kosync_documents",
+  {
+    /** The digest KOReader sends as `document` — lowercase hex MD5. */
+    hash: text("hash").primaryKey(),
+    /** AT-URI of the `site.standard.document` the file was built from. */
+    documentUri: text("document_uri").notNull(),
+    /** `binary` (partial MD5 of contents) or `filename` (MD5 of basename). */
+    method: text("method").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [index("kosync_documents_uri_idx").on(table.documentUri)],
+);
+
+/**
+ * A device's reading position, exactly as KOReader sent it.
+ *
+ * Stored verbatim rather than normalised because `progress` is opaque: for a
+ * reflowable book it is a CRE xpointer into that device's rendering, for a
+ * paged one a page number. Only KOReader can interpret it, so only KOReader's
+ * own bytes go back out — the app never fabricates one.
+ *
+ * `percentage` is the part both worlds understand, and it is mirrored into
+ * `reading_progress` when the hash resolves to a document we know: finish a
+ * chapter on the Kobo and the article shows as part-read in the app.
+ */
+export const kosyncProgress = pgTable(
+  "kosync_progress",
+  {
+    /** DID of the reader, resolved from the kosync credentials. */
+    ownerDid: text("owner_did").notNull(),
+    /** The `document` digest the device reported. */
+    documentHash: text("document_hash").notNull(),
+    /** Opaque position string — an xpointer or a page number. */
+    progress: text("progress").notNull(),
+    /** Fraction read, 0–1. The only field that means anything outside KOReader. */
+    percentage: real("percentage").notNull(),
+    /** Human device name ("Kobo Clara"), shown when positions conflict. */
+    device: text("device"),
+    /** Stable per-device id, so a device does not sync with itself. */
+    deviceId: text("device_id"),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.ownerDid, table.documentHash] }),
+    index("kosync_progress_owner_idx").on(
+      table.ownerDid,
+      table.updatedAt.desc(),
+    ),
+  ],
+);
+
+export type KosyncDocument = typeof kosyncDocuments.$inferSelect;
+export type KosyncProgress = typeof kosyncProgress.$inferSelect;

--- a/apps/standard-reader/src/integrations/tanstack-query/api-ereader.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-ereader.functions.ts
@@ -1,0 +1,71 @@
+import { queryOptions } from "@tanstack/react-query";
+import { createServerFn } from "@tanstack/react-start";
+import { getRequest } from "@tanstack/react-start/server";
+import { eq } from "drizzle-orm";
+
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import { kosyncBaseUrl, opdsShelfUrl } from "#/lib/opds/urls";
+import { getPublicUrl } from "#/lib/public-url";
+import { getReaderDidForRequest } from "#/middleware/auth-session.server";
+import { kosyncKeyForDid } from "#/server/kosync/credentials";
+import { observe } from "#/server/observability/log";
+
+/**
+ * The three values a reader needs to connect an e-reader.
+ *
+ * A server function rather than a client-side derivation because the sync key
+ * is an HMAC under a server secret (see `server/kosync/credentials.ts`) — the
+ * key is the whole reason this cannot be computed in the browser.
+ */
+export interface EreaderConnection {
+  /** OPDS catalog URL carrying this reader's shelves. */
+  catalogUrl: string;
+  /** Base URL for KOReader's "Custom sync server". */
+  kosyncUrl: string;
+  /** What to type as the kosync username — their handle, or DID as a fallback. */
+  username: string;
+  /** What to type as the kosync password. */
+  syncKey: string;
+}
+
+const getEreaderConnection = createServerFn({ method: "GET" }).handler(
+  observe("ereader.getConnection", async (_, span) => {
+    const did = await getReaderDidForRequest(getRequest());
+    if (!did) return null;
+    span.set("did", did);
+
+    const [profile] = await db
+      .select({ handle: schema.profiles.handle })
+      .from(schema.profiles)
+      .where(eq(schema.profiles.did, did))
+      .limit(1);
+
+    const baseUrl = getPublicUrl();
+    return {
+      catalogUrl: opdsShelfUrl(baseUrl, did),
+      kosyncUrl: kosyncBaseUrl(baseUrl),
+      syncKey: kosyncKeyForDid(did),
+      // The handle is friendlier to type on a device keyboard, but a reader
+      // whose profile has not been backfilled yet still needs something that
+      // works — and the DID always resolves.
+      username: profile?.handle ?? did,
+    } satisfies EreaderConnection;
+  }),
+);
+
+function getEreaderConnectionQueryOptions() {
+  return queryOptions({
+    queryFn: async () => getEreaderConnection(),
+    queryKey: ["reader", "ereaderConnection"] as const,
+    refetchOnWindowFocus: false,
+    // Derived from the reader's DID and a server secret — it does not change
+    // between sessions, so there is nothing to poll for.
+    staleTime: 60 * 60_000,
+  });
+}
+
+export const ereaderApi = {
+  getEreaderConnection,
+  getEreaderConnectionQueryOptions,
+};

--- a/apps/standard-reader/src/integrations/tanstack-query/api-ereader.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-ereader.functions.ts
@@ -1,4 +1,4 @@
-import { queryOptions } from "@tanstack/react-query";
+import { mutationOptions, queryOptions } from "@tanstack/react-query";
 import { createServerFn } from "@tanstack/react-start";
 import { getRequest } from "@tanstack/react-start/server";
 import { eq } from "drizzle-orm";
@@ -7,8 +7,11 @@ import { db } from "#/db/index.server";
 import * as schema from "#/db/schema";
 import { kosyncBaseUrl, opdsShelfUrl } from "#/lib/opds/urls";
 import { getPublicUrl } from "#/lib/public-url";
-import { getReaderDidForRequest } from "#/middleware/auth-session.server";
-import { kosyncKeyForDid } from "#/server/kosync/credentials";
+import {
+  getAtprotoSessionForRequest,
+  getReaderDidForRequest,
+} from "#/middleware/auth-session.server";
+import { kosyncKeyForDid, newKosyncSalt } from "#/server/kosync/credentials";
 import { observe } from "#/server/observability/log";
 
 /**
@@ -35,17 +38,24 @@ const getEreaderConnection = createServerFn({ method: "GET" }).handler(
     if (!did) return null;
     span.set("did", did);
 
-    const [profile] = await db
-      .select({ handle: schema.profiles.handle })
-      .from(schema.profiles)
-      .where(eq(schema.profiles.did, did))
-      .limit(1);
+    const [[profile], [account]] = await Promise.all([
+      db
+        .select({ handle: schema.profiles.handle })
+        .from(schema.profiles)
+        .where(eq(schema.profiles.did, did))
+        .limit(1),
+      db
+        .select({ salt: schema.user.kosyncKeySalt })
+        .from(schema.user)
+        .where(eq(schema.user.did, did))
+        .limit(1),
+    ]);
 
     const baseUrl = getPublicUrl();
     return {
       catalogUrl: opdsShelfUrl(baseUrl, did),
       kosyncUrl: kosyncBaseUrl(baseUrl),
-      syncKey: kosyncKeyForDid(did),
+      syncKey: kosyncKeyForDid(did, account?.salt ?? null),
       // The handle is friendlier to type on a device keyboard, but a reader
       // whose profile has not been backfilled yet still needs something that
       // works — and the DID always resolves.
@@ -65,7 +75,42 @@ function getEreaderConnectionQueryOptions() {
   });
 }
 
+/**
+ * Retire this reader's sync key and issue a new one.
+ *
+ * Writing a fresh salt is the whole rotation: the key is derived from it and
+ * never stored, so the old one stops authenticating the moment this lands.
+ * Reading positions are keyed by document hash rather than by credential, so
+ * nothing a device already synced is lost — those devices just have to be given
+ * the new key before they sync again.
+ */
+const rotateKosyncKey = createServerFn({ method: "POST" }).handler(
+  observe("ereader.rotateKosyncKey", async (_, span) => {
+    const session = await getAtprotoSessionForRequest(getRequest());
+    if (!session) {
+      throw new Error("Sign in to rotate your sync key.");
+    }
+    span.set("did", session.did);
+
+    await db
+      .update(schema.user)
+      .set({ kosyncKeySalt: newKosyncSalt() })
+      .where(eq(schema.user.did, session.did));
+
+    return { ok: true as const };
+  }),
+);
+
+function rotateKosyncKeyMutationOptions() {
+  return mutationOptions({
+    mutationFn: async () => rotateKosyncKey(),
+    mutationKey: ["reader", "rotateKosyncKey"] as const,
+  });
+}
+
 export const ereaderApi = {
   getEreaderConnection,
   getEreaderConnectionQueryOptions,
+  rotateKosyncKey,
+  rotateKosyncKeyMutationOptions,
 };

--- a/apps/standard-reader/src/lib/guide/navigation.ts
+++ b/apps/standard-reader/src/lib/guide/navigation.ts
@@ -24,6 +24,7 @@ export type GuideArea =
   | "collections"
   | "personalizing"
   | "extension"
+  | "e-readers"
   | "publishing"
   | "comics"
   | "your-data";
@@ -38,6 +39,7 @@ export type GuideRoute =
   | "/guide/collections"
   | "/guide/personalizing"
   | "/guide/extension"
+  | "/guide/e-readers"
   | "/guide/publishing"
   | "/guide/comics"
   | "/guide/your-data";
@@ -130,6 +132,13 @@ export const GUIDE_AREAS: ReadonlyArray<GuideAreaMeta> = [
     to: "/guide/extension",
     label: msg`The browser extension`,
     blurb: msg`Save and subscribe from anywhere on the web, without breaking your stride.`,
+  },
+  {
+    area: "e-readers",
+    group: "further",
+    to: "/guide/e-readers",
+    label: msg`Reading on an e-reader`,
+    blurb: msg`Put your unread queue on a Kobo, Kindle or phone as real EPUB files.`,
   },
   {
     area: "publishing",
@@ -251,6 +260,13 @@ export const GUIDE_SECTIONS: Record<GuideArea, ReadonlyArray<GuideSection>> = {
     },
     { id: "content-formats", label: msg`Supported content formats` },
     { id: "example", label: msg`Example record` },
+  ],
+  "e-readers": [
+    { id: "what-you-get", label: msg`What you get` },
+    { id: "setting-it-up", label: msg`Setting it up` },
+    { id: "one-article", label: msg`Sending one article` },
+    { id: "progress-sync", label: msg`Keeping your place` },
+    { id: "whats-missing", label: msg`What will not be there` },
   ],
   comics: [
     { id: "what-readers-get", label: msg`What readers get` },

--- a/apps/standard-reader/src/lib/opds/atom.ts
+++ b/apps/standard-reader/src/lib/opds/atom.ts
@@ -1,0 +1,240 @@
+/**
+ * OPDS 1.2 (Atom) serialization.
+ *
+ * Pure string building, like `lib/feeds/rss.ts` — an OPDS feed is a small,
+ * fixed shape, and a generic XML library would add a dependency without adding
+ * correctness.
+ *
+ * The dialect matters more than the syntax. Every catalog client in the wild is
+ * a little different about which links it honours, so this writes the belt and
+ * braces version: `dc:issued` next to `published`, a thumbnail alongside the
+ * full cover, an `alternate` link to the web page next to the acquisition link,
+ * and OpenSearch pagination counts on every paged feed.
+ */
+
+import type {
+  OpdsAcquisition,
+  OpdsFeed,
+  OpdsLink,
+  OpdsNavigationEntry,
+  OpdsPublicationEntry,
+} from "./model";
+import { feedTypeFor, OPDS_REL } from "./model";
+
+function escape(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+/** Strip the code points XML 1.0 cannot represent at all. */
+function safe(value: string): string {
+  return value.replaceAll(
+    // eslint-disable-next-line no-control-regex -- matching them is the point
+    /[\u0000-\u0008\u000B\u000C\u000E-\u001F\uFFFE\uFFFF]/gu,
+    "",
+  );
+}
+
+function text(value: string): string {
+  return escape(safe(value));
+}
+
+function isoOrEpoch(value: string): string {
+  const time = Date.parse(value);
+  return new Date(Number.isNaN(time) ? 0 : time).toISOString();
+}
+
+function renderLink(link: OpdsLink): string {
+  const parts = [
+    `rel="${escape(link.rel)}"`,
+    `href="${escape(link.href)}"`,
+    `type="${escape(link.type)}"`,
+  ];
+  if (link.title) parts.push(`title="${text(link.title)}"`);
+  if (link.facetGroup) {
+    parts.push(`opds:facetGroup="${text(link.facetGroup)}"`);
+  }
+  if (link.activeFacet) parts.push(`opds:activeFacet="true"`);
+  if (typeof link.count === "number") {
+    parts.push(`thr:count="${link.count}"`);
+  }
+  return `  <link ${parts.join(" ")}/>`;
+}
+
+function renderNavigationEntry(entry: OpdsNavigationEntry): string {
+  const lines = [
+    "  <entry>",
+    `    <title>${text(entry.title)}</title>`,
+    `    <id>${text(entry.id)}</id>`,
+    `    <updated>${isoOrEpoch(entry.updated)}</updated>`,
+  ];
+  if (entry.summary) {
+    lines.push(`    <content type="text">${text(entry.summary)}</content>`);
+  }
+  if (entry.imageUrl) {
+    lines.push(
+      `    <link rel="${OPDS_REL.image}" href="${escape(entry.imageUrl)}"/>`,
+    );
+  }
+  if (entry.thumbnailUrl) {
+    lines.push(
+      `    <link rel="${OPDS_REL.thumbnail}" href="${escape(entry.thumbnailUrl)}"/>`,
+    );
+  }
+  lines.push(
+    `    <link rel="${escape(entry.rel ?? "subsection")}" href="${escape(entry.href)}" type="${escape(feedTypeFor(entry.kind))}"/>`,
+    "  </entry>",
+  );
+  return lines.join("\n");
+}
+
+function renderAcquisition(acquisition: OpdsAcquisition): string {
+  const parts = [
+    `rel="${escape(acquisition.rel ?? OPDS_REL.openAccess)}"`,
+    `href="${escape(acquisition.href)}"`,
+    `type="${escape(acquisition.type)}"`,
+  ];
+  if (acquisition.title) parts.push(`title="${text(acquisition.title)}"`);
+  if (typeof acquisition.length === "number") {
+    parts.push(`length="${acquisition.length}"`);
+  }
+  return `    <link ${parts.join(" ")}/>`;
+}
+
+function renderPublicationEntry(entry: OpdsPublicationEntry): string {
+  const lines = [
+    "  <entry>",
+    `    <title>${text(entry.title)}</title>`,
+    `    <id>${text(entry.id)}</id>`,
+    `    <updated>${isoOrEpoch(entry.updated)}</updated>`,
+  ];
+
+  for (const author of entry.authors) {
+    lines.push(
+      "    <author>",
+      `      <name>${text(author.name)}</name>`,
+      ...(author.uri ? [`      <uri>${escape(author.uri)}</uri>`] : []),
+      "    </author>",
+    );
+  }
+  if (entry.published) {
+    // `published` is Atom's; `dc:issued` is what several catalog clients read.
+    lines.push(
+      `    <published>${isoOrEpoch(entry.published)}</published>`,
+      `    <dc:issued>${isoOrEpoch(entry.published)}</dc:issued>`,
+    );
+  }
+  if (entry.language) {
+    lines.push(`    <dc:language>${text(entry.language)}</dc:language>`);
+  }
+  if (entry.publisher) {
+    lines.push(`    <dc:publisher>${text(entry.publisher)}</dc:publisher>`);
+  }
+  if (entry.summary) {
+    lines.push(`    <content type="text">${text(entry.summary)}</content>`);
+  }
+  for (const category of entry.categories ?? []) {
+    lines.push(`    <category term="${text(category)}"/>`);
+  }
+  if (entry.coverImageUrl) {
+    lines.push(
+      `    <link rel="${OPDS_REL.image}" href="${escape(entry.coverImageUrl)}"/>`,
+    );
+  }
+  if (entry.thumbnailUrl) {
+    lines.push(
+      `    <link rel="${OPDS_REL.thumbnail}" href="${escape(entry.thumbnailUrl)}"/>`,
+    );
+  }
+  if (entry.webUrl) {
+    lines.push(
+      `    <link rel="alternate" href="${escape(entry.webUrl)}" type="text/html"/>`,
+    );
+  }
+  for (const acquisition of entry.acquisitions) {
+    lines.push(renderAcquisition(acquisition));
+  }
+  lines.push("  </entry>");
+  return lines.join("\n");
+}
+
+/** Serialize a feed as OPDS 1.2 Atom. */
+export function renderOpdsAtom(feed: OpdsFeed): string {
+  const lines: Array<string> = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<feed xmlns="http://www.w3.org/2005/Atom"',
+    '      xmlns:opds="http://opds-spec.org/2010/catalog"',
+    '      xmlns:dc="http://purl.org/dc/terms/"',
+    '      xmlns:thr="http://purl.org/syndication/thread/1.0"',
+    '      xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">',
+    `  <id>${text(feed.id)}</id>`,
+    `  <title>${text(feed.title)}</title>`,
+    `  <updated>${isoOrEpoch(feed.updated)}</updated>`,
+  ];
+  if (feed.subtitle) {
+    lines.push(`  <subtitle>${text(feed.subtitle)}</subtitle>`);
+  }
+  if (feed.iconUrl) lines.push(`  <icon>${escape(feed.iconUrl)}</icon>`);
+
+  if (feed.pagination) {
+    lines.push(
+      `  <opensearch:totalResults>${feed.pagination.totalResults}</opensearch:totalResults>`,
+      `  <opensearch:itemsPerPage>${feed.pagination.itemsPerPage}</opensearch:itemsPerPage>`,
+      `  <opensearch:startIndex>${feed.pagination.startIndex}</opensearch:startIndex>`,
+    );
+  }
+
+  lines.push(
+    renderLink({
+      href: feed.selfHref,
+      rel: "self",
+      type: feedTypeFor(feed.kind),
+    }),
+  );
+  for (const link of feed.links ?? []) lines.push(renderLink(link));
+
+  for (const entry of feed.navigation ?? []) {
+    lines.push(renderNavigationEntry(entry));
+  }
+  for (const entry of feed.publications ?? []) {
+    lines.push(renderPublicationEntry(entry));
+  }
+
+  lines.push("</feed>", "");
+  return lines.join("\n");
+}
+
+/**
+ * The OpenSearch description document.
+ *
+ * Catalog clients fetch this once and then build their own search box from it;
+ * `{searchTerms}` is the placeholder they substitute into.
+ */
+export function renderOpenSearchDescription({
+  shortName,
+  description,
+  searchTemplate,
+  jsonSearchTemplate,
+}: {
+  shortName: string;
+  description: string;
+  searchTemplate: string;
+  jsonSearchTemplate?: string;
+}): string {
+  const jsonUrl = jsonSearchTemplate
+    ? `\n  <Url type="application/opds+json" template="${escape(jsonSearchTemplate)}"/>`
+    : "";
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>${text(shortName)}</ShortName>
+  <Description>${text(description)}</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <OutputEncoding>UTF-8</OutputEncoding>
+  <Url type="application/atom+xml;profile=opds-catalog;kind=acquisition" template="${escape(searchTemplate)}"/>${jsonUrl}
+</OpenSearchDescription>
+`;
+}

--- a/apps/standard-reader/src/lib/opds/json.ts
+++ b/apps/standard-reader/src/lib/opds/json.ts
@@ -1,0 +1,155 @@
+/**
+ * OPDS 2.0 (JSON) serialization of the same {@link OpdsFeed} the Atom
+ * serializer renders.
+ *
+ * Two differences from 1.2 are worth knowing about:
+ *
+ *  - **One media type for both feed kinds.** 1.2 distinguishes navigation from
+ *    acquisition in the type parameter; 2.0 distinguishes them structurally, by
+ *    which array the entries land in. So every link *into* the catalog gets its
+ *    type rewritten to `application/opds+json`.
+ *  - **Format is sticky.** A client that started in JSON must not be handed an
+ *    Atom URL three levels down, so internal hrefs carry the format marker
+ *    forward. Acquisition links are left alone — an EPUB is an EPUB.
+ */
+
+import type {
+  OpdsFeed,
+  OpdsLink,
+  OpdsNavigationEntry,
+  OpdsPublicationEntry,
+} from "./model";
+import { isOpdsFeedType, OPDS_JSON_TYPE, OPDS_REL } from "./model";
+
+/** Query parameter that pins a catalog response to JSON. */
+export const OPDS_FORMAT_PARAM = "format";
+export const OPDS_JSON_FORMAT = "json";
+
+/** Carry `?format=json` down into a catalog URL. */
+export function withJsonFormat(href: string): string {
+  try {
+    // Base only matters for relative hrefs; the catalog builds absolute ones.
+    const url = new URL(href, "https://standard-reader.invalid");
+    url.searchParams.set(OPDS_FORMAT_PARAM, OPDS_JSON_FORMAT);
+    return href.startsWith("http")
+      ? url.toString()
+      : `${url.pathname}${url.search}`;
+  } catch {
+    return href;
+  }
+}
+
+interface JsonLink {
+  rel?: string | Array<string>;
+  href: string;
+  type?: string;
+  title?: string;
+  templated?: boolean;
+  properties?: Record<string, unknown>;
+}
+
+/** Rewrite a link that points back into the catalog so it stays JSON. */
+function catalogLink(link: OpdsLink): JsonLink {
+  const internal = isOpdsFeedType(link.type);
+  const json: JsonLink = {
+    href: internal ? withJsonFormat(link.href) : link.href,
+    rel: link.rel,
+    type: internal ? OPDS_JSON_TYPE : link.type,
+  };
+  if (link.title) json.title = link.title;
+
+  const properties: Record<string, unknown> = {};
+  if (link.facetGroup) properties.group = link.facetGroup;
+  if (link.activeFacet) properties.active = true;
+  if (typeof link.count === "number") properties.numberOfItems = link.count;
+  if (Object.keys(properties).length > 0) json.properties = properties;
+
+  return json;
+}
+
+function navigationLink(entry: OpdsNavigationEntry): JsonLink {
+  return {
+    href: withJsonFormat(entry.href),
+    rel: entry.rel ?? "subsection",
+    title: entry.title,
+    type: OPDS_JSON_TYPE,
+  };
+}
+
+function publicationJson(entry: OpdsPublicationEntry) {
+  const images: Array<{ href: string; rel?: string }> = [];
+  if (entry.coverImageUrl) images.push({ href: entry.coverImageUrl });
+  if (entry.thumbnailUrl) {
+    images.push({ href: entry.thumbnailUrl, rel: OPDS_REL.thumbnail });
+  }
+
+  const links: Array<JsonLink> = entry.acquisitions.map((acquisition) => ({
+    href: acquisition.href,
+    rel: acquisition.rel ?? OPDS_REL.openAccess,
+    title: acquisition.title,
+    type: acquisition.type,
+    ...(typeof acquisition.length === "number"
+      ? { properties: { length: acquisition.length } }
+      : {}),
+  }));
+  if (entry.webUrl) {
+    links.push({ href: entry.webUrl, rel: "alternate", type: "text/html" });
+  }
+
+  return {
+    images: images.length > 0 ? images : undefined,
+    links,
+    metadata: {
+      "@type": "http://schema.org/Article",
+      author: entry.authors.map((author) => ({
+        name: author.name,
+        ...(author.uri ? { links: [{ href: author.uri }] } : {}),
+      })),
+      description: entry.summary ?? undefined,
+      identifier: entry.id,
+      language: entry.language ?? undefined,
+      modified: entry.updated,
+      published: entry.published ?? undefined,
+      publisher: entry.publisher ? { name: entry.publisher } : undefined,
+      subject: entry.categories?.length ? entry.categories : undefined,
+      title: entry.title,
+    },
+  };
+}
+
+/** Serialize a feed as an OPDS 2.0 JSON document. */
+export function renderOpdsJson(feed: OpdsFeed): string {
+  const links: Array<JsonLink> = [
+    {
+      href: withJsonFormat(feed.selfHref),
+      rel: "self",
+      type: OPDS_JSON_TYPE,
+    },
+    ...(feed.links ?? []).map((link) => catalogLink(link)),
+  ];
+
+  const document = {
+    links,
+    metadata: {
+      currentPage: feed.pagination
+        ? Math.floor(
+            feed.pagination.startIndex / feed.pagination.itemsPerPage,
+          ) + 1
+        : undefined,
+      description: feed.subtitle ?? undefined,
+      identifier: feed.id,
+      itemsPerPage: feed.pagination?.itemsPerPage,
+      modified: feed.updated,
+      numberOfItems: feed.pagination?.totalResults,
+      title: feed.title,
+    },
+    navigation: feed.navigation?.length
+      ? feed.navigation.map(navigationLink)
+      : undefined,
+    publications: feed.publications?.length
+      ? feed.publications.map(publicationJson)
+      : undefined,
+  };
+
+  return `${JSON.stringify(document, null, 2)}\n`;
+}

--- a/apps/standard-reader/src/lib/opds/model.ts
+++ b/apps/standard-reader/src/lib/opds/model.ts
@@ -1,0 +1,135 @@
+/**
+ * A format-neutral model of an OPDS catalog feed.
+ *
+ * OPDS has two incompatible serializations in active use: 1.2, which is Atom
+ * XML, and 2.0, which is JSON. KOReader — the client this catalog was built
+ * for — speaks 1.2; Thorium and the Readium stack speak 2.0. Rather than write
+ * the catalog twice, the builders in `server/opds/` produce this model and the
+ * two serializers (`atom.ts`, `json.ts`) render it.
+ *
+ * The model is deliberately closer to 1.2, because 1.2 is the lossier of the
+ * two: anything Atom can carry, OPDS 2.0 can carry, and the reverse is not
+ * true.
+ */
+
+/** `application/atom+xml;profile=opds-catalog;kind=navigation`. */
+export const OPDS_NAVIGATION_TYPE =
+  "application/atom+xml;profile=opds-catalog;kind=navigation";
+
+/** `application/atom+xml;profile=opds-catalog;kind=acquisition`. */
+export const OPDS_ACQUISITION_TYPE =
+  "application/atom+xml;profile=opds-catalog;kind=acquisition";
+
+/** The OPDS 2.0 media type — one type for both feed kinds. */
+export const OPDS_JSON_TYPE = "application/opds+json";
+
+export const EPUB_TYPE = "application/epub+zip";
+export const CBZ_TYPE = "application/vnd.comicbook+zip";
+export const OPENSEARCH_TYPE = "application/opensearchdescription+xml";
+
+/** OPDS relation URIs, spelled once. */
+export const OPDS_REL = {
+  acquisition: "http://opds-spec.org/acquisition",
+  facet: "http://opds-spec.org/facet",
+  image: "http://opds-spec.org/image",
+  openAccess: "http://opds-spec.org/acquisition/open-access",
+  shelf: "http://opds-spec.org/shelf",
+  thumbnail: "http://opds-spec.org/image/thumbnail",
+} as const;
+
+export type OpdsFeedKind = "acquisition" | "navigation";
+
+export interface OpdsLink {
+  rel: string;
+  href: string;
+  type: string;
+  title?: string;
+  /**
+   * Groups mutually-exclusive facets (a "Sort" group, a "Show" group). Clients
+   * render one group per menu, so a facet without a group is a facet the
+   * reader cannot tell apart from the others.
+   */
+  facetGroup?: string;
+  /** Marks the facet the current feed already applies. */
+  activeFacet?: boolean;
+  /** Number of entries behind this link, when cheaply known. */
+  count?: number;
+}
+
+/** An entry that leads somewhere else in the catalog. */
+export interface OpdsNavigationEntry {
+  id: string;
+  title: string;
+  href: string;
+  /** What the reader lands on — decides the link's media type. */
+  kind: OpdsFeedKind;
+  updated: string;
+  summary?: string | null;
+  imageUrl?: string | null;
+  thumbnailUrl?: string | null;
+  /** `subsection` by default; `http://opds-spec.org/shelf` for personal shelves. */
+  rel?: string;
+}
+
+/** A downloadable rendition of an entry. */
+export interface OpdsAcquisition {
+  href: string;
+  type: string;
+  /** Defaults to open-access — everything in this catalog is free to take. */
+  rel?: string;
+  title?: string;
+  /** Bytes, when known without building the file. */
+  length?: number;
+}
+
+/** An entry a reader can download. */
+export interface OpdsPublicationEntry {
+  /** Stable, globally unique — the AT-URI of the record. */
+  id: string;
+  title: string;
+  updated: string;
+  summary?: string | null;
+  authors: Array<{ name: string; uri?: string | null }>;
+  publisher?: string | null;
+  /** ISO timestamp the work was published. */
+  published?: string | null;
+  language?: string | null;
+  categories?: Array<string>;
+  /** The web page this entry mirrors. */
+  webUrl?: string | null;
+  coverImageUrl?: string | null;
+  thumbnailUrl?: string | null;
+  acquisitions: Array<OpdsAcquisition>;
+}
+
+export interface OpdsPagination {
+  totalResults: number;
+  itemsPerPage: number;
+  startIndex: number;
+}
+
+export interface OpdsFeed {
+  id: string;
+  title: string;
+  updated: string;
+  /** Absolute URL of this feed — becomes `rel="self"`. */
+  selfHref: string;
+  kind: OpdsFeedKind;
+  subtitle?: string | null;
+  iconUrl?: string | null;
+  /** `start`, `up`, `next`, `previous`, `search`, facets. */
+  links?: Array<OpdsLink>;
+  navigation?: Array<OpdsNavigationEntry>;
+  publications?: Array<OpdsPublicationEntry>;
+  pagination?: OpdsPagination;
+}
+
+/** The media type a link to a feed of `kind` should declare. */
+export function feedTypeFor(kind: OpdsFeedKind): string {
+  return kind === "navigation" ? OPDS_NAVIGATION_TYPE : OPDS_ACQUISITION_TYPE;
+}
+
+/** True for the OPDS 1.2 feed media types — the ones JSON output rewrites. */
+export function isOpdsFeedType(type: string): boolean {
+  return type === OPDS_NAVIGATION_TYPE || type === OPDS_ACQUISITION_TYPE;
+}

--- a/apps/standard-reader/src/lib/opds/respond.ts
+++ b/apps/standard-reader/src/lib/opds/respond.ts
@@ -1,0 +1,59 @@
+/**
+ * Choosing a serialization and returning it.
+ *
+ * A catalog client says what it wants twice — in `Accept`, and (once it has
+ * followed one of our links) in the URL. The URL wins: it is the explicit
+ * choice, and it is what keeps a JSON client in JSON as it walks deeper into
+ * the catalog. `Accept` decides only the first request, which is the one a
+ * reader typed by hand.
+ */
+
+import { renderOpdsAtom } from "./atom";
+import { OPDS_FORMAT_PARAM, OPDS_JSON_FORMAT, renderOpdsJson } from "./json";
+import type { OpdsFeed } from "./model";
+import { feedTypeFor, OPDS_JSON_TYPE } from "./model";
+
+export type OpdsFormat = "atom" | "json";
+
+/**
+ * Catalog feeds change as often as the feeds they mirror. Fifteen minutes with
+ * a generous stale window keeps a shelf feeling live without asking the DB to
+ * rebuild it for every device that syncs.
+ */
+export const OPDS_CACHE_CONTROL =
+  "public, max-age=900, stale-while-revalidate=3600";
+
+/** A reader's own shelves are per-DID; caches must not share them between readers. */
+export const OPDS_PRIVATE_CACHE_CONTROL = "private, max-age=300";
+
+export function opdsFormatFromRequest(request: Request): OpdsFormat {
+  const url = new URL(request.url);
+  const explicit = url.searchParams.get(OPDS_FORMAT_PARAM);
+  if (explicit === OPDS_JSON_FORMAT) return "json";
+  if (explicit === "atom") return "atom";
+
+  // No explicit choice: honour `Accept`, defaulting to 1.2 because that is what
+  // the widest set of clients understands.
+  const accept = request.headers.get("accept") ?? "";
+  return accept.includes(OPDS_JSON_TYPE) ? "json" : "atom";
+}
+
+export function opdsResponse(
+  feed: OpdsFeed,
+  format: OpdsFormat,
+  { cacheControl = OPDS_CACHE_CONTROL }: { cacheControl?: string } = {},
+): Response {
+  const body = format === "json" ? renderOpdsJson(feed) : renderOpdsAtom(feed);
+  const contentType =
+    format === "json" ? OPDS_JSON_TYPE : feedTypeFor(feed.kind);
+
+  return new Response(body, {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Cache-Control": cacheControl,
+      "Content-Type": `${contentType}; charset=utf-8`,
+      // Same URL, two representations — caches must key on `Accept` too.
+      Vary: "Accept",
+    },
+  });
+}

--- a/apps/standard-reader/src/lib/opds/serialize.test.ts
+++ b/apps/standard-reader/src/lib/opds/serialize.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+
+import { renderOpdsAtom } from "#/lib/opds/atom";
+import { renderOpdsJson, withJsonFormat } from "#/lib/opds/json";
+import type { OpdsFeed } from "#/lib/opds/model";
+import {
+  EPUB_TYPE,
+  OPDS_ACQUISITION_TYPE,
+  OPDS_JSON_TYPE,
+  OPDS_NAVIGATION_TYPE,
+  OPDS_REL,
+} from "#/lib/opds/model";
+import { opdsFormatFromRequest } from "#/lib/opds/respond";
+
+const BASE = "https://standard-reader.app";
+
+const acquisitionFeed: OpdsFeed = {
+  id: `${BASE}/opds/latest`,
+  kind: "acquisition",
+  links: [
+    {
+      href: `${BASE}/opds/latest?page=2`,
+      rel: "next",
+      type: OPDS_ACQUISITION_TYPE,
+    },
+    {
+      activeFacet: true,
+      facetGroup: "Sort",
+      href: `${BASE}/opds/latest?sort=recent`,
+      rel: OPDS_REL.facet,
+      title: "Newest",
+      type: OPDS_ACQUISITION_TYPE,
+    },
+  ],
+  pagination: { itemsPerPage: 40, startIndex: 0, totalResults: 137 },
+  publications: [
+    {
+      acquisitions: [
+        {
+          href: `${BASE}/book/a/did:plc:abc/xyz.epub`,
+          title: "EPUB",
+          type: EPUB_TYPE,
+        },
+      ],
+      authors: [{ name: "Ada & Co", uri: `${BASE}/u/did:plc:abc` }],
+      categories: ["design", "<script>"],
+      coverImageUrl: "https://cdn.example/cover.jpg",
+      id: "at://did:plc:abc/site.standard.document/xyz",
+      published: "2026-08-01T00:00:00.000Z",
+      summary: 'A "quoted" summary',
+      title: "Tools & Toys",
+      updated: "2026-08-01T00:00:00.000Z",
+      webUrl: "https://example.com/post?a=1&b=2",
+    },
+  ],
+  selfHref: `${BASE}/opds/latest`,
+  title: "Latest",
+  updated: "2026-08-01T00:00:00.000Z",
+};
+
+const navigationFeed: OpdsFeed = {
+  id: `${BASE}/opds`,
+  kind: "navigation",
+  navigation: [
+    {
+      href: `${BASE}/opds/latest`,
+      id: `${BASE}/opds/latest`,
+      kind: "acquisition",
+      summary: "The newest articles.",
+      title: "Latest",
+      updated: "2026-08-01T00:00:00.000Z",
+    },
+  ],
+  selfHref: `${BASE}/opds`,
+  title: "Standard Reader",
+  updated: "2026-08-01T00:00:00.000Z",
+};
+
+describe("renderOpdsAtom", () => {
+  it("escapes markup and ampersands in text and attributes", () => {
+    const xml = renderOpdsAtom(acquisitionFeed);
+    expect(xml).toContain("<title>Tools &amp; Toys</title>");
+    expect(xml).toContain("A &quot;quoted&quot; summary");
+    expect(xml).toContain('<category term="&lt;script&gt;"/>');
+    expect(xml).toContain("post?a=1&amp;b=2");
+    expect(xml).not.toContain("<script>");
+  });
+
+  it("declares the feed kind on its self link", () => {
+    expect(renderOpdsAtom(acquisitionFeed)).toContain(
+      `<link rel="self" href="${BASE}/opds/latest" type="${OPDS_ACQUISITION_TYPE}"/>`,
+    );
+    expect(renderOpdsAtom(navigationFeed)).toContain(
+      `type="${OPDS_NAVIGATION_TYPE}"`,
+    );
+  });
+
+  it("carries pagination counts and facet grouping", () => {
+    const xml = renderOpdsAtom(acquisitionFeed);
+    expect(xml).toContain(
+      "<opensearch:totalResults>137</opensearch:totalResults>",
+    );
+    expect(xml).toContain('opds:facetGroup="Sort"');
+    expect(xml).toContain('opds:activeFacet="true"');
+  });
+
+  it("writes both `published` and `dc:issued` for date-reading clients", () => {
+    const xml = renderOpdsAtom(acquisitionFeed);
+    expect(xml).toContain("<published>2026-08-01T00:00:00.000Z</published>");
+    expect(xml).toContain("<dc:issued>2026-08-01T00:00:00.000Z</dc:issued>");
+  });
+
+  it("defaults an acquisition link to open-access", () => {
+    expect(renderOpdsAtom(acquisitionFeed)).toContain(
+      `rel="${OPDS_REL.openAccess}"`,
+    );
+  });
+
+  it("survives an unparseable timestamp rather than emitting `Invalid Date`", () => {
+    const xml = renderOpdsAtom({ ...acquisitionFeed, updated: "not a date" });
+    expect(xml).toContain("<updated>1970-01-01T00:00:00.000Z</updated>");
+    expect(xml).not.toContain("Invalid");
+  });
+});
+
+describe("renderOpdsJson", () => {
+  it("splits navigation and publications into their own arrays", () => {
+    const nav = JSON.parse(renderOpdsJson(navigationFeed));
+    expect(nav.navigation).toHaveLength(1);
+    expect(nav.publications).toBeUndefined();
+
+    const acquisition = JSON.parse(renderOpdsJson(acquisitionFeed));
+    expect(acquisition.publications).toHaveLength(1);
+    expect(acquisition.navigation).toBeUndefined();
+  });
+
+  it("keeps a client in JSON as it walks deeper into the catalog", () => {
+    const document = JSON.parse(renderOpdsJson(navigationFeed));
+    expect(document.links[0].href).toContain("format=json");
+    expect(document.links[0].type).toBe(OPDS_JSON_TYPE);
+    expect(document.navigation[0].href).toContain("format=json");
+    expect(document.navigation[0].type).toBe(OPDS_JSON_TYPE);
+  });
+
+  it("leaves acquisition links alone — an EPUB is an EPUB", () => {
+    const document = JSON.parse(renderOpdsJson(acquisitionFeed));
+    const [link] = document.publications[0].links;
+    expect(link.href).toBe(`${BASE}/book/a/did:plc:abc/xyz.epub`);
+    expect(link.href).not.toContain("format=json");
+    expect(link.type).toBe(EPUB_TYPE);
+  });
+
+  it("carries facets as link properties", () => {
+    const document = JSON.parse(renderOpdsJson(acquisitionFeed));
+    const facet = document.links.find(
+      (link: { rel: string }) => link.rel === OPDS_REL.facet,
+    );
+    expect(facet.properties).toEqual({ active: true, group: "Sort" });
+  });
+
+  it("reports paging in the metadata block", () => {
+    const document = JSON.parse(renderOpdsJson(acquisitionFeed));
+    expect(document.metadata.numberOfItems).toBe(137);
+    expect(document.metadata.itemsPerPage).toBe(40);
+    expect(document.metadata.currentPage).toBe(1);
+  });
+});
+
+describe("withJsonFormat", () => {
+  it("adds the marker without disturbing existing query params", () => {
+    expect(withJsonFormat(`${BASE}/opds/tag/design?page=2`)).toBe(
+      `${BASE}/opds/tag/design?page=2&format=json`,
+    );
+  });
+
+  it("does not add it twice", () => {
+    const once = withJsonFormat(`${BASE}/opds`);
+    expect(withJsonFormat(once)).toBe(once);
+  });
+});
+
+describe("opdsFormatFromRequest", () => {
+  const get = (url: string, accept?: string) =>
+    opdsFormatFromRequest(
+      new Request(url, { headers: accept ? { accept } : {} }),
+    );
+
+  it("defaults to Atom, the dialect every client understands", () => {
+    expect(get(`${BASE}/opds`)).toBe("atom");
+    expect(get(`${BASE}/opds`, "*/*")).toBe("atom");
+  });
+
+  it("honours an Accept header asking for OPDS 2.0", () => {
+    expect(get(`${BASE}/opds`, OPDS_JSON_TYPE)).toBe("json");
+  });
+
+  it("lets the URL override the header, in both directions", () => {
+    // The URL is the explicit choice — and it is what keeps a JSON client in
+    // JSON once it has followed one of our own links.
+    expect(get(`${BASE}/opds?format=json`, "application/atom+xml")).toBe(
+      "json",
+    );
+    expect(get(`${BASE}/opds?format=atom`, OPDS_JSON_TYPE)).toBe("atom");
+  });
+});

--- a/apps/standard-reader/src/lib/opds/urls.ts
+++ b/apps/standard-reader/src/lib/opds/urls.ts
@@ -1,0 +1,196 @@
+/**
+ * Every URL the catalog and the download routes hand out, in one place.
+ *
+ * Isomorphic on purpose: the settings page shows a reader their own catalog
+ * URL, article pages link their own EPUB, and the catalog builders emit
+ * acquisition links — all from these helpers, so a route rename cannot leave
+ * one of the three behind.
+ */
+
+function trim(baseUrl: string): string {
+  return baseUrl.replace(/\/$/, "");
+}
+
+const did = encodeURIComponent;
+const rkey = encodeURIComponent;
+
+// ── Catalog ────────────────────────────────────────────────────────────────
+
+/** Catalog root — the URL a reader pastes into KOReader. */
+export function opdsRootUrl(baseUrl: string): string {
+  return `${trim(baseUrl)}/opds`;
+}
+
+/** A reader's personal catalog: their subscriptions, unread, saved and lists. */
+export function opdsShelfUrl(baseUrl: string, readerDid: string): string {
+  return `${trim(baseUrl)}/opds/u/${did(readerDid)}`;
+}
+
+export function opdsLatestUrl(baseUrl: string): string {
+  return `${trim(baseUrl)}/opds/latest`;
+}
+
+export function opdsTrendingUrl(baseUrl: string): string {
+  return `${trim(baseUrl)}/opds/trending`;
+}
+
+export function opdsPublicationsUrl(baseUrl: string): string {
+  return `${trim(baseUrl)}/opds/publications`;
+}
+
+export function opdsPublicationUrl(
+  baseUrl: string,
+  ownerDid: string,
+  publicationRkey: string,
+): string {
+  return `${trim(baseUrl)}/opds/p/${did(ownerDid)}/${rkey(publicationRkey)}`;
+}
+
+export function opdsCollectionsUrl(baseUrl: string): string {
+  return `${trim(baseUrl)}/opds/collections`;
+}
+
+/**
+ * Comic publications on their own.
+ *
+ * A comic app pointed at the whole directory would have to wade through
+ * hundreds of prose blogs to find the handful of things it can actually open.
+ */
+export function opdsComicsUrl(baseUrl: string): string {
+  return `${trim(baseUrl)}/opds/comics`;
+}
+
+export function opdsCollectionUrl(
+  baseUrl: string,
+  ownerDid: string,
+  collectionRkey: string,
+): string {
+  return `${trim(baseUrl)}/opds/c/${did(ownerDid)}/${rkey(collectionRkey)}`;
+}
+
+export function opdsTagsUrl(baseUrl: string): string {
+  return `${trim(baseUrl)}/opds/tags`;
+}
+
+export function opdsTagUrl(baseUrl: string, tag: string): string {
+  return `${trim(baseUrl)}/opds/tag/${encodeURIComponent(tag)}`;
+}
+
+export function opdsListUrl(
+  baseUrl: string,
+  ownerDid: string,
+  listRkey: string,
+): string {
+  return `${trim(baseUrl)}/opds/l/${did(ownerDid)}/${rkey(listRkey)}`;
+}
+
+export function opdsSearchUrl(baseUrl: string, query?: string): string {
+  const base = `${trim(baseUrl)}/opds/search`;
+  return query ? `${base}?q=${encodeURIComponent(query)}` : base;
+}
+
+/**
+ * The OpenSearch template. `{searchTerms}` is a placeholder the *client*
+ * substitutes, so it must survive un-encoded.
+ */
+export function opdsSearchTemplate(baseUrl: string): string {
+  return `${trim(baseUrl)}/opds/search?q={searchTerms}`;
+}
+
+export function opdsOpenSearchUrl(baseUrl: string): string {
+  return `${trim(baseUrl)}/opds/opensearch.xml`;
+}
+
+// ── Downloads ──────────────────────────────────────────────────────────────
+
+/** One article as an EPUB. */
+export function articleEpubUrl(
+  baseUrl: string,
+  authorDid: string,
+  documentRkey: string,
+): string {
+  return `${trim(baseUrl)}/book/a/${did(authorDid)}/${rkey(documentRkey)}.epub`;
+}
+
+/** One comic issue as a CBZ. */
+export function articleCbzUrl(
+  baseUrl: string,
+  authorDid: string,
+  documentRkey: string,
+): string {
+  return `${trim(baseUrl)}/book/a/${did(authorDid)}/${rkey(documentRkey)}.cbz`;
+}
+
+/**
+ * One comic *issue* as a CBZ, addressed by the document that fronts it.
+ *
+ * Not the same as {@link articleCbzUrl}: a comic posts one page per document,
+ * so packaging a document gives a one-page file. This collects the whole issue
+ * that page belongs to — the unit the shelf, the reader and a comic app all
+ * mean by "an issue".
+ */
+export function comicIssueCbzUrl(
+  baseUrl: string,
+  authorDid: string,
+  frontRkey: string,
+): string {
+  return `${trim(baseUrl)}/book/i/${did(authorDid)}/${rkey(frontRkey)}.cbz`;
+}
+
+/** A comic publication's whole run as one CBZ. */
+export function publicationCbzUrl(
+  baseUrl: string,
+  ownerDid: string,
+  publicationRkey: string,
+): string {
+  return `${trim(baseUrl)}/book/p/${did(ownerDid)}/${rkey(publicationRkey)}.cbz`;
+}
+
+/** A publication's recent articles as one book. */
+export function publicationEpubUrl(
+  baseUrl: string,
+  ownerDid: string,
+  publicationRkey: string,
+): string {
+  return `${trim(baseUrl)}/book/p/${did(ownerDid)}/${rkey(publicationRkey)}.epub`;
+}
+
+/** A curated collection as one book. */
+export function collectionEpubUrl(
+  baseUrl: string,
+  ownerDid: string,
+  collectionRkey: string,
+): string {
+  return `${trim(baseUrl)}/book/c/${did(ownerDid)}/${rkey(collectionRkey)}.epub`;
+}
+
+/** A subscription list as one book. */
+export function listEpubUrl(
+  baseUrl: string,
+  ownerDid: string,
+  listRkey: string,
+): string {
+  return `${trim(baseUrl)}/book/l/${did(ownerDid)}/${rkey(listRkey)}.epub`;
+}
+
+/** Everything a reader saved for later, as one book. */
+export function savedEpubUrl(baseUrl: string, readerDid: string): string {
+  return `${trim(baseUrl)}/book/u/${did(readerDid)}/saved.epub`;
+}
+
+/** A reader's unread queue, as one book. */
+export function unreadEpubUrl(baseUrl: string, readerDid: string): string {
+  return `${trim(baseUrl)}/book/u/${did(readerDid)}/unread.epub`;
+}
+
+/** A tag's recent articles, as one book. */
+export function tagEpubUrl(baseUrl: string, tag: string): string {
+  return `${trim(baseUrl)}/book/tag/${encodeURIComponent(tag)}.epub`;
+}
+
+// ── KOReader progress sync ─────────────────────────────────────────────────
+
+/** The kosync base URL a reader enters in KOReader's sync settings. */
+export function kosyncBaseUrl(baseUrl: string): string {
+  return `${trim(baseUrl)}/kosync`;
+}

--- a/apps/standard-reader/src/lib/site-metadata.ts
+++ b/apps/standard-reader/src/lib/site-metadata.ts
@@ -166,6 +166,12 @@ export const PAGE_OG_CARDS = {
     title: "Publishing your site",
     tagline: "Wire a personal site's own site.standard.* records by hand.",
   },
+  guideEreaders: {
+    path: "/guide/e-readers",
+    title: "Reading on an e-reader",
+    tagline:
+      "Put your unread queue on a Kobo, Kindle or phone as real EPUB files.",
+  },
   guideComics: {
     path: "/guide/comics",
     title: "Publishing a comic",

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -205,6 +205,10 @@ msgstr ""
 msgid "find publications, people, topics, and headlines by name."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Every device syncing with the old key stops until you enter the new one. Nothing you have already read is lost — reading positions are kept against the books themselves, not the key."
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Change language"
@@ -2066,6 +2070,10 @@ msgstr ""
 msgid "Subscribed to list"
 msgstr "تم الاشتراك في القائمة"
 
+#: src/components/ereader-settings.tsx
+msgid "Rotate your sync key?"
+msgstr ""
+
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "See which of the people you pass on Bluesky write long-form."
 msgstr ""
@@ -2171,6 +2179,10 @@ msgstr "حذف المجموعة"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Interface font"
+msgstr ""
+
+#: src/components/ereader-settings.tsx
+msgid "Rotate"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
@@ -5273,6 +5285,10 @@ msgstr ""
 msgid "Subscribe to list"
 msgstr "اشترك في القائمة"
 
+#: src/components/ereader-settings.tsx
+msgid "Rotate key"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #: src/lib/guide/navigation.ts
 #~ msgid "Following a publication"
@@ -6513,6 +6529,10 @@ msgstr ""
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #~ msgid "Eight presets, or your own paper and accent. The rest of the interface is derived from them."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. Lost a device? <0>Rotate</0> in Settings issues a new key and stops the old one working."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 #: src/components/reading-custom-font-picker.tsx
@@ -8780,5 +8800,5 @@ msgid "Describe this image"
 msgstr ""
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
-msgstr ""
+#~ msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
+#~ msgstr ""

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -17,6 +17,10 @@ msgstr ""
 msgid "This is the difference between making one anthology and running something with a rhythm to it — a weekly roundup, a themed quarterly, a reading list you keep adding to."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Add your catalog to KOReader, Foliate, Marvin, Panels or any other OPDS app and your unread queue, saved articles, subscriptions and lists show up on the device — each one downloadable as an EPUB."
+msgstr ""
+
 #: src/routes/_layout.discover.tsx
 msgid "Every publication the network knows about — subscribe to the ones worth your mornings."
 msgstr "كل منشورة تعرفها الشبكة — اشترك في ما يستحق صباحاتك منها."
@@ -287,6 +291,10 @@ msgstr ""
 msgid "Mark as read"
 msgstr "تعليم كمقروء"
 
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Send to your e-reader"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "This list is empty — add publications or people to it."
 msgstr "هذه القائمة فارغة — أضف إليها منشورات أو أشخاصًا."
@@ -347,6 +355,11 @@ msgstr "يرجى إضافة عنوان."
 #: src/components/guide/pages/finding-guide-page.tsx
 #~ msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Follow it and it starts appearing in your feeds like any other."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/components/user-settings-view.tsx
+msgid "E-readers"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
@@ -530,8 +543,16 @@ msgstr ""
 msgid "We couldn’t find that issue."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Comics come down as <0>CBZ</0> as well, so comic apps get their page turns and their scrubber instead of a reflowable book that fights them."
+msgstr ""
+
 #: src/routes/_layout.friends.tsx
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
+msgstr ""
+
+#: src/components/ereader-settings.tsx
+msgid "Sync username"
 msgstr ""
 
 #: src/components/reader/format-i18n.ts
@@ -541,6 +562,10 @@ msgstr ""
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "List"
 msgstr "قائمة"
+
+#: src/components/reader/publication-actions.tsx
+msgid "Send to e-reader…"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "The spacing between things — tighter for more on screen, looser for more room to read."
@@ -733,6 +758,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Sync key"
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Landscape fits a compact row. Height adjusts automatically once the embed loads. Change the iframe width as needed."
 msgstr "الوضع العرضي يناسب صفًا مضغوطًا. يُضبط الارتفاع تلقائيًا بعد تحميل الإطار المضمَّن. غيّر عرض iframe حسب الحاجة."
@@ -867,6 +896,11 @@ msgstr ""
 msgid "Log in to follow publications"
 msgstr "سجّل الدخول لمتابعة المنشورات"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What will not be there"
+msgstr ""
+
 #: src/routes/_layout.discover.tsx
 msgid "Search publications"
 msgstr "ابحث في المنشورات"
@@ -946,6 +980,10 @@ msgstr "فشل تسجيل الدخول. حاول مجددًا."
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Loading publications"
 msgstr "جارٍ تحميل المنشورات"
+
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "OPDS catalog URL"
+msgstr ""
 
 #. placeholder {0}: meta.minutes
 #: src/magazine/flow.tsx
@@ -1218,6 +1256,11 @@ msgstr "عرض المجموعات"
 msgid "Name"
 msgstr "الاسم"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Setting it up"
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "Where data lives"
 msgstr "أين تُخزَّن البيانات"
@@ -1305,6 +1348,10 @@ msgstr "حُفِظ في {savedName} على {appLabel}."
 #: src/lib/guide/navigation.ts
 msgid "Getting started"
 msgstr "البداية"
+
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Download {name} as a file — images and all, ready to read offline."
+msgstr ""
 
 #: src/components/onboarding/step-settings.tsx
 msgid "Open posts on their original site"
@@ -1423,6 +1470,10 @@ msgstr ""
 #~ msgid "You don't have any subscriptions to reorder yet."
 #~ msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "What the sync key can do"
+msgstr ""
+
 #: src/components/reader/notify-button.tsx
 #: src/components/user-settings-view.tsx
 msgid "This browser doesn’t support web notifications."
@@ -1444,6 +1495,10 @@ msgstr "نوع الملاحظات"
 #: src/components/guide/pages/welcome-guide-page.tsx
 #~ msgid "Home leads with one article worth your attention, then everything new from the publications you follow."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Downloading does not mark anything read, and reading on a device does not remove it from your unread shelf until KOReader syncs a position back. Polls, signup forms and other live embeds become links — a book cannot run them."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Enable the weekly digest"
@@ -1493,6 +1548,11 @@ msgstr "متابعة الكل"
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "That's every issue published so far."
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Sending one article"
 msgstr ""
 
 #. placeholder {0}: view.clientName
@@ -1794,6 +1854,10 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Turn on <0>Sync every N pages</0> if you want it to happen without asking."
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
 #~ msgstr "أدرِج تلميح <0>site.standard.publication</0> فقط إذا كان المستند ينتمي إلى سجل منشورة. أضِف كليهما بغضّ النظر عن القارئ الذي يهمّك — فهما وسيلة أي عميل على الشبكة لربط صفحتك بسجلّها، لا إضافتنا وحدها."
@@ -1842,6 +1906,10 @@ msgstr ""
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Who can use your catalog URL"
+msgstr ""
+
 #: src/components/reader/continue-reading.tsx
 #~ msgid "Reading progress"
 #~ msgstr ""
@@ -1870,6 +1938,10 @@ msgstr ""
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "e.g. To Read"
 msgstr "مثال: للقراءة"
+
+#: src/lib/guide/navigation.ts
+msgid "Reading on an e-reader"
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/OpenLinksMenuItem.tsx
@@ -1954,6 +2026,10 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Making the text comfortable"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The files are built when you ask for them, from the same article bodies the reader shows — images pulled in, footnotes as real endnotes, a link back to the original at the end of every piece. Nothing is trimmed to an excerpt. A whole publication, a list or a collection can also come down as one book, with a table of contents."
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -2237,6 +2313,10 @@ msgstr "المزيد من <0>{0}</0>"
 msgid "On this device"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Add it to your reading app.</0> In KOReader that is <1>Search → OPDS catalog → +</1>. Foliate, Marvin, Aldiko, Thorium, Panels and Chunky all have a similar “add catalog” screen. Paste the URL and leave the username and password blank."
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
 msgstr "قد نحدّث هذه السياسة مع تطوّر الإضافة. وسيتغيّر تاريخ «آخر تحديث» في الأعلى عند حدوث ذلك. ويعني استمرارك في استخدام الإضافة بعد التحديث قبولك للسياسة المعدَّلة."
@@ -2253,6 +2333,10 @@ msgstr ""
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
+
+#: src/lib/guide/navigation.ts
+msgid "Put your unread queue on a Kobo, Kindle or phone as real EPUB files."
+msgstr ""
 
 #: src/components/reader/block-user-menu-item.tsx
 msgid "Block"
@@ -3147,6 +3231,10 @@ msgstr ""
 msgid "Plenty of people you already follow on Bluesky write long-form somewhere. <0>People you follow</0> finds them and puts their publications, and their newest articles, in one place. It is usually the highest-yield screen in the app the first week you use it."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Use this as the password. It only carries your reading position between devices — it cannot read or change anything else."
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "Second, it brings you <0>what they recommend</0>. Articles they have recommended start appearing in your feed, marked with who recommended them. That is the quiet engine behind finding new writing here: you are not only subscribing to what someone writes, you are borrowing their taste in what to read."
 msgstr ""
@@ -3337,6 +3425,10 @@ msgstr "من اشتراكاتك"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>When you browse without signing in,</0> we serve public writing from our read-model index. We may store a theme preference cookie and, if you have signed in before on this device, a short list of recently used account handles (and optional avatar URLs) to speed up sign-in. We do not require an account to read."
 msgstr "<0>عند التصفح دون تسجيل الدخول،</0> نعرض الكتابات العامة من فهرس نموذج القراءة لدينا. وقد نحفظ ملف تعريف ارتباط لتفضيل السمة، وإذا سبق أن سجّلت الدخول على هذا الجهاز، قائمة قصيرة بمعرّفات الحسابات المستخدمة مؤخرًا (وروابط الصور الرمزية اختياريًا) لتسريع تسجيل الدخول. لا نشترط وجود حساب للقراءة."
+
+#: src/components/ereader-settings.tsx
+msgid "Sync server"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Paper"
@@ -3720,6 +3812,10 @@ msgstr ""
 msgid "Subscribe to this list to read new articles from its publications."
 msgstr "اشترك في هذه القائمة لقراءة المقالات الجديدة من منشوراتها."
 
+#: src/components/ereader-settings.tsx
+msgid "In KOReader: Tools → Progress sync → Custom sync server."
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "{itemCount} of {MAX_ITEMS}"
 msgstr "{itemCount} من {MAX_ITEMS}"
@@ -3771,6 +3867,10 @@ msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter subscriptions"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Standard Reader publishes an <0>OPDS catalog</0> — the same thing a library or a bookstore hands an e-reading app. Point an app at it once and your shelves appear on the device: <1>Unread</1>, <2>Saved for later</2>, <3>Subscriptions</3>, each of your lists, and every publication you follow. Open any of them and each article has a download button."
 msgstr ""
 
 #: src/components/reader/mention-hover-card.tsx
@@ -3856,6 +3956,10 @@ msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "Signing in asks for permission to write only the kinds of records the app actually needs — follows, saves, recommendations, read records, and lists. It cannot post to Bluesky as you."
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "In KOReader, open <0>Tools → Progress sync</0> and choose <1>Custom sync server</1>."
 msgstr ""
 
 #: src/components/comic/comic-reader.tsx
@@ -4601,6 +4705,10 @@ msgstr "كن أول من يشارك خللًا أو فكرة أو سؤالًا."
 msgid "Browse the publication directory to find new writers."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your unread queue, your saved articles and every publication you subscribe to, on a Kobo, a Kindle, a reMarkable or a phone — as real EPUB files, with the images, ready to read on a plane."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "الأكثر قراءة عبر الشبكة الآن."
@@ -5183,6 +5291,10 @@ msgstr ""
 msgid "Most posts"
 msgstr "الأكثر نشرًا"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "You do not need a catalog for a single piece. Every article's share menu has <0>Download EPUB</0> — and <1>Download CBZ</1> on a comic. A publication's <2>…</2> menu has <3>Send to e-reader…</3>, which offers its recent articles as one book and shows the catalog URL for that publication on its own."
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>1. Identity & signing key.</0> Give it a DID (a <1>did:web</1> is simplest) whose DID document advertises an <2>#atproto_labeler</2> service endpoint and an <3>#atproto_label</3> public signing key."
 msgstr "<0>1. الهوية ومفتاح التوقيع.</0> امنحه DID (الأبسط هو <1>did:web</1>) بحيث يعلن مستند DID الخاص به عن نقطة نهاية خدمة <2>#atproto_labeler</2> ومفتاح توقيع عام <3>#atproto_label</3>."
@@ -5465,6 +5577,10 @@ msgstr "تتبّع سجل القراءة"
 #: src/components/reader/format-i18n.ts
 msgid "{readCount, plural, one {# read} other {{value} reads}}"
 msgstr "{readCount, plural, zero {لا قراءات} one {قراءة واحدة} two {قراءتان} few {# قراءات} many {# قراءةً} other {{value} قراءة}}"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "A few articles on the network are really link posts — a headline and a URL, bridged in from somewhere else, with no body to package. Those are left out of the catalog rather than offered as a file that would open to nothing. You will still find them in the app, where they link out to the site that has the writing."
+msgstr ""
 
 #: src/components/offline-sync-debug.tsx
 #: src/routes/_layout.collections.index.tsx
@@ -5896,6 +6012,10 @@ msgstr ""
 msgid "Collection"
 msgstr "مجموعة"
 
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Or add this catalog URL to KOReader, Foliate, Marvin or any other OPDS app, and browse {name} from the device itself."
+msgstr ""
+
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Most liked"
 msgstr ""
@@ -5951,6 +6071,10 @@ msgstr "يحفظ رابطًا في مجموعتك على <0>{appLabel}</0>."
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Drag to change the order your subscriptions appear in the sidebar."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Paste the sync server URL, then log in with your handle and the sync key. There is no separate account to register."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Appearance, reading preferences, and personal data."
@@ -6366,6 +6490,11 @@ msgstr "‏DID الخدمة هو <0>{appviewDid}</0>. تنشر الخدمة <1>�
 #: src/components/reader/about-view.tsx
 msgid "The Slow Web, Revisited"
 msgstr "الويب البطيء، إعادة نظر"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What you get"
+msgstr ""
 
 #. placeholder {0}: visible.length
 #: src/routes/_layout.communities.index.tsx
@@ -7067,6 +7196,10 @@ msgstr "إجراءات الحساب"
 msgid "Read article"
 msgstr "قراءة المقالة"
 
+#: src/components/ereader-settings.tsx
+msgid "Your shelves, as an OPDS catalog. Anyone with this URL can see the same public records your profile already shows."
+msgstr ""
+
 #. placeholder {0}: formatBytes(usage.usage)
 #: src/components/offline-settings.tsx
 msgid "Standard Reader is using {0} on this device."
@@ -7169,6 +7302,10 @@ msgstr ""
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "التفاصيل"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
+msgstr ""
 
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Topic views"
@@ -7465,6 +7602,10 @@ msgstr ""
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "{unreadCount} unread"
 msgstr "{unreadCount} غير مقروءة"
+
+#: src/components/ereader-settings.tsx
+msgid "Log in with this as your username — there is no separate sync account."
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "Below those, the publications you follow are listed for quick access. The <0>Subscriptions</0> heading above them opens the full management view. At the very bottom, your avatar opens a menu with your profile, reading history, recommended articles, feedback, settings, and log out."
@@ -7765,6 +7906,10 @@ msgstr "جارٍ تحميل المقال"
 msgid "Upvoted."
 msgstr "تم التصويت."
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Browse and download.</0> Your shelves are the top level. Tap an article to pull the EPUB onto the device."
+msgstr ""
+
 #: src/components/reader/list-edit-modal.tsx
 msgid "Search your subscriptions"
 msgstr "ابحث في اشتراكاتك"
@@ -7870,6 +8015,10 @@ msgstr ""
 msgid "Discussion here is gathered from posts across the network, so you comment wherever you already post."
 msgstr ""
 
+#: src/components/comic/comic-reader.tsx
+msgid "Download this issue (CBZ)"
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Subscribe all"
 msgstr "الاشتراك في الكل"
@@ -7895,6 +8044,11 @@ msgstr "<0>كتل مُهيكلة.</0> مستندات محرّر كتل غنية�
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Keeping your place"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"
@@ -7969,6 +8123,10 @@ msgstr "تصفية حسب الموضوع"
 
 #: src/components/reader/mute-menu-item.tsx
 msgid "Unmute {name}"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Copy your catalog URL.</0> It is in <1>Settings</1> under <2>E-readers</2>. It is yours — it carries your subscriptions and your saved articles."
 msgstr ""
 
 #. placeholder {0}: image.file.name
@@ -8176,6 +8334,10 @@ msgstr ""
 msgid "Standard Reader indexes <0>site.standard.document</0> and <1>site.standard.publication</1> records out of AT Proto repos. Platforms like Leaflet, Pckt, and Offprint write these records for you as part of publishing, so their authors get the full reader treatment automatically. If you run your own site and hand-roll your own <2>site.standard</2> integration instead, you write those records yourself — this page covers what to add, including Markpub, the markdown format we recommend for a hand-rolled body."
 msgstr "يفهرس Standard Reader سجلات <0>site.standard.document</0> و<1>site.standard.publication</1> من مستودعات AT Proto. تكتب منصات مثل Leaflet وPckt وOffprint هذه السجلات نيابةً عنك ضمن عملية النشر، فيحصل مؤلفوها على تجربة القارئ الكاملة تلقائيًا. أما إن كنت تدير موقعك بنفسك وتبني تكاملك مع <2>site.standard</2> يدويًا، فعليك كتابة تلك السجلات بنفسك — وتغطي هذه الصفحة ما يلزم إضافته، بما في ذلك Markpub، وهي صيغة markdown التي نوصي بها لمتن مكتوب يدويًا."
 
+#: src/components/ereader-settings.tsx
+msgid "Catalog URL"
+msgstr ""
+
 #: src/components/reader/add-to-list-modal.tsx
 #: src/components/reader/list-edit-modal.tsx
 msgid "e.g. Tech, Friends, Cooking"
@@ -8282,6 +8444,10 @@ msgstr "عند التفعيل، يُحتسب أرشيف المنشورة بال�
 #~ msgid "tuned to what you already follow."
 #~ msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your position also flows back here: read half of something on the Kobo and the article shows as half-read in the app, and in <0>Continue reading</0>. That direction is one-way. A position on a device is a place in <1>that device's</1> rendering of the file, and there is no honest way to turn a percentage back into one, so the app never sends a position out to a device that did not record it."
+msgstr ""
+
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this reply on Bluesky"
 msgstr "فتح هذا الرد على Bluesky"
@@ -8309,6 +8475,7 @@ msgstr ""
 
 #: src/components/reader/discover-topic-filters.tsx
 #: src/components/reader/rss-feed-button.tsx
+#: src/components/reader/send-to-ereader-dialog.tsx
 #: src/components/reader/share-menu.tsx
 msgid "Close"
 msgstr "إغلاق"
@@ -8553,6 +8720,10 @@ msgstr ""
 msgid "Cited by"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "KOReader can sync your reading position through Standard Reader, so picking up a book on a second device puts you where you stopped. Settings → <0>E-readers</0> has the three values it wants: the sync server URL, your username, and a sync key."
+msgstr ""
+
 #: src/routes/mcp/authorize.tsx
 msgid "Signed in as"
 msgstr ""
@@ -8606,4 +8777,8 @@ msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Describe this image"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
 msgstr ""

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -1907,8 +1907,8 @@ msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "Who can use your catalog URL"
-msgstr ""
+#~ msgid "Who can use your catalog URL"
+#~ msgstr ""
 
 #: src/components/reader/continue-reading.tsx
 #~ msgid "Reading progress"
@@ -7304,8 +7304,8 @@ msgid "Details"
 msgstr "التفاصيل"
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
-msgstr ""
+#~ msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
+#~ msgstr ""
 
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Topic views"

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -1907,8 +1907,8 @@ msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "Who can use your catalog URL"
-msgstr ""
+#~ msgid "Who can use your catalog URL"
+#~ msgstr ""
 
 #: src/components/reader/continue-reading.tsx
 #~ msgid "Reading progress"
@@ -7304,8 +7304,8 @@ msgid "Details"
 msgstr "Details"
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
-msgstr ""
+#~ msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
+#~ msgstr ""
 
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Topic views"

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -205,6 +205,10 @@ msgstr ""
 msgid "find publications, people, topics, and headlines by name."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Every device syncing with the old key stops until you enter the new one. Nothing you have already read is lost — reading positions are kept against the books themselves, not the key."
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Change language"
@@ -2066,6 +2070,10 @@ msgstr ""
 msgid "Subscribed to list"
 msgstr "Liste abonniert"
 
+#: src/components/ereader-settings.tsx
+msgid "Rotate your sync key?"
+msgstr ""
+
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "See which of the people you pass on Bluesky write long-form."
 msgstr ""
@@ -2171,6 +2179,10 @@ msgstr "Sammlung löschen"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Interface font"
+msgstr ""
+
+#: src/components/ereader-settings.tsx
+msgid "Rotate"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
@@ -5273,6 +5285,10 @@ msgstr ""
 msgid "Subscribe to list"
 msgstr "Liste abonnieren"
 
+#: src/components/ereader-settings.tsx
+msgid "Rotate key"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #: src/lib/guide/navigation.ts
 #~ msgid "Following a publication"
@@ -6513,6 +6529,10 @@ msgstr ""
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #~ msgid "Eight presets, or your own paper and accent. The rest of the interface is derived from them."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. Lost a device? <0>Rotate</0> in Settings issues a new key and stops the old one working."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 #: src/components/reading-custom-font-picker.tsx
@@ -8780,5 +8800,5 @@ msgid "Describe this image"
 msgstr ""
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
-msgstr ""
+#~ msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
+#~ msgstr ""

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -17,6 +17,10 @@ msgstr ""
 msgid "This is the difference between making one anthology and running something with a rhythm to it — a weekly roundup, a themed quarterly, a reading list you keep adding to."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Add your catalog to KOReader, Foliate, Marvin, Panels or any other OPDS app and your unread queue, saved articles, subscriptions and lists show up on the device — each one downloadable as an EPUB."
+msgstr ""
+
 #: src/routes/_layout.discover.tsx
 msgid "Every publication the network knows about — subscribe to the ones worth your mornings."
 msgstr "Jede Publikation, die das Netzwerk kennt – abonnieren Sie die, die Ihre Morgen wert sind."
@@ -287,6 +291,10 @@ msgstr ""
 msgid "Mark as read"
 msgstr "Als gelesen markieren"
 
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Send to your e-reader"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "This list is empty — add publications or people to it."
 msgstr "Diese Liste ist leer – fügen Sie Publikationen oder Personen hinzu."
@@ -347,6 +355,11 @@ msgstr "Bitte fügen Sie einen Titel hinzu."
 #: src/components/guide/pages/finding-guide-page.tsx
 #~ msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Follow it and it starts appearing in your feeds like any other."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/components/user-settings-view.tsx
+msgid "E-readers"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
@@ -530,8 +543,16 @@ msgstr ""
 msgid "We couldn’t find that issue."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Comics come down as <0>CBZ</0> as well, so comic apps get their page turns and their scrubber instead of a reflowable book that fights them."
+msgstr ""
+
 #: src/routes/_layout.friends.tsx
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
+msgstr ""
+
+#: src/components/ereader-settings.tsx
+msgid "Sync username"
 msgstr ""
 
 #: src/components/reader/format-i18n.ts
@@ -541,6 +562,10 @@ msgstr ""
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "List"
 msgstr "Liste"
+
+#: src/components/reader/publication-actions.tsx
+msgid "Send to e-reader…"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "The spacing between things — tighter for more on screen, looser for more room to read."
@@ -733,6 +758,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Sync key"
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Landscape fits a compact row. Height adjusts automatically once the embed loads. Change the iframe width as needed."
 msgstr "Das Querformat passt in eine kompakte Zeile. Die Höhe passt sich automatisch an, sobald das Embed geladen ist. Ändern Sie die iframe-Breite nach Bedarf."
@@ -867,6 +896,11 @@ msgstr ""
 msgid "Log in to follow publications"
 msgstr "Anmelden, um Publikationen zu folgen"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What will not be there"
+msgstr ""
+
 #: src/routes/_layout.discover.tsx
 msgid "Search publications"
 msgstr "Publikationen suchen"
@@ -946,6 +980,10 @@ msgstr "Anmeldung fehlgeschlagen. Bitte erneut versuchen."
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Loading publications"
 msgstr "Publikationen werden geladen"
+
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "OPDS catalog URL"
+msgstr ""
 
 #. placeholder {0}: meta.minutes
 #: src/magazine/flow.tsx
@@ -1218,6 +1256,11 @@ msgstr "Sammlungen ansehen"
 msgid "Name"
 msgstr "Name"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Setting it up"
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "Where data lives"
 msgstr "Wo die Daten liegen"
@@ -1305,6 +1348,10 @@ msgstr "In {savedName} auf {appLabel} gespeichert."
 #: src/lib/guide/navigation.ts
 msgid "Getting started"
 msgstr "Erste Schritte"
+
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Download {name} as a file — images and all, ready to read offline."
+msgstr ""
 
 #: src/components/onboarding/step-settings.tsx
 msgid "Open posts on their original site"
@@ -1423,6 +1470,10 @@ msgstr ""
 #~ msgid "You don't have any subscriptions to reorder yet."
 #~ msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "What the sync key can do"
+msgstr ""
+
 #: src/components/reader/notify-button.tsx
 #: src/components/user-settings-view.tsx
 msgid "This browser doesn’t support web notifications."
@@ -1444,6 +1495,10 @@ msgstr "Art des Feedbacks"
 #: src/components/guide/pages/welcome-guide-page.tsx
 #~ msgid "Home leads with one article worth your attention, then everything new from the publications you follow."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Downloading does not mark anything read, and reading on a device does not remove it from your unread shelf until KOReader syncs a position back. Polls, signup forms and other live embeds become links — a book cannot run them."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Enable the weekly digest"
@@ -1493,6 +1548,11 @@ msgstr "Allen folgen"
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "That's every issue published so far."
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Sending one article"
 msgstr ""
 
 #. placeholder {0}: view.clientName
@@ -1794,6 +1854,10 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Turn on <0>Sync every N pages</0> if you want it to happen without asking."
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
 #~ msgstr "Fügen Sie den Hinweis <0>site.standard.publication</0> nur hinzu, wenn das Dokument zu einer Publikation gehört. Fügen Sie beide hinzu, unabhängig davon, welcher Leser Sie interessiert – so löst jeder Client im Netzwerk Ihre Seite zu ihrem Record auf, nicht nur unsere Erweiterung."
@@ -1842,6 +1906,10 @@ msgstr ""
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Who can use your catalog URL"
+msgstr ""
+
 #: src/components/reader/continue-reading.tsx
 #~ msgid "Reading progress"
 #~ msgstr ""
@@ -1870,6 +1938,10 @@ msgstr ""
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "e.g. To Read"
 msgstr "z. B. Zu lesen"
+
+#: src/lib/guide/navigation.ts
+msgid "Reading on an e-reader"
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/OpenLinksMenuItem.tsx
@@ -1954,6 +2026,10 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Making the text comfortable"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The files are built when you ask for them, from the same article bodies the reader shows — images pulled in, footnotes as real endnotes, a link back to the original at the end of every piece. Nothing is trimmed to an excerpt. A whole publication, a list or a collection can also come down as one book, with a table of contents."
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -2237,6 +2313,10 @@ msgstr "Mehr von <0>{0}</0>"
 msgid "On this device"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Add it to your reading app.</0> In KOReader that is <1>Search → OPDS catalog → +</1>. Foliate, Marvin, Aldiko, Thorium, Panels and Chunky all have a similar “add catalog” screen. Paste the URL and leave the username and password blank."
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
 msgstr "Wir können diese Richtlinie ändern, wenn sich die Erweiterung ändert. Das Datum „Zuletzt aktualisiert“ oben ändert sich dann entsprechend. Wenn Sie die Erweiterung nach einer Änderung weiter nutzen, akzeptieren Sie die überarbeitete Richtlinie."
@@ -2253,6 +2333,10 @@ msgstr ""
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
+
+#: src/lib/guide/navigation.ts
+msgid "Put your unread queue on a Kobo, Kindle or phone as real EPUB files."
+msgstr ""
 
 #: src/components/reader/block-user-menu-item.tsx
 msgid "Block"
@@ -3147,6 +3231,10 @@ msgstr ""
 msgid "Plenty of people you already follow on Bluesky write long-form somewhere. <0>People you follow</0> finds them and puts their publications, and their newest articles, in one place. It is usually the highest-yield screen in the app the first week you use it."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Use this as the password. It only carries your reading position between devices — it cannot read or change anything else."
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "Second, it brings you <0>what they recommend</0>. Articles they have recommended start appearing in your feed, marked with who recommended them. That is the quiet engine behind finding new writing here: you are not only subscribing to what someone writes, you are borrowing their taste in what to read."
 msgstr ""
@@ -3337,6 +3425,10 @@ msgstr "Aus Ihren Abos"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>When you browse without signing in,</0> we serve public writing from our read-model index. We may store a theme preference cookie and, if you have signed in before on this device, a short list of recently used account handles (and optional avatar URLs) to speed up sign-in. We do not require an account to read."
 msgstr "<0>Wenn Sie ohne Anmeldung stöbern,</0> liefern wir öffentliche Texte aus unserem Lesemodell-Index aus. Wir speichern eventuell ein Cookie mit Ihrer Theme-Einstellung und, falls Sie sich auf diesem Gerät schon einmal angemeldet haben, eine kurze Liste zuletzt genutzter Konto-Handles (und optionaler Avatar-URLs), um die Anmeldung zu beschleunigen. Zum Lesen ist kein Konto nötig."
+
+#: src/components/ereader-settings.tsx
+msgid "Sync server"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Paper"
@@ -3720,6 +3812,10 @@ msgstr ""
 msgid "Subscribe to this list to read new articles from its publications."
 msgstr "Abonnieren Sie diese Liste, um neue Artikel ihrer Publikationen zu lesen."
 
+#: src/components/ereader-settings.tsx
+msgid "In KOReader: Tools → Progress sync → Custom sync server."
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "{itemCount} of {MAX_ITEMS}"
 msgstr "{itemCount} von {MAX_ITEMS}"
@@ -3771,6 +3867,10 @@ msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter subscriptions"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Standard Reader publishes an <0>OPDS catalog</0> — the same thing a library or a bookstore hands an e-reading app. Point an app at it once and your shelves appear on the device: <1>Unread</1>, <2>Saved for later</2>, <3>Subscriptions</3>, each of your lists, and every publication you follow. Open any of them and each article has a download button."
 msgstr ""
 
 #: src/components/reader/mention-hover-card.tsx
@@ -3856,6 +3956,10 @@ msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "Signing in asks for permission to write only the kinds of records the app actually needs — follows, saves, recommendations, read records, and lists. It cannot post to Bluesky as you."
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "In KOReader, open <0>Tools → Progress sync</0> and choose <1>Custom sync server</1>."
 msgstr ""
 
 #: src/components/comic/comic-reader.tsx
@@ -4601,6 +4705,10 @@ msgstr "Teilen Sie als Erste(r) einen Fehler, eine Idee oder eine Frage."
 msgid "Browse the publication directory to find new writers."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your unread queue, your saved articles and every publication you subscribe to, on a Kobo, a Kindle, a reMarkable or a phone — as real EPUB files, with the images, ready to read on a plane."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "Die meistgelesenen Texte im Netzwerk gerade jetzt."
@@ -5183,6 +5291,10 @@ msgstr ""
 msgid "Most posts"
 msgstr "Meiste Beiträge"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "You do not need a catalog for a single piece. Every article's share menu has <0>Download EPUB</0> — and <1>Download CBZ</1> on a comic. A publication's <2>…</2> menu has <3>Send to e-reader…</3>, which offers its recent articles as one book and shows the catalog URL for that publication on its own."
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>1. Identity & signing key.</0> Give it a DID (a <1>did:web</1> is simplest) whose DID document advertises an <2>#atproto_labeler</2> service endpoint and an <3>#atproto_label</3> public signing key."
 msgstr "<0>1. Identität & Signaturschlüssel.</0> Geben Sie ihm eine DID (am einfachsten ist eine <1>did:web</1>), deren DID-Dokument einen <2>#atproto_labeler</2>-Dienstendpunkt und einen öffentlichen <3>#atproto_label</3>-Signaturschlüssel angibt."
@@ -5465,6 +5577,10 @@ msgstr "Leseverlauf speichern"
 #: src/components/reader/format-i18n.ts
 msgid "{readCount, plural, one {# read} other {{value} reads}}"
 msgstr "{readCount, plural, one {# gelesen} other {{value} gelesen}}"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "A few articles on the network are really link posts — a headline and a URL, bridged in from somewhere else, with no body to package. Those are left out of the catalog rather than offered as a file that would open to nothing. You will still find them in the app, where they link out to the site that has the writing."
+msgstr ""
 
 #: src/components/offline-sync-debug.tsx
 #: src/routes/_layout.collections.index.tsx
@@ -5896,6 +6012,10 @@ msgstr ""
 msgid "Collection"
 msgstr "Sammlung"
 
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Or add this catalog URL to KOReader, Foliate, Marvin or any other OPDS app, and browse {name} from the device itself."
+msgstr ""
+
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Most liked"
 msgstr ""
@@ -5951,6 +6071,10 @@ msgstr "Speichert einen Link in Ihrer <0>{appLabel}</0>-Sammlung."
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Drag to change the order your subscriptions appear in the sidebar."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Paste the sync server URL, then log in with your handle and the sync key. There is no separate account to register."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Appearance, reading preferences, and personal data."
@@ -6366,6 +6490,11 @@ msgstr "Die Dienst-DID lautet <0>{appviewDid}</0>. Der Dienst stellt ein <1>DID-
 #: src/components/reader/about-view.tsx
 msgid "The Slow Web, Revisited"
 msgstr "Das langsame Web, neu betrachtet"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What you get"
+msgstr ""
 
 #. placeholder {0}: visible.length
 #: src/routes/_layout.communities.index.tsx
@@ -7067,6 +7196,10 @@ msgstr "Kontoaktionen"
 msgid "Read article"
 msgstr "Artikel lesen"
 
+#: src/components/ereader-settings.tsx
+msgid "Your shelves, as an OPDS catalog. Anyone with this URL can see the same public records your profile already shows."
+msgstr ""
+
 #. placeholder {0}: formatBytes(usage.usage)
 #: src/components/offline-settings.tsx
 msgid "Standard Reader is using {0} on this device."
@@ -7169,6 +7302,10 @@ msgstr ""
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "Details"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
+msgstr ""
 
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Topic views"
@@ -7465,6 +7602,10 @@ msgstr ""
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "{unreadCount} unread"
 msgstr "{unreadCount} ungelesen"
+
+#: src/components/ereader-settings.tsx
+msgid "Log in with this as your username — there is no separate sync account."
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "Below those, the publications you follow are listed for quick access. The <0>Subscriptions</0> heading above them opens the full management view. At the very bottom, your avatar opens a menu with your profile, reading history, recommended articles, feedback, settings, and log out."
@@ -7765,6 +7906,10 @@ msgstr "Artikel wird geladen"
 msgid "Upvoted."
 msgstr "Hochgestimmt."
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Browse and download.</0> Your shelves are the top level. Tap an article to pull the EPUB onto the device."
+msgstr ""
+
 #: src/components/reader/list-edit-modal.tsx
 msgid "Search your subscriptions"
 msgstr "Ihre Abos durchsuchen"
@@ -7870,6 +8015,10 @@ msgstr ""
 msgid "Discussion here is gathered from posts across the network, so you comment wherever you already post."
 msgstr ""
 
+#: src/components/comic/comic-reader.tsx
+msgid "Download this issue (CBZ)"
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Subscribe all"
 msgstr "Alle abonnieren"
@@ -7895,6 +8044,11 @@ msgstr "<0>Strukturierte Blöcke.</0> Dokumente aus Block-Editoren, jeweils im S
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Keeping your place"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"
@@ -7969,6 +8123,10 @@ msgstr "Nach Thema filtern"
 
 #: src/components/reader/mute-menu-item.tsx
 msgid "Unmute {name}"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Copy your catalog URL.</0> It is in <1>Settings</1> under <2>E-readers</2>. It is yours — it carries your subscriptions and your saved articles."
 msgstr ""
 
 #. placeholder {0}: image.file.name
@@ -8176,6 +8334,10 @@ msgstr ""
 msgid "Standard Reader indexes <0>site.standard.document</0> and <1>site.standard.publication</1> records out of AT Proto repos. Platforms like Leaflet, Pckt, and Offprint write these records for you as part of publishing, so their authors get the full reader treatment automatically. If you run your own site and hand-roll your own <2>site.standard</2> integration instead, you write those records yourself — this page covers what to add, including Markpub, the markdown format we recommend for a hand-rolled body."
 msgstr "Standard Reader indexiert <0>site.standard.document</0>- und <1>site.standard.publication</1>-Records aus AT-Proto-Repos. Plattformen wie Leaflet, Pckt und Offprint schreiben diese Records beim Veröffentlichen für Sie, sodass deren Autoren automatisch die volle Reader-Darstellung erhalten. Wenn Sie eine eigene Website betreiben und Ihre <2>site.standard</2>-Anbindung selbst bauen, schreiben Sie die Records selbst — diese Seite zeigt, was dazugehört, inklusive Markpub, dem Markdown-Format, das wir für selbst gebaute Inhalte empfehlen."
 
+#: src/components/ereader-settings.tsx
+msgid "Catalog URL"
+msgstr ""
+
 #: src/components/reader/add-to-list-modal.tsx
 #: src/components/reader/list-edit-modal.tsx
 msgid "e.g. Tech, Friends, Cooking"
@@ -8282,6 +8444,10 @@ msgstr "Wenn aktiv, gilt beim Abonnieren der gesamte Backkatalog einer Publikati
 #~ msgid "tuned to what you already follow."
 #~ msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your position also flows back here: read half of something on the Kobo and the article shows as half-read in the app, and in <0>Continue reading</0>. That direction is one-way. A position on a device is a place in <1>that device's</1> rendering of the file, and there is no honest way to turn a percentage back into one, so the app never sends a position out to a device that did not record it."
+msgstr ""
+
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this reply on Bluesky"
 msgstr "Diese Antwort auf Bluesky öffnen"
@@ -8309,6 +8475,7 @@ msgstr ""
 
 #: src/components/reader/discover-topic-filters.tsx
 #: src/components/reader/rss-feed-button.tsx
+#: src/components/reader/send-to-ereader-dialog.tsx
 #: src/components/reader/share-menu.tsx
 msgid "Close"
 msgstr "Schließen"
@@ -8553,6 +8720,10 @@ msgstr ""
 msgid "Cited by"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "KOReader can sync your reading position through Standard Reader, so picking up a book on a second device puts you where you stopped. Settings → <0>E-readers</0> has the three values it wants: the sync server URL, your username, and a sync key."
+msgstr ""
+
 #: src/routes/mcp/authorize.tsx
 msgid "Signed in as"
 msgstr ""
@@ -8606,4 +8777,8 @@ msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Describe this image"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
 msgstr ""

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -205,6 +205,10 @@ msgstr ""
 msgid "find publications, people, topics, and headlines by name."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Every device syncing with the old key stops until you enter the new one. Nothing you have already read is lost — reading positions are kept against the books themselves, not the key."
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Change language"
@@ -2066,6 +2070,10 @@ msgstr ""
 msgid "Subscribed to list"
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Rotate your sync key?"
+msgstr ""
+
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "See which of the people you pass on Bluesky write long-form."
 msgstr ""
@@ -2171,6 +2179,10 @@ msgstr ""
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Interface font"
+msgstr ""
+
+#: src/components/ereader-settings.tsx
+msgid "Rotate"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
@@ -5273,6 +5285,10 @@ msgstr ""
 msgid "Subscribe to list"
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Rotate key"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #: src/lib/guide/navigation.ts
 #~ msgid "Following a publication"
@@ -6513,6 +6529,10 @@ msgstr ""
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #~ msgid "Eight presets, or your own paper and accent. The rest of the interface is derived from them."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. Lost a device? <0>Rotate</0> in Settings issues a new key and stops the old one working."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 #: src/components/reading-custom-font-picker.tsx
@@ -8780,5 +8800,5 @@ msgid "Describe this image"
 msgstr ""
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
-msgstr ""
+#~ msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
+#~ msgstr ""

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -1907,8 +1907,8 @@ msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "Who can use your catalog URL"
-msgstr ""
+#~ msgid "Who can use your catalog URL"
+#~ msgstr ""
 
 #: src/components/reader/continue-reading.tsx
 #~ msgid "Reading progress"
@@ -7304,8 +7304,8 @@ msgid "Details"
 msgstr ""
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
-msgstr ""
+#~ msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
+#~ msgstr ""
 
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Topic views"

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -17,6 +17,10 @@ msgstr ""
 msgid "This is the difference between making one anthology and running something with a rhythm to it — a weekly roundup, a themed quarterly, a reading list you keep adding to."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Add your catalog to KOReader, Foliate, Marvin, Panels or any other OPDS app and your unread queue, saved articles, subscriptions and lists show up on the device — each one downloadable as an EPUB."
+msgstr ""
+
 #: src/routes/_layout.discover.tsx
 msgid "Every publication the network knows about — subscribe to the ones worth your mornings."
 msgstr ""
@@ -287,6 +291,10 @@ msgstr ""
 msgid "Mark as read"
 msgstr ""
 
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Send to your e-reader"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "This list is empty — add publications or people to it."
 msgstr ""
@@ -347,6 +355,11 @@ msgstr ""
 #: src/components/guide/pages/finding-guide-page.tsx
 #~ msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Follow it and it starts appearing in your feeds like any other."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/components/user-settings-view.tsx
+msgid "E-readers"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
@@ -530,8 +543,16 @@ msgstr ""
 msgid "We couldn’t find that issue."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Comics come down as <0>CBZ</0> as well, so comic apps get their page turns and their scrubber instead of a reflowable book that fights them."
+msgstr ""
+
 #: src/routes/_layout.friends.tsx
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
+msgstr ""
+
+#: src/components/ereader-settings.tsx
+msgid "Sync username"
 msgstr ""
 
 #: src/components/reader/format-i18n.ts
@@ -540,6 +561,10 @@ msgstr ""
 
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "List"
+msgstr ""
+
+#: src/components/reader/publication-actions.tsx
+msgid "Send to e-reader…"
 msgstr ""
 
 #: src/components/appearance-settings.tsx
@@ -733,6 +758,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Sync key"
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Landscape fits a compact row. Height adjusts automatically once the embed loads. Change the iframe width as needed."
 msgstr ""
@@ -867,6 +896,11 @@ msgstr ""
 msgid "Log in to follow publications"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What will not be there"
+msgstr ""
+
 #: src/routes/_layout.discover.tsx
 msgid "Search publications"
 msgstr ""
@@ -945,6 +979,10 @@ msgstr ""
 #: src/routes/_layout.tag.$tag.tsx
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Loading publications"
+msgstr ""
+
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "OPDS catalog URL"
 msgstr ""
 
 #. placeholder {0}: meta.minutes
@@ -1218,6 +1256,11 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Setting it up"
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "Where data lives"
 msgstr ""
@@ -1304,6 +1347,10 @@ msgstr ""
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Getting started"
+msgstr ""
+
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Download {name} as a file — images and all, ready to read offline."
 msgstr ""
 
 #: src/components/onboarding/step-settings.tsx
@@ -1423,6 +1470,10 @@ msgstr ""
 #~ msgid "You don't have any subscriptions to reorder yet."
 #~ msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "What the sync key can do"
+msgstr ""
+
 #: src/components/reader/notify-button.tsx
 #: src/components/user-settings-view.tsx
 msgid "This browser doesn’t support web notifications."
@@ -1444,6 +1495,10 @@ msgstr ""
 #: src/components/guide/pages/welcome-guide-page.tsx
 #~ msgid "Home leads with one article worth your attention, then everything new from the publications you follow."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Downloading does not mark anything read, and reading on a device does not remove it from your unread shelf until KOReader syncs a position back. Polls, signup forms and other live embeds become links — a book cannot run them."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Enable the weekly digest"
@@ -1493,6 +1548,11 @@ msgstr ""
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "That's every issue published so far."
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Sending one article"
 msgstr ""
 
 #. placeholder {0}: view.clientName
@@ -1794,6 +1854,10 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Turn on <0>Sync every N pages</0> if you want it to happen without asking."
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
 #~ msgstr ""
@@ -1842,6 +1906,10 @@ msgstr ""
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Who can use your catalog URL"
+msgstr ""
+
 #: src/components/reader/continue-reading.tsx
 #~ msgid "Reading progress"
 #~ msgstr ""
@@ -1869,6 +1937,10 @@ msgstr ""
 
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "e.g. To Read"
+msgstr ""
+
+#: src/lib/guide/navigation.ts
+msgid "Reading on an e-reader"
 msgstr ""
 
 #: src/components/labeler-detail-view.tsx
@@ -1954,6 +2026,10 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Making the text comfortable"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The files are built when you ask for them, from the same article bodies the reader shows — images pulled in, footnotes as real endnotes, a link back to the original at the end of every piece. Nothing is trimmed to an excerpt. A whole publication, a list or a collection can also come down as one book, with a table of contents."
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -2237,6 +2313,10 @@ msgstr ""
 msgid "On this device"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Add it to your reading app.</0> In KOReader that is <1>Search → OPDS catalog → +</1>. Foliate, Marvin, Aldiko, Thorium, Panels and Chunky all have a similar “add catalog” screen. Paste the URL and leave the username and password blank."
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
 msgstr ""
@@ -2253,6 +2333,10 @@ msgstr ""
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
+
+#: src/lib/guide/navigation.ts
+msgid "Put your unread queue on a Kobo, Kindle or phone as real EPUB files."
+msgstr ""
 
 #: src/components/reader/block-user-menu-item.tsx
 msgid "Block"
@@ -3147,6 +3231,10 @@ msgstr ""
 msgid "Plenty of people you already follow on Bluesky write long-form somewhere. <0>People you follow</0> finds them and puts their publications, and their newest articles, in one place. It is usually the highest-yield screen in the app the first week you use it."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Use this as the password. It only carries your reading position between devices — it cannot read or change anything else."
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "Second, it brings you <0>what they recommend</0>. Articles they have recommended start appearing in your feed, marked with who recommended them. That is the quiet engine behind finding new writing here: you are not only subscribing to what someone writes, you are borrowing their taste in what to read."
 msgstr ""
@@ -3336,6 +3424,10 @@ msgstr ""
 
 #: src/components/reader/privacy-view.tsx
 msgid "<0>When you browse without signing in,</0> we serve public writing from our read-model index. We may store a theme preference cookie and, if you have signed in before on this device, a short list of recently used account handles (and optional avatar URLs) to speed up sign-in. We do not require an account to read."
+msgstr ""
+
+#: src/components/ereader-settings.tsx
+msgid "Sync server"
 msgstr ""
 
 #: src/components/appearance-settings.tsx
@@ -3720,6 +3812,10 @@ msgstr ""
 msgid "Subscribe to this list to read new articles from its publications."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "In KOReader: Tools → Progress sync → Custom sync server."
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "{itemCount} of {MAX_ITEMS}"
 msgstr ""
@@ -3771,6 +3867,10 @@ msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter subscriptions"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Standard Reader publishes an <0>OPDS catalog</0> — the same thing a library or a bookstore hands an e-reading app. Point an app at it once and your shelves appear on the device: <1>Unread</1>, <2>Saved for later</2>, <3>Subscriptions</3>, each of your lists, and every publication you follow. Open any of them and each article has a download button."
 msgstr ""
 
 #: src/components/reader/mention-hover-card.tsx
@@ -3856,6 +3956,10 @@ msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "Signing in asks for permission to write only the kinds of records the app actually needs — follows, saves, recommendations, read records, and lists. It cannot post to Bluesky as you."
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "In KOReader, open <0>Tools → Progress sync</0> and choose <1>Custom sync server</1>."
 msgstr ""
 
 #: src/components/comic/comic-reader.tsx
@@ -4601,6 +4705,10 @@ msgstr ""
 msgid "Browse the publication directory to find new writers."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your unread queue, your saved articles and every publication you subscribe to, on a Kobo, a Kindle, a reMarkable or a phone — as real EPUB files, with the images, ready to read on a plane."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr ""
@@ -5183,6 +5291,10 @@ msgstr ""
 msgid "Most posts"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "You do not need a catalog for a single piece. Every article's share menu has <0>Download EPUB</0> — and <1>Download CBZ</1> on a comic. A publication's <2>…</2> menu has <3>Send to e-reader…</3>, which offers its recent articles as one book and shows the catalog URL for that publication on its own."
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>1. Identity & signing key.</0> Give it a DID (a <1>did:web</1> is simplest) whose DID document advertises an <2>#atproto_labeler</2> service endpoint and an <3>#atproto_label</3> public signing key."
 msgstr ""
@@ -5464,6 +5576,10 @@ msgstr ""
 
 #: src/components/reader/format-i18n.ts
 msgid "{readCount, plural, one {# read} other {{value} reads}}"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "A few articles on the network are really link posts — a headline and a URL, bridged in from somewhere else, with no body to package. Those are left out of the catalog rather than offered as a file that would open to nothing. You will still find them in the app, where they link out to the site that has the writing."
 msgstr ""
 
 #: src/components/offline-sync-debug.tsx
@@ -5896,6 +6012,10 @@ msgstr ""
 msgid "Collection"
 msgstr ""
 
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Or add this catalog URL to KOReader, Foliate, Marvin or any other OPDS app, and browse {name} from the device itself."
+msgstr ""
+
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Most liked"
 msgstr ""
@@ -5951,6 +6071,10 @@ msgstr ""
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Drag to change the order your subscriptions appear in the sidebar."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Paste the sync server URL, then log in with your handle and the sync key. There is no separate account to register."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Appearance, reading preferences, and personal data."
@@ -6365,6 +6489,11 @@ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "The Slow Web, Revisited"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What you get"
 msgstr ""
 
 #. placeholder {0}: visible.length
@@ -7067,6 +7196,10 @@ msgstr ""
 msgid "Read article"
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Your shelves, as an OPDS catalog. Anyone with this URL can see the same public records your profile already shows."
+msgstr ""
+
 #. placeholder {0}: formatBytes(usage.usage)
 #: src/components/offline-settings.tsx
 msgid "Standard Reader is using {0} on this device."
@@ -7168,6 +7301,10 @@ msgstr ""
 
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
 msgstr ""
 
 #: src/routes/_layout.topics.$slug.tsx
@@ -7464,6 +7601,10 @@ msgstr ""
 
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "{unreadCount} unread"
+msgstr ""
+
+#: src/components/ereader-settings.tsx
+msgid "Log in with this as your username — there is no separate sync account."
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -7765,6 +7906,10 @@ msgstr ""
 msgid "Upvoted."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Browse and download.</0> Your shelves are the top level. Tap an article to pull the EPUB onto the device."
+msgstr ""
+
 #: src/components/reader/list-edit-modal.tsx
 msgid "Search your subscriptions"
 msgstr ""
@@ -7870,6 +8015,10 @@ msgstr ""
 msgid "Discussion here is gathered from posts across the network, so you comment wherever you already post."
 msgstr ""
 
+#: src/components/comic/comic-reader.tsx
+msgid "Download this issue (CBZ)"
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Subscribe all"
 msgstr ""
@@ -7895,6 +8044,11 @@ msgstr ""
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Keeping your place"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"
@@ -7969,6 +8123,10 @@ msgstr ""
 
 #: src/components/reader/mute-menu-item.tsx
 msgid "Unmute {name}"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Copy your catalog URL.</0> It is in <1>Settings</1> under <2>E-readers</2>. It is yours — it carries your subscriptions and your saved articles."
 msgstr ""
 
 #. placeholder {0}: image.file.name
@@ -8176,6 +8334,10 @@ msgstr ""
 msgid "Standard Reader indexes <0>site.standard.document</0> and <1>site.standard.publication</1> records out of AT Proto repos. Platforms like Leaflet, Pckt, and Offprint write these records for you as part of publishing, so their authors get the full reader treatment automatically. If you run your own site and hand-roll your own <2>site.standard</2> integration instead, you write those records yourself — this page covers what to add, including Markpub, the markdown format we recommend for a hand-rolled body."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Catalog URL"
+msgstr ""
+
 #: src/components/reader/add-to-list-modal.tsx
 #: src/components/reader/list-edit-modal.tsx
 msgid "e.g. Tech, Friends, Cooking"
@@ -8282,6 +8444,10 @@ msgstr ""
 #~ msgid "tuned to what you already follow."
 #~ msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your position also flows back here: read half of something on the Kobo and the article shows as half-read in the app, and in <0>Continue reading</0>. That direction is one-way. A position on a device is a place in <1>that device's</1> rendering of the file, and there is no honest way to turn a percentage back into one, so the app never sends a position out to a device that did not record it."
+msgstr ""
+
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this reply on Bluesky"
 msgstr ""
@@ -8309,6 +8475,7 @@ msgstr ""
 
 #: src/components/reader/discover-topic-filters.tsx
 #: src/components/reader/rss-feed-button.tsx
+#: src/components/reader/send-to-ereader-dialog.tsx
 #: src/components/reader/share-menu.tsx
 msgid "Close"
 msgstr ""
@@ -8553,6 +8720,10 @@ msgstr ""
 msgid "Cited by"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "KOReader can sync your reading position through Standard Reader, so picking up a book on a second device puts you where you stopped. Settings → <0>E-readers</0> has the three values it wants: the sync server URL, your username, and a sync key."
+msgstr ""
+
 #: src/routes/mcp/authorize.tsx
 msgid "Signed in as"
 msgstr ""
@@ -8606,4 +8777,8 @@ msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Describe this image"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
 msgstr ""

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -205,6 +205,10 @@ msgstr "Topic areas the network's writing clusters into, rebuilt as it grows. Ea
 msgid "find publications, people, topics, and headlines by name."
 msgstr "find publications, people, topics, and headlines by name."
 
+#: src/components/ereader-settings.tsx
+msgid "Every device syncing with the old key stops until you enter the new one. Nothing you have already read is lost — reading positions are kept against the books themselves, not the key."
+msgstr "Every device syncing with the old key stops until you enter the new one. Nothing you have already read is lost — reading positions are kept against the books themselves, not the key."
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Change language"
@@ -2066,6 +2070,10 @@ msgstr "Soft"
 msgid "Subscribed to list"
 msgstr "Subscribed to list"
 
+#: src/components/ereader-settings.tsx
+msgid "Rotate your sync key?"
+msgstr "Rotate your sync key?"
+
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "See which of the people you pass on Bluesky write long-form."
 msgstr "See which of the people you pass on Bluesky write long-form."
@@ -2172,6 +2180,10 @@ msgstr "Delete collection"
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Interface font"
 msgstr "Interface font"
+
+#: src/components/ereader-settings.tsx
+msgid "Rotate"
+msgstr "Rotate"
 
 #: src/components/blocks-settings-view.tsx
 msgid "We're re-reading your blocks from your account. This page updates when it finishes."
@@ -5273,6 +5285,10 @@ msgstr "Your five most recently saved-for-later articles."
 msgid "Subscribe to list"
 msgstr "Subscribe to list"
 
+#: src/components/ereader-settings.tsx
+msgid "Rotate key"
+msgstr "Rotate key"
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #: src/lib/guide/navigation.ts
 #~ msgid "Following a publication"
@@ -6513,6 +6529,10 @@ msgstr "Nothing in your queue matches the current search and filters. Try removi
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #~ msgid "Eight presets, or your own paper and accent. The rest of the interface is derived from them."
 #~ msgstr "Eight presets, or your own paper and accent. The rest of the interface is derived from them."
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. Lost a device? <0>Rotate</0> in Settings issues a new key and stops the old one working."
+msgstr "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. Lost a device? <0>Rotate</0> in Settings issues a new key and stops the old one working."
 
 #: src/components/appearance-settings.tsx
 #: src/components/reading-custom-font-picker.tsx
@@ -8780,5 +8800,5 @@ msgid "Describe this image"
 msgstr "Describe this image"
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
-msgstr "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
+#~ msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
+#~ msgstr "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -1907,8 +1907,8 @@ msgid "No topics match “{debouncedQuery}”."
 msgstr "No topics match “{debouncedQuery}”."
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "Who can use your catalog URL"
-msgstr "Who can use your catalog URL"
+#~ msgid "Who can use your catalog URL"
+#~ msgstr "Who can use your catalog URL"
 
 #: src/components/reader/continue-reading.tsx
 #~ msgid "Reading progress"
@@ -7304,8 +7304,8 @@ msgid "Details"
 msgstr "Details"
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
-msgstr "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
+#~ msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
+#~ msgstr "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
 
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Topic views"

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -17,6 +17,10 @@ msgstr ""
 msgid "This is the difference between making one anthology and running something with a rhythm to it — a weekly roundup, a themed quarterly, a reading list you keep adding to."
 msgstr "This is the difference between making one anthology and running something with a rhythm to it — a weekly roundup, a themed quarterly, a reading list you keep adding to."
 
+#: src/components/ereader-settings.tsx
+msgid "Add your catalog to KOReader, Foliate, Marvin, Panels or any other OPDS app and your unread queue, saved articles, subscriptions and lists show up on the device — each one downloadable as an EPUB."
+msgstr "Add your catalog to KOReader, Foliate, Marvin, Panels or any other OPDS app and your unread queue, saved articles, subscriptions and lists show up on the device — each one downloadable as an EPUB."
+
 #: src/routes/_layout.discover.tsx
 msgid "Every publication the network knows about — subscribe to the ones worth your mornings."
 msgstr "Every publication the network knows about — subscribe to the ones worth your mornings."
@@ -287,6 +291,10 @@ msgstr "Nothing in the format has a field for “issue 3” — the only place t
 msgid "Mark as read"
 msgstr "Mark as read"
 
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Send to your e-reader"
+msgstr "Send to your e-reader"
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "This list is empty — add publications or people to it."
 msgstr "This list is empty — add publications or people to it."
@@ -347,6 +355,11 @@ msgstr "Please add a title."
 #: src/components/guide/pages/finding-guide-page.tsx
 #~ msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Follow it and it starts appearing in your feeds like any other."
 #~ msgstr "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Follow it and it starts appearing in your feeds like any other."
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/components/user-settings-view.tsx
+msgid "E-readers"
+msgstr "E-readers"
 
 #: src/components/reader/about-view.tsx
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
@@ -530,9 +543,17 @@ msgstr "Every piece is a door to the next one"
 msgid "We couldn’t find that issue."
 msgstr "We couldn’t find that issue."
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Comics come down as <0>CBZ</0> as well, so comic apps get their page turns and their scrubber instead of a reflowable book that fights them."
+msgstr "Comics come down as <0>CBZ</0> as well, so comic apps get their page turns and their scrubber instead of a reflowable book that fights them."
+
 #: src/routes/_layout.friends.tsx
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 msgstr "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
+
+#: src/components/ereader-settings.tsx
+msgid "Sync username"
+msgstr "Sync username"
 
 #: src/components/reader/format-i18n.ts
 msgid "{years}y ago"
@@ -541,6 +562,10 @@ msgstr "{years}y ago"
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "List"
 msgstr "List"
+
+#: src/components/reader/publication-actions.tsx
+msgid "Send to e-reader…"
+msgstr "Send to e-reader…"
 
 #: src/components/appearance-settings.tsx
 msgid "The spacing between things — tighter for more on screen, looser for more room to read."
@@ -733,6 +758,10 @@ msgstr "Order: {0}"
 msgid "Partial"
 msgstr "Partial"
 
+#: src/components/ereader-settings.tsx
+msgid "Sync key"
+msgstr "Sync key"
+
 #: src/components/reader/share-menu.tsx
 msgid "Landscape fits a compact row. Height adjusts automatically once the embed loads. Change the iframe width as needed."
 msgstr "Landscape fits a compact row. Height adjusts automatically once the embed loads. Change the iframe width as needed."
@@ -867,6 +896,11 @@ msgstr "publish AT Protocol labels Standard Reader shows — and can warn on or 
 msgid "Log in to follow publications"
 msgstr "Log in to follow publications"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What will not be there"
+msgstr "What will not be there"
+
 #: src/routes/_layout.discover.tsx
 msgid "Search publications"
 msgstr "Search publications"
@@ -946,6 +980,10 @@ msgstr "Sign-in failed. Try again."
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Loading publications"
 msgstr "Loading publications"
+
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "OPDS catalog URL"
+msgstr "OPDS catalog URL"
 
 #. placeholder {0}: meta.minutes
 #: src/magazine/flow.tsx
@@ -1218,6 +1256,11 @@ msgstr "See collections"
 msgid "Name"
 msgstr "Name"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Setting it up"
+msgstr "Setting it up"
+
 #: src/components/reader/privacy-view.tsx
 msgid "Where data lives"
 msgstr "Where data lives"
@@ -1305,6 +1348,10 @@ msgstr "Saved to {savedName} on {appLabel}."
 #: src/lib/guide/navigation.ts
 msgid "Getting started"
 msgstr "Getting started"
+
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Download {name} as a file — images and all, ready to read offline."
+msgstr "Download {name} as a file — images and all, ready to read offline."
 
 #: src/components/onboarding/step-settings.tsx
 msgid "Open posts on their original site"
@@ -1423,6 +1470,10 @@ msgstr "Browse the directory"
 #~ msgid "You don't have any subscriptions to reorder yet."
 #~ msgstr "You don't have any subscriptions to reorder yet."
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "What the sync key can do"
+msgstr "What the sync key can do"
+
 #: src/components/reader/notify-button.tsx
 #: src/components/user-settings-view.tsx
 msgid "This browser doesn’t support web notifications."
@@ -1444,6 +1495,10 @@ msgstr "Feedback type"
 #: src/components/guide/pages/welcome-guide-page.tsx
 #~ msgid "Home leads with one article worth your attention, then everything new from the publications you follow."
 #~ msgstr "Home leads with one article worth your attention, then everything new from the publications you follow."
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Downloading does not mark anything read, and reading on a device does not remove it from your unread shelf until KOReader syncs a position back. Polls, signup forms and other live embeds become links — a book cannot run them."
+msgstr "Downloading does not mark anything read, and reading on a device does not remove it from your unread shelf until KOReader syncs a position back. Polls, signup forms and other live embeds become links — a book cannot run them."
 
 #: src/components/user-settings-view.tsx
 msgid "Enable the weekly digest"
@@ -1494,6 +1549,11 @@ msgstr "Follow all"
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "That's every issue published so far."
 msgstr "That's every issue published so far."
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Sending one article"
+msgstr "Sending one article"
 
 #. placeholder {0}: view.clientName
 #. placeholder {1}: view.reader.handle
@@ -1794,6 +1854,10 @@ msgstr "If you already know what you want, <0>Discover</0> lists everything on t
 msgid "Images"
 msgstr "Images"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Turn on <0>Sync every N pages</0> if you want it to happen without asking."
+msgstr "Turn on <0>Sync every N pages</0> if you want it to happen without asking."
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
 #~ msgstr "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
@@ -1842,6 +1906,10 @@ msgstr "Your own curated sets of articles."
 msgid "No topics match “{debouncedQuery}”."
 msgstr "No topics match “{debouncedQuery}”."
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Who can use your catalog URL"
+msgstr "Who can use your catalog URL"
+
 #: src/components/reader/continue-reading.tsx
 #~ msgid "Reading progress"
 #~ msgstr "Reading progress"
@@ -1870,6 +1938,10 @@ msgstr "Page {0} of {totalPages}"
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "e.g. To Read"
 msgstr "e.g. To Read"
+
+#: src/lib/guide/navigation.ts
+msgid "Reading on an e-reader"
+msgstr "Reading on an e-reader"
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/OpenLinksMenuItem.tsx
@@ -1955,6 +2027,10 @@ msgstr "+{UNNAMED_FORMAT_COUNT} more"
 #: src/lib/guide/navigation.ts
 msgid "Making the text comfortable"
 msgstr "Making the text comfortable"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The files are built when you ask for them, from the same article bodies the reader shows — images pulled in, footnotes as real endnotes, a link back to the original at the end of every piece. Nothing is trimmed to an excerpt. A whole publication, a list or a collection can also come down as one book, with a table of contents."
+msgstr "The files are built when you ask for them, from the same article bodies the reader shows — images pulled in, footnotes as real endnotes, a link back to the original at the end of every piece. Nothing is trimmed to an excerpt. A whole publication, a list or a collection can also come down as one book, with a table of contents."
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 msgid "What signing in adds is memory: following publications, saving articles, tracking what you have read, recommending, lists, and settings that follow you between devices. All of that needs somewhere to store it — which is your account."
@@ -2237,6 +2313,10 @@ msgstr "More from <0>{0}</0>"
 msgid "On this device"
 msgstr "On this device"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Add it to your reading app.</0> In KOReader that is <1>Search → OPDS catalog → +</1>. Foliate, Marvin, Aldiko, Thorium, Panels and Chunky all have a similar “add catalog” screen. Paste the URL and leave the username and password blank."
+msgstr "<0>Add it to your reading app.</0> In KOReader that is <1>Search → OPDS catalog → +</1>. Foliate, Marvin, Aldiko, Thorium, Panels and Chunky all have a similar “add catalog” screen. Paste the URL and leave the username and password blank."
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
 msgstr "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
@@ -2253,6 +2333,10 @@ msgstr "Installed to Home Screen"
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr "Pick the package for your framework; all sit on the same core."
+
+#: src/lib/guide/navigation.ts
+msgid "Put your unread queue on a Kobo, Kindle or phone as real EPUB files."
+msgstr "Put your unread queue on a Kobo, Kindle or phone as real EPUB files."
 
 #: src/components/reader/block-user-menu-item.tsx
 msgid "Block"
@@ -3147,6 +3231,10 @@ msgstr "Keep the essay for its own post"
 msgid "Plenty of people you already follow on Bluesky write long-form somewhere. <0>People you follow</0> finds them and puts their publications, and their newest articles, in one place. It is usually the highest-yield screen in the app the first week you use it."
 msgstr "Plenty of people you already follow on Bluesky write long-form somewhere. <0>People you follow</0> finds them and puts their publications, and their newest articles, in one place. It is usually the highest-yield screen in the app the first week you use it."
 
+#: src/components/ereader-settings.tsx
+msgid "Use this as the password. It only carries your reading position between devices — it cannot read or change anything else."
+msgstr "Use this as the password. It only carries your reading position between devices — it cannot read or change anything else."
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "Second, it brings you <0>what they recommend</0>. Articles they have recommended start appearing in your feed, marked with who recommended them. That is the quiet engine behind finding new writing here: you are not only subscribing to what someone writes, you are borrowing their taste in what to read."
 msgstr "Second, it brings you <0>what they recommend</0>. Articles they have recommended start appearing in your feed, marked with who recommended them. That is the quiet engine behind finding new writing here: you are not only subscribing to what someone writes, you are borrowing their taste in what to read."
@@ -3337,6 +3425,10 @@ msgstr "From your subscriptions"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>When you browse without signing in,</0> we serve public writing from our read-model index. We may store a theme preference cookie and, if you have signed in before on this device, a short list of recently used account handles (and optional avatar URLs) to speed up sign-in. We do not require an account to read."
 msgstr "<0>When you browse without signing in,</0> we serve public writing from our read-model index. We may store a theme preference cookie and, if you have signed in before on this device, a short list of recently used account handles (and optional avatar URLs) to speed up sign-in. We do not require an account to read."
+
+#: src/components/ereader-settings.tsx
+msgid "Sync server"
+msgstr "Sync server"
 
 #: src/components/appearance-settings.tsx
 msgid "Paper"
@@ -3720,6 +3812,10 @@ msgstr "This labeler’s labels aren’t applied while you read on Standard Read
 msgid "Subscribe to this list to read new articles from its publications."
 msgstr "Subscribe to this list to read new articles from its publications."
 
+#: src/components/ereader-settings.tsx
+msgid "In KOReader: Tools → Progress sync → Custom sync server."
+msgstr "In KOReader: Tools → Progress sync → Custom sync server."
+
 #: src/components/reader/collection-builder.tsx
 msgid "{itemCount} of {MAX_ITEMS}"
 msgstr "{itemCount} of {MAX_ITEMS}"
@@ -3772,6 +3868,10 @@ msgstr "everything, filtered by topic and sorted by readers, activity, or name. 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter subscriptions"
 msgstr "Filter subscriptions"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Standard Reader publishes an <0>OPDS catalog</0> — the same thing a library or a bookstore hands an e-reading app. Point an app at it once and your shelves appear on the device: <1>Unread</1>, <2>Saved for later</2>, <3>Subscriptions</3>, each of your lists, and every publication you follow. Open any of them and each article has a download button."
+msgstr "Standard Reader publishes an <0>OPDS catalog</0> — the same thing a library or a bookstore hands an e-reading app. Point an app at it once and your shelves appear on the device: <1>Unread</1>, <2>Saved for later</2>, <3>Subscriptions</3>, each of your lists, and every publication you follow. Open any of them and each article has a download button."
 
 #: src/components/reader/mention-hover-card.tsx
 msgid "{n, plural, one {# publication} other {{value} publications}}"
@@ -3857,6 +3957,10 @@ msgstr "Unfinished listed"
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "Signing in asks for permission to write only the kinds of records the app actually needs — follows, saves, recommendations, read records, and lists. It cannot post to Bluesky as you."
 msgstr "Signing in asks for permission to write only the kinds of records the app actually needs — follows, saves, recommendations, read records, and lists. It cannot post to Bluesky as you."
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "In KOReader, open <0>Tools → Progress sync</0> and choose <1>Custom sync server</1>."
+msgstr "In KOReader, open <0>Tools → Progress sync</0> and choose <1>Custom sync server</1>."
 
 #: src/components/comic/comic-reader.tsx
 msgid "Opening the comic…"
@@ -4601,6 +4705,10 @@ msgstr "Be the first to share a bug, idea, or question."
 msgid "Browse the publication directory to find new writers."
 msgstr "Browse the publication directory to find new writers."
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your unread queue, your saved articles and every publication you subscribe to, on a Kobo, a Kindle, a reMarkable or a phone — as real EPUB files, with the images, ready to read on a plane."
+msgstr "Your unread queue, your saved articles and every publication you subscribe to, on a Kobo, a Kindle, a reMarkable or a phone — as real EPUB files, with the images, ready to read on a plane."
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "The most-read writing across the network right now."
@@ -5183,6 +5291,10 @@ msgstr "An edition is not only a list of links. You can write an <0>introduction
 msgid "Most posts"
 msgstr "Most posts"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "You do not need a catalog for a single piece. Every article's share menu has <0>Download EPUB</0> — and <1>Download CBZ</1> on a comic. A publication's <2>…</2> menu has <3>Send to e-reader…</3>, which offers its recent articles as one book and shows the catalog URL for that publication on its own."
+msgstr "You do not need a catalog for a single piece. Every article's share menu has <0>Download EPUB</0> — and <1>Download CBZ</1> on a comic. A publication's <2>…</2> menu has <3>Send to e-reader…</3>, which offers its recent articles as one book and shows the catalog URL for that publication on its own."
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>1. Identity & signing key.</0> Give it a DID (a <1>did:web</1> is simplest) whose DID document advertises an <2>#atproto_labeler</2> service endpoint and an <3>#atproto_label</3> public signing key."
 msgstr "<0>1. Identity & signing key.</0> Give it a DID (a <1>did:web</1> is simplest) whose DID document advertises an <2>#atproto_labeler</2> service endpoint and an <3>#atproto_label</3> public signing key."
@@ -5465,6 +5577,10 @@ msgstr "Track reading history"
 #: src/components/reader/format-i18n.ts
 msgid "{readCount, plural, one {# read} other {{value} reads}}"
 msgstr "{readCount, plural, one {# read} other {{value} reads}}"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "A few articles on the network are really link posts — a headline and a URL, bridged in from somewhere else, with no body to package. Those are left out of the catalog rather than offered as a file that would open to nothing. You will still find them in the app, where they link out to the site that has the writing."
+msgstr "A few articles on the network are really link posts — a headline and a URL, bridged in from somewhere else, with no body to package. Those are left out of the catalog rather than offered as a file that would open to nothing. You will still find them in the app, where they link out to the site that has the writing."
 
 #: src/components/offline-sync-debug.tsx
 #: src/routes/_layout.collections.index.tsx
@@ -5896,6 +6012,10 @@ msgstr "Either no one you follow on Bluesky publishes here yet, or you're alread
 msgid "Collection"
 msgstr "Collection"
 
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Or add this catalog URL to KOReader, Foliate, Marvin or any other OPDS app, and browse {name} from the device itself."
+msgstr "Or add this catalog URL to KOReader, Foliate, Marvin or any other OPDS app, and browse {name} from the device itself."
+
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Most liked"
 msgstr "Most liked"
@@ -5951,6 +6071,10 @@ msgstr "Saves a link to your <0>{appLabel}</0> collection."
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Drag to change the order your subscriptions appear in the sidebar."
 #~ msgstr "Drag to change the order your subscriptions appear in the sidebar."
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Paste the sync server URL, then log in with your handle and the sync key. There is no separate account to register."
+msgstr "Paste the sync server URL, then log in with your handle and the sync key. There is no separate account to register."
 
 #: src/components/user-settings-view.tsx
 msgid "Appearance, reading preferences, and personal data."
@@ -6366,6 +6490,11 @@ msgstr "Service DID is <0>{appviewDid}</0>. The service advertises a <1>DID docu
 #: src/components/reader/about-view.tsx
 msgid "The Slow Web, Revisited"
 msgstr "The Slow Web, Revisited"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What you get"
+msgstr "What you get"
 
 #. placeholder {0}: visible.length
 #: src/routes/_layout.communities.index.tsx
@@ -7067,6 +7196,10 @@ msgstr "Account actions"
 msgid "Read article"
 msgstr "Read article"
 
+#: src/components/ereader-settings.tsx
+msgid "Your shelves, as an OPDS catalog. Anyone with this URL can see the same public records your profile already shows."
+msgstr "Your shelves, as an OPDS catalog. Anyone with this URL can see the same public records your profile already shows."
+
 #. placeholder {0}: formatBytes(usage.usage)
 #: src/components/offline-settings.tsx
 msgid "Standard Reader is using {0} on this device."
@@ -7169,6 +7302,10 @@ msgstr "Reading without an account"
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "Details"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
+msgstr "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
 
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Topic views"
@@ -7465,6 +7602,10 @@ msgstr "Blocked by a list you use"
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "{unreadCount} unread"
 msgstr "{unreadCount} unread"
+
+#: src/components/ereader-settings.tsx
+msgid "Log in with this as your username — there is no separate sync account."
+msgstr "Log in with this as your username — there is no separate sync account."
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "Below those, the publications you follow are listed for quick access. The <0>Subscriptions</0> heading above them opens the full management view. At the very bottom, your avatar opens a menu with your profile, reading history, recommended articles, feedback, settings, and log out."
@@ -7765,6 +7906,10 @@ msgstr "Loading article"
 msgid "Upvoted."
 msgstr "Upvoted."
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Browse and download.</0> Your shelves are the top level. Tap an article to pull the EPUB onto the device."
+msgstr "<0>Browse and download.</0> Your shelves are the top level. Tap an article to pull the EPUB onto the device."
+
 #: src/components/reader/list-edit-modal.tsx
 msgid "Search your subscriptions"
 msgstr "Search your subscriptions"
@@ -7870,6 +8015,10 @@ msgstr "The weekly digest"
 msgid "Discussion here is gathered from posts across the network, so you comment wherever you already post."
 msgstr "Discussion here is gathered from posts across the network, so you comment wherever you already post."
 
+#: src/components/comic/comic-reader.tsx
+msgid "Download this issue (CBZ)"
+msgstr "Download this issue (CBZ)"
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Subscribe all"
 msgstr "Subscribe all"
@@ -7895,6 +8044,11 @@ msgstr "<0>Structured blocks.</0> Rich block-editor documents, each in that edit
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
 #~ msgstr "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Keeping your place"
+msgstr "Keeping your place"
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"
@@ -7970,6 +8124,10 @@ msgstr "Filter by topic"
 #: src/components/reader/mute-menu-item.tsx
 msgid "Unmute {name}"
 msgstr "Unmute {name}"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Copy your catalog URL.</0> It is in <1>Settings</1> under <2>E-readers</2>. It is yours — it carries your subscriptions and your saved articles."
+msgstr "<0>Copy your catalog URL.</0> It is in <1>Settings</1> under <2>E-readers</2>. It is yours — it carries your subscriptions and your saved articles."
 
 #. placeholder {0}: image.file.name
 #: src/components/feedback/feedback-image-picker.tsx
@@ -8176,6 +8334,10 @@ msgstr "Find publications, people, topics, and headlines."
 msgid "Standard Reader indexes <0>site.standard.document</0> and <1>site.standard.publication</1> records out of AT Proto repos. Platforms like Leaflet, Pckt, and Offprint write these records for you as part of publishing, so their authors get the full reader treatment automatically. If you run your own site and hand-roll your own <2>site.standard</2> integration instead, you write those records yourself — this page covers what to add, including Markpub, the markdown format we recommend for a hand-rolled body."
 msgstr "Standard Reader indexes <0>site.standard.document</0> and <1>site.standard.publication</1> records out of AT Proto repos. Platforms like Leaflet, Pckt, and Offprint write these records for you as part of publishing, so their authors get the full reader treatment automatically. If you run your own site and hand-roll your own <2>site.standard</2> integration instead, you write those records yourself — this page covers what to add, including Markpub, the markdown format we recommend for a hand-rolled body."
 
+#: src/components/ereader-settings.tsx
+msgid "Catalog URL"
+msgstr "Catalog URL"
+
 #: src/components/reader/add-to-list-modal.tsx
 #: src/components/reader/list-edit-modal.tsx
 msgid "e.g. Tech, Friends, Cooking"
@@ -8282,6 +8444,10 @@ msgstr "When on, a publication's whole back catalogue counts as unread when you 
 #~ msgid "tuned to what you already follow."
 #~ msgstr "tuned to what you already follow."
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your position also flows back here: read half of something on the Kobo and the article shows as half-read in the app, and in <0>Continue reading</0>. That direction is one-way. A position on a device is a place in <1>that device's</1> rendering of the file, and there is no honest way to turn a percentage back into one, so the app never sends a position out to a device that did not record it."
+msgstr "Your position also flows back here: read half of something on the Kobo and the article shows as half-read in the app, and in <0>Continue reading</0>. That direction is one-way. A position on a device is a place in <1>that device's</1> rendering of the file, and there is no honest way to turn a percentage back into one, so the app never sends a position out to a device that did not record it."
+
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this reply on Bluesky"
 msgstr "Open this reply on Bluesky"
@@ -8309,6 +8475,7 @@ msgstr "Clear all"
 
 #: src/components/reader/discover-topic-filters.tsx
 #: src/components/reader/rss-feed-button.tsx
+#: src/components/reader/send-to-ereader-dialog.tsx
 #: src/components/reader/share-menu.tsx
 msgid "Close"
 msgstr "Close"
@@ -8553,6 +8720,10 @@ msgstr "Finding your way around"
 msgid "Cited by"
 msgstr "Cited by"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "KOReader can sync your reading position through Standard Reader, so picking up a book on a second device puts you where you stopped. Settings → <0>E-readers</0> has the three values it wants: the sync server URL, your username, and a sync key."
+msgstr "KOReader can sync your reading position through Standard Reader, so picking up a book on a second device puts you where you stopped. Settings → <0>E-readers</0> has the three values it wants: the sync server URL, your username, and a sync key."
+
 #: src/routes/mcp/authorize.tsx
 msgid "Signed in as"
 msgstr "Signed in as"
@@ -8607,3 +8778,7 @@ msgstr "Palette"
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Describe this image"
 msgstr "Describe this image"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
+msgstr "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -205,6 +205,10 @@ msgstr ""
 msgid "find publications, people, topics, and headlines by name."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Every device syncing with the old key stops until you enter the new one. Nothing you have already read is lost — reading positions are kept against the books themselves, not the key."
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Change language"
@@ -2066,6 +2070,10 @@ msgstr ""
 msgid "Subscribed to list"
 msgstr "Suscrito a la lista"
 
+#: src/components/ereader-settings.tsx
+msgid "Rotate your sync key?"
+msgstr ""
+
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "See which of the people you pass on Bluesky write long-form."
 msgstr ""
@@ -2171,6 +2179,10 @@ msgstr "Eliminar colección"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Interface font"
+msgstr ""
+
+#: src/components/ereader-settings.tsx
+msgid "Rotate"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
@@ -5273,6 +5285,10 @@ msgstr ""
 msgid "Subscribe to list"
 msgstr "Suscribirse a la lista"
 
+#: src/components/ereader-settings.tsx
+msgid "Rotate key"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #: src/lib/guide/navigation.ts
 #~ msgid "Following a publication"
@@ -6513,6 +6529,10 @@ msgstr ""
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #~ msgid "Eight presets, or your own paper and accent. The rest of the interface is derived from them."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. Lost a device? <0>Rotate</0> in Settings issues a new key and stops the old one working."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 #: src/components/reading-custom-font-picker.tsx
@@ -8780,5 +8800,5 @@ msgid "Describe this image"
 msgstr ""
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
-msgstr ""
+#~ msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
+#~ msgstr ""

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -17,6 +17,10 @@ msgstr ""
 msgid "This is the difference between making one anthology and running something with a rhythm to it — a weekly roundup, a themed quarterly, a reading list you keep adding to."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Add your catalog to KOReader, Foliate, Marvin, Panels or any other OPDS app and your unread queue, saved articles, subscriptions and lists show up on the device — each one downloadable as an EPUB."
+msgstr ""
+
 #: src/routes/_layout.discover.tsx
 msgid "Every publication the network knows about — subscribe to the ones worth your mornings."
 msgstr "Todas las publicaciones que la red conoce: suscríbase a las que valgan sus mañanas."
@@ -287,6 +291,10 @@ msgstr ""
 msgid "Mark as read"
 msgstr "Marcar como leído"
 
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Send to your e-reader"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "This list is empty — add publications or people to it."
 msgstr "Esta lista está vacía: añádale publicaciones o personas."
@@ -347,6 +355,11 @@ msgstr "Añada un título."
 #: src/components/guide/pages/finding-guide-page.tsx
 #~ msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Follow it and it starts appearing in your feeds like any other."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/components/user-settings-view.tsx
+msgid "E-readers"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
@@ -530,8 +543,16 @@ msgstr ""
 msgid "We couldn’t find that issue."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Comics come down as <0>CBZ</0> as well, so comic apps get their page turns and their scrubber instead of a reflowable book that fights them."
+msgstr ""
+
 #: src/routes/_layout.friends.tsx
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
+msgstr ""
+
+#: src/components/ereader-settings.tsx
+msgid "Sync username"
 msgstr ""
 
 #: src/components/reader/format-i18n.ts
@@ -541,6 +562,10 @@ msgstr ""
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "List"
 msgstr "Lista"
+
+#: src/components/reader/publication-actions.tsx
+msgid "Send to e-reader…"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "The spacing between things — tighter for more on screen, looser for more room to read."
@@ -733,6 +758,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Sync key"
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Landscape fits a compact row. Height adjusts automatically once the embed loads. Change the iframe width as needed."
 msgstr "El formato horizontal encaja en una fila compacta. La altura se ajusta automáticamente al cargar el embed. Cambie el ancho del iframe según necesite."
@@ -867,6 +896,11 @@ msgstr ""
 msgid "Log in to follow publications"
 msgstr "Inicie sesión para seguir publicaciones"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What will not be there"
+msgstr ""
+
 #: src/routes/_layout.discover.tsx
 msgid "Search publications"
 msgstr "Buscar publicaciones"
@@ -946,6 +980,10 @@ msgstr "Error al iniciar sesión. Inténtelo de nuevo."
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Loading publications"
 msgstr "Cargando publicaciones"
+
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "OPDS catalog URL"
+msgstr ""
 
 #. placeholder {0}: meta.minutes
 #: src/magazine/flow.tsx
@@ -1218,6 +1256,11 @@ msgstr "Ver colecciones"
 msgid "Name"
 msgstr "Nombre"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Setting it up"
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "Where data lives"
 msgstr "Dónde viven los datos"
@@ -1305,6 +1348,10 @@ msgstr "Guardado en {savedName} en {appLabel}."
 #: src/lib/guide/navigation.ts
 msgid "Getting started"
 msgstr "Primeros pasos"
+
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Download {name} as a file — images and all, ready to read offline."
+msgstr ""
 
 #: src/components/onboarding/step-settings.tsx
 msgid "Open posts on their original site"
@@ -1423,6 +1470,10 @@ msgstr ""
 #~ msgid "You don't have any subscriptions to reorder yet."
 #~ msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "What the sync key can do"
+msgstr ""
+
 #: src/components/reader/notify-button.tsx
 #: src/components/user-settings-view.tsx
 msgid "This browser doesn’t support web notifications."
@@ -1444,6 +1495,10 @@ msgstr "Tipo de comentario"
 #: src/components/guide/pages/welcome-guide-page.tsx
 #~ msgid "Home leads with one article worth your attention, then everything new from the publications you follow."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Downloading does not mark anything read, and reading on a device does not remove it from your unread shelf until KOReader syncs a position back. Polls, signup forms and other live embeds become links — a book cannot run them."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Enable the weekly digest"
@@ -1493,6 +1548,11 @@ msgstr "Seguir todo"
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "That's every issue published so far."
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Sending one article"
 msgstr ""
 
 #. placeholder {0}: view.clientName
@@ -1794,6 +1854,10 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Turn on <0>Sync every N pages</0> if you want it to happen without asking."
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
 #~ msgstr "Incluya la pista <0>site.standard.publication</0> solo si el documento pertenece a un registro de publicación. Agregue ambas sin importar qué lector le interese: así es como cualquier cliente de la red resuelve su página hasta su registro, no solo nuestra extensión."
@@ -1842,6 +1906,10 @@ msgstr ""
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Who can use your catalog URL"
+msgstr ""
+
 #: src/components/reader/continue-reading.tsx
 #~ msgid "Reading progress"
 #~ msgstr ""
@@ -1870,6 +1938,10 @@ msgstr ""
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "e.g. To Read"
 msgstr "p. ej. Para leer"
+
+#: src/lib/guide/navigation.ts
+msgid "Reading on an e-reader"
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/OpenLinksMenuItem.tsx
@@ -1954,6 +2026,10 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Making the text comfortable"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The files are built when you ask for them, from the same article bodies the reader shows — images pulled in, footnotes as real endnotes, a link back to the original at the end of every piece. Nothing is trimmed to an excerpt. A whole publication, a list or a collection can also come down as one book, with a table of contents."
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -2237,6 +2313,10 @@ msgstr "Más de <0>{0}</0>"
 msgid "On this device"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Add it to your reading app.</0> In KOReader that is <1>Search → OPDS catalog → +</1>. Foliate, Marvin, Aldiko, Thorium, Panels and Chunky all have a similar “add catalog” screen. Paste the URL and leave the username and password blank."
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
 msgstr "Podemos actualizar esta política a medida que cambie la extensión. La fecha de «Última actualización» en la parte superior cambiará cuando lo hagamos. Seguir usando la extensión después de una actualización implica que acepta la política revisada."
@@ -2253,6 +2333,10 @@ msgstr ""
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
+
+#: src/lib/guide/navigation.ts
+msgid "Put your unread queue on a Kobo, Kindle or phone as real EPUB files."
+msgstr ""
 
 #: src/components/reader/block-user-menu-item.tsx
 msgid "Block"
@@ -3147,6 +3231,10 @@ msgstr ""
 msgid "Plenty of people you already follow on Bluesky write long-form somewhere. <0>People you follow</0> finds them and puts their publications, and their newest articles, in one place. It is usually the highest-yield screen in the app the first week you use it."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Use this as the password. It only carries your reading position between devices — it cannot read or change anything else."
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "Second, it brings you <0>what they recommend</0>. Articles they have recommended start appearing in your feed, marked with who recommended them. That is the quiet engine behind finding new writing here: you are not only subscribing to what someone writes, you are borrowing their taste in what to read."
 msgstr ""
@@ -3337,6 +3425,10 @@ msgstr "De sus suscripciones"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>When you browse without signing in,</0> we serve public writing from our read-model index. We may store a theme preference cookie and, if you have signed in before on this device, a short list of recently used account handles (and optional avatar URLs) to speed up sign-in. We do not require an account to read."
 msgstr "<0>Cuando navega sin iniciar sesión,</0> servimos textos públicos desde nuestro índice del modelo de lectura. Es posible que guardemos una cookie con la preferencia de tema y, si ya inició sesión antes en este dispositivo, una lista breve de handles de cuentas usados recientemente (y URL de avatar opcionales) para agilizar el inicio de sesión. No exigimos una cuenta para leer."
+
+#: src/components/ereader-settings.tsx
+msgid "Sync server"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Paper"
@@ -3720,6 +3812,10 @@ msgstr ""
 msgid "Subscribe to this list to read new articles from its publications."
 msgstr "Suscríbase a esta lista para leer los nuevos artículos de sus publicaciones."
 
+#: src/components/ereader-settings.tsx
+msgid "In KOReader: Tools → Progress sync → Custom sync server."
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "{itemCount} of {MAX_ITEMS}"
 msgstr "{itemCount} de {MAX_ITEMS}"
@@ -3771,6 +3867,10 @@ msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter subscriptions"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Standard Reader publishes an <0>OPDS catalog</0> — the same thing a library or a bookstore hands an e-reading app. Point an app at it once and your shelves appear on the device: <1>Unread</1>, <2>Saved for later</2>, <3>Subscriptions</3>, each of your lists, and every publication you follow. Open any of them and each article has a download button."
 msgstr ""
 
 #: src/components/reader/mention-hover-card.tsx
@@ -3856,6 +3956,10 @@ msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "Signing in asks for permission to write only the kinds of records the app actually needs — follows, saves, recommendations, read records, and lists. It cannot post to Bluesky as you."
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "In KOReader, open <0>Tools → Progress sync</0> and choose <1>Custom sync server</1>."
 msgstr ""
 
 #: src/components/comic/comic-reader.tsx
@@ -4601,6 +4705,10 @@ msgstr "Sea la primera persona en compartir un error, una idea o una pregunta."
 msgid "Browse the publication directory to find new writers."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your unread queue, your saved articles and every publication you subscribe to, on a Kobo, a Kindle, a reMarkable or a phone — as real EPUB files, with the images, ready to read on a plane."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "Los textos más leídos de toda la red en este momento."
@@ -5183,6 +5291,10 @@ msgstr ""
 msgid "Most posts"
 msgstr "Más entradas"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "You do not need a catalog for a single piece. Every article's share menu has <0>Download EPUB</0> — and <1>Download CBZ</1> on a comic. A publication's <2>…</2> menu has <3>Send to e-reader…</3>, which offers its recent articles as one book and shows the catalog URL for that publication on its own."
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>1. Identity & signing key.</0> Give it a DID (a <1>did:web</1> is simplest) whose DID document advertises an <2>#atproto_labeler</2> service endpoint and an <3>#atproto_label</3> public signing key."
 msgstr "<0>1. Identidad y clave de firma.</0> Asígnele un DID (un <1>did:web</1> es lo más sencillo) cuyo documento DID anuncie un punto de conexión de servicio <2>#atproto_labeler</2> y una clave pública de firma <3>#atproto_label</3>."
@@ -5465,6 +5577,10 @@ msgstr "Registrar el historial de lectura"
 #: src/components/reader/format-i18n.ts
 msgid "{readCount, plural, one {# read} other {{value} reads}}"
 msgstr "{readCount, plural, one {# lectura} other {{value} lecturas}}"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "A few articles on the network are really link posts — a headline and a URL, bridged in from somewhere else, with no body to package. Those are left out of the catalog rather than offered as a file that would open to nothing. You will still find them in the app, where they link out to the site that has the writing."
+msgstr ""
 
 #: src/components/offline-sync-debug.tsx
 #: src/routes/_layout.collections.index.tsx
@@ -5896,6 +6012,10 @@ msgstr ""
 msgid "Collection"
 msgstr "Colección"
 
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Or add this catalog URL to KOReader, Foliate, Marvin or any other OPDS app, and browse {name} from the device itself."
+msgstr ""
+
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Most liked"
 msgstr ""
@@ -5951,6 +6071,10 @@ msgstr "Guarda un enlace en su colección de <0>{appLabel}</0>."
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Drag to change the order your subscriptions appear in the sidebar."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Paste the sync server URL, then log in with your handle and the sync key. There is no separate account to register."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Appearance, reading preferences, and personal data."
@@ -6366,6 +6490,11 @@ msgstr "El DID del servicio es <0>{appviewDid}</0>. El servicio publica un <1>do
 #: src/components/reader/about-view.tsx
 msgid "The Slow Web, Revisited"
 msgstr "La web lenta, revisitada"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What you get"
+msgstr ""
 
 #. placeholder {0}: visible.length
 #: src/routes/_layout.communities.index.tsx
@@ -7067,6 +7196,10 @@ msgstr "Acciones de la cuenta"
 msgid "Read article"
 msgstr "Leer artículo"
 
+#: src/components/ereader-settings.tsx
+msgid "Your shelves, as an OPDS catalog. Anyone with this URL can see the same public records your profile already shows."
+msgstr ""
+
 #. placeholder {0}: formatBytes(usage.usage)
 #: src/components/offline-settings.tsx
 msgid "Standard Reader is using {0} on this device."
@@ -7169,6 +7302,10 @@ msgstr ""
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "Detalles"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
+msgstr ""
 
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Topic views"
@@ -7465,6 +7602,10 @@ msgstr ""
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "{unreadCount} unread"
 msgstr "{unreadCount} sin leer"
+
+#: src/components/ereader-settings.tsx
+msgid "Log in with this as your username — there is no separate sync account."
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "Below those, the publications you follow are listed for quick access. The <0>Subscriptions</0> heading above them opens the full management view. At the very bottom, your avatar opens a menu with your profile, reading history, recommended articles, feedback, settings, and log out."
@@ -7765,6 +7906,10 @@ msgstr "Cargando artículo"
 msgid "Upvoted."
 msgstr "Votado."
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Browse and download.</0> Your shelves are the top level. Tap an article to pull the EPUB onto the device."
+msgstr ""
+
 #: src/components/reader/list-edit-modal.tsx
 msgid "Search your subscriptions"
 msgstr "Buscar en sus suscripciones"
@@ -7870,6 +8015,10 @@ msgstr ""
 msgid "Discussion here is gathered from posts across the network, so you comment wherever you already post."
 msgstr ""
 
+#: src/components/comic/comic-reader.tsx
+msgid "Download this issue (CBZ)"
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Subscribe all"
 msgstr "Suscribirse a todo"
@@ -7895,6 +8044,11 @@ msgstr "<0>Bloques estructurados.</0> Documentos de editor de bloques enriquecid
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Keeping your place"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"
@@ -7969,6 +8123,10 @@ msgstr "Filtrar por tema"
 
 #: src/components/reader/mute-menu-item.tsx
 msgid "Unmute {name}"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Copy your catalog URL.</0> It is in <1>Settings</1> under <2>E-readers</2>. It is yours — it carries your subscriptions and your saved articles."
 msgstr ""
 
 #. placeholder {0}: image.file.name
@@ -8176,6 +8334,10 @@ msgstr ""
 msgid "Standard Reader indexes <0>site.standard.document</0> and <1>site.standard.publication</1> records out of AT Proto repos. Platforms like Leaflet, Pckt, and Offprint write these records for you as part of publishing, so their authors get the full reader treatment automatically. If you run your own site and hand-roll your own <2>site.standard</2> integration instead, you write those records yourself — this page covers what to add, including Markpub, the markdown format we recommend for a hand-rolled body."
 msgstr "Standard Reader indexa registros <0>site.standard.document</0> y <1>site.standard.publication</1> de repositorios de AT Proto. Plataformas como Leaflet, Pckt y Offprint escriben estos registros por usted como parte de la publicación, así que sus autores obtienen la experiencia de lectura completa automáticamente. Si gestiona su propio sitio y prefiere hacer a mano su integración con <2>site.standard</2>, tendrá que escribir esos registros usted mismo: esta página explica qué añadir, incluido Markpub, el formato markdown que recomendamos para un cuerpo hecho a mano."
 
+#: src/components/ereader-settings.tsx
+msgid "Catalog URL"
+msgstr ""
+
 #: src/components/reader/add-to-list-modal.tsx
 #: src/components/reader/list-edit-modal.tsx
 msgid "e.g. Tech, Friends, Cooking"
@@ -8282,6 +8444,10 @@ msgstr "Al activarlo, todo el catálogo anterior de una publicación cuenta como
 #~ msgid "tuned to what you already follow."
 #~ msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your position also flows back here: read half of something on the Kobo and the article shows as half-read in the app, and in <0>Continue reading</0>. That direction is one-way. A position on a device is a place in <1>that device's</1> rendering of the file, and there is no honest way to turn a percentage back into one, so the app never sends a position out to a device that did not record it."
+msgstr ""
+
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this reply on Bluesky"
 msgstr "Abrir esta respuesta en Bluesky"
@@ -8309,6 +8475,7 @@ msgstr ""
 
 #: src/components/reader/discover-topic-filters.tsx
 #: src/components/reader/rss-feed-button.tsx
+#: src/components/reader/send-to-ereader-dialog.tsx
 #: src/components/reader/share-menu.tsx
 msgid "Close"
 msgstr "Cerrar"
@@ -8553,6 +8720,10 @@ msgstr ""
 msgid "Cited by"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "KOReader can sync your reading position through Standard Reader, so picking up a book on a second device puts you where you stopped. Settings → <0>E-readers</0> has the three values it wants: the sync server URL, your username, and a sync key."
+msgstr ""
+
 #: src/routes/mcp/authorize.tsx
 msgid "Signed in as"
 msgstr ""
@@ -8606,4 +8777,8 @@ msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Describe this image"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
 msgstr ""

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -1907,8 +1907,8 @@ msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "Who can use your catalog URL"
-msgstr ""
+#~ msgid "Who can use your catalog URL"
+#~ msgstr ""
 
 #: src/components/reader/continue-reading.tsx
 #~ msgid "Reading progress"
@@ -7304,8 +7304,8 @@ msgid "Details"
 msgstr "Detalles"
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
-msgstr ""
+#~ msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
+#~ msgstr ""
 
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Topic views"

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -1907,8 +1907,8 @@ msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "Who can use your catalog URL"
-msgstr ""
+#~ msgid "Who can use your catalog URL"
+#~ msgstr ""
 
 #: src/components/reader/continue-reading.tsx
 #~ msgid "Reading progress"
@@ -7304,8 +7304,8 @@ msgid "Details"
 msgstr "Détails"
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
-msgstr ""
+#~ msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
+#~ msgstr ""
 
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Topic views"

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -17,6 +17,10 @@ msgstr ""
 msgid "This is the difference between making one anthology and running something with a rhythm to it — a weekly roundup, a themed quarterly, a reading list you keep adding to."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Add your catalog to KOReader, Foliate, Marvin, Panels or any other OPDS app and your unread queue, saved articles, subscriptions and lists show up on the device — each one downloadable as an EPUB."
+msgstr ""
+
 #: src/routes/_layout.discover.tsx
 msgid "Every publication the network knows about — subscribe to the ones worth your mornings."
 msgstr "Toutes les publications que le réseau connaît — abonnez-vous à celles qui méritent vos matinées."
@@ -287,6 +291,10 @@ msgstr ""
 msgid "Mark as read"
 msgstr "Marquer comme lu"
 
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Send to your e-reader"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "This list is empty — add publications or people to it."
 msgstr "Cette liste est vide — ajoutez-y des publications ou des personnes."
@@ -347,6 +355,11 @@ msgstr "Veuillez ajouter un titre."
 #: src/components/guide/pages/finding-guide-page.tsx
 #~ msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Follow it and it starts appearing in your feeds like any other."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/components/user-settings-view.tsx
+msgid "E-readers"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
@@ -530,8 +543,16 @@ msgstr ""
 msgid "We couldn’t find that issue."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Comics come down as <0>CBZ</0> as well, so comic apps get their page turns and their scrubber instead of a reflowable book that fights them."
+msgstr ""
+
 #: src/routes/_layout.friends.tsx
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
+msgstr ""
+
+#: src/components/ereader-settings.tsx
+msgid "Sync username"
 msgstr ""
 
 #: src/components/reader/format-i18n.ts
@@ -541,6 +562,10 @@ msgstr ""
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "List"
 msgstr "Liste"
+
+#: src/components/reader/publication-actions.tsx
+msgid "Send to e-reader…"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "The spacing between things — tighter for more on screen, looser for more room to read."
@@ -733,6 +758,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Sync key"
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Landscape fits a compact row. Height adjusts automatically once the embed loads. Change the iframe width as needed."
 msgstr "Le format paysage tient dans une rangée compacte. La hauteur s’ajuste automatiquement une fois l’intégration chargée. Modifiez la largeur de l’iframe si besoin."
@@ -867,6 +896,11 @@ msgstr ""
 msgid "Log in to follow publications"
 msgstr "Connectez-vous pour suivre des publications"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What will not be there"
+msgstr ""
+
 #: src/routes/_layout.discover.tsx
 msgid "Search publications"
 msgstr "Rechercher des publications"
@@ -946,6 +980,10 @@ msgstr "Échec de la connexion. Réessayez."
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Loading publications"
 msgstr "Chargement des publications"
+
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "OPDS catalog URL"
+msgstr ""
 
 #. placeholder {0}: meta.minutes
 #: src/magazine/flow.tsx
@@ -1218,6 +1256,11 @@ msgstr "Voir les collections"
 msgid "Name"
 msgstr "Nom"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Setting it up"
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "Where data lives"
 msgstr "Où vivent les données"
@@ -1305,6 +1348,10 @@ msgstr "Enregistré dans {savedName} sur {appLabel}."
 #: src/lib/guide/navigation.ts
 msgid "Getting started"
 msgstr "Premiers pas"
+
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Download {name} as a file — images and all, ready to read offline."
+msgstr ""
 
 #: src/components/onboarding/step-settings.tsx
 msgid "Open posts on their original site"
@@ -1423,6 +1470,10 @@ msgstr ""
 #~ msgid "You don't have any subscriptions to reorder yet."
 #~ msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "What the sync key can do"
+msgstr ""
+
 #: src/components/reader/notify-button.tsx
 #: src/components/user-settings-view.tsx
 msgid "This browser doesn’t support web notifications."
@@ -1444,6 +1495,10 @@ msgstr "Type de retour"
 #: src/components/guide/pages/welcome-guide-page.tsx
 #~ msgid "Home leads with one article worth your attention, then everything new from the publications you follow."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Downloading does not mark anything read, and reading on a device does not remove it from your unread shelf until KOReader syncs a position back. Polls, signup forms and other live embeds become links — a book cannot run them."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Enable the weekly digest"
@@ -1493,6 +1548,11 @@ msgstr "Tout suivre"
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "That's every issue published so far."
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Sending one article"
 msgstr ""
 
 #. placeholder {0}: view.clientName
@@ -1794,6 +1854,10 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Turn on <0>Sync every N pages</0> if you want it to happen without asking."
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
 #~ msgstr "N'incluez l'indice <0>site.standard.publication</0> que si le document appartient à un enregistrement de publication. Ajoutez les deux quel que soit le lecteur qui vous intéresse : c'est ainsi que n'importe quel client du réseau relie votre page à son enregistrement, et pas seulement notre extension."
@@ -1842,6 +1906,10 @@ msgstr ""
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Who can use your catalog URL"
+msgstr ""
+
 #: src/components/reader/continue-reading.tsx
 #~ msgid "Reading progress"
 #~ msgstr ""
@@ -1870,6 +1938,10 @@ msgstr ""
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "e.g. To Read"
 msgstr "ex. À lire"
+
+#: src/lib/guide/navigation.ts
+msgid "Reading on an e-reader"
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/OpenLinksMenuItem.tsx
@@ -1954,6 +2026,10 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Making the text comfortable"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The files are built when you ask for them, from the same article bodies the reader shows — images pulled in, footnotes as real endnotes, a link back to the original at the end of every piece. Nothing is trimmed to an excerpt. A whole publication, a list or a collection can also come down as one book, with a table of contents."
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -2237,6 +2313,10 @@ msgstr "Plus de <0>{0}</0>"
 msgid "On this device"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Add it to your reading app.</0> In KOReader that is <1>Search → OPDS catalog → +</1>. Foliate, Marvin, Aldiko, Thorium, Panels and Chunky all have a similar “add catalog” screen. Paste the URL and leave the username and password blank."
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
 msgstr "Nous pouvons faire évoluer cette politique à mesure que l'extension change. La date de « dernière mise à jour » en haut de page sera modifiée en conséquence. Continuer à utiliser l'extension après une mise à jour vaut acceptation de la politique révisée."
@@ -2253,6 +2333,10 @@ msgstr ""
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
+
+#: src/lib/guide/navigation.ts
+msgid "Put your unread queue on a Kobo, Kindle or phone as real EPUB files."
+msgstr ""
 
 #: src/components/reader/block-user-menu-item.tsx
 msgid "Block"
@@ -3147,6 +3231,10 @@ msgstr ""
 msgid "Plenty of people you already follow on Bluesky write long-form somewhere. <0>People you follow</0> finds them and puts their publications, and their newest articles, in one place. It is usually the highest-yield screen in the app the first week you use it."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Use this as the password. It only carries your reading position between devices — it cannot read or change anything else."
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "Second, it brings you <0>what they recommend</0>. Articles they have recommended start appearing in your feed, marked with who recommended them. That is the quiet engine behind finding new writing here: you are not only subscribing to what someone writes, you are borrowing their taste in what to read."
 msgstr ""
@@ -3337,6 +3425,10 @@ msgstr "Depuis vos abonnements"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>When you browse without signing in,</0> we serve public writing from our read-model index. We may store a theme preference cookie and, if you have signed in before on this device, a short list of recently used account handles (and optional avatar URLs) to speed up sign-in. We do not require an account to read."
 msgstr "<0>Lorsque vous naviguez sans être connecté,</0> nous servons des textes publics issus de notre index de lecture. Nous pouvons stocker un cookie de préférence de thème et, si vous vous êtes déjà connecté sur cet appareil, une courte liste d'identifiants de comptes récemment utilisés (et éventuellement les URL de leurs avatars) afin d'accélérer la connexion. Aucun compte n'est requis pour lire."
+
+#: src/components/ereader-settings.tsx
+msgid "Sync server"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Paper"
@@ -3720,6 +3812,10 @@ msgstr ""
 msgid "Subscribe to this list to read new articles from its publications."
 msgstr "Abonnez-vous à cette liste pour lire les nouveaux articles de ses publications."
 
+#: src/components/ereader-settings.tsx
+msgid "In KOReader: Tools → Progress sync → Custom sync server."
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "{itemCount} of {MAX_ITEMS}"
 msgstr "{itemCount} sur {MAX_ITEMS}"
@@ -3771,6 +3867,10 @@ msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter subscriptions"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Standard Reader publishes an <0>OPDS catalog</0> — the same thing a library or a bookstore hands an e-reading app. Point an app at it once and your shelves appear on the device: <1>Unread</1>, <2>Saved for later</2>, <3>Subscriptions</3>, each of your lists, and every publication you follow. Open any of them and each article has a download button."
 msgstr ""
 
 #: src/components/reader/mention-hover-card.tsx
@@ -3856,6 +3956,10 @@ msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "Signing in asks for permission to write only the kinds of records the app actually needs — follows, saves, recommendations, read records, and lists. It cannot post to Bluesky as you."
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "In KOReader, open <0>Tools → Progress sync</0> and choose <1>Custom sync server</1>."
 msgstr ""
 
 #: src/components/comic/comic-reader.tsx
@@ -4601,6 +4705,10 @@ msgstr "Soyez le premier à signaler un bug, une idée ou une question."
 msgid "Browse the publication directory to find new writers."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your unread queue, your saved articles and every publication you subscribe to, on a Kobo, a Kindle, a reMarkable or a phone — as real EPUB files, with the images, ready to read on a plane."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "Les textes les plus lus du réseau en ce moment."
@@ -5183,6 +5291,10 @@ msgstr ""
 msgid "Most posts"
 msgstr "Le plus de parutions"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "You do not need a catalog for a single piece. Every article's share menu has <0>Download EPUB</0> — and <1>Download CBZ</1> on a comic. A publication's <2>…</2> menu has <3>Send to e-reader…</3>, which offers its recent articles as one book and shows the catalog URL for that publication on its own."
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>1. Identity & signing key.</0> Give it a DID (a <1>did:web</1> is simplest) whose DID document advertises an <2>#atproto_labeler</2> service endpoint and an <3>#atproto_label</3> public signing key."
 msgstr "<0>1. Identité et clé de signature.</0> Donnez-lui un DID (un <1>did:web</1> est le plus simple) dont le document DID annonce un point de terminaison de service <2>#atproto_labeler</2> et une clé publique de signature <3>#atproto_label</3>."
@@ -5465,6 +5577,10 @@ msgstr "Suivre l'historique de lecture"
 #: src/components/reader/format-i18n.ts
 msgid "{readCount, plural, one {# read} other {{value} reads}}"
 msgstr "{readCount, plural, one {# lecture} other {{value} lectures}}"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "A few articles on the network are really link posts — a headline and a URL, bridged in from somewhere else, with no body to package. Those are left out of the catalog rather than offered as a file that would open to nothing. You will still find them in the app, where they link out to the site that has the writing."
+msgstr ""
 
 #: src/components/offline-sync-debug.tsx
 #: src/routes/_layout.collections.index.tsx
@@ -5896,6 +6012,10 @@ msgstr ""
 msgid "Collection"
 msgstr "Collection"
 
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Or add this catalog URL to KOReader, Foliate, Marvin or any other OPDS app, and browse {name} from the device itself."
+msgstr ""
+
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Most liked"
 msgstr ""
@@ -5951,6 +6071,10 @@ msgstr "Enregistre un lien dans votre collection <0>{appLabel}</0>."
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Drag to change the order your subscriptions appear in the sidebar."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Paste the sync server URL, then log in with your handle and the sync key. There is no separate account to register."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Appearance, reading preferences, and personal data."
@@ -6366,6 +6490,11 @@ msgstr "Le DID du service est <0>{appviewDid}</0>. Le service publie un <1>docum
 #: src/components/reader/about-view.tsx
 msgid "The Slow Web, Revisited"
 msgstr "Le Slow Web, revisité"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What you get"
+msgstr ""
 
 #. placeholder {0}: visible.length
 #: src/routes/_layout.communities.index.tsx
@@ -7067,6 +7196,10 @@ msgstr "Actions du compte"
 msgid "Read article"
 msgstr "Lire l'article"
 
+#: src/components/ereader-settings.tsx
+msgid "Your shelves, as an OPDS catalog. Anyone with this URL can see the same public records your profile already shows."
+msgstr ""
+
 #. placeholder {0}: formatBytes(usage.usage)
 #: src/components/offline-settings.tsx
 msgid "Standard Reader is using {0} on this device."
@@ -7169,6 +7302,10 @@ msgstr ""
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "Détails"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
+msgstr ""
 
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Topic views"
@@ -7465,6 +7602,10 @@ msgstr ""
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "{unreadCount} unread"
 msgstr "{unreadCount} non lus"
+
+#: src/components/ereader-settings.tsx
+msgid "Log in with this as your username — there is no separate sync account."
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "Below those, the publications you follow are listed for quick access. The <0>Subscriptions</0> heading above them opens the full management view. At the very bottom, your avatar opens a menu with your profile, reading history, recommended articles, feedback, settings, and log out."
@@ -7765,6 +7906,10 @@ msgstr "Chargement de l'article"
 msgid "Upvoted."
 msgstr "Vote enregistré."
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Browse and download.</0> Your shelves are the top level. Tap an article to pull the EPUB onto the device."
+msgstr ""
+
 #: src/components/reader/list-edit-modal.tsx
 msgid "Search your subscriptions"
 msgstr "Rechercher dans vos abonnements"
@@ -7870,6 +8015,10 @@ msgstr ""
 msgid "Discussion here is gathered from posts across the network, so you comment wherever you already post."
 msgstr ""
 
+#: src/components/comic/comic-reader.tsx
+msgid "Download this issue (CBZ)"
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Subscribe all"
 msgstr "Tout suivre"
@@ -7895,6 +8044,11 @@ msgstr "<0>Blocs structurés.</0> Documents riches issus d'éditeurs de blocs, c
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Keeping your place"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"
@@ -7969,6 +8123,10 @@ msgstr "Filtrer par sujet"
 
 #: src/components/reader/mute-menu-item.tsx
 msgid "Unmute {name}"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Copy your catalog URL.</0> It is in <1>Settings</1> under <2>E-readers</2>. It is yours — it carries your subscriptions and your saved articles."
 msgstr ""
 
 #. placeholder {0}: image.file.name
@@ -8176,6 +8334,10 @@ msgstr ""
 msgid "Standard Reader indexes <0>site.standard.document</0> and <1>site.standard.publication</1> records out of AT Proto repos. Platforms like Leaflet, Pckt, and Offprint write these records for you as part of publishing, so their authors get the full reader treatment automatically. If you run your own site and hand-roll your own <2>site.standard</2> integration instead, you write those records yourself — this page covers what to add, including Markpub, the markdown format we recommend for a hand-rolled body."
 msgstr "Standard Reader indexe les enregistrements <0>site.standard.document</0> et <1>site.standard.publication</1> des dépôts AT Proto. Des plateformes comme Leaflet, Pckt et Offprint écrivent ces enregistrements pour vous dans le cadre de la publication, si bien que leurs auteurs bénéficient automatiquement de toute l'expérience de lecture. Si vous gérez votre propre site et réalisez vous-même votre intégration <2>site.standard</2>, c'est à vous d'écrire ces enregistrements — cette page détaille ce qu'il faut ajouter, y compris Markpub, le format markdown que nous recommandons pour un corps d'article fait main."
 
+#: src/components/ereader-settings.tsx
+msgid "Catalog URL"
+msgstr ""
+
 #: src/components/reader/add-to-list-modal.tsx
 #: src/components/reader/list-edit-modal.tsx
 msgid "e.g. Tech, Friends, Cooking"
@@ -8282,6 +8444,10 @@ msgstr "Lorsque cette option est activée, tout le catalogue antérieur d'une pu
 #~ msgid "tuned to what you already follow."
 #~ msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your position also flows back here: read half of something on the Kobo and the article shows as half-read in the app, and in <0>Continue reading</0>. That direction is one-way. A position on a device is a place in <1>that device's</1> rendering of the file, and there is no honest way to turn a percentage back into one, so the app never sends a position out to a device that did not record it."
+msgstr ""
+
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this reply on Bluesky"
 msgstr "Ouvrir cette réponse sur Bluesky"
@@ -8309,6 +8475,7 @@ msgstr ""
 
 #: src/components/reader/discover-topic-filters.tsx
 #: src/components/reader/rss-feed-button.tsx
+#: src/components/reader/send-to-ereader-dialog.tsx
 #: src/components/reader/share-menu.tsx
 msgid "Close"
 msgstr "Fermer"
@@ -8553,6 +8720,10 @@ msgstr ""
 msgid "Cited by"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "KOReader can sync your reading position through Standard Reader, so picking up a book on a second device puts you where you stopped. Settings → <0>E-readers</0> has the three values it wants: the sync server URL, your username, and a sync key."
+msgstr ""
+
 #: src/routes/mcp/authorize.tsx
 msgid "Signed in as"
 msgstr ""
@@ -8606,4 +8777,8 @@ msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Describe this image"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
 msgstr ""

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -205,6 +205,10 @@ msgstr ""
 msgid "find publications, people, topics, and headlines by name."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Every device syncing with the old key stops until you enter the new one. Nothing you have already read is lost — reading positions are kept against the books themselves, not the key."
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Change language"
@@ -2066,6 +2070,10 @@ msgstr ""
 msgid "Subscribed to list"
 msgstr "Abonné à la liste"
 
+#: src/components/ereader-settings.tsx
+msgid "Rotate your sync key?"
+msgstr ""
+
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "See which of the people you pass on Bluesky write long-form."
 msgstr ""
@@ -2171,6 +2179,10 @@ msgstr "Supprimer la collection"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Interface font"
+msgstr ""
+
+#: src/components/ereader-settings.tsx
+msgid "Rotate"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
@@ -5273,6 +5285,10 @@ msgstr ""
 msgid "Subscribe to list"
 msgstr "S’abonner à la liste"
 
+#: src/components/ereader-settings.tsx
+msgid "Rotate key"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #: src/lib/guide/navigation.ts
 #~ msgid "Following a publication"
@@ -6513,6 +6529,10 @@ msgstr ""
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #~ msgid "Eight presets, or your own paper and accent. The rest of the interface is derived from them."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. Lost a device? <0>Rotate</0> in Settings issues a new key and stops the old one working."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 #: src/components/reading-custom-font-picker.tsx
@@ -8780,5 +8800,5 @@ msgid "Describe this image"
 msgstr ""
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
-msgstr ""
+#~ msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
+#~ msgstr ""

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -1907,8 +1907,8 @@ msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "Who can use your catalog URL"
-msgstr ""
+#~ msgid "Who can use your catalog URL"
+#~ msgstr ""
 
 #: src/components/reader/continue-reading.tsx
 #~ msgid "Reading progress"
@@ -7304,8 +7304,8 @@ msgid "Details"
 msgstr "詳細"
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
-msgstr ""
+#~ msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
+#~ msgstr ""
 
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Topic views"

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -205,6 +205,10 @@ msgstr ""
 msgid "find publications, people, topics, and headlines by name."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Every device syncing with the old key stops until you enter the new one. Nothing you have already read is lost — reading positions are kept against the books themselves, not the key."
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Change language"
@@ -2066,6 +2070,10 @@ msgstr ""
 msgid "Subscribed to list"
 msgstr "リストを購読しました"
 
+#: src/components/ereader-settings.tsx
+msgid "Rotate your sync key?"
+msgstr ""
+
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "See which of the people you pass on Bluesky write long-form."
 msgstr ""
@@ -2171,6 +2179,10 @@ msgstr "コレクションを削除"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Interface font"
+msgstr ""
+
+#: src/components/ereader-settings.tsx
+msgid "Rotate"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
@@ -5273,6 +5285,10 @@ msgstr ""
 msgid "Subscribe to list"
 msgstr "リストを購読"
 
+#: src/components/ereader-settings.tsx
+msgid "Rotate key"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #: src/lib/guide/navigation.ts
 #~ msgid "Following a publication"
@@ -6513,6 +6529,10 @@ msgstr ""
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #~ msgid "Eight presets, or your own paper and accent. The rest of the interface is derived from them."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. Lost a device? <0>Rotate</0> in Settings issues a new key and stops the old one working."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 #: src/components/reading-custom-font-picker.tsx
@@ -8780,5 +8800,5 @@ msgid "Describe this image"
 msgstr ""
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
-msgstr ""
+#~ msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
+#~ msgstr ""

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -17,6 +17,10 @@ msgstr ""
 msgid "This is the difference between making one anthology and running something with a rhythm to it — a weekly roundup, a themed quarterly, a reading list you keep adding to."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Add your catalog to KOReader, Foliate, Marvin, Panels or any other OPDS app and your unread queue, saved articles, subscriptions and lists show up on the device — each one downloadable as an EPUB."
+msgstr ""
+
 #: src/routes/_layout.discover.tsx
 msgid "Every publication the network knows about — subscribe to the ones worth your mornings."
 msgstr "ネットワーク上のすべての発行物。朝の時間を使う価値のあるものを購読しましょう。"
@@ -287,6 +291,10 @@ msgstr ""
 msgid "Mark as read"
 msgstr "既読にする"
 
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Send to your e-reader"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "This list is empty — add publications or people to it."
 msgstr "このリストは空です。発行物やユーザーを追加してください。"
@@ -347,6 +355,11 @@ msgstr "タイトルを入力してください。"
 #: src/components/guide/pages/finding-guide-page.tsx
 #~ msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Follow it and it starts appearing in your feeds like any other."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/components/user-settings-view.tsx
+msgid "E-readers"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
@@ -530,8 +543,16 @@ msgstr ""
 msgid "We couldn’t find that issue."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Comics come down as <0>CBZ</0> as well, so comic apps get their page turns and their scrubber instead of a reflowable book that fights them."
+msgstr ""
+
 #: src/routes/_layout.friends.tsx
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
+msgstr ""
+
+#: src/components/ereader-settings.tsx
+msgid "Sync username"
 msgstr ""
 
 #: src/components/reader/format-i18n.ts
@@ -541,6 +562,10 @@ msgstr ""
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "List"
 msgstr "リスト"
+
+#: src/components/reader/publication-actions.tsx
+msgid "Send to e-reader…"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "The spacing between things — tighter for more on screen, looser for more room to read."
@@ -733,6 +758,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Sync key"
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Landscape fits a compact row. Height adjusts automatically once the embed loads. Change the iframe width as needed."
 msgstr "横長は高さの低い行に収まります。埋め込みが読み込まれると高さは自動で調整されます。iframe の幅は必要に応じて変更してください。"
@@ -867,6 +896,11 @@ msgstr ""
 msgid "Log in to follow publications"
 msgstr "発行物をフォローするにはログインしてください"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What will not be there"
+msgstr ""
+
 #: src/routes/_layout.discover.tsx
 msgid "Search publications"
 msgstr "発行物を検索"
@@ -946,6 +980,10 @@ msgstr "サインインに失敗しました。もう一度お試しください
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Loading publications"
 msgstr "発行物を読み込み中"
+
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "OPDS catalog URL"
+msgstr ""
 
 #. placeholder {0}: meta.minutes
 #: src/magazine/flow.tsx
@@ -1218,6 +1256,11 @@ msgstr "コレクションを見る"
 msgid "Name"
 msgstr "名前"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Setting it up"
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "Where data lives"
 msgstr "データの保存先"
@@ -1305,6 +1348,10 @@ msgstr "{appLabel} の {savedName} に保存しました。"
 #: src/lib/guide/navigation.ts
 msgid "Getting started"
 msgstr "はじめかた"
+
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Download {name} as a file — images and all, ready to read offline."
+msgstr ""
 
 #: src/components/onboarding/step-settings.tsx
 msgid "Open posts on their original site"
@@ -1423,6 +1470,10 @@ msgstr ""
 #~ msgid "You don't have any subscriptions to reorder yet."
 #~ msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "What the sync key can do"
+msgstr ""
+
 #: src/components/reader/notify-button.tsx
 #: src/components/user-settings-view.tsx
 msgid "This browser doesn’t support web notifications."
@@ -1444,6 +1495,10 @@ msgstr "フィードバックの種類"
 #: src/components/guide/pages/welcome-guide-page.tsx
 #~ msgid "Home leads with one article worth your attention, then everything new from the publications you follow."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Downloading does not mark anything read, and reading on a device does not remove it from your unread shelf until KOReader syncs a position back. Polls, signup forms and other live embeds become links — a book cannot run them."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Enable the weekly digest"
@@ -1493,6 +1548,11 @@ msgstr "すべてフォロー"
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "That's every issue published so far."
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Sending one article"
 msgstr ""
 
 #. placeholder {0}: view.clientName
@@ -1794,6 +1854,10 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Turn on <0>Sync every N pages</0> if you want it to happen without asking."
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
 #~ msgstr "<0>site.standard.publication</0> のヒントは、そのドキュメントが発行物のレコードに属している場合にのみ含めてください。どのリーダーを想定していても両方を追加してください。これは当社の拡張機能だけでなく、ネットワーク上のあらゆるクライアントがページからレコードを解決するための仕組みです。"
@@ -1842,6 +1906,10 @@ msgstr ""
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Who can use your catalog URL"
+msgstr ""
+
 #: src/components/reader/continue-reading.tsx
 #~ msgid "Reading progress"
 #~ msgstr ""
@@ -1870,6 +1938,10 @@ msgstr ""
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "e.g. To Read"
 msgstr "例: あとで読む"
+
+#: src/lib/guide/navigation.ts
+msgid "Reading on an e-reader"
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/OpenLinksMenuItem.tsx
@@ -1954,6 +2026,10 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Making the text comfortable"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The files are built when you ask for them, from the same article bodies the reader shows — images pulled in, footnotes as real endnotes, a link back to the original at the end of every piece. Nothing is trimmed to an excerpt. A whole publication, a list or a collection can also come down as one book, with a table of contents."
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -2237,6 +2313,10 @@ msgstr "<0>{0}</0>の他の記事"
 msgid "On this device"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Add it to your reading app.</0> In KOReader that is <1>Search → OPDS catalog → +</1>. Foliate, Marvin, Aldiko, Thorium, Panels and Chunky all have a similar “add catalog” screen. Paste the URL and leave the username and password blank."
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
 msgstr "拡張機能の変更に合わせて、このポリシーを更新する場合があります。更新した際は、上部の「最終更新日」も変更されます。更新後も拡張機能を使い続けた場合、改訂後のポリシーに同意したものとみなされます。"
@@ -2253,6 +2333,10 @@ msgstr ""
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
+
+#: src/lib/guide/navigation.ts
+msgid "Put your unread queue on a Kobo, Kindle or phone as real EPUB files."
+msgstr ""
 
 #: src/components/reader/block-user-menu-item.tsx
 msgid "Block"
@@ -3147,6 +3231,10 @@ msgstr ""
 msgid "Plenty of people you already follow on Bluesky write long-form somewhere. <0>People you follow</0> finds them and puts their publications, and their newest articles, in one place. It is usually the highest-yield screen in the app the first week you use it."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Use this as the password. It only carries your reading position between devices — it cannot read or change anything else."
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "Second, it brings you <0>what they recommend</0>. Articles they have recommended start appearing in your feed, marked with who recommended them. That is the quiet engine behind finding new writing here: you are not only subscribing to what someone writes, you are borrowing their taste in what to read."
 msgstr ""
@@ -3337,6 +3425,10 @@ msgstr "購読中の発行物から"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>When you browse without signing in,</0> we serve public writing from our read-model index. We may store a theme preference cookie and, if you have signed in before on this device, a short list of recently used account handles (and optional avatar URLs) to speed up sign-in. We do not require an account to read."
 msgstr "<0>サインインせずに閲覧する場合、</0>読み取りモデルのインデックスから公開されている記事を配信します。テーマ設定の Cookie と、このデバイスで以前サインインしたことがある場合はサインインを速くするために最近使用したアカウントのハンドル（および任意でアバターの URL）の短いリストを保存することがあります。読むためにアカウントは必要ありません。"
+
+#: src/components/ereader-settings.tsx
+msgid "Sync server"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Paper"
@@ -3720,6 +3812,10 @@ msgstr ""
 msgid "Subscribe to this list to read new articles from its publications."
 msgstr "このリストを購読すると、含まれる発行物の新着記事を読めます。"
 
+#: src/components/ereader-settings.tsx
+msgid "In KOReader: Tools → Progress sync → Custom sync server."
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "{itemCount} of {MAX_ITEMS}"
 msgstr "{itemCount} / {MAX_ITEMS}"
@@ -3771,6 +3867,10 @@ msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter subscriptions"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Standard Reader publishes an <0>OPDS catalog</0> — the same thing a library or a bookstore hands an e-reading app. Point an app at it once and your shelves appear on the device: <1>Unread</1>, <2>Saved for later</2>, <3>Subscriptions</3>, each of your lists, and every publication you follow. Open any of them and each article has a download button."
 msgstr ""
 
 #: src/components/reader/mention-hover-card.tsx
@@ -3856,6 +3956,10 @@ msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "Signing in asks for permission to write only the kinds of records the app actually needs — follows, saves, recommendations, read records, and lists. It cannot post to Bluesky as you."
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "In KOReader, open <0>Tools → Progress sync</0> and choose <1>Custom sync server</1>."
 msgstr ""
 
 #: src/components/comic/comic-reader.tsx
@@ -4601,6 +4705,10 @@ msgstr "最初にバグ・アイデア・質問を投稿しましょう。"
 msgid "Browse the publication directory to find new writers."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your unread queue, your saved articles and every publication you subscribe to, on a Kobo, a Kindle, a reMarkable or a phone — as real EPUB files, with the images, ready to read on a plane."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "いまネットワークで最も読まれている記事です。"
@@ -5183,6 +5291,10 @@ msgstr ""
 msgid "Most posts"
 msgstr "投稿数が多い順"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "You do not need a catalog for a single piece. Every article's share menu has <0>Download EPUB</0> — and <1>Download CBZ</1> on a comic. A publication's <2>…</2> menu has <3>Send to e-reader…</3>, which offers its recent articles as one book and shows the catalog URL for that publication on its own."
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>1. Identity & signing key.</0> Give it a DID (a <1>did:web</1> is simplest) whose DID document advertises an <2>#atproto_labeler</2> service endpoint and an <3>#atproto_label</3> public signing key."
 msgstr "<0>1. アイデンティティと署名鍵。</0> DID（<1>did:web</1> が最も簡単です）を用意し、その DID ドキュメントで <2>#atproto_labeler</2> サービスエンドポイントと <3>#atproto_label</3> 公開署名鍵を公開します。"
@@ -5465,6 +5577,10 @@ msgstr "閲覧履歴を記録"
 #: src/components/reader/format-i18n.ts
 msgid "{readCount, plural, one {# read} other {{value} reads}}"
 msgstr "{readCount, plural, one {# 回読了} other {{value} 回読了}}"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "A few articles on the network are really link posts — a headline and a URL, bridged in from somewhere else, with no body to package. Those are left out of the catalog rather than offered as a file that would open to nothing. You will still find them in the app, where they link out to the site that has the writing."
+msgstr ""
 
 #: src/components/offline-sync-debug.tsx
 #: src/routes/_layout.collections.index.tsx
@@ -5896,6 +6012,10 @@ msgstr ""
 msgid "Collection"
 msgstr "コレクション"
 
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Or add this catalog URL to KOReader, Foliate, Marvin or any other OPDS app, and browse {name} from the device itself."
+msgstr ""
+
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Most liked"
 msgstr ""
@@ -5951,6 +6071,10 @@ msgstr "リンクを <0>{appLabel}</0> コレクションに保存します。"
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Drag to change the order your subscriptions appear in the sidebar."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Paste the sync server URL, then log in with your handle and the sync key. There is no separate account to register."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Appearance, reading preferences, and personal data."
@@ -6366,6 +6490,11 @@ msgstr "サービスの DID は <0>{appviewDid}</0> です。スコープを調�
 #: src/components/reader/about-view.tsx
 msgid "The Slow Web, Revisited"
 msgstr "スロー・ウェブ再訪"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What you get"
+msgstr ""
 
 #. placeholder {0}: visible.length
 #: src/routes/_layout.communities.index.tsx
@@ -7067,6 +7196,10 @@ msgstr "アカウント操作"
 msgid "Read article"
 msgstr "記事を読む"
 
+#: src/components/ereader-settings.tsx
+msgid "Your shelves, as an OPDS catalog. Anyone with this URL can see the same public records your profile already shows."
+msgstr ""
+
 #. placeholder {0}: formatBytes(usage.usage)
 #: src/components/offline-settings.tsx
 msgid "Standard Reader is using {0} on this device."
@@ -7169,6 +7302,10 @@ msgstr ""
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "詳細"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
+msgstr ""
 
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Topic views"
@@ -7465,6 +7602,10 @@ msgstr ""
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "{unreadCount} unread"
 msgstr "未読 {unreadCount} 件"
+
+#: src/components/ereader-settings.tsx
+msgid "Log in with this as your username — there is no separate sync account."
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "Below those, the publications you follow are listed for quick access. The <0>Subscriptions</0> heading above them opens the full management view. At the very bottom, your avatar opens a menu with your profile, reading history, recommended articles, feedback, settings, and log out."
@@ -7765,6 +7906,10 @@ msgstr "記事を読み込み中"
 msgid "Upvoted."
 msgstr "高評価しました。"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Browse and download.</0> Your shelves are the top level. Tap an article to pull the EPUB onto the device."
+msgstr ""
+
 #: src/components/reader/list-edit-modal.tsx
 msgid "Search your subscriptions"
 msgstr "購読中から検索"
@@ -7870,6 +8015,10 @@ msgstr ""
 msgid "Discussion here is gathered from posts across the network, so you comment wherever you already post."
 msgstr ""
 
+#: src/components/comic/comic-reader.tsx
+msgid "Download this issue (CBZ)"
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Subscribe all"
 msgstr "すべて購読"
@@ -7895,6 +8044,11 @@ msgstr "<0>構造化ブロック。</0> リッチなブロックエディタの�
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Keeping your place"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"
@@ -7969,6 +8123,10 @@ msgstr "トピックで絞り込む"
 
 #: src/components/reader/mute-menu-item.tsx
 msgid "Unmute {name}"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Copy your catalog URL.</0> It is in <1>Settings</1> under <2>E-readers</2>. It is yours — it carries your subscriptions and your saved articles."
 msgstr ""
 
 #. placeholder {0}: image.file.name
@@ -8176,6 +8334,10 @@ msgstr ""
 msgid "Standard Reader indexes <0>site.standard.document</0> and <1>site.standard.publication</1> records out of AT Proto repos. Platforms like Leaflet, Pckt, and Offprint write these records for you as part of publishing, so their authors get the full reader treatment automatically. If you run your own site and hand-roll your own <2>site.standard</2> integration instead, you write those records yourself — this page covers what to add, including Markpub, the markdown format we recommend for a hand-rolled body."
 msgstr "Standard Reader は AT Proto リポジトリから <0>site.standard.document</0> と <1>site.standard.publication</1> のレコードをインデックスします。Leaflet、Pckt、Offprint などのプラットフォームは公開時にこれらのレコードを書き込むため、その著者は自動的にリーダーの機能をフルに使えます。自分でサイトを運営し、<2>site.standard</2> 連携を独自に実装する場合は、これらのレコードを自分で書き込むことになります。このページでは追加すべき内容を説明します。独自実装の本文には Markpub という markdown 形式をおすすめしており、それについても解説します。"
 
+#: src/components/ereader-settings.tsx
+msgid "Catalog URL"
+msgstr ""
+
 #: src/components/reader/add-to-list-modal.tsx
 #: src/components/reader/list-edit-modal.tsx
 msgid "e.g. Tech, Friends, Cooking"
@@ -8282,6 +8444,10 @@ msgstr "オンにすると、購読時に発行物の過去記事すべてが未
 #~ msgid "tuned to what you already follow."
 #~ msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your position also flows back here: read half of something on the Kobo and the article shows as half-read in the app, and in <0>Continue reading</0>. That direction is one-way. A position on a device is a place in <1>that device's</1> rendering of the file, and there is no honest way to turn a percentage back into one, so the app never sends a position out to a device that did not record it."
+msgstr ""
+
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this reply on Bluesky"
 msgstr "この返信を Bluesky で開く"
@@ -8309,6 +8475,7 @@ msgstr ""
 
 #: src/components/reader/discover-topic-filters.tsx
 #: src/components/reader/rss-feed-button.tsx
+#: src/components/reader/send-to-ereader-dialog.tsx
 #: src/components/reader/share-menu.tsx
 msgid "Close"
 msgstr "閉じる"
@@ -8553,6 +8720,10 @@ msgstr ""
 msgid "Cited by"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "KOReader can sync your reading position through Standard Reader, so picking up a book on a second device puts you where you stopped. Settings → <0>E-readers</0> has the three values it wants: the sync server URL, your username, and a sync key."
+msgstr ""
+
 #: src/routes/mcp/authorize.tsx
 msgid "Signed in as"
 msgstr ""
@@ -8606,4 +8777,8 @@ msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Describe this image"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
 msgstr ""

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -1907,8 +1907,8 @@ msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "Who can use your catalog URL"
-msgstr ""
+#~ msgid "Who can use your catalog URL"
+#~ msgstr ""
 
 #: src/components/reader/continue-reading.tsx
 #~ msgid "Reading progress"
@@ -7304,8 +7304,8 @@ msgid "Details"
 msgstr "세부 정보"
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
-msgstr ""
+#~ msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
+#~ msgstr ""
 
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Topic views"

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -205,6 +205,10 @@ msgstr ""
 msgid "find publications, people, topics, and headlines by name."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Every device syncing with the old key stops until you enter the new one. Nothing you have already read is lost — reading positions are kept against the books themselves, not the key."
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Change language"
@@ -2066,6 +2070,10 @@ msgstr ""
 msgid "Subscribed to list"
 msgstr "목록 구독 완료"
 
+#: src/components/ereader-settings.tsx
+msgid "Rotate your sync key?"
+msgstr ""
+
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "See which of the people you pass on Bluesky write long-form."
 msgstr ""
@@ -2171,6 +2179,10 @@ msgstr "컬렉션 삭제"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Interface font"
+msgstr ""
+
+#: src/components/ereader-settings.tsx
+msgid "Rotate"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
@@ -5273,6 +5285,10 @@ msgstr ""
 msgid "Subscribe to list"
 msgstr "목록 구독"
 
+#: src/components/ereader-settings.tsx
+msgid "Rotate key"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #: src/lib/guide/navigation.ts
 #~ msgid "Following a publication"
@@ -6513,6 +6529,10 @@ msgstr ""
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #~ msgid "Eight presets, or your own paper and accent. The rest of the interface is derived from them."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. Lost a device? <0>Rotate</0> in Settings issues a new key and stops the old one working."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 #: src/components/reading-custom-font-picker.tsx
@@ -8780,5 +8800,5 @@ msgid "Describe this image"
 msgstr ""
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
-msgstr ""
+#~ msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
+#~ msgstr ""

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -17,6 +17,10 @@ msgstr ""
 msgid "This is the difference between making one anthology and running something with a rhythm to it — a weekly roundup, a themed quarterly, a reading list you keep adding to."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Add your catalog to KOReader, Foliate, Marvin, Panels or any other OPDS app and your unread queue, saved articles, subscriptions and lists show up on the device — each one downloadable as an EPUB."
+msgstr ""
+
 #: src/routes/_layout.discover.tsx
 msgid "Every publication the network knows about — subscribe to the ones worth your mornings."
 msgstr "네트워크가 알고 있는 모든 발행물 — 아침 시간을 내줄 만한 곳을 구독하세요."
@@ -287,6 +291,10 @@ msgstr ""
 msgid "Mark as read"
 msgstr "읽음으로 표시"
 
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Send to your e-reader"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "This list is empty — add publications or people to it."
 msgstr "이 목록은 비어 있습니다 — 발행물이나 사람을 추가하세요."
@@ -347,6 +355,11 @@ msgstr "제목을 입력하세요."
 #: src/components/guide/pages/finding-guide-page.tsx
 #~ msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Follow it and it starts appearing in your feeds like any other."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/components/user-settings-view.tsx
+msgid "E-readers"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
@@ -530,8 +543,16 @@ msgstr ""
 msgid "We couldn’t find that issue."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Comics come down as <0>CBZ</0> as well, so comic apps get their page turns and their scrubber instead of a reflowable book that fights them."
+msgstr ""
+
 #: src/routes/_layout.friends.tsx
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
+msgstr ""
+
+#: src/components/ereader-settings.tsx
+msgid "Sync username"
 msgstr ""
 
 #: src/components/reader/format-i18n.ts
@@ -541,6 +562,10 @@ msgstr ""
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "List"
 msgstr "목록"
+
+#: src/components/reader/publication-actions.tsx
+msgid "Send to e-reader…"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "The spacing between things — tighter for more on screen, looser for more room to read."
@@ -733,6 +758,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Sync key"
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Landscape fits a compact row. Height adjusts automatically once the embed loads. Change the iframe width as needed."
 msgstr "가로형은 좁은 행에 알맞습니다. 임베드가 로드되면 높이는 자동으로 조정됩니다. iframe 너비는 필요에 따라 변경하세요."
@@ -867,6 +896,11 @@ msgstr ""
 msgid "Log in to follow publications"
 msgstr "발행물을 팔로우하려면 로그인하세요"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What will not be there"
+msgstr ""
+
 #: src/routes/_layout.discover.tsx
 msgid "Search publications"
 msgstr "발행물 검색"
@@ -946,6 +980,10 @@ msgstr "로그인에 실패했습니다. 다시 시도하세요."
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Loading publications"
 msgstr "발행물 불러오는 중"
+
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "OPDS catalog URL"
+msgstr ""
 
 #. placeholder {0}: meta.minutes
 #: src/magazine/flow.tsx
@@ -1218,6 +1256,11 @@ msgstr "컬렉션 보기"
 msgid "Name"
 msgstr "이름"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Setting it up"
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "Where data lives"
 msgstr "데이터가 저장되는 곳"
@@ -1305,6 +1348,10 @@ msgstr "{appLabel}의 {savedName}에 저장했습니다."
 #: src/lib/guide/navigation.ts
 msgid "Getting started"
 msgstr "시작하기"
+
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Download {name} as a file — images and all, ready to read offline."
+msgstr ""
 
 #: src/components/onboarding/step-settings.tsx
 msgid "Open posts on their original site"
@@ -1423,6 +1470,10 @@ msgstr ""
 #~ msgid "You don't have any subscriptions to reorder yet."
 #~ msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "What the sync key can do"
+msgstr ""
+
 #: src/components/reader/notify-button.tsx
 #: src/components/user-settings-view.tsx
 msgid "This browser doesn’t support web notifications."
@@ -1444,6 +1495,10 @@ msgstr "피드백 유형"
 #: src/components/guide/pages/welcome-guide-page.tsx
 #~ msgid "Home leads with one article worth your attention, then everything new from the publications you follow."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Downloading does not mark anything read, and reading on a device does not remove it from your unread shelf until KOReader syncs a position back. Polls, signup forms and other live embeds become links — a book cannot run them."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Enable the weekly digest"
@@ -1493,6 +1548,11 @@ msgstr "모두 팔로우"
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "That's every issue published so far."
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Sending one article"
 msgstr ""
 
 #. placeholder {0}: view.clientName
@@ -1794,6 +1854,10 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Turn on <0>Sync every N pages</0> if you want it to happen without asking."
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
 #~ msgstr "문서가 발행물 레코드에 속한 경우에만 <0>site.standard.publication</0> 힌트를 포함하세요. 어떤 리더를 염두에 두든 둘 다 추가하세요. 이는 우리 확장 프로그램뿐 아니라 네트워크의 모든 클라이언트가 페이지를 해당 레코드로 연결하는 방식입니다."
@@ -1842,6 +1906,10 @@ msgstr ""
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Who can use your catalog URL"
+msgstr ""
+
 #: src/components/reader/continue-reading.tsx
 #~ msgid "Reading progress"
 #~ msgstr ""
@@ -1870,6 +1938,10 @@ msgstr ""
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "e.g. To Read"
 msgstr "예: 읽을거리"
+
+#: src/lib/guide/navigation.ts
+msgid "Reading on an e-reader"
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/OpenLinksMenuItem.tsx
@@ -1954,6 +2026,10 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Making the text comfortable"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The files are built when you ask for them, from the same article bodies the reader shows — images pulled in, footnotes as real endnotes, a link back to the original at the end of every piece. Nothing is trimmed to an excerpt. A whole publication, a list or a collection can also come down as one book, with a table of contents."
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -2237,6 +2313,10 @@ msgstr "<0>{0}</0>의 다른 글"
 msgid "On this device"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Add it to your reading app.</0> In KOReader that is <1>Search → OPDS catalog → +</1>. Foliate, Marvin, Aldiko, Thorium, Panels and Chunky all have a similar “add catalog” screen. Paste the URL and leave the username and password blank."
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
 msgstr "확장 프로그램이 변경되면 본 정책을 업데이트할 수 있습니다. 업데이트 시 상단의 “최종 수정일”이 변경됩니다. 업데이트 후에도 확장 프로그램을 계속 사용하면 개정된 정책에 동의한 것으로 간주됩니다."
@@ -2253,6 +2333,10 @@ msgstr ""
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
+
+#: src/lib/guide/navigation.ts
+msgid "Put your unread queue on a Kobo, Kindle or phone as real EPUB files."
+msgstr ""
 
 #: src/components/reader/block-user-menu-item.tsx
 msgid "Block"
@@ -3147,6 +3231,10 @@ msgstr ""
 msgid "Plenty of people you already follow on Bluesky write long-form somewhere. <0>People you follow</0> finds them and puts their publications, and their newest articles, in one place. It is usually the highest-yield screen in the app the first week you use it."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Use this as the password. It only carries your reading position between devices — it cannot read or change anything else."
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "Second, it brings you <0>what they recommend</0>. Articles they have recommended start appearing in your feed, marked with who recommended them. That is the quiet engine behind finding new writing here: you are not only subscribing to what someone writes, you are borrowing their taste in what to read."
 msgstr ""
@@ -3337,6 +3425,10 @@ msgstr "구독 중인 곳에서"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>When you browse without signing in,</0> we serve public writing from our read-model index. We may store a theme preference cookie and, if you have signed in before on this device, a short list of recently used account handles (and optional avatar URLs) to speed up sign-in. We do not require an account to read."
 msgstr "<0>로그인하지 않고 둘러볼 때는</0> 읽기 모델 색인에 있는 공개 글을 제공합니다. 테마 설정 쿠키를 저장할 수 있으며, 이 기기에서 이전에 로그인한 적이 있다면 로그인을 빠르게 하기 위해 최근 사용한 계정 핸들 목록(및 선택적으로 아바타 URL)을 저장할 수 있습니다. 읽는 데 계정은 필요하지 않습니다."
+
+#: src/components/ereader-settings.tsx
+msgid "Sync server"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Paper"
@@ -3720,6 +3812,10 @@ msgstr ""
 msgid "Subscribe to this list to read new articles from its publications."
 msgstr "이 리스트를 구독하면 소속 발행물의 새 글을 받아볼 수 있습니다."
 
+#: src/components/ereader-settings.tsx
+msgid "In KOReader: Tools → Progress sync → Custom sync server."
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "{itemCount} of {MAX_ITEMS}"
 msgstr "{MAX_ITEMS}개 중 {itemCount}개"
@@ -3771,6 +3867,10 @@ msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter subscriptions"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Standard Reader publishes an <0>OPDS catalog</0> — the same thing a library or a bookstore hands an e-reading app. Point an app at it once and your shelves appear on the device: <1>Unread</1>, <2>Saved for later</2>, <3>Subscriptions</3>, each of your lists, and every publication you follow. Open any of them and each article has a download button."
 msgstr ""
 
 #: src/components/reader/mention-hover-card.tsx
@@ -3856,6 +3956,10 @@ msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "Signing in asks for permission to write only the kinds of records the app actually needs — follows, saves, recommendations, read records, and lists. It cannot post to Bluesky as you."
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "In KOReader, open <0>Tools → Progress sync</0> and choose <1>Custom sync server</1>."
 msgstr ""
 
 #: src/components/comic/comic-reader.tsx
@@ -4601,6 +4705,10 @@ msgstr "버그, 아이디어, 질문을 가장 먼저 남겨보세요."
 msgid "Browse the publication directory to find new writers."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your unread queue, your saved articles and every publication you subscribe to, on a Kobo, a Kindle, a reMarkable or a phone — as real EPUB files, with the images, ready to read on a plane."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "지금 네트워크에서 가장 많이 읽히는 글입니다."
@@ -5183,6 +5291,10 @@ msgstr ""
 msgid "Most posts"
 msgstr "게시물 많은 순"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "You do not need a catalog for a single piece. Every article's share menu has <0>Download EPUB</0> — and <1>Download CBZ</1> on a comic. A publication's <2>…</2> menu has <3>Send to e-reader…</3>, which offers its recent articles as one book and shows the catalog URL for that publication on its own."
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>1. Identity & signing key.</0> Give it a DID (a <1>did:web</1> is simplest) whose DID document advertises an <2>#atproto_labeler</2> service endpoint and an <3>#atproto_label</3> public signing key."
 msgstr "<0>1. 신원 및 서명 키.</0> DID를 부여하세요(<1>did:web</1>이 가장 간단합니다). 해당 DID 문서는 <2>#atproto_labeler</2> 서비스 엔드포인트와 <3>#atproto_label</3> 공개 서명 키를 알려야 합니다."
@@ -5465,6 +5577,10 @@ msgstr "읽기 기록 추적"
 #: src/components/reader/format-i18n.ts
 msgid "{readCount, plural, one {# read} other {{value} reads}}"
 msgstr "{readCount, plural, one {# 읽음} other {{value} 읽음}}"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "A few articles on the network are really link posts — a headline and a URL, bridged in from somewhere else, with no body to package. Those are left out of the catalog rather than offered as a file that would open to nothing. You will still find them in the app, where they link out to the site that has the writing."
+msgstr ""
 
 #: src/components/offline-sync-debug.tsx
 #: src/routes/_layout.collections.index.tsx
@@ -5896,6 +6012,10 @@ msgstr ""
 msgid "Collection"
 msgstr "컬렉션"
 
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Or add this catalog URL to KOReader, Foliate, Marvin or any other OPDS app, and browse {name} from the device itself."
+msgstr ""
+
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Most liked"
 msgstr ""
@@ -5951,6 +6071,10 @@ msgstr "<0>{appLabel}</0> 컬렉션에 링크를 저장합니다."
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Drag to change the order your subscriptions appear in the sidebar."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Paste the sync server URL, then log in with your handle and the sync key. There is no separate account to register."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Appearance, reading preferences, and personal data."
@@ -6366,6 +6490,11 @@ msgstr "서비스 DID는 <0>{appviewDid}</0>입니다. 이 서비스는 스코�
 #: src/components/reader/about-view.tsx
 msgid "The Slow Web, Revisited"
 msgstr "느린 웹, 다시 보기"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What you get"
+msgstr ""
 
 #. placeholder {0}: visible.length
 #: src/routes/_layout.communities.index.tsx
@@ -7067,6 +7196,10 @@ msgstr "계정 작업"
 msgid "Read article"
 msgstr "글 읽기"
 
+#: src/components/ereader-settings.tsx
+msgid "Your shelves, as an OPDS catalog. Anyone with this URL can see the same public records your profile already shows."
+msgstr ""
+
 #. placeholder {0}: formatBytes(usage.usage)
 #: src/components/offline-settings.tsx
 msgid "Standard Reader is using {0} on this device."
@@ -7169,6 +7302,10 @@ msgstr ""
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "세부 정보"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
+msgstr ""
 
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Topic views"
@@ -7465,6 +7602,10 @@ msgstr ""
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "{unreadCount} unread"
 msgstr "안 읽음 {unreadCount}"
+
+#: src/components/ereader-settings.tsx
+msgid "Log in with this as your username — there is no separate sync account."
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "Below those, the publications you follow are listed for quick access. The <0>Subscriptions</0> heading above them opens the full management view. At the very bottom, your avatar opens a menu with your profile, reading history, recommended articles, feedback, settings, and log out."
@@ -7765,6 +7906,10 @@ msgstr "글 불러오는 중"
 msgid "Upvoted."
 msgstr "추천했습니다."
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Browse and download.</0> Your shelves are the top level. Tap an article to pull the EPUB onto the device."
+msgstr ""
+
 #: src/components/reader/list-edit-modal.tsx
 msgid "Search your subscriptions"
 msgstr "구독 검색"
@@ -7870,6 +8015,10 @@ msgstr ""
 msgid "Discussion here is gathered from posts across the network, so you comment wherever you already post."
 msgstr ""
 
+#: src/components/comic/comic-reader.tsx
+msgid "Download this issue (CBZ)"
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Subscribe all"
 msgstr "전체 구독"
@@ -7895,6 +8044,11 @@ msgstr "<0>구조화된 블록.</0> 리치 블록 에디터 문서로, 각각 �
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Keeping your place"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"
@@ -7969,6 +8123,10 @@ msgstr "주제로 필터"
 
 #: src/components/reader/mute-menu-item.tsx
 msgid "Unmute {name}"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Copy your catalog URL.</0> It is in <1>Settings</1> under <2>E-readers</2>. It is yours — it carries your subscriptions and your saved articles."
 msgstr ""
 
 #. placeholder {0}: image.file.name
@@ -8176,6 +8334,10 @@ msgstr ""
 msgid "Standard Reader indexes <0>site.standard.document</0> and <1>site.standard.publication</1> records out of AT Proto repos. Platforms like Leaflet, Pckt, and Offprint write these records for you as part of publishing, so their authors get the full reader treatment automatically. If you run your own site and hand-roll your own <2>site.standard</2> integration instead, you write those records yourself — this page covers what to add, including Markpub, the markdown format we recommend for a hand-rolled body."
 msgstr "Standard Reader는 AT Proto 저장소에서 <0>site.standard.document</0>와 <1>site.standard.publication</1> 레코드를 색인합니다. Leaflet, Pckt, Offprint 같은 플랫폼은 발행 과정에서 이 레코드를 대신 작성해 주므로, 해당 저자들은 자동으로 완전한 리더 경험을 얻습니다. 직접 사이트를 운영하며 <2>site.standard</2> 연동을 직접 구현한다면 이 레코드를 스스로 작성해야 합니다 — 이 페이지에서는 무엇을 추가해야 하는지, 그리고 직접 작성하는 본문에 권장하는 마크다운 형식인 Markpub까지 다룹니다."
 
+#: src/components/ereader-settings.tsx
+msgid "Catalog URL"
+msgstr ""
+
 #: src/components/reader/add-to-list-modal.tsx
 #: src/components/reader/list-edit-modal.tsx
 msgid "e.g. Tech, Friends, Cooking"
@@ -8282,6 +8444,10 @@ msgstr "켜면 구독할 때 해당 발행물의 지난 글 전체가 읽지 않
 #~ msgid "tuned to what you already follow."
 #~ msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your position also flows back here: read half of something on the Kobo and the article shows as half-read in the app, and in <0>Continue reading</0>. That direction is one-way. A position on a device is a place in <1>that device's</1> rendering of the file, and there is no honest way to turn a percentage back into one, so the app never sends a position out to a device that did not record it."
+msgstr ""
+
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this reply on Bluesky"
 msgstr "이 답글을 Bluesky에서 열기"
@@ -8309,6 +8475,7 @@ msgstr ""
 
 #: src/components/reader/discover-topic-filters.tsx
 #: src/components/reader/rss-feed-button.tsx
+#: src/components/reader/send-to-ereader-dialog.tsx
 #: src/components/reader/share-menu.tsx
 msgid "Close"
 msgstr "닫기"
@@ -8553,6 +8720,10 @@ msgstr ""
 msgid "Cited by"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "KOReader can sync your reading position through Standard Reader, so picking up a book on a second device puts you where you stopped. Settings → <0>E-readers</0> has the three values it wants: the sync server URL, your username, and a sync key."
+msgstr ""
+
 #: src/routes/mcp/authorize.tsx
 msgid "Signed in as"
 msgstr ""
@@ -8606,4 +8777,8 @@ msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Describe this image"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
 msgstr ""

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -205,6 +205,10 @@ msgstr ""
 msgid "find publications, people, topics, and headlines by name."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Every device syncing with the old key stops until you enter the new one. Nothing you have already read is lost — reading positions are kept against the books themselves, not the key."
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Change language"
@@ -2066,6 +2070,10 @@ msgstr ""
 msgid "Subscribed to list"
 msgstr "Inscrito na lista"
 
+#: src/components/ereader-settings.tsx
+msgid "Rotate your sync key?"
+msgstr ""
+
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "See which of the people you pass on Bluesky write long-form."
 msgstr ""
@@ -2171,6 +2179,10 @@ msgstr "Apagar coleção"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Interface font"
+msgstr ""
+
+#: src/components/ereader-settings.tsx
+msgid "Rotate"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
@@ -5273,6 +5285,10 @@ msgstr "Seus últimos cinco artigos salvos para mais tarde"
 msgid "Subscribe to list"
 msgstr "Inscreva-se na lista"
 
+#: src/components/ereader-settings.tsx
+msgid "Rotate key"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #: src/lib/guide/navigation.ts
 #~ msgid "Following a publication"
@@ -6513,6 +6529,10 @@ msgstr ""
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #~ msgid "Eight presets, or your own paper and accent. The rest of the interface is derived from them."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. Lost a device? <0>Rotate</0> in Settings issues a new key and stops the old one working."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 #: src/components/reading-custom-font-picker.tsx
@@ -8780,5 +8800,5 @@ msgid "Describe this image"
 msgstr ""
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
-msgstr ""
+#~ msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
+#~ msgstr ""

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -1907,8 +1907,8 @@ msgid "No topics match “{debouncedQuery}”."
 msgstr "Nenhum tema corresponde a “{debouncedQuery}”"
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "Who can use your catalog URL"
-msgstr ""
+#~ msgid "Who can use your catalog URL"
+#~ msgstr ""
 
 #: src/components/reader/continue-reading.tsx
 #~ msgid "Reading progress"
@@ -7304,8 +7304,8 @@ msgid "Details"
 msgstr "Detalhes"
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
-msgstr ""
+#~ msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
+#~ msgstr ""
 
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Topic views"

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -17,6 +17,10 @@ msgstr ""
 msgid "This is the difference between making one anthology and running something with a rhythm to it — a weekly roundup, a themed quarterly, a reading list you keep adding to."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Add your catalog to KOReader, Foliate, Marvin, Panels or any other OPDS app and your unread queue, saved articles, subscriptions and lists show up on the device — each one downloadable as an EPUB."
+msgstr ""
+
 #: src/routes/_layout.discover.tsx
 msgid "Every publication the network knows about — subscribe to the ones worth your mornings."
 msgstr "Todas as publicações que a rede conhece — inscreva-se nas que merecem as suas manhãs."
@@ -287,6 +291,10 @@ msgstr ""
 msgid "Mark as read"
 msgstr "Marcar como lido"
 
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Send to your e-reader"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "This list is empty — add publications or people to it."
 msgstr "Esta lista está vazia — adicione publicações ou pessoas."
@@ -347,6 +355,11 @@ msgstr "Adicione um título."
 #: src/components/guide/pages/finding-guide-page.tsx
 #~ msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Follow it and it starts appearing in your feeds like any other."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/components/user-settings-view.tsx
+msgid "E-readers"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
@@ -530,9 +543,17 @@ msgstr ""
 msgid "We couldn’t find that issue."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Comics come down as <0>CBZ</0> as well, so comic apps get their page turns and their scrubber instead of a reflowable book that fights them."
+msgstr ""
+
 #: src/routes/_layout.friends.tsx
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
 msgstr "Publicações escritas pelas pessoas que você segue no Bluesky, exceto as que você já está inscrito."
+
+#: src/components/ereader-settings.tsx
+msgid "Sync username"
+msgstr ""
 
 #: src/components/reader/format-i18n.ts
 msgid "{years}y ago"
@@ -541,6 +562,10 @@ msgstr ""
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "List"
 msgstr "Lista"
+
+#: src/components/reader/publication-actions.tsx
+msgid "Send to e-reader…"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "The spacing between things — tighter for more on screen, looser for more room to read."
@@ -733,6 +758,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Sync key"
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Landscape fits a compact row. Height adjusts automatically once the embed loads. Change the iframe width as needed."
 msgstr "O formato horizontal cabe numa linha compacta. A altura ajusta-se automaticamente assim que o elemento carrega. Altere a largura do iframe conforme necessário."
@@ -867,6 +896,11 @@ msgstr "publicar rótulos do AT Protocol que o Standard Reader exibe — e com b
 msgid "Log in to follow publications"
 msgstr "Inicie sessão para seguir publicações"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What will not be there"
+msgstr ""
+
 #: src/routes/_layout.discover.tsx
 msgid "Search publications"
 msgstr "Pesquisar publicações"
@@ -946,6 +980,10 @@ msgstr "Falha ao iniciar sessão. Tente novamente."
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Loading publications"
 msgstr "Carregando publicações"
+
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "OPDS catalog URL"
+msgstr ""
 
 #. placeholder {0}: meta.minutes
 #: src/magazine/flow.tsx
@@ -1218,6 +1256,11 @@ msgstr "Ver coleções"
 msgid "Name"
 msgstr "Nome"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Setting it up"
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "Where data lives"
 msgstr "Onde residem os dados"
@@ -1305,6 +1348,10 @@ msgstr "Salvo em {savedName} no {appLabel}."
 #: src/lib/guide/navigation.ts
 msgid "Getting started"
 msgstr "Primeiros passos"
+
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Download {name} as a file — images and all, ready to read offline."
+msgstr ""
 
 #: src/components/onboarding/step-settings.tsx
 msgid "Open posts on their original site"
@@ -1423,6 +1470,10 @@ msgstr "Navegue pelo diretório"
 #~ msgid "You don't have any subscriptions to reorder yet."
 #~ msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "What the sync key can do"
+msgstr ""
+
 #: src/components/reader/notify-button.tsx
 #: src/components/user-settings-view.tsx
 msgid "This browser doesn’t support web notifications."
@@ -1444,6 +1495,10 @@ msgstr "Tipo de comentário"
 #: src/components/guide/pages/welcome-guide-page.tsx
 #~ msgid "Home leads with one article worth your attention, then everything new from the publications you follow."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Downloading does not mark anything read, and reading on a device does not remove it from your unread shelf until KOReader syncs a position back. Polls, signup forms and other live embeds become links — a book cannot run them."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Enable the weekly digest"
@@ -1493,6 +1548,11 @@ msgstr "Seguir todas"
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "That's every issue published so far."
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Sending one article"
 msgstr ""
 
 #. placeholder {0}: view.clientName
@@ -1794,6 +1854,10 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Turn on <0>Sync every N pages</0> if you want it to happen without asking."
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
 #~ msgstr "Inclua a dica <0>site.standard.publication</0> apenas se o documento pertencer a um registo de publicação. Adicione ambas, independentemente do leitor que lhe interessa — é assim que qualquer cliente na rede resolve a sua página para o respetivo registo, não só a nossa extensão."
@@ -1842,6 +1906,10 @@ msgstr ""
 msgid "No topics match “{debouncedQuery}”."
 msgstr "Nenhum tema corresponde a “{debouncedQuery}”"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Who can use your catalog URL"
+msgstr ""
+
 #: src/components/reader/continue-reading.tsx
 #~ msgid "Reading progress"
 #~ msgstr ""
@@ -1870,6 +1938,10 @@ msgstr ""
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "e.g. To Read"
 msgstr "ex.: Para ler"
+
+#: src/lib/guide/navigation.ts
+msgid "Reading on an e-reader"
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/OpenLinksMenuItem.tsx
@@ -1954,6 +2026,10 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Making the text comfortable"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The files are built when you ask for them, from the same article bodies the reader shows — images pulled in, footnotes as real endnotes, a link back to the original at the end of every piece. Nothing is trimmed to an excerpt. A whole publication, a list or a collection can also come down as one book, with a table of contents."
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -2237,6 +2313,10 @@ msgstr "Mais de <0>{0}</0>"
 msgid "On this device"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Add it to your reading app.</0> In KOReader that is <1>Search → OPDS catalog → +</1>. Foliate, Marvin, Aldiko, Thorium, Panels and Chunky all have a similar “add catalog” screen. Paste the URL and leave the username and password blank."
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
 msgstr "Podemos atualizar esta política à medida que a extensão evolui. A data de “Última atualização” no topo mudará quando o fizermos. A utilização continuada da extensão após uma atualização significa que aceita a política revista."
@@ -2253,6 +2333,10 @@ msgstr ""
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr "Escolha o pacote para o seu framework; todos se baseiam no mesmo núcleo."
+
+#: src/lib/guide/navigation.ts
+msgid "Put your unread queue on a Kobo, Kindle or phone as real EPUB files."
+msgstr ""
 
 #: src/components/reader/block-user-menu-item.tsx
 msgid "Block"
@@ -3147,6 +3231,10 @@ msgstr ""
 msgid "Plenty of people you already follow on Bluesky write long-form somewhere. <0>People you follow</0> finds them and puts their publications, and their newest articles, in one place. It is usually the highest-yield screen in the app the first week you use it."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Use this as the password. It only carries your reading position between devices — it cannot read or change anything else."
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "Second, it brings you <0>what they recommend</0>. Articles they have recommended start appearing in your feed, marked with who recommended them. That is the quiet engine behind finding new writing here: you are not only subscribing to what someone writes, you are borrowing their taste in what to read."
 msgstr ""
@@ -3337,6 +3425,10 @@ msgstr "Das suas inscrições"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>When you browse without signing in,</0> we serve public writing from our read-model index. We may store a theme preference cookie and, if you have signed in before on this device, a short list of recently used account handles (and optional avatar URLs) to speed up sign-in. We do not require an account to read."
 msgstr "<0>Quando navega sem iniciar sessão,</0> servimos textos públicos do nosso índice de modelo de leitura. Podemos guardar um cookie com a preferência de tema e, se já tiver iniciado sessão neste dispositivo, uma lista curta de identificadores de conta usados recentemente (e URLs de avatar opcionais) para acelerar o início de sessão. Não exigimos conta para ler."
+
+#: src/components/ereader-settings.tsx
+msgid "Sync server"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Paper"
@@ -3720,6 +3812,10 @@ msgstr ""
 msgid "Subscribe to this list to read new articles from its publications."
 msgstr "Inscreva-se nesta lista para ler os novos artigos das suas publicações."
 
+#: src/components/ereader-settings.tsx
+msgid "In KOReader: Tools → Progress sync → Custom sync server."
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "{itemCount} of {MAX_ITEMS}"
 msgstr "{itemCount} de {MAX_ITEMS}"
@@ -3772,6 +3868,10 @@ msgstr ""
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter subscriptions"
 msgstr "Filtrar inscrições"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Standard Reader publishes an <0>OPDS catalog</0> — the same thing a library or a bookstore hands an e-reading app. Point an app at it once and your shelves appear on the device: <1>Unread</1>, <2>Saved for later</2>, <3>Subscriptions</3>, each of your lists, and every publication you follow. Open any of them and each article has a download button."
+msgstr ""
 
 #: src/components/reader/mention-hover-card.tsx
 msgid "{n, plural, one {# publication} other {{value} publications}}"
@@ -3856,6 +3956,10 @@ msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "Signing in asks for permission to write only the kinds of records the app actually needs — follows, saves, recommendations, read records, and lists. It cannot post to Bluesky as you."
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "In KOReader, open <0>Tools → Progress sync</0> and choose <1>Custom sync server</1>."
 msgstr ""
 
 #: src/components/comic/comic-reader.tsx
@@ -4601,6 +4705,10 @@ msgstr "Seja o primeiro a compartilhar um erro, uma ideia ou uma pergunta."
 msgid "Browse the publication directory to find new writers."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your unread queue, your saved articles and every publication you subscribe to, on a Kobo, a Kindle, a reMarkable or a phone — as real EPUB files, with the images, ready to read on a plane."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "Os textos mais lidos em toda a rede neste momento."
@@ -5183,6 +5291,10 @@ msgstr ""
 msgid "Most posts"
 msgstr "Mais artigos"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "You do not need a catalog for a single piece. Every article's share menu has <0>Download EPUB</0> — and <1>Download CBZ</1> on a comic. A publication's <2>…</2> menu has <3>Send to e-reader…</3>, which offers its recent articles as one book and shows the catalog URL for that publication on its own."
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>1. Identity & signing key.</0> Give it a DID (a <1>did:web</1> is simplest) whose DID document advertises an <2>#atproto_labeler</2> service endpoint and an <3>#atproto_label</3> public signing key."
 msgstr "<0>1. Identidade e chave de assinatura.</0> Atribua-lhe um DID (um <1>did:web</1> é o mais simples) cujo documento DID anuncie um ponto final de serviço <2>#atproto_labeler</2> e uma chave pública de assinatura <3>#atproto_label</3>."
@@ -5465,6 +5577,10 @@ msgstr "Registar histórico de leitura"
 #: src/components/reader/format-i18n.ts
 msgid "{readCount, plural, one {# read} other {{value} reads}}"
 msgstr "{readCount, plural, one {# leitura} other {{value} leituras}}"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "A few articles on the network are really link posts — a headline and a URL, bridged in from somewhere else, with no body to package. Those are left out of the catalog rather than offered as a file that would open to nothing. You will still find them in the app, where they link out to the site that has the writing."
+msgstr ""
 
 #: src/components/offline-sync-debug.tsx
 #: src/routes/_layout.collections.index.tsx
@@ -5896,6 +6012,10 @@ msgstr "Ou ninguém que você segue no Bluesky publica aqui ainda, ou você já 
 msgid "Collection"
 msgstr "Coleção"
 
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Or add this catalog URL to KOReader, Foliate, Marvin or any other OPDS app, and browse {name} from the device itself."
+msgstr ""
+
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Most liked"
 msgstr ""
@@ -5951,6 +6071,10 @@ msgstr "Salva um link na sua coleção <0>{appLabel}</0>."
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Drag to change the order your subscriptions appear in the sidebar."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Paste the sync server URL, then log in with your handle and the sync key. There is no separate account to register."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Appearance, reading preferences, and personal data."
@@ -6366,6 +6490,11 @@ msgstr "O DID do serviço é <0>{appviewDid}</0>. O serviço divulga um <1>docum
 #: src/components/reader/about-view.tsx
 msgid "The Slow Web, Revisited"
 msgstr "A Slow Web, Revisitada"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What you get"
+msgstr ""
 
 #. placeholder {0}: visible.length
 #: src/routes/_layout.communities.index.tsx
@@ -7067,6 +7196,10 @@ msgstr "Ações da conta"
 msgid "Read article"
 msgstr "Ler artigo"
 
+#: src/components/ereader-settings.tsx
+msgid "Your shelves, as an OPDS catalog. Anyone with this URL can see the same public records your profile already shows."
+msgstr ""
+
 #. placeholder {0}: formatBytes(usage.usage)
 #: src/components/offline-settings.tsx
 msgid "Standard Reader is using {0} on this device."
@@ -7169,6 +7302,10 @@ msgstr ""
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "Detalhes"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
+msgstr ""
 
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Topic views"
@@ -7465,6 +7602,10 @@ msgstr ""
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "{unreadCount} unread"
 msgstr "{unreadCount} não lido"
+
+#: src/components/ereader-settings.tsx
+msgid "Log in with this as your username — there is no separate sync account."
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "Below those, the publications you follow are listed for quick access. The <0>Subscriptions</0> heading above them opens the full management view. At the very bottom, your avatar opens a menu with your profile, reading history, recommended articles, feedback, settings, and log out."
@@ -7765,6 +7906,10 @@ msgstr "Carregando artigo"
 msgid "Upvoted."
 msgstr "Votado."
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Browse and download.</0> Your shelves are the top level. Tap an article to pull the EPUB onto the device."
+msgstr ""
+
 #: src/components/reader/list-edit-modal.tsx
 msgid "Search your subscriptions"
 msgstr "Pesquisar nas suas inscrições"
@@ -7870,6 +8015,10 @@ msgstr ""
 msgid "Discussion here is gathered from posts across the network, so you comment wherever you already post."
 msgstr ""
 
+#: src/components/comic/comic-reader.tsx
+msgid "Download this issue (CBZ)"
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Subscribe all"
 msgstr "Inscrever se em tudo"
@@ -7895,6 +8044,11 @@ msgstr "<0>Blocos estruturados.</0> Documentos de editores de blocos, cada um no
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Keeping your place"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"
@@ -7969,6 +8123,10 @@ msgstr "Filtrar por tópico"
 
 #: src/components/reader/mute-menu-item.tsx
 msgid "Unmute {name}"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Copy your catalog URL.</0> It is in <1>Settings</1> under <2>E-readers</2>. It is yours — it carries your subscriptions and your saved articles."
 msgstr ""
 
 #. placeholder {0}: image.file.name
@@ -8176,6 +8334,10 @@ msgstr ""
 msgid "Standard Reader indexes <0>site.standard.document</0> and <1>site.standard.publication</1> records out of AT Proto repos. Platforms like Leaflet, Pckt, and Offprint write these records for you as part of publishing, so their authors get the full reader treatment automatically. If you run your own site and hand-roll your own <2>site.standard</2> integration instead, you write those records yourself — this page covers what to add, including Markpub, the markdown format we recommend for a hand-rolled body."
 msgstr "O Standard Reader indexa registos <0>site.standard.document</0> e <1>site.standard.publication</1> de repositórios AT Proto. Plataformas como o Leaflet, o Pckt e o Offprint escrevem estes registos por si como parte da publicação, pelo que os seus autores recebem automaticamente o tratamento completo no leitor. Se gere o seu próprio site e cria à mão a sua integração <2>site.standard</2>, é você que escreve esses registos — esta página explica o que adicionar, incluindo o Markpub, o formato markdown que recomendamos para um corpo feito à mão."
 
+#: src/components/ereader-settings.tsx
+msgid "Catalog URL"
+msgstr ""
+
 #: src/components/reader/add-to-list-modal.tsx
 #: src/components/reader/list-edit-modal.tsx
 msgid "e.g. Tech, Friends, Cooking"
@@ -8282,6 +8444,10 @@ msgstr "Quando ativo, todos os artigos anteriores de uma publicação contam com
 #~ msgid "tuned to what you already follow."
 #~ msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your position also flows back here: read half of something on the Kobo and the article shows as half-read in the app, and in <0>Continue reading</0>. That direction is one-way. A position on a device is a place in <1>that device's</1> rendering of the file, and there is no honest way to turn a percentage back into one, so the app never sends a position out to a device that did not record it."
+msgstr ""
+
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this reply on Bluesky"
 msgstr "Abrir esta resposta no Bluesky"
@@ -8309,6 +8475,7 @@ msgstr ""
 
 #: src/components/reader/discover-topic-filters.tsx
 #: src/components/reader/rss-feed-button.tsx
+#: src/components/reader/send-to-ereader-dialog.tsx
 #: src/components/reader/share-menu.tsx
 msgid "Close"
 msgstr "Fechar"
@@ -8553,6 +8720,10 @@ msgstr ""
 msgid "Cited by"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "KOReader can sync your reading position through Standard Reader, so picking up a book on a second device puts you where you stopped. Settings → <0>E-readers</0> has the three values it wants: the sync server URL, your username, and a sync key."
+msgstr ""
+
 #: src/routes/mcp/authorize.tsx
 msgid "Signed in as"
 msgstr ""
@@ -8606,4 +8777,8 @@ msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Describe this image"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
 msgstr ""

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -17,6 +17,10 @@ msgstr ""
 msgid "This is the difference between making one anthology and running something with a rhythm to it — a weekly roundup, a themed quarterly, a reading list you keep adding to."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Add your catalog to KOReader, Foliate, Marvin, Panels or any other OPDS app and your unread queue, saved articles, subscriptions and lists show up on the device — each one downloadable as an EPUB."
+msgstr ""
+
 #: src/routes/_layout.discover.tsx
 msgid "Every publication the network knows about — subscribe to the ones worth your mornings."
 msgstr "网络中已知的全部刊物——订阅那些值得你清晨时光的刊物。"
@@ -287,6 +291,10 @@ msgstr ""
 msgid "Mark as read"
 msgstr "标记为已读"
 
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Send to your e-reader"
+msgstr ""
+
 #: src/routes/_layout.l.$did.$rkey.tsx
 msgid "This list is empty — add publications or people to it."
 msgstr "此列表为空——请向其中添加刊物或人。"
@@ -347,6 +355,11 @@ msgstr "请添加标题。"
 #: src/components/guide/pages/finding-guide-page.tsx
 #~ msgid "Pasting a handle works even for publications the network has not indexed yet — it goes and asks that author's account directly. Follow it and it starts appearing in your feeds like any other."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/components/user-settings-view.tsx
+msgid "E-readers"
+msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "There’s an MCP server on the same host, so you can point an agent at the network too."
@@ -530,8 +543,16 @@ msgstr ""
 msgid "We couldn’t find that issue."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Comics come down as <0>CBZ</0> as well, so comic apps get their page turns and their scrubber instead of a reflowable book that fights them."
+msgstr ""
+
 #: src/routes/_layout.friends.tsx
 msgid "Publications written by the people you follow on Bluesky, minus the ones you already subscribe to."
+msgstr ""
+
+#: src/components/ereader-settings.tsx
+msgid "Sync username"
 msgstr ""
 
 #: src/components/reader/format-i18n.ts
@@ -541,6 +562,10 @@ msgstr ""
 #: src/components/reader/content/renderers/shared/bsky-client-embed.tsx
 msgid "List"
 msgstr "列表"
+
+#: src/components/reader/publication-actions.tsx
+msgid "Send to e-reader…"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "The spacing between things — tighter for more on screen, looser for more room to read."
@@ -733,6 +758,10 @@ msgstr ""
 msgid "Partial"
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Sync key"
+msgstr ""
+
 #: src/components/reader/share-menu.tsx
 msgid "Landscape fits a compact row. Height adjusts automatically once the embed loads. Change the iframe width as needed."
 msgstr "横版适合紧凑的一行。嵌入内容加载后高度会自动调整。可按需修改 iframe 宽度。"
@@ -867,6 +896,11 @@ msgstr ""
 msgid "Log in to follow publications"
 msgstr "登录后可关注刊物"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What will not be there"
+msgstr ""
+
 #: src/routes/_layout.discover.tsx
 msgid "Search publications"
 msgstr "搜索刊物"
@@ -946,6 +980,10 @@ msgstr "登录失败，请重试。"
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Loading publications"
 msgstr "正在加载刊物"
+
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "OPDS catalog URL"
+msgstr ""
 
 #. placeholder {0}: meta.minutes
 #: src/magazine/flow.tsx
@@ -1218,6 +1256,11 @@ msgstr "查看合集"
 msgid "Name"
 msgstr "名称"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Setting it up"
+msgstr ""
+
 #: src/components/reader/privacy-view.tsx
 msgid "Where data lives"
 msgstr "数据存放在哪里"
@@ -1305,6 +1348,10 @@ msgstr "已保存到 {appLabel} 上的 {savedName}。"
 #: src/lib/guide/navigation.ts
 msgid "Getting started"
 msgstr "快速上手"
+
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Download {name} as a file — images and all, ready to read offline."
+msgstr ""
 
 #: src/components/onboarding/step-settings.tsx
 msgid "Open posts on their original site"
@@ -1423,6 +1470,10 @@ msgstr ""
 #~ msgid "You don't have any subscriptions to reorder yet."
 #~ msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "What the sync key can do"
+msgstr ""
+
 #: src/components/reader/notify-button.tsx
 #: src/components/user-settings-view.tsx
 msgid "This browser doesn’t support web notifications."
@@ -1444,6 +1495,10 @@ msgstr "反馈类型"
 #: src/components/guide/pages/welcome-guide-page.tsx
 #~ msgid "Home leads with one article worth your attention, then everything new from the publications you follow."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Downloading does not mark anything read, and reading on a device does not remove it from your unread shelf until KOReader syncs a position back. Polls, signup forms and other live embeds become links — a book cannot run them."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Enable the weekly digest"
@@ -1493,6 +1548,11 @@ msgstr "全部关注"
 
 #: src/routes/_layout.p.$did.$rkey.tsx
 msgid "That's every issue published so far."
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Sending one article"
 msgstr ""
 
 #. placeholder {0}: view.clientName
@@ -1794,6 +1854,10 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Turn on <0>Sync every N pages</0> if you want it to happen without asking."
+msgstr ""
+
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Include the <0>site.standard.publication</0> hint only if the document belongs to a publication record. Add both regardless of which reader you care about — they're how any client on the network resolves your page to its record, not just our extension."
 #~ msgstr "仅当该文档属于某个刊物记录时，才加入 <0>site.standard.publication</0> 提示。无论你在意哪个阅读器，两者都请加上——网络上任何客户端都靠它们把你的页面解析到对应记录，不只是我们的扩展。"
@@ -1842,6 +1906,10 @@ msgstr ""
 msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Who can use your catalog URL"
+msgstr ""
+
 #: src/components/reader/continue-reading.tsx
 #~ msgid "Reading progress"
 #~ msgstr ""
@@ -1870,6 +1938,10 @@ msgstr ""
 #: src/components/reader/save-to-collection-dialog.tsx
 msgid "e.g. To Read"
 msgstr "例如：待读"
+
+#: src/lib/guide/navigation.ts
+msgid "Reading on an e-reader"
+msgstr ""
 
 #: src/components/labeler-detail-view.tsx
 #: src/components/OpenLinksMenuItem.tsx
@@ -1954,6 +2026,10 @@ msgstr ""
 #: src/components/guide/pages/reading-guide-page.tsx
 #: src/lib/guide/navigation.ts
 msgid "Making the text comfortable"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The files are built when you ask for them, from the same article bodies the reader shows — images pulled in, footnotes as real endnotes, a link back to the original at the end of every piece. Nothing is trimmed to an excerpt. A whole publication, a list or a collection can also come down as one book, with a table of contents."
 msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
@@ -2237,6 +2313,10 @@ msgstr "更多来自 <0>{0}</0>"
 msgid "On this device"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Add it to your reading app.</0> In KOReader that is <1>Search → OPDS catalog → +</1>. Foliate, Marvin, Aldiko, Thorium, Panels and Chunky all have a similar “add catalog” screen. Paste the URL and leave the username and password blank."
+msgstr ""
+
 #: src/components/reader/extension-privacy-view.tsx
 msgid "We may update this policy as the extension changes. The “Last updated” date at the top will change when we do. Continued use of the extension after an update means you accept the revised policy."
 msgstr "我们可能会随着扩展的变化更新本政策。更新时，顶部的「最后更新」日期也会随之改变。更新后继续使用本扩展即表示你接受修订后的政策。"
@@ -2253,6 +2333,10 @@ msgstr ""
 #: src/components/docs/renderers-docs-page.tsx
 #~ msgid "Pick the package for your framework; all sit on the same core."
 #~ msgstr ""
+
+#: src/lib/guide/navigation.ts
+msgid "Put your unread queue on a Kobo, Kindle or phone as real EPUB files."
+msgstr ""
 
 #: src/components/reader/block-user-menu-item.tsx
 msgid "Block"
@@ -3147,6 +3231,10 @@ msgstr ""
 msgid "Plenty of people you already follow on Bluesky write long-form somewhere. <0>People you follow</0> finds them and puts their publications, and their newest articles, in one place. It is usually the highest-yield screen in the app the first week you use it."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Use this as the password. It only carries your reading position between devices — it cannot read or change anything else."
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 msgid "Second, it brings you <0>what they recommend</0>. Articles they have recommended start appearing in your feed, marked with who recommended them. That is the quiet engine behind finding new writing here: you are not only subscribing to what someone writes, you are borrowing their taste in what to read."
 msgstr ""
@@ -3337,6 +3425,10 @@ msgstr "来自你的订阅"
 #: src/components/reader/privacy-view.tsx
 msgid "<0>When you browse without signing in,</0> we serve public writing from our read-model index. We may store a theme preference cookie and, if you have signed in before on this device, a short list of recently used account handles (and optional avatar URLs) to speed up sign-in. We do not require an account to read."
 msgstr "<0>当你未登录浏览时，</0>我们从读模型索引提供公开文章。我们可能会存储主题偏好 cookie；如果你此前在本设备登录过，还会存储一份最近使用的账号 handle 简表（以及可选的头像 URL），以加快登录。阅读无需账号。"
+
+#: src/components/ereader-settings.tsx
+msgid "Sync server"
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 msgid "Paper"
@@ -3720,6 +3812,10 @@ msgstr ""
 msgid "Subscribe to this list to read new articles from its publications."
 msgstr "订阅此列表，即可阅读其中刊物的新文章。"
 
+#: src/components/ereader-settings.tsx
+msgid "In KOReader: Tools → Progress sync → Custom sync server."
+msgstr ""
+
 #: src/components/reader/collection-builder.tsx
 msgid "{itemCount} of {MAX_ITEMS}"
 msgstr "{itemCount} / {MAX_ITEMS}"
@@ -3771,6 +3867,10 @@ msgstr ""
 
 #: src/components/reader/subscriptions-table.tsx
 msgid "Filter subscriptions"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Standard Reader publishes an <0>OPDS catalog</0> — the same thing a library or a bookstore hands an e-reading app. Point an app at it once and your shelves appear on the device: <1>Unread</1>, <2>Saved for later</2>, <3>Subscriptions</3>, each of your lists, and every publication you follow. Open any of them and each article has a download button."
 msgstr ""
 
 #: src/components/reader/mention-hover-card.tsx
@@ -3856,6 +3956,10 @@ msgstr ""
 
 #: src/components/guide/pages/your-data-guide-page.tsx
 msgid "Signing in asks for permission to write only the kinds of records the app actually needs — follows, saves, recommendations, read records, and lists. It cannot post to Bluesky as you."
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "In KOReader, open <0>Tools → Progress sync</0> and choose <1>Custom sync server</1>."
 msgstr ""
 
 #: src/components/comic/comic-reader.tsx
@@ -4601,6 +4705,10 @@ msgstr "来做第一个提交缺陷、想法或问题的人。"
 msgid "Browse the publication directory to find new writers."
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your unread queue, your saved articles and every publication you subscribe to, on a Kobo, a Kindle, a reMarkable or a phone — as real EPUB files, with the images, ready to read on a plane."
+msgstr ""
+
 #: src/routes/_layout.index.tsx
 msgid "The most-read writing across the network right now."
 msgstr "当下整个网络阅读量最高的文章。"
@@ -5183,6 +5291,10 @@ msgstr ""
 msgid "Most posts"
 msgstr "内容最多"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "You do not need a catalog for a single piece. Every article's share menu has <0>Download EPUB</0> — and <1>Download CBZ</1> on a comic. A publication's <2>…</2> menu has <3>Send to e-reader…</3>, which offers its recent articles as one book and shows the catalog URL for that publication on its own."
+msgstr ""
+
 #: src/components/docs/labelers-docs-page.tsx
 msgid "<0>1. Identity & signing key.</0> Give it a DID (a <1>did:web</1> is simplest) whose DID document advertises an <2>#atproto_labeler</2> service endpoint and an <3>#atproto_label</3> public signing key."
 msgstr "<0>1. 身份与签名密钥。</0>为它分配一个 DID（用 <1>did:web</1> 最简单），其 DID 文档需声明 <2>#atproto_labeler</2> 服务端点和 <3>#atproto_label</3> 公开签名密钥。"
@@ -5465,6 +5577,10 @@ msgstr "记录阅读历史"
 #: src/components/reader/format-i18n.ts
 msgid "{readCount, plural, one {# read} other {{value} reads}}"
 msgstr "{readCount, plural, one {# 次阅读} other {{value} 次阅读}}"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "A few articles on the network are really link posts — a headline and a URL, bridged in from somewhere else, with no body to package. Those are left out of the catalog rather than offered as a file that would open to nothing. You will still find them in the app, where they link out to the site that has the writing."
+msgstr ""
 
 #: src/components/offline-sync-debug.tsx
 #: src/routes/_layout.collections.index.tsx
@@ -5896,6 +6012,10 @@ msgstr ""
 msgid "Collection"
 msgstr "合集"
 
+#: src/components/reader/send-to-ereader-dialog.tsx
+msgid "Or add this catalog URL to KOReader, Foliate, Marvin or any other OPDS app, and browse {name} from the device itself."
+msgstr ""
+
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Most liked"
 msgstr ""
@@ -5951,6 +6071,10 @@ msgstr "将链接保存到你的 <0>{appLabel}</0> 合集。"
 #: src/components/reader/reorder-subscriptions-modal.tsx
 #~ msgid "Drag to change the order your subscriptions appear in the sidebar."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Paste the sync server URL, then log in with your handle and the sync key. There is no separate account to register."
+msgstr ""
 
 #: src/components/user-settings-view.tsx
 msgid "Appearance, reading preferences, and personal data."
@@ -6366,6 +6490,11 @@ msgstr "服务 DID 是 <0>{appviewDid}</0>。该服务为需要协商 scope 的�
 #: src/components/reader/about-view.tsx
 msgid "The Slow Web, Revisited"
 msgstr "重访慢速网络"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "What you get"
+msgstr ""
 
 #. placeholder {0}: visible.length
 #: src/routes/_layout.communities.index.tsx
@@ -7067,6 +7196,10 @@ msgstr "账户操作"
 msgid "Read article"
 msgstr "阅读文章"
 
+#: src/components/ereader-settings.tsx
+msgid "Your shelves, as an OPDS catalog. Anyone with this URL can see the same public records your profile already shows."
+msgstr ""
+
 #. placeholder {0}: formatBytes(usage.usage)
 #: src/components/offline-settings.tsx
 msgid "Standard Reader is using {0} on this device."
@@ -7169,6 +7302,10 @@ msgstr ""
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Details"
 msgstr "详情"
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
+msgstr ""
 
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Topic views"
@@ -7465,6 +7602,10 @@ msgstr ""
 #: src/components/reader/subscriptions-sheet.tsx
 msgid "{unreadCount} unread"
 msgstr "{unreadCount} 篇未读"
+
+#: src/components/ereader-settings.tsx
+msgid "Log in with this as your username — there is no separate sync account."
+msgstr ""
 
 #: src/components/guide/pages/getting-started-guide-page.tsx
 #~ msgid "Below those, the publications you follow are listed for quick access. The <0>Subscriptions</0> heading above them opens the full management view. At the very bottom, your avatar opens a menu with your profile, reading history, recommended articles, feedback, settings, and log out."
@@ -7765,6 +7906,10 @@ msgstr "正在加载文章"
 msgid "Upvoted."
 msgstr "已点赞。"
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Browse and download.</0> Your shelves are the top level. Tap an article to pull the EPUB onto the device."
+msgstr ""
+
 #: src/components/reader/list-edit-modal.tsx
 msgid "Search your subscriptions"
 msgstr "搜索你的订阅"
@@ -7870,6 +8015,10 @@ msgstr ""
 msgid "Discussion here is gathered from posts across the network, so you comment wherever you already post."
 msgstr ""
 
+#: src/components/comic/comic-reader.tsx
+msgid "Download this issue (CBZ)"
+msgstr ""
+
 #: src/routes/_layout.tag.$tag.tsx
 msgid "Subscribe all"
 msgstr "全部订阅"
@@ -7895,6 +8044,11 @@ msgstr "<0>结构化区块。</0>富文本区块编辑器文档，各自采用�
 #: src/components/docs/publishing-docs-page.tsx
 #~ msgid "Standard Reader emits these on its own article, publication, list and profile pages, and reads them from yours."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+#: src/lib/guide/navigation.ts
+msgid "Keeping your place"
+msgstr ""
 
 #: src/components/reader/collection-theme-editor.tsx
 msgid "Text"
@@ -7969,6 +8123,10 @@ msgstr "按话题筛选"
 
 #: src/components/reader/mute-menu-item.tsx
 msgid "Unmute {name}"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "<0>Copy your catalog URL.</0> It is in <1>Settings</1> under <2>E-readers</2>. It is yours — it carries your subscriptions and your saved articles."
 msgstr ""
 
 #. placeholder {0}: image.file.name
@@ -8176,6 +8334,10 @@ msgstr ""
 msgid "Standard Reader indexes <0>site.standard.document</0> and <1>site.standard.publication</1> records out of AT Proto repos. Platforms like Leaflet, Pckt, and Offprint write these records for you as part of publishing, so their authors get the full reader treatment automatically. If you run your own site and hand-roll your own <2>site.standard</2> integration instead, you write those records yourself — this page covers what to add, including Markpub, the markdown format we recommend for a hand-rolled body."
 msgstr "Standard Reader 从 AT Proto 仓库中收录 <0>site.standard.document</0> 和 <1>site.standard.publication</1> 记录。Leaflet、Pckt、Offprint 等平台会在发布时替你写入这些记录，因此其作者可自动获得完整的阅读体验。如果你运行自己的站点并手动实现 <2>site.standard</2> 集成，则需自行写入这些记录——本页说明需要添加的内容，包括 Markpub，即我们推荐用于手写正文的 markdown 格式。"
 
+#: src/components/ereader-settings.tsx
+msgid "Catalog URL"
+msgstr ""
+
 #: src/components/reader/add-to-list-modal.tsx
 #: src/components/reader/list-edit-modal.tsx
 msgid "e.g. Tech, Friends, Cooking"
@@ -8282,6 +8444,10 @@ msgstr "开启后，订阅刊物时其全部历史文章都会计为未读。关
 #~ msgid "tuned to what you already follow."
 #~ msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "Your position also flows back here: read half of something on the Kobo and the article shows as half-read in the app, and in <0>Continue reading</0>. That direction is one-way. A position on a device is a place in <1>that device's</1> rendering of the file, and there is no honest way to turn a percentage back into one, so the app never sends a position out to a device that did not record it."
+msgstr ""
+
 #: src/components/reader/comments/comment-card.tsx
 msgid "Open this reply on Bluesky"
 msgstr "在 Bluesky 上打开这条回复"
@@ -8309,6 +8475,7 @@ msgstr ""
 
 #: src/components/reader/discover-topic-filters.tsx
 #: src/components/reader/rss-feed-button.tsx
+#: src/components/reader/send-to-ereader-dialog.tsx
 #: src/components/reader/share-menu.tsx
 msgid "Close"
 msgstr "关闭"
@@ -8553,6 +8720,10 @@ msgstr ""
 msgid "Cited by"
 msgstr ""
 
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "KOReader can sync your reading position through Standard Reader, so picking up a book on a second device puts you where you stopped. Settings → <0>E-readers</0> has the three values it wants: the sync server URL, your username, and a sync key."
+msgstr ""
+
 #: src/routes/mcp/authorize.tsx
 msgid "Signed in as"
 msgstr ""
@@ -8606,4 +8777,8 @@ msgstr ""
 
 #: src/components/feedback/feedback-image-picker.tsx
 msgid "Describe this image"
+msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
 msgstr ""

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -205,6 +205,10 @@ msgstr ""
 msgid "find publications, people, topics, and headlines by name."
 msgstr ""
 
+#: src/components/ereader-settings.tsx
+msgid "Every device syncing with the old key stops until you enter the new one. Nothing you have already read is lost — reading positions are kept against the books themselves, not the key."
+msgstr ""
+
 #: src/components/NavbarAuth.tsx
 #: src/components/reader/language-hint-prompt.tsx
 msgid "Change language"
@@ -2066,6 +2070,10 @@ msgstr ""
 msgid "Subscribed to list"
 msgstr "已订阅列表"
 
+#: src/components/ereader-settings.tsx
+msgid "Rotate your sync key?"
+msgstr ""
+
 #: src/components/guide/pages/extension-guide-page.tsx
 msgid "See which of the people you pass on Bluesky write long-form."
 msgstr ""
@@ -2171,6 +2179,10 @@ msgstr "删除合集"
 #: src/components/appearance-settings.tsx
 #: src/components/guide/pages/personalizing-guide-page.tsx
 msgid "Interface font"
+msgstr ""
+
+#: src/components/ereader-settings.tsx
+msgid "Rotate"
 msgstr ""
 
 #: src/components/blocks-settings-view.tsx
@@ -5273,6 +5285,10 @@ msgstr ""
 msgid "Subscribe to list"
 msgstr "订阅列表"
 
+#: src/components/ereader-settings.tsx
+msgid "Rotate key"
+msgstr ""
+
 #: src/components/guide/pages/keeping-track-guide-page.tsx
 #: src/lib/guide/navigation.ts
 #~ msgid "Following a publication"
@@ -6513,6 +6529,10 @@ msgstr ""
 #: src/components/guide/pages/personalizing-guide-page.tsx
 #~ msgid "Eight presets, or your own paper and accent. The rest of the interface is derived from them."
 #~ msgstr ""
+
+#: src/components/guide/pages/e-readers-guide-page.tsx
+msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. Lost a device? <0>Rotate</0> in Settings issues a new key and stops the old one working."
+msgstr ""
 
 #: src/components/appearance-settings.tsx
 #: src/components/reading-custom-font-picker.tsx
@@ -8780,5 +8800,5 @@ msgid "Describe this image"
 msgstr ""
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
-msgstr ""
+#~ msgid "The sync key only carries your reading position. It cannot read your account, post anything, or change what you subscribe to — and it is not your Bluesky password. If you lose a device, ask us to rotate it."
+#~ msgstr ""

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -1907,8 +1907,8 @@ msgid "No topics match “{debouncedQuery}”."
 msgstr ""
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "Who can use your catalog URL"
-msgstr ""
+#~ msgid "Who can use your catalog URL"
+#~ msgstr ""
 
 #: src/components/reader/continue-reading.tsx
 #~ msgid "Reading progress"
@@ -7304,8 +7304,8 @@ msgid "Details"
 msgstr "详情"
 
 #: src/components/guide/pages/e-readers-guide-page.tsx
-msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
-msgstr ""
+#~ msgid "Your catalog URL is not a secret, but it is not a password either — anyone who has it can see the same things your public profile already shows: what you subscribe to and what you have saved. Treat it like a share link rather than a login."
+#~ msgstr ""
 
 #: src/routes/_layout.topics.$slug.tsx
 msgid "Topic views"

--- a/apps/standard-reader/src/routeTree.gen.ts
+++ b/apps/standard-reader/src/routeTree.gen.ts
@@ -35,8 +35,18 @@ import { Route as DevDigestRouteImport } from './routes/dev.digest'
 import { Route as DevRtlRouteImport } from './routes/dev.rtl'
 import { Route as DevWelcomeEmailRouteImport } from './routes/dev.welcome-email'
 import { Route as ExtensionConnectedRouteImport } from './routes/extension.connected'
+import { Route as KosyncHealthcheckRouteImport } from './routes/kosync.healthcheck'
 import { Route as McpIndexRouteImport } from './routes/mcp/index'
 import { Route as McpAuthorizeRouteImport } from './routes/mcp/authorize'
+import { Route as OpdsIndexRouteImport } from './routes/opds.index'
+import { Route as OpdsCollectionsRouteImport } from './routes/opds.collections'
+import { Route as OpdsComicsRouteImport } from './routes/opds.comics'
+import { Route as OpdsLatestRouteImport } from './routes/opds.latest'
+import { Route as OpdsOpensearchDotxmlRouteImport } from './routes/opds.opensearch[.]xml'
+import { Route as OpdsPublicationsRouteImport } from './routes/opds.publications'
+import { Route as OpdsSearchRouteImport } from './routes/opds.search'
+import { Route as OpdsTagsRouteImport } from './routes/opds.tags'
+import { Route as OpdsTrendingRouteImport } from './routes/opds.trending'
 import { Route as ReviewThanksRouteImport } from './routes/review.thanks'
 import { Route as XrpcSplatRouteImport } from './routes/xrpc/$'
 import { Route as DotwellKnownOauthProtectedResourceMcpRouteImport } from './routes/[.]well-known/oauth-protected-resource/mcp'
@@ -49,6 +59,7 @@ import { Route as DocsHeaderLayoutDocsRenderersRouteImport } from './routes/_doc
 import { Route as GuideLayoutGuideIndexRouteImport } from './routes/_guide-layout.guide.index'
 import { Route as GuideLayoutGuideCollectionsRouteImport } from './routes/_guide-layout.guide.collections'
 import { Route as GuideLayoutGuideComicsRouteImport } from './routes/_guide-layout.guide.comics'
+import { Route as GuideLayoutGuideEReadersRouteImport } from './routes/_guide-layout.guide.e-readers'
 import { Route as GuideLayoutGuideExtensionRouteImport } from './routes/_guide-layout.guide.extension'
 import { Route as GuideLayoutGuideFindingRouteImport } from './routes/_guide-layout.guide.finding'
 import { Route as GuideLayoutGuideGettingStartedRouteImport } from './routes/_guide-layout.guide.getting-started'
@@ -95,11 +106,15 @@ import { Route as ApiOgPublicationRouteImport } from './routes/api/og/publicatio
 import { Route as ApiOgQuoteRouteImport } from './routes/api/og/quote'
 import { Route as ApiOgSiteRouteImport } from './routes/api/og/site'
 import { Route as ApiPushResubscribeRouteImport } from './routes/api/push/resubscribe'
+import { Route as BookTagChar123tagChar125DotepubRouteImport } from './routes/book.tag.{$tag}[.]epub'
 import { Route as CollectionDidRkeyRouteImport } from './routes/collection.$did.$rkey'
 import { Route as ComicDidRkeyRouteImport } from './routes/comic.$did.$rkey'
 import { Route as FeedLatestDidRouteImport } from './routes/feed.latest.$did'
 import { Route as FeedTagTagRouteImport } from './routes/feed.tag.$tag'
 import { Route as FeedUDidRouteImport } from './routes/feed.u.$did'
+import { Route as KosyncUsersAuthRouteImport } from './routes/kosync.users.auth'
+import { Route as KosyncUsersCreateRouteImport } from './routes/kosync.users.create'
+import { Route as OpdsTagTagRouteImport } from './routes/opds.tag.$tag'
 import { Route as SubscribeLoginDidRkeyRouteImport } from './routes/subscribe-login.$did.$rkey'
 import { Route as SubscribeDidRkeyRouteImport } from './routes/subscribe.$did.$rkey'
 import { Route as LayoutADidRkeyRouteImport } from './routes/_layout.a.$did.$rkey'
@@ -112,10 +127,29 @@ import { Route as ApiAuthAtprotoJwksDotjsonRouteImport } from './routes/api/auth
 import { Route as ApiAuthAtprotoMetadataDotjsonRouteImport } from './routes/api/auth/atproto/metadata[.]json'
 import { Route as ApiAuthAtprotoSignupRouteImport } from './routes/api/auth/atproto/signup'
 import { Route as ApiOgPageSlugRouteImport } from './routes/api/og/page.$slug'
+import { Route as BookADidChar123rkeyChar125DotcbzRouteImport } from './routes/book.a.$did.{$rkey}[.]cbz'
+import { Route as BookADidChar123rkeyChar125DotepubRouteImport } from './routes/book.a.$did.{$rkey}[.]epub'
+import { Route as BookCDidChar123rkeyChar125DotepubRouteImport } from './routes/book.c.$did.{$rkey}[.]epub'
+import { Route as BookIDidChar123rkeyChar125DotcbzRouteImport } from './routes/book.i.$did.{$rkey}[.]cbz'
+import { Route as BookLDidChar123rkeyChar125DotepubRouteImport } from './routes/book.l.$did.{$rkey}[.]epub'
+import { Route as BookPDidChar123rkeyChar125DotcbzRouteImport } from './routes/book.p.$did.{$rkey}[.]cbz'
+import { Route as BookPDidChar123rkeyChar125DotepubRouteImport } from './routes/book.p.$did.{$rkey}[.]epub'
+import { Route as BookUDidSavedDotepubRouteImport } from './routes/book.u.$did.saved[.]epub'
+import { Route as BookUDidUnreadDotepubRouteImport } from './routes/book.u.$did.unread[.]epub'
 import { Route as EmbedSubscribeDidRkeyRouteImport } from './routes/embed.subscribe.$did.$rkey'
 import { Route as FeedCollectionDidRkeyRouteImport } from './routes/feed.collection.$did.$rkey'
 import { Route as FeedLDidRkeyRouteImport } from './routes/feed.l.$did.$rkey'
 import { Route as FeedPDidRkeyRouteImport } from './routes/feed.p.$did.$rkey'
+import { Route as KosyncSyncsProgressIndexRouteImport } from './routes/kosync.syncs.progress.index'
+import { Route as KosyncSyncsProgressDocumentRouteImport } from './routes/kosync.syncs.progress.$document'
+import { Route as OpdsCDidRkeyRouteImport } from './routes/opds.c.$did.$rkey'
+import { Route as OpdsLDidRkeyRouteImport } from './routes/opds.l.$did.$rkey'
+import { Route as OpdsPDidRkeyRouteImport } from './routes/opds.p.$did.$rkey'
+import { Route as OpdsUDidIndexRouteImport } from './routes/opds.u.$did.index'
+import { Route as OpdsUDidPublicationsRouteImport } from './routes/opds.u.$did.publications'
+import { Route as OpdsUDidSavedRouteImport } from './routes/opds.u.$did.saved'
+import { Route as OpdsUDidSubscriptionsRouteImport } from './routes/opds.u.$did.subscriptions'
+import { Route as OpdsUDidUnreadRouteImport } from './routes/opds.u.$did.unread'
 import { Route as ApiAuthAtprotoReviewCallbackRouteImport } from './routes/api/auth/atproto/review/callback'
 import { Route as ApiAuthAtprotoReviewMetadataDotjsonRouteImport } from './routes/api/auth/atproto/review/metadata[.]json'
 
@@ -248,6 +282,11 @@ const ExtensionConnectedRoute = ExtensionConnectedRouteImport.update({
   path: '/extension/connected',
   getParentRoute: () => rootRouteImport,
 } as any)
+const KosyncHealthcheckRoute = KosyncHealthcheckRouteImport.update({
+  id: '/kosync/healthcheck',
+  path: '/kosync/healthcheck',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const McpIndexRoute = McpIndexRouteImport.update({
   id: '/mcp/',
   path: '/mcp/',
@@ -256,6 +295,51 @@ const McpIndexRoute = McpIndexRouteImport.update({
 const McpAuthorizeRoute = McpAuthorizeRouteImport.update({
   id: '/mcp/authorize',
   path: '/mcp/authorize',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OpdsIndexRoute = OpdsIndexRouteImport.update({
+  id: '/opds/',
+  path: '/opds/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OpdsCollectionsRoute = OpdsCollectionsRouteImport.update({
+  id: '/opds/collections',
+  path: '/opds/collections',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OpdsComicsRoute = OpdsComicsRouteImport.update({
+  id: '/opds/comics',
+  path: '/opds/comics',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OpdsLatestRoute = OpdsLatestRouteImport.update({
+  id: '/opds/latest',
+  path: '/opds/latest',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OpdsOpensearchDotxmlRoute = OpdsOpensearchDotxmlRouteImport.update({
+  id: '/opds/opensearch.xml',
+  path: '/opds/opensearch.xml',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OpdsPublicationsRoute = OpdsPublicationsRouteImport.update({
+  id: '/opds/publications',
+  path: '/opds/publications',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OpdsSearchRoute = OpdsSearchRouteImport.update({
+  id: '/opds/search',
+  path: '/opds/search',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OpdsTagsRoute = OpdsTagsRouteImport.update({
+  id: '/opds/tags',
+  path: '/opds/tags',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OpdsTrendingRoute = OpdsTrendingRouteImport.update({
+  id: '/opds/trending',
+  path: '/opds/trending',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ReviewThanksRoute = ReviewThanksRouteImport.update({
@@ -325,6 +409,12 @@ const GuideLayoutGuideComicsRoute = GuideLayoutGuideComicsRouteImport.update({
   path: '/guide/comics',
   getParentRoute: () => GuideLayoutRoute,
 } as any)
+const GuideLayoutGuideEReadersRoute =
+  GuideLayoutGuideEReadersRouteImport.update({
+    id: '/guide/e-readers',
+    path: '/guide/e-readers',
+    getParentRoute: () => GuideLayoutRoute,
+  } as any)
 const GuideLayoutGuideExtensionRoute =
   GuideLayoutGuideExtensionRouteImport.update({
     id: '/guide/extension',
@@ -561,6 +651,12 @@ const ApiPushResubscribeRoute = ApiPushResubscribeRouteImport.update({
   path: '/api/push/resubscribe',
   getParentRoute: () => rootRouteImport,
 } as any)
+const BookTagChar123tagChar125DotepubRoute =
+  BookTagChar123tagChar125DotepubRouteImport.update({
+    id: '/book/tag/{$tag}.epub',
+    path: '/book/tag/{$tag}.epub',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const CollectionDidRkeyRoute = CollectionDidRkeyRouteImport.update({
   id: '/collection/$did/$rkey',
   path: '/collection/$did/$rkey',
@@ -584,6 +680,21 @@ const FeedTagTagRoute = FeedTagTagRouteImport.update({
 const FeedUDidRoute = FeedUDidRouteImport.update({
   id: '/feed/u/$did',
   path: '/feed/u/$did',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const KosyncUsersAuthRoute = KosyncUsersAuthRouteImport.update({
+  id: '/kosync/users/auth',
+  path: '/kosync/users/auth',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const KosyncUsersCreateRoute = KosyncUsersCreateRouteImport.update({
+  id: '/kosync/users/create',
+  path: '/kosync/users/create',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OpdsTagTagRoute = OpdsTagTagRouteImport.update({
+  id: '/opds/tag/$tag',
+  path: '/opds/tag/$tag',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SubscribeLoginDidRkeyRoute = SubscribeLoginDidRkeyRouteImport.update({
@@ -649,6 +760,58 @@ const ApiOgPageSlugRoute = ApiOgPageSlugRouteImport.update({
   path: '/api/og/page/$slug',
   getParentRoute: () => rootRouteImport,
 } as any)
+const BookADidChar123rkeyChar125DotcbzRoute =
+  BookADidChar123rkeyChar125DotcbzRouteImport.update({
+    id: '/book/a/$did/{$rkey}.cbz',
+    path: '/book/a/$did/{$rkey}.cbz',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const BookADidChar123rkeyChar125DotepubRoute =
+  BookADidChar123rkeyChar125DotepubRouteImport.update({
+    id: '/book/a/$did/{$rkey}.epub',
+    path: '/book/a/$did/{$rkey}.epub',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const BookCDidChar123rkeyChar125DotepubRoute =
+  BookCDidChar123rkeyChar125DotepubRouteImport.update({
+    id: '/book/c/$did/{$rkey}.epub',
+    path: '/book/c/$did/{$rkey}.epub',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const BookIDidChar123rkeyChar125DotcbzRoute =
+  BookIDidChar123rkeyChar125DotcbzRouteImport.update({
+    id: '/book/i/$did/{$rkey}.cbz',
+    path: '/book/i/$did/{$rkey}.cbz',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const BookLDidChar123rkeyChar125DotepubRoute =
+  BookLDidChar123rkeyChar125DotepubRouteImport.update({
+    id: '/book/l/$did/{$rkey}.epub',
+    path: '/book/l/$did/{$rkey}.epub',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const BookPDidChar123rkeyChar125DotcbzRoute =
+  BookPDidChar123rkeyChar125DotcbzRouteImport.update({
+    id: '/book/p/$did/{$rkey}.cbz',
+    path: '/book/p/$did/{$rkey}.cbz',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const BookPDidChar123rkeyChar125DotepubRoute =
+  BookPDidChar123rkeyChar125DotepubRouteImport.update({
+    id: '/book/p/$did/{$rkey}.epub',
+    path: '/book/p/$did/{$rkey}.epub',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const BookUDidSavedDotepubRoute = BookUDidSavedDotepubRouteImport.update({
+  id: '/book/u/$did/saved.epub',
+  path: '/book/u/$did/saved.epub',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BookUDidUnreadDotepubRoute = BookUDidUnreadDotepubRouteImport.update({
+  id: '/book/u/$did/unread.epub',
+  path: '/book/u/$did/unread.epub',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const EmbedSubscribeDidRkeyRoute = EmbedSubscribeDidRkeyRouteImport.update({
   id: '/embed/subscribe/$did/$rkey',
   path: '/embed/subscribe/$did/$rkey',
@@ -667,6 +830,58 @@ const FeedLDidRkeyRoute = FeedLDidRkeyRouteImport.update({
 const FeedPDidRkeyRoute = FeedPDidRkeyRouteImport.update({
   id: '/feed/p/$did/$rkey',
   path: '/feed/p/$did/$rkey',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const KosyncSyncsProgressIndexRoute =
+  KosyncSyncsProgressIndexRouteImport.update({
+    id: '/kosync/syncs/progress/',
+    path: '/kosync/syncs/progress/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const KosyncSyncsProgressDocumentRoute =
+  KosyncSyncsProgressDocumentRouteImport.update({
+    id: '/kosync/syncs/progress/$document',
+    path: '/kosync/syncs/progress/$document',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const OpdsCDidRkeyRoute = OpdsCDidRkeyRouteImport.update({
+  id: '/opds/c/$did/$rkey',
+  path: '/opds/c/$did/$rkey',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OpdsLDidRkeyRoute = OpdsLDidRkeyRouteImport.update({
+  id: '/opds/l/$did/$rkey',
+  path: '/opds/l/$did/$rkey',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OpdsPDidRkeyRoute = OpdsPDidRkeyRouteImport.update({
+  id: '/opds/p/$did/$rkey',
+  path: '/opds/p/$did/$rkey',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OpdsUDidIndexRoute = OpdsUDidIndexRouteImport.update({
+  id: '/opds/u/$did/',
+  path: '/opds/u/$did/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OpdsUDidPublicationsRoute = OpdsUDidPublicationsRouteImport.update({
+  id: '/opds/u/$did/publications',
+  path: '/opds/u/$did/publications',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OpdsUDidSavedRoute = OpdsUDidSavedRouteImport.update({
+  id: '/opds/u/$did/saved',
+  path: '/opds/u/$did/saved',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OpdsUDidSubscriptionsRoute = OpdsUDidSubscriptionsRouteImport.update({
+  id: '/opds/u/$did/subscriptions',
+  path: '/opds/u/$did/subscriptions',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OpdsUDidUnreadRoute = OpdsUDidUnreadRouteImport.update({
+  id: '/opds/u/$did/unread',
+  path: '/opds/u/$did/unread',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiAuthAtprotoReviewCallbackRoute =
@@ -706,10 +921,20 @@ export interface FileRoutesByFullPath {
   '/dev/rtl': typeof DevRtlRoute
   '/dev/welcome-email': typeof DevWelcomeEmailRoute
   '/extension/connected': typeof ExtensionConnectedRoute
+  '/kosync/healthcheck': typeof KosyncHealthcheckRoute
   '/mcp/authorize': typeof McpAuthorizeRoute
+  '/opds/collections': typeof OpdsCollectionsRoute
+  '/opds/comics': typeof OpdsComicsRoute
+  '/opds/latest': typeof OpdsLatestRoute
+  '/opds/opensearch.xml': typeof OpdsOpensearchDotxmlRoute
+  '/opds/publications': typeof OpdsPublicationsRoute
+  '/opds/search': typeof OpdsSearchRoute
+  '/opds/tags': typeof OpdsTagsRoute
+  '/opds/trending': typeof OpdsTrendingRoute
   '/review/thanks': typeof ReviewThanksRoute
   '/xrpc/$': typeof XrpcSplatRoute
   '/mcp/': typeof McpIndexRoute
+  '/opds/': typeof OpdsIndexRoute
   '/.well-known/oauth-protected-resource/mcp': typeof DotwellKnownOauthProtectedResourceMcpRoute
   '/docs/api': typeof DocsHeaderLayoutDocsApiRoute
   '/docs/introduction': typeof DocsHeaderLayoutDocsIntroductionRoute
@@ -719,6 +944,7 @@ export interface FileRoutesByFullPath {
   '/docs/renderers': typeof DocsHeaderLayoutDocsRenderersRoute
   '/guide/collections': typeof GuideLayoutGuideCollectionsRoute
   '/guide/comics': typeof GuideLayoutGuideComicsRoute
+  '/guide/e-readers': typeof GuideLayoutGuideEReadersRoute
   '/guide/extension': typeof GuideLayoutGuideExtensionRoute
   '/guide/finding': typeof GuideLayoutGuideFindingRoute
   '/guide/getting-started': typeof GuideLayoutGuideGettingStartedRoute
@@ -760,11 +986,15 @@ export interface FileRoutesByFullPath {
   '/api/og/quote': typeof ApiOgQuoteRoute
   '/api/og/site': typeof ApiOgSiteRoute
   '/api/push/resubscribe': typeof ApiPushResubscribeRoute
+  '/book/tag/{$tag}.epub': typeof BookTagChar123tagChar125DotepubRoute
   '/collection/$did/$rkey': typeof CollectionDidRkeyRoute
   '/comic/$did/$rkey': typeof ComicDidRkeyRoute
   '/feed/latest/$did': typeof FeedLatestDidRoute
   '/feed/tag/$tag': typeof FeedTagTagRoute
   '/feed/u/$did': typeof FeedUDidRoute
+  '/kosync/users/auth': typeof KosyncUsersAuthRoute
+  '/kosync/users/create': typeof KosyncUsersCreateRoute
+  '/opds/tag/$tag': typeof OpdsTagTagRoute
   '/subscribe-login/$did/$rkey': typeof SubscribeLoginDidRkeyRoute
   '/subscribe/$did/$rkey': typeof SubscribeDidRkeyRoute
   '/guide/': typeof GuideLayoutGuideIndexRoute
@@ -783,10 +1013,29 @@ export interface FileRoutesByFullPath {
   '/api/auth/atproto/metadata.json': typeof ApiAuthAtprotoMetadataDotjsonRoute
   '/api/auth/atproto/signup': typeof ApiAuthAtprotoSignupRoute
   '/api/og/page/$slug': typeof ApiOgPageSlugRoute
+  '/book/a/$did/{$rkey}.cbz': typeof BookADidChar123rkeyChar125DotcbzRoute
+  '/book/a/$did/{$rkey}.epub': typeof BookADidChar123rkeyChar125DotepubRoute
+  '/book/c/$did/{$rkey}.epub': typeof BookCDidChar123rkeyChar125DotepubRoute
+  '/book/i/$did/{$rkey}.cbz': typeof BookIDidChar123rkeyChar125DotcbzRoute
+  '/book/l/$did/{$rkey}.epub': typeof BookLDidChar123rkeyChar125DotepubRoute
+  '/book/p/$did/{$rkey}.cbz': typeof BookPDidChar123rkeyChar125DotcbzRoute
+  '/book/p/$did/{$rkey}.epub': typeof BookPDidChar123rkeyChar125DotepubRoute
+  '/book/u/$did/saved.epub': typeof BookUDidSavedDotepubRoute
+  '/book/u/$did/unread.epub': typeof BookUDidUnreadDotepubRoute
   '/embed/subscribe/$did/$rkey': typeof EmbedSubscribeDidRkeyRoute
   '/feed/collection/$did/$rkey': typeof FeedCollectionDidRkeyRoute
   '/feed/l/$did/$rkey': typeof FeedLDidRkeyRoute
   '/feed/p/$did/$rkey': typeof FeedPDidRkeyRoute
+  '/kosync/syncs/progress/$document': typeof KosyncSyncsProgressDocumentRoute
+  '/opds/c/$did/$rkey': typeof OpdsCDidRkeyRoute
+  '/opds/l/$did/$rkey': typeof OpdsLDidRkeyRoute
+  '/opds/p/$did/$rkey': typeof OpdsPDidRkeyRoute
+  '/opds/u/$did/publications': typeof OpdsUDidPublicationsRoute
+  '/opds/u/$did/saved': typeof OpdsUDidSavedRoute
+  '/opds/u/$did/subscriptions': typeof OpdsUDidSubscriptionsRoute
+  '/opds/u/$did/unread': typeof OpdsUDidUnreadRoute
+  '/kosync/syncs/progress/': typeof KosyncSyncsProgressIndexRoute
+  '/opds/u/$did/': typeof OpdsUDidIndexRoute
   '/api/auth/atproto/review/callback': typeof ApiAuthAtprotoReviewCallbackRoute
   '/api/auth/atproto/review/metadata.json': typeof ApiAuthAtprotoReviewMetadataDotjsonRoute
 }
@@ -813,10 +1062,20 @@ export interface FileRoutesByTo {
   '/dev/rtl': typeof DevRtlRoute
   '/dev/welcome-email': typeof DevWelcomeEmailRoute
   '/extension/connected': typeof ExtensionConnectedRoute
+  '/kosync/healthcheck': typeof KosyncHealthcheckRoute
   '/mcp/authorize': typeof McpAuthorizeRoute
+  '/opds/collections': typeof OpdsCollectionsRoute
+  '/opds/comics': typeof OpdsComicsRoute
+  '/opds/latest': typeof OpdsLatestRoute
+  '/opds/opensearch.xml': typeof OpdsOpensearchDotxmlRoute
+  '/opds/publications': typeof OpdsPublicationsRoute
+  '/opds/search': typeof OpdsSearchRoute
+  '/opds/tags': typeof OpdsTagsRoute
+  '/opds/trending': typeof OpdsTrendingRoute
   '/review/thanks': typeof ReviewThanksRoute
   '/xrpc/$': typeof XrpcSplatRoute
   '/mcp': typeof McpIndexRoute
+  '/opds': typeof OpdsIndexRoute
   '/.well-known/oauth-protected-resource/mcp': typeof DotwellKnownOauthProtectedResourceMcpRoute
   '/docs/api': typeof DocsHeaderLayoutDocsApiRoute
   '/docs/introduction': typeof DocsHeaderLayoutDocsIntroductionRoute
@@ -826,6 +1085,7 @@ export interface FileRoutesByTo {
   '/docs/renderers': typeof DocsHeaderLayoutDocsRenderersRoute
   '/guide/collections': typeof GuideLayoutGuideCollectionsRoute
   '/guide/comics': typeof GuideLayoutGuideComicsRoute
+  '/guide/e-readers': typeof GuideLayoutGuideEReadersRoute
   '/guide/extension': typeof GuideLayoutGuideExtensionRoute
   '/guide/finding': typeof GuideLayoutGuideFindingRoute
   '/guide/getting-started': typeof GuideLayoutGuideGettingStartedRoute
@@ -867,11 +1127,15 @@ export interface FileRoutesByTo {
   '/api/og/quote': typeof ApiOgQuoteRoute
   '/api/og/site': typeof ApiOgSiteRoute
   '/api/push/resubscribe': typeof ApiPushResubscribeRoute
+  '/book/tag/{$tag}.epub': typeof BookTagChar123tagChar125DotepubRoute
   '/collection/$did/$rkey': typeof CollectionDidRkeyRoute
   '/comic/$did/$rkey': typeof ComicDidRkeyRoute
   '/feed/latest/$did': typeof FeedLatestDidRoute
   '/feed/tag/$tag': typeof FeedTagTagRoute
   '/feed/u/$did': typeof FeedUDidRoute
+  '/kosync/users/auth': typeof KosyncUsersAuthRoute
+  '/kosync/users/create': typeof KosyncUsersCreateRoute
+  '/opds/tag/$tag': typeof OpdsTagTagRoute
   '/subscribe-login/$did/$rkey': typeof SubscribeLoginDidRkeyRoute
   '/subscribe/$did/$rkey': typeof SubscribeDidRkeyRoute
   '/guide': typeof GuideLayoutGuideIndexRoute
@@ -890,10 +1154,29 @@ export interface FileRoutesByTo {
   '/api/auth/atproto/metadata.json': typeof ApiAuthAtprotoMetadataDotjsonRoute
   '/api/auth/atproto/signup': typeof ApiAuthAtprotoSignupRoute
   '/api/og/page/$slug': typeof ApiOgPageSlugRoute
+  '/book/a/$did/{$rkey}.cbz': typeof BookADidChar123rkeyChar125DotcbzRoute
+  '/book/a/$did/{$rkey}.epub': typeof BookADidChar123rkeyChar125DotepubRoute
+  '/book/c/$did/{$rkey}.epub': typeof BookCDidChar123rkeyChar125DotepubRoute
+  '/book/i/$did/{$rkey}.cbz': typeof BookIDidChar123rkeyChar125DotcbzRoute
+  '/book/l/$did/{$rkey}.epub': typeof BookLDidChar123rkeyChar125DotepubRoute
+  '/book/p/$did/{$rkey}.cbz': typeof BookPDidChar123rkeyChar125DotcbzRoute
+  '/book/p/$did/{$rkey}.epub': typeof BookPDidChar123rkeyChar125DotepubRoute
+  '/book/u/$did/saved.epub': typeof BookUDidSavedDotepubRoute
+  '/book/u/$did/unread.epub': typeof BookUDidUnreadDotepubRoute
   '/embed/subscribe/$did/$rkey': typeof EmbedSubscribeDidRkeyRoute
   '/feed/collection/$did/$rkey': typeof FeedCollectionDidRkeyRoute
   '/feed/l/$did/$rkey': typeof FeedLDidRkeyRoute
   '/feed/p/$did/$rkey': typeof FeedPDidRkeyRoute
+  '/kosync/syncs/progress/$document': typeof KosyncSyncsProgressDocumentRoute
+  '/opds/c/$did/$rkey': typeof OpdsCDidRkeyRoute
+  '/opds/l/$did/$rkey': typeof OpdsLDidRkeyRoute
+  '/opds/p/$did/$rkey': typeof OpdsPDidRkeyRoute
+  '/opds/u/$did/publications': typeof OpdsUDidPublicationsRoute
+  '/opds/u/$did/saved': typeof OpdsUDidSavedRoute
+  '/opds/u/$did/subscriptions': typeof OpdsUDidSubscriptionsRoute
+  '/opds/u/$did/unread': typeof OpdsUDidUnreadRoute
+  '/kosync/syncs/progress': typeof KosyncSyncsProgressIndexRoute
+  '/opds/u/$did': typeof OpdsUDidIndexRoute
   '/api/auth/atproto/review/callback': typeof ApiAuthAtprotoReviewCallbackRoute
   '/api/auth/atproto/review/metadata.json': typeof ApiAuthAtprotoReviewMetadataDotjsonRoute
 }
@@ -924,11 +1207,21 @@ export interface FileRoutesById {
   '/dev/rtl': typeof DevRtlRoute
   '/dev/welcome-email': typeof DevWelcomeEmailRoute
   '/extension/connected': typeof ExtensionConnectedRoute
+  '/kosync/healthcheck': typeof KosyncHealthcheckRoute
   '/mcp/authorize': typeof McpAuthorizeRoute
+  '/opds/collections': typeof OpdsCollectionsRoute
+  '/opds/comics': typeof OpdsComicsRoute
+  '/opds/latest': typeof OpdsLatestRoute
+  '/opds/opensearch.xml': typeof OpdsOpensearchDotxmlRoute
+  '/opds/publications': typeof OpdsPublicationsRoute
+  '/opds/search': typeof OpdsSearchRoute
+  '/opds/tags': typeof OpdsTagsRoute
+  '/opds/trending': typeof OpdsTrendingRoute
   '/review/thanks': typeof ReviewThanksRoute
   '/xrpc/$': typeof XrpcSplatRoute
   '/_layout/': typeof LayoutIndexRoute
   '/mcp/': typeof McpIndexRoute
+  '/opds/': typeof OpdsIndexRoute
   '/.well-known/oauth-protected-resource/mcp': typeof DotwellKnownOauthProtectedResourceMcpRoute
   '/_docs-header-layout/docs/api': typeof DocsHeaderLayoutDocsApiRoute
   '/_docs-header-layout/docs/introduction': typeof DocsHeaderLayoutDocsIntroductionRoute
@@ -938,6 +1231,7 @@ export interface FileRoutesById {
   '/_docs-header-layout/docs/renderers': typeof DocsHeaderLayoutDocsRenderersRoute
   '/_guide-layout/guide/collections': typeof GuideLayoutGuideCollectionsRoute
   '/_guide-layout/guide/comics': typeof GuideLayoutGuideComicsRoute
+  '/_guide-layout/guide/e-readers': typeof GuideLayoutGuideEReadersRoute
   '/_guide-layout/guide/extension': typeof GuideLayoutGuideExtensionRoute
   '/_guide-layout/guide/finding': typeof GuideLayoutGuideFindingRoute
   '/_guide-layout/guide/getting-started': typeof GuideLayoutGuideGettingStartedRoute
@@ -979,11 +1273,15 @@ export interface FileRoutesById {
   '/api/og/quote': typeof ApiOgQuoteRoute
   '/api/og/site': typeof ApiOgSiteRoute
   '/api/push/resubscribe': typeof ApiPushResubscribeRoute
+  '/book/tag/{$tag}.epub': typeof BookTagChar123tagChar125DotepubRoute
   '/collection/$did/$rkey': typeof CollectionDidRkeyRoute
   '/comic/$did/$rkey': typeof ComicDidRkeyRoute
   '/feed/latest/$did': typeof FeedLatestDidRoute
   '/feed/tag/$tag': typeof FeedTagTagRoute
   '/feed/u/$did': typeof FeedUDidRoute
+  '/kosync/users/auth': typeof KosyncUsersAuthRoute
+  '/kosync/users/create': typeof KosyncUsersCreateRoute
+  '/opds/tag/$tag': typeof OpdsTagTagRoute
   '/subscribe-login/$did/$rkey': typeof SubscribeLoginDidRkeyRoute
   '/subscribe/$did/$rkey': typeof SubscribeDidRkeyRoute
   '/_guide-layout/guide/': typeof GuideLayoutGuideIndexRoute
@@ -1002,10 +1300,29 @@ export interface FileRoutesById {
   '/api/auth/atproto/metadata.json': typeof ApiAuthAtprotoMetadataDotjsonRoute
   '/api/auth/atproto/signup': typeof ApiAuthAtprotoSignupRoute
   '/api/og/page/$slug': typeof ApiOgPageSlugRoute
+  '/book/a/$did/{$rkey}.cbz': typeof BookADidChar123rkeyChar125DotcbzRoute
+  '/book/a/$did/{$rkey}.epub': typeof BookADidChar123rkeyChar125DotepubRoute
+  '/book/c/$did/{$rkey}.epub': typeof BookCDidChar123rkeyChar125DotepubRoute
+  '/book/i/$did/{$rkey}.cbz': typeof BookIDidChar123rkeyChar125DotcbzRoute
+  '/book/l/$did/{$rkey}.epub': typeof BookLDidChar123rkeyChar125DotepubRoute
+  '/book/p/$did/{$rkey}.cbz': typeof BookPDidChar123rkeyChar125DotcbzRoute
+  '/book/p/$did/{$rkey}.epub': typeof BookPDidChar123rkeyChar125DotepubRoute
+  '/book/u/$did/saved.epub': typeof BookUDidSavedDotepubRoute
+  '/book/u/$did/unread.epub': typeof BookUDidUnreadDotepubRoute
   '/embed/subscribe/$did/$rkey': typeof EmbedSubscribeDidRkeyRoute
   '/feed/collection/$did/$rkey': typeof FeedCollectionDidRkeyRoute
   '/feed/l/$did/$rkey': typeof FeedLDidRkeyRoute
   '/feed/p/$did/$rkey': typeof FeedPDidRkeyRoute
+  '/kosync/syncs/progress/$document': typeof KosyncSyncsProgressDocumentRoute
+  '/opds/c/$did/$rkey': typeof OpdsCDidRkeyRoute
+  '/opds/l/$did/$rkey': typeof OpdsLDidRkeyRoute
+  '/opds/p/$did/$rkey': typeof OpdsPDidRkeyRoute
+  '/opds/u/$did/publications': typeof OpdsUDidPublicationsRoute
+  '/opds/u/$did/saved': typeof OpdsUDidSavedRoute
+  '/opds/u/$did/subscriptions': typeof OpdsUDidSubscriptionsRoute
+  '/opds/u/$did/unread': typeof OpdsUDidUnreadRoute
+  '/kosync/syncs/progress/': typeof KosyncSyncsProgressIndexRoute
+  '/opds/u/$did/': typeof OpdsUDidIndexRoute
   '/api/auth/atproto/review/callback': typeof ApiAuthAtprotoReviewCallbackRoute
   '/api/auth/atproto/review/metadata.json': typeof ApiAuthAtprotoReviewMetadataDotjsonRoute
 }
@@ -1035,10 +1352,20 @@ export interface FileRouteTypes {
     | '/dev/rtl'
     | '/dev/welcome-email'
     | '/extension/connected'
+    | '/kosync/healthcheck'
     | '/mcp/authorize'
+    | '/opds/collections'
+    | '/opds/comics'
+    | '/opds/latest'
+    | '/opds/opensearch.xml'
+    | '/opds/publications'
+    | '/opds/search'
+    | '/opds/tags'
+    | '/opds/trending'
     | '/review/thanks'
     | '/xrpc/$'
     | '/mcp/'
+    | '/opds/'
     | '/.well-known/oauth-protected-resource/mcp'
     | '/docs/api'
     | '/docs/introduction'
@@ -1048,6 +1375,7 @@ export interface FileRouteTypes {
     | '/docs/renderers'
     | '/guide/collections'
     | '/guide/comics'
+    | '/guide/e-readers'
     | '/guide/extension'
     | '/guide/finding'
     | '/guide/getting-started'
@@ -1089,11 +1417,15 @@ export interface FileRouteTypes {
     | '/api/og/quote'
     | '/api/og/site'
     | '/api/push/resubscribe'
+    | '/book/tag/{$tag}.epub'
     | '/collection/$did/$rkey'
     | '/comic/$did/$rkey'
     | '/feed/latest/$did'
     | '/feed/tag/$tag'
     | '/feed/u/$did'
+    | '/kosync/users/auth'
+    | '/kosync/users/create'
+    | '/opds/tag/$tag'
     | '/subscribe-login/$did/$rkey'
     | '/subscribe/$did/$rkey'
     | '/guide/'
@@ -1112,10 +1444,29 @@ export interface FileRouteTypes {
     | '/api/auth/atproto/metadata.json'
     | '/api/auth/atproto/signup'
     | '/api/og/page/$slug'
+    | '/book/a/$did/{$rkey}.cbz'
+    | '/book/a/$did/{$rkey}.epub'
+    | '/book/c/$did/{$rkey}.epub'
+    | '/book/i/$did/{$rkey}.cbz'
+    | '/book/l/$did/{$rkey}.epub'
+    | '/book/p/$did/{$rkey}.cbz'
+    | '/book/p/$did/{$rkey}.epub'
+    | '/book/u/$did/saved.epub'
+    | '/book/u/$did/unread.epub'
     | '/embed/subscribe/$did/$rkey'
     | '/feed/collection/$did/$rkey'
     | '/feed/l/$did/$rkey'
     | '/feed/p/$did/$rkey'
+    | '/kosync/syncs/progress/$document'
+    | '/opds/c/$did/$rkey'
+    | '/opds/l/$did/$rkey'
+    | '/opds/p/$did/$rkey'
+    | '/opds/u/$did/publications'
+    | '/opds/u/$did/saved'
+    | '/opds/u/$did/subscriptions'
+    | '/opds/u/$did/unread'
+    | '/kosync/syncs/progress/'
+    | '/opds/u/$did/'
     | '/api/auth/atproto/review/callback'
     | '/api/auth/atproto/review/metadata.json'
   fileRoutesByTo: FileRoutesByTo
@@ -1142,10 +1493,20 @@ export interface FileRouteTypes {
     | '/dev/rtl'
     | '/dev/welcome-email'
     | '/extension/connected'
+    | '/kosync/healthcheck'
     | '/mcp/authorize'
+    | '/opds/collections'
+    | '/opds/comics'
+    | '/opds/latest'
+    | '/opds/opensearch.xml'
+    | '/opds/publications'
+    | '/opds/search'
+    | '/opds/tags'
+    | '/opds/trending'
     | '/review/thanks'
     | '/xrpc/$'
     | '/mcp'
+    | '/opds'
     | '/.well-known/oauth-protected-resource/mcp'
     | '/docs/api'
     | '/docs/introduction'
@@ -1155,6 +1516,7 @@ export interface FileRouteTypes {
     | '/docs/renderers'
     | '/guide/collections'
     | '/guide/comics'
+    | '/guide/e-readers'
     | '/guide/extension'
     | '/guide/finding'
     | '/guide/getting-started'
@@ -1196,11 +1558,15 @@ export interface FileRouteTypes {
     | '/api/og/quote'
     | '/api/og/site'
     | '/api/push/resubscribe'
+    | '/book/tag/{$tag}.epub'
     | '/collection/$did/$rkey'
     | '/comic/$did/$rkey'
     | '/feed/latest/$did'
     | '/feed/tag/$tag'
     | '/feed/u/$did'
+    | '/kosync/users/auth'
+    | '/kosync/users/create'
+    | '/opds/tag/$tag'
     | '/subscribe-login/$did/$rkey'
     | '/subscribe/$did/$rkey'
     | '/guide'
@@ -1219,10 +1585,29 @@ export interface FileRouteTypes {
     | '/api/auth/atproto/metadata.json'
     | '/api/auth/atproto/signup'
     | '/api/og/page/$slug'
+    | '/book/a/$did/{$rkey}.cbz'
+    | '/book/a/$did/{$rkey}.epub'
+    | '/book/c/$did/{$rkey}.epub'
+    | '/book/i/$did/{$rkey}.cbz'
+    | '/book/l/$did/{$rkey}.epub'
+    | '/book/p/$did/{$rkey}.cbz'
+    | '/book/p/$did/{$rkey}.epub'
+    | '/book/u/$did/saved.epub'
+    | '/book/u/$did/unread.epub'
     | '/embed/subscribe/$did/$rkey'
     | '/feed/collection/$did/$rkey'
     | '/feed/l/$did/$rkey'
     | '/feed/p/$did/$rkey'
+    | '/kosync/syncs/progress/$document'
+    | '/opds/c/$did/$rkey'
+    | '/opds/l/$did/$rkey'
+    | '/opds/p/$did/$rkey'
+    | '/opds/u/$did/publications'
+    | '/opds/u/$did/saved'
+    | '/opds/u/$did/subscriptions'
+    | '/opds/u/$did/unread'
+    | '/kosync/syncs/progress'
+    | '/opds/u/$did'
     | '/api/auth/atproto/review/callback'
     | '/api/auth/atproto/review/metadata.json'
   id:
@@ -1252,11 +1637,21 @@ export interface FileRouteTypes {
     | '/dev/rtl'
     | '/dev/welcome-email'
     | '/extension/connected'
+    | '/kosync/healthcheck'
     | '/mcp/authorize'
+    | '/opds/collections'
+    | '/opds/comics'
+    | '/opds/latest'
+    | '/opds/opensearch.xml'
+    | '/opds/publications'
+    | '/opds/search'
+    | '/opds/tags'
+    | '/opds/trending'
     | '/review/thanks'
     | '/xrpc/$'
     | '/_layout/'
     | '/mcp/'
+    | '/opds/'
     | '/.well-known/oauth-protected-resource/mcp'
     | '/_docs-header-layout/docs/api'
     | '/_docs-header-layout/docs/introduction'
@@ -1266,6 +1661,7 @@ export interface FileRouteTypes {
     | '/_docs-header-layout/docs/renderers'
     | '/_guide-layout/guide/collections'
     | '/_guide-layout/guide/comics'
+    | '/_guide-layout/guide/e-readers'
     | '/_guide-layout/guide/extension'
     | '/_guide-layout/guide/finding'
     | '/_guide-layout/guide/getting-started'
@@ -1307,11 +1703,15 @@ export interface FileRouteTypes {
     | '/api/og/quote'
     | '/api/og/site'
     | '/api/push/resubscribe'
+    | '/book/tag/{$tag}.epub'
     | '/collection/$did/$rkey'
     | '/comic/$did/$rkey'
     | '/feed/latest/$did'
     | '/feed/tag/$tag'
     | '/feed/u/$did'
+    | '/kosync/users/auth'
+    | '/kosync/users/create'
+    | '/opds/tag/$tag'
     | '/subscribe-login/$did/$rkey'
     | '/subscribe/$did/$rkey'
     | '/_guide-layout/guide/'
@@ -1330,10 +1730,29 @@ export interface FileRouteTypes {
     | '/api/auth/atproto/metadata.json'
     | '/api/auth/atproto/signup'
     | '/api/og/page/$slug'
+    | '/book/a/$did/{$rkey}.cbz'
+    | '/book/a/$did/{$rkey}.epub'
+    | '/book/c/$did/{$rkey}.epub'
+    | '/book/i/$did/{$rkey}.cbz'
+    | '/book/l/$did/{$rkey}.epub'
+    | '/book/p/$did/{$rkey}.cbz'
+    | '/book/p/$did/{$rkey}.epub'
+    | '/book/u/$did/saved.epub'
+    | '/book/u/$did/unread.epub'
     | '/embed/subscribe/$did/$rkey'
     | '/feed/collection/$did/$rkey'
     | '/feed/l/$did/$rkey'
     | '/feed/p/$did/$rkey'
+    | '/kosync/syncs/progress/$document'
+    | '/opds/c/$did/$rkey'
+    | '/opds/l/$did/$rkey'
+    | '/opds/p/$did/$rkey'
+    | '/opds/u/$did/publications'
+    | '/opds/u/$did/saved'
+    | '/opds/u/$did/subscriptions'
+    | '/opds/u/$did/unread'
+    | '/kosync/syncs/progress/'
+    | '/opds/u/$did/'
     | '/api/auth/atproto/review/callback'
     | '/api/auth/atproto/review/metadata.json'
   fileRoutesById: FileRoutesById
@@ -1351,10 +1770,20 @@ export interface RootRouteChildren {
   DevRtlRoute: typeof DevRtlRoute
   DevWelcomeEmailRoute: typeof DevWelcomeEmailRoute
   ExtensionConnectedRoute: typeof ExtensionConnectedRoute
+  KosyncHealthcheckRoute: typeof KosyncHealthcheckRoute
   McpAuthorizeRoute: typeof McpAuthorizeRoute
+  OpdsCollectionsRoute: typeof OpdsCollectionsRoute
+  OpdsComicsRoute: typeof OpdsComicsRoute
+  OpdsLatestRoute: typeof OpdsLatestRoute
+  OpdsOpensearchDotxmlRoute: typeof OpdsOpensearchDotxmlRoute
+  OpdsPublicationsRoute: typeof OpdsPublicationsRoute
+  OpdsSearchRoute: typeof OpdsSearchRoute
+  OpdsTagsRoute: typeof OpdsTagsRoute
+  OpdsTrendingRoute: typeof OpdsTrendingRoute
   ReviewThanksRoute: typeof ReviewThanksRoute
   XrpcSplatRoute: typeof XrpcSplatRoute
   McpIndexRoute: typeof McpIndexRoute
+  OpdsIndexRoute: typeof OpdsIndexRoute
   DotwellKnownOauthProtectedResourceMcpRoute: typeof DotwellKnownOauthProtectedResourceMcpRoute
   ApiBskyPostRoute: typeof ApiBskyPostRoute
   ApiDevDigestPreviewRoute: typeof ApiDevDigestPreviewRoute
@@ -1379,11 +1808,15 @@ export interface RootRouteChildren {
   ApiOgQuoteRoute: typeof ApiOgQuoteRoute
   ApiOgSiteRoute: typeof ApiOgSiteRoute
   ApiPushResubscribeRoute: typeof ApiPushResubscribeRoute
+  BookTagChar123tagChar125DotepubRoute: typeof BookTagChar123tagChar125DotepubRoute
   CollectionDidRkeyRoute: typeof CollectionDidRkeyRoute
   ComicDidRkeyRoute: typeof ComicDidRkeyRoute
   FeedLatestDidRoute: typeof FeedLatestDidRoute
   FeedTagTagRoute: typeof FeedTagTagRoute
   FeedUDidRoute: typeof FeedUDidRoute
+  KosyncUsersAuthRoute: typeof KosyncUsersAuthRoute
+  KosyncUsersCreateRoute: typeof KosyncUsersCreateRoute
+  OpdsTagTagRoute: typeof OpdsTagTagRoute
   SubscribeLoginDidRkeyRoute: typeof SubscribeLoginDidRkeyRoute
   SubscribeDidRkeyRoute: typeof SubscribeDidRkeyRoute
   ApiAuthAtprotoAuthorizeRoute: typeof ApiAuthAtprotoAuthorizeRoute
@@ -1392,10 +1825,29 @@ export interface RootRouteChildren {
   ApiAuthAtprotoMetadataDotjsonRoute: typeof ApiAuthAtprotoMetadataDotjsonRoute
   ApiAuthAtprotoSignupRoute: typeof ApiAuthAtprotoSignupRoute
   ApiOgPageSlugRoute: typeof ApiOgPageSlugRoute
+  BookADidChar123rkeyChar125DotcbzRoute: typeof BookADidChar123rkeyChar125DotcbzRoute
+  BookADidChar123rkeyChar125DotepubRoute: typeof BookADidChar123rkeyChar125DotepubRoute
+  BookCDidChar123rkeyChar125DotepubRoute: typeof BookCDidChar123rkeyChar125DotepubRoute
+  BookIDidChar123rkeyChar125DotcbzRoute: typeof BookIDidChar123rkeyChar125DotcbzRoute
+  BookLDidChar123rkeyChar125DotepubRoute: typeof BookLDidChar123rkeyChar125DotepubRoute
+  BookPDidChar123rkeyChar125DotcbzRoute: typeof BookPDidChar123rkeyChar125DotcbzRoute
+  BookPDidChar123rkeyChar125DotepubRoute: typeof BookPDidChar123rkeyChar125DotepubRoute
+  BookUDidSavedDotepubRoute: typeof BookUDidSavedDotepubRoute
+  BookUDidUnreadDotepubRoute: typeof BookUDidUnreadDotepubRoute
   EmbedSubscribeDidRkeyRoute: typeof EmbedSubscribeDidRkeyRoute
   FeedCollectionDidRkeyRoute: typeof FeedCollectionDidRkeyRoute
   FeedLDidRkeyRoute: typeof FeedLDidRkeyRoute
   FeedPDidRkeyRoute: typeof FeedPDidRkeyRoute
+  KosyncSyncsProgressDocumentRoute: typeof KosyncSyncsProgressDocumentRoute
+  OpdsCDidRkeyRoute: typeof OpdsCDidRkeyRoute
+  OpdsLDidRkeyRoute: typeof OpdsLDidRkeyRoute
+  OpdsPDidRkeyRoute: typeof OpdsPDidRkeyRoute
+  OpdsUDidPublicationsRoute: typeof OpdsUDidPublicationsRoute
+  OpdsUDidSavedRoute: typeof OpdsUDidSavedRoute
+  OpdsUDidSubscriptionsRoute: typeof OpdsUDidSubscriptionsRoute
+  OpdsUDidUnreadRoute: typeof OpdsUDidUnreadRoute
+  KosyncSyncsProgressIndexRoute: typeof KosyncSyncsProgressIndexRoute
+  OpdsUDidIndexRoute: typeof OpdsUDidIndexRoute
   ApiAuthAtprotoReviewCallbackRoute: typeof ApiAuthAtprotoReviewCallbackRoute
   ApiAuthAtprotoReviewMetadataDotjsonRoute: typeof ApiAuthAtprotoReviewMetadataDotjsonRoute
 }
@@ -1584,6 +2036,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ExtensionConnectedRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/kosync/healthcheck': {
+      id: '/kosync/healthcheck'
+      path: '/kosync/healthcheck'
+      fullPath: '/kosync/healthcheck'
+      preLoaderRoute: typeof KosyncHealthcheckRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/mcp/': {
       id: '/mcp/'
       path: '/mcp'
@@ -1596,6 +2055,69 @@ declare module '@tanstack/react-router' {
       path: '/mcp/authorize'
       fullPath: '/mcp/authorize'
       preLoaderRoute: typeof McpAuthorizeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/opds/': {
+      id: '/opds/'
+      path: '/opds'
+      fullPath: '/opds/'
+      preLoaderRoute: typeof OpdsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/opds/collections': {
+      id: '/opds/collections'
+      path: '/opds/collections'
+      fullPath: '/opds/collections'
+      preLoaderRoute: typeof OpdsCollectionsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/opds/comics': {
+      id: '/opds/comics'
+      path: '/opds/comics'
+      fullPath: '/opds/comics'
+      preLoaderRoute: typeof OpdsComicsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/opds/latest': {
+      id: '/opds/latest'
+      path: '/opds/latest'
+      fullPath: '/opds/latest'
+      preLoaderRoute: typeof OpdsLatestRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/opds/opensearch.xml': {
+      id: '/opds/opensearch.xml'
+      path: '/opds/opensearch.xml'
+      fullPath: '/opds/opensearch.xml'
+      preLoaderRoute: typeof OpdsOpensearchDotxmlRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/opds/publications': {
+      id: '/opds/publications'
+      path: '/opds/publications'
+      fullPath: '/opds/publications'
+      preLoaderRoute: typeof OpdsPublicationsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/opds/search': {
+      id: '/opds/search'
+      path: '/opds/search'
+      fullPath: '/opds/search'
+      preLoaderRoute: typeof OpdsSearchRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/opds/tags': {
+      id: '/opds/tags'
+      path: '/opds/tags'
+      fullPath: '/opds/tags'
+      preLoaderRoute: typeof OpdsTagsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/opds/trending': {
+      id: '/opds/trending'
+      path: '/opds/trending'
+      fullPath: '/opds/trending'
+      preLoaderRoute: typeof OpdsTrendingRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/review/thanks': {
@@ -1680,6 +2202,13 @@ declare module '@tanstack/react-router' {
       path: '/guide/comics'
       fullPath: '/guide/comics'
       preLoaderRoute: typeof GuideLayoutGuideComicsRouteImport
+      parentRoute: typeof GuideLayoutRoute
+    }
+    '/_guide-layout/guide/e-readers': {
+      id: '/_guide-layout/guide/e-readers'
+      path: '/guide/e-readers'
+      fullPath: '/guide/e-readers'
+      preLoaderRoute: typeof GuideLayoutGuideEReadersRouteImport
       parentRoute: typeof GuideLayoutRoute
     }
     '/_guide-layout/guide/extension': {
@@ -2004,6 +2533,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiPushResubscribeRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/book/tag/{$tag}.epub': {
+      id: '/book/tag/{$tag}.epub'
+      path: '/book/tag/{$tag}.epub'
+      fullPath: '/book/tag/{$tag}.epub'
+      preLoaderRoute: typeof BookTagChar123tagChar125DotepubRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/collection/$did/$rkey': {
       id: '/collection/$did/$rkey'
       path: '/collection/$did/$rkey'
@@ -2037,6 +2573,27 @@ declare module '@tanstack/react-router' {
       path: '/feed/u/$did'
       fullPath: '/feed/u/$did'
       preLoaderRoute: typeof FeedUDidRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/kosync/users/auth': {
+      id: '/kosync/users/auth'
+      path: '/kosync/users/auth'
+      fullPath: '/kosync/users/auth'
+      preLoaderRoute: typeof KosyncUsersAuthRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/kosync/users/create': {
+      id: '/kosync/users/create'
+      path: '/kosync/users/create'
+      fullPath: '/kosync/users/create'
+      preLoaderRoute: typeof KosyncUsersCreateRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/opds/tag/$tag': {
+      id: '/opds/tag/$tag'
+      path: '/opds/tag/$tag'
+      fullPath: '/opds/tag/$tag'
+      preLoaderRoute: typeof OpdsTagTagRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/subscribe-login/$did/$rkey': {
@@ -2123,6 +2680,69 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiOgPageSlugRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/book/a/$did/{$rkey}.cbz': {
+      id: '/book/a/$did/{$rkey}.cbz'
+      path: '/book/a/$did/{$rkey}.cbz'
+      fullPath: '/book/a/$did/{$rkey}.cbz'
+      preLoaderRoute: typeof BookADidChar123rkeyChar125DotcbzRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/book/a/$did/{$rkey}.epub': {
+      id: '/book/a/$did/{$rkey}.epub'
+      path: '/book/a/$did/{$rkey}.epub'
+      fullPath: '/book/a/$did/{$rkey}.epub'
+      preLoaderRoute: typeof BookADidChar123rkeyChar125DotepubRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/book/c/$did/{$rkey}.epub': {
+      id: '/book/c/$did/{$rkey}.epub'
+      path: '/book/c/$did/{$rkey}.epub'
+      fullPath: '/book/c/$did/{$rkey}.epub'
+      preLoaderRoute: typeof BookCDidChar123rkeyChar125DotepubRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/book/i/$did/{$rkey}.cbz': {
+      id: '/book/i/$did/{$rkey}.cbz'
+      path: '/book/i/$did/{$rkey}.cbz'
+      fullPath: '/book/i/$did/{$rkey}.cbz'
+      preLoaderRoute: typeof BookIDidChar123rkeyChar125DotcbzRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/book/l/$did/{$rkey}.epub': {
+      id: '/book/l/$did/{$rkey}.epub'
+      path: '/book/l/$did/{$rkey}.epub'
+      fullPath: '/book/l/$did/{$rkey}.epub'
+      preLoaderRoute: typeof BookLDidChar123rkeyChar125DotepubRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/book/p/$did/{$rkey}.cbz': {
+      id: '/book/p/$did/{$rkey}.cbz'
+      path: '/book/p/$did/{$rkey}.cbz'
+      fullPath: '/book/p/$did/{$rkey}.cbz'
+      preLoaderRoute: typeof BookPDidChar123rkeyChar125DotcbzRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/book/p/$did/{$rkey}.epub': {
+      id: '/book/p/$did/{$rkey}.epub'
+      path: '/book/p/$did/{$rkey}.epub'
+      fullPath: '/book/p/$did/{$rkey}.epub'
+      preLoaderRoute: typeof BookPDidChar123rkeyChar125DotepubRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/book/u/$did/saved.epub': {
+      id: '/book/u/$did/saved.epub'
+      path: '/book/u/$did/saved.epub'
+      fullPath: '/book/u/$did/saved.epub'
+      preLoaderRoute: typeof BookUDidSavedDotepubRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/book/u/$did/unread.epub': {
+      id: '/book/u/$did/unread.epub'
+      path: '/book/u/$did/unread.epub'
+      fullPath: '/book/u/$did/unread.epub'
+      preLoaderRoute: typeof BookUDidUnreadDotepubRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/embed/subscribe/$did/$rkey': {
       id: '/embed/subscribe/$did/$rkey'
       path: '/embed/subscribe/$did/$rkey'
@@ -2149,6 +2769,76 @@ declare module '@tanstack/react-router' {
       path: '/feed/p/$did/$rkey'
       fullPath: '/feed/p/$did/$rkey'
       preLoaderRoute: typeof FeedPDidRkeyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/kosync/syncs/progress/': {
+      id: '/kosync/syncs/progress/'
+      path: '/kosync/syncs/progress'
+      fullPath: '/kosync/syncs/progress/'
+      preLoaderRoute: typeof KosyncSyncsProgressIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/kosync/syncs/progress/$document': {
+      id: '/kosync/syncs/progress/$document'
+      path: '/kosync/syncs/progress/$document'
+      fullPath: '/kosync/syncs/progress/$document'
+      preLoaderRoute: typeof KosyncSyncsProgressDocumentRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/opds/c/$did/$rkey': {
+      id: '/opds/c/$did/$rkey'
+      path: '/opds/c/$did/$rkey'
+      fullPath: '/opds/c/$did/$rkey'
+      preLoaderRoute: typeof OpdsCDidRkeyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/opds/l/$did/$rkey': {
+      id: '/opds/l/$did/$rkey'
+      path: '/opds/l/$did/$rkey'
+      fullPath: '/opds/l/$did/$rkey'
+      preLoaderRoute: typeof OpdsLDidRkeyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/opds/p/$did/$rkey': {
+      id: '/opds/p/$did/$rkey'
+      path: '/opds/p/$did/$rkey'
+      fullPath: '/opds/p/$did/$rkey'
+      preLoaderRoute: typeof OpdsPDidRkeyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/opds/u/$did/': {
+      id: '/opds/u/$did/'
+      path: '/opds/u/$did'
+      fullPath: '/opds/u/$did/'
+      preLoaderRoute: typeof OpdsUDidIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/opds/u/$did/publications': {
+      id: '/opds/u/$did/publications'
+      path: '/opds/u/$did/publications'
+      fullPath: '/opds/u/$did/publications'
+      preLoaderRoute: typeof OpdsUDidPublicationsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/opds/u/$did/saved': {
+      id: '/opds/u/$did/saved'
+      path: '/opds/u/$did/saved'
+      fullPath: '/opds/u/$did/saved'
+      preLoaderRoute: typeof OpdsUDidSavedRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/opds/u/$did/subscriptions': {
+      id: '/opds/u/$did/subscriptions'
+      path: '/opds/u/$did/subscriptions'
+      fullPath: '/opds/u/$did/subscriptions'
+      preLoaderRoute: typeof OpdsUDidSubscriptionsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/opds/u/$did/unread': {
+      id: '/opds/u/$did/unread'
+      path: '/opds/u/$did/unread'
+      fullPath: '/opds/u/$did/unread'
+      preLoaderRoute: typeof OpdsUDidUnreadRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/auth/atproto/review/callback': {
@@ -2192,6 +2882,7 @@ const DocsHeaderLayoutRouteWithChildren =
 interface GuideLayoutRouteChildren {
   GuideLayoutGuideCollectionsRoute: typeof GuideLayoutGuideCollectionsRoute
   GuideLayoutGuideComicsRoute: typeof GuideLayoutGuideComicsRoute
+  GuideLayoutGuideEReadersRoute: typeof GuideLayoutGuideEReadersRoute
   GuideLayoutGuideExtensionRoute: typeof GuideLayoutGuideExtensionRoute
   GuideLayoutGuideFindingRoute: typeof GuideLayoutGuideFindingRoute
   GuideLayoutGuideGettingStartedRoute: typeof GuideLayoutGuideGettingStartedRoute
@@ -2207,6 +2898,7 @@ interface GuideLayoutRouteChildren {
 const GuideLayoutRouteChildren: GuideLayoutRouteChildren = {
   GuideLayoutGuideCollectionsRoute: GuideLayoutGuideCollectionsRoute,
   GuideLayoutGuideComicsRoute: GuideLayoutGuideComicsRoute,
+  GuideLayoutGuideEReadersRoute: GuideLayoutGuideEReadersRoute,
   GuideLayoutGuideExtensionRoute: GuideLayoutGuideExtensionRoute,
   GuideLayoutGuideFindingRoute: GuideLayoutGuideFindingRoute,
   GuideLayoutGuideGettingStartedRoute: GuideLayoutGuideGettingStartedRoute,
@@ -2330,10 +3022,20 @@ const rootRouteChildren: RootRouteChildren = {
   DevRtlRoute: DevRtlRoute,
   DevWelcomeEmailRoute: DevWelcomeEmailRoute,
   ExtensionConnectedRoute: ExtensionConnectedRoute,
+  KosyncHealthcheckRoute: KosyncHealthcheckRoute,
   McpAuthorizeRoute: McpAuthorizeRoute,
+  OpdsCollectionsRoute: OpdsCollectionsRoute,
+  OpdsComicsRoute: OpdsComicsRoute,
+  OpdsLatestRoute: OpdsLatestRoute,
+  OpdsOpensearchDotxmlRoute: OpdsOpensearchDotxmlRoute,
+  OpdsPublicationsRoute: OpdsPublicationsRoute,
+  OpdsSearchRoute: OpdsSearchRoute,
+  OpdsTagsRoute: OpdsTagsRoute,
+  OpdsTrendingRoute: OpdsTrendingRoute,
   ReviewThanksRoute: ReviewThanksRoute,
   XrpcSplatRoute: XrpcSplatRoute,
   McpIndexRoute: McpIndexRoute,
+  OpdsIndexRoute: OpdsIndexRoute,
   DotwellKnownOauthProtectedResourceMcpRoute:
     DotwellKnownOauthProtectedResourceMcpRoute,
   ApiBskyPostRoute: ApiBskyPostRoute,
@@ -2359,11 +3061,15 @@ const rootRouteChildren: RootRouteChildren = {
   ApiOgQuoteRoute: ApiOgQuoteRoute,
   ApiOgSiteRoute: ApiOgSiteRoute,
   ApiPushResubscribeRoute: ApiPushResubscribeRoute,
+  BookTagChar123tagChar125DotepubRoute: BookTagChar123tagChar125DotepubRoute,
   CollectionDidRkeyRoute: CollectionDidRkeyRoute,
   ComicDidRkeyRoute: ComicDidRkeyRoute,
   FeedLatestDidRoute: FeedLatestDidRoute,
   FeedTagTagRoute: FeedTagTagRoute,
   FeedUDidRoute: FeedUDidRoute,
+  KosyncUsersAuthRoute: KosyncUsersAuthRoute,
+  KosyncUsersCreateRoute: KosyncUsersCreateRoute,
+  OpdsTagTagRoute: OpdsTagTagRoute,
   SubscribeLoginDidRkeyRoute: SubscribeLoginDidRkeyRoute,
   SubscribeDidRkeyRoute: SubscribeDidRkeyRoute,
   ApiAuthAtprotoAuthorizeRoute: ApiAuthAtprotoAuthorizeRoute,
@@ -2372,10 +3078,33 @@ const rootRouteChildren: RootRouteChildren = {
   ApiAuthAtprotoMetadataDotjsonRoute: ApiAuthAtprotoMetadataDotjsonRoute,
   ApiAuthAtprotoSignupRoute: ApiAuthAtprotoSignupRoute,
   ApiOgPageSlugRoute: ApiOgPageSlugRoute,
+  BookADidChar123rkeyChar125DotcbzRoute: BookADidChar123rkeyChar125DotcbzRoute,
+  BookADidChar123rkeyChar125DotepubRoute:
+    BookADidChar123rkeyChar125DotepubRoute,
+  BookCDidChar123rkeyChar125DotepubRoute:
+    BookCDidChar123rkeyChar125DotepubRoute,
+  BookIDidChar123rkeyChar125DotcbzRoute: BookIDidChar123rkeyChar125DotcbzRoute,
+  BookLDidChar123rkeyChar125DotepubRoute:
+    BookLDidChar123rkeyChar125DotepubRoute,
+  BookPDidChar123rkeyChar125DotcbzRoute: BookPDidChar123rkeyChar125DotcbzRoute,
+  BookPDidChar123rkeyChar125DotepubRoute:
+    BookPDidChar123rkeyChar125DotepubRoute,
+  BookUDidSavedDotepubRoute: BookUDidSavedDotepubRoute,
+  BookUDidUnreadDotepubRoute: BookUDidUnreadDotepubRoute,
   EmbedSubscribeDidRkeyRoute: EmbedSubscribeDidRkeyRoute,
   FeedCollectionDidRkeyRoute: FeedCollectionDidRkeyRoute,
   FeedLDidRkeyRoute: FeedLDidRkeyRoute,
   FeedPDidRkeyRoute: FeedPDidRkeyRoute,
+  KosyncSyncsProgressDocumentRoute: KosyncSyncsProgressDocumentRoute,
+  OpdsCDidRkeyRoute: OpdsCDidRkeyRoute,
+  OpdsLDidRkeyRoute: OpdsLDidRkeyRoute,
+  OpdsPDidRkeyRoute: OpdsPDidRkeyRoute,
+  OpdsUDidPublicationsRoute: OpdsUDidPublicationsRoute,
+  OpdsUDidSavedRoute: OpdsUDidSavedRoute,
+  OpdsUDidSubscriptionsRoute: OpdsUDidSubscriptionsRoute,
+  OpdsUDidUnreadRoute: OpdsUDidUnreadRoute,
+  KosyncSyncsProgressIndexRoute: KosyncSyncsProgressIndexRoute,
+  OpdsUDidIndexRoute: OpdsUDidIndexRoute,
   ApiAuthAtprotoReviewCallbackRoute: ApiAuthAtprotoReviewCallbackRoute,
   ApiAuthAtprotoReviewMetadataDotjsonRoute:
     ApiAuthAtprotoReviewMetadataDotjsonRoute,

--- a/apps/standard-reader/src/routes/_guide-layout.guide.e-readers.tsx
+++ b/apps/standard-reader/src/routes/_guide-layout.guide.e-readers.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { getPublicUrlClient } from "#/lib/public-url";
+import { pageSocialMeta } from "#/lib/site-metadata";
+
+import { EreadersGuidePage } from "../components/guide/pages/e-readers-guide-page";
+
+export const Route = createFileRoute("/_guide-layout/guide/e-readers")({
+  head: () => ({
+    meta: pageSocialMeta("guideEreaders", getPublicUrlClient()),
+  }),
+  component: EreadersGuidePage,
+});

--- a/apps/standard-reader/src/routes/_layout.p.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/_layout.p.$did.$rkey.tsx
@@ -666,6 +666,14 @@ function PublicationProfileContent({
     setNextOffset(initialPage.nextOffset);
   }, [initialPage]);
 
+  // Whether a book of this publication would have anything in it. A bridged
+  // mirror's archive is all link posts, and offering a download there would be
+  // a button that 404s — so the first page of the archive decides, which is the
+  // same set the book is built from.
+  const hasDownloadableArticles = documents.some(
+    (document) => document.hasRenderableBody,
+  );
+
   const { enabled: trackReading } = useTrackReadingHistory();
   const isUnread = (article: ArticleCard) =>
     isArticleUnreadForReader(queryClient, article, {
@@ -822,6 +830,7 @@ function PublicationProfileContent({
               pub={pub}
               pageUrl={`${getPublicUrlClient()}/p/${did}/${rkey}`}
               feedUrl={publicationFeedUrl(getPublicUrlClient(), did, rkey)}
+              hasDownloadableArticles={hasDownloadableArticles}
               signedIn={signedIn}
               embed={embedMeta}
               markAllRead={markAllReadAction}

--- a/apps/standard-reader/src/routes/book.a.$did.{$rkey}[.]cbz.tsx
+++ b/apps/standard-reader/src/routes/book.a.$did.{$rkey}[.]cbz.tsx
@@ -1,0 +1,91 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { and, eq } from "drizzle-orm";
+
+import { documentUriFromParams } from "#/components/reader/format";
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import { parseComicIssueTitle } from "#/lib/comic/issue-title";
+import { documentImages } from "#/lib/document/images";
+import { getPublicUrl } from "#/lib/public-url";
+import { buildCbz } from "#/server/books/cbz";
+import { bookResponse } from "#/server/books/respond";
+import { bookFilename } from "#/server/books/sources";
+import { rememberDownloadHashes } from "#/server/kosync/register";
+
+export const Route = createFileRoute("/book/a/$did/{$rkey}.cbz")({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const { did, rkey } = params;
+        if (!did.startsWith("did:")) {
+          return new Response("Bad Request", { status: 400 });
+        }
+
+        const uri = documentUriFromParams(did, rkey);
+        const [row] = await db
+          .select({
+            canonicalUrl: schema.documents.canonicalUrl,
+            contentFormat: schema.documents.contentFormat,
+            contentJson: schema.documents.contentJson,
+            description: schema.documents.description,
+            did: schema.documents.did,
+            publicationName: schema.publications.name,
+            publishedAt: schema.documents.publishedAt,
+            tags: schema.documents.tags,
+            title: schema.documents.title,
+          })
+          .from(schema.documents)
+          .leftJoin(
+            schema.publications,
+            eq(schema.publications.uri, schema.documents.publicationUri),
+          )
+          .where(
+            and(
+              eq(schema.documents.uri, uri),
+              eq(schema.documents.deleted, false),
+            ),
+          )
+          .limit(1);
+
+        if (!row) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        // The same page list the comic reader flips through, in the same order.
+        const pages = documentImages({
+          contentFormat: row.contentFormat,
+          contentJson: row.contentJson as never,
+          did: row.did,
+        });
+        if (pages.length === 0) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        const issue = parseComicIssueTitle(row.title);
+        const cbz = await buildCbz({
+          genres: row.tags ?? [],
+          number: issue?.issueNumber ?? null,
+          pageUrls: pages.map((page) => page.url),
+          published: row.publishedAt.toISOString(),
+          publisher: row.publicationName ?? "Standard Reader",
+          series: row.publicationName ?? (issue?.series || null),
+          summary: row.description,
+          title: row.title,
+          web: row.canonicalUrl ?? `${getPublicUrl()}/comic/${did}/${rkey}`,
+        });
+        if (!cbz) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        const filename = bookFilename(row.title, ".cbz");
+        await rememberDownloadHashes(uri, cbz, filename);
+
+        return bookResponse(cbz, {
+          contentType: "application/vnd.comicbook+zip",
+          filename,
+          request,
+        });
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/book.a.$did.{$rkey}[.]epub.tsx
+++ b/apps/standard-reader/src/routes/book.a.$did.{$rkey}[.]epub.tsx
@@ -1,0 +1,65 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { documentUriFromParams } from "#/components/reader/format";
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import { getPublicUrl } from "#/lib/public-url";
+import { buildEpub } from "#/server/books/epub";
+import { bookResponse } from "#/server/books/respond";
+import {
+  bookFilename,
+  bookFromCards,
+  cardByline,
+  cardSourceUrl,
+} from "#/server/books/sources";
+import { rememberDownloadHashes } from "#/server/kosync/register";
+import { selectArticleCardsByUris } from "#/server/reader/queries";
+
+export const Route = createFileRoute("/book/a/$did/{$rkey}.epub")({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const { did, rkey } = params;
+        if (!did.startsWith("did:")) {
+          return new Response("Bad Request", { status: 400 });
+        }
+
+        const uri = documentUriFromParams(did, rkey);
+        const [card] = await selectArticleCardsByUris(db, schema, [uri]);
+        // `hasRenderableBody` is the app's own judgement that a document has a
+        // body worth showing — bridged link posts and bare Bluesky anchors do
+        // not. Packaging one of those would produce a "book" that is a title
+        // and a link, so the catalog never offers it and neither does this.
+        if (!card || !card.hasRenderableBody) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        const baseUrl = getPublicUrl();
+        const byline = cardByline(card);
+        const spec = await bookFromCards(db, schema, [card], {
+          authors: byline ? [byline] : [],
+          baseUrl,
+          coverImageUrl: card.coverImageUrl,
+          description: card.description,
+          identifier: card.uri,
+          publisher: card.publicationName ?? "Standard Reader",
+          sourceUrl: cardSourceUrl(card, baseUrl),
+          title: card.title,
+        });
+
+        const epub = await buildEpub(spec);
+        const filename = bookFilename(card.title, ".epub");
+        // The device will report progress against a hash of these exact bytes,
+        // with no way to say which article it means — so the mapping is recorded
+        // now, while both are in hand. See `server/kosync/document-hash.ts`.
+        await rememberDownloadHashes(card.uri, epub, filename);
+
+        return bookResponse(epub, {
+          contentType: "application/epub+zip",
+          filename,
+          request,
+        });
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/book.c.$did.{$rkey}[.]epub.tsx
+++ b/apps/standard-reader/src/routes/book.c.$did.{$rkey}[.]epub.tsx
@@ -1,0 +1,89 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { and, eq } from "drizzle-orm";
+
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import { collectionDocumentUri } from "#/lib/atproto/collection-uris";
+import { parseCollectionManifest } from "#/lib/collections/manifest";
+import { getPublicUrl } from "#/lib/public-url";
+import { cdnImageUrl } from "#/server/atproto/blob";
+import { buildEpub } from "#/server/books/epub";
+import { bookResponse } from "#/server/books/respond";
+import {
+  bookFilename,
+  bookFromCards,
+  packageableCards,
+} from "#/server/books/sources";
+import { selectArticleCardsByUris } from "#/server/reader/queries";
+
+export const Route = createFileRoute("/book/c/$did/{$rkey}.epub")({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const { did, rkey } = params;
+        if (!did.startsWith("did:")) {
+          return new Response("Bad Request", { status: 400 });
+        }
+
+        const uri = collectionDocumentUri(did, rkey);
+        const [row] = await db
+          .select({
+            collectionJson: schema.documents.collectionJson,
+            coverImageCid: schema.documents.coverImageCid,
+            description: schema.documents.description,
+            title: schema.documents.title,
+          })
+          .from(schema.documents)
+          .where(
+            and(
+              eq(schema.documents.uri, uri),
+              eq(schema.documents.deleted, false),
+            ),
+          )
+          .limit(1);
+
+        const manifest = row
+          ? parseCollectionManifest(row.collectionJson)
+          : null;
+        if (!row || !manifest) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        // The manifest is an editor's running order; the DB returns rows in
+        // whatever order it likes, so the manifest is re-imposed on them.
+        const itemUris = manifest.items.map((item) => item.document);
+        const itemCards = await selectArticleCardsByUris(db, schema, itemUris);
+        const byUri = new Map(itemCards.map((card) => [card.uri, card]));
+        const cards = packageableCards(
+          itemUris.flatMap((itemUri) => {
+            const card = byUri.get(itemUri);
+            return card ? [card] : [];
+          }),
+        );
+        if (cards.length === 0) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        const baseUrl = getPublicUrl();
+        const spec = await bookFromCards(db, schema, cards, {
+          baseUrl,
+          coverImageUrl: row.coverImageCid
+            ? cdnImageUrl(did, row.coverImageCid)
+            : null,
+          description: row.description,
+          identifier: uri,
+          sourceUrl: `${baseUrl}/collection/${did}/${rkey}`,
+          subtitle: `${cards.length} ${cards.length === 1 ? "piece" : "pieces"}`,
+          title: row.title,
+        });
+
+        const epub = await buildEpub(spec);
+        return bookResponse(epub, {
+          contentType: "application/epub+zip",
+          filename: bookFilename(row.title, ".epub"),
+          request,
+        });
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/book.i.$did.{$rkey}[.]cbz.tsx
+++ b/apps/standard-reader/src/routes/book.i.$did.{$rkey}[.]cbz.tsx
@@ -1,0 +1,91 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { and, eq } from "drizzle-orm";
+
+import { documentUriFromParams } from "#/components/reader/format";
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import { getPublicUrl } from "#/lib/public-url";
+import { buildCbz } from "#/server/books/cbz";
+import { comicIssueFile } from "#/server/books/comic-issue";
+import { bookResponse } from "#/server/books/respond";
+import { bookFilename } from "#/server/books/sources";
+
+/**
+ * One comic issue as a CBZ, addressed by the document that fronts it.
+ *
+ * Distinct from `/book/a/:did/:rkey.cbz`, which packages a single document: on
+ * this network a comic posts one page per document, so that route yields a
+ * one-page file. This one collects the whole issue the page belongs to — the
+ * same grouping the shelf and the reader show.
+ */
+export const Route = createFileRoute("/book/i/$did/{$rkey}.cbz")({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const { did, rkey } = params;
+        if (!did.startsWith("did:")) {
+          return new Response("Bad Request", { status: 400 });
+        }
+
+        const [front] = await db
+          .select({
+            publicationName: schema.publications.name,
+            publicationUri: schema.documents.publicationUri,
+            tags: schema.documents.tags,
+          })
+          .from(schema.documents)
+          .leftJoin(
+            schema.publications,
+            eq(schema.publications.uri, schema.documents.publicationUri),
+          )
+          .where(
+            and(
+              eq(schema.documents.uri, documentUriFromParams(did, rkey)),
+              eq(schema.documents.deleted, false),
+            ),
+          )
+          .limit(1);
+
+        if (!front?.publicationUri) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        const issue = await comicIssueFile(
+          db,
+          schema,
+          front.publicationUri,
+          rkey,
+        );
+        if (!issue) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        const series = front.publicationName ?? null;
+        // "Fray In The Veil #3" reads better on a device's shelf than "#3",
+        // which is what the in-app shelf shows under a cover that already sits
+        // inside the publication.
+        const title = series ? `${series} ${issue.title}` : issue.title;
+
+        const cbz = await buildCbz({
+          genres: front.tags ?? [],
+          number: issue.issueNumber,
+          pageUrls: issue.pageUrls,
+          published: issue.publishedAt,
+          publisher: series ?? "Standard Reader",
+          series,
+          title,
+          web: `${getPublicUrl()}/comic/${did}/${rkey}`,
+        });
+        if (!cbz) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        return bookResponse(cbz, {
+          contentType: "application/vnd.comicbook+zip",
+          filename: bookFilename(title, ".cbz"),
+          request,
+        });
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/book.l.$did.{$rkey}[.]epub.tsx
+++ b/apps/standard-reader/src/routes/book.l.$did.{$rkey}[.]epub.tsx
@@ -1,0 +1,65 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import { getPublicUrl } from "#/lib/public-url";
+import { blockFilterDid } from "#/server/blocks/blocks";
+import { buildEpub } from "#/server/books/epub";
+import {
+  BOOK_PRIVATE_CACHE_CONTROL,
+  bookResponse,
+} from "#/server/books/respond";
+import {
+  BOOK_ARTICLE_LIMIT,
+  bookFilename,
+  bookFromCards,
+  packageableCards,
+} from "#/server/books/sources";
+import { selectArticleCards } from "#/server/reader/queries";
+import { readList } from "#/server/reader/saved-lists";
+
+export const Route = createFileRoute("/book/l/$did/{$rkey}.epub")({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const { did, rkey } = params;
+        const list = await readList(db, did, rkey);
+        if (!list) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        // The list owner is the reader this book is for, so their blocks apply
+        // — the same reasoning as the list's RSS feed.
+        const cards = packageableCards(
+          await selectArticleCards(db, schema, {
+            limit: BOOK_ARTICLE_LIMIT,
+            publicationUris: list.publications,
+            renderableOnly: true,
+            viewerDid: await blockFilterDid(db, schema, did),
+          }),
+        );
+        if (cards.length === 0) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        const baseUrl = getPublicUrl();
+        const spec = await bookFromCards(db, schema, cards, {
+          baseUrl,
+          description: list.description,
+          identifier: `at://${did}/app.standard-reader.list/${rkey}`,
+          sourceUrl: `${baseUrl}/l/${did}/${rkey}`,
+          subtitle: `${cards.length} recent ${cards.length === 1 ? "article" : "articles"}`,
+          title: list.name,
+        });
+
+        const epub = await buildEpub(spec);
+        return bookResponse(epub, {
+          cacheControl: BOOK_PRIVATE_CACHE_CONTROL,
+          contentType: "application/epub+zip",
+          filename: bookFilename(list.name, ".epub"),
+          request,
+        });
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/book.p.$did.{$rkey}[.]cbz.tsx
+++ b/apps/standard-reader/src/routes/book.p.$did.{$rkey}[.]cbz.tsx
@@ -1,0 +1,69 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { publicationUriFromParams } from "#/components/reader/format";
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import { getPublicUrl } from "#/lib/public-url";
+import { buildCbz } from "#/server/books/cbz";
+import { comicRunFile } from "#/server/books/comic-issue";
+import { bookResponse } from "#/server/books/respond";
+import { bookFilename } from "#/server/books/sources";
+import { selectPublicationHeader } from "#/server/reader/publication-header";
+
+/**
+ * A comic publication's whole run as one CBZ.
+ *
+ * The right unit for a comic whose posts carry no issue numbers: there is no
+ * issue to package, so one file of everything beats a shelf of one-page files.
+ */
+export const Route = createFileRoute("/book/p/$did/{$rkey}.cbz")({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const { did, rkey } = params;
+        if (!did.startsWith("did:")) {
+          return new Response("Bad Request", { status: 400 });
+        }
+
+        const publicationUri = publicationUriFromParams(did, rkey);
+        const header = await selectPublicationHeader(
+          db,
+          schema,
+          publicationUri,
+        );
+        if (!header) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        const run = await comicRunFile(
+          db,
+          schema,
+          publicationUri,
+          header.publication.name,
+        );
+        if (!run) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        const cbz = await buildCbz({
+          pageUrls: run.pageUrls,
+          published: run.publishedAt,
+          publisher: header.publication.name,
+          series: header.publication.name,
+          summary: header.publication.description,
+          title: run.title,
+          web: `${getPublicUrl()}/p/${did}/${rkey}`,
+        });
+        if (!cbz) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        return bookResponse(cbz, {
+          contentType: "application/vnd.comicbook+zip",
+          filename: bookFilename(run.title, ".cbz"),
+          request,
+        });
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/book.p.$did.{$rkey}[.]epub.tsx
+++ b/apps/standard-reader/src/routes/book.p.$did.{$rkey}[.]epub.tsx
@@ -1,0 +1,74 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { publicationUriFromParams } from "#/components/reader/format";
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import { getPublicUrl } from "#/lib/public-url";
+import { buildEpub } from "#/server/books/epub";
+import { bookResponse } from "#/server/books/respond";
+import {
+  BOOK_ARTICLE_LIMIT,
+  bookFilename,
+  bookFromCards,
+  packageableCards,
+} from "#/server/books/sources";
+import { selectPublicationHeader } from "#/server/reader/publication-header";
+import { selectPublicationArticleCards } from "#/server/reader/queries";
+
+export const Route = createFileRoute("/book/p/$did/{$rkey}.epub")({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const { did, rkey } = params;
+        if (!did.startsWith("did:")) {
+          return new Response("Bad Request", { status: 400 });
+        }
+
+        const publicationUri = publicationUriFromParams(did, rkey);
+        const header = await selectPublicationHeader(
+          db,
+          schema,
+          publicationUri,
+        );
+        if (!header) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        const baseUrl = getPublicUrl();
+        const cards = packageableCards(
+          await selectPublicationArticleCards(db, schema, {
+            limit: BOOK_ARTICLE_LIMIT,
+            publicationUri,
+            renderableOnly: true,
+          }),
+        );
+        if (cards.length === 0) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        const publication = header.publication;
+        // A serial reads front-to-back, so its book does too. Everything else
+        // is a blog, and a blog anthology reads newest-first like the archive.
+        const ordered = publication.serial ? cards.toReversed() : cards;
+
+        const spec = await bookFromCards(db, schema, ordered, {
+          baseUrl,
+          coverImageUrl: publication.iconUrl,
+          description: publication.description,
+          identifier: publicationUri,
+          publisher: publication.name,
+          sourceUrl: `${baseUrl}/p/${did}/${rkey}`,
+          subtitle: `${ordered.length} ${ordered.length === 1 ? "article" : "articles"} from ${publication.name}`,
+          title: publication.name,
+        });
+
+        const epub = await buildEpub(spec);
+        return bookResponse(epub, {
+          contentType: "application/epub+zip",
+          filename: bookFilename(publication.name, ".epub"),
+          request,
+        });
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/book.tag.{$tag}[.]epub.tsx
+++ b/apps/standard-reader/src/routes/book.tag.{$tag}[.]epub.tsx
@@ -1,0 +1,60 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { tagDisplayTitle } from "#/components/reader/format";
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import { getPublicUrl } from "#/lib/public-url";
+import { buildEpub } from "#/server/books/epub";
+import { bookResponse } from "#/server/books/respond";
+import {
+  BOOK_ARTICLE_LIMIT,
+  bookFilename,
+  bookFromCards,
+  packageableCards,
+} from "#/server/books/sources";
+import { selectArticleCards } from "#/server/reader/queries";
+
+export const Route = createFileRoute("/book/tag/{$tag}.epub")({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const tag = decodeURIComponent(params.tag).trim();
+        if (!tag) {
+          return new Response("Bad Request", { status: 400 });
+        }
+
+        const cards = packageableCards(
+          await selectArticleCards(db, schema, {
+            discoverOnly: true,
+            limit: BOOK_ARTICLE_LIMIT,
+            renderableOnly: true,
+            tag,
+          }),
+        );
+        if (cards.length === 0) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        const baseUrl = getPublicUrl();
+        const title = tagDisplayTitle(tag);
+        const spec = await bookFromCards(db, schema, cards, {
+          authors: [],
+          baseUrl,
+          description: `Recent articles tagged "${tag}" from across the network.`,
+          identifier: `${baseUrl}/book/tag/${encodeURIComponent(tag)}.epub`,
+          sourceUrl: `${baseUrl}/tag/${encodeURIComponent(tag)}`,
+          subjects: [tag],
+          subtitle: `${cards.length} recent ${cards.length === 1 ? "article" : "articles"}`,
+          title,
+        });
+
+        const epub = await buildEpub(spec);
+        return bookResponse(epub, {
+          contentType: "application/epub+zip",
+          filename: bookFilename(title, ".epub"),
+          request,
+        });
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/book.u.$did.saved[.]epub.tsx
+++ b/apps/standard-reader/src/routes/book.u.$did.saved[.]epub.tsx
@@ -1,0 +1,68 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { eq } from "drizzle-orm";
+
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import { getPublicUrl } from "#/lib/public-url";
+import { SITE_NAME } from "#/lib/site-metadata";
+import { buildEpub } from "#/server/books/epub";
+import {
+  BOOK_PRIVATE_CACHE_CONTROL,
+  bookResponse,
+} from "#/server/books/respond";
+import {
+  BOOK_ARTICLE_LIMIT,
+  bookFilename,
+  bookFromCards,
+  packageableCards,
+} from "#/server/books/sources";
+import { savedForLater } from "#/server/reader/queries";
+
+export const Route = createFileRoute("/book/u/$did/saved.epub")({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const did = params.did;
+        if (!did.startsWith("did:")) {
+          return new Response("Bad Request", { status: 400 });
+        }
+
+        const cards = packageableCards(
+          await savedForLater(db, schema, { did, limit: BOOK_ARTICLE_LIMIT }),
+        );
+        if (cards.length === 0) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        const [profile] = await db
+          .select({
+            displayName: schema.profiles.displayName,
+            handle: schema.profiles.handle,
+          })
+          .from(schema.profiles)
+          .where(eq(schema.profiles.did, did))
+          .limit(1);
+        const reader = profile?.displayName ?? profile?.handle ?? did;
+
+        const baseUrl = getPublicUrl();
+        const spec = await bookFromCards(db, schema, cards, {
+          authors: [],
+          baseUrl,
+          description: `Articles ${reader} saved to read later on ${SITE_NAME}.`,
+          identifier: `${baseUrl}/book/u/${did}/saved.epub`,
+          sourceUrl: `${baseUrl}/saved`,
+          subtitle: `${cards.length} ${cards.length === 1 ? "article" : "articles"} saved by ${reader}`,
+          title: "Saved for later",
+        });
+
+        const epub = await buildEpub(spec);
+        return bookResponse(epub, {
+          cacheControl: BOOK_PRIVATE_CACHE_CONTROL,
+          contentType: "application/epub+zip",
+          filename: bookFilename("Saved for later", ".epub"),
+          request,
+        });
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/book.u.$did.unread[.]epub.tsx
+++ b/apps/standard-reader/src/routes/book.u.$did.unread[.]epub.tsx
@@ -1,0 +1,63 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import { getPublicUrl } from "#/lib/public-url";
+import { buildEpub } from "#/server/books/epub";
+import {
+  shelfReader,
+  shelfReaderName,
+  unreadShelfCards,
+} from "#/server/books/reader-shelf";
+import {
+  BOOK_PRIVATE_CACHE_CONTROL,
+  bookResponse,
+} from "#/server/books/respond";
+import {
+  BOOK_ARTICLE_LIMIT,
+  bookFilename,
+  bookFromCards,
+  packageableCards,
+} from "#/server/books/sources";
+
+export const Route = createFileRoute("/book/u/$did/unread.epub")({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const did = params.did;
+        if (!did.startsWith("did:")) {
+          return new Response("Bad Request", { status: 400 });
+        }
+
+        const cards = packageableCards(
+          await unreadShelfCards(db, schema, did, {
+            limit: BOOK_ARTICLE_LIMIT,
+          }),
+        );
+        if (cards.length === 0) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        const reader = shelfReaderName(await shelfReader(db, schema, did), did);
+        const baseUrl = getPublicUrl();
+        const spec = await bookFromCards(db, schema, cards, {
+          authors: [],
+          baseUrl,
+          description: `Unread articles from the publications ${reader} subscribes to.`,
+          identifier: `${baseUrl}/book/u/${did}/unread.epub`,
+          sourceUrl: `${baseUrl}/latest`,
+          subtitle: `${cards.length} unread ${cards.length === 1 ? "article" : "articles"}`,
+          title: "Unread",
+        });
+
+        const epub = await buildEpub(spec);
+        return bookResponse(epub, {
+          cacheControl: BOOK_PRIVATE_CACHE_CONTROL,
+          contentType: "application/epub+zip",
+          filename: bookFilename("Unread", ".epub"),
+          request,
+        });
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/kosync.healthcheck.tsx
+++ b/apps/standard-reader/src/routes/kosync.healthcheck.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { kosyncJson } from "#/server/kosync/http";
+
+/** KOReader pings this when the reader taps "Check server". */
+export const Route = createFileRoute("/kosync/healthcheck")({
+  server: {
+    handlers: {
+      GET: () => kosyncJson({ state: "OK" }),
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/kosync.syncs.progress.$document.tsx
+++ b/apps/standard-reader/src/routes/kosync.syncs.progress.$document.tsx
@@ -1,0 +1,39 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import { kosyncJson, kosyncReader } from "#/server/kosync/http";
+import { readPosition } from "#/server/kosync/store";
+
+export const Route = createFileRoute("/kosync/syncs/progress/$document")({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const reader = await kosyncReader(request);
+        if ("response" in reader) return reader.response;
+
+        const position = await readPosition(
+          db,
+          schema,
+          reader.did,
+          params.document,
+        );
+
+        // No position yet is not an error — it is the first device to open the
+        // book. KOReader treats an empty body as "nothing to restore", which is
+        // exactly right; a 404 makes it show a sync failure instead.
+        //
+        // Deliberately *not* synthesised from the app's own `reading_progress`:
+        // that is a percentage, and `progress` has to be a position string this
+        // device can act on. Inventing one would jump the reader somewhere the
+        // app never meant. The crossover runs the other way — see
+        // `writePosition`.
+        if (!position) {
+          return kosyncJson({ document: params.document });
+        }
+
+        return kosyncJson({ ...position });
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/kosync.syncs.progress.index.tsx
+++ b/apps/standard-reader/src/routes/kosync.syncs.progress.index.tsx
@@ -1,0 +1,53 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import { kosyncError, kosyncJson, kosyncReader } from "#/server/kosync/http";
+import { writePosition } from "#/server/kosync/store";
+
+/**
+ * What KOReader PUTs after a page turn.
+ *
+ * `progress` is a string in both modes — an xpointer for reflowable books, a
+ * page number for paged ones — and `percentage` is the 0–1 fraction. Older
+ * builds omit `device_id`.
+ */
+const progressInput = z.object({
+  device: z.string().max(200).optional().nullable(),
+  device_id: z.string().max(200).optional().nullable(),
+  document: z.string().min(1).max(200),
+  percentage: z.coerce.number().min(0).max(1),
+  progress: z.string().min(1).max(2000),
+});
+
+export const Route = createFileRoute("/kosync/syncs/progress/")({
+  server: {
+    handlers: {
+      PUT: async ({ request }) => {
+        const reader = await kosyncReader(request);
+        if ("response" in reader) return reader.response;
+
+        const parsed = progressInput.safeParse(
+          await request.json().catch(() => null),
+        );
+        if (!parsed.success) {
+          return kosyncError("Invalid progress payload.", 400);
+        }
+
+        await writePosition(db, schema, reader.did, {
+          device: parsed.data.device ?? null,
+          deviceId: parsed.data.device_id ?? null,
+          document: parsed.data.document,
+          percentage: parsed.data.percentage,
+          progress: parsed.data.progress,
+        });
+
+        return kosyncJson({
+          document: parsed.data.document,
+          timestamp: Math.floor(Date.now() / 1000),
+        });
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/kosync.users.auth.tsx
+++ b/apps/standard-reader/src/routes/kosync.users.auth.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { kosyncJson, kosyncReader } from "#/server/kosync/http";
+
+/** "Login" in KOReader's sync settings lands here. */
+export const Route = createFileRoute("/kosync/users/auth")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const reader = await kosyncReader(request);
+        if ("response" in reader) return reader.response;
+        return kosyncJson({ authorized: "OK" });
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/kosync.users.create.tsx
+++ b/apps/standard-reader/src/routes/kosync.users.create.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { kosyncError } from "#/server/kosync/http";
+
+/**
+ * Registration, refused.
+ *
+ * A reference kosync server lets any device create an account. Here the account
+ * already exists — it is the reader's AT Proto identity — and there is nothing
+ * for a device to register. Answering with a clear message beats a 404: KOReader
+ * shows `message` to the reader, so this is where they find out where their key
+ * lives.
+ */
+export const Route = createFileRoute("/kosync/users/create")({
+  server: {
+    handlers: {
+      POST: () =>
+        kosyncError(
+          "Standard Reader has no separate sync account. Use your handle as the username and the sync key from Settings → E-readers as the password.",
+          403,
+        ),
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/opds.c.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/opds.c.$did.$rkey.tsx
@@ -1,0 +1,93 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { and, eq } from "drizzle-orm";
+
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import { collectionDocumentUri } from "#/lib/atproto/collection-uris";
+import { parseCollectionManifest } from "#/lib/collections/manifest";
+import { EPUB_TYPE, OPDS_REL } from "#/lib/opds/model";
+import { opdsFormatFromRequest, opdsResponse } from "#/lib/opds/respond";
+import {
+  collectionEpubUrl,
+  opdsCollectionsUrl,
+  opdsCollectionUrl,
+} from "#/lib/opds/urls";
+import { getPublicUrl } from "#/lib/public-url";
+import { cdnImageUrl } from "#/server/atproto/blob";
+import { packageableCards } from "#/server/books/sources";
+import { articleFeed } from "#/server/opds/catalog";
+import { selectArticleCardsByUris } from "#/server/reader/queries";
+
+export const Route = createFileRoute("/opds/c/$did/$rkey")({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const { did, rkey } = params;
+        if (!did.startsWith("did:")) {
+          return new Response("Bad Request", { status: 400 });
+        }
+
+        const uri = collectionDocumentUri(did, rkey);
+        const [row] = await db
+          .select({
+            collectionJson: schema.documents.collectionJson,
+            coverImageCid: schema.documents.coverImageCid,
+            description: schema.documents.description,
+            title: schema.documents.title,
+          })
+          .from(schema.documents)
+          .where(
+            and(
+              eq(schema.documents.uri, uri),
+              eq(schema.documents.deleted, false),
+            ),
+          )
+          .limit(1);
+
+        const manifest = row
+          ? parseCollectionManifest(row.collectionJson)
+          : null;
+        if (!row || !manifest) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        const baseUrl = getPublicUrl();
+        const itemUris = manifest.items.map((item) => item.document);
+        const itemCards = await selectArticleCardsByUris(db, schema, itemUris);
+        const byUri = new Map(itemCards.map((card) => [card.uri, card]));
+        // A collection is an editor's running order, so it is served in that
+        // order rather than by date.
+        const cards = packageableCards(
+          itemUris.flatMap((itemUri) => {
+            const card = byUri.get(itemUri);
+            return card ? [card] : [];
+          }),
+        );
+
+        return opdsResponse(
+          articleFeed(cards, {
+            baseUrl,
+            extraLinks: [
+              {
+                href: collectionEpubUrl(baseUrl, did, rkey),
+                rel: OPDS_REL.openAccess,
+                title: `${row.title} as one book`,
+                type: EPUB_TYPE,
+              },
+            ],
+            iconUrl: row.coverImageCid
+              ? cdnImageUrl(did, row.coverImageCid)
+              : null,
+            id: uri,
+            page: 1,
+            selfHref: opdsCollectionUrl(baseUrl, did, rkey),
+            subtitle: row.description,
+            title: row.title,
+            upHref: opdsCollectionsUrl(baseUrl),
+          }),
+          opdsFormatFromRequest(request),
+        );
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/opds.collections.tsx
+++ b/apps/standard-reader/src/routes/opds.collections.tsx
@@ -1,0 +1,77 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { and, desc, eq, isNotNull } from "drizzle-orm";
+
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import type { OpdsNavigationEntry } from "#/lib/opds/model";
+import { opdsFormatFromRequest, opdsResponse } from "#/lib/opds/respond";
+import { opdsCollectionsUrl, opdsCollectionUrl } from "#/lib/opds/urls";
+import { getPublicUrl } from "#/lib/public-url";
+import { cdnImageUrl } from "#/server/atproto/blob";
+import {
+  navigationFeed,
+  OPDS_PAGE_SIZE,
+  pageFromRequest,
+} from "#/server/opds/catalog";
+
+export const Route = createFileRoute("/opds/collections")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const baseUrl = getPublicUrl();
+        const page = pageFromRequest(request);
+
+        // A collection is an ordinary document carrying a manifest sidecar, so
+        // "the collections" is just the documents that have one.
+        const rows = await db
+          .select({
+            coverImageCid: schema.documents.coverImageCid,
+            description: schema.documents.description,
+            did: schema.documents.did,
+            publishedAt: schema.documents.publishedAt,
+            rkey: schema.documents.rkey,
+            title: schema.documents.title,
+            uri: schema.documents.uri,
+          })
+          .from(schema.documents)
+          .where(
+            and(
+              eq(schema.documents.deleted, false),
+              isNotNull(schema.documents.collectionJson),
+            ),
+          )
+          .orderBy(desc(schema.documents.publishedAt))
+          .limit(OPDS_PAGE_SIZE)
+          .offset((page - 1) * OPDS_PAGE_SIZE);
+
+        const entries: Array<OpdsNavigationEntry> = rows.map((row) => {
+          const cover = row.coverImageCid
+            ? cdnImageUrl(row.did, row.coverImageCid)
+            : null;
+          return {
+            href: opdsCollectionUrl(baseUrl, row.did, row.rkey),
+            id: row.uri,
+            imageUrl: cover,
+            kind: "acquisition",
+            summary: row.description,
+            thumbnailUrl: cover,
+            title: row.title,
+            updated: row.publishedAt.toISOString(),
+          };
+        });
+
+        return opdsResponse(
+          navigationFeed(entries, {
+            baseUrl,
+            id: opdsCollectionsUrl(baseUrl),
+            page,
+            selfHref: opdsCollectionsUrl(baseUrl),
+            subtitle: "Anthologies readers assembled from across the network.",
+            title: "Collections",
+          }),
+          opdsFormatFromRequest(request),
+        );
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/opds.comics.tsx
+++ b/apps/standard-reader/src/routes/opds.comics.tsx
@@ -1,0 +1,94 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { and, desc, eq } from "drizzle-orm";
+
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import type { OpdsNavigationEntry } from "#/lib/opds/model";
+import { opdsFormatFromRequest, opdsResponse } from "#/lib/opds/respond";
+import { opdsComicsUrl, opdsPublicationUrl } from "#/lib/opds/urls";
+import { getPublicUrl } from "#/lib/public-url";
+import { cdnImageUrl } from "#/server/atproto/blob";
+import {
+  navigationFeed,
+  OPDS_PAGE_SIZE,
+  pageFromRequest,
+} from "#/server/opds/catalog";
+
+/**
+ * Comics, on their own.
+ *
+ * `serial_kind` is app-derived: a publication that reads forwards *and* whose
+ * posts are mostly art (`recomputeSerialKinds`). Pointing a comic app at the
+ * full directory would make it wade through hundreds of prose blogs to reach
+ * the handful of things it can open.
+ */
+export const Route = createFileRoute("/opds/comics")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const baseUrl = getPublicUrl();
+        const page = pageFromRequest(request);
+
+        const rows = await db
+          .select({
+            description: schema.publications.description,
+            did: schema.publications.did,
+            iconCid: schema.publications.iconCid,
+            lastDocumentAt: schema.publicationStats.lastDocumentAt,
+            name: schema.publications.name,
+            ownerAvatarUrl: schema.profiles.avatarUrl,
+            rkey: schema.publications.rkey,
+            uri: schema.publications.uri,
+          })
+          .from(schema.publications)
+          .leftJoin(
+            schema.publicationStats,
+            eq(schema.publicationStats.publicationUri, schema.publications.uri),
+          )
+          .leftJoin(
+            schema.profiles,
+            eq(schema.profiles.did, schema.publications.did),
+          )
+          .where(
+            and(
+              eq(schema.publications.deleted, false),
+              eq(schema.publications.showInDiscover, true),
+              eq(schema.publications.serialKind, "comic"),
+            ),
+          )
+          .orderBy(desc(schema.publicationStats.lastDocumentAt))
+          .limit(OPDS_PAGE_SIZE)
+          .offset((page - 1) * OPDS_PAGE_SIZE);
+
+        const entries: Array<OpdsNavigationEntry> = rows.map((row) => {
+          const icon = row.iconCid
+            ? cdnImageUrl(row.did, row.iconCid)
+            : row.ownerAvatarUrl;
+          return {
+            href: opdsPublicationUrl(baseUrl, row.did, row.rkey),
+            id: row.uri,
+            imageUrl: icon,
+            kind: "acquisition",
+            summary: row.description,
+            thumbnailUrl: icon,
+            title: row.name,
+            updated:
+              row.lastDocumentAt?.toISOString() ?? new Date(0).toISOString(),
+          };
+        });
+
+        return opdsResponse(
+          navigationFeed(entries, {
+            baseUrl,
+            id: opdsComicsUrl(baseUrl),
+            page,
+            selfHref: opdsComicsUrl(baseUrl),
+            subtitle: "Comics on the network, as CBZ.",
+            title: "Comics",
+          }),
+          opdsFormatFromRequest(request),
+        );
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/opds.index.tsx
+++ b/apps/standard-reader/src/routes/opds.index.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { opdsFormatFromRequest, opdsResponse } from "#/lib/opds/respond";
+import { getPublicUrl } from "#/lib/public-url";
+import { rootFeed } from "#/server/opds/catalog";
+
+export const Route = createFileRoute("/opds/")({
+  server: {
+    handlers: {
+      GET: ({ request }) =>
+        opdsResponse(rootFeed(getPublicUrl()), opdsFormatFromRequest(request)),
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/opds.l.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/opds.l.$did.$rkey.tsx
@@ -1,0 +1,67 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import { EPUB_TYPE, OPDS_REL } from "#/lib/opds/model";
+import {
+  OPDS_PRIVATE_CACHE_CONTROL,
+  opdsFormatFromRequest,
+  opdsResponse,
+} from "#/lib/opds/respond";
+import { listEpubUrl, opdsShelfUrl } from "#/lib/opds/urls";
+import { getPublicUrl } from "#/lib/public-url";
+import { blockFilterDid } from "#/server/blocks/blocks";
+import {
+  articleFeed,
+  OPDS_PAGE_SIZE,
+  pageFromRequest,
+} from "#/server/opds/catalog";
+import { selectArticleCards } from "#/server/reader/queries";
+import { readList } from "#/server/reader/saved-lists";
+
+export const Route = createFileRoute("/opds/l/$did/$rkey")({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const { did, rkey } = params;
+        const list = await readList(db, did, rkey);
+        if (!list) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        const baseUrl = getPublicUrl();
+        const page = pageFromRequest(request);
+        const cards = await selectArticleCards(db, schema, {
+          limit: OPDS_PAGE_SIZE,
+          offset: (page - 1) * OPDS_PAGE_SIZE,
+          publicationUris: list.publications,
+          renderableOnly: true,
+          viewerDid: await blockFilterDid(db, schema, did),
+        });
+        const self = `${baseUrl}/opds/l/${encodeURIComponent(did)}/${encodeURIComponent(rkey)}`;
+
+        return opdsResponse(
+          articleFeed(cards, {
+            baseUrl,
+            extraLinks: [
+              {
+                href: listEpubUrl(baseUrl, did, rkey),
+                rel: OPDS_REL.openAccess,
+                title: `${list.name} as one book`,
+                type: EPUB_TYPE,
+              },
+            ],
+            id: list.uri,
+            page,
+            selfHref: self,
+            subtitle: list.description,
+            title: list.name,
+            upHref: opdsShelfUrl(baseUrl, did),
+          }),
+          opdsFormatFromRequest(request),
+          { cacheControl: OPDS_PRIVATE_CACHE_CONTROL },
+        );
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/opds.latest.tsx
+++ b/apps/standard-reader/src/routes/opds.latest.tsx
@@ -1,0 +1,46 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import { opdsFormatFromRequest, opdsResponse } from "#/lib/opds/respond";
+import { opdsLatestUrl } from "#/lib/opds/urls";
+import { getPublicUrl } from "#/lib/public-url";
+import { SITE_NAME } from "#/lib/site-metadata";
+import {
+  articleFeed,
+  OPDS_PAGE_SIZE,
+  pageFromRequest,
+} from "#/server/opds/catalog";
+import { selectArticleCards } from "#/server/reader/queries";
+
+export const Route = createFileRoute("/opds/latest")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const baseUrl = getPublicUrl();
+        const page = pageFromRequest(request);
+
+        // Only what a reader can actually take: a catalog entry with no
+        // acquisition link is a download button that does nothing.
+        const cards = await selectArticleCards(db, schema, {
+          discoverOnly: true,
+          limit: OPDS_PAGE_SIZE,
+          offset: (page - 1) * OPDS_PAGE_SIZE,
+          renderableOnly: true,
+        });
+
+        return opdsResponse(
+          articleFeed(cards, {
+            baseUrl,
+            id: opdsLatestUrl(baseUrl),
+            page,
+            selfHref: opdsLatestUrl(baseUrl),
+            subtitle: `The newest articles across ${SITE_NAME}.`,
+            title: "Latest",
+          }),
+          opdsFormatFromRequest(request),
+        );
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/opds.opensearch[.]xml.tsx
+++ b/apps/standard-reader/src/routes/opds.opensearch[.]xml.tsx
@@ -1,0 +1,40 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { renderOpenSearchDescription } from "#/lib/opds/atom";
+import { withJsonFormat } from "#/lib/opds/json";
+import { OPDS_CACHE_CONTROL } from "#/lib/opds/respond";
+import { opdsSearchTemplate } from "#/lib/opds/urls";
+import { getPublicUrl } from "#/lib/public-url";
+import { SITE_NAME } from "#/lib/site-metadata";
+
+export const Route = createFileRoute("/opds/opensearch.xml")({
+  server: {
+    handlers: {
+      GET: () => {
+        const baseUrl = getPublicUrl();
+        const template = opdsSearchTemplate(baseUrl);
+
+        const xml = renderOpenSearchDescription({
+          description: `Search articles across ${SITE_NAME}.`,
+          // `{searchTerms}` must survive as a literal placeholder — the client
+          // substitutes it, so it is not URL-encoded on either template.
+          jsonSearchTemplate: withJsonFormat(template).replace(
+            "%7BsearchTerms%7D",
+            "{searchTerms}",
+          ),
+          searchTemplate: template,
+          shortName: SITE_NAME,
+        });
+
+        return new Response(xml, {
+          headers: {
+            "Access-Control-Allow-Origin": "*",
+            "Cache-Control": OPDS_CACHE_CONTROL,
+            "Content-Type":
+              "application/opensearchdescription+xml; charset=utf-8",
+          },
+        });
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/opds.p.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/opds.p.$did.$rkey.tsx
@@ -1,0 +1,106 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { publicationUriFromParams } from "#/components/reader/format";
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import { opdsFormatFromRequest, opdsResponse } from "#/lib/opds/respond";
+import {
+  opdsComicsUrl,
+  opdsPublicationsUrl,
+  opdsPublicationUrl,
+} from "#/lib/opds/urls";
+import { getPublicUrl } from "#/lib/public-url";
+import {
+  articleFeed,
+  OPDS_PAGE_SIZE,
+  pageFromRequest,
+} from "#/server/opds/catalog";
+import { comicShelfEntries } from "#/server/opds/comics";
+import { publicationBookEntry } from "#/server/opds/entries";
+import { selectComicShelf } from "#/server/reader/comic";
+import { selectPublicationHeader } from "#/server/reader/publication-header";
+import { selectPublicationArticleCards } from "#/server/reader/queries";
+
+export const Route = createFileRoute("/opds/p/$did/$rkey")({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const { did, rkey } = params;
+        if (!did.startsWith("did:")) {
+          return new Response("Bad Request", { status: 400 });
+        }
+
+        const publicationUri = publicationUriFromParams(did, rkey);
+        const header = await selectPublicationHeader(
+          db,
+          schema,
+          publicationUri,
+        );
+        if (!header) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        const baseUrl = getPublicUrl();
+        const page = pageFromRequest(request);
+        const publication = header.publication;
+        const self = opdsPublicationUrl(baseUrl, did, rkey);
+
+        // A comic's documents are pages, not issues — an article feed here
+        // would offer a comic app dozens of one-page "comics". The shelf is
+        // where the app already works out what one unit is.
+        if (publication.serial?.kind === "comic") {
+          const shelf = await selectComicShelf(db, schema, publicationUri);
+          const comicFeed = articleFeed([], {
+            baseUrl,
+            iconUrl: publication.iconUrl,
+            id: publicationUri,
+            page: 1,
+            selfHref: self,
+            subtitle: publication.description,
+            title: publication.name,
+            upHref: opdsComicsUrl(baseUrl),
+          });
+          comicFeed.publications = comicShelfEntries(
+            shelf,
+            publication,
+            baseUrl,
+          );
+          return opdsResponse(comicFeed, opdsFormatFromRequest(request));
+        }
+
+        const cards = await selectPublicationArticleCards(db, schema, {
+          limit: OPDS_PAGE_SIZE,
+          offset: (page - 1) * OPDS_PAGE_SIZE,
+          publicationUri,
+          renderableOnly: true,
+        });
+
+        const feed = articleFeed(cards, {
+          baseUrl,
+          iconUrl: publication.iconUrl,
+          id: publicationUri,
+          page,
+          selfHref: self,
+          subtitle: publication.description,
+          title: publication.name,
+          upHref: opdsPublicationsUrl(baseUrl),
+        });
+
+        // The whole-publication book leads the first page: a reader who came
+        // here to take the publication with them should not have to page to the
+        // end to find it.
+        if (page === 1 && cards.length > 0) {
+          feed.publications = [
+            publicationBookEntry(publication, baseUrl, {
+              articleCount: cards.length,
+              updated: feed.updated,
+            }),
+            ...(feed.publications ?? []),
+          ];
+        }
+
+        return opdsResponse(feed, opdsFormatFromRequest(request));
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/opds.publications.tsx
+++ b/apps/standard-reader/src/routes/opds.publications.tsx
@@ -1,0 +1,81 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import type { OpdsLink } from "#/lib/opds/model";
+import { feedTypeFor } from "#/lib/opds/model";
+import { opdsFormatFromRequest, opdsResponse } from "#/lib/opds/respond";
+import { opdsPublicationsUrl } from "#/lib/opds/urls";
+import { getPublicUrl } from "#/lib/public-url";
+import { SITE_NAME } from "#/lib/site-metadata";
+import {
+  navigationFeed,
+  OPDS_PAGE_SIZE,
+  pageFromRequest,
+  publicationEntries,
+} from "#/server/opds/catalog";
+import {
+  countKnownPublications,
+  discoverDirectoryPublications,
+} from "#/server/reader/queries";
+
+/** Sort facets, matching the Discover directory's own controls. */
+const SORTS = [
+  { key: "active", label: "Recently published" },
+  { key: "readers", label: "Most subscribers" },
+  { key: "az", label: "A–Z" },
+] as const;
+
+type SortKey = (typeof SORTS)[number]["key"];
+
+function sortFromRequest(request: Request): SortKey {
+  const raw = new URL(request.url).searchParams.get("sort");
+  return SORTS.some((sort) => sort.key === raw) ? (raw as SortKey) : "active";
+}
+
+export const Route = createFileRoute("/opds/publications")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const baseUrl = getPublicUrl();
+        const page = pageFromRequest(request);
+        const sort = sortFromRequest(request);
+        const self = opdsPublicationsUrl(baseUrl);
+
+        const [publications, total] = await Promise.all([
+          discoverDirectoryPublications(db, schema, {
+            limit: OPDS_PAGE_SIZE,
+            offset: (page - 1) * OPDS_PAGE_SIZE,
+            sort,
+          }),
+          countKnownPublications(db),
+        ]);
+
+        // Facets are how a catalog client offers a sort menu — one group, one
+        // active entry, so the reader sees which order they are in.
+        const facets: Array<OpdsLink> = SORTS.map((option) => ({
+          activeFacet: option.key === sort,
+          facetGroup: "Sort",
+          href: `${self}?sort=${option.key}`,
+          rel: "http://opds-spec.org/facet",
+          title: option.label,
+          type: feedTypeFor("navigation"),
+        }));
+
+        return opdsResponse(
+          navigationFeed(publicationEntries(publications, baseUrl), {
+            baseUrl,
+            extraLinks: facets,
+            id: self,
+            page,
+            selfHref: sort === "active" ? self : `${self}?sort=${sort}`,
+            subtitle: `Every publication on ${SITE_NAME}.`,
+            title: "Publications",
+            totalResults: total,
+          }),
+          opdsFormatFromRequest(request),
+        );
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/opds.search.tsx
+++ b/apps/standard-reader/src/routes/opds.search.tsx
@@ -1,0 +1,58 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { searchApi } from "#/integrations/tanstack-query/api-search.functions";
+import { opdsFormatFromRequest, opdsResponse } from "#/lib/opds/respond";
+import { opdsSearchUrl } from "#/lib/opds/urls";
+import { getPublicUrl } from "#/lib/public-url";
+import { SITE_NAME } from "#/lib/site-metadata";
+import {
+  articleFeed,
+  OPDS_PAGE_SIZE,
+  pageFromRequest,
+} from "#/server/opds/catalog";
+
+export const Route = createFileRoute("/opds/search")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const baseUrl = getPublicUrl();
+        const url = new URL(request.url);
+        // OpenSearch clients send `q`; a few send `query` or `searchTerms`.
+        const query = (
+          url.searchParams.get("q") ??
+          url.searchParams.get("query") ??
+          url.searchParams.get("searchTerms") ??
+          ""
+        ).trim();
+        const page = pageFromRequest(request);
+
+        // Reuse the app's own search server function rather than restating its
+        // query: it carries the ranking, the block/mute filters and the
+        // index-friendly shape that took real work to get right.
+        const results = query
+          ? await searchApi.searchArticles({
+              data: {
+                limit: OPDS_PAGE_SIZE,
+                offset: (page - 1) * OPDS_PAGE_SIZE,
+                q: query.slice(0, 512),
+              },
+            })
+          : { items: [] };
+
+        return opdsResponse(
+          articleFeed(results.items, {
+            baseUrl,
+            id: opdsSearchUrl(baseUrl, query || undefined),
+            page,
+            selfHref: opdsSearchUrl(baseUrl, query || undefined),
+            subtitle: query
+              ? `Articles matching “${query}”.`
+              : `Search ${SITE_NAME} for an article.`,
+            title: query ? `Search: ${query}` : "Search",
+          }),
+          opdsFormatFromRequest(request),
+        );
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/opds.tag.$tag.tsx
+++ b/apps/standard-reader/src/routes/opds.tag.$tag.tsx
@@ -1,0 +1,65 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { tagDisplayTitle } from "#/components/reader/format";
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import { EPUB_TYPE, OPDS_REL } from "#/lib/opds/model";
+import { opdsFormatFromRequest, opdsResponse } from "#/lib/opds/respond";
+import { opdsTagsUrl, opdsTagUrl, tagEpubUrl } from "#/lib/opds/urls";
+import { getPublicUrl } from "#/lib/public-url";
+import {
+  articleFeed,
+  OPDS_PAGE_SIZE,
+  pageFromRequest,
+} from "#/server/opds/catalog";
+import { selectArticleCards } from "#/server/reader/queries";
+
+export const Route = createFileRoute("/opds/tag/$tag")({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const tag = decodeURIComponent(params.tag).trim();
+        if (!tag) {
+          return new Response("Bad Request", { status: 400 });
+        }
+
+        const baseUrl = getPublicUrl();
+        const page = pageFromRequest(request);
+
+        // No `totalResults`: `countTagArticles` counts every tagged document,
+        // including the bridged link posts this feed leaves out, so reporting it
+        // would tell the client to keep paging past the end. The short-page
+        // heuristic in `articleFeed` is the honest signal here.
+        const cards = await selectArticleCards(db, schema, {
+          discoverOnly: true,
+          limit: OPDS_PAGE_SIZE,
+          offset: (page - 1) * OPDS_PAGE_SIZE,
+          renderableOnly: true,
+          tag,
+        });
+
+        return opdsResponse(
+          articleFeed(cards, {
+            baseUrl,
+            // The whole tag as one book, alongside the per-article downloads.
+            extraLinks: [
+              {
+                href: tagEpubUrl(baseUrl, tag),
+                rel: OPDS_REL.openAccess,
+                title: `${tagDisplayTitle(tag)} as one book`,
+                type: EPUB_TYPE,
+              },
+            ],
+            id: opdsTagUrl(baseUrl, tag),
+            page,
+            selfHref: opdsTagUrl(baseUrl, tag),
+            subtitle: `Articles tagged “${tag}” from across the network.`,
+            title: tagDisplayTitle(tag),
+            upHref: opdsTagsUrl(baseUrl),
+          }),
+          opdsFormatFromRequest(request),
+        );
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/opds.tags.tsx
+++ b/apps/standard-reader/src/routes/opds.tags.tsx
@@ -1,0 +1,35 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { db } from "#/db/index.server";
+import { opdsFormatFromRequest, opdsResponse } from "#/lib/opds/respond";
+import { opdsTagsUrl } from "#/lib/opds/urls";
+import { getPublicUrl } from "#/lib/public-url";
+import { navigationFeed, topicEntries } from "#/server/opds/catalog";
+import { discoverPublicationTopics } from "#/server/reader/queries";
+
+/** One page of topics is the whole list — there are not many, and paging hurts. */
+const TOPIC_LIMIT = 200;
+
+export const Route = createFileRoute("/opds/tags")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const baseUrl = getPublicUrl();
+        const topics = await discoverPublicationTopics(db, {
+          limit: TOPIC_LIMIT,
+        });
+
+        return opdsResponse(
+          navigationFeed(topicEntries(topics, baseUrl), {
+            baseUrl,
+            id: opdsTagsUrl(baseUrl),
+            selfHref: opdsTagsUrl(baseUrl),
+            subtitle: "Browse the network by subject.",
+            title: "Topics",
+          }),
+          opdsFormatFromRequest(request),
+        );
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/opds.trending.tsx
+++ b/apps/standard-reader/src/routes/opds.trending.tsx
@@ -1,0 +1,41 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import { opdsFormatFromRequest, opdsResponse } from "#/lib/opds/respond";
+import { opdsTrendingUrl } from "#/lib/opds/urls";
+import { getPublicUrl } from "#/lib/public-url";
+import {
+  articleFeed,
+  OPDS_PAGE_SIZE,
+  pageFromRequest,
+} from "#/server/opds/catalog";
+import { trendingArticles } from "#/server/reader/queries";
+
+export const Route = createFileRoute("/opds/trending")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const baseUrl = getPublicUrl();
+        const page = pageFromRequest(request);
+
+        const cards = await trendingArticles(db, schema, OPDS_PAGE_SIZE, {
+          offset: (page - 1) * OPDS_PAGE_SIZE,
+          scope: "page",
+        });
+
+        return opdsResponse(
+          articleFeed(cards, {
+            baseUrl,
+            id: opdsTrendingUrl(baseUrl),
+            page,
+            selfHref: opdsTrendingUrl(baseUrl),
+            subtitle: "What the network is reading and recommending right now.",
+            title: "Trending",
+          }),
+          opdsFormatFromRequest(request),
+        );
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/opds.u.$did.index.tsx
+++ b/apps/standard-reader/src/routes/opds.u.$did.index.tsx
@@ -1,0 +1,47 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import {
+  OPDS_PRIVATE_CACHE_CONTROL,
+  opdsFormatFromRequest,
+  opdsResponse,
+} from "#/lib/opds/respond";
+import { getPublicUrl } from "#/lib/public-url";
+import { shelfReader, shelfReaderName } from "#/server/books/reader-shelf";
+import { shelfNavigation } from "#/server/opds/catalog";
+import { savedListsForReader } from "#/server/reader/saved-lists";
+
+export const Route = createFileRoute("/opds/u/$did/")({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const did = params.did;
+        if (!did.startsWith("did:")) {
+          return new Response("Bad Request", { status: 400 });
+        }
+
+        const [reader, lists] = await Promise.all([
+          shelfReader(db, schema, did),
+          savedListsForReader(db, did),
+        ]);
+
+        return opdsResponse(
+          shelfNavigation({
+            baseUrl: getPublicUrl(),
+            did,
+            lists: lists.map((list) => ({
+              description: list.description,
+              name: list.name,
+              rkey: list.rkey,
+            })),
+            readerName: shelfReaderName(reader, did),
+            trackReadingHistory: reader.trackReadingHistory,
+          }),
+          opdsFormatFromRequest(request),
+          { cacheControl: OPDS_PRIVATE_CACHE_CONTROL },
+        );
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/opds.u.$did.publications.tsx
+++ b/apps/standard-reader/src/routes/opds.u.$did.publications.tsx
@@ -1,0 +1,46 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import {
+  OPDS_PRIVATE_CACHE_CONTROL,
+  opdsFormatFromRequest,
+  opdsResponse,
+} from "#/lib/opds/respond";
+import { opdsShelfUrl } from "#/lib/opds/urls";
+import { getPublicUrl } from "#/lib/public-url";
+import { navigationFeed, publicationEntries } from "#/server/opds/catalog";
+import { followedPublications } from "#/server/reader/queries";
+import { effectiveFollowUris } from "#/server/reader/saved-lists";
+
+export const Route = createFileRoute("/opds/u/$did/publications")({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const did = params.did;
+        if (!did.startsWith("did:")) {
+          return new Response("Bad Request", { status: 400 });
+        }
+
+        const baseUrl = getPublicUrl();
+        const uris = await effectiveFollowUris(db, schema, did);
+        const publications = await followedPublications(db, schema, uris);
+        const self = `${opdsShelfUrl(baseUrl, did)}/publications`;
+
+        return opdsResponse(
+          navigationFeed(publicationEntries(publications, baseUrl), {
+            baseUrl,
+            id: self,
+            selfHref: self,
+            subtitle:
+              "Every publication you subscribe to — open one to browse or download it.",
+            title: "Your publications",
+            upHref: opdsShelfUrl(baseUrl, did),
+          }),
+          opdsFormatFromRequest(request),
+          { cacheControl: OPDS_PRIVATE_CACHE_CONTROL },
+        );
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/opds.u.$did.saved.tsx
+++ b/apps/standard-reader/src/routes/opds.u.$did.saved.tsx
@@ -1,0 +1,67 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import { EPUB_TYPE, OPDS_REL } from "#/lib/opds/model";
+import {
+  OPDS_PRIVATE_CACHE_CONTROL,
+  opdsFormatFromRequest,
+  opdsResponse,
+} from "#/lib/opds/respond";
+import { opdsShelfUrl, savedEpubUrl } from "#/lib/opds/urls";
+import { getPublicUrl } from "#/lib/public-url";
+import { packageableCards } from "#/server/books/sources";
+import {
+  articleFeed,
+  OPDS_PAGE_SIZE,
+  pageFromRequest,
+} from "#/server/opds/catalog";
+import { savedForLater } from "#/server/reader/queries";
+
+export const Route = createFileRoute("/opds/u/$did/saved")({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const did = params.did;
+        if (!did.startsWith("did:")) {
+          return new Response("Bad Request", { status: 400 });
+        }
+
+        const baseUrl = getPublicUrl();
+        const page = pageFromRequest(request);
+        // `savedForLater` has no offset, so pages are sliced from one read —
+        // a reading list long enough for that to hurt is not a reading list.
+        const through = packageableCards(
+          await savedForLater(db, schema, {
+            did,
+            limit: OPDS_PAGE_SIZE * page,
+          }),
+        );
+        const cards = through.slice((page - 1) * OPDS_PAGE_SIZE);
+        const self = `${opdsShelfUrl(baseUrl, did)}/saved`;
+
+        return opdsResponse(
+          articleFeed(cards, {
+            baseUrl,
+            extraLinks: [
+              {
+                href: savedEpubUrl(baseUrl, did),
+                rel: OPDS_REL.openAccess,
+                title: "Everything saved, as one book",
+                type: EPUB_TYPE,
+              },
+            ],
+            id: self,
+            page,
+            selfHref: self,
+            subtitle: "Articles you saved to read later.",
+            title: "Saved for later",
+            upHref: opdsShelfUrl(baseUrl, did),
+          }),
+          opdsFormatFromRequest(request),
+          { cacheControl: OPDS_PRIVATE_CACHE_CONTROL },
+        );
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/opds.u.$did.subscriptions.tsx
+++ b/apps/standard-reader/src/routes/opds.u.$did.subscriptions.tsx
@@ -1,0 +1,68 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import {
+  OPDS_PRIVATE_CACHE_CONTROL,
+  opdsFormatFromRequest,
+  opdsResponse,
+} from "#/lib/opds/respond";
+import { opdsShelfUrl } from "#/lib/opds/urls";
+import { getPublicUrl } from "#/lib/public-url";
+import { blockFilterDid } from "#/server/blocks/blocks";
+import {
+  articleFeed,
+  OPDS_PAGE_SIZE,
+  pageFromRequest,
+} from "#/server/opds/catalog";
+import { selectArticleCards } from "#/server/reader/queries";
+import { effectiveFollowSets } from "#/server/reader/saved-lists";
+
+export const Route = createFileRoute("/opds/u/$did/subscriptions")({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const did = params.did;
+        if (!did.startsWith("did:")) {
+          return new Response("Bad Request", { status: 400 });
+        }
+
+        const baseUrl = getPublicUrl();
+        const page = pageFromRequest(request);
+
+        // This shelf belongs to `$did`, so their blocks apply — the same
+        // reasoning as their personalised RSS feed: the URL is the only way in,
+        // and a reader who subscribed on a device cannot "just not look".
+        const [{ publicationUris, userDids }, viewerDid] = await Promise.all([
+          effectiveFollowSets(db, schema, did),
+          blockFilterDid(db, schema, did),
+        ]);
+
+        const cards = await selectArticleCards(db, schema, {
+          followedUserDids: userDids,
+          limit: OPDS_PAGE_SIZE,
+          offset: (page - 1) * OPDS_PAGE_SIZE,
+          publicationUris,
+          renderableOnly: true,
+          viewerDid,
+        });
+        const self = `${opdsShelfUrl(baseUrl, did)}/subscriptions`;
+
+        return opdsResponse(
+          articleFeed(cards, {
+            baseUrl,
+            id: self,
+            page,
+            selfHref: self,
+            subtitle:
+              "The newest articles from the publications and people you follow.",
+            title: "Subscriptions",
+            upHref: opdsShelfUrl(baseUrl, did),
+          }),
+          opdsFormatFromRequest(request),
+          { cacheControl: OPDS_PRIVATE_CACHE_CONTROL },
+        );
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/routes/opds.u.$did.unread.tsx
+++ b/apps/standard-reader/src/routes/opds.u.$did.unread.tsx
@@ -1,0 +1,68 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+import { EPUB_TYPE, OPDS_REL } from "#/lib/opds/model";
+import {
+  OPDS_PRIVATE_CACHE_CONTROL,
+  opdsFormatFromRequest,
+  opdsResponse,
+} from "#/lib/opds/respond";
+import { opdsShelfUrl, unreadEpubUrl } from "#/lib/opds/urls";
+import { getPublicUrl } from "#/lib/public-url";
+import { unreadShelfCards } from "#/server/books/reader-shelf";
+import { packageableCards } from "#/server/books/sources";
+import {
+  articleFeed,
+  OPDS_PAGE_SIZE,
+  pageFromRequest,
+} from "#/server/opds/catalog";
+
+export const Route = createFileRoute("/opds/u/$did/unread")({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const did = params.did;
+        if (!did.startsWith("did:")) {
+          return new Response("Bad Request", { status: 400 });
+        }
+
+        const baseUrl = getPublicUrl();
+        const page = pageFromRequest(request);
+        // The unread walk is a keyset over the follow feed, so it does not page
+        // by offset — fetching through the current page and slicing keeps the
+        // catalog's paging honest without a second cursor vocabulary.
+        const through = packageableCards(
+          await unreadShelfCards(db, schema, did, {
+            limit: OPDS_PAGE_SIZE * page,
+          }),
+        );
+        const cards = through.slice((page - 1) * OPDS_PAGE_SIZE);
+        const self = `${opdsShelfUrl(baseUrl, did)}/unread`;
+
+        return opdsResponse(
+          articleFeed(cards, {
+            baseUrl,
+            extraLinks: [
+              {
+                href: unreadEpubUrl(baseUrl, did),
+                rel: OPDS_REL.openAccess,
+                title: "Everything unread, as one book",
+                type: EPUB_TYPE,
+              },
+            ],
+            id: self,
+            page,
+            selfHref: self,
+            subtitle:
+              "Articles you have not read yet, from the publications and people you follow.",
+            title: "Unread",
+            upHref: opdsShelfUrl(baseUrl, did),
+          }),
+          opdsFormatFromRequest(request),
+          { cacheControl: OPDS_PRIVATE_CACHE_CONTROL },
+        );
+      },
+    },
+  },
+});

--- a/apps/standard-reader/src/server/books/assets.ts
+++ b/apps/standard-reader/src/server/books/assets.ts
@@ -1,0 +1,155 @@
+/**
+ * Fetching the images a book embeds.
+ *
+ * A downloaded book is an offline artifact — an image left as a remote URL is
+ * an image the reader does not have on the train. So every image the body
+ * references is pulled into the archive.
+ *
+ * That makes generation a fan-out over the network, on a request the reader is
+ * waiting on, so it is bounded in all three directions that can hurt: how many
+ * fetches run at once, how large one image may be, and how many bytes the whole
+ * book may spend on images. A book that hits a limit is still a good book —
+ * it just keeps the remote URL for the images that did not fit, which resolve
+ * when the reader is online.
+ */
+
+/* eslint-disable unicorn/number-literal-case -- image magic numbers are
+   written the way every format spec writes them, and oxfmt lowercases hex
+   literals on save (see `server/reader/rail-rotation.ts`). */
+
+import { mapWithConcurrency } from "#/lib/concurrency";
+
+/** Simultaneous image fetches per book. */
+const CONCURRENCY = 6;
+
+/** Per-image ceiling. Above this, the image stays a remote URL. */
+const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
+
+/** Whole-book image budget, across every chapter. */
+const MAX_TOTAL_BYTES = 96 * 1024 * 1024;
+
+/** How long one image gets before the book goes on without it. */
+const FETCH_TIMEOUT_MS = 15_000;
+
+export interface FetchedImage {
+  /** The URL as it appeared in the body — the key callers rewrite from. */
+  url: string;
+  data: Uint8Array;
+  mediaType: string;
+  /** File extension including the dot, derived from the media type. */
+  extension: string;
+}
+
+const MEDIA_TYPE_EXTENSIONS: Record<string, string> = {
+  "image/avif": ".avif",
+  "image/gif": ".gif",
+  "image/jpeg": ".jpg",
+  "image/png": ".png",
+  "image/svg+xml": ".svg",
+  "image/webp": ".webp",
+};
+
+/**
+ * Media types EPUB 3 requires every reading system to support. Anything else
+ * (AVIF, and WebP on older devices) is carried as-is: it is what the publisher
+ * uploaded, and re-encoding it server-side would cost more than it buys.
+ */
+export function isSupportedImageType(mediaType: string): boolean {
+  return mediaType in MEDIA_TYPE_EXTENSIONS;
+}
+
+/**
+ * Identify an image from its leading bytes.
+ *
+ * The declared `Content-Type` is the first source, but CDNs mislabel and some
+ * PDS blobs come back `application/octet-stream`; the magic number is the
+ * thing that actually determines whether a reader can decode the file.
+ */
+export function sniffImageType(data: Uint8Array): string | null {
+  if (data.length < 12) return null;
+  const [b0, b1, b2, b3] = data;
+  if (b0 === 0xff && b1 === 0xd8 && b2 === 0xff) return "image/jpeg";
+  if (b0 === 0x89 && b1 === 0x50 && b2 === 0x4e && b3 === 0x47) {
+    return "image/png";
+  }
+  if (b0 === 0x47 && b1 === 0x49 && b2 === 0x46) return "image/gif";
+  const ascii = (at: number, text: string) =>
+    [...text].every((char, index) => data[at + index] === char.codePointAt(0));
+  if (ascii(0, "RIFF") && ascii(8, "WEBP")) return "image/webp";
+  if (ascii(4, "ftyp") && (ascii(8, "avif") || ascii(8, "avis"))) {
+    return "image/avif";
+  }
+  // SVG is text, and may open with a comment or an XML declaration.
+  const head = new TextDecoder().decode(data.slice(0, 256)).trimStart();
+  if (head.startsWith("<?xml") || head.startsWith("<svg")) {
+    return "image/svg+xml";
+  }
+  return null;
+}
+
+async function fetchOne(url: string): Promise<FetchedImage | null> {
+  try {
+    const response = await fetch(url, {
+      headers: { accept: "image/*" },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) return null;
+
+    // Trust the header enough to skip the download when it is clearly too big;
+    // the real check is on the bytes, since the header can lie or be absent.
+    const declaredLength = Number(response.headers.get("content-length"));
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_IMAGE_BYTES) {
+      return null;
+    }
+
+    const data = new Uint8Array(await response.arrayBuffer());
+    if (data.length === 0 || data.length > MAX_IMAGE_BYTES) return null;
+
+    const declaredType = (response.headers.get("content-type") ?? "")
+      .split(";")[0]
+      ?.trim()
+      .toLowerCase();
+    const mediaType =
+      declaredType && isSupportedImageType(declaredType)
+        ? declaredType
+        : sniffImageType(data);
+    if (!mediaType) return null;
+
+    return {
+      data,
+      extension: MEDIA_TYPE_EXTENSIONS[mediaType] ?? ".img",
+      mediaType,
+      url,
+    };
+  } catch {
+    // Timeouts, DNS failures, a PDS that has gone away: the book is still
+    // worth building, so the image just stays remote.
+    return null;
+  }
+}
+
+/**
+ * Fetch every URL in `urls`, in order, until the whole-book budget runs out.
+ *
+ * Order matters: images earlier in the book are the ones the reader sees first,
+ * so when the budget binds it should bind on the tail.
+ */
+export async function fetchImages(
+  urls: Array<string>,
+): Promise<Array<FetchedImage>> {
+  if (urls.length === 0) return [];
+
+  const results = await mapWithConcurrency(urls, CONCURRENCY, fetchOne);
+
+  const kept: Array<FetchedImage> = [];
+  let total = 0;
+  for (const image of results) {
+    if (!image) continue;
+    if (total + image.data.length > MAX_TOTAL_BYTES) break;
+    total += image.data.length;
+    kept.push(image);
+  }
+  return kept;
+}
+
+/* eslint-enable unicorn/number-literal-case */

--- a/apps/standard-reader/src/server/books/cbz.ts
+++ b/apps/standard-reader/src/server/books/cbz.ts
@@ -1,0 +1,110 @@
+/**
+ * The CBZ packager — comics, as comic readers expect them.
+ *
+ * A comic issue on this network is a document whose body is a run of images
+ * (see `lib/document/images.ts`, and `server/reader/comic.ts` for how the app
+ * flattens a serial into one continuous page list). Wrapping those pages in an
+ * EPUB would technically work and would read badly: comic readers have page
+ * turns, spread detection, zoom and a page-number scrubber, and they get none
+ * of it from a reflowable book.
+ *
+ * So comics are offered as CBZ as well — a ZIP of page images in filename
+ * order, plus the `ComicInfo.xml` sidecar that Panels, Chunky, Komga, Kavita
+ * and KOReader all read for series and issue metadata.
+ */
+
+import { fetchImages } from "./assets";
+import { xmlEscape, xmlSafeText } from "./xhtml";
+import { buildZip } from "./zip";
+import type { ZipEntry } from "./zip";
+
+export interface CbzSpec {
+  /** Issue title ("Chapter 3"). */
+  title: string;
+  /** Series the issue belongs to — the publication name. */
+  series?: string | null;
+  /** Issue number within the series, when the title parses as one. */
+  number?: number | null;
+  /** Total issues in the series, when known. */
+  count?: number | null;
+  summary?: string | null;
+  writer?: string | null;
+  publisher?: string | null;
+  /** ISO timestamp of publication. */
+  published?: string | null;
+  web?: string | null;
+  genres?: Array<string>;
+  /** Page image URLs, in reading order. */
+  pageUrls: Array<string>;
+}
+
+/**
+ * ComicInfo.xml — the de-facto metadata sidecar for comic archives.
+ *
+ * Undefined fields are omitted rather than written empty: readers treat an
+ * empty `<Series/>` as a series literally named "", which is worse than none.
+ */
+function comicInfoXml(spec: CbzSpec, pageCount: number): string {
+  const published = spec.published ? new Date(spec.published) : null;
+  const valid = published && !Number.isNaN(published.getTime());
+
+  const fields: Array<[string, string | number | null | undefined]> = [
+    ["Title", spec.title],
+    ["Series", spec.series],
+    ["Number", spec.number],
+    ["Count", spec.count],
+    ["Summary", spec.summary],
+    ["Writer", spec.writer],
+    ["Publisher", spec.publisher],
+    ["Year", valid ? published.getUTCFullYear() : null],
+    ["Month", valid ? published.getUTCMonth() + 1 : null],
+    ["Day", valid ? published.getUTCDate() : null],
+    ["Web", spec.web],
+    ["Genre", spec.genres?.length ? spec.genres.join(", ") : null],
+    ["PageCount", pageCount],
+    ["Manga", "No"],
+  ];
+
+  const body = fields
+    .filter(
+      ([, value]) => value !== null && value !== undefined && value !== "",
+    )
+    .map(
+      ([name, value]) =>
+        `  <${name}>${xmlEscape(xmlSafeText(String(value)))}</${name}>`,
+    )
+    .join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<ComicInfo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+${body}
+</ComicInfo>
+`;
+}
+
+/**
+ * Build a CBZ. Returns `null` when no page survived fetching — an empty archive
+ * is a file that opens to nothing, and a 404 is the more honest answer.
+ */
+export async function buildCbz(spec: CbzSpec): Promise<Uint8Array | null> {
+  const images = await fetchImages(spec.pageUrls);
+  if (images.length === 0) return null;
+
+  // Comic readers sort pages by filename, so the numbering *is* the reading
+  // order. Zero-padded to the archive's own width so page 10 never sorts
+  // before page 2.
+  const width = Math.max(3, String(images.length).length);
+  const entries: Array<ZipEntry> = images.map((image, index) => ({
+    // Already-compressed pixels: storing is smaller in practice and much faster.
+    data: image.data,
+    method: "store",
+    name: `${String(index + 1).padStart(width, "0")}${image.extension}`,
+  }));
+
+  entries.push({
+    data: new TextEncoder().encode(comicInfoXml(spec, images.length)),
+    name: "ComicInfo.xml",
+  });
+
+  return buildZip(entries);
+}

--- a/apps/standard-reader/src/server/books/comic-issue.ts
+++ b/apps/standard-reader/src/server/books/comic-issue.ts
@@ -1,0 +1,114 @@
+/**
+ * What a comic file should contain.
+ *
+ * The unit question is the whole problem here. On this network a comic
+ * publication posts **one page per document** — `FITV #1, Cover`,
+ * `FITV #1, Pg. 1`, `FITV #1, Pg. 2` — so packaging a document produces a
+ * one-page CBZ, and a catalog built from documents offers a comic app fifty
+ * separate one-page "comics". That is not a comic library; it is a mess.
+ *
+ * The app already answers the unit question for its own shelf
+ * (`selectComicShelf`), by parsing issue numbers back out of the titles — the
+ * only place they exist, since the lexicon has no field for them. This module
+ * reuses that answer so a downloaded file matches what the shelf shows:
+ *
+ *  - **`issues` mode** — titles carry issue numbers, so one file is one issue.
+ *  - **`pages` mode** — they do not, so there is no issue to package and the
+ *    honest unit is the publication's whole run in one file.
+ */
+
+import type { Db, Schema } from "#/integrations/tanstack-query/api-shapes";
+import type { ComicShelfIssue } from "#/server/reader/comic";
+import { selectComicPages, selectComicShelf } from "#/server/reader/comic";
+
+/**
+ * Pages in one file, at most. A comic that runs longer is served up to this and
+ * the reader takes the rest issue by issue — a single request should not fan out
+ * to a thousand image fetches.
+ */
+export const COMIC_FILE_PAGE_LIMIT = 400;
+
+export interface ComicFile {
+  /** Title for the file and its `ComicInfo.xml`. */
+  title: string;
+  /** Issue number when the titles carried one. */
+  issueNumber: number | null;
+  /** Page image URLs, in reading order. */
+  pageUrls: Array<string>;
+  publishedAt: string;
+}
+
+/**
+ * The spine-document index a shelf entry starts at.
+ *
+ * `planComicShelf` groups *consecutive* spine entries, so an entry's documents
+ * are the run beginning after everything the entries before it consumed.
+ */
+function spineOffsetOf(issues: Array<ComicShelfIssue>, index: number): number {
+  let offset = 0;
+  for (let at = 0; at < index; at += 1) {
+    offset += issues[at]?.documentCount ?? 0;
+  }
+  return offset;
+}
+
+/**
+ * One issue as a file, addressed by the document that fronts it on the shelf.
+ *
+ * The front document's rkey is the key rather than the issue number because it
+ * is stable in both shelf modes and needs no numbering scheme of its own — it
+ * is exactly what the shelf already links to.
+ */
+export async function comicIssueFile(
+  db: Db,
+  schema: Schema,
+  publicationUri: string,
+  frontRkey: string,
+): Promise<ComicFile | null> {
+  const shelf = await selectComicShelf(db, schema, publicationUri);
+  const index = shelf.issues.findIndex((issue) => issue.rkey === frontRkey);
+  const entry = shelf.issues[index];
+  if (!entry) return null;
+
+  const { pages } = await selectComicPages(db, schema, {
+    issueLimit: entry.documentCount,
+    issueOffset: spineOffsetOf(shelf.issues, index),
+    publicationUri,
+  });
+
+  return {
+    issueNumber: entry.issueNumber,
+    pageUrls: pages.slice(0, COMIC_FILE_PAGE_LIMIT).map((page) => page.url),
+    publishedAt: entry.publishedAt,
+    title: entry.label,
+  };
+}
+
+/** The publication's whole run as one file. */
+export async function comicRunFile(
+  db: Db,
+  schema: Schema,
+  publicationUri: string,
+  publicationName: string,
+): Promise<ComicFile | null> {
+  const shelf = await selectComicShelf(db, schema, publicationUri);
+  if (shelf.issues.length === 0) return null;
+
+  const documentCount = shelf.issues.reduce(
+    (total, issue) => total + issue.documentCount,
+    0,
+  );
+  const { pages } = await selectComicPages(db, schema, {
+    issueLimit: documentCount,
+    issueOffset: 0,
+    publicationUri,
+  });
+  if (pages.length === 0) return null;
+
+  return {
+    issueNumber: null,
+    pageUrls: pages.slice(0, COMIC_FILE_PAGE_LIMIT).map((page) => page.url),
+    publishedAt: shelf.issues[0]?.publishedAt ?? new Date(0).toISOString(),
+    title: publicationName,
+  };
+}

--- a/apps/standard-reader/src/server/books/epub.test.ts
+++ b/apps/standard-reader/src/server/books/epub.test.ts
@@ -1,0 +1,297 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * jsdom only for `DOMParser`: an EPUB content document is XHTML, and the
+ * cheapest honest test of that is to parse it as XML and see whether a real
+ * parser objects.
+ */
+
+/* eslint-disable unicorn/number-literal-case -- ZIP signatures and CRC
+   constants are written the way the spec and every reference implementation
+   write them, and oxfmt lowercases hex literals on save (see
+   `server/reader/rail-rotation.ts` for the same conflict). */
+import { inflateRawSync } from "node:zlib";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { buildEpub } from "#/server/books/epub";
+import type { EpubSpec } from "#/server/books/epub";
+
+const decoder = new TextDecoder();
+
+/** Read an archive's entries back out, by name. */
+function readZip(bytes: Uint8Array): Map<string, Uint8Array> {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const files = new Map<string, Uint8Array>();
+  let at = 0;
+
+  while (at + 4 <= bytes.length && view.getUint32(at, true) === 0x04_03_4b_50) {
+    const method = view.getUint16(at + 8, true);
+    const compressedSize = view.getUint32(at + 18, true);
+    const nameLength = view.getUint16(at + 26, true);
+    const extraLength = view.getUint16(at + 28, true);
+    const nameAt = at + 30;
+    const dataAt = nameAt + nameLength + extraLength;
+    const body = bytes.subarray(dataAt, dataAt + compressedSize);
+
+    files.set(
+      decoder.decode(bytes.subarray(nameAt, nameAt + nameLength)),
+      method === 0 ? body : new Uint8Array(inflateRawSync(body)),
+    );
+    at = dataAt + compressedSize;
+  }
+  return files;
+}
+
+const text = (files: Map<string, Uint8Array>, name: string): string =>
+  decoder.decode(files.get(name) ?? new Uint8Array());
+
+function chapter(
+  id: string,
+  title: string,
+  body: string,
+  images: Array<string> = [],
+) {
+  return {
+    id,
+    render: (localImages: Map<string, string> | undefined) => ({
+      imageUrls: images,
+      markup:
+        images.length > 0
+          ? `${body}${images.map((url) => `<img src="${localImages?.get(url) ?? url}"/>`).join("")}`
+          : body,
+    }),
+    title,
+  };
+}
+
+function spec(overrides: Partial<EpubSpec> = {}): EpubSpec {
+  return {
+    authors: ["Ada Lovelace"],
+    chapters: [chapter("ch0001", "First & Last", "<p>Hello</p>")],
+    identifier: "at://did:plc:abc/site.standard.document/xyz",
+    modified: "2026-08-01T12:30:45.123Z",
+    title: "A Book",
+    ...overrides,
+  };
+}
+
+/** A 1×1 PNG, enough for the sniffer to call it an image. */
+const PNG = Uint8Array.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49,
+  0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06,
+  0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89,
+]);
+
+function stubImageFetch(bytes: Uint8Array = PNG) {
+  vi.stubGlobal(
+    "fetch",
+    async () =>
+      new Response(bytes as BodyInit, {
+        headers: { "content-type": "image/png" },
+        status: 200,
+      }),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("buildEpub", () => {
+  it("puts `mimetype` first and stores it uncompressed", async () => {
+    // The one structural rule EPUB actually enforces: a reader identifies the
+    // file from these bytes without inflating anything.
+    const epub = await buildEpub(spec());
+    expect(decoder.decode(epub.subarray(30, 38))).toBe("mimetype");
+    expect(decoder.decode(epub.subarray(38, 58))).toBe("application/epub+zip");
+  });
+
+  it("ships a container pointing at the package document", async () => {
+    const files = readZip(await buildEpub(spec()));
+    expect(text(files, "META-INF/container.xml")).toContain(
+      'full-path="OEBPS/content.opf"',
+    );
+    expect(files.has("OEBPS/content.opf")).toBe(true);
+  });
+
+  it("writes well-formed XML in every document it generates", async () => {
+    const files = readZip(
+      await buildEpub(
+        spec({
+          chapters: [
+            chapter("ch0001", "One", "<p>a</p>"),
+            chapter("ch0002", "Two", "<p>b</p>"),
+          ],
+        }),
+      ),
+    );
+
+    for (const [name, bytes] of files) {
+      if (!/\.(xhtml|xml|opf|ncx)$/.test(name)) continue;
+      const parsed = new DOMParser().parseFromString(
+        decoder.decode(bytes),
+        "application/xml",
+      );
+      expect(
+        parsed.querySelector("parsererror"),
+        `${name} is not well-formed XML`,
+      ).toBeNull();
+    }
+  });
+
+  it("escapes record text that would otherwise break the package", async () => {
+    const files = readZip(
+      await buildEpub(
+        spec({ subjects: ["a & b"], title: 'Tools & <Toys> "quoted"' }),
+      ),
+    );
+    const opf = text(files, "OEBPS/content.opf");
+    expect(opf).toContain("Tools &amp; &lt;Toys&gt;");
+    expect(opf).toContain("<dc:subject>a &amp; b</dc:subject>");
+  });
+
+  it("strips control characters XML cannot represent", async () => {
+    const files = readZip(
+      await buildEpub(spec({ title: "Bad\u0007Title\u0000Here" })),
+    );
+    expect(text(files, "OEBPS/content.opf")).toContain(
+      "<dc:title>BadTitleHere</dc:title>",
+    );
+  });
+
+  it("carries both tables of contents", async () => {
+    // EPUB 3 readers use the nav document; plenty of shipping devices still
+    // read only the NCX.
+    const files = readZip(await buildEpub(spec()));
+    expect(text(files, "OEBPS/nav.xhtml")).toContain('epub:type="toc"');
+    expect(text(files, "OEBPS/toc.ncx")).toContain("<navPoint");
+    expect(text(files, "OEBPS/content.opf")).toContain('<spine toc="ncx">');
+  });
+
+  it("uses content time for `dcterms:modified`, not the clock", async () => {
+    const files = readZip(await buildEpub(spec()));
+    // Seconds precision, and derived from the newest thing in the book — which
+    // is what makes a rebuild byte-identical.
+    expect(text(files, "OEBPS/content.opf")).toContain(
+      '<meta property="dcterms:modified">2026-08-01T12:30:45Z</meta>',
+    );
+  });
+
+  it("produces identical bytes for identical input", async () => {
+    const first = await buildEpub(spec());
+    const second = await buildEpub(spec());
+    expect(Buffer.from(first)).toEqual(Buffer.from(second));
+  });
+
+  it("gives a single article no title page, and a collection one", async () => {
+    const single = readZip(await buildEpub(spec()));
+    expect(single.has("OEBPS/text/title.xhtml")).toBe(false);
+
+    const many = readZip(
+      await buildEpub(
+        spec({
+          chapters: [
+            chapter("ch0001", "One", "<p>a</p>"),
+            chapter("ch0002", "Two", "<p>b</p>"),
+          ],
+          subtitle: "2 articles",
+        }),
+      ),
+    );
+    expect(many.has("OEBPS/text/title.xhtml")).toBe(true);
+    expect(text(many, "OEBPS/text/title.xhtml")).toContain("2 articles");
+  });
+
+  it("prints the byline and dateline above a chapter body", async () => {
+    const files = readZip(
+      await buildEpub(
+        spec({
+          chapters: [
+            {
+              ...chapter("ch0001", "One", "<p>a</p>"),
+              meta: {
+                byline: "Ada Lovelace",
+                dateline: "1 August 2026",
+                sourceLabel: "Example",
+                sourceUrl: "https://example.com/post",
+              },
+            },
+          ],
+        }),
+      ),
+    );
+    const body = text(files, "OEBPS/text/ch0001.xhtml");
+    expect(body).toContain("Ada Lovelace · 1 August 2026");
+    expect(body).toContain('href="https://example.com/post"');
+  });
+
+  it("embeds fetched images and rewrites the body to point at them", async () => {
+    stubImageFetch();
+    const files = readZip(
+      await buildEpub(
+        spec({
+          chapters: [
+            chapter("ch0001", "One", "<p>a</p>", [
+              "https://cdn.example/one.png",
+            ]),
+          ],
+        }),
+      ),
+    );
+
+    expect(files.has("OEBPS/images/img0001.png")).toBe(true);
+    expect(text(files, "OEBPS/text/ch0001.xhtml")).toContain(
+      '<img src="../images/img0001.png"/>',
+    );
+    expect(text(files, "OEBPS/content.opf")).toContain(
+      'media-type="image/png"',
+    );
+  });
+
+  it("keeps the remote URL when an image cannot be fetched", async () => {
+    // A book missing one image is still a book; a book that failed to build
+    // because a CDN was down is not.
+    vi.stubGlobal("fetch", async () => new Response("nope", { status: 500 }));
+    const files = readZip(
+      await buildEpub(
+        spec({
+          chapters: [
+            chapter("ch0001", "One", "<p>a</p>", [
+              "https://cdn.example/gone.png",
+            ]),
+          ],
+        }),
+      ),
+    );
+    expect(text(files, "OEBPS/text/ch0001.xhtml")).toContain(
+      'src="https://cdn.example/gone.png"',
+    );
+    expect([...files.keys()].some((name) => name.includes("images/"))).toBe(
+      false,
+    );
+  });
+
+  it("marks a cover both ways so either generation of reader finds it", async () => {
+    stubImageFetch();
+    const files = readZip(
+      await buildEpub(spec({ coverImageUrl: "https://cdn.example/cover.png" })),
+    );
+    const opf = text(files, "OEBPS/content.opf");
+    expect(opf).toContain('properties="cover-image"');
+    expect(opf).toContain('<meta name="cover" content="cover-image"/>');
+    expect(files.has("OEBPS/text/cover.xhtml")).toBe(true);
+  });
+
+  it("keeps the cover out of the body-image manifest entries", async () => {
+    stubImageFetch();
+    const files = readZip(
+      await buildEpub(spec({ coverImageUrl: "https://cdn.example/cover.png" })),
+    );
+    const opf = text(files, "OEBPS/content.opf");
+    // One manifest item per image file — the cover must not appear twice.
+    expect(opf.match(/href="images\/img0001\.png"/g)).toHaveLength(1);
+  });
+});
+
+/* eslint-enable unicorn/number-literal-case */

--- a/apps/standard-reader/src/server/books/epub.ts
+++ b/apps/standard-reader/src/server/books/epub.ts
@@ -1,0 +1,461 @@
+/**
+ * The EPUB packager.
+ *
+ * Builds EPUB 3.2 with the EPUB 2 fallbacks that still matter in the wild: an
+ * NCX table of contents alongside the EPUB 3 nav document, and the legacy
+ * `<meta name="cover">` pointer alongside the `cover-image` property. KOReader,
+ * Kobo, Kindle-via-conversion and Apple Books do not agree on which of those
+ * they read, and carrying both costs a few hundred bytes.
+ *
+ * Generation is two-pass because images cannot be resolved in one (see
+ * `render.tsx`): every chapter renders once to discover its image URLs, those
+ * are fetched together, then the chapters render again against the map of what
+ * actually arrived. Rendering is pure and cheap; the network is neither.
+ *
+ * Output is deterministic — same document in, byte-identical file out (see
+ * `zip.ts`). Nothing here reads the clock.
+ */
+
+import { fetchImages } from "./assets";
+import type { FetchedImage } from "./assets";
+import type { RenderedBody } from "./render";
+import {
+  BOOK_STYLESHEET,
+  xhtmlDocument,
+  xmlEscape,
+  xmlSafeText,
+} from "./xhtml";
+import { buildZip } from "./zip";
+import type { ZipEntry } from "./zip";
+
+const OPF_PATH = "OEBPS/content.opf";
+const NAV_ID = "nav";
+const NCX_ID = "ncx";
+const COVER_IMAGE_ID = "cover-image";
+
+export interface EpubChapterMeta {
+  /** Byline line above the body ("Alice Example"). */
+  byline?: string | null;
+  /** Human date, already formatted for display. */
+  dateline?: string | null;
+  /** Where this piece lives on the web. */
+  sourceUrl?: string | null;
+  sourceLabel?: string | null;
+}
+
+export interface EpubChapterSource {
+  /** Stable, filename-safe id — also the manifest id and file stem. */
+  id: string;
+  title: string;
+  meta?: EpubChapterMeta;
+  /**
+   * Render the body. Called twice: once with no map (to discover images), then
+   * again with the images that were fetched.
+   */
+  render: (localImages?: Map<string, string>) => RenderedBody;
+}
+
+export interface EpubSpec {
+  /**
+   * Unique, permanent id for the book — the AT-URI of the document or
+   * publication it was built from. Readers use it to recognise a re-download as
+   * the same book rather than a second copy.
+   */
+  identifier: string;
+  title: string;
+  authors: Array<string>;
+  language?: string;
+  description?: string | null;
+  publisher?: string | null;
+  /** ISO timestamp of publication. */
+  published?: string | null;
+  /**
+   * ISO timestamp of the newest content in the book. EPUB 3 requires a
+   * `dcterms:modified`, and using the content's own timestamp instead of "now"
+   * is what keeps the output byte-stable across rebuilds.
+   */
+  modified: string;
+  subjects?: Array<string>;
+  /** Remote URL of the cover image, fetched alongside body images. */
+  coverImageUrl?: string | null;
+  /** Second line on the title page of a multi-piece book. */
+  subtitle?: string | null;
+  /** Where the collection as a whole came from. */
+  sourceUrl?: string | null;
+  chapters: Array<EpubChapterSource>;
+}
+
+/** EPUB 3 wants a plain UTC instant, no fractional seconds. */
+function epubTimestamp(iso: string): string {
+  const time = Date.parse(iso);
+  const date = Number.isNaN(time) ? new Date(0) : new Date(time);
+  return `${date.toISOString().split(".")[0]}Z`;
+}
+
+function chapterHref(id: string): string {
+  return `text/${id}.xhtml`;
+}
+
+/** Front matter above a chapter body: who wrote it, and when. */
+function chapterMetaMarkup(meta: EpubChapterMeta | undefined): string {
+  if (!meta) return "";
+  const parts = [meta.byline, meta.dateline].filter((part): part is string =>
+    Boolean(part && part.trim()),
+  );
+  if (parts.length === 0) return "";
+  return `<p class="sr-chapter-meta">${parts.map((part) => xmlEscape(xmlSafeText(part))).join(" · ")}</p>`;
+}
+
+/**
+ * The per-chapter colophon.
+ *
+ * A book assembled from the network should say where each piece came from —
+ * both so the reader can go back to the live version (for comments, updates,
+ * the publication itself) and because attribution is the least a reader owes
+ * a writer whose work they took offline.
+ */
+function chapterSourceMarkup(meta: EpubChapterMeta | undefined): string {
+  if (!meta?.sourceUrl) return "";
+  const label = meta.sourceLabel ?? meta.sourceUrl;
+  return `<p class="sr-source">Read online: <a href="${xmlEscape(meta.sourceUrl)}">${xmlEscape(xmlSafeText(label))}</a></p>`;
+}
+
+function containerXml(): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="${OPF_PATH}" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>
+`;
+}
+
+interface ManifestItem {
+  id: string;
+  href: string;
+  mediaType: string;
+  properties?: string;
+}
+
+function packageOpf({
+  spec,
+  items,
+  spine,
+}: {
+  spec: EpubSpec;
+  items: Array<ManifestItem>;
+  spine: Array<string>;
+}): string {
+  const language = spec.language ?? "en";
+  const metadata: Array<string> = [
+    `<dc:identifier id="book-id">${xmlEscape(xmlSafeText(spec.identifier))}</dc:identifier>`,
+    `<dc:title>${xmlEscape(xmlSafeText(spec.title))}</dc:title>`,
+    `<dc:language>${xmlEscape(language)}</dc:language>`,
+    `<meta property="dcterms:modified">${epubTimestamp(spec.modified)}</meta>`,
+  ];
+  for (const author of spec.authors) {
+    metadata.push(`<dc:creator>${xmlEscape(xmlSafeText(author))}</dc:creator>`);
+  }
+  if (spec.description) {
+    metadata.push(
+      `<dc:description>${xmlEscape(xmlSafeText(spec.description))}</dc:description>`,
+    );
+  }
+  if (spec.publisher) {
+    metadata.push(
+      `<dc:publisher>${xmlEscape(xmlSafeText(spec.publisher))}</dc:publisher>`,
+    );
+  }
+  if (spec.published) {
+    metadata.push(`<dc:date>${epubTimestamp(spec.published)}</dc:date>`);
+  }
+  if (spec.sourceUrl) {
+    metadata.push(`<dc:source>${xmlEscape(spec.sourceUrl)}</dc:source>`);
+  }
+  for (const subject of spec.subjects ?? []) {
+    metadata.push(
+      `<dc:subject>${xmlEscape(xmlSafeText(subject))}</dc:subject>`,
+    );
+  }
+  // EPUB 2 readers find the cover through this, not through `properties`.
+  if (items.some((item) => item.id === COVER_IMAGE_ID)) {
+    metadata.push(`<meta name="cover" content="${COVER_IMAGE_ID}"/>`);
+  }
+
+  const manifest = items
+    .map(
+      (item) =>
+        `    <item id="${xmlEscape(item.id)}" href="${xmlEscape(item.href)}" media-type="${xmlEscape(item.mediaType)}"${item.properties ? ` properties="${xmlEscape(item.properties)}"` : ""}/>`,
+    )
+    .join("\n");
+
+  const spineItems = spine
+    .map((id) => `    <itemref idref="${xmlEscape(id)}"/>`)
+    .join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="book-id" xml:lang="${xmlEscape(language)}">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+${metadata.map((line) => `    ${line}`).join("\n")}
+  </metadata>
+  <manifest>
+${manifest}
+  </manifest>
+  <spine toc="${NCX_ID}">
+${spineItems}
+  </spine>
+</package>
+`;
+}
+
+function navDocument(
+  spec: EpubSpec,
+  entries: Array<{ href: string; title: string }>,
+): string {
+  const items = entries
+    .map(
+      (entry) =>
+        `      <li><a href="${xmlEscape(entry.href)}">${xmlEscape(xmlSafeText(entry.title))}</a></li>`,
+    )
+    .join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" lang="${xmlEscape(spec.language ?? "en")}">
+<head>
+<meta charset="utf-8"/>
+<title>${xmlEscape(xmlSafeText(spec.title))}</title>
+<link rel="stylesheet" type="text/css" href="style.css"/>
+</head>
+<body>
+  <nav epub:type="toc" id="toc" role="doc-toc">
+    <h1>Contents</h1>
+    <ol>
+${items}
+    </ol>
+  </nav>
+</body>
+</html>
+`;
+}
+
+/** The EPUB 2 table of contents, for readers that ignore the nav document. */
+function ncxDocument(
+  spec: EpubSpec,
+  entries: Array<{ href: string; title: string }>,
+): string {
+  const points = entries
+    .map(
+      (
+        entry,
+        index,
+      ) => `    <navPoint id="navpoint-${index + 1}" playOrder="${index + 1}">
+      <navLabel><text>${xmlEscape(xmlSafeText(entry.title))}</text></navLabel>
+      <content src="${xmlEscape(entry.href)}"/>
+    </navPoint>`,
+    )
+    .join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+  <head>
+    <meta name="dtb:uid" content="${xmlEscape(xmlSafeText(spec.identifier))}"/>
+    <meta name="dtb:depth" content="1"/>
+    <meta name="dtb:totalPageCount" content="0"/>
+    <meta name="dtb:maxPageNumber" content="0"/>
+  </head>
+  <docTitle><text>${xmlEscape(xmlSafeText(spec.title))}</text></docTitle>
+  <navMap>
+${points}
+  </navMap>
+</ncx>
+`;
+}
+
+function coverDocument(spec: EpubSpec, imageHref: string): string {
+  return xhtmlDocument({
+    body: `<div class="sr-cover"><img src="${xmlEscape(imageHref)}" alt="${xmlEscape(xmlSafeText(spec.title))}"/></div>`,
+    language: spec.language,
+    title: "Cover",
+  });
+}
+
+function titleDocument(spec: EpubSpec): string {
+  const byline = spec.authors.length > 0 ? spec.authors.join(", ") : null;
+  const lines = [
+    `<h1>${xmlEscape(xmlSafeText(spec.title))}</h1>`,
+    spec.subtitle
+      ? `<p class="sr-subtitle">${xmlEscape(xmlSafeText(spec.subtitle))}</p>`
+      : null,
+    byline ? `<p>${xmlEscape(xmlSafeText(byline))}</p>` : null,
+    spec.sourceUrl
+      ? `<p class="sr-source"><a href="${xmlEscape(spec.sourceUrl)}">${xmlEscape(spec.sourceUrl)}</a></p>`
+      : null,
+  ].filter((line): line is string => line !== null);
+
+  return xhtmlDocument({
+    body: `<section class="sr-title-page">\n${lines.join("\n")}\n</section>`,
+    language: spec.language,
+    title: spec.title,
+  });
+}
+
+/**
+ * Assign in-book paths to the images that arrived, keyed by the URL the bodies
+ * referenced. Names are positional, so the same book always names the same
+ * image the same way.
+ */
+function imagePaths(
+  images: Array<FetchedImage>,
+): Map<string, { href: string; id: string; image: FetchedImage }> {
+  const map = new Map<
+    string,
+    { href: string; id: string; image: FetchedImage }
+  >();
+  for (const [index, image] of images.entries()) {
+    const id = `img${String(index + 1).padStart(4, "0")}`;
+    map.set(image.url, { href: `images/${id}${image.extension}`, id, image });
+  }
+  return map;
+}
+
+/** Build a complete EPUB file. */
+export async function buildEpub(spec: EpubSpec): Promise<Uint8Array> {
+  // Pass one: render every chapter to find the images, in reading order.
+  const discovery = spec.chapters.map((chapter) => chapter.render());
+  const wanted: Array<string> = [];
+  const seen = new Set<string>();
+  const remember = (url: string | null | undefined) => {
+    if (!url || seen.has(url)) return;
+    seen.add(url);
+    wanted.push(url);
+  };
+  // The cover leads, so it survives a budget that the tail of the book does not.
+  remember(spec.coverImageUrl);
+  for (const body of discovery) {
+    for (const url of body.imageUrls) remember(url);
+  }
+
+  const fetched = await fetchImages(wanted);
+  const assets = imagePaths(fetched);
+
+  const cover = spec.coverImageUrl ? assets.get(spec.coverImageUrl) : undefined;
+
+  // Chapter bodies live one directory below the OPF, so their image and
+  // stylesheet references climb out of `text/`.
+  const chapterImageHrefs = new Map<string, string>();
+  for (const [url, asset] of assets) {
+    chapterImageHrefs.set(url, `../${asset.href}`);
+  }
+
+  const items: Array<ManifestItem> = [
+    {
+      href: "nav.xhtml",
+      id: NAV_ID,
+      mediaType: "application/xhtml+xml",
+      properties: "nav",
+    },
+    { href: "toc.ncx", id: NCX_ID, mediaType: "application/x-dtbncx+xml" },
+    { href: "style.css", id: "style", mediaType: "text/css" },
+  ];
+  const spine: Array<string> = [];
+  const entries: Array<ZipEntry> = [];
+  const encoder = new TextEncoder();
+  const addText = (name: string, text: string) => {
+    entries.push({ data: encoder.encode(text), name });
+  };
+
+  // `mimetype` must come first, stored, so the file is sniffable.
+  entries.push({
+    data: encoder.encode("application/epub+zip"),
+    method: "store",
+    name: "mimetype",
+  });
+  addText("META-INF/container.xml", containerXml());
+  addText("OEBPS/style.css", BOOK_STYLESHEET);
+
+  if (cover) {
+    items.push({
+      href: cover.href,
+      id: COVER_IMAGE_ID,
+      mediaType: cover.image.mediaType,
+      properties: "cover-image",
+    });
+    items.push({
+      href: "text/cover.xhtml",
+      id: "cover-page",
+      mediaType: "application/xhtml+xml",
+    });
+    spine.push("cover-page");
+    addText("OEBPS/text/cover.xhtml", coverDocument(spec, `../${cover.href}`));
+  }
+
+  // A single article is its own title page — its chapter already opens with the
+  // title and byline. A collection needs one.
+  if (spec.chapters.length > 1) {
+    items.push({
+      href: "text/title.xhtml",
+      id: "title-page",
+      mediaType: "application/xhtml+xml",
+    });
+    spine.push("title-page");
+    addText("OEBPS/text/title.xhtml", titleDocument(spec));
+  }
+
+  const tocEntries: Array<{ href: string; title: string }> = [];
+
+  for (const [index, chapter] of spec.chapters.entries()) {
+    // Pass two: the same render, now pointing at the images we actually have.
+    const body =
+      fetched.length > 0
+        ? chapter.render(chapterImageHrefs)
+        : (discovery[index] as RenderedBody);
+
+    const href = chapterHref(chapter.id);
+    const markup = [
+      `<h1>${xmlEscape(xmlSafeText(chapter.title))}</h1>`,
+      chapterMetaMarkup(chapter.meta),
+      body.markup,
+      chapterSourceMarkup(chapter.meta),
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    addText(
+      `OEBPS/${href}`,
+      xhtmlDocument({
+        body: markup,
+        language: spec.language,
+        title: chapter.title,
+      }),
+    );
+    items.push({
+      href,
+      id: chapter.id,
+      mediaType: "application/xhtml+xml",
+    });
+    spine.push(chapter.id);
+    tocEntries.push({ href, title: chapter.title });
+  }
+
+  for (const [, asset] of assets) {
+    if (asset.id === cover?.id) continue;
+    items.push({
+      href: asset.href,
+      id: asset.id,
+      mediaType: asset.image.mediaType,
+    });
+  }
+  for (const [, asset] of assets) {
+    entries.push({
+      // Images are already compressed; deflating them spends CPU to add bytes.
+      data: asset.image.data,
+      method: "store",
+      name: `OEBPS/${asset.href}`,
+    });
+  }
+
+  addText("OEBPS/nav.xhtml", navDocument(spec, tocEntries));
+  addText("OEBPS/toc.ncx", ncxDocument(spec, tocEntries));
+  addText(OPF_PATH, packageOpf({ items, spec, spine }));
+
+  return buildZip(entries);
+}

--- a/apps/standard-reader/src/server/books/reader-shelf.ts
+++ b/apps/standard-reader/src/server/books/reader-shelf.ts
@@ -1,0 +1,117 @@
+/**
+ * The reader-specific reads behind the personal shelves.
+ *
+ * The catalog and the download routes address a reader by DID, not by session
+ * — a KOReader device has no cookie, and a shelf URL is meant to be pasted into
+ * one. So the two preferences that shape an unread queue are resolved straight
+ * off the `user` row here, rather than through the session-cookie helpers the
+ * in-app server functions use.
+ */
+
+import { eq } from "drizzle-orm";
+
+import type {
+  ArticleCard,
+  Db,
+  Schema,
+} from "#/integrations/tanstack-query/api-shapes";
+import { DEFAULT_COUNT_OLD_POSTS_AS_UNREAD } from "#/lib/count-old-posts-as-unread";
+import {
+  selectArticleCardsByUris,
+  selectUnreadDocumentPage,
+} from "#/server/reader/queries";
+import { effectiveFollowSets } from "#/server/reader/saved-lists";
+
+export interface ShelfReaderPreferences {
+  /** Reading history is off — there is no meaningful unread queue. */
+  trackReadingHistory: boolean;
+  countOldPostsAsUnread: boolean;
+  displayName: string | null;
+  handle: string | null;
+}
+
+/** Preferences and byline for a reader addressed by DID. */
+export async function shelfReader(
+  db: Db,
+  schema: Schema,
+  did: string,
+): Promise<ShelfReaderPreferences> {
+  const [row] = await db
+    .select({
+      countOldPostsAsUnread: schema.user.countOldPostsAsUnread,
+      trackReadingHistory: schema.user.trackReadingHistory,
+    })
+    .from(schema.user)
+    .where(eq(schema.user.did, did))
+    .limit(1);
+
+  const [profile] = await db
+    .select({
+      displayName: schema.profiles.displayName,
+      handle: schema.profiles.handle,
+    })
+    .from(schema.profiles)
+    .where(eq(schema.profiles.did, did))
+    .limit(1);
+
+  return {
+    countOldPostsAsUnread:
+      row?.countOldPostsAsUnread ?? DEFAULT_COUNT_OLD_POSTS_AS_UNREAD,
+    displayName: profile?.displayName ?? null,
+    handle: profile?.handle ?? null,
+    // Null means the reader never touched the setting, and the app's default is
+    // on — the same reading `resolveTrackReadingHistoryEnabled` takes.
+    trackReadingHistory: row?.trackReadingHistory ?? true,
+  };
+}
+
+/** Display name for a reader's own shelves. */
+export function shelfReaderName(
+  reader: ShelfReaderPreferences,
+  did: string,
+): string {
+  return reader.displayName ?? reader.handle ?? did;
+}
+
+/**
+ * The reader's unread queue as cards, newest first.
+ *
+ * Empty when reading history is off: with nothing marked read, every article
+ * in the follow feed is "unread", and syncing the reader's entire subscription
+ * archive to their e-reader is not what they asked for.
+ */
+export async function unreadShelfCards(
+  db: Db,
+  schema: Schema,
+  did: string,
+  { limit }: { limit: number },
+): Promise<Array<ArticleCard>> {
+  const reader = await shelfReader(db, schema, did);
+  if (!reader.trackReadingHistory) return [];
+
+  const { publicationUris, userDids } = await effectiveFollowSets(
+    db,
+    schema,
+    did,
+  );
+  const rows = await selectUnreadDocumentPage(db, schema, {
+    countOldPostsAsUnread: reader.countOldPostsAsUnread,
+    followedUserDids: userDids,
+    limit,
+    publicationUris,
+    readerDid: did,
+  });
+  if (rows.length === 0) return [];
+
+  // `selectUnreadDocumentPage` returns the keyset order; the card query does
+  // not preserve it, so the unread order is re-imposed.
+  const order = new Map(rows.map((row, index) => [row.uri, index]));
+  const cards = await selectArticleCardsByUris(
+    db,
+    schema,
+    rows.map((row) => row.uri),
+  );
+  return cards.toSorted(
+    (a, b) => (order.get(a.uri) ?? 0) - (order.get(b.uri) ?? 0),
+  );
+}

--- a/apps/standard-reader/src/server/books/render.tsx
+++ b/apps/standard-reader/src/server/books/render.tsx
@@ -1,0 +1,292 @@
+/**
+ * A document body, rendered to EPUB-ready XHTML.
+ *
+ * The RSS feeds get their HTML from `lib/document/content-html.ts`, which only
+ * covers the formats with a straight text-to-HTML path — a Leaflet or pckt
+ * document falls back to its excerpt there. That is an acceptable trade for a
+ * feed item; it is not one for a book, where the excerpt *is* the whole
+ * download.
+ *
+ * So books render through `@standard-reader/renderer-react` instead — the same
+ * headless renderer the in-app reader uses — with `renderToStaticMarkup`. Every
+ * block vocabulary the app can display, a book can carry, and the two stay in
+ * step by construction: a new block type shows up in both or neither.
+ *
+ * Images are the one thing that cannot be resolved in a single pass. Blob refs
+ * become CDN URLs, but a book wants its images *inside* the file, and which
+ * ones we managed to fetch is not known until we have tried. So rendering is
+ * two-phase: render once to discover the URLs, fetch them, then render again
+ * with the fetched ones pointing at in-book paths (see `epub.ts`).
+ */
+
+import type {
+  ImageUrlResolver,
+  StandardSiteDocument,
+} from "@standard-reader/renderer-core";
+import {
+  buildRenderTree,
+  defaultImageUrlResolver,
+} from "@standard-reader/renderer-core";
+import { StandardDocumentRenderer } from "@standard-reader/renderer-react";
+import type { RendererComponentsInput } from "@standard-reader/renderer-react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { documentContentHtml } from "#/lib/document/content-html";
+import { bskyPostUrl } from "#/lib/leaflet/bsky";
+
+import { sanitizeToXhtml } from "./xhtml";
+
+/**
+ * `epub:type` carries the semantics that make a reader treat these as endnotes
+ * — popped up in place rather than jumped to. React renders namespaced
+ * attributes verbatim; JSX has no typing for them, hence the spread.
+ */
+const EPUB_TYPE = {
+  backlink: { "epub:type": "backlink" },
+  footnote: { "epub:type": "footnote" },
+  footnotes: { "epub:type": "footnotes" },
+} satisfies Record<string, Record<string, string>>;
+
+export interface RenderBodyInput {
+  /** The `content` union payload from the document record. */
+  content: unknown;
+  contentFormat: string | null;
+  /** DID of the repo hosting the body's image blobs. */
+  authorDid: string;
+  description?: string | null;
+  /** Absolute URL the document lives at, for resolving relative links. */
+  documentUrl?: string | null;
+  /**
+   * Remote image URL to in-book href. Absent on the discovery pass; on the
+   * final pass, any URL missing from the map keeps its remote address (the
+   * image failed to fetch, and a live URL degrades better than a dead one).
+   */
+  localImages?: Map<string, string>;
+}
+
+export interface RenderedBody {
+  /** XHTML markup for the chapter body — no `<html>` wrapper. */
+  markup: string;
+  /** Every remote image URL the body referenced, first appearance first. */
+  imageUrls: Array<string>;
+}
+
+/**
+ * Make `href` absolute so a link still works on a device that has no idea what
+ * site the book came from. Fragments stay relative — they address the chapter.
+ */
+function absoluteHref(href: string, base: string | null): string {
+  const trimmed = href.trim();
+  if (!trimmed || trimmed.startsWith("#")) return trimmed;
+  if (/^[a-z][\d+.a-z-]*:/i.test(trimmed)) return trimmed;
+  if (!base) return trimmed;
+  try {
+    return new URL(trimmed, base).toString();
+  } catch {
+    return trimmed;
+  }
+}
+
+/**
+ * Component overrides for book output.
+ *
+ * The headless defaults are already semantic HTML, so this is a short list of
+ * genuine differences between a web page and a book:
+ *
+ *  - **Raw HTML blocks render.** The default drops them (deciding what markup
+ *    is safe is the host's call, not the renderer's); a book that silently
+ *    dropped an HTML-format article's entire body would be an empty book.
+ *  - **Nothing embeds.** `iframe` is dead weight in an offline file — every
+ *    embed becomes a link the reader can follow when they are back online.
+ *  - **No lazy-loading or referrer hints.** Both are browser affordances that
+ *    mean nothing to an e-reader, and they only add bytes per image.
+ */
+function bookComponents(
+  documentUrl: string | null,
+  resolveImage: (url: string) => string,
+): RendererComponentsInput {
+  const link = (href: string) => absoluteHref(href, documentUrl);
+
+  return {
+    shared: {
+      Link: ({ href, children }) => <a href={link(href)}>{children}</a>,
+
+      Html: ({ html }) => {
+        const safe = sanitizeToXhtml(html);
+        if (!safe) return null;
+        return <div dangerouslySetInnerHTML={{ __html: safe }} />;
+      },
+      HtmlEmbed: ({ html }) => {
+        // A `srcdoc` embed is a self-contained document; inlined, it is just
+        // more of this chapter. The sandbox it needs on the web is moot here —
+        // scripts do not run in an e-reader.
+        const safe = sanitizeToXhtml(html);
+        if (!safe) return null;
+        return <div dangerouslySetInnerHTML={{ __html: safe }} />;
+      },
+      Iframe: ({ url }) => (
+        <p>
+          <a href={link(url)}>{url}</a>
+        </p>
+      ),
+      Website: ({ src, title, description }) => (
+        <p>
+          <a href={link(src)}>{title || src}</a>
+          {description ? <span> — {description}</span> : null}
+        </p>
+      ),
+      BlueskyEmbed: ({ postUri }) => {
+        const url = bskyPostUrl(postUri);
+        return (
+          <p>
+            <a href={url ?? postUri}>{url ?? postUri}</a>
+          </p>
+        );
+      },
+
+      Image: ({ src, alt, caption }) => (
+        <figure>
+          <img src={resolveImage(src)} alt={alt} />
+          {caption ? <figcaption>{caption}</figcaption> : null}
+        </figure>
+      ),
+      ImageGrid: ({ images, caption }) => (
+        <figure>
+          {images.map((image, index) => (
+            <img key={index} src={resolveImage(image.src)} alt={image.alt} />
+          ))}
+          {caption ? <figcaption>{caption}</figcaption> : null}
+        </figure>
+      ),
+      ImageCarousel: ({ images, caption }) => (
+        <figure>
+          {images.map((image, index) => (
+            <img key={index} src={resolveImage(image.src)} alt={image.alt} />
+          ))}
+          {caption ? <figcaption>{caption}</figcaption> : null}
+        </figure>
+      ),
+      ImageDiff: ({ before, after, caption, labels }) => (
+        <figure>
+          <img
+            src={resolveImage(before.src)}
+            alt={before.alt || labels?.[0] || ""}
+          />
+          <img
+            src={resolveImage(after.src)}
+            alt={after.alt || labels?.[1] || ""}
+          />
+          {caption ? <figcaption>{caption}</figcaption> : null}
+        </figure>
+      ),
+
+      // Endnote semantics: a reader that understands these pops the note up in
+      // place instead of throwing the reader to the back of the book.
+      Footnotes: ({ children }) => (
+        <section {...EPUB_TYPE.footnotes} role="doc-endnotes">
+          <hr />
+          <ol>{children}</ol>
+        </section>
+      ),
+      FootnoteItem: ({ id, children }) => (
+        <li {...EPUB_TYPE.footnote} id={`fn-${id}`} role="doc-endnote">
+          {children}{" "}
+          <a {...EPUB_TYPE.backlink} href={`#fnref-${id}`} role="doc-backlink">
+            ↩
+          </a>
+        </li>
+      ),
+    },
+  };
+}
+
+/**
+ * The fallback body, for formats the block renderer does not know.
+ *
+ * `renderer-core` covers the block vocabularies (Leaflet, pckt, Offprint,
+ * structured, markdown). It does not cover the HTML families a bridge produces
+ * — WordPress/Gutenberg, micro.blog — which the app renders through its own
+ * HTML pipeline. Without this, a book of bridged posts would be a book of
+ * empty chapters, which is exactly the failure the whole two-tier render was
+ * meant to avoid.
+ *
+ * The markup is sanitized against the article schema (same as the reader), then
+ * its images are pulled out by hand: they never passed through the resolver, so
+ * this is the only chance to collect and rewrite them.
+ */
+function renderHtmlFallback(
+  input: RenderBodyInput,
+  collect: (url: string) => void,
+  resolveImage: (url: string) => string,
+): string {
+  const html = documentContentHtml(input.content, input.contentFormat);
+  if (!html) return "";
+
+  const safe = sanitizeToXhtml(html);
+  if (!safe) return "";
+
+  return safe.replaceAll(
+    /(<img\b[^>]*?\bsrc=")([^"]*)(")/gi,
+    (match, prefix: string, src: string, suffix: string) => {
+      const absolute = absoluteHref(src, input.documentUrl ?? null);
+      if (!/^https?:/i.test(absolute)) return match;
+      collect(absolute);
+      return `${prefix}${resolveImage(absolute)}${suffix}`;
+    },
+  );
+}
+
+/** Render one document body to XHTML, collecting the images it references. */
+export function renderDocumentBody(input: RenderBodyInput): RenderedBody {
+  const seen = new Set<string>();
+  const imageUrls: Array<string> = [];
+
+  // Discovery and rewriting share one hook: the resolver hands back the CDN URL
+  // (recording it), and the component layer swaps in the in-book path if we
+  // have one by then.
+  const resolveImageUrl: ImageUrlResolver = (args) => {
+    const url = defaultImageUrlResolver(args);
+    if (url && !seen.has(url)) {
+      seen.add(url);
+      imageUrls.push(url);
+    }
+    return url;
+  };
+
+  const collect = (url: string) => {
+    if (seen.has(url)) return;
+    seen.add(url);
+    imageUrls.push(url);
+  };
+
+  const resolveImage = (url: string): string =>
+    input.localImages?.get(url) ?? url;
+
+  const document: StandardSiteDocument = {
+    authorDid: input.authorDid,
+    content: input.content,
+    contentFormat: input.contentFormat,
+    description: input.description,
+  };
+
+  // Ask the block renderer first, and check before rendering rather than after:
+  // an empty tree still serializes to a wrapper element, which reads as "we
+  // rendered something" when nothing was rendered at all.
+  const tree = buildRenderTree(document, { resolveImageUrl });
+  if (!tree || tree.children.length === 0) {
+    return {
+      imageUrls,
+      markup: renderHtmlFallback(input, collect, resolveImage),
+    };
+  }
+
+  const markup = renderToStaticMarkup(
+    <StandardDocumentRenderer
+      components={bookComponents(input.documentUrl ?? null, resolveImage)}
+      document={document}
+      options={{ resolveImageUrl }}
+    />,
+  );
+
+  return { imageUrls, markup };
+}

--- a/apps/standard-reader/src/server/books/respond.ts
+++ b/apps/standard-reader/src/server/books/respond.ts
@@ -1,0 +1,65 @@
+/**
+ * Handing a generated book to the client.
+ *
+ * Generation is deterministic (see `zip.ts`), so the bytes hash to a stable
+ * `ETag` — which matters more here than for a page: e-reader sync tools refetch
+ * whole shelves on a schedule, and a 304 is the difference between a KOReader
+ * sync that costs one round trip and one that re-downloads forty megabytes over
+ * hotel wifi.
+ */
+
+import { createHash } from "node:crypto";
+
+/**
+ * A book is only as fresh as the newest thing in it, and the reader's device
+ * caches the file anyway. Short public cache, long stale window.
+ */
+export const BOOK_CACHE_CONTROL =
+  "public, max-age=600, stale-while-revalidate=86400";
+
+/** A reader's own shelf, built from their subscriptions — never shared cache. */
+export const BOOK_PRIVATE_CACHE_CONTROL = "private, max-age=300";
+
+/**
+ * RFC 6266 `Content-Disposition` with both the ASCII and UTF-8 filename forms.
+ *
+ * The plain `filename` is ASCII-safe by construction (`bookFilename`); the
+ * `filename*` form carries the accented original for clients that read it.
+ */
+function contentDisposition(filename: string): string {
+  const ascii = filename.replaceAll(/[^ -~]/g, "_").replaceAll('"', "");
+  return `attachment; filename="${ascii}"; filename*=UTF-8''${encodeURIComponent(filename)}`;
+}
+
+export function bookResponse(
+  bytes: Uint8Array,
+  {
+    filename,
+    contentType,
+    request,
+    cacheControl = BOOK_CACHE_CONTROL,
+  }: {
+    filename: string;
+    contentType: string;
+    request: Request;
+    cacheControl?: string;
+  },
+): Response {
+  const etag = `"${createHash("sha1").update(bytes).digest("hex")}"`;
+
+  const headers: Record<string, string> = {
+    "Access-Control-Allow-Origin": "*",
+    "Cache-Control": cacheControl,
+    "Content-Disposition": contentDisposition(filename),
+    "Content-Type": contentType,
+    ETag: etag,
+  };
+
+  if (request.headers.get("if-none-match") === etag) {
+    return new Response(null, { headers, status: 304 });
+  }
+
+  return new Response(bytes as BodyInit, {
+    headers: { ...headers, "Content-Length": String(bytes.length) },
+  });
+}

--- a/apps/standard-reader/src/server/books/sources.ts
+++ b/apps/standard-reader/src/server/books/sources.ts
@@ -1,0 +1,193 @@
+/**
+ * Read model to book: turning the same cards the feeds and the catalog serve
+ * into an {@link EpubSpec}.
+ *
+ * Everything here reads from the DB mirror, never the PDS — the bodies come
+ * from `documents.content_json`, which the ingester keeps current (see the
+ * "AT Protocol data model" rules in CLAUDE.md). A download is a read.
+ */
+
+import { articleReaderUrl } from "#/components/reader/format";
+import type {
+  ArticleCard,
+  Db,
+  JsonValue,
+  Schema,
+} from "#/integrations/tanstack-query/api-shapes";
+import { loadFeedItemBodies } from "#/server/feeds/build";
+
+import type { EpubChapterSource, EpubSpec } from "./epub";
+import { renderDocumentBody } from "./render";
+
+/** How many articles a collection-shaped book carries at most. */
+export const BOOK_ARTICLE_LIMIT = 50;
+
+/**
+ * Drop the cards that have no body to package.
+ *
+ * `hasRenderableBody` is the app's existing judgement that a document is worth
+ * opening in the reader rather than linking out to (bridged link posts, bare
+ * Bluesky anchors). A chapter for one of those is a title and a URL, and forty
+ * of them is a book that wastes the reader's time — so a shelf silently carries
+ * only what it can actually deliver.
+ */
+export function packageableCards(
+  cards: Array<ArticleCard>,
+): Array<ArticleCard> {
+  return cards.filter((card) => card.hasRenderableBody);
+}
+
+interface FeedItemBody {
+  contentJson: JsonValue | null;
+  contentFormat: string | null;
+}
+
+/** Byline for a card — author first, then the publication, as the feeds do. */
+export function cardByline(card: ArticleCard): string | null {
+  if (card.authorDisplayName) return card.authorDisplayName;
+  if (card.authorHandle) return `@${card.authorHandle}`;
+  if (card.publicationName) return card.publicationName;
+  if (card.publicationOwnerHandle) return `@${card.publicationOwnerHandle}`;
+  return null;
+}
+
+function formatDateline(iso: string): string | null {
+  const time = Date.parse(iso);
+  if (Number.isNaN(time)) return null;
+  return new Date(time).toLocaleDateString("en-US", {
+    day: "numeric",
+    month: "long",
+    timeZone: "UTC",
+    year: "numeric",
+  });
+}
+
+/** Public URL for a card — the publication's own page when it has one. */
+export function cardSourceUrl(card: ArticleCard, baseUrl: string): string {
+  return card.canonicalUrl ?? articleReaderUrl(card.uri, baseUrl) ?? baseUrl;
+}
+
+/**
+ * The newest timestamp in a set of cards, as the book's `dcterms:modified`.
+ *
+ * Using content time rather than build time is what makes a rebuild produce
+ * the same bytes — and what lets a reader's device tell a genuinely updated
+ * book from the same book fetched twice.
+ */
+function newestTimestamp(cards: Array<ArticleCard>, fallback: string): string {
+  let newest = 0;
+  for (const card of cards) {
+    const time = Date.parse(card.publishedAt);
+    if (!Number.isNaN(time) && time > newest) newest = time;
+  }
+  return newest === 0 ? fallback : new Date(newest).toISOString();
+}
+
+/** Distinct bylines across a book, most frequent first, capped for sanity. */
+function collectAuthors(cards: Array<ArticleCard>, limit = 6): Array<string> {
+  const counts = new Map<string, number>();
+  for (const card of cards) {
+    const byline = cardByline(card);
+    if (!byline) continue;
+    counts.set(byline, (counts.get(byline) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .toSorted((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, limit)
+    .map(([byline]) => byline);
+}
+
+function chapterFromCard(
+  card: ArticleCard,
+  body: FeedItemBody | undefined,
+  index: number,
+  baseUrl: string,
+): EpubChapterSource {
+  const sourceUrl = cardSourceUrl(card, baseUrl);
+  return {
+    id: `ch${String(index + 1).padStart(4, "0")}`,
+    meta: {
+      byline: cardByline(card),
+      dateline: formatDateline(card.publishedAt),
+      sourceLabel: card.publicationName ?? card.canonicalUrl ?? sourceUrl,
+      sourceUrl,
+    },
+    render: (localImages) =>
+      renderDocumentBody({
+        authorDid: card.did,
+        content: body?.contentJson ?? null,
+        contentFormat: body?.contentFormat ?? null,
+        description: card.description,
+        documentUrl: sourceUrl,
+        localImages,
+      }),
+    title: card.title,
+  };
+}
+
+export interface BookFromCardsOptions {
+  identifier: string;
+  title: string;
+  baseUrl: string;
+  description?: string | null;
+  publisher?: string | null;
+  subtitle?: string | null;
+  sourceUrl?: string | null;
+  coverImageUrl?: string | null;
+  subjects?: Array<string>;
+  /** Byline for the book as a whole; defaults to the bylines inside it. */
+  authors?: Array<string>;
+}
+
+/** Assemble a book from cards plus their bodies, in the order given. */
+export async function bookFromCards(
+  db: Db,
+  schema: Schema,
+  cards: Array<ArticleCard>,
+  options: BookFromCardsOptions,
+): Promise<EpubSpec> {
+  const bodies = await loadFeedItemBodies(
+    db,
+    schema,
+    cards.map((card) => card.uri),
+  );
+
+  const first = cards[0];
+  return {
+    authors: options.authors ?? collectAuthors(cards),
+    chapters: cards.map((card, index) =>
+      chapterFromCard(card, bodies.get(card.uri), index, options.baseUrl),
+    ),
+    coverImageUrl: options.coverImageUrl ?? first?.coverImageUrl ?? null,
+    description: options.description ?? null,
+    identifier: options.identifier,
+    modified: newestTimestamp(cards, new Date(0).toISOString()),
+    published: first?.publishedAt ?? null,
+    publisher: options.publisher ?? "Standard Reader",
+    sourceUrl: options.sourceUrl ?? null,
+    subjects:
+      options.subjects ??
+      [...new Set(cards.flatMap((c) => c.tags ?? []))].slice(0, 12),
+    subtitle: options.subtitle ?? null,
+    title: options.title,
+  };
+}
+
+/**
+ * A filename a reader will recognise on their device.
+ *
+ * Kept ASCII and punctuation-free: these files travel to e-readers over USB,
+ * SD cards and FTP, through filesystems that still disagree about everything
+ * except `[A-Za-z0-9._-]`.
+ */
+export function bookFilename(title: string, extension: string): string {
+  const slug = title
+    .normalize("NFKD")
+    .replaceAll(/[\u0300-\u036F]/gu, "")
+    .replaceAll(/[^\w\s-]/gu, "")
+    .trim()
+    .replaceAll(/\s+/gu, "-")
+    .slice(0, 80)
+    .replaceAll(/^-+|-+$/gu, "");
+  return `${slug || "standard-reader"}${extension}`;
+}

--- a/apps/standard-reader/src/server/books/xhtml.ts
+++ b/apps/standard-reader/src/server/books/xhtml.ts
@@ -1,0 +1,149 @@
+/**
+ * XHTML plumbing shared by every generated book: escaping, the per-chapter
+ * document wrapper, and the one stylesheet the whole EPUB uses.
+ *
+ * EPUB content documents are XHTML, not HTML — an unclosed `<img>` or a bare
+ * `&nbsp;` is a parse error, not a quirk the reader forgives. Everything that
+ * reaches a chapter file therefore goes through {@link sanitizeToXhtml} (raw
+ * publisher HTML) or comes from `renderToStaticMarkup`, which already
+ * self-closes void elements and emits numeric character references.
+ */
+
+import rehypeParse from "rehype-parse";
+import rehypeSanitize from "rehype-sanitize";
+import rehypeStringify from "rehype-stringify";
+import { unified } from "unified";
+
+import { articleMarkdownSanitizeSchema } from "#/lib/markdown/article-sanitize-schema";
+
+export function xmlEscape(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+/**
+ * Strip characters XML 1.0 forbids outright. Record text is arbitrary user
+ * input and a single stray control byte makes the whole package unparseable —
+ * which a reader reports as "corrupt file", with no clue which of 40 chapters
+ * carried it.
+ */
+export function xmlSafeText(value: string): string {
+  // XML 1.0 allows #x9, #xA and #xD, then #x20 upward. Everything below that,
+  // plus the two permanently-unassigned code points, is illegal anywhere in a
+  // document — including inside CDATA.
+  return value.replaceAll(
+    // eslint-disable-next-line no-control-regex -- matching them is the point
+    /[\u0000-\u0008\u000B\u000C\u000E-\u001F\uFFFE\uFFFF]/gu,
+    "",
+  );
+}
+
+/**
+ * Sanitize a raw HTML fragment from a document body and re-serialize it as
+ * XHTML.
+ *
+ * Same schema as the in-app reader (`lib/markdown/sanitize-html.ts`) so a
+ * publisher's markup means the same thing in a downloaded book as on the site;
+ * the difference is purely serialization — void elements are closed and named
+ * character references (`&nbsp;`, undefined in XHTML without a DTD) are written
+ * numerically.
+ */
+export function sanitizeToXhtml(html: string): string {
+  if (!html.trim()) return "";
+  const file = unified()
+    .use(rehypeParse, { fragment: true })
+    .use(rehypeSanitize, articleMarkdownSanitizeSchema)
+    .use(rehypeStringify, {
+      characterReferences: { useNamedReferences: false },
+      closeSelfClosing: true,
+    })
+    .processSync(html);
+  return String(file).trim();
+}
+
+/** Wrap rendered body markup in a complete XHTML content document. */
+export function xhtmlDocument({
+  title,
+  body,
+  language = "en",
+  stylesheetHref = "../style.css",
+}: {
+  title: string;
+  body: string;
+  language?: string;
+  stylesheetHref?: string;
+}): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" lang="${xmlEscape(language)}" xml:lang="${xmlEscape(language)}">
+<head>
+<meta charset="utf-8"/>
+<title>${xmlEscape(xmlSafeText(title))}</title>
+<link rel="stylesheet" type="text/css" href="${xmlEscape(stylesheetHref)}"/>
+</head>
+<body>
+${body}
+</body>
+</html>
+`;
+}
+
+/**
+ * The book stylesheet.
+ *
+ * Deliberately small. An e-reader owns typography — the reader picked their
+ * font, size, margins and theme on the device, and a book that overrides those
+ * is a book they have to fight. This sets only what the device cannot infer:
+ * that images fit the page, that captions read as captions, and that code does
+ * not run off the edge. No colors, no font families, no font sizes on body
+ * text.
+ */
+export const BOOK_STYLESHEET = `@namespace epub "http://www.idpf.org/2007/ops";
+
+body { margin: 0 5%; line-height: 1.5; widows: 2; orphans: 2; }
+
+h1, h2, h3, h4, h5, h6 { line-height: 1.25; page-break-after: avoid; }
+
+img { max-width: 100%; height: auto; }
+
+figure { margin: 1.5em 0; text-align: center; page-break-inside: avoid; }
+figcaption { font-size: 0.85em; font-style: italic; text-align: center; margin-top: 0.4em; }
+
+blockquote { margin: 1em 1.5em; font-style: italic; }
+
+pre { white-space: pre-wrap; word-wrap: break-word; font-size: 0.85em; padding: 0.5em; }
+code { font-size: 0.9em; }
+
+hr { border: 0; border-top: 1px solid currentColor; opacity: 0.3; margin: 2em auto; width: 40%; }
+
+table { border-collapse: collapse; width: 100%; font-size: 0.9em; }
+th, td { border: 1px solid currentColor; padding: 0.3em 0.5em; text-align: left; }
+
+aside[role="note"] { border-left: 3px solid currentColor; padding-left: 0.8em; margin: 1em 0; }
+
+/* Chapter front matter: the byline and dateline above each article. */
+.sr-chapter-meta { font-size: 0.85em; opacity: 0.75; margin: 0 0 1.5em; }
+.sr-chapter-meta a { text-decoration: none; }
+
+/* Where the article lives on the web, in the book's own words. */
+.sr-source { font-size: 0.8em; opacity: 0.7; margin-top: 2.5em; border-top: 1px solid currentColor; padding-top: 0.8em; }
+
+.sr-cover { margin: 0; padding: 0; text-align: center; }
+.sr-cover img { max-width: 100%; max-height: 100%; }
+
+/* Comic pages: one image per page, no margins to fight with. */
+.sr-page { margin: 0; padding: 0; text-align: center; page-break-after: always; }
+.sr-page img { max-width: 100%; max-height: 100%; }
+
+/* Endnotes read better small and tight. */
+section[epub|type="footnotes"] { font-size: 0.85em; }
+
+/* Title page of a multi-article book. */
+.sr-title-page { text-align: center; margin-top: 20%; }
+.sr-title-page h1 { font-size: 1.8em; margin-bottom: 0.2em; }
+.sr-title-page .sr-subtitle { font-size: 1em; opacity: 0.75; }
+`;

--- a/apps/standard-reader/src/server/books/zip.test.ts
+++ b/apps/standard-reader/src/server/books/zip.test.ts
@@ -1,0 +1,166 @@
+/* eslint-disable unicorn/number-literal-case -- ZIP signatures and CRC
+   constants are written the way the spec and every reference implementation
+   write them, and oxfmt lowercases hex literals on save (see
+   `server/reader/rail-rotation.ts` for the same conflict). */
+import { inflateRawSync } from "node:zlib";
+
+import { describe, expect, it } from "vitest";
+
+import { buildZip, crc32 } from "#/server/books/zip";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+interface ParsedEntry {
+  name: string;
+  method: number;
+  flags: number;
+  crc: number;
+  content: string;
+}
+
+/**
+ * Read the archive back through its local file headers.
+ *
+ * Deliberately not using a zip library: the point of these tests is that the
+ * bytes are a correct archive, and a parser sharing code with the writer would
+ * agree with it about any mistake they both made.
+ */
+function parseZip(bytes: Uint8Array): Array<ParsedEntry> {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const entries: Array<ParsedEntry> = [];
+  let at = 0;
+
+  while (at + 4 <= bytes.length && view.getUint32(at, true) === 0x04_03_4b_50) {
+    const flags = view.getUint16(at + 6, true);
+    const method = view.getUint16(at + 8, true);
+    const crc = view.getUint32(at + 14, true);
+    const compressedSize = view.getUint32(at + 18, true);
+    const nameLength = view.getUint16(at + 26, true);
+    const extraLength = view.getUint16(at + 28, true);
+    const nameAt = at + 30;
+    const dataAt = nameAt + nameLength + extraLength;
+    const body = bytes.subarray(dataAt, dataAt + compressedSize);
+
+    entries.push({
+      content: decoder.decode(method === 0 ? body : inflateRawSync(body)),
+      crc,
+      flags,
+      method,
+      name: decoder.decode(bytes.subarray(nameAt, nameAt + nameLength)),
+    });
+    at = dataAt + compressedSize;
+  }
+  return entries;
+}
+
+describe("crc32", () => {
+  it("matches the reference value for a known input", () => {
+    // The canonical CRC-32 of "123456789".
+    expect(crc32(encoder.encode("123456789"))).toBe(0xcb_f4_39_26);
+  });
+
+  it("is zero for empty input", () => {
+    expect(crc32(new Uint8Array())).toBe(0);
+  });
+});
+
+describe("buildZip", () => {
+  it("preserves entry order and round-trips content", () => {
+    const zip = buildZip([
+      { data: encoder.encode("first"), name: "a.txt" },
+      { data: encoder.encode("second"), name: "nested/b.txt" },
+    ]);
+
+    const entries = parseZip(zip);
+    expect(entries.map((entry) => entry.name)).toEqual([
+      "a.txt",
+      "nested/b.txt",
+    ]);
+    expect(entries.map((entry) => entry.content)).toEqual(["first", "second"]);
+  });
+
+  it("stores an entry verbatim when asked, whatever its content", () => {
+    // EPUB requires `mimetype` to be the first entry and STORED, so a reader
+    // can identify the file from its first bytes without inflating anything.
+    const zip = buildZip([
+      {
+        data: encoder.encode("application/epub+zip"),
+        method: "store",
+        name: "mimetype",
+      },
+    ]);
+
+    const [entry] = parseZip(zip);
+    expect(entry?.method).toBe(0);
+    expect(entry?.content).toBe("application/epub+zip");
+    // The literal bytes appear right after the 30-byte header plus the name.
+    expect(decoder.decode(zip.subarray(38, 58))).toBe("application/epub+zip");
+  });
+
+  it("deflates compressible content", () => {
+    const zip = buildZip([
+      { data: encoder.encode("ab".repeat(2000)), name: "big.txt" },
+    ]);
+
+    const [entry] = parseZip(zip);
+    expect(entry?.method).toBe(8);
+    expect(entry?.content).toBe("ab".repeat(2000));
+    expect(zip.length).toBeLessThan(1000);
+  });
+
+  it("falls back to storing when deflate would grow the entry", () => {
+    // Incompressible bytes come back from deflate with framing overhead.
+    const random = new Uint8Array(64);
+    for (let index = 0; index < random.length; index += 1) {
+      random[index] = (index * 37 + 11) % 256;
+    }
+    const zip = buildZip([{ data: random, name: "noise.bin" }]);
+    expect(parseZip(zip)[0]?.method).toBe(0);
+  });
+
+  it("marks filenames as UTF-8 and round-trips non-ASCII names", () => {
+    const zip = buildZip([
+      { data: encoder.encode("x"), name: "café/naïve.txt" },
+    ]);
+    const [entry] = parseZip(zip);
+    expect(entry?.name).toBe("café/naïve.txt");
+    expect(entry?.flags & 0x08_00).toBe(0x08_00);
+  });
+
+  it("is byte-identical across builds", () => {
+    // Nothing in the writer reads the clock — this is what makes ETags stable
+    // across replicas and lets kosync precompute a file's hash.
+    const build = () =>
+      buildZip([
+        { data: encoder.encode("mimetype"), method: "store", name: "mimetype" },
+        { data: encoder.encode("<x/>"), name: "META-INF/container.xml" },
+      ]);
+    expect(Buffer.from(build())).toEqual(Buffer.from(build()));
+  });
+
+  it("records a CRC over the uncompressed bytes", () => {
+    const data = encoder.encode("ab".repeat(2000));
+    const [entry] = parseZip(buildZip([{ data, name: "big.txt" }]));
+    expect(entry?.crc).toBe(crc32(data));
+  });
+
+  it("writes a central directory covering every entry", () => {
+    const zip = buildZip([
+      { data: encoder.encode("one"), name: "1.txt" },
+      { data: encoder.encode("two"), name: "2.txt" },
+    ]);
+    const view = new DataView(zip.buffer, zip.byteOffset, zip.byteLength);
+
+    // The end-of-central-directory record is the last 22 bytes (no comment).
+    const eocdAt = zip.length - 22;
+    expect(view.getUint32(eocdAt, true)).toBe(0x06_05_4b_50);
+    expect(view.getUint16(eocdAt + 8, true)).toBe(2);
+    expect(view.getUint16(eocdAt + 10, true)).toBe(2);
+
+    const centralOffset = view.getUint32(eocdAt + 16, true);
+    expect(view.getUint32(centralOffset, true)).toBe(0x02_01_4b_50);
+  });
+});
+
+/* eslint-enable unicorn/number-literal-case */

--- a/apps/standard-reader/src/server/books/zip.ts
+++ b/apps/standard-reader/src/server/books/zip.ts
@@ -1,0 +1,207 @@
+/**
+ * A minimal, deterministic ZIP writer — the container both EPUB and CBZ are.
+ *
+ * Hand-rolled for the same reason `lib/feeds/rss.ts` builds XML by hand: the
+ * format we need is small, the dependency would be large, and we need control a
+ * general-purpose library does not give us:
+ *
+ *  - **EPUB's first-entry rule.** `mimetype` must be the first entry, STORED
+ *    (never deflated), with no extra field, so a reader can sniff the format
+ *    from the first bytes of the file. {@link buildZip} writes entries in the
+ *    order given and takes the method per entry.
+ *  - **Determinism.** Every timestamp is the DOS epoch and nothing else varies,
+ *    so the same document always produces byte-identical output. That is what
+ *    makes `ETag`s stable across replicas — and what lets kosync precompute a
+ *    file's partial MD5 without having served that exact file before (see
+ *    `server/kosync/document-hash.ts`).
+ */
+
+/* eslint-disable unicorn/number-literal-case -- ZIP signatures and CRC
+   constants are written the way the spec and every reference implementation
+   write them, and oxfmt lowercases hex literals on save (see
+   `server/reader/rail-rotation.ts` for the same conflict). */
+
+import { deflateRawSync } from "node:zlib";
+
+/** DOS epoch (1980-01-01 00:00) — the earliest a ZIP timestamp can express. */
+const DOS_DATE = 0x00_21;
+const DOS_TIME = 0x00_00;
+
+/** General-purpose flag bit 11: filenames and comments are UTF-8. */
+const FLAG_UTF8 = 0x08_00;
+
+const SIG_LOCAL = 0x04_03_4b_50;
+const SIG_CENTRAL = 0x02_01_4b_50;
+const SIG_EOCD = 0x06_05_4b_50;
+
+export interface ZipEntry {
+  /** Path inside the archive, `/`-separated, no leading slash. */
+  name: string;
+  data: Uint8Array;
+  /**
+   * `"store"` writes the bytes verbatim. Required for EPUB's `mimetype`, and
+   * the honest choice for already-compressed payloads (JPEG/PNG/WebP pages),
+   * where deflate spends CPU to add bytes.
+   */
+  method?: "deflate" | "store";
+}
+
+let crcTable: Uint32Array | null = null;
+
+function crc32Table(): Uint32Array {
+  if (crcTable) return crcTable;
+  const table = new Uint32Array(256);
+  for (let index = 0; index < 256; index += 1) {
+    let value = index;
+    for (let bit = 0; bit < 8; bit += 1) {
+      value = (value & 1) === 1 ? 0xed_b8_83_20 ^ (value >>> 1) : value >>> 1;
+    }
+    // `>>> 0` for the unsigned coercion, not for truncation — `Math.trunc`
+    // would leave the sign bit set and every CRC above 2^31 wrong.
+    // eslint-disable-next-line unicorn/prefer-math-trunc -- unsigned coercion
+    table[index] = value >>> 0;
+  }
+  crcTable = table;
+  return table;
+}
+
+export function crc32(data: Uint8Array): number {
+  const table = crc32Table();
+  let crc = 0xff_ff_ff_ff;
+  for (const byte of data) {
+    crc = (table[(crc ^ byte) & 0xff] ?? 0) ^ (crc >>> 8);
+  }
+  // eslint-disable-next-line unicorn/prefer-math-trunc -- unsigned coercion
+  return (crc ^ 0xff_ff_ff_ff) >>> 0;
+}
+
+/** A growable little-endian byte sink — every ZIP field is little-endian. */
+class ByteSink {
+  private readonly chunks: Array<Uint8Array> = [];
+  private length = 0;
+
+  get offset(): number {
+    return this.length;
+  }
+
+  push(bytes: Uint8Array): void {
+    this.chunks.push(bytes);
+    this.length += bytes.length;
+  }
+
+  u16(value: number): void {
+    this.push(new Uint8Array([value & 0xff, (value >>> 8) & 0xff]));
+  }
+
+  u32(value: number): void {
+    this.push(
+      new Uint8Array([
+        value & 0xff,
+        (value >>> 8) & 0xff,
+        (value >>> 16) & 0xff,
+        (value >>> 24) & 0xff,
+      ]),
+    );
+  }
+
+  toBytes(): Uint8Array {
+    const out = new Uint8Array(this.length);
+    let at = 0;
+    for (const chunk of this.chunks) {
+      out.set(chunk, at);
+      at += chunk.length;
+    }
+    return out;
+  }
+}
+
+interface PreparedEntry {
+  nameBytes: Uint8Array;
+  body: Uint8Array;
+  crc: number;
+  uncompressedSize: number;
+  compressionMethod: number;
+  localOffset: number;
+}
+
+/**
+ * Build a ZIP archive from `entries`, in order. Entries are never reordered —
+ * the caller owns the order, because EPUB depends on it.
+ */
+export function buildZip(entries: Array<ZipEntry>): Uint8Array {
+  const encoder = new TextEncoder();
+  const sink = new ByteSink();
+  const prepared: Array<PreparedEntry> = [];
+
+  for (const entry of entries) {
+    const nameBytes = encoder.encode(entry.name);
+    const deflated =
+      entry.method === "store"
+        ? null
+        : new Uint8Array(deflateRawSync(entry.data, { level: 9 }));
+    // Deflate can inflate: incompressible bytes come back with overhead. Store
+    // those instead of paying for a bigger file.
+    const useStore = deflated === null || deflated.length >= entry.data.length;
+    const body = useStore ? entry.data : deflated;
+
+    const record: PreparedEntry = {
+      body,
+      compressionMethod: useStore ? 0 : 8,
+      crc: crc32(entry.data),
+      localOffset: sink.offset,
+      nameBytes,
+      uncompressedSize: entry.data.length,
+    };
+    prepared.push(record);
+
+    sink.u32(SIG_LOCAL);
+    sink.u16(20); // version needed to extract (2.0 — deflate)
+    sink.u16(FLAG_UTF8);
+    sink.u16(record.compressionMethod);
+    sink.u16(DOS_TIME);
+    sink.u16(DOS_DATE);
+    sink.u32(record.crc);
+    sink.u32(body.length);
+    sink.u32(record.uncompressedSize);
+    sink.u16(nameBytes.length);
+    sink.u16(0); // extra field length — EPUB forbids one on `mimetype`
+    sink.push(nameBytes);
+    sink.push(body);
+  }
+
+  const centralOffset = sink.offset;
+  for (const record of prepared) {
+    sink.u32(SIG_CENTRAL);
+    sink.u16(20); // version made by
+    sink.u16(20); // version needed to extract
+    sink.u16(FLAG_UTF8);
+    sink.u16(record.compressionMethod);
+    sink.u16(DOS_TIME);
+    sink.u16(DOS_DATE);
+    sink.u32(record.crc);
+    sink.u32(record.body.length);
+    sink.u32(record.uncompressedSize);
+    sink.u16(record.nameBytes.length);
+    sink.u16(0); // extra field length
+    sink.u16(0); // file comment length
+    sink.u16(0); // disk number start
+    sink.u16(0); // internal file attributes
+    sink.u32(0); // external file attributes
+    sink.u32(record.localOffset);
+    sink.push(record.nameBytes);
+  }
+  const centralSize = sink.offset - centralOffset;
+
+  sink.u32(SIG_EOCD);
+  sink.u16(0); // this disk
+  sink.u16(0); // disk holding the central directory
+  sink.u16(prepared.length);
+  sink.u16(prepared.length);
+  sink.u32(centralSize);
+  sink.u32(centralOffset);
+  sink.u16(0); // archive comment length
+
+  return sink.toBytes();
+}
+
+/* eslint-enable unicorn/number-literal-case */

--- a/apps/standard-reader/src/server/kosync/credentials.test.ts
+++ b/apps/standard-reader/src/server/kosync/credentials.test.ts
@@ -1,0 +1,94 @@
+import { createHash } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  authenticateKosync,
+  kosyncAuthKeyForDid,
+  kosyncKeyForDid,
+} from "#/server/kosync/credentials";
+
+const DID = "did:plc:vmdqoelhettxubov4hejncg2";
+const OTHER = "did:plc:stznz7qsokto2345qtdzogjb";
+
+function request(headers: Record<string, string>): Request {
+  return new Request("https://example.invalid/kosync/users/auth", { headers });
+}
+
+const resolve = async (username: string) =>
+  username === "reader.example" ? DID : null;
+
+describe("kosyncKeyForDid", () => {
+  it("is stable for a DID and different for another", () => {
+    expect(kosyncKeyForDid(DID)).toBe(kosyncKeyForDid(DID));
+    expect(kosyncKeyForDid(DID)).not.toBe(kosyncKeyForDid(OTHER));
+  });
+
+  it("is typeable on an e-reader keyboard", () => {
+    // Lowercase, no look-alike characters (no l/1/i, no o/0), fixed length.
+    expect(kosyncKeyForDid(DID)).toMatch(/^[a-z2-9]{20}$/);
+    expect(kosyncKeyForDid(DID)).not.toMatch(/[ilo01]/);
+  });
+
+  it("hands KOReader the MD5 of the key, which is what it sends", () => {
+    expect(kosyncAuthKeyForDid(DID)).toBe(
+      createHash("md5").update(kosyncKeyForDid(DID)).digest("hex"),
+    );
+  });
+});
+
+describe("authenticateKosync", () => {
+  it("accepts the right key for a resolvable username", async () => {
+    const did = await authenticateKosync(
+      request({
+        "x-auth-key": kosyncAuthKeyForDid(DID),
+        "x-auth-user": "reader.example",
+      }),
+      resolve,
+    );
+    expect(did).toBe(DID);
+  });
+
+  it("accepts an upper-case key, which some clients send", async () => {
+    const did = await authenticateKosync(
+      request({
+        "x-auth-key": kosyncAuthKeyForDid(DID).toUpperCase(),
+        "x-auth-user": "reader.example",
+      }),
+      resolve,
+    );
+    expect(did).toBe(DID);
+  });
+
+  it("rejects another reader's key", async () => {
+    const did = await authenticateKosync(
+      request({
+        "x-auth-key": kosyncAuthKeyForDid(OTHER),
+        "x-auth-user": "reader.example",
+      }),
+      resolve,
+    );
+    expect(did).toBeNull();
+  });
+
+  it("rejects an unknown username without checking the key", async () => {
+    const did = await authenticateKosync(
+      request({
+        "x-auth-key": kosyncAuthKeyForDid(DID),
+        "x-auth-user": "nobody.example",
+      }),
+      resolve,
+    );
+    expect(did).toBeNull();
+  });
+
+  it("rejects a request with no credentials", async () => {
+    expect(await authenticateKosync(request({}), resolve)).toBeNull();
+    expect(
+      await authenticateKosync(
+        request({ "x-auth-user": "reader.example" }),
+        resolve,
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/standard-reader/src/server/kosync/credentials.test.ts
+++ b/apps/standard-reader/src/server/kosync/credentials.test.ts
@@ -6,34 +6,59 @@ import {
   authenticateKosync,
   kosyncAuthKeyForDid,
   kosyncKeyForDid,
+  newKosyncSalt,
 } from "#/server/kosync/credentials";
 
 const DID = "did:plc:vmdqoelhettxubov4hejncg2";
 const OTHER = "did:plc:stznz7qsokto2345qtdzogjb";
+const SALT = "3PPOtKbmk3rQ0tKcHRAA1Q";
 
 function request(headers: Record<string, string>): Request {
   return new Request("https://example.invalid/kosync/users/auth", { headers });
 }
 
-const resolve = async (username: string) =>
-  username === "reader.example" ? DID : null;
+const resolve =
+  (salt: string | null = null) =>
+  async (username: string) =>
+    username === "reader.example" ? { did: DID, salt } : null;
 
 describe("kosyncKeyForDid", () => {
   it("is stable for a DID and different for another", () => {
-    expect(kosyncKeyForDid(DID)).toBe(kosyncKeyForDid(DID));
-    expect(kosyncKeyForDid(DID)).not.toBe(kosyncKeyForDid(OTHER));
+    expect(kosyncKeyForDid(DID, null)).toBe(kosyncKeyForDid(DID, null));
+    expect(kosyncKeyForDid(DID, null)).not.toBe(kosyncKeyForDid(OTHER, null));
   });
 
   it("is typeable on an e-reader keyboard", () => {
     // Lowercase, no look-alike characters (no l/1/i, no o/0), fixed length.
-    expect(kosyncKeyForDid(DID)).toMatch(/^[a-z2-9]{20}$/);
-    expect(kosyncKeyForDid(DID)).not.toMatch(/[ilo01]/);
+    expect(kosyncKeyForDid(DID, null)).toMatch(/^[a-z2-9]{20}$/);
+    expect(kosyncKeyForDid(DID, null)).not.toMatch(/[ilo01]/);
+    expect(kosyncKeyForDid(DID, SALT)).toMatch(/^[a-z2-9]{20}$/);
   });
 
   it("hands KOReader the MD5 of the key, which is what it sends", () => {
-    expect(kosyncAuthKeyForDid(DID)).toBe(
-      createHash("md5").update(kosyncKeyForDid(DID)).digest("hex"),
+    expect(kosyncAuthKeyForDid(DID, null)).toBe(
+      createHash("md5").update(kosyncKeyForDid(DID, null)).digest("hex"),
     );
+  });
+
+  it("keeps deriving the original key for a reader who never rotated", () => {
+    // `null` is what every account carries until it rotates, so this is the
+    // guarantee that shipping rotation did not log every device out.
+    expect(kosyncKeyForDid(DID, null)).toBe(kosyncKeyForDid(DID, null));
+  });
+
+  it("changes the key when the salt changes", () => {
+    expect(kosyncKeyForDid(DID, SALT)).not.toBe(kosyncKeyForDid(DID, null));
+    expect(kosyncKeyForDid(DID, SALT)).not.toBe(
+      kosyncKeyForDid(DID, newKosyncSalt()),
+    );
+  });
+});
+
+describe("newKosyncSalt", () => {
+  it("is different every time", () => {
+    const salts = new Set(Array.from({ length: 50 }, () => newKosyncSalt()));
+    expect(salts.size).toBe(50);
   });
 });
 
@@ -41,10 +66,10 @@ describe("authenticateKosync", () => {
   it("accepts the right key for a resolvable username", async () => {
     const did = await authenticateKosync(
       request({
-        "x-auth-key": kosyncAuthKeyForDid(DID),
+        "x-auth-key": kosyncAuthKeyForDid(DID, null),
         "x-auth-user": "reader.example",
       }),
-      resolve,
+      resolve(),
     );
     expect(did).toBe(DID);
   });
@@ -52,10 +77,34 @@ describe("authenticateKosync", () => {
   it("accepts an upper-case key, which some clients send", async () => {
     const did = await authenticateKosync(
       request({
-        "x-auth-key": kosyncAuthKeyForDid(DID).toUpperCase(),
+        "x-auth-key": kosyncAuthKeyForDid(DID, null).toUpperCase(),
         "x-auth-user": "reader.example",
       }),
-      resolve,
+      resolve(),
+    );
+    expect(did).toBe(DID);
+  });
+
+  it("rejects the old key once the reader has rotated", async () => {
+    // The whole point of rotation: a device holding the previous key stops
+    // syncing the moment the new salt lands.
+    const did = await authenticateKosync(
+      request({
+        "x-auth-key": kosyncAuthKeyForDid(DID, null),
+        "x-auth-user": "reader.example",
+      }),
+      resolve(SALT),
+    );
+    expect(did).toBeNull();
+  });
+
+  it("accepts the new key after rotating", async () => {
+    const did = await authenticateKosync(
+      request({
+        "x-auth-key": kosyncAuthKeyForDid(DID, SALT),
+        "x-auth-user": "reader.example",
+      }),
+      resolve(SALT),
     );
     expect(did).toBe(DID);
   });
@@ -63,10 +112,10 @@ describe("authenticateKosync", () => {
   it("rejects another reader's key", async () => {
     const did = await authenticateKosync(
       request({
-        "x-auth-key": kosyncAuthKeyForDid(OTHER),
+        "x-auth-key": kosyncAuthKeyForDid(OTHER, null),
         "x-auth-user": "reader.example",
       }),
-      resolve,
+      resolve(),
     );
     expect(did).toBeNull();
   });
@@ -74,20 +123,20 @@ describe("authenticateKosync", () => {
   it("rejects an unknown username without checking the key", async () => {
     const did = await authenticateKosync(
       request({
-        "x-auth-key": kosyncAuthKeyForDid(DID),
+        "x-auth-key": kosyncAuthKeyForDid(DID, null),
         "x-auth-user": "nobody.example",
       }),
-      resolve,
+      resolve(),
     );
     expect(did).toBeNull();
   });
 
   it("rejects a request with no credentials", async () => {
-    expect(await authenticateKosync(request({}), resolve)).toBeNull();
+    expect(await authenticateKosync(request({}), resolve())).toBeNull();
     expect(
       await authenticateKosync(
         request({ "x-auth-user": "reader.example" }),
-        resolve,
+        resolve(),
       ),
     ).toBeNull();
   });

--- a/apps/standard-reader/src/server/kosync/credentials.ts
+++ b/apps/standard-reader/src/server/kosync/credentials.ts
@@ -8,20 +8,24 @@
  *
  * So this does not reuse the reader's AT Proto identity in any form that could
  * be replayed elsewhere. The sync key is *derived* — an HMAC of the reader's
- * DID under a server secret — which means:
+ * DID and a per-reader salt, under a server secret — which means:
  *
- *  - nothing new is stored: no credentials table, no rotation bookkeeping;
- *  - the key grants exactly one capability, reading and writing that reader's
+ *  - the key itself is never stored, so there is nothing to leak from the DB;
+ *  - it grants exactly one capability, reading and writing that reader's
  *    KOReader positions, and nothing else in the app;
- *  - a leaked key is contained, and every key can be invalidated at once by
- *    rotating `KOSYNC_SECRET`.
+ *  - rotating is a single column write (`user.kosync_key_salt`), and the old
+ *    key stops working the moment it lands.
  *
- * The trade is that a single key cannot be revoked on its own. For a
- * position-sync credential that is the right trade — but it is a trade, and it
- * is why the key must never become a general-purpose token.
+ * A `null` salt derives the pre-rotation key, so readers already syncing when
+ * rotation shipped keep working without touching anything.
  */
 
-import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+import {
+  createHash,
+  createHmac,
+  randomBytes,
+  timingSafeEqual,
+} from "node:crypto";
 
 function secret(): string {
   const value = process.env.KOSYNC_SECRET;
@@ -33,6 +37,11 @@ function secret(): string {
   throw new Error("KOSYNC_SECRET is not set");
 }
 
+/** A fresh salt. Random rather than a counter, so rotating is unguessable. */
+export function newKosyncSalt(): string {
+  return randomBytes(16).toString("base64url");
+}
+
 /**
  * The sync key a reader types into KOReader's "Password" field.
  *
@@ -40,9 +49,9 @@ function secret(): string {
  * unguessable, short enough to be typed on an e-reader's on-screen keyboard,
  * and free of the characters that look alike on an e-ink screen.
  */
-export function kosyncKeyForDid(did: string): string {
+export function kosyncKeyForDid(did: string, salt: string | null): string {
   const digest = createHmac("sha256", secret())
-    .update(`kosync:${did}`)
+    .update(salt ? `kosync:${did}:${salt}` : `kosync:${did}`)
     .digest();
   const alphabet = "abcdefghjkmnpqrstuvwxyz23456789";
   let key = "";
@@ -53,8 +62,8 @@ export function kosyncKeyForDid(did: string): string {
 }
 
 /** What KOReader sends as `x-auth-key`: the MD5 of the typed password. */
-export function kosyncAuthKeyForDid(did: string): string {
-  return createHash("md5").update(kosyncKeyForDid(did)).digest("hex");
+export function kosyncAuthKeyForDid(did: string, salt: string | null): string {
+  return createHash("md5").update(kosyncKeyForDid(did, salt)).digest("hex");
 }
 
 function constantTimeEquals(a: string, b: string): boolean {
@@ -64,22 +73,31 @@ function constantTimeEquals(a: string, b: string): boolean {
   return timingSafeEqual(left, right);
 }
 
+/** The reader a kosync username resolves to, with the salt their key uses. */
+export interface KosyncReader {
+  did: string;
+  salt: string | null;
+}
+
 /**
  * Verify a request's kosync headers and return the reader's DID.
  *
  * `resolveUsername` turns whatever the reader typed as their username into a
- * DID — they may have typed a handle, which is what the settings page shows.
+ * DID and salt — they may have typed a handle, which is what the settings page
+ * shows.
  */
 export async function authenticateKosync(
   request: Request,
-  resolveUsername: (username: string) => Promise<string | null>,
+  resolveUsername: (username: string) => Promise<KosyncReader | null>,
 ): Promise<string | null> {
   const username = request.headers.get("x-auth-user")?.trim();
   const key = request.headers.get("x-auth-key")?.trim().toLowerCase();
   if (!username || !key) return null;
 
-  const did = await resolveUsername(username);
-  if (!did) return null;
+  const reader = await resolveUsername(username);
+  if (!reader) return null;
 
-  return constantTimeEquals(key, kosyncAuthKeyForDid(did)) ? did : null;
+  return constantTimeEquals(key, kosyncAuthKeyForDid(reader.did, reader.salt))
+    ? reader.did
+    : null;
 }

--- a/apps/standard-reader/src/server/kosync/credentials.ts
+++ b/apps/standard-reader/src/server/kosync/credentials.ts
@@ -1,0 +1,85 @@
+/**
+ * Credentials for KOReader's progress sync.
+ *
+ * kosync predates every modern auth story: a device sends `x-auth-user` and
+ * `x-auth-key` on each request, where the key is the MD5 of a password the
+ * reader typed. There is no OAuth in it, no refresh, no scopes — and KOReader
+ * stores the key on the device in the clear.
+ *
+ * So this does not reuse the reader's AT Proto identity in any form that could
+ * be replayed elsewhere. The sync key is *derived* — an HMAC of the reader's
+ * DID under a server secret — which means:
+ *
+ *  - nothing new is stored: no credentials table, no rotation bookkeeping;
+ *  - the key grants exactly one capability, reading and writing that reader's
+ *    KOReader positions, and nothing else in the app;
+ *  - a leaked key is contained, and every key can be invalidated at once by
+ *    rotating `KOSYNC_SECRET`.
+ *
+ * The trade is that a single key cannot be revoked on its own. For a
+ * position-sync credential that is the right trade — but it is a trade, and it
+ * is why the key must never become a general-purpose token.
+ */
+
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+
+function secret(): string {
+  const value = process.env.KOSYNC_SECRET;
+  if (value) return value;
+  // Same shape as `digestConfig.unsubscribeSecret`: a dev placeholder so the
+  // feature works locally, and a hard failure in production rather than a
+  // silently guessable key.
+  if (process.env.NODE_ENV !== "production") return "dev-kosync-secret";
+  throw new Error("KOSYNC_SECRET is not set");
+}
+
+/**
+ * The sync key a reader types into KOReader's "Password" field.
+ *
+ * Base32-ish over an HMAC, cut to 20 characters: long enough to be
+ * unguessable, short enough to be typed on an e-reader's on-screen keyboard,
+ * and free of the characters that look alike on an e-ink screen.
+ */
+export function kosyncKeyForDid(did: string): string {
+  const digest = createHmac("sha256", secret())
+    .update(`kosync:${did}`)
+    .digest();
+  const alphabet = "abcdefghjkmnpqrstuvwxyz23456789";
+  let key = "";
+  for (let index = 0; index < 20; index += 1) {
+    key += alphabet[(digest[index] ?? 0) % alphabet.length];
+  }
+  return key;
+}
+
+/** What KOReader sends as `x-auth-key`: the MD5 of the typed password. */
+export function kosyncAuthKeyForDid(did: string): string {
+  return createHash("md5").update(kosyncKeyForDid(did)).digest("hex");
+}
+
+function constantTimeEquals(a: string, b: string): boolean {
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  if (left.length !== right.length) return false;
+  return timingSafeEqual(left, right);
+}
+
+/**
+ * Verify a request's kosync headers and return the reader's DID.
+ *
+ * `resolveUsername` turns whatever the reader typed as their username into a
+ * DID — they may have typed a handle, which is what the settings page shows.
+ */
+export async function authenticateKosync(
+  request: Request,
+  resolveUsername: (username: string) => Promise<string | null>,
+): Promise<string | null> {
+  const username = request.headers.get("x-auth-user")?.trim();
+  const key = request.headers.get("x-auth-key")?.trim().toLowerCase();
+  if (!username || !key) return null;
+
+  const did = await resolveUsername(username);
+  if (!did) return null;
+
+  return constantTimeEquals(key, kosyncAuthKeyForDid(did)) ? did : null;
+}

--- a/apps/standard-reader/src/server/kosync/document-hash.test.ts
+++ b/apps/standard-reader/src/server/kosync/document-hash.test.ts
@@ -1,0 +1,85 @@
+import { createHash } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  koreaderFilenameMd5,
+  koreaderPartialMd5,
+} from "#/server/kosync/document-hash";
+
+/**
+ * An independent transcription of KOReader's `util.partialMD5`, written from
+ * the Lua rather than from our implementation — including the `lshift(1024, -2)`
+ * overflow that puts the first sample at offset 0.
+ *
+ * If the two ever disagree, every device in the wild follows this one.
+ */
+function referencePartialMd5(data: Uint8Array): string {
+  const hash = createHash("md5");
+  const offsets = [0];
+  for (let i = 0; i <= 10; i += 1) offsets.push(1024 * 4 ** i);
+
+  for (const offset of offsets) {
+    if (offset >= data.length) break;
+    hash.update(data.subarray(offset, offset + 1024));
+  }
+  return hash.digest("hex");
+}
+
+function filled(length: number): Uint8Array {
+  const bytes = new Uint8Array(length);
+  for (let index = 0; index < length; index += 1) {
+    bytes[index] = (index * 31 + 7) % 256;
+  }
+  return bytes;
+}
+
+describe("koreaderPartialMd5", () => {
+  it("samples from offset 0 first", () => {
+    // The Lua reads `lshift(step, 2*i)` starting at i = -1, and LuaJIT masks the
+    // shift to five bits — so the first sample is the head of the file. A
+    // reimplementation that "corrects" this hashes files no device can match.
+    const data = filled(512);
+    expect(koreaderPartialMd5(data)).toBe(
+      createHash("md5").update(data).digest("hex"),
+    );
+  });
+
+  it("matches the reference walk at every size that crosses an offset", () => {
+    for (const size of [1, 1023, 1024, 1025, 4095, 4096, 20_000, 300_000]) {
+      const data = filled(size);
+      expect(koreaderPartialMd5(data)).toBe(referencePartialMd5(data));
+    }
+  });
+
+  it("only samples 1 KiB per offset, not the whole file", () => {
+    // Two 40 KiB files differing only outside every sample window hash the
+    // same. That is the point of a *partial* MD5 — and the reason a device can
+    // hash a large book in twelve reads.
+    const a = filled(40 * 1024);
+    const b = filled(40 * 1024);
+    b[3000] = (b[3000] ?? 0) ^ 255; // between the 1KiB and 4KiB windows
+    expect(koreaderPartialMd5(a)).toBe(koreaderPartialMd5(b));
+  });
+
+  it("notices a change inside a sample window", () => {
+    const a = filled(40 * 1024);
+    const b = filled(40 * 1024);
+    b[1030] = (b[1030] ?? 0) ^ 255; // inside the window at offset 1024
+    expect(koreaderPartialMd5(a)).not.toBe(koreaderPartialMd5(b));
+  });
+
+  it("hashes an empty file to the empty MD5", () => {
+    expect(koreaderPartialMd5(new Uint8Array())).toBe(
+      createHash("md5").digest("hex"),
+    );
+  });
+});
+
+describe("koreaderFilenameMd5", () => {
+  it("is a plain MD5 of the basename", () => {
+    expect(koreaderFilenameMd5("A-Great-Article.epub")).toBe(
+      createHash("md5").update("A-Great-Article.epub").digest("hex"),
+    );
+  });
+});

--- a/apps/standard-reader/src/server/kosync/document-hash.ts
+++ b/apps/standard-reader/src/server/kosync/document-hash.ts
@@ -1,0 +1,59 @@
+/**
+ * KOReader's document digests, computed server-side.
+ *
+ * KOReader has no field for "which article is this" — a device reports progress
+ * against a hash of the file it is holding. To connect that back to a document
+ * we have to be able to compute the same hash from the same bytes, which works
+ * only because book generation is deterministic (see `server/books/zip.ts`).
+ *
+ * Two hashes, because KOReader offers two matching methods:
+ *
+ *  - **binary** (its default): a *partial* MD5 — twelve 1 KiB samples at
+ *    exponentially spaced offsets, so a 40 MB book hashes in twelve reads.
+ *    {@link koreaderPartialMd5} reproduces that sampling exactly, including the
+ *    quirk that makes the first sample land at offset 0.
+ *  - **filename**: MD5 of the file's basename.
+ *
+ * Both are recorded per download, so a reader who switches methods on their
+ * device does not silently lose their place.
+ */
+
+import { createHash } from "node:crypto";
+
+/**
+ * Offsets KOReader samples, in order.
+ *
+ * From `util.partialMD5`: `for i = -1, 10 do file:seek("set", lshift(step, 2*i))`
+ * with `step = 1024`. The first iteration is the interesting one — LuaJIT masks
+ * shift counts to five bits, so `lshift(1024, -2)` is `lshift(1024, 30)`, which
+ * overflows 32 bits to **0**. So the first sample is the head of the file, not
+ * a quarter-kilobyte in, and any reimplementation that "fixes" the negative
+ * shift produces hashes no device will ever match.
+ */
+const SAMPLE_OFFSETS = ((): Array<number> => {
+  const offsets = [0];
+  for (let i = 0; i <= 10; i += 1) offsets.push(1024 * 4 ** i);
+  return offsets;
+})();
+
+const SAMPLE_SIZE = 1024;
+
+/** The digest KOReader computes for a file in `binary` matching mode. */
+export function koreaderPartialMd5(data: Uint8Array): string {
+  const hash = createHash("md5");
+  for (const offset of SAMPLE_OFFSETS) {
+    // Lua's `read` returns nil past EOF and the loop stops there — so a short
+    // file contributes only the samples that exist, and a seek beyond the end
+    // ends the walk rather than mixing in zero bytes.
+    if (offset >= data.length) break;
+    hash.update(
+      data.subarray(offset, Math.min(offset + SAMPLE_SIZE, data.length)),
+    );
+  }
+  return hash.digest("hex");
+}
+
+/** The digest KOReader computes for a file in `filename` matching mode. */
+export function koreaderFilenameMd5(filename: string): string {
+  return createHash("md5").update(filename).digest("hex");
+}

--- a/apps/standard-reader/src/server/kosync/http.ts
+++ b/apps/standard-reader/src/server/kosync/http.ts
@@ -1,0 +1,52 @@
+/**
+ * The HTTP shapes kosync clients expect.
+ *
+ * KOReader's sync plugin is unforgiving about the envelope: it reads
+ * `authorized`, `message`, `document` and `timestamp` out of a flat JSON body
+ * and treats anything else as a failure. These helpers keep every route
+ * speaking that dialect rather than the app's.
+ */
+
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+
+import { authenticateKosync } from "./credentials";
+import { didForKosyncUsername } from "./store";
+
+export function kosyncJson(
+  body: Record<string, unknown>,
+  status = 200,
+): Response {
+  return Response.json(body, {
+    headers: { "Cache-Control": "no-store" },
+    status,
+  });
+}
+
+/** KOReader shows `message` to the reader verbatim, so it is worth writing. */
+export function kosyncError(message: string, status: number): Response {
+  return kosyncJson({ code: status, message }, status);
+}
+
+/**
+ * The reader behind a request's credentials, or a ready-made 401.
+ *
+ * Returns a tuple rather than throwing so handlers stay flat — there is no
+ * error boundary in a route handler that would render a kosync-shaped body.
+ */
+export async function kosyncReader(
+  request: Request,
+): Promise<{ did: string } | { response: Response }> {
+  const did = await authenticateKosync(request, (username) =>
+    didForKosyncUsername(db, schema, username),
+  );
+  if (!did) {
+    return {
+      response: kosyncError(
+        "Unauthorized. Use your Standard Reader handle and the sync key from Settings.",
+        401,
+      ),
+    };
+  }
+  return { did };
+}

--- a/apps/standard-reader/src/server/kosync/http.ts
+++ b/apps/standard-reader/src/server/kosync/http.ts
@@ -11,7 +11,7 @@ import { db } from "#/db/index.server";
 import * as schema from "#/db/schema";
 
 import { authenticateKosync } from "./credentials";
-import { didForKosyncUsername } from "./store";
+import { kosyncReaderForUsername } from "./store";
 
 export function kosyncJson(
   body: Record<string, unknown>,
@@ -38,7 +38,7 @@ export async function kosyncReader(
   request: Request,
 ): Promise<{ did: string } | { response: Response }> {
   const did = await authenticateKosync(request, (username) =>
-    didForKosyncUsername(db, schema, username),
+    kosyncReaderForUsername(db, schema, username),
   );
   if (!did) {
     return {

--- a/apps/standard-reader/src/server/kosync/register.ts
+++ b/apps/standard-reader/src/server/kosync/register.ts
@@ -1,0 +1,32 @@
+/**
+ * Recording what a downloaded file will look like to KOReader.
+ *
+ * Called from the single-document download routes, where one file maps to one
+ * article. Anthologies deliberately do not register: a shelf of forty pieces is
+ * one file to a device, and there is no honest way to mirror "62% through the
+ * book" onto any single article. Positions in an anthology still sync between
+ * devices — they just do not reach back into the app's reading history.
+ */
+
+import { db } from "#/db/index.server";
+import * as schema from "#/db/schema";
+
+import { koreaderFilenameMd5, koreaderPartialMd5 } from "./document-hash";
+import { rememberBookHashes } from "./store";
+
+export async function rememberDownloadHashes(
+  documentUri: string,
+  bytes: Uint8Array,
+  filename: string,
+): Promise<void> {
+  try {
+    await rememberBookHashes(db, schema, documentUri, [
+      { hash: koreaderPartialMd5(bytes), method: "binary" },
+      { hash: koreaderFilenameMd5(filename), method: "filename" },
+    ]);
+  } catch {
+    // A download is the reader's file; a bookkeeping row that failed to write
+    // is not worth failing it over. The worst case is that progress from that
+    // device does not mirror into reading history until the next download.
+  }
+}

--- a/apps/standard-reader/src/server/kosync/store.ts
+++ b/apps/standard-reader/src/server/kosync/store.ts
@@ -6,6 +6,7 @@
 import { and, eq, sql } from "drizzle-orm";
 
 import type { Db, Schema } from "#/integrations/tanstack-query/api-shapes";
+import type { KosyncReader } from "#/server/kosync/credentials";
 
 export interface KosyncPosition {
   document: string;
@@ -16,22 +17,39 @@ export interface KosyncPosition {
   timestamp: number;
 }
 
-/** Resolve a username (handle or DID) to a DID. */
-export async function didForKosyncUsername(
+/**
+ * Resolve a kosync username (handle or DID) to the reader and the salt their
+ * key is derived from.
+ *
+ * The salt lookup is a second read rather than a join because the username may
+ * already be a DID, in which case there is no profile row to join through.
+ */
+export async function kosyncReaderForUsername(
   db: Db,
   schema: Schema,
   username: string,
-): Promise<string | null> {
+): Promise<KosyncReader | null> {
   const trimmed = username.trim();
-  if (trimmed.startsWith("did:")) return trimmed;
+  let did: string | null = trimmed.startsWith("did:") ? trimmed : null;
 
-  const handle = trimmed.replace(/^@/, "").toLowerCase();
-  const [row] = await db
-    .select({ did: schema.profiles.did })
-    .from(schema.profiles)
-    .where(eq(schema.profiles.handle, handle))
+  if (!did) {
+    const handle = trimmed.replace(/^@/, "").toLowerCase();
+    const [profile] = await db
+      .select({ did: schema.profiles.did })
+      .from(schema.profiles)
+      .where(eq(schema.profiles.handle, handle))
+      .limit(1);
+    did = profile?.did ?? null;
+  }
+  if (!did) return null;
+
+  const [account] = await db
+    .select({ salt: schema.user.kosyncKeySalt })
+    .from(schema.user)
+    .where(eq(schema.user.did, did))
     .limit(1);
-  return row?.did ?? null;
+
+  return { did, salt: account?.salt ?? null };
 }
 
 /** Record the digests a freshly generated book will have on a device. */

--- a/apps/standard-reader/src/server/kosync/store.ts
+++ b/apps/standard-reader/src/server/kosync/store.ts
@@ -1,0 +1,164 @@
+/**
+ * Reading and writing KOReader positions, and keeping the app's own
+ * `reading_progress` in step with them.
+ */
+
+import { and, eq, sql } from "drizzle-orm";
+
+import type { Db, Schema } from "#/integrations/tanstack-query/api-shapes";
+
+export interface KosyncPosition {
+  document: string;
+  progress: string;
+  percentage: number;
+  device: string | null;
+  device_id: string | null;
+  timestamp: number;
+}
+
+/** Resolve a username (handle or DID) to a DID. */
+export async function didForKosyncUsername(
+  db: Db,
+  schema: Schema,
+  username: string,
+): Promise<string | null> {
+  const trimmed = username.trim();
+  if (trimmed.startsWith("did:")) return trimmed;
+
+  const handle = trimmed.replace(/^@/, "").toLowerCase();
+  const [row] = await db
+    .select({ did: schema.profiles.did })
+    .from(schema.profiles)
+    .where(eq(schema.profiles.handle, handle))
+    .limit(1);
+  return row?.did ?? null;
+}
+
+/** Record the digests a freshly generated book will have on a device. */
+export async function rememberBookHashes(
+  db: Db,
+  schema: Schema,
+  documentUri: string,
+  hashes: Array<{ hash: string; method: "binary" | "filename" }>,
+): Promise<void> {
+  if (hashes.length === 0) return;
+  await db
+    .insert(schema.kosyncDocuments)
+    .values(
+      hashes.map((entry) => ({
+        documentUri,
+        hash: entry.hash,
+        method: entry.method,
+      })),
+    )
+    // The same book generated twice hashes the same, so a conflict is the
+    // normal case, not an error. A hash that somehow moved to another document
+    // takes the newer mapping.
+    .onConflictDoUpdate({
+      set: { documentUri },
+      target: schema.kosyncDocuments.hash,
+    });
+}
+
+/** The document a KOReader digest refers to, if we ever generated that file. */
+export async function documentUriForHash(
+  db: Db,
+  schema: Schema,
+  hash: string,
+): Promise<string | null> {
+  const [row] = await db
+    .select({ documentUri: schema.kosyncDocuments.documentUri })
+    .from(schema.kosyncDocuments)
+    .where(eq(schema.kosyncDocuments.hash, hash))
+    .limit(1);
+  return row?.documentUri ?? null;
+}
+
+export async function readPosition(
+  db: Db,
+  schema: Schema,
+  ownerDid: string,
+  documentHash: string,
+): Promise<KosyncPosition | null> {
+  const [row] = await db
+    .select()
+    .from(schema.kosyncProgress)
+    .where(
+      and(
+        eq(schema.kosyncProgress.ownerDid, ownerDid),
+        eq(schema.kosyncProgress.documentHash, documentHash),
+      ),
+    )
+    .limit(1);
+  if (!row) return null;
+
+  return {
+    device: row.device,
+    device_id: row.deviceId,
+    document: row.documentHash,
+    percentage: row.percentage,
+    progress: row.progress,
+    timestamp: Math.floor(row.updatedAt.getTime() / 1000),
+  };
+}
+
+/**
+ * Store a device's position, and mirror the part the app understands.
+ *
+ * `progress` is opaque (a CRE xpointer, or a page number) and only KOReader can
+ * act on it, so it is stored verbatim for other devices to pick up. The
+ * percentage is the crossover: written into `reading_progress`, it is what makes
+ * an article read half-way on a Kobo show up half-read in the app.
+ */
+export async function writePosition(
+  db: Db,
+  schema: Schema,
+  ownerDid: string,
+  position: {
+    document: string;
+    progress: string;
+    percentage: number;
+    device?: string | null;
+    deviceId?: string | null;
+  },
+): Promise<void> {
+  const percentage = Math.min(Math.max(position.percentage, 0), 1);
+
+  await db
+    .insert(schema.kosyncProgress)
+    .values({
+      device: position.device ?? null,
+      deviceId: position.deviceId ?? null,
+      documentHash: position.document,
+      ownerDid,
+      percentage,
+      progress: position.progress,
+    })
+    .onConflictDoUpdate({
+      set: {
+        device: position.device ?? null,
+        deviceId: position.deviceId ?? null,
+        percentage,
+        progress: position.progress,
+        updatedAt: sql`now()`,
+      },
+      target: [
+        schema.kosyncProgress.ownerDid,
+        schema.kosyncProgress.documentHash,
+      ],
+    });
+
+  const documentUri = await documentUriForHash(db, schema, position.document);
+  if (!documentUri) return;
+
+  await db
+    .insert(schema.readingProgress)
+    .values({ documentUri, ownerDid, progress: percentage })
+    .onConflictDoUpdate({
+      set: { progress: percentage, updatedAt: sql`now()` },
+      target: [
+        schema.readingProgress.ownerDid,
+        schema.readingProgress.documentUri,
+      ],
+    });
+}

--- a/apps/standard-reader/src/server/opds/catalog.ts
+++ b/apps/standard-reader/src/server/opds/catalog.ts
@@ -1,0 +1,432 @@
+/**
+ * The catalog itself: read-model queries in, {@link OpdsFeed}s out.
+ *
+ * Every feed here is built from the same queries the web app's pages use, so
+ * the catalog cannot drift from the site — a publication that is hidden from
+ * discovery is hidden here, a blocked account is filtered here, and a shelf
+ * shows what the reader's own page shows.
+ */
+
+import type {
+  ArticleCard,
+  PublicationCard,
+} from "#/integrations/tanstack-query/api-shapes";
+import type {
+  OpdsFeed,
+  OpdsLink,
+  OpdsNavigationEntry,
+  OpdsPagination,
+} from "#/lib/opds/model";
+import { feedTypeFor, OPDS_REL, OPENSEARCH_TYPE } from "#/lib/opds/model";
+import {
+  opdsCollectionsUrl,
+  opdsComicsUrl,
+  opdsLatestUrl,
+  opdsListUrl,
+  opdsOpenSearchUrl,
+  opdsPublicationsUrl,
+  opdsRootUrl,
+  opdsShelfUrl,
+  opdsTagsUrl,
+  opdsTagUrl,
+  opdsTrendingUrl,
+} from "#/lib/opds/urls";
+import { SITE_DESCRIPTION, SITE_NAME } from "#/lib/site-metadata";
+
+import { articleEntry, publicationNavEntry } from "./entries";
+
+/** Entries per page. Generous — catalog rows are cheap and paging is clumsy. */
+export const OPDS_PAGE_SIZE = 40;
+
+/** The epoch a feed reports when it has nothing dated in it. */
+const EMPTY_UPDATED = new Date(0).toISOString();
+
+/** Newest timestamp across a set of rows — the feed's `updated`. */
+export function newestUpdated(dates: Array<string | null | undefined>): string {
+  let newest = 0;
+  for (const value of dates) {
+    if (!value) continue;
+    const time = Date.parse(value);
+    if (!Number.isNaN(time) && time > newest) newest = time;
+  }
+  return newest === 0 ? EMPTY_UPDATED : new Date(newest).toISOString();
+}
+
+/** `?page=` as a 1-based page number; anything unparseable is page 1. */
+export function pageFromRequest(request: Request): number {
+  const raw = new URL(request.url).searchParams.get("page");
+  const page = Number.parseInt(raw ?? "1", 10);
+  return Number.isFinite(page) && page > 1 ? page : 1;
+}
+
+function withPage(href: string, page: number): string {
+  const url = new URL(href);
+  if (page > 1) url.searchParams.set("page", String(page));
+  else url.searchParams.delete("page");
+  return url.toString();
+}
+
+/**
+ * `start` (and `up`) on every feed, so a client that landed deep — from a saved
+ * bookmark, or a shelf URL pasted straight into a device — can still find its
+ * way to the rest of the catalog.
+ */
+function baseLinks(baseUrl: string, upHref?: string): Array<OpdsLink> {
+  const links: Array<OpdsLink> = [
+    {
+      href: opdsRootUrl(baseUrl),
+      rel: "start",
+      title: SITE_NAME,
+      type: feedTypeFor("navigation"),
+    },
+    {
+      href: opdsOpenSearchUrl(baseUrl),
+      rel: "search",
+      title: `Search ${SITE_NAME}`,
+      type: OPENSEARCH_TYPE,
+    },
+  ];
+  if (upHref) {
+    links.push({
+      href: upHref,
+      rel: "up",
+      type: feedTypeFor("navigation"),
+    });
+  }
+  return links;
+}
+
+/** `next`/`previous` links plus the OpenSearch counts, for a paged feed. */
+function pageLinks(
+  selfHref: string,
+  page: number,
+  kind: "acquisition" | "navigation",
+  {
+    itemCount,
+    totalResults,
+  }: { itemCount: number; totalResults?: number | null },
+): { links: Array<OpdsLink>; pagination: OpdsPagination | undefined } {
+  const links: Array<OpdsLink> = [];
+  const startIndex = (page - 1) * OPDS_PAGE_SIZE;
+
+  // A full page means there is probably more; a short page means there is not.
+  // Where a real total is known it decides instead.
+  const hasMore =
+    typeof totalResults === "number"
+      ? startIndex + itemCount < totalResults
+      : itemCount === OPDS_PAGE_SIZE;
+
+  if (hasMore) {
+    links.push({
+      href: withPage(selfHref, page + 1),
+      rel: "next",
+      type: feedTypeFor(kind),
+    });
+  }
+  if (page > 1) {
+    links.push({
+      href: withPage(selfHref, page - 1),
+      rel: "previous",
+      type: feedTypeFor(kind),
+    });
+  }
+
+  return {
+    links,
+    pagination:
+      typeof totalResults === "number"
+        ? { itemsPerPage: OPDS_PAGE_SIZE, startIndex, totalResults }
+        : undefined,
+  };
+}
+
+export interface ArticleFeedOptions {
+  id: string;
+  title: string;
+  selfHref: string;
+  baseUrl: string;
+  page: number;
+  subtitle?: string | null;
+  iconUrl?: string | null;
+  upHref?: string;
+  totalResults?: number | null;
+  /** Extra links (facets, a whole-shelf download) merged in after the standard set. */
+  extraLinks?: Array<OpdsLink>;
+}
+
+/** A feed of articles — the shape every acquisition feed in the catalog takes. */
+export function articleFeed(
+  cards: Array<ArticleCard>,
+  options: ArticleFeedOptions,
+): OpdsFeed {
+  const { links: paging, pagination } = pageLinks(
+    options.selfHref,
+    options.page,
+    "acquisition",
+    { itemCount: cards.length, totalResults: options.totalResults },
+  );
+
+  return {
+    iconUrl: options.iconUrl,
+    id: options.id,
+    kind: "acquisition",
+    links: [
+      ...baseLinks(options.baseUrl, options.upHref),
+      ...paging,
+      ...(options.extraLinks ?? []),
+    ],
+    pagination,
+    publications: cards.map((card) => articleEntry(card, options.baseUrl)),
+    selfHref: withPage(options.selfHref, options.page),
+    subtitle: options.subtitle,
+    title: options.title,
+    updated: newestUpdated(cards.map((card) => card.publishedAt)),
+  };
+}
+
+export interface NavigationFeedOptions {
+  id: string;
+  title: string;
+  selfHref: string;
+  baseUrl: string;
+  subtitle?: string | null;
+  upHref?: string;
+  page?: number;
+  totalResults?: number | null;
+  extraLinks?: Array<OpdsLink>;
+}
+
+/** A feed of places to go. */
+export function navigationFeed(
+  entries: Array<OpdsNavigationEntry>,
+  options: NavigationFeedOptions,
+): OpdsFeed {
+  const page = options.page ?? 1;
+  const { links: paging, pagination } = pageLinks(
+    options.selfHref,
+    page,
+    "navigation",
+    { itemCount: entries.length, totalResults: options.totalResults },
+  );
+
+  return {
+    id: options.id,
+    kind: "navigation",
+    links: [
+      ...baseLinks(options.baseUrl, options.upHref),
+      ...paging,
+      ...(options.extraLinks ?? []),
+    ],
+    navigation: entries,
+    pagination,
+    selfHref: withPage(options.selfHref, page),
+    subtitle: options.subtitle,
+    title: options.title,
+    updated: newestUpdated(entries.map((entry) => entry.updated)),
+  };
+}
+
+/**
+ * The catalog root.
+ *
+ * Deliberately public and reader-agnostic: this is the URL that gets shared,
+ * printed in docs, and pasted into a device by someone who is not signed in.
+ * A reader's own shelves hang off {@link shelfNavigation} instead, at a URL
+ * that carries their DID.
+ */
+export function rootFeed(baseUrl: string): OpdsFeed {
+  const updated = new Date(0).toISOString();
+  const nav = (
+    title: string,
+    href: string,
+    summary: string,
+    kind: "acquisition" | "navigation",
+  ): OpdsNavigationEntry => ({ href, id: href, kind, summary, title, updated });
+
+  return {
+    id: opdsRootUrl(baseUrl),
+    kind: "navigation",
+    links: baseLinks(baseUrl),
+    navigation: [
+      nav(
+        "Latest",
+        opdsLatestUrl(baseUrl),
+        "The newest articles from across the network.",
+        "acquisition",
+      ),
+      nav(
+        "Trending",
+        opdsTrendingUrl(baseUrl),
+        "What the network is reading and recommending right now.",
+        "acquisition",
+      ),
+      nav(
+        "Publications",
+        opdsPublicationsUrl(baseUrl),
+        "Every publication on the network, newest first.",
+        "navigation",
+      ),
+      nav(
+        "Comics",
+        opdsComicsUrl(baseUrl),
+        "Comics on the network, packaged as CBZ.",
+        "navigation",
+      ),
+      nav("Topics", opdsTagsUrl(baseUrl), "Browse by subject.", "navigation"),
+      nav(
+        "Collections",
+        opdsCollectionsUrl(baseUrl),
+        "Curated anthologies assembled by readers.",
+        "navigation",
+      ),
+    ],
+    selfHref: opdsRootUrl(baseUrl),
+    subtitle: SITE_DESCRIPTION,
+    title: SITE_NAME,
+    // The root has no content of its own; leaving `updated` at the epoch is
+    // honest and keeps the document byte-stable for conditional requests.
+    updated,
+  };
+}
+
+/**
+ * A reader's own catalog: their shelves first, then the public sections.
+ *
+ * This is the URL a reader actually pastes into KOReader, so it has to be the
+ * whole catalog rather than a side branch — hence the public sections repeated
+ * underneath.
+ */
+export function shelfNavigation({
+  baseUrl,
+  did,
+  readerName,
+  lists,
+  trackReadingHistory,
+}: {
+  baseUrl: string;
+  did: string;
+  readerName: string;
+  lists: Array<{ name: string; rkey: string; description: string | null }>;
+  trackReadingHistory: boolean;
+}): OpdsFeed {
+  const self = opdsShelfUrl(baseUrl, did);
+  const updated = new Date(0).toISOString();
+  const shelf = (
+    title: string,
+    path: string,
+    summary: string,
+  ): OpdsNavigationEntry => ({
+    href: `${self}/${path}`,
+    id: `${self}/${path}`,
+    kind: "acquisition",
+    rel: OPDS_REL.shelf,
+    summary,
+    title,
+    updated,
+  });
+
+  const entries: Array<OpdsNavigationEntry> = [];
+  // Reading history off means every article is "unread"; an unread shelf would
+  // be the whole subscription archive, which is not what the reader asked for.
+  if (trackReadingHistory) {
+    entries.push(shelf("Unread", "unread", "Articles you have not read yet."));
+  }
+  entries.push(
+    shelf("Saved for later", "saved", "Everything you saved to read later."),
+    shelf(
+      "Subscriptions",
+      "subscriptions",
+      "The newest articles from the publications you subscribe to.",
+    ),
+  );
+
+  entries.push({
+    href: `${self}/publications`,
+    id: `${self}/publications`,
+    kind: "navigation",
+    rel: OPDS_REL.shelf,
+    summary: "Browse each publication you subscribe to on its own.",
+    title: "Your publications",
+    updated,
+  });
+
+  for (const list of lists) {
+    entries.push({
+      href: opdsListUrl(baseUrl, did, list.rkey),
+      id: `at://${did}/app.standard-reader.list/${list.rkey}`,
+      kind: "acquisition",
+      rel: OPDS_REL.shelf,
+      summary: list.description,
+      title: list.name,
+      updated,
+    });
+  }
+
+  // The public catalog, repeated so this one URL is a complete catalog.
+  entries.push(
+    {
+      href: opdsLatestUrl(baseUrl),
+      id: opdsLatestUrl(baseUrl),
+      kind: "acquisition",
+      summary: "The newest articles from across the network.",
+      title: "Latest across the network",
+      updated,
+    },
+    {
+      href: opdsPublicationsUrl(baseUrl),
+      id: opdsPublicationsUrl(baseUrl),
+      kind: "navigation",
+      summary: "Every publication on the network.",
+      title: "All publications",
+      updated,
+    },
+    {
+      href: opdsTagsUrl(baseUrl),
+      id: opdsTagsUrl(baseUrl),
+      kind: "navigation",
+      summary: "Browse by subject.",
+      title: "Topics",
+      updated,
+    },
+  );
+
+  return {
+    id: self,
+    kind: "navigation",
+    links: baseLinks(baseUrl),
+    navigation: entries,
+    selfHref: self,
+    subtitle: `Shelves for ${readerName}, plus everything on ${SITE_NAME}.`,
+    title: `${readerName} · ${SITE_NAME}`,
+    updated,
+  };
+}
+
+/** Publications as navigation entries, for any list of them. */
+export function publicationEntries(
+  publications: Array<PublicationCard>,
+  baseUrl: string,
+): Array<OpdsNavigationEntry> {
+  return publications.map((publication) =>
+    publicationNavEntry(
+      publication,
+      baseUrl,
+      publication.lastDocumentAt ?? EMPTY_UPDATED,
+    ),
+  );
+}
+
+/** Topic chips as navigation entries into per-tag acquisition feeds. */
+export function topicEntries(
+  topics: Array<{ topic: string; count: number }>,
+  baseUrl: string,
+): Array<OpdsNavigationEntry> {
+  return topics.map((topic) => ({
+    href: opdsTagUrl(baseUrl, topic.topic),
+    id: opdsTagUrl(baseUrl, topic.topic),
+    kind: "acquisition",
+    summary: `${topic.count} ${topic.count === 1 ? "publication" : "publications"}`,
+    title: topic.topic,
+    updated: EMPTY_UPDATED,
+  }));
+}

--- a/apps/standard-reader/src/server/opds/catalog.ts
+++ b/apps/standard-reader/src/server/opds/catalog.ts
@@ -373,6 +373,14 @@ export function shelfNavigation({
       updated,
     },
     {
+      href: opdsTrendingUrl(baseUrl),
+      id: opdsTrendingUrl(baseUrl),
+      kind: "acquisition",
+      summary: "What the network is reading and recommending right now.",
+      title: "Trending",
+      updated,
+    },
+    {
       href: opdsPublicationsUrl(baseUrl),
       id: opdsPublicationsUrl(baseUrl),
       kind: "navigation",

--- a/apps/standard-reader/src/server/opds/comics.ts
+++ b/apps/standard-reader/src/server/opds/comics.ts
@@ -1,0 +1,101 @@
+/**
+ * Comics in the catalog.
+ *
+ * A comic publication cannot use the ordinary article feed: its documents are
+ * single pages, so that feed offers a comic app fifty one-page "comics" in
+ * place of one series. These entries are built from the shelf instead
+ * (`selectComicShelf`), which is where the app already decides what one comic
+ * unit is — see `server/books/comic-issue.ts`.
+ */
+
+import type { PublicationCard } from "#/integrations/tanstack-query/api-shapes";
+import type { OpdsPublicationEntry } from "#/lib/opds/model";
+import { CBZ_TYPE } from "#/lib/opds/model";
+import { comicIssueCbzUrl, publicationCbzUrl } from "#/lib/opds/urls";
+import type { ComicShelf } from "#/server/reader/comic";
+
+function rkeyOf(uri: string): string {
+  return uri.split("/").pop() ?? "";
+}
+
+/**
+ * A comic publication's shelf as OPDS entries.
+ *
+ * In `issues` mode each entry is an issue and carries its own CBZ. In `pages`
+ * mode the titles gave nothing to group by, so a per-entry file would be one
+ * page — there the whole run is offered as a single entry instead.
+ *
+ * Only CBZ is offered, and only one link per entry: a comic app shows a button
+ * for every acquisition link it understands, and a second format is a second
+ * button that downloads the same pages in a shape the app is worse at.
+ */
+export function comicShelfEntries(
+  shelf: ComicShelf,
+  publication: PublicationCard,
+  baseUrl: string,
+): Array<OpdsPublicationEntry> {
+  const publicationRkey = rkeyOf(publication.uri);
+  const byline = publication.ownerHandle
+    ? [
+        {
+          name: publication.ownerHandle,
+          uri: `${baseUrl}/u/${encodeURIComponent(publication.did)}`,
+        },
+      ]
+    : [];
+
+  if (shelf.mode === "pages") {
+    const cover =
+      shelf.issues[0]?.coverImageUrl ??
+      publication.iconUrl ??
+      publication.ownerAvatarUrl;
+    return [
+      {
+        acquisitions: [
+          {
+            href: publicationCbzUrl(baseUrl, publication.did, publicationRkey),
+            title: "CBZ",
+            type: CBZ_TYPE,
+          },
+        ],
+        authors: byline,
+        coverImageUrl: cover,
+        id: `${publication.uri}#run`,
+        published: shelf.issues.at(-1)?.publishedAt,
+        publisher: publication.name,
+        summary:
+          publication.description ??
+          `The complete run — ${shelf.totalPages} ${shelf.totalPages === 1 ? "page" : "pages"}.`,
+        thumbnailUrl: cover,
+        title: publication.name,
+        updated: shelf.issues[0]?.publishedAt ?? new Date(0).toISOString(),
+      },
+    ];
+  }
+
+  return shelf.issues.map((issue) => {
+    // "Fray In The Veil #3" — on a device the file leaves the publication page
+    // behind, so the series name has to travel with it. The shelf can say "#3"
+    // because it is already inside the comic.
+    const title = `${publication.name} ${issue.label}`;
+    return {
+      acquisitions: [
+        {
+          href: comicIssueCbzUrl(baseUrl, issue.did, issue.rkey),
+          title: "CBZ",
+          type: CBZ_TYPE,
+        },
+      ],
+      authors: byline,
+      coverImageUrl: issue.coverImageUrl,
+      id: issue.uri,
+      published: issue.publishedAt,
+      publisher: publication.name,
+      summary: `${issue.pageCount} ${issue.pageCount === 1 ? "page" : "pages"}`,
+      thumbnailUrl: issue.coverImageUrl,
+      title,
+      updated: issue.publishedAt,
+      webUrl: `${baseUrl}/comic/${encodeURIComponent(issue.did)}/${encodeURIComponent(issue.rkey)}`,
+    };
+  });
+}

--- a/apps/standard-reader/src/server/opds/entries.ts
+++ b/apps/standard-reader/src/server/opds/entries.ts
@@ -1,0 +1,136 @@
+/**
+ * Read-model rows as OPDS entries.
+ *
+ * One rule shapes all of this: **an acquisition link is a promise**. A catalog
+ * client shows a download button for every acquisition link it sees, and a
+ * button that 404s is worse than no button. So an article only gets an EPUB
+ * link when it has a body worth packaging (`hasRenderableBody`). Everything else
+ * still appears — with an `alternate` link out to the web.
+ *
+ * Comics do not come through here at all: their documents are pages rather than
+ * issues, so they are built from the shelf instead (`server/opds/comics.ts`).
+ */
+
+import type {
+  ArticleCard,
+  PublicationCard,
+} from "#/integrations/tanstack-query/api-shapes";
+import type {
+  OpdsAcquisition,
+  OpdsNavigationEntry,
+  OpdsPublicationEntry,
+} from "#/lib/opds/model";
+import { EPUB_TYPE } from "#/lib/opds/model";
+import {
+  articleEpubUrl,
+  opdsPublicationUrl,
+  publicationEpubUrl,
+} from "#/lib/opds/urls";
+import { cardByline, cardSourceUrl } from "#/server/books/sources";
+
+/** `at://did/collection/rkey` → `rkey`, for building download URLs. */
+function rkeyOf(uri: string): string | null {
+  const rkey = uri.split("/").pop();
+  return rkey || null;
+}
+
+export function articleEntry(
+  card: ArticleCard,
+  baseUrl: string,
+): OpdsPublicationEntry {
+  const rkey = rkeyOf(card.uri);
+  const acquisitions: Array<OpdsAcquisition> = [];
+
+  if (rkey && card.hasRenderableBody) {
+    acquisitions.push({
+      href: articleEpubUrl(baseUrl, card.did, rkey),
+      title: "EPUB",
+      type: EPUB_TYPE,
+    });
+  }
+
+  const byline = cardByline(card);
+  return {
+    acquisitions,
+    authors: byline
+      ? [
+          {
+            name: byline,
+            uri: `${baseUrl}/u/${encodeURIComponent(card.publicationOwnerDid ?? card.did)}`,
+          },
+        ]
+      : [],
+    categories: card.tags ?? [],
+    coverImageUrl: card.coverImageUrl,
+    id: card.uri,
+    published: card.publishedAt,
+    publisher: card.publicationName,
+    summary: card.description,
+    thumbnailUrl: card.coverImageUrl,
+    title: card.title,
+    updated: card.publishedAt,
+    webUrl: cardSourceUrl(card, baseUrl),
+  };
+}
+
+/**
+ * A publication as a navigation entry — a shelf to open, not a file to take.
+ *
+ * The whole-publication EPUB lives on the publication's own feed rather than
+ * here: navigation entries carry one link, and "browse the issues" is the more
+ * useful of the two.
+ */
+export function publicationNavEntry(
+  publication: PublicationCard,
+  baseUrl: string,
+  updated: string,
+): OpdsNavigationEntry {
+  const rkey = rkeyOf(publication.uri) ?? "";
+  const icon = publication.iconUrl ?? publication.ownerAvatarUrl;
+  return {
+    href: opdsPublicationUrl(baseUrl, publication.did, rkey),
+    id: publication.uri,
+    imageUrl: icon,
+    kind: "acquisition",
+    summary: publication.description,
+    thumbnailUrl: icon,
+    title: publication.name,
+    updated,
+  };
+}
+
+/** The "download the whole publication" entry, at the head of its own feed. */
+export function publicationBookEntry(
+  publication: PublicationCard,
+  baseUrl: string,
+  { articleCount, updated }: { articleCount: number; updated: string },
+): OpdsPublicationEntry {
+  const rkey = rkeyOf(publication.uri) ?? "";
+  const icon = publication.iconUrl ?? publication.ownerAvatarUrl;
+  return {
+    acquisitions: [
+      {
+        href: publicationEpubUrl(baseUrl, publication.did, rkey),
+        title: "EPUB",
+        type: EPUB_TYPE,
+      },
+    ],
+    authors: publication.ownerHandle
+      ? [
+          {
+            name: publication.ownerHandle,
+            uri: `${baseUrl}/u/${encodeURIComponent(publication.did)}`,
+          },
+        ]
+      : [],
+    coverImageUrl: icon,
+    id: `${publication.uri}#book`,
+    publisher: publication.name,
+    summary:
+      publication.description ??
+      `The ${articleCount} most recent articles from ${publication.name}, as one book.`,
+    thumbnailUrl: icon,
+    title: `${publication.name} — recent articles`,
+    updated,
+  };
+}

--- a/apps/standard-reader/src/server/reader/queries.ts
+++ b/apps/standard-reader/src/server/reader/queries.ts
@@ -146,6 +146,16 @@ export interface ArticleCardQuery {
   /** Match documents whose `tags` array includes this label (case-insensitive). */
   tag?: string;
   /**
+   * Only documents with a body the app can render (`has_renderable_body`).
+   *
+   * For the OPDS catalog and the EPUB/CBZ downloads, where an entry the reader
+   * cannot take offline is dead weight: catalog clients show a download button
+   * for every entry, and a bridged link post has nothing to put behind it. Off
+   * everywhere else — a feed row for an external post is useful, it just links
+   * out.
+   */
+  renderableOnly?: boolean;
+  /**
    * Followed-user DIDs. When present (even alongside `publicationUris`), the
    * query switches to "follow-feed union" mode: it returns documents authored
    * by these users OR recommended by them OR belonging to `publicationUris`,
@@ -471,6 +481,8 @@ async function selectFollowFeedCandidateUris(
     featuredOnly?: boolean;
     unreadForDid?: string;
     countOldPostsAsUnread?: boolean;
+    /** See {@link ArticleCardQuery.renderableOnly}. */
+    renderableOnly?: boolean;
     /** See {@link ArticleCardQuery.viewerDid}. */
     viewerDid?: string;
     /** See {@link ArticleCardQuery.muterDid}. */
@@ -499,6 +511,8 @@ export function buildFollowFeedCandidateSql(
     featuredOnly?: boolean;
     unreadForDid?: string;
     countOldPostsAsUnread?: boolean;
+    /** See {@link ArticleCardQuery.renderableOnly}. */
+    renderableOnly?: boolean;
     /** See {@link ArticleCardQuery.viewerDid}. */
     viewerDid?: string;
     /** See {@link ArticleCardQuery.muterDid}. */
@@ -528,6 +542,7 @@ export function buildFollowFeedCandidateSql(
     documentPublishedNotInFuture(d),
   ];
   if (opts.featuredOnly) base.push(eq(d.featured, true));
+  if (opts.renderableOnly) base.push(eq(d.hasRenderableBody, true));
   if (opts.unreadForDid)
     base.push(documentNotReadWhere(schema, opts.unreadForDid));
   // Applied to every union branch, not just the direct one: a followed
@@ -787,6 +802,7 @@ export async function selectArticleCards(
       featuredOnly: opts.featuredOnly,
       unreadForDid: opts.unreadForDid,
       countOldPostsAsUnread: opts.countOldPostsAsUnread,
+      renderableOnly: opts.renderableOnly,
       viewerDid: opts.viewerDid,
       muterDid: opts.muterDid,
       limit: opts.limit,
@@ -804,7 +820,18 @@ export async function selectArticleCards(
   // Tag feed with the mirrors hidden: resolve the page's URIs through the
   // tag-first query below, which is the only shape that survives a tag whose
   // matches are almost all `*.web.brid.gy`. See `selectTagArticleUris`.
-  if (opts.tag && opts.excludeWebBridge && !opts.unreadForDid) {
+  //
+  // `renderableOnly` opts out of this shape rather than being threaded through
+  // it: that predicate already removes almost every mirror (they are exactly
+  // the documents with no renderable body), so the two would be doing the same
+  // work twice — and silently dropping the option here would hand a catalog
+  // client entries it cannot download.
+  if (
+    opts.tag &&
+    opts.excludeWebBridge &&
+    !opts.unreadForDid &&
+    !opts.renderableOnly
+  ) {
     const pageUris = await selectTagArticleUris(db, schema, {
       tag: opts.tag,
       sort: opts.sort,
@@ -843,6 +870,9 @@ export async function selectArticleCards(
   }
   if (opts.tag) {
     conds.push(documentCarriesTagWhere(d, opts.tag));
+  }
+  if (opts.renderableOnly) {
+    conds.push(eq(d.hasRenderableBody, true));
   }
   if (opts.viewerDid) {
     conds.push(
@@ -984,6 +1014,8 @@ export async function selectPublicationArticleCards(
      * computed against one ordering.
      */
     order?: "newest" | "oldest";
+    /** See {@link ArticleCardQuery.renderableOnly}. */
+    renderableOnly?: boolean;
     /** See {@link ArticleCardQuery.viewerDid}. */
     viewerDid?: string;
   },
@@ -1032,6 +1064,7 @@ export async function selectPublicationArticleCards(
         eq(d.deleted, false),
         documentPublishedNotInFuture(d),
         eq(d.publicationUri, opts.publicationUri),
+        ...(opts.renderableOnly ? [eq(d.hasRenderableBody, true)] : []),
         publicationFilterWhere(schema, opts.filter, opts.readerDid, {
           countOldPostsAsUnread: opts.countOldPostsAsUnread,
         }),


### PR DESCRIPTION
Standard Reader becomes a library an e-reading app can browse. Prompted by [chris.pardy.family](https://bsky.app/profile/chris.pardy.family/post/3mth3xnismk2t), who built the same thing for cavu.page.

## What's in it

**OPDS catalog** — one neutral feed model, two serializers. OPDS 1.2 Atom by default (KOReader, Foliate, Marvin, Panels), OPDS 2.0 JSON on `?format=json` or an `application/opds+json` `Accept`, and the format is sticky as a client walks deeper. Public sections at `/opds`: Latest, Trending, Publications (sort facets), Comics, Topics, Collections, OpenSearch. A reader's own shelves at `/opds/u/:did` — unread, saved, subscriptions, their publications, each list — keyed by DID with no token, exactly like the personalised RSS feeds, carrying the same block filtering.

**Books** — EPUB 3.2, with the EPUB 2 NCX and cover fallbacks shipping devices still read, for an article, a publication, a collection, a list, a tag, or a shelf. CBZ with a `ComicInfo.xml` sidecar for comics. Bodies render server-side through `@standard-reader/renderer-react`, so **every** block vocabulary the app can display a book can carry — not just the formats with a markdown/HTML path, which is all the RSS feeds manage. Verified against real records in all seven content formats on the network.

**KOReader sync** — the kosync protocol at `/kosync`, authenticated with a derived key (`HMAC(KOSYNC_SECRET, did + salt)`), so there's no credential stored anywhere. A reader can rotate their own key from Settings: writing a fresh salt *is* the rotation, and the old key stops authenticating the moment it lands. KOReader identifies a book by a hash of the *file*, so every single-document download records the digests that file will have; that's what lets a position reported by a device resolve back to an AT-URI.

Generation is deterministic — nothing reads the clock — which is what makes `ETag`s stable across replicas and those hashes precomputable before we've ever served that exact file.

## Three decisions worth a look

**Only what can be downloaded appears in the catalog.** `renderableOnly` keeps documents with no packageable body out. A catalog client renders a download button for every entry it sees, and a bridged link post has nothing to put behind one — without this the `design` tag serves 40 entries and zero downloads.

**Comics are packaged by issue, not by document.** A comic publication posts *one page per document* (`FITV #1, Cover`, `FITV #1, Pg. 1`, …), so the obvious implementation offers a comic app fifty one-page "comics". These build from `selectComicShelf` instead — the same grouping the app's own shelf and reader already use — so one file is one issue, or the whole run when the titles carry no issue numbers. Comics get their own catalog section too.

Before / after on a real 54-page comic:

| | entries | first file |
|---|---|---|
| document-based | 54 | 1 page |
| shelf-based | 2 issues | 30 pages + `ComicInfo.xml` |

**Position sync is one-way into the app.** A device's percentage lands in `reading_progress`, so an article read half-way on a Kobo shows half-read here. The app never sends a position *out*: KOReader's `progress` is an xpointer into that device's own rendering, and synthesising one from a fraction would jump the reader somewhere nobody chose.

## In the app

`Download EPUB` / `Download CBZ` in an article's share menu, `Send to e-reader…` on a publication, a CBZ control in the comic theater, a Settings → E-readers section (catalog URL, sync server, username, key), and reader docs at [`/guide/e-readers`](/guide/e-readers).

## Before deploy

- [ ] Run migrations **0042** (`kosync_documents`, `kosync_progress`) and **0043** (`user.kosync_key_salt`). They have only been applied to the `opds` Neon branch — rebase before applying anywhere else.
- [ ] Set **`KOSYNC_SECRET`** on the Railway `web` service. It has a dev fallback; production refuses to start the sync routes without it.

## Testing

`pnpm lint`, `format:check` and `tsc --noEmit` are clean; 1078 tests pass, 54 of them new (deterministic ZIP structure, EPUB packaging and XHTML well-formedness, KOReader's partial-MD5 walk against an independent transcription of the Lua, both OPDS serializers, content negotiation).

Verified end to end against real data on the `opds` branch: every catalog route, EPUB generation for all seven content formats, comic issue packaging, and the full kosync walk — auth → download → PUT position → GET → mirrored into `reading_progress` — with the device-side partial MD5 computed independently and matching.

## Known gaps

- Five anthology downloads (collection, list, saved, unread, tag) are reachable only through the catalog; no web UI button yet.
- An anthology's position syncs between devices but can't mirror onto a single article — one file, forty pieces.
- Every download re-renders and re-fetches images. The `ETag` saves the transfer, not the work; the determinism is already there for an object-store cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
