### PR TITLE
Stop percent-encoding the colon in catalog URLs

### DIFF
--- a/apps/standard-reader/src/lib/opds/did-param.test.ts
+++ b/apps/standard-reader/src/lib/opds/did-param.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { didFromParam } from "#/lib/opds/did-param";
+import { opdsShelfUrl, opdsPublicationUrl } from "#/lib/opds/urls";
+
+const DID = "did:plc:wt6bh5dtjdps7umi7yhidooi";
+
+describe("didFromParam", () => {
+  it("passes through the DID the router already decoded", () => {
+    expect(didFromParam(DID)).toBe(DID);
+  });
+
+  it("recovers a DID a client re-encoded on its way back to us", () => {
+    // Panels stores a catalog as host + path and rebuilds the URL, which turns
+    // a `%3A` into `%253A`. After the router's single decode we see this.
+    expect(didFromParam("did%3Aplc%3Awt6bh5dtjdps7umi7yhidooi")).toBe(DID);
+  });
+
+  it("rejects anything that is not a DID", () => {
+    expect(didFromParam("not-a-did")).toBeNull();
+    expect(didFromParam("")).toBeNull();
+    expect(didFromParam("https%3A%2F%2Fexample.com")).toBeNull();
+  });
+
+  it("rejects a malformed escape rather than throwing", () => {
+    expect(didFromParam("%E0%A4%A")).toBeNull();
+  });
+
+  it("decodes at most one extra time", () => {
+    // Triple-encoded is not a real client behaviour, and looping until a string
+    // stops changing is how a parameter gets decoded onto something it should
+    // not reach.
+    expect(didFromParam("did%253Aplc%253Aabc")).toBeNull();
+  });
+});
+
+describe("catalog URLs", () => {
+  it("leaves the colon in a DID unencoded", () => {
+    // RFC 3986 allows `:` in a path segment, and a URL with no `%` in it is one
+    // a third-party client cannot mangle by re-encoding.
+    const url = opdsShelfUrl("https://standard-reader.app", DID);
+    expect(url).toBe(`https://standard-reader.app/opds/u/${DID}`);
+    expect(url).not.toContain("%3A");
+  });
+
+  it("still encodes anything a segment cannot carry literally", () => {
+    const url = opdsPublicationUrl("https://standard-reader.app", DID, "a/b c");
+    expect(url).toContain("a%2Fb%20c");
+  });
+});

--- a/apps/standard-reader/src/lib/opds/did-param.ts
+++ b/apps/standard-reader/src/lib/opds/did-param.ts
@@ -1,0 +1,32 @@
+/**
+ * Reading a DID out of a path parameter, whatever a client did to it on the way.
+ *
+ * The router decodes a path segment once, so `did%3Aplc%3Aabc` arrives as
+ * `did:plc:abc` and a plain `did:plc:abc` arrives unchanged. Neither needs help.
+ *
+ * What needs help is a client that re-encodes a URL it was handed. Panels, for
+ * one, stores an OPDS catalog as a host plus a path and rebuilds the URL itself
+ * — and a `%3A` that goes through that round trip comes back as `%253A`. After
+ * the router's single decode that is `did%3Aplc%3Aabc`, which is not a DID, and
+ * the route answers 400 for a URL the reader copied correctly.
+ *
+ * The URLs we hand out no longer contain `%3A` at all (see `urls.ts`), which
+ * removes the cause. This is the belt to that pair of braces: it costs one
+ * string check and covers every catalog URL already saved on someone's device.
+ */
+
+/** The DID a path parameter denotes, or `null` if it is not one. */
+export function didFromParam(raw: string): string | null {
+  let value = raw;
+  // At most one extra decode: two rounds covers a client that re-encoded once,
+  // and refusing to loop keeps a crafted parameter from being decoded onto
+  // something it should not reach.
+  if (!value.startsWith("did:") && value.includes("%")) {
+    try {
+      value = decodeURIComponent(value);
+    } catch {
+      return null;
+    }
+  }
+  return value.startsWith("did:") ? value : null;
+}

--- a/apps/standard-reader/src/lib/opds/urls.ts
+++ b/apps/standard-reader/src/lib/opds/urls.ts
@@ -11,8 +11,23 @@ function trim(baseUrl: string): string {
   return baseUrl.replace(/\/$/, "");
 }
 
-const did = encodeURIComponent;
-const rkey = encodeURIComponent;
+/**
+ * Encode a path segment, but leave `:` alone.
+ *
+ * RFC 3986 allows a colon in a path segment, so `/opds/u/did:plc:abc` is a
+ * perfectly good URL — and a far safer one to hand to a third-party client than
+ * `/opds/u/did%3Aplc%3Aabc`. A client that re-encodes a URL string it was given
+ * turns `%3A` into `%253A`, and the DID that arrives no longer starts with
+ * `did:`. Giving it nothing to re-encode removes the whole failure mode.
+ *
+ * Everything else is still encoded, so a hostile rkey cannot escape its segment.
+ */
+function segment(value: string): string {
+  return encodeURIComponent(value).replaceAll("%3A", ":");
+}
+
+const did = segment;
+const rkey = segment;
 
 // ── Catalog ────────────────────────────────────────────────────────────────
 

--- a/apps/standard-reader/src/routes/book.a.$did.{$rkey}[.]cbz.tsx
+++ b/apps/standard-reader/src/routes/book.a.$did.{$rkey}[.]cbz.tsx
@@ -6,6 +6,7 @@ import { db } from "#/db/index.server";
 import * as schema from "#/db/schema";
 import { parseComicIssueTitle } from "#/lib/comic/issue-title";
 import { documentImages } from "#/lib/document/images";
+import { didFromParam } from "#/lib/opds/did-param";
 import { getPublicUrl } from "#/lib/public-url";
 import { buildCbz } from "#/server/books/cbz";
 import { bookResponse } from "#/server/books/respond";
@@ -16,8 +17,9 @@ export const Route = createFileRoute("/book/a/$did/{$rkey}.cbz")({
   server: {
     handlers: {
       GET: async ({ params, request }) => {
-        const { did, rkey } = params;
-        if (!did.startsWith("did:")) {
+        const { rkey } = params;
+        const did = didFromParam(params.did);
+        if (!did) {
           return new Response("Bad Request", { status: 400 });
         }
 

--- a/apps/standard-reader/src/routes/book.a.$did.{$rkey}[.]epub.tsx
+++ b/apps/standard-reader/src/routes/book.a.$did.{$rkey}[.]epub.tsx
@@ -3,6 +3,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { documentUriFromParams } from "#/components/reader/format";
 import { db } from "#/db/index.server";
 import * as schema from "#/db/schema";
+import { didFromParam } from "#/lib/opds/did-param";
 import { getPublicUrl } from "#/lib/public-url";
 import { buildEpub } from "#/server/books/epub";
 import { bookResponse } from "#/server/books/respond";
@@ -19,8 +20,9 @@ export const Route = createFileRoute("/book/a/$did/{$rkey}.epub")({
   server: {
     handlers: {
       GET: async ({ params, request }) => {
-        const { did, rkey } = params;
-        if (!did.startsWith("did:")) {
+        const { rkey } = params;
+        const did = didFromParam(params.did);
+        if (!did) {
           return new Response("Bad Request", { status: 400 });
         }
 

--- a/apps/standard-reader/src/routes/book.c.$did.{$rkey}[.]epub.tsx
+++ b/apps/standard-reader/src/routes/book.c.$did.{$rkey}[.]epub.tsx
@@ -5,6 +5,7 @@ import { db } from "#/db/index.server";
 import * as schema from "#/db/schema";
 import { collectionDocumentUri } from "#/lib/atproto/collection-uris";
 import { parseCollectionManifest } from "#/lib/collections/manifest";
+import { didFromParam } from "#/lib/opds/did-param";
 import { getPublicUrl } from "#/lib/public-url";
 import { cdnImageUrl } from "#/server/atproto/blob";
 import { buildEpub } from "#/server/books/epub";
@@ -20,8 +21,9 @@ export const Route = createFileRoute("/book/c/$did/{$rkey}.epub")({
   server: {
     handlers: {
       GET: async ({ params, request }) => {
-        const { did, rkey } = params;
-        if (!did.startsWith("did:")) {
+        const { rkey } = params;
+        const did = didFromParam(params.did);
+        if (!did) {
           return new Response("Bad Request", { status: 400 });
         }
 

--- a/apps/standard-reader/src/routes/book.i.$did.{$rkey}[.]cbz.tsx
+++ b/apps/standard-reader/src/routes/book.i.$did.{$rkey}[.]cbz.tsx
@@ -4,6 +4,7 @@ import { and, eq } from "drizzle-orm";
 import { documentUriFromParams } from "#/components/reader/format";
 import { db } from "#/db/index.server";
 import * as schema from "#/db/schema";
+import { didFromParam } from "#/lib/opds/did-param";
 import { getPublicUrl } from "#/lib/public-url";
 import { buildCbz } from "#/server/books/cbz";
 import { comicIssueFile } from "#/server/books/comic-issue";
@@ -22,8 +23,9 @@ export const Route = createFileRoute("/book/i/$did/{$rkey}.cbz")({
   server: {
     handlers: {
       GET: async ({ params, request }) => {
-        const { did, rkey } = params;
-        if (!did.startsWith("did:")) {
+        const { rkey } = params;
+        const did = didFromParam(params.did);
+        if (!did) {
           return new Response("Bad Request", { status: 400 });
         }
 

--- a/apps/standard-reader/src/routes/book.p.$did.{$rkey}[.]cbz.tsx
+++ b/apps/standard-reader/src/routes/book.p.$did.{$rkey}[.]cbz.tsx
@@ -3,6 +3,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { publicationUriFromParams } from "#/components/reader/format";
 import { db } from "#/db/index.server";
 import * as schema from "#/db/schema";
+import { didFromParam } from "#/lib/opds/did-param";
 import { getPublicUrl } from "#/lib/public-url";
 import { buildCbz } from "#/server/books/cbz";
 import { comicRunFile } from "#/server/books/comic-issue";
@@ -20,8 +21,9 @@ export const Route = createFileRoute("/book/p/$did/{$rkey}.cbz")({
   server: {
     handlers: {
       GET: async ({ params, request }) => {
-        const { did, rkey } = params;
-        if (!did.startsWith("did:")) {
+        const { rkey } = params;
+        const did = didFromParam(params.did);
+        if (!did) {
           return new Response("Bad Request", { status: 400 });
         }
 

--- a/apps/standard-reader/src/routes/book.p.$did.{$rkey}[.]epub.tsx
+++ b/apps/standard-reader/src/routes/book.p.$did.{$rkey}[.]epub.tsx
@@ -3,6 +3,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { publicationUriFromParams } from "#/components/reader/format";
 import { db } from "#/db/index.server";
 import * as schema from "#/db/schema";
+import { didFromParam } from "#/lib/opds/did-param";
 import { getPublicUrl } from "#/lib/public-url";
 import { buildEpub } from "#/server/books/epub";
 import { bookResponse } from "#/server/books/respond";
@@ -19,8 +20,9 @@ export const Route = createFileRoute("/book/p/$did/{$rkey}.epub")({
   server: {
     handlers: {
       GET: async ({ params, request }) => {
-        const { did, rkey } = params;
-        if (!did.startsWith("did:")) {
+        const { rkey } = params;
+        const did = didFromParam(params.did);
+        if (!did) {
           return new Response("Bad Request", { status: 400 });
         }
 

--- a/apps/standard-reader/src/routes/book.u.$did.saved[.]epub.tsx
+++ b/apps/standard-reader/src/routes/book.u.$did.saved[.]epub.tsx
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 
 import { db } from "#/db/index.server";
 import * as schema from "#/db/schema";
+import { didFromParam } from "#/lib/opds/did-param";
 import { getPublicUrl } from "#/lib/public-url";
 import { SITE_NAME } from "#/lib/site-metadata";
 import { buildEpub } from "#/server/books/epub";
@@ -22,8 +23,8 @@ export const Route = createFileRoute("/book/u/$did/saved.epub")({
   server: {
     handlers: {
       GET: async ({ params, request }) => {
-        const did = params.did;
-        if (!did.startsWith("did:")) {
+        const did = didFromParam(params.did);
+        if (!did) {
           return new Response("Bad Request", { status: 400 });
         }
 

--- a/apps/standard-reader/src/routes/book.u.$did.unread[.]epub.tsx
+++ b/apps/standard-reader/src/routes/book.u.$did.unread[.]epub.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import { db } from "#/db/index.server";
 import * as schema from "#/db/schema";
+import { didFromParam } from "#/lib/opds/did-param";
 import { getPublicUrl } from "#/lib/public-url";
 import { buildEpub } from "#/server/books/epub";
 import {
@@ -24,8 +25,8 @@ export const Route = createFileRoute("/book/u/$did/unread.epub")({
   server: {
     handlers: {
       GET: async ({ params, request }) => {
-        const did = params.did;
-        if (!did.startsWith("did:")) {
+        const did = didFromParam(params.did);
+        if (!did) {
           return new Response("Bad Request", { status: 400 });
         }
 

--- a/apps/standard-reader/src/routes/feed.latest.$did.tsx
+++ b/apps/standard-reader/src/routes/feed.latest.$did.tsx
@@ -3,6 +3,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { db } from "#/db/index.server";
 import * as schema from "#/db/schema";
 import { renderRssFeed } from "#/lib/feeds/rss";
+import { didFromParam } from "#/lib/opds/did-param";
 import { getPublicUrl } from "#/lib/public-url";
 import { latestFeedUrl, SITE_NAME } from "#/lib/site-metadata";
 import { blockFilterDid } from "#/server/blocks/blocks";
@@ -17,8 +18,8 @@ export const Route = createFileRoute("/feed/latest/$did")({
   server: {
     handlers: {
       GET: async ({ params }) => {
-        const did = params.did;
-        if (!did.startsWith("did:")) {
+        const did = didFromParam(params.did);
+        if (!did) {
           return new Response("Bad Request", { status: 400 });
         }
 

--- a/apps/standard-reader/src/routes/feed.u.$did.tsx
+++ b/apps/standard-reader/src/routes/feed.u.$did.tsx
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { db } from "#/db/index.server";
 import * as schema from "#/db/schema";
 import { renderRssFeed } from "#/lib/feeds/rss";
+import { didFromParam } from "#/lib/opds/did-param";
 import { getPublicUrl } from "#/lib/public-url";
 import { authorFeedUrl, SITE_NAME } from "#/lib/site-metadata";
 import { feedItemsFromCards, loadFeedItemBodies } from "#/server/feeds/build";
@@ -16,8 +17,8 @@ export const Route = createFileRoute("/feed/u/$did")({
   server: {
     handlers: {
       GET: async ({ params }) => {
-        const did = params.did;
-        if (!did.startsWith("did:")) {
+        const did = didFromParam(params.did);
+        if (!did) {
           return new Response("Bad Request", { status: 400 });
         }
 

--- a/apps/standard-reader/src/routes/opds.c.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/opds.c.$did.$rkey.tsx
@@ -5,6 +5,7 @@ import { db } from "#/db/index.server";
 import * as schema from "#/db/schema";
 import { collectionDocumentUri } from "#/lib/atproto/collection-uris";
 import { parseCollectionManifest } from "#/lib/collections/manifest";
+import { didFromParam } from "#/lib/opds/did-param";
 import { EPUB_TYPE, OPDS_REL } from "#/lib/opds/model";
 import { opdsFormatFromRequest, opdsResponse } from "#/lib/opds/respond";
 import {
@@ -22,8 +23,9 @@ export const Route = createFileRoute("/opds/c/$did/$rkey")({
   server: {
     handlers: {
       GET: async ({ params, request }) => {
-        const { did, rkey } = params;
-        if (!did.startsWith("did:")) {
+        const { rkey } = params;
+        const did = didFromParam(params.did);
+        if (!did) {
           return new Response("Bad Request", { status: 400 });
         }
 

--- a/apps/standard-reader/src/routes/opds.p.$did.$rkey.tsx
+++ b/apps/standard-reader/src/routes/opds.p.$did.$rkey.tsx
@@ -3,6 +3,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { publicationUriFromParams } from "#/components/reader/format";
 import { db } from "#/db/index.server";
 import * as schema from "#/db/schema";
+import { didFromParam } from "#/lib/opds/did-param";
 import { opdsFormatFromRequest, opdsResponse } from "#/lib/opds/respond";
 import {
   opdsComicsUrl,
@@ -25,8 +26,9 @@ export const Route = createFileRoute("/opds/p/$did/$rkey")({
   server: {
     handlers: {
       GET: async ({ params, request }) => {
-        const { did, rkey } = params;
-        if (!did.startsWith("did:")) {
+        const { rkey } = params;
+        const did = didFromParam(params.did);
+        if (!did) {
           return new Response("Bad Request", { status: 400 });
         }
 

--- a/apps/standard-reader/src/routes/opds.u.$did.index.tsx
+++ b/apps/standard-reader/src/routes/opds.u.$did.index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import { db } from "#/db/index.server";
 import * as schema from "#/db/schema";
+import { didFromParam } from "#/lib/opds/did-param";
 import {
   OPDS_PRIVATE_CACHE_CONTROL,
   opdsFormatFromRequest,
@@ -16,8 +17,8 @@ export const Route = createFileRoute("/opds/u/$did/")({
   server: {
     handlers: {
       GET: async ({ params, request }) => {
-        const did = params.did;
-        if (!did.startsWith("did:")) {
+        const did = didFromParam(params.did);
+        if (!did) {
           return new Response("Bad Request", { status: 400 });
         }
 

--- a/apps/standard-reader/src/routes/opds.u.$did.publications.tsx
+++ b/apps/standard-reader/src/routes/opds.u.$did.publications.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import { db } from "#/db/index.server";
 import * as schema from "#/db/schema";
+import { didFromParam } from "#/lib/opds/did-param";
 import {
   OPDS_PRIVATE_CACHE_CONTROL,
   opdsFormatFromRequest,
@@ -17,8 +18,8 @@ export const Route = createFileRoute("/opds/u/$did/publications")({
   server: {
     handlers: {
       GET: async ({ params, request }) => {
-        const did = params.did;
-        if (!did.startsWith("did:")) {
+        const did = didFromParam(params.did);
+        if (!did) {
           return new Response("Bad Request", { status: 400 });
         }
 

--- a/apps/standard-reader/src/routes/opds.u.$did.saved.tsx
+++ b/apps/standard-reader/src/routes/opds.u.$did.saved.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import { db } from "#/db/index.server";
 import * as schema from "#/db/schema";
+import { didFromParam } from "#/lib/opds/did-param";
 import { EPUB_TYPE, OPDS_REL } from "#/lib/opds/model";
 import {
   OPDS_PRIVATE_CACHE_CONTROL,
@@ -22,8 +23,8 @@ export const Route = createFileRoute("/opds/u/$did/saved")({
   server: {
     handlers: {
       GET: async ({ params, request }) => {
-        const did = params.did;
-        if (!did.startsWith("did:")) {
+        const did = didFromParam(params.did);
+        if (!did) {
           return new Response("Bad Request", { status: 400 });
         }
 

--- a/apps/standard-reader/src/routes/opds.u.$did.subscriptions.tsx
+++ b/apps/standard-reader/src/routes/opds.u.$did.subscriptions.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import { db } from "#/db/index.server";
 import * as schema from "#/db/schema";
+import { didFromParam } from "#/lib/opds/did-param";
 import {
   OPDS_PRIVATE_CACHE_CONTROL,
   opdsFormatFromRequest,
@@ -22,8 +23,8 @@ export const Route = createFileRoute("/opds/u/$did/subscriptions")({
   server: {
     handlers: {
       GET: async ({ params, request }) => {
-        const did = params.did;
-        if (!did.startsWith("did:")) {
+        const did = didFromParam(params.did);
+        if (!did) {
           return new Response("Bad Request", { status: 400 });
         }
 

--- a/apps/standard-reader/src/routes/opds.u.$did.unread.tsx
+++ b/apps/standard-reader/src/routes/opds.u.$did.unread.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import { db } from "#/db/index.server";
 import * as schema from "#/db/schema";
+import { didFromParam } from "#/lib/opds/did-param";
 import { EPUB_TYPE, OPDS_REL } from "#/lib/opds/model";
 import {
   OPDS_PRIVATE_CACHE_CONTROL,
@@ -22,8 +23,8 @@ export const Route = createFileRoute("/opds/u/$did/unread")({
   server: {
     handlers: {
       GET: async ({ params, request }) => {
-        const did = params.did;
-        if (!did.startsWith("did:")) {
+        const did = didFromParam(params.did);
+        if (!did) {
           return new Response("Bad Request", { status: 400 });
         }
 

--- a/apps/standard-reader/src/server/opds/catalog.ts
+++ b/apps/standard-reader/src/server/opds/catalog.ts
@@ -311,6 +311,11 @@ export function shelfNavigation({
 }): OpdsFeed {
   const self = opdsShelfUrl(baseUrl, did);
   const updated = new Date(0).toISOString();
+  // `subsection` rather than `http://opds-spec.org/shelf`: the shelf relation
+  // describes a *link to* the reader's shelf, which is what the feed-level link
+  // below is for. On a navigation entry, clients look for `subsection` — a
+  // stricter one skips an entry whose rel it does not recognise, which is a
+  // shelf the reader can see in a browser and not in their reading app.
   const shelf = (
     title: string,
     path: string,
@@ -319,7 +324,6 @@ export function shelfNavigation({
     href: `${self}/${path}`,
     id: `${self}/${path}`,
     kind: "acquisition",
-    rel: OPDS_REL.shelf,
     summary,
     title,
     updated,
@@ -344,7 +348,6 @@ export function shelfNavigation({
     href: `${self}/publications`,
     id: `${self}/publications`,
     kind: "navigation",
-    rel: OPDS_REL.shelf,
     summary: "Browse each publication you subscribe to on its own.",
     title: "Your publications",
     updated,
@@ -355,7 +358,6 @@ export function shelfNavigation({
       href: opdsListUrl(baseUrl, did, list.rkey),
       id: `at://${did}/app.standard-reader.list/${list.rkey}`,
       kind: "acquisition",
-      rel: OPDS_REL.shelf,
       summary: list.description,
       title: list.name,
       updated,
@@ -401,11 +403,20 @@ export function shelfNavigation({
   return {
     id: self,
     kind: "navigation",
-    links: baseLinks(baseUrl),
+    links: [
+      ...baseLinks(baseUrl),
+      {
+        href: `${self}/saved`,
+        rel: OPDS_REL.shelf,
+        title: "Saved for later",
+        type: feedTypeFor("acquisition"),
+      },
+    ],
     navigation: entries,
     selfHref: self,
     subtitle: `Shelves for ${readerName}, plus everything on ${SITE_NAME}.`,
-    title: `${readerName} · ${SITE_NAME}`,
+    title:
+      readerName === SITE_NAME ? SITE_NAME : `${readerName} · ${SITE_NAME}`,
     updated,
   };
 }


### PR DESCRIPTION
Panels can't add a Standard Reader catalog. This is why.

## The cause

Panels doesn't take an OPDS **URL** — its config has separate **Host** and **Port** fields. It stores the host plus the path and rebuilds the URL itself, and a `%3A` that makes that round trip comes back as `%253A`. The router decodes once, the route sees `did%3Aplc%3A…`, decides that isn't a DID, and answers **400** for a URL the reader copied correctly.

Reproduced against production:

| URL form | before | after |
|---|---|---|
| `/opds/p/did:plc:…/rkey` | 200 | 200 |
| `/opds/p/did%3Aplc%3A…/rkey` | 200 | 200 |
| `/opds/p/did%253Aplc%253A…/rkey` | **400** | **200** |

## The fix

**Stop encoding the colon.** RFC 3986 allows `:` in a path segment, so `/opds/u/did:plc:abc` was always legal — and it's a far safer thing to hand a third-party client, because there's nothing left in it to re-encode. Everything else in a segment is still encoded, so a hostile rkey can't escape it.

**`didFromParam`** is the belt to those braces: one extra decode when the parameter still doesn't look like a DID. That covers every catalog URL already saved on someone's device — which is every one handed out before this commit. Deliberately *not* a loop; decoding until a string stops changing is how a crafted parameter reaches somewhere it shouldn't.

## Two more things this turned up

- Shelf navigation entries advertised `rel="http://opds-spec.org/shelf"`. That relation describes a *link to* a shelf, which is what the feed-level link now does. On an entry, clients look for `subsection` — and a strict one skips a rel it doesn't recognise, which is a shelf the reader can see in a browser but not in their reading app. Plausibly a second reason Panels showed nothing.
- A reader whose display name is "Standard Reader" got a feed titled "Standard Reader · Standard Reader".

## Testing

7 new tests over the parameter parsing and URL shape, including that a triple-encoded value is rejected rather than decoded. 1090 pass overall; lint, format and typecheck clean.

Verified locally that all three encodings serve the same feed, that the catalog now advertises `did:plc:…` hrefs with no `%3A`, and that shelf entries carry `rel="subsection"`.

## Note

`http://standard-reader.app/opds/…` answers `301` to https. If Panels tries the scheme-less host over http and doesn't follow redirects, that's a second thing to rule out — but it's outside what this PR can fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
