### PR TITLE
Stop the OAuth refresh lock starving the request pool

### DIFF
--- a/apps/standard-reader/.env.example
+++ b/apps/standard-reader/.env.example
@@ -16,6 +16,17 @@ DATABASE_URL="postgresql://[user]:[password]@[neon_hostname]/[dbname]?sslmode=re
 # queries skip per-request TLS/proxy overhead. In prod (Railway ↔ Neon, same
 # region) the TCP+TLS handshake is <5ms — far cheaper than per-query HTTP.
 DB_DRIVER="pg"
+# Request pool size, and how long a query may wait for a free connection before
+# it errors. node-postgres queues acquires forever if unset, which turns pool
+# exhaustion into multi-minute hangs that still answer 200 — set this so a
+# drained pool fails loudly instead of silently.
+DB_POOL_MAX="16"
+DB_POOL_ACQUIRE_TIMEOUT_MS="5000"
+# Separate pool for the OAuth refresh advisory lock, which holds its connection
+# across the PDS token-refresh round trip. Isolating it means a slow third-party
+# PDS can stall refreshes without starving ordinary signed-in reads.
+DB_LOCK_POOL_MAX="8"
+DB_LOCK_ACQUIRE_TIMEOUT_MS="20000"
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Analytics — Plausible (client-side, `@plausible-analytics/tracker`)

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -503,16 +503,33 @@ stores in `src/integrations/auth/`, session/user server fns in
       transaction to claim, release the connection, refresh, short transaction to
       release) with a TTL so a crashed process can't strand the lease — replacing
       `pg_advisory_xact_lock`. Needs a migration.
-- [ ] **The refresh lock is not actually preventing logouts.** `attachSessionEventLogging` calls
-      `auth.oauth.session_deleted` "the primary breadcrumb for the logout-on-deploy bug" and says a
-      recurring stream means refresh rotation is still racing. Over 7d there are **25,331** of them,
-      and **25,286 (99.8%) carry `cause: "session was deleted by another process"`** — the exact
-      racing-refresh signature, not genuine PDS revocation (that accounts for ~40). Meanwhile
-      `auth.oauth.refresh_lock_contended` fires only 186×/24h, so the lock is rarely even engaging:
-      something is bypassing `dbRequestLock` rather than the lock failing to hold. Worth checking
-      whether every process that restores a session goes through it (ingest/cron included) and
-      whether `isNeonHttpDriver` is silently true anywhere — that branch degrades to in-process-only
-      serialization and logs `refresh_lock_unavailable` just once per process.
+- [ ] **Readers get stuck in a zombie signed-in state when their OAuth session vanishes.** Nothing
+      reconciles our app `session` row with atcute's stored OAuth session: the only place a session
+      row is deleted is the explicit `user.signOut`
+      ([`api-user.functions.ts:1568`](src/integrations/tanstack-query/api-user.functions.ts)). So
+      once the OAuth blob is gone, the reader's session cookie stays valid, the app keeps believing
+      they're signed in, and every request silently degrades to guest data forever.
+      `attachSessionEventLogging` only *logs* the `deleted` event — it doesn't invalidate anything.
+
+      The telemetry signature: `auth.oauth.session_deleted` fires **every 60 seconds on the dot**
+      for an affected DID, inside a `GET` span, indefinitely (one account has been looping since at
+      least 2026-08-13). Each attempt also takes the advisory lock and a lock-pool connection.
+
+      Scale, measured rather than assumed: 25,331 events over 7d sounds like mass logouts but is
+      **21 distinct DIDs**, with 4 accounting for 99.8% (16,800 / 5,060 / 2,178 / 1,216). The raw
+      count is also ~2× inflated — each restore attempt emits one event per OAuth client kind
+      (`default` **and** `review`, same trace, ~20ms apart), so both listeners report one underlying
+      deletion.
+
+      **The lock itself is fine** — over 7d `auth.oauth.refresh_lock_unavailable` and
+      `auth.oauth.refresh_lock_timeout` are both **0**, so `isNeonHttpDriver` is not silently true
+      anywhere and the lock never times out. Low `refresh_lock_contended` volume (1,002/7d) is
+      expected when only a handful of DIDs are involved; it is not evidence of a bypass.
+
+      Fix carefully: `"session was deleted by another process"` can also occur on a benign race, so
+      tearing down the app session straight from the global `deleted` listener risks logging people
+      out on a transient blip. Better to handle it where a restore fails during a request (with the
+      session token in hand) than in the by-DID listener.
 - [ ] **Re-check `JETSTREAM_APPLY_CONCURRENCY` against `DB_POOL_MAX`.** Both
       default to 16, so ingest apply can by itself own every connection in a
       process that also serves requests (519 `ingest.*` spans were observed on

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -241,6 +241,19 @@ Check items off as they land.
       events at ~1,000/s before being stopped, and `planSnapshot` reports blocks rather than
       matching events, so the total is unknown. Measure before planning a window around it.
 
+- [ ] **`reconcile-cron` is running a stale build — the sweep is 100% dead.** `ingest.repoReconcile`
+      fails ~99.9% of the time (43,495 failures over 7d, flat at ~350–440/hr for the whole window;
+      96.5% of failures are one query). It selects `tracked_repos.last_seen_rev` — the column
+      migration [`0041_tidy_last_seen_seq`](drizzle/0041_tidy_last_seen_seq.sql) **dropped** in favor
+      of `last_seen_seq`. No current source generates that query, so the deployed reconcile service
+      predates 0041. Only the web service runs `preDeployCommand` migrations, so the shared DB moved
+      on without it. **Redeploy `reconcile-cron`/ingest**, then confirm the failures stop — no repo
+      has been reconciled (i.e. no drift repaired) for at least a week.
+- [ ] **Clean up the dropped column's leftovers.** [`scripts/tmp-drain.ts`](scripts/tmp-drain.ts)
+      still filters on `t.last_seen_rev is null` (raw SQL, so it fails at runtime rather than
+      typecheck), and several `repo-sync.ts` comments still describe `last_seen_rev` as the
+      watermark. Delete the temp script if it has outlived its purpose; refresh the comments.
+
 - [x] **Personal state no longer waits on the ingest queue** (2026-08-01). With the ingest worker
       backlogged, a reader's own read/unread state — the one thing they watch change in the moment —
       queued behind everyone else's backfill, so articles stayed unread for hours after being read.
@@ -475,6 +488,36 @@ stores in `src/integrations/auth/`, session/user server fns in
       for `app.standard-reader.authBasicFeatures` +
       `app.standard-reader.authCollections` when `_lexicon.*` DNS ready (manual,
       requires `LEXICON_PUBLISH_*` creds).
+- [x] **Stop the refresh lock starving the request pool.** `withAdvisoryLock`
+      holds its connection across the PDS refresh round trip, so slow
+      third-party PDSes drained the shared `pg` pool (`max: 16`); with no
+      `connectionTimeoutMillis`, node-postgres queued acquires forever and every
+      signed-in read parked behind them — `user.getShellBootstrap` P95 hit ~9.7
+      min (max 50 min) while still returning 200, so it never showed up as an
+      error. The lock now borrows from an isolated pool (`getLockDb`), and both
+      pools have acquire timeouts so exhaustion fails loudly. See
+      [`src/db/index.ts`](src/db/index.ts).
+- [ ] **Don't hold a pool connection across PDS I/O at all.** The isolated pool
+      contains the blast radius but the refresh still pins a connection for a
+      whole network round trip. The real fix is a lease/claim row (short
+      transaction to claim, release the connection, refresh, short transaction to
+      release) with a TTL so a crashed process can't strand the lease — replacing
+      `pg_advisory_xact_lock`. Needs a migration.
+- [ ] **The refresh lock is not actually preventing logouts.** `attachSessionEventLogging` calls
+      `auth.oauth.session_deleted` "the primary breadcrumb for the logout-on-deploy bug" and says a
+      recurring stream means refresh rotation is still racing. Over 7d there are **25,331** of them,
+      and **25,286 (99.8%) carry `cause: "session was deleted by another process"`** — the exact
+      racing-refresh signature, not genuine PDS revocation (that accounts for ~40). Meanwhile
+      `auth.oauth.refresh_lock_contended` fires only 186×/24h, so the lock is rarely even engaging:
+      something is bypassing `dbRequestLock` rather than the lock failing to hold. Worth checking
+      whether every process that restores a session goes through it (ingest/cron included) and
+      whether `isNeonHttpDriver` is silently true anywhere — that branch degrades to in-process-only
+      serialization and logs `refresh_lock_unavailable` just once per process.
+- [ ] **Re-check `JETSTREAM_APPLY_CONCURRENCY` against `DB_POOL_MAX`.** Both
+      default to 16, so ingest apply can by itself own every connection in a
+      process that also serves requests (519 `ingest.*` spans were observed on
+      the `web` component). Either lower the apply ceiling or give ingest its own
+      pool the way the refresh lock now has one.
 
 ## 4. Lexicons & writes (records = source of truth)
 

--- a/apps/standard-reader/src/db/index.server.ts
+++ b/apps/standard-reader/src/db/index.server.ts
@@ -4,4 +4,4 @@
  * when auth route modules statically import `db`. Re-exports the singleton from
  * `./index.ts` so there is still exactly one client instance.
  */
-export { db, isNeonHttpDriver } from "./index.ts";
+export { db, getLockDb, isNeonHttpDriver } from "./index.ts";

--- a/apps/standard-reader/src/db/index.ts
+++ b/apps/standard-reader/src/db/index.ts
@@ -11,6 +11,10 @@ if (!url) {
   throw new Error("DATABASE_URL is not set");
 }
 
+// The guard above narrows `url` at module scope, but that narrowing does not
+// reach into the deferred body of `getLockDb`. Bind the checked value once.
+const connectionUrl: string = url;
+
 /**
  * The read-model runs on Neon in dev/prod but a plain local Postgres for
  * testing. The `@neondatabase/serverless` HTTP driver only speaks to Neon-style
@@ -28,21 +32,36 @@ function isNeonConnection(connectionString: string): boolean {
   return /neon\.tech|supabase\.co|vercel-storage\.com/i.test(connectionString);
 }
 
+/** Read a positive integer from the environment, falling back when unset/invalid. */
+function envInt(name: string, fallback: number): number {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
 /**
- * Build the `pg` Pool used by the node-postgres driver (local tests + the
+ * Build a `pg` Pool for the node-postgres driver (local tests + the
  * long-running ingest worker via `DB_DRIVER=pg`). The worker processes events
  * concurrently, so size the pool for that; Neon's pooler (pgbouncer) endpoint
  * multiplexes these onto far fewer Postgres backends. Loopback connections run
  * without TLS; everything else (Neon) uses SSL with full certificate
  * verification (`rejectUnauthorized: true`). Neon's certificates are signed
  * by DigiCert, which is in Node's default trust store.
+ *
+ * `connectionTimeoutMillis` is not optional: node-postgres queues acquires
+ * FOREVER by default, so a drained pool degrades into multi-minute request
+ * hangs that raise no error and still answer 200 — invisible in error rates and
+ * indistinguishable from "the site doesn't load". Failing fast turns pool
+ * exhaustion into something a dashboard can actually see.
  */
-function createPgPool(connectionString: string): Pool {
+function createPgPool(
+  connectionString: string,
+  options: { max: number; connectionTimeoutMillis: number },
+): Pool {
   const isLocal = /@(localhost|127\.0\.0\.1|::1)[:/]/.test(connectionString);
-  const max = Number(process.env.DB_POOL_MAX);
   return new Pool({
     connectionString,
-    max: Number.isFinite(max) && max > 0 ? max : 16,
+    max: options.max,
+    connectionTimeoutMillis: options.connectionTimeoutMillis,
     ssl: isLocal ? undefined : { rejectUnauthorized: true },
   });
 }
@@ -64,4 +83,44 @@ export const db: NodePgDatabase<typeof schema> = isNeonHttpDriver
   ? (drizzleHttp({ client: neon(url), schema }) as unknown as NodePgDatabase<
       typeof schema
     >)
-  : drizzleNode({ client: createPgPool(url), schema });
+  : drizzleNode({
+      client: createPgPool(url, {
+        max: envInt("DB_POOL_MAX", 16),
+        connectionTimeoutMillis: envInt("DB_POOL_ACQUIRE_TIMEOUT_MS", 5000),
+      }),
+      schema,
+    });
+
+/**
+ * A second, small pool reserved for the OAuth refresh advisory lock.
+ *
+ * `withAdvisoryLock` (see `src/integrations/auth/db-lock.server.ts`) holds its
+ * connection across the PDS token-refresh round trip — a network call to an
+ * arbitrary third-party server that atcute only bounds at 30s. Run on the
+ * shared pool, sixteen concurrent slow refreshes drain it, and every unrelated
+ * signed-in read then parks in the acquire queue behind them. Isolating those
+ * long holds here means a slow PDS can stall refreshes but never ordinary
+ * request traffic.
+ *
+ * Sized small on purpose: refreshes already serialize per-DID in-process, so
+ * this only needs enough slots for distinct DIDs refreshing at once. The
+ * acquire timeout is generous relative to the request pool because atcute
+ * aborts the whole session get at 30s anyway, and because a failed acquire here
+ * surfaces as a plain error — `deleteOnError` returns false, so the stored
+ * session survives and the reader stays logged in.
+ *
+ * Created lazily so nothing opens a second pool under the neon-http driver or
+ * in tests that never take the lock.
+ */
+let lockDbInstance: NodePgDatabase<typeof schema> | undefined;
+
+export function getLockDb(): NodePgDatabase<typeof schema> {
+  lockDbInstance ??= drizzleNode({
+    client: createPgPool(connectionUrl, {
+      max: envInt("DB_LOCK_POOL_MAX", 8),
+      connectionTimeoutMillis: envInt("DB_LOCK_ACQUIRE_TIMEOUT_MS", 20_000),
+    }),
+    schema,
+  });
+  return lockDbInstance;
+}

--- a/apps/standard-reader/src/integrations/auth/db-lock.server.ts
+++ b/apps/standard-reader/src/integrations/auth/db-lock.server.ts
@@ -28,7 +28,7 @@
  */
 import { sql } from "drizzle-orm";
 
-import { db, isNeonHttpDriver } from "#/db/index.server";
+import { getLockDb, isNeonHttpDriver } from "#/db/index.server";
 import { logEvent } from "#/server/observability/log";
 
 /**
@@ -69,7 +69,11 @@ async function withAdvisoryLock<T>(
     return await fn();
   }
 
-  return await db.transaction(async (tx) => {
+  // Deliberately NOT the shared request pool. This transaction stays open
+  // across `fn()` — the PDS refresh round trip — so it must borrow from the
+  // isolated lock pool, or slow third-party PDSes drain the pool every
+  // signed-in read depends on. See `getLockDb` in `src/db/index.ts`.
+  return await getLockDb().transaction(async (tx) => {
     // LOCAL so the setting reverts when the transaction ends. LOCK_TIMEOUT is a
     // hardcoded constant, so interpolating it is safe (SET rejects bind params
     // for its value anyway).


### PR DESCRIPTION
## The symptom

A reader reported the site "doesn't load"; it wasn't reproducible from another account.

Their requests weren't erroring — they were **hanging**. `user.getShellBootstrap` returned HTTP 200 with `ok: true` after up to **50 minutes**. Because nothing ever errored, this was invisible in error-rate dashboards.

It wasn't user-specific either. Across all signed-in traffic:

| | P50 | P95 | MAX |
|---|---|---|---|
| all `getShellBootstrap` (mostly guests) | 0.32ms | 1.14ms | — |
| **signed-in only** (4,308 calls / 7d) | — | **584,200ms (9.7 min)** | — |
| the reporting account (24h) | 210,678ms | — | 3,010,486ms |

Guests are fine because the guest path returns before touching the DB. Signed-in readers all share one tail.

## Root cause: pool starvation, not slow SQL

`withAdvisoryLock` holds its transaction — and therefore its pool connection — open across `fn()`, which is the OAuth **token-refresh round trip to the reader's PDS**: a network call to an arbitrary third-party server that atcute only bounds at 30s.

Run against the shared pool (`max: 16`), a handful of slow PDSes drain it. And the pool had **no `connectionTimeoutMillis`**, so node-postgres queued acquires *forever*. Every unrelated signed-in read parked behind those refreshes with no error, no timeout, and then completed with a 200 once a connection freed.

The tell is queries that *cannot* be slow degrading in lockstep with everything else, at the same wall-clock moments:

| span | P50 | P95 |
|---|---|---|
| `sidebarPref.get` — a single-row indexed lookup | 4.7s | **314s** |
| `shell.getShellSnapshot` | 32s | 733s |
| `lists.getAuthorLists` | 21s | 925s |
| `lists.getLists` | 31s | 493s |

Synchronized spikes across unrelated queries = contention on a shared resource. Guest traffic over the same window (77k spans, never touches the DB) stayed at P50 0.65ms / P95 334ms.

## The fix

**Give the advisory lock its own small pool** (`getLockDb`, `max: 8`). A slow PDS can now stall refreshes without touching the 16 connections ordinary reads depend on. Created lazily, so nothing opens a second pool under neon-http or in tests.

The locking semantics are **deliberately untouched**. The obvious-looking fix — moving `fn()` outside the transaction — would drop the cross-process mutual exclusion this file exists to provide and reintroduce the `invalid_grant` logout race that motivated it.

**Require `connectionTimeoutMillis` on every pool.** Unset, exhaustion degrades into silent multi-minute hangs that still answer 200. Set, it fails fast and becomes something a dashboard can see.

New env vars, all with working defaults (documented in `.env.example`): `DB_POOL_ACQUIRE_TIMEOUT_MS` (5000), `DB_LOCK_POOL_MAX` (8), `DB_LOCK_ACQUIRE_TIMEOUT_MS` (20000). `DB_POOL_MAX` (16) is unchanged.

## This is a mitigation, not the complete fix

The refresh still pins a connection across a network round trip — the blast radius is just contained. The real fix is a lease/claim row with a TTL replacing `pg_advisory_xact_lock`, so no connection is held across PDS I/O. That needs a migration, so it's filed in TODO.md rather than bundled here.

## Two unrelated problems this turned up

Both are diagnosis only — no code here addresses them. Filed in TODO.md.

**1. `reconcile-cron` is running a stale build; the sweep is 100% dead.** `ingest.repoReconcile` fails ~99.9% of the time — **43,495 failures over 7d, flat at ~350–440/hr** for the entire window. 96.5% are one query selecting `tracked_repos.last_seen_rev`, the column migration `0041_tidy_last_seen_seq` **dropped**. No current source generates that query, so the deployed service predates 0041; only the web service runs `preDeployCommand` migrations, so the shared DB moved on without it. **No repo has been reconciled for at least a week.** Needs a redeploy, not a patch.

**2. Readers get stuck in a zombie signed-in state.** Nothing reconciles our app `session` row with atcute's stored OAuth session — the only place a session row is deleted is the explicit `user.signOut`. Once the OAuth blob is gone the session cookie stays valid, so the app keeps believing the reader is signed in while silently serving them guest data, forever. `auth.oauth.session_deleted` then fires **every 60s on the dot**, inside a `GET` span, indefinitely; one account has been looping since at least 2026-08-13. Each attempt also takes the advisory lock and a lock-pool connection.

Worth stating precisely, because the raw number is misleading: 25,331 events over 7d is **21 distinct DIDs**, 4 of them 99.8%, and the count is ~2x inflated (one event per OAuth client kind per attempt). The lock itself is healthy — `refresh_lock_unavailable` and `refresh_lock_timeout` are both **0** over 7d.

## Verification

- **Typecheck**: 10 errors before, 10 after — stash-diffed against baseline. All pre-existing `@bsky/jetstream` module-resolution failures from #158; none in changed files.
- **oxlint / oxfmt**: clean.
- **Tests**: `src/integrations/auth` + `src/db` — 6 passed.

Not load-tested against a genuinely saturated pool; the reasoning rests on the telemetry above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

