### PR TITLE
Put embedded Bluesky posts in the book, not a link to them

### DIFF
--- a/apps/standard-reader/src/server/atproto/bsky-posts.ts
+++ b/apps/standard-reader/src/server/atproto/bsky-posts.ts
@@ -13,6 +13,13 @@ export interface BskyPostAuthor {
   avatar: string | null;
 }
 
+/** An image attached to a post, as the AppView serves it. */
+export interface BskyPostImage {
+  /** Full-size CDN URL. */
+  url: string;
+  alt: string;
+}
+
 export interface BskyPostView {
   uri: string;
   cid: string;
@@ -24,6 +31,14 @@ export interface BskyPostView {
   indexedAt: string;
   /** True when the post is a reply to another post. */
   isReply: boolean;
+  /**
+   * Images attached to the post. Empty for a text-only post.
+   *
+   * Only populated for the in-app narration path's callers by accident — it
+   * exists for the EPUB writer, where an embedded post has to carry its own
+   * picture: a book cannot go and fetch one later.
+   */
+  images: Array<BskyPostImage>;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -41,6 +56,33 @@ function parseAuthor(value: unknown): BskyPostAuthor | null {
       typeof value.displayName === "string" ? value.displayName : null,
     avatar: typeof value.avatar === "string" ? value.avatar : null,
   };
+}
+
+/**
+ * Images out of a post's hydrated embed view.
+ *
+ * Two shapes carry them: `app.bsky.embed.images#view` on its own, and
+ * `app.bsky.embed.recordWithMedia#view`, where the images hang off `media`
+ * because the post also quotes something.
+ */
+function parsePostImages(embed: unknown): Array<BskyPostImage> {
+  if (!isRecord(embed)) return [];
+
+  const media = isRecord(embed.media) ? embed.media : embed;
+  const images = Array.isArray(media.images) ? media.images : [];
+
+  return images.flatMap((image) => {
+    if (!isRecord(image)) return [];
+    // `fullsize` is the readable one; `thumb` is a grid tile.
+    const url =
+      typeof image.fullsize === "string"
+        ? image.fullsize
+        : typeof image.thumb === "string"
+          ? image.thumb
+          : null;
+    if (!url) return [];
+    return [{ alt: typeof image.alt === "string" ? image.alt : "", url }];
+  });
 }
 
 function parsePostView(value: unknown): BskyPostView | null {
@@ -74,6 +116,7 @@ function parsePostView(value: unknown): BskyPostView | null {
     likeCount,
     indexedAt,
     isReply,
+    images: parsePostImages(value.embed),
   };
 }
 

--- a/apps/standard-reader/src/server/books/bsky-embeds.ts
+++ b/apps/standard-reader/src/server/books/bsky-embeds.ts
@@ -1,0 +1,61 @@
+/**
+ * Bluesky posts embedded in an article, hydrated for a book.
+ *
+ * On the web an embedded post is a live component — it fetches itself. A book
+ * has no runtime, so the post has to be *in* the file: author, text, pictures
+ * and all. Otherwise a reader on a plane gets a bare `bsky.app` URL where the
+ * writer put the thing they were responding to, which is usually the half of
+ * the conversation that carries the point.
+ *
+ * Hydration happens once per book rather than once per chapter: the AppView
+ * takes 25 URIs at a time, and an anthology of forty articles quoting posts
+ * would otherwise be forty round trips.
+ */
+
+import { buildRenderTree } from "@standard-reader/renderer-core";
+import type {
+  BlockNode,
+  StandardSiteDocument,
+} from "@standard-reader/renderer-core";
+
+import type { BskyPostView } from "#/server/atproto/bsky-posts";
+import { getPosts } from "#/server/atproto/bsky-posts";
+
+/** Every post URI a document embeds, in reading order. */
+export function bskyPostUrisInDocument(
+  document: StandardSiteDocument,
+): Array<string> {
+  const tree = buildRenderTree(document);
+  if (!tree) return [];
+
+  const uris: Array<string> = [];
+  const walk = (nodes: Array<BlockNode>) => {
+    for (const node of nodes) {
+      if (node.type === "blueskyEmbed") uris.push(node.postUri);
+      // Embeds nest: a post quoted inside a callout, a list item, a page embed.
+      const children = (node as { children?: Array<BlockNode> }).children;
+      if (Array.isArray(children)) walk(children);
+    }
+  };
+  walk(tree.children);
+  return uris;
+}
+
+/**
+ * Hydrate every post a set of documents embeds, keyed by URI.
+ *
+ * Failures are silent by design — the renderer falls back to the link it drew
+ * before, and a book is not worth failing over a post that has been deleted or
+ * an AppView that is briefly unreachable.
+ */
+export async function hydrateBskyPosts(
+  uris: Array<string>,
+): Promise<Map<string, BskyPostView>> {
+  if (uris.length === 0) return new Map();
+  try {
+    const posts = await getPosts(uris);
+    return new Map(posts.map((post) => [post.uri, post]));
+  } catch {
+    return new Map();
+  }
+}

--- a/apps/standard-reader/src/server/books/render.tsx
+++ b/apps/standard-reader/src/server/books/render.tsx
@@ -33,6 +33,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { documentContentHtml } from "#/lib/document/content-html";
 import { bskyPostUrl } from "#/lib/leaflet/bsky";
+import type { BskyPostView } from "#/server/atproto/bsky-posts";
 
 import { sanitizeToXhtml } from "./xhtml";
 
@@ -62,6 +63,12 @@ export interface RenderBodyInput {
    * image failed to fetch, and a live URL degrades better than a dead one).
    */
   localImages?: Map<string, string>;
+  /**
+   * Embedded Bluesky posts, already hydrated (`bsky-embeds.ts`). A URI missing
+   * from the map falls back to a link — the post was deleted, or the AppView
+   * was unreachable when the book was built.
+   */
+  posts?: Map<string, BskyPostView>;
 }
 
 export interface RenderedBody {
@@ -69,6 +76,18 @@ export interface RenderedBody {
   markup: string;
   /** Every remote image URL the body referenced, first appearance first. */
   imageUrls: Array<string>;
+}
+
+/** The date under an embedded post, or null when it has no usable one. */
+function formatPostDate(iso: string): string | null {
+  const time = Date.parse(iso);
+  if (Number.isNaN(time)) return null;
+  return new Date(time).toLocaleDateString("en-US", {
+    day: "numeric",
+    month: "long",
+    timeZone: "UTC",
+    year: "numeric",
+  });
 }
 
 /**
@@ -104,6 +123,12 @@ function absoluteHref(href: string, base: string | null): string {
 function bookComponents(
   documentUrl: string | null,
   resolveImage: (url: string) => string,
+  /**
+   * Record an image the renderer's own resolver never sees — a post's avatar or
+   * attachment — and hand back the path it will have in the book.
+   */
+  collectAndResolve: (url: string) => string,
+  posts: Map<string, BskyPostView> | undefined,
 ): RendererComponentsInput {
   const link = (href: string) => absoluteHref(href, documentUrl);
 
@@ -136,11 +161,57 @@ function bookComponents(
         </p>
       ),
       BlueskyEmbed: ({ postUri }) => {
-        const url = bskyPostUrl(postUri);
+        const url = bskyPostUrl(postUri) ?? postUri;
+        const post = posts?.get(postUri);
+
+        // No post: the link, as before. Better than an empty box where the
+        // writer put a quotation.
+        if (!post) {
+          return (
+            <p>
+              <a href={url}>{url}</a>
+            </p>
+          );
+        }
+
+        const name = post.author.displayName || post.author.handle || "";
+        const handle = post.author.handle ? `@${post.author.handle}` : null;
+
         return (
-          <p>
-            <a href={url ?? postUri}>{url ?? postUri}</a>
-          </p>
+          <aside className="sr-post">
+            <p className="sr-post-byline">
+              {post.author.avatar ? (
+                <img
+                  alt=""
+                  className="sr-post-avatar"
+                  src={collectAndResolve(post.author.avatar)}
+                />
+              ) : null}
+              <strong>{name}</strong>
+              {handle ? (
+                <span className="sr-post-handle"> {handle}</span>
+              ) : null}
+            </p>
+            {/* The record's own line breaks are the author's paragraphing —
+                a post is written in short lines and reads as noise without
+                them. */}
+            {post.text
+              .split("\n")
+              .map((line, index) => (line ? <p key={index}>{line}</p> : null))}
+            {post.images.map((image) => (
+              <img
+                alt={image.alt}
+                className="sr-post-image"
+                key={image.url}
+                src={collectAndResolve(image.url)}
+              />
+            ))}
+            <p className="sr-post-source">
+              <a href={url}>
+                {formatPostDate(post.indexedAt) ?? "View on Bluesky"}
+              </a>
+            </p>
+          </aside>
         );
       },
 
@@ -262,6 +333,11 @@ export function renderDocumentBody(input: RenderBodyInput): RenderedBody {
   const resolveImage = (url: string): string =>
     input.localImages?.get(url) ?? url;
 
+  const collectAndResolve = (url: string): string => {
+    collect(url);
+    return resolveImage(url);
+  };
+
   const document: StandardSiteDocument = {
     authorDid: input.authorDid,
     content: input.content,
@@ -282,7 +358,12 @@ export function renderDocumentBody(input: RenderBodyInput): RenderedBody {
 
   const markup = renderToStaticMarkup(
     <StandardDocumentRenderer
-      components={bookComponents(input.documentUrl ?? null, resolveImage)}
+      components={bookComponents(
+        input.documentUrl ?? null,
+        resolveImage,
+        collectAndResolve,
+        input.posts,
+      )}
       document={document}
       options={{ resolveImageUrl }}
     />,

--- a/apps/standard-reader/src/server/books/sources.ts
+++ b/apps/standard-reader/src/server/books/sources.ts
@@ -14,8 +14,10 @@ import type {
   JsonValue,
   Schema,
 } from "#/integrations/tanstack-query/api-shapes";
+import type { BskyPostView } from "#/server/atproto/bsky-posts";
 import { loadFeedItemBodies } from "#/server/feeds/build";
 
+import { bskyPostUrisInDocument, hydrateBskyPosts } from "./bsky-embeds";
 import type { EpubChapterSource, EpubSpec } from "./epub";
 import { renderDocumentBody } from "./render";
 
@@ -102,6 +104,7 @@ function chapterFromCard(
   body: FeedItemBody | undefined,
   index: number,
   baseUrl: string,
+  posts: Map<string, BskyPostView>,
 ): EpubChapterSource {
   const sourceUrl = cardSourceUrl(card, baseUrl);
   return {
@@ -120,6 +123,7 @@ function chapterFromCard(
         description: card.description,
         documentUrl: sourceUrl,
         localImages,
+        posts,
       }),
     title: card.title,
   };
@@ -152,11 +156,32 @@ export async function bookFromCards(
     cards.map((card) => card.uri),
   );
 
+  // One round trip for every post the whole book embeds: the AppView takes 25
+  // URIs at a time, and a forty-article anthology would otherwise be forty
+  // requests to hydrate what is often the same handful of posts.
+  const posts = await hydrateBskyPosts(
+    cards.flatMap((card) => {
+      const body = bodies.get(card.uri);
+      return bskyPostUrisInDocument({
+        authorDid: card.did,
+        content: body?.contentJson ?? null,
+        contentFormat: body?.contentFormat ?? null,
+        description: card.description,
+      });
+    }),
+  );
+
   const first = cards[0];
   return {
     authors: options.authors ?? collectAuthors(cards),
     chapters: cards.map((card, index) =>
-      chapterFromCard(card, bodies.get(card.uri), index, options.baseUrl),
+      chapterFromCard(
+        card,
+        bodies.get(card.uri),
+        index,
+        options.baseUrl,
+        posts,
+      ),
     ),
     coverImageUrl: options.coverImageUrl ?? first?.coverImageUrl ?? null,
     description: options.description ?? null,

--- a/apps/standard-reader/src/server/books/xhtml.ts
+++ b/apps/standard-reader/src/server/books/xhtml.ts
@@ -142,6 +142,17 @@ aside[role="note"] { border-left: 3px solid currentColor; padding-left: 0.8em; m
 /* Endnotes read better small and tight. */
 section[epub|type="footnotes"] { font-size: 0.85em; }
 
+/* An embedded Bluesky post. Bordered rather than tinted: an e-ink screen has
+   no colour to spend, and a border survives every reader theme. */
+.sr-post { border: 1px solid currentColor; border-radius: 0.4em; padding: 0.8em 1em; margin: 1.5em 0; font-size: 0.9em; }
+.sr-post p { margin: 0.4em 0; }
+.sr-post-byline { font-weight: bold; }
+.sr-post-handle { font-weight: normal; opacity: 0.7; }
+.sr-post-avatar { width: 1.4em; height: 1.4em; border-radius: 50%; vertical-align: middle; margin-right: 0.4em; }
+.sr-post-image { display: block; max-width: 100%; height: auto; margin: 0.6em auto; }
+.sr-post-source { font-size: 0.85em; opacity: 0.7; }
+.sr-post-source a { text-decoration: none; }
+
 /* Title page of a multi-article book. */
 .sr-title-page { text-align: center; margin-top: 20%; }
 .sr-title-page h1 { font-size: 1.8em; margin-bottom: 0.2em; }


### PR DESCRIPTION
On the web an embedded Bluesky post is a live component that fetches itself. A book has no runtime, so it was rendering as a bare `bsky.app` URL — a dead end for a reader on a plane, at exactly the spot where the writer put the thing they were responding to.

Posts are now hydrated at build time and written into the chapter.

## Before / after

```
before:  <p><a href="https://bsky.app/…">https://bsky.app/…</a></p>

after:   ┌──────────────────────────────────────────────┐
         │ (avatar) Miguel Batres  @btrs.co             │
         │                                              │
         │ Building a new publishing platform built on  │
         │ top of #atproto that will act as a drop in   │
         │ replacement for Substack essentially.        │
         │                                              │
         │ Publishing, audience tools, content          │
         │ subscriptions and more.                      │
         │                                              │
         │ August 30, 2025                              │
         └──────────────────────────────────────────────┘
```

## Three things worth a look

**One round trip per book, not per chapter.** The AppView takes 25 URIs at a time, so a forty-article anthology hydrates in one or two requests instead of forty. URIs come from walking the render tree for `blueskyEmbed` nodes, which covers *every* content format rather than just Leaflet's — the app already had `leafletBskyPostUris`, but that would have missed the Offprint posts that turn out to be where most embeds actually live.

**The pictures come too.** `getPosts` was dropping the embed view, so a post whose entire content was four screenshots arrived as an empty quote. It now parses `app.bsky.embed.images#view` and the `recordWithMedia` shape, and those images ride the same fetch-and-embed pass as the article's own images — alt text intact.

**A missing post is still a link.** Deleted post, unreachable AppView, a URI that never resolved: the card falls back to exactly what it drew before, rather than leaving a hole where a quotation was.

## Testing

Verified against real articles on the network:

| | result |
|---|---|
| Offprint post w/ text | card renders, avatar embedded, line breaks kept, 0 bare links |
| Offprint post w/ 4 screenshots | 6 images embedded, all 4 with original alt text |
| chapter XHTML | well-formed |

1090 tests pass; lint, format and typecheck clean.

## Note

Only the post itself is inlined — a *quoted* post inside an embed still renders as its parent's text plus link. Worth doing if it turns up in practice; it needs another level of the embed view and I did not want to guess at how common it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
