### PR TITLE
Fix two ways a signed-in reader silently loses the site

### DIFF
--- a/apps/standard-reader/.env.example
+++ b/apps/standard-reader/.env.example
@@ -16,6 +16,17 @@ DATABASE_URL="postgresql://[user]:[password]@[neon_hostname]/[dbname]?sslmode=re
 # queries skip per-request TLS/proxy overhead. In prod (Railway ↔ Neon, same
 # region) the TCP+TLS handshake is <5ms — far cheaper than per-query HTTP.
 DB_DRIVER="pg"
+# Request pool size, and how long a query may wait for a free connection before
+# it errors. node-postgres queues acquires forever if unset, which turns pool
+# exhaustion into multi-minute hangs that still answer 200 — set this so a
+# drained pool fails loudly instead of silently.
+DB_POOL_MAX="16"
+DB_POOL_ACQUIRE_TIMEOUT_MS="5000"
+# Separate pool for the OAuth refresh advisory lock, which holds its connection
+# across the PDS token-refresh round trip. Isolating it means a slow third-party
+# PDS can stall refreshes without starving ordinary signed-in reads.
+DB_LOCK_POOL_MAX="8"
+DB_LOCK_ACQUIRE_TIMEOUT_MS="20000"
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Analytics — Plausible (client-side, `@plausible-analytics/tracker`)

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -503,16 +503,33 @@ stores in `src/integrations/auth/`, session/user server fns in
       transaction to claim, release the connection, refresh, short transaction to
       release) with a TTL so a crashed process can't strand the lease — replacing
       `pg_advisory_xact_lock`. Needs a migration.
-- [ ] **The refresh lock is not actually preventing logouts.** `attachSessionEventLogging` calls
-      `auth.oauth.session_deleted` "the primary breadcrumb for the logout-on-deploy bug" and says a
-      recurring stream means refresh rotation is still racing. Over 7d there are **25,331** of them,
-      and **25,286 (99.8%) carry `cause: "session was deleted by another process"`** — the exact
-      racing-refresh signature, not genuine PDS revocation (that accounts for ~40). Meanwhile
-      `auth.oauth.refresh_lock_contended` fires only 186×/24h, so the lock is rarely even engaging:
-      something is bypassing `dbRequestLock` rather than the lock failing to hold. Worth checking
-      whether every process that restores a session goes through it (ingest/cron included) and
-      whether `isNeonHttpDriver` is silently true anywhere — that branch degrades to in-process-only
-      serialization and logs `refresh_lock_unavailable` just once per process.
+- [ ] **Readers get stuck in a zombie signed-in state when their OAuth session vanishes.** Nothing
+      reconciles our app `session` row with atcute's stored OAuth session: the only place a session
+      row is deleted is the explicit `user.signOut`
+      ([`api-user.functions.ts:1568`](src/integrations/tanstack-query/api-user.functions.ts)). So
+      once the OAuth blob is gone, the reader's session cookie stays valid, the app keeps believing
+      they're signed in, and every request silently degrades to guest data forever.
+      `attachSessionEventLogging` only *logs* the `deleted` event — it doesn't invalidate anything.
+
+      The telemetry signature: `auth.oauth.session_deleted` fires **every 60 seconds on the dot**
+      for an affected DID, inside a `GET` span, indefinitely (one account has been looping since at
+      least 2026-08-13). Each attempt also takes the advisory lock and a lock-pool connection.
+
+      Scale, measured rather than assumed: 25,331 events over 7d sounds like mass logouts but is
+      **21 distinct DIDs**, with 4 accounting for 99.8% (16,800 / 5,060 / 2,178 / 1,216). The raw
+      count is also ~2× inflated — each restore attempt emits one event per OAuth client kind
+      (`default` **and** `review`, same trace, ~20ms apart), so both listeners report one underlying
+      deletion.
+
+      **The lock itself is fine** — over 7d `auth.oauth.refresh_lock_unavailable` and
+      `auth.oauth.refresh_lock_timeout` are both **0**, so `isNeonHttpDriver` is not silently true
+      anywhere and the lock never times out. Low `refresh_lock_contended` volume (1,002/7d) is
+      expected when only a handful of DIDs are involved; it is not evidence of a bypass.
+
+      Fix carefully: `"session was deleted by another process"` can also occur on a benign race, so
+      tearing down the app session straight from the global `deleted` listener risks logging people
+      out on a transient blip. Better to handle it where a restore fails during a request (with the
+      session token in hand) than in the by-DID listener.
 - [ ] **Re-check `JETSTREAM_APPLY_CONCURRENCY` against `DB_POOL_MAX`.** Both
       default to 16, so ingest apply can by itself own every connection in a
       process that also serves requests (519 `ingest.*` spans were observed on

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -504,36 +504,29 @@ stores in `src/integrations/auth/`, session/user server fns in
       release) with a TTL so a crashed process can't strand the lease — replacing
       `pg_advisory_xact_lock`. Needs a migration.
 - [x] **Readers got stuck in a zombie signed-in state when their OAuth session vanished.** Nothing
-      reconciled our app `session` row with atcute's stored OAuth session: the only place a session
+      reconciled our app `session` row with atcute's stored OAuth session — the only place a session
       row was deleted was the explicit `user.signOut`
-      ([`api-user.functions.ts:1568`](src/integrations/tanstack-query/api-user.functions.ts)). So
-      once the OAuth blob is gone, the reader's session cookie stays valid, the app keeps believing
-      they're signed in, and every request silently degrades to guest data forever.
-      `attachSessionEventLogging` only *logs* the `deleted` event — it doesn't invalidate anything.
-
-      The telemetry signature: `auth.oauth.session_deleted` fires **every 60 seconds on the dot**
-      for an affected DID, inside a `GET` span, indefinitely (one account has been looping since at
-      least 2026-08-13). Each attempt also takes the advisory lock and a lock-pool connection.
-
-      Scale, measured rather than assumed: 25,331 events over 7d sounds like mass logouts but is
-      **21 distinct DIDs**, with 4 accounting for 99.8% (16,800 / 5,060 / 2,178 / 1,216). The raw
-      count is also ~2× inflated — each restore attempt emits one event per OAuth client kind
-      (`default` **and** `review`, same trace, ~20ms apart), so both listeners report one underlying
-      deletion.
-
-      **The lock itself is fine** — over 7d `auth.oauth.refresh_lock_unavailable` and
-      `auth.oauth.refresh_lock_timeout` are both **0**, so `isNeonHttpDriver` is not silently true
-      anywhere and the lock never times out. Low `refresh_lock_contended` volume (1,002/7d) is
-      expected when only a handful of DIDs are involved; it is not evidence of a bypass.
-
-      Fixed request-scoped rather than from the global listener, because
-      `"session was deleted by another process"` can also occur on a benign race and tearing down
-      sessions by DID would risk logging people out on a transient blip. The OAuth client now
-      records deletions in
-      [`session-deletions.ts`](src/integrations/auth/session-deletions.ts) and
+      ([`api-user.functions.ts:1568`](src/integrations/tanstack-query/api-user.functions.ts)) — so
+      once the OAuth blob was gone the session cookie stayed valid, the app kept believing the
+      reader was signed in, and every request silently degraded to guest data forever;
+      `attachSessionEventLogging` only logged the `deleted` event. The signature was
+      `auth.oauth.session_deleted` firing **every 60 seconds on the dot** for an affected DID,
+      inside a `GET` span, indefinitely (one account looping since at least 2026-08-13), each
+      attempt also taking the advisory lock and a lock-pool connection. Fixed request-scoped rather
+      than from the global listener, because `"session was deleted by another process"` can also
+      occur on a benign race and tearing down sessions by DID would risk logging people out on a
+      transient blip: the OAuth client records deletions in
+      [`session-deletions.ts`](src/integrations/auth/session-deletions.ts), and
       `endSessionIfOauthSessionDeleted` in
       [`auth-session.server.ts`](src/middleware/auth-session.server.ts) consumes that signal when a
       restore fails, ending only the session row for the token on that request.
+- [ ] **Read `auth.oauth.session_deleted` counts as ~half what they say.** Both OAuth client kinds
+      get a listener and `restoreAtprotoSession` tries both, so one failed restore emits the event
+      twice (`default` **and** `review`, same trace, ~20ms apart). Worth collapsing to one event per
+      restore so the number means what it looks like. For reference, the 25,331 events over 7d that
+      looked like mass logouts were **21 distinct DIDs**, 4 of them 99.8% (16,800 / 5,060 / 2,178 /
+      1,216) — and the refresh lock itself was fine: `auth.oauth.refresh_lock_unavailable` and
+      `auth.oauth.refresh_lock_timeout` were both **0** over the same window.
 - [ ] **Re-check `JETSTREAM_APPLY_CONCURRENCY` against `DB_POOL_MAX`.** Both
       default to 16, so ingest apply can by itself own every connection in a
       process that also serves requests (519 `ingest.*` spans were observed on

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -241,6 +241,19 @@ Check items off as they land.
       events at ~1,000/s before being stopped, and `planSnapshot` reports blocks rather than
       matching events, so the total is unknown. Measure before planning a window around it.
 
+- [ ] **`reconcile-cron` is running a stale build — the sweep is 100% dead.** `ingest.repoReconcile`
+      fails ~99.9% of the time (43,495 failures over 7d, flat at ~350–440/hr for the whole window;
+      96.5% of failures are one query). It selects `tracked_repos.last_seen_rev` — the column
+      migration [`0041_tidy_last_seen_seq`](drizzle/0041_tidy_last_seen_seq.sql) **dropped** in favor
+      of `last_seen_seq`. No current source generates that query, so the deployed reconcile service
+      predates 0041. Only the web service runs `preDeployCommand` migrations, so the shared DB moved
+      on without it. **Redeploy `reconcile-cron`/ingest**, then confirm the failures stop — no repo
+      has been reconciled (i.e. no drift repaired) for at least a week.
+- [ ] **Clean up the dropped column's leftovers.** [`scripts/tmp-drain.ts`](scripts/tmp-drain.ts)
+      still filters on `t.last_seen_rev is null` (raw SQL, so it fails at runtime rather than
+      typecheck), and several `repo-sync.ts` comments still describe `last_seen_rev` as the
+      watermark. Delete the temp script if it has outlived its purpose; refresh the comments.
+
 - [x] **Personal state no longer waits on the ingest queue** (2026-08-01). With the ingest worker
       backlogged, a reader's own read/unread state — the one thing they watch change in the moment —
       queued behind everyone else's backfill, so articles stayed unread for hours after being read.
@@ -475,6 +488,36 @@ stores in `src/integrations/auth/`, session/user server fns in
       for `app.standard-reader.authBasicFeatures` +
       `app.standard-reader.authCollections` when `_lexicon.*` DNS ready (manual,
       requires `LEXICON_PUBLISH_*` creds).
+- [x] **Stop the refresh lock starving the request pool.** `withAdvisoryLock`
+      holds its connection across the PDS refresh round trip, so slow
+      third-party PDSes drained the shared `pg` pool (`max: 16`); with no
+      `connectionTimeoutMillis`, node-postgres queued acquires forever and every
+      signed-in read parked behind them — `user.getShellBootstrap` P95 hit ~9.7
+      min (max 50 min) while still returning 200, so it never showed up as an
+      error. The lock now borrows from an isolated pool (`getLockDb`), and both
+      pools have acquire timeouts so exhaustion fails loudly. See
+      [`src/db/index.ts`](src/db/index.ts).
+- [ ] **Don't hold a pool connection across PDS I/O at all.** The isolated pool
+      contains the blast radius but the refresh still pins a connection for a
+      whole network round trip. The real fix is a lease/claim row (short
+      transaction to claim, release the connection, refresh, short transaction to
+      release) with a TTL so a crashed process can't strand the lease — replacing
+      `pg_advisory_xact_lock`. Needs a migration.
+- [ ] **The refresh lock is not actually preventing logouts.** `attachSessionEventLogging` calls
+      `auth.oauth.session_deleted` "the primary breadcrumb for the logout-on-deploy bug" and says a
+      recurring stream means refresh rotation is still racing. Over 7d there are **25,331** of them,
+      and **25,286 (99.8%) carry `cause: "session was deleted by another process"`** — the exact
+      racing-refresh signature, not genuine PDS revocation (that accounts for ~40). Meanwhile
+      `auth.oauth.refresh_lock_contended` fires only 186×/24h, so the lock is rarely even engaging:
+      something is bypassing `dbRequestLock` rather than the lock failing to hold. Worth checking
+      whether every process that restores a session goes through it (ingest/cron included) and
+      whether `isNeonHttpDriver` is silently true anywhere — that branch degrades to in-process-only
+      serialization and logs `refresh_lock_unavailable` just once per process.
+- [ ] **Re-check `JETSTREAM_APPLY_CONCURRENCY` against `DB_POOL_MAX`.** Both
+      default to 16, so ingest apply can by itself own every connection in a
+      process that also serves requests (519 `ingest.*` spans were observed on
+      the `web` component). Either lower the apply ceiling or give ingest its own
+      pool the way the refresh lock now has one.
 
 ## 4. Lexicons & writes (records = source of truth)
 

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -503,9 +503,9 @@ stores in `src/integrations/auth/`, session/user server fns in
       transaction to claim, release the connection, refresh, short transaction to
       release) with a TTL so a crashed process can't strand the lease — replacing
       `pg_advisory_xact_lock`. Needs a migration.
-- [ ] **Readers get stuck in a zombie signed-in state when their OAuth session vanishes.** Nothing
-      reconciles our app `session` row with atcute's stored OAuth session: the only place a session
-      row is deleted is the explicit `user.signOut`
+- [x] **Readers got stuck in a zombie signed-in state when their OAuth session vanished.** Nothing
+      reconciled our app `session` row with atcute's stored OAuth session: the only place a session
+      row was deleted was the explicit `user.signOut`
       ([`api-user.functions.ts:1568`](src/integrations/tanstack-query/api-user.functions.ts)). So
       once the OAuth blob is gone, the reader's session cookie stays valid, the app keeps believing
       they're signed in, and every request silently degrades to guest data forever.
@@ -526,10 +526,14 @@ stores in `src/integrations/auth/`, session/user server fns in
       anywhere and the lock never times out. Low `refresh_lock_contended` volume (1,002/7d) is
       expected when only a handful of DIDs are involved; it is not evidence of a bypass.
 
-      Fix carefully: `"session was deleted by another process"` can also occur on a benign race, so
-      tearing down the app session straight from the global `deleted` listener risks logging people
-      out on a transient blip. Better to handle it where a restore fails during a request (with the
-      session token in hand) than in the by-DID listener.
+      Fixed request-scoped rather than from the global listener, because
+      `"session was deleted by another process"` can also occur on a benign race and tearing down
+      sessions by DID would risk logging people out on a transient blip. The OAuth client now
+      records deletions in
+      [`session-deletions.ts`](src/integrations/auth/session-deletions.ts) and
+      `endSessionIfOauthSessionDeleted` in
+      [`auth-session.server.ts`](src/middleware/auth-session.server.ts) consumes that signal when a
+      restore fails, ending only the session row for the token on that request.
 - [ ] **Re-check `JETSTREAM_APPLY_CONCURRENCY` against `DB_POOL_MAX`.** Both
       default to 16, so ingest apply can by itself own every connection in a
       process that also serves requests (519 `ingest.*` spans were observed on

--- a/apps/standard-reader/src/db/index.server.ts
+++ b/apps/standard-reader/src/db/index.server.ts
@@ -4,4 +4,4 @@
  * when auth route modules statically import `db`. Re-exports the singleton from
  * `./index.ts` so there is still exactly one client instance.
  */
-export { db, isNeonHttpDriver } from "./index.ts";
+export { db, getLockDb, isNeonHttpDriver } from "./index.ts";

--- a/apps/standard-reader/src/db/index.ts
+++ b/apps/standard-reader/src/db/index.ts
@@ -11,6 +11,10 @@ if (!url) {
   throw new Error("DATABASE_URL is not set");
 }
 
+// The guard above narrows `url` at module scope, but that narrowing does not
+// reach into the deferred body of `getLockDb`. Bind the checked value once.
+const connectionUrl: string = url;
+
 /**
  * The read-model runs on Neon in dev/prod but a plain local Postgres for
  * testing. The `@neondatabase/serverless` HTTP driver only speaks to Neon-style
@@ -28,21 +32,36 @@ function isNeonConnection(connectionString: string): boolean {
   return /neon\.tech|supabase\.co|vercel-storage\.com/i.test(connectionString);
 }
 
+/** Read a positive integer from the environment, falling back when unset/invalid. */
+function envInt(name: string, fallback: number): number {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
 /**
- * Build the `pg` Pool used by the node-postgres driver (local tests + the
+ * Build a `pg` Pool for the node-postgres driver (local tests + the
  * long-running ingest worker via `DB_DRIVER=pg`). The worker processes events
  * concurrently, so size the pool for that; Neon's pooler (pgbouncer) endpoint
  * multiplexes these onto far fewer Postgres backends. Loopback connections run
  * without TLS; everything else (Neon) uses SSL with full certificate
  * verification (`rejectUnauthorized: true`). Neon's certificates are signed
  * by DigiCert, which is in Node's default trust store.
+ *
+ * `connectionTimeoutMillis` is not optional: node-postgres queues acquires
+ * FOREVER by default, so a drained pool degrades into multi-minute request
+ * hangs that raise no error and still answer 200 — invisible in error rates and
+ * indistinguishable from "the site doesn't load". Failing fast turns pool
+ * exhaustion into something a dashboard can actually see.
  */
-function createPgPool(connectionString: string): Pool {
+function createPgPool(
+  connectionString: string,
+  options: { max: number; connectionTimeoutMillis: number },
+): Pool {
   const isLocal = /@(localhost|127\.0\.0\.1|::1)[:/]/.test(connectionString);
-  const max = Number(process.env.DB_POOL_MAX);
   return new Pool({
     connectionString,
-    max: Number.isFinite(max) && max > 0 ? max : 16,
+    max: options.max,
+    connectionTimeoutMillis: options.connectionTimeoutMillis,
     ssl: isLocal ? undefined : { rejectUnauthorized: true },
   });
 }
@@ -64,4 +83,44 @@ export const db: NodePgDatabase<typeof schema> = isNeonHttpDriver
   ? (drizzleHttp({ client: neon(url), schema }) as unknown as NodePgDatabase<
       typeof schema
     >)
-  : drizzleNode({ client: createPgPool(url), schema });
+  : drizzleNode({
+      client: createPgPool(url, {
+        max: envInt("DB_POOL_MAX", 16),
+        connectionTimeoutMillis: envInt("DB_POOL_ACQUIRE_TIMEOUT_MS", 5000),
+      }),
+      schema,
+    });
+
+/**
+ * A second, small pool reserved for the OAuth refresh advisory lock.
+ *
+ * `withAdvisoryLock` (see `src/integrations/auth/db-lock.server.ts`) holds its
+ * connection across the PDS token-refresh round trip — a network call to an
+ * arbitrary third-party server that atcute only bounds at 30s. Run on the
+ * shared pool, sixteen concurrent slow refreshes drain it, and every unrelated
+ * signed-in read then parks in the acquire queue behind them. Isolating those
+ * long holds here means a slow PDS can stall refreshes but never ordinary
+ * request traffic.
+ *
+ * Sized small on purpose: refreshes already serialize per-DID in-process, so
+ * this only needs enough slots for distinct DIDs refreshing at once. The
+ * acquire timeout is generous relative to the request pool because atcute
+ * aborts the whole session get at 30s anyway, and because a failed acquire here
+ * surfaces as a plain error — `deleteOnError` returns false, so the stored
+ * session survives and the reader stays logged in.
+ *
+ * Created lazily so nothing opens a second pool under the neon-http driver or
+ * in tests that never take the lock.
+ */
+let lockDbInstance: NodePgDatabase<typeof schema> | undefined;
+
+export function getLockDb(): NodePgDatabase<typeof schema> {
+  lockDbInstance ??= drizzleNode({
+    client: createPgPool(connectionUrl, {
+      max: envInt("DB_LOCK_POOL_MAX", 8),
+      connectionTimeoutMillis: envInt("DB_LOCK_ACQUIRE_TIMEOUT_MS", 20_000),
+    }),
+    schema,
+  });
+  return lockDbInstance;
+}

--- a/apps/standard-reader/src/integrations/auth/atproto.ts
+++ b/apps/standard-reader/src/integrations/auth/atproto.ts
@@ -24,6 +24,7 @@ import { logEvent } from "#/server/observability/log";
 
 import { dbRequestLock } from "./db-lock.server";
 import { atstoreReviewClientMetadataScope, clientMetadataScope } from "./scope";
+import { recordSessionDeletion } from "./session-deletions";
 
 const OAUTH_STORE_PREFIX = "atproto-oauth";
 const OAUTH_STATE_TTL_MS = 15 * 60_000;
@@ -314,12 +315,18 @@ function createOAuthClient(
 }
 
 /**
- * Emit OAuth session lifecycle telemetry. A `deleted` event means atcute
- * dropped the stored session — which is exactly a user getting logged out.
- * After the `requestLock` fix this should only happen on a genuine PDS-side
- * revocation; a recurring stream of these in prod (especially correlated with a
- * deploy) is the signal that refresh rotation is still racing and warrants
- * investigation. This is the primary breadcrumb for the logout-on-deploy bug.
+ * Emit OAuth session lifecycle telemetry, and record the deletion so the
+ * request path can tear down the matching app session.
+ *
+ * A `deleted` event means atcute dropped the stored session — which is exactly
+ * a user getting logged out. A recurring stream of these in prod (especially
+ * correlated with a deploy) is the signal that refresh rotation is still racing
+ * and warrants investigation. This is the primary breadcrumb for the
+ * logout-on-deploy bug.
+ *
+ * Note both client kinds get a listener and {@link restoreAtprotoSession} tries
+ * both, so a single failed restore emits this event twice — halve the counts
+ * when reading them as "sessions lost".
  */
 function attachSessionEventLogging(
   client: InstanceType<typeof OAuthClient>,
@@ -327,6 +334,7 @@ function attachSessionEventLogging(
 ): void {
   client.addEventListener((event) => {
     if (event.type === "deleted") {
+      recordSessionDeletion(event.sub);
       logEvent("auth.oauth.session_deleted", {
         client: kind,
         did: event.sub,

--- a/apps/standard-reader/src/integrations/auth/db-lock.server.ts
+++ b/apps/standard-reader/src/integrations/auth/db-lock.server.ts
@@ -28,7 +28,7 @@
  */
 import { sql } from "drizzle-orm";
 
-import { db, isNeonHttpDriver } from "#/db/index.server";
+import { getLockDb, isNeonHttpDriver } from "#/db/index.server";
 import { logEvent } from "#/server/observability/log";
 
 /**
@@ -69,7 +69,11 @@ async function withAdvisoryLock<T>(
     return await fn();
   }
 
-  return await db.transaction(async (tx) => {
+  // Deliberately NOT the shared request pool. This transaction stays open
+  // across `fn()` — the PDS refresh round trip — so it must borrow from the
+  // isolated lock pool, or slow third-party PDSes drain the pool every
+  // signed-in read depends on. See `getLockDb` in `src/db/index.ts`.
+  return await getLockDb().transaction(async (tx) => {
     // LOCAL so the setting reverts when the transaction ends. LOCK_TIMEOUT is a
     // hardcoded constant, so interpolating it is safe (SET rejects bind params
     // for its value anyway).

--- a/apps/standard-reader/src/integrations/auth/session-deletions.test.ts
+++ b/apps/standard-reader/src/integrations/auth/session-deletions.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  SESSION_DELETION_TTL_MS,
+  consumeRecentSessionDeletion,
+  recordSessionDeletion,
+  resetSessionDeletionsForTest,
+} from "./session-deletions";
+
+const DID = "did:plc:v4zpi74gy7enfiwke7hmoxv5";
+const OTHER_DID = "did:plc:wayh7z4drxle722hs2cgnhsx";
+
+describe("session deletion tracking", () => {
+  beforeEach(() => {
+    resetSessionDeletionsForTest();
+  });
+
+  it("reports nothing for a DID that was never recorded", () => {
+    // The common case: a restore failed for some transient reason. Signing the
+    // reader out here would be the bug, not the fix.
+    expect(consumeRecentSessionDeletion(DID)).toBe(false);
+  });
+
+  it("reports a deletion recorded moments ago", () => {
+    recordSessionDeletion(DID);
+    expect(consumeRecentSessionDeletion(DID)).toBe(true);
+  });
+
+  it("only reports the DID that was actually deleted", () => {
+    recordSessionDeletion(DID);
+    expect(consumeRecentSessionDeletion(OTHER_DID)).toBe(false);
+    expect(consumeRecentSessionDeletion(DID)).toBe(true);
+  });
+
+  it("consumes the record so one deletion signs out at most once", () => {
+    // Both OAuth client kinds are tried per restore, so the same DID can be
+    // asked about twice in quick succession.
+    recordSessionDeletion(DID);
+    expect(consumeRecentSessionDeletion(DID)).toBe(true);
+    expect(consumeRecentSessionDeletion(DID)).toBe(false);
+  });
+
+  it("ignores a record older than the TTL", () => {
+    const now = 1_000_000;
+    recordSessionDeletion(DID, now);
+    expect(
+      consumeRecentSessionDeletion(DID, now + SESSION_DELETION_TTL_MS + 1),
+    ).toBe(false);
+  });
+
+  it("still reports a record exactly at the TTL boundary", () => {
+    const now = 1_000_000;
+    recordSessionDeletion(DID, now);
+    expect(
+      consumeRecentSessionDeletion(DID, now + SESSION_DELETION_TTL_MS),
+    ).toBe(true);
+  });
+
+  it("consumes an expired record rather than leaving it to fire later", () => {
+    // A stale entry must not survive to sign out a reader who has since
+    // signed back in.
+    const now = 1_000_000;
+    recordSessionDeletion(DID, now);
+    consumeRecentSessionDeletion(DID, now + SESSION_DELETION_TTL_MS + 1);
+    expect(consumeRecentSessionDeletion(DID, now + 1)).toBe(false);
+  });
+
+  it("prunes expired entries for other DIDs as new ones arrive", () => {
+    const now = 1_000_000;
+    recordSessionDeletion(DID, now);
+    recordSessionDeletion(OTHER_DID, now + SESSION_DELETION_TTL_MS + 1);
+    // The first DID's record aged out and was pruned by the second record.
+    expect(consumeRecentSessionDeletion(DID, now + 1)).toBe(false);
+  });
+
+  it("lets a re-recorded deletion fire again", () => {
+    // A reader who signs back in and loses the session again should still be
+    // recovered the second time.
+    recordSessionDeletion(DID);
+    expect(consumeRecentSessionDeletion(DID)).toBe(true);
+    recordSessionDeletion(DID);
+    expect(consumeRecentSessionDeletion(DID)).toBe(true);
+  });
+});

--- a/apps/standard-reader/src/integrations/auth/session-deletions.ts
+++ b/apps/standard-reader/src/integrations/auth/session-deletions.ts
@@ -1,0 +1,67 @@
+/**
+ * Tracks DIDs whose stored OAuth session atcute just reported as deleted.
+ *
+ * A failed session restore is ambiguous on its own: `restoreAtprotoSession`
+ * swallows every error and returns `null`, so "the session is gone" and "the
+ * PDS was briefly unreachable" look identical to callers. atcute's `deleted`
+ * event is the one signal that separates them.
+ *
+ * The OAuth client records deletions here; the request path consumes them (see
+ * `endSessionIfOauthSessionDeleted` in `src/middleware/auth-session.server.ts`)
+ * so a reader's app session is only torn down when their OAuth session is
+ * genuinely gone, never on a transient blip.
+ *
+ * Kept in its own dependency-free module so the request path can read the
+ * signal without importing the OAuth client, and so this is testable without
+ * standing up OAuth config.
+ */
+
+/** DID -> epoch ms of the most recently observed deletion. */
+const recentSessionDeletions = new Map<string, number>();
+
+/**
+ * How long a recorded deletion stays relevant. Comfortably longer than the
+ * restore it belongs to, short enough that a stale record can't sign out a
+ * reader who has since signed back in.
+ */
+export const SESSION_DELETION_TTL_MS = 30_000;
+
+/** Drop expired entries so the map can't grow unbounded if nothing consumes. */
+function prune(now: number): void {
+  for (const [did, at] of recentSessionDeletions) {
+    if (now - at > SESSION_DELETION_TTL_MS) {
+      recentSessionDeletions.delete(did);
+    }
+  }
+}
+
+/** Record that atcute dropped this DID's stored session. */
+export function recordSessionDeletion(did: string, now = Date.now()): void {
+  prune(now);
+  recentSessionDeletions.set(did, now);
+}
+
+/**
+ * True when a deletion was recorded for this DID within
+ * {@link SESSION_DELETION_TTL_MS} — i.e. the restore that just failed did so
+ * because the session is gone, not because the PDS was unreachable.
+ *
+ * Consumes the record either way, so one deletion drives at most one sign-out
+ * and a stale entry can't linger into a later request.
+ */
+export function consumeRecentSessionDeletion(
+  did: string,
+  now = Date.now(),
+): boolean {
+  const at = recentSessionDeletions.get(did);
+  if (at === undefined) {
+    return false;
+  }
+  recentSessionDeletions.delete(did);
+  return now - at <= SESSION_DELETION_TTL_MS;
+}
+
+/** Test seam. */
+export function resetSessionDeletionsForTest(): void {
+  recentSessionDeletions.clear();
+}

--- a/apps/standard-reader/src/middleware/auth-session.server.ts
+++ b/apps/standard-reader/src/middleware/auth-session.server.ts
@@ -7,6 +7,7 @@ import { cache } from "react";
 import type { db as DrizzleDb } from "#/db/index.server";
 import type * as DbSchema from "#/db/schema";
 import { AUTH_SESSION_TOKEN_COOKIE } from "#/integrations/auth/constants";
+import { consumeRecentSessionDeletion } from "#/integrations/auth/session-deletions";
 import { logEvent } from "#/server/observability/log";
 
 type Db = typeof DrizzleDb;
@@ -313,6 +314,77 @@ async function resolveReaderDid(request: Request): Promise<string | undefined> {
   return did;
 }
 
+/**
+ * End the app session when the reader's stored OAuth session is genuinely gone.
+ *
+ * Without this the two halves disagree forever. The `session` row stays valid,
+ * so the app keeps believing the reader is signed in, while every request
+ * quietly falls back to guest data and re-attempts a restore that can never
+ * succeed. Readers sat in that loop for weeks, re-reporting a deleted session
+ * once a minute; the only escape was clearing cookies. Ending the session turns
+ * a permanent zombie state into an ordinary signed-out one they can recover
+ * from by logging in again.
+ *
+ * Deliberately narrow, because the failure mode of over-firing is logging
+ * people out for no reason:
+ *  - It runs only when atcute actually reported the session deleted. A bare
+ *    restore failure is ambiguous — a transient PDS error looks identical — and
+ *    `"session was deleted by another process"` can itself be a benign race, so
+ *    the signal is consumed once rather than latched.
+ *  - It deletes only the row for the token on THIS request, not every session
+ *    for the DID, so one wedged device can't sign the reader out everywhere.
+ */
+async function endSessionIfOauthSessionDeleted({
+  did,
+  sessionToken,
+  sessionId,
+  db,
+  schema,
+}: {
+  did: string;
+  sessionToken: string;
+  sessionId: string;
+  db: Db;
+  schema: Schema;
+}): Promise<void> {
+  if (!consumeRecentSessionDeletion(did)) {
+    return;
+  }
+
+  try {
+    await db.delete(schema.session).where(eq(schema.session.id, sessionId));
+  } catch (error) {
+    // Leave the caches and cookie alone if the row survived — a half-cleared
+    // state would report signed-out while the session still works.
+    logEvent("auth.session.end_after_oauth_delete_failed", {
+      did,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
+
+  sessionTokenCache.delete(sessionToken);
+  readerContextCache.delete(sessionToken);
+  didTokenCache.delete(sessionToken);
+
+  // Best effort: drop the cookie too so the browser stops sending a token that
+  // no longer resolves. The DB row is already gone, so this is cosmetic.
+  try {
+    const isSecure = getRequest().url.startsWith("https://");
+    setCookie(AUTH_SESSION_TOKEN_COOKIE, "", {
+      path: "/",
+      httpOnly: true,
+      sameSite: "lax",
+      secure: isSecure,
+      maxAge: 0,
+    });
+  } catch {
+    // No active request context — the deleted row is authoritative.
+  }
+
+  logEvent("auth.session.ended_after_oauth_delete", { did });
+}
+
 async function resolveAtprotoSession(
   request: Request,
 ): Promise<AtprotoSessionContext | undefined> {
@@ -352,6 +424,13 @@ async function resolveAtprotoSession(
     await import("#/integrations/auth/restore-client.server");
   const client = await restoreAuthenticatedClient(did);
   if (!client) {
+    await endSessionIfOauthSessionDeleted({
+      did,
+      sessionToken,
+      sessionId: sessionRow.id,
+      db,
+      schema,
+    });
     return;
   }
 


### PR DESCRIPTION
Started from a report that the site "doesn't load" for one reader, which wasn't reproducible from another account. It turned out to be two independent bugs, both of which strand signed-in readers while reporting success — so neither showed up in error rates.

---

# 1. The OAuth refresh lock starves the request pool

## The symptom

Requests weren't erroring, they were **hanging**. `user.getShellBootstrap` returned HTTP 200 with `ok: true` after up to **50 minutes**.

It wasn't user-specific either. Across all signed-in traffic:

| | P50 | P95 | MAX |
|---|---|---|---|
| all `getShellBootstrap` (mostly guests) | 0.32ms | 1.14ms | — |
| **signed-in only** (4,308 calls / 7d) | — | **584,200ms (9.7 min)** | — |
| the reporting account (24h) | 210,678ms | — | 3,010,486ms |

Guests are fine because the guest path returns before touching the DB. Signed-in readers all share one tail.

## Root cause: pool starvation, not slow SQL

`withAdvisoryLock` holds its transaction — and therefore its pool connection — open across `fn()`, which is the OAuth **token-refresh round trip to the reader's PDS**: a network call to an arbitrary third-party server that atcute only bounds at 30s.

Run against the shared pool (`max: 16`), a handful of slow PDSes drain it. And the pool had **no `connectionTimeoutMillis`**, so node-postgres queued acquires *forever*. Every unrelated signed-in read parked behind those refreshes with no error, no timeout, and then completed with a 200 once a connection freed.

The tell is queries that *cannot* be slow degrading in lockstep with everything else, at the same wall-clock moments:

| span | P50 | P95 |
|---|---|---|
| `sidebarPref.get` — a single-row indexed lookup | 4.7s | **314s** |
| `shell.getShellSnapshot` | 32s | 733s |
| `lists.getAuthorLists` | 21s | 925s |
| `lists.getLists` | 31s | 493s |

Synchronized spikes across unrelated queries = contention on a shared resource. Guest traffic over the same window (77k spans, never touches the DB) stayed at P50 0.65ms / P95 334ms.

## The fix

**Give the advisory lock its own small pool** (`getLockDb`, `max: 8`). A slow PDS can now stall refreshes without touching the 16 connections ordinary reads depend on. Created lazily, so nothing opens a second pool under neon-http or in tests.

The locking semantics are **deliberately untouched**. The obvious-looking fix — moving `fn()` outside the transaction — would drop the cross-process mutual exclusion this file exists to provide and reintroduce the `invalid_grant` logout race that motivated it.

**Require `connectionTimeoutMillis` on every pool.** Unset, exhaustion degrades into silent multi-minute hangs that still answer 200. Set, it fails fast and becomes something a dashboard can see.

New env vars, all with working defaults (documented in `.env.example`): `DB_POOL_ACQUIRE_TIMEOUT_MS` (5000), `DB_LOCK_POOL_MAX` (8), `DB_LOCK_ACQUIRE_TIMEOUT_MS` (20000). `DB_POOL_MAX` (16) is unchanged.

**This is a mitigation, not the complete fix.** The refresh still pins a connection across a network round trip — the blast radius is just contained. The real fix is a lease/claim row with a TTL replacing `pg_advisory_xact_lock`, so no connection is held across PDS I/O. That needs a migration, so it's filed in TODO.md rather than bundled here.

---

# 2. Readers get stuck in a zombie signed-in state

## The bug

Nothing reconciles our app `session` row with atcute's stored OAuth session. The only place a session row is deleted is the explicit `user.signOut` (`api-user.functions.ts:1568`); `attachSessionEventLogging` only *logs* the `deleted` event.

So once the OAuth blob vanishes the two halves disagree **forever**: the session cookie stays valid, the app keeps believing the reader is signed in, and every request quietly falls back to guest data while re-attempting a restore that can never succeed. The only escape is clearing cookies.

The telemetry signature is unmistakable — `auth.oauth.session_deleted` for one DID:

```
14:35:30  14:36:29  14:37:29  14:38:29  14:39:29
```

Every 60 seconds on the dot, inside a `GET` span, indefinitely. One account has been looping since at least 2026-08-13. Each attempt also takes the advisory lock and a lock-pool connection, feeding bug #1 above.

Scale, measured rather than assumed: 25,331 events over 7d is **21 distinct DIDs**, 4 of them 99.8%.

## Why this was not a one-liner

The obvious fix — tear down the session in the `deleted` listener — is the dangerous version. `restoreAtprotoSession` swallows every error and returns `null`, so **"the session is gone" and "the PDS was briefly unreachable" are indistinguishable to callers**. And `"session was deleted by another process"` can itself fire on a benign race. Acting on that signal from a global, DID-keyed listener would log people out for no reason — the exact failure class the refresh lock was added to fix.

atcute's `deleted` event is the one signal that separates the two cases. So: record it, and consume it at the point a restore actually fails, where the session token is in hand.

Kept deliberately narrow:

- **Fires only on a recorded deletion**, consumed once rather than latched, so a stale record can't sign out a reader who has since signed back in.
- **Ends only the row for the token on this request**, not every session for the DID — one wedged device can't sign the reader out everywhere.
- **Leaves caches and cookie untouched if the row delete fails**, rather than reporting signed-out while the session still works.

The result: a permanent zombie state becomes an ordinary signed-out one the reader recovers from by logging in again.

Tracking lives in its own dependency-free module (`session-deletions.ts`) so the request path can read the signal without importing the OAuth client, and so it's testable without standing up OAuth config.

Also documents something that was quietly skewing the telemetry: `restoreAtprotoSession` tries **both** client kinds and both have listeners, so a single failed restore emits `session_deleted` **twice**. Counts read as roughly double the real number of lost sessions.

---

# A third problem, diagnosis only

No code here addresses it; it needs a redeploy, not a patch. Filed in TODO.md.

**`reconcile-cron` is running a stale build; the sweep is 100% dead.** `ingest.repoReconcile` fails ~99.9% of the time — **43,495 failures over 7d, flat at ~350–440/hr** for the entire window. 96.5% are one query selecting `tracked_repos.last_seen_rev`, the column migration `0041_tidy_last_seen_seq` **dropped**. No current source generates that query, so the deployed service predates 0041; only the web service runs `preDeployCommand` migrations, so the shared DB moved on without it. **No repo has been reconciled for at least a week.**

(Related leftover: `scripts/tmp-drain.ts:19` still filters on `t.last_seen_rev is null` in raw SQL, so it fails at runtime rather than typecheck.)

---

# Verification

Full CI gate run locally, with dependencies installed from the lockfile:

- **`pnpm lint`** — 0 errors, 1,429 files
- **`pnpm format:check`** — clean, 1,609 files
- **`pnpm typecheck`** — clean, **0 errors** across every workspace package
- **`pnpm build`** — succeeds
- **Tests**: 9 new cases in `session-deletions.test.ts` covering the semantics that matter — never firing for an unrecorded DID (the over-fire risk), consuming once across the two client kinds, the TTL boundary, expired records being consumed rather than left to fire later, cross-DID pruning, and re-arming after a re-record. `src/integrations/auth` + `src/db` — 15 passed.

**Not verified:** neither fix is exercised against the real failure conditions — I couldn't reproduce a saturated pool or a wedged account locally, so both rest on production telemetry plus tests of the decision rules. After deploy, worth watching: signed-in `getShellBootstrap` P95 should collapse toward the guest numbers, and `auth.session.ended_after_oauth_delete` should fire a handful of times for those 4 DIDs and then go quiet. If the latter fires steadily instead, the deletion signal is being consumed too eagerly and needs another look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
