### PR TITLE
Stop an unreachable archive from signing readers out

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -834,7 +834,9 @@ source of truth; Neon holds a derived view for speed and cross-network querying.
   `src/server/reader/saved-lists.ts` with a short-TTL per-reader cache) — no individual
   `site.standard.graph.subscription` records are written. Both `list` and `listSave` records are
   **mirrored into Neon** (`lists` + `list_saves` tables) by the ingester so the shell snapshot
-  never blocks on PDS I/O. A backfill from the PDS runs on first access when no rows exist yet.
+  never blocks on PDS I/O. A repo we have never reconciled is hydrated from the archive on first
+  access (`hydrateRepoForRead`); once it carries a `tracked_repos.last_seen_seq` the read-model is
+  authoritative and an empty read means "no lists", not "not hydrated yet".
 - **Sidebar personalization:** `app.standard-reader.sidebarPref` — a per-reader singleton (rkey
   `self`, mirrored into `sidebar_prefs`) holding collapsed groups (`collapsed`), the sort mode
   (`subscriptionSort`), the reader's manual top-level tree arrangement (`treeOrder` — list-group
@@ -1449,6 +1451,14 @@ AT Proto network (standard.site publications, profiles, follows)
   `site.standard.*`, `app.standard-reader.*`, `site.mochott.article` — replays Jetstream's sealed
   archive from the cursor in `ingest_state`, then cuts over to the live tail through one iterator.
   The product app server does not process the firehose.
+- **A read path never hard-depends on the archive.** When the read-model comes up empty for a
+  reader's own records the shell hydrates the repo through `hydrateRepoForRead`
+  (`#/server/ingest/archive-replay`), which is deliberately weaker than the raw fold in two ways:
+  it skips repos that already carry a `last_seen_seq` watermark, and it resolves rather than
+  throws when Jetstream is unreachable. Both come from an outage — most readers own no sidebar
+  lists, so awaiting the raw fold re-planned ~97% of readers' repos on every shell load, and one
+  503 from the planner rejected `loadShellSnapshot` and every signed-in surface with it. An
+  unreachable archive degrades a sidebar; it must never sign a reader out of the product.
 - **There is no repo-tracking boundary any more.** This is the load-bearing difference from the
   `tap` era it replaced. tap only streamed repos we had registered with it, so coverage was
   something we had to _construct_: a signal collection to discover publishers, a second instance

--- a/apps/standard-reader/src/server/ingest/archive-replay.test.ts
+++ b/apps/standard-reader/src/server/ingest/archive-replay.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `hydrateRepoForRead` is the read path's entry into the archive, and the two
+ * things that matter about it are things the raw backfill got wrong: it must
+ * not fold a repo the reconcile watermark says we already folded, and it must
+ * never propagate a Jetstream failure into the caller. A 503 from the planner
+ * used to reject `loadShellSnapshot`, which took every signed-in surface down
+ * with it.
+ */
+
+const rows: Array<{ lastSeenSeq: number | null }> = [];
+const snapshot = vi.fn();
+
+vi.mock("../../db/index.ts", () => {
+  const limit = vi.fn(async () => rows);
+  const where = vi.fn(() => ({ limit }));
+  const from = vi.fn(() => ({ where }));
+  const updateWhere = vi.fn(async () => {});
+  return {
+    db: {
+      select: vi.fn(() => ({ from })),
+      update: vi.fn(() => ({ set: vi.fn(() => ({ where: updateWhere })) })),
+    },
+  };
+});
+
+vi.mock("../../db/schema.ts", () => ({
+  trackedRepos: { did: "did", lastSeenSeq: "last_seen_seq" },
+}));
+
+vi.mock("drizzle-orm", () => ({ eq: vi.fn(() => "eq") }));
+
+vi.mock("../observability/log.ts", () => ({ logEvent: vi.fn() }));
+
+vi.mock("./consumer.ts", () => ({
+  handleRecord: vi.fn(async () => {}),
+}));
+
+vi.mock("@bsky/jetstream", () => ({
+  Jetstream: class {
+    snapshot(...args: Array<unknown>) {
+      return snapshot(...args) as AsyncIterable<never>;
+    }
+  },
+}));
+
+async function loadModule() {
+  vi.resetModules();
+  return import("./archive-replay.ts");
+}
+
+async function* empty(): AsyncGenerator<never> {
+  // No archived events for this repo.
+}
+
+beforeEach(() => {
+  rows.length = 0;
+  snapshot.mockReset();
+});
+
+describe("hydrateRepoForRead", () => {
+  it("skips the fold when the repo already carries a reconcile watermark", async () => {
+    rows.push({ lastSeenSeq: 25_045_926_020 });
+    const { hydrateRepoForRead } = await loadModule();
+
+    await hydrateRepoForRead("did:plc:already-folded");
+
+    // The read-model is authoritative for a repo the sweep has seen, so an
+    // empty `lists` read means "no lists", not "not hydrated yet".
+    expect(snapshot).not.toHaveBeenCalled();
+  });
+
+  it("folds once for a repo that has never been reconciled, then never again", async () => {
+    snapshot.mockImplementation(() => empty());
+    const { hydrateRepoForRead } = await loadModule();
+
+    await hydrateRepoForRead("did:plc:fresh");
+    await hydrateRepoForRead("did:plc:fresh");
+
+    expect(snapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves instead of throwing when the archive is unreachable", async () => {
+    snapshot.mockImplementation(() => {
+      throw new Error("Upstream server responded with a 503 error");
+    });
+    const { hydrateRepoForRead } = await loadModule();
+
+    await expect(hydrateRepoForRead("did:plc:fresh")).resolves.toBeUndefined();
+  });
+
+  it("retries on a later request after a failure", async () => {
+    snapshot.mockImplementationOnce(() => {
+      throw new Error("Upstream server responded with a 503 error");
+    });
+    snapshot.mockImplementation(() => empty());
+    const { hydrateRepoForRead } = await loadModule();
+
+    await hydrateRepoForRead("did:plc:fresh");
+    await hydrateRepoForRead("did:plc:fresh");
+
+    expect(snapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces the concurrent calls one shell snapshot makes", async () => {
+    snapshot.mockImplementation(() => empty());
+    const { hydrateRepoForRead } = await loadModule();
+
+    await Promise.all([
+      hydrateRepoForRead("did:plc:fresh"),
+      hydrateRepoForRead("did:plc:fresh"),
+    ]);
+
+    expect(snapshot).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/standard-reader/src/server/ingest/archive-replay.ts
+++ b/apps/standard-reader/src/server/ingest/archive-replay.ts
@@ -329,3 +329,66 @@ export function backfillRepoFromArchive(did: string): Promise<RepoFold> {
   backfillInflight.set(did, run);
   return run;
 }
+
+/**
+ * Repos this process has already settled for the read path — either folded
+ * here or found to carry a reconcile watermark, which says the same thing.
+ * DID strings only, one per signed-in reader the process has served, so it is
+ * bounded by the user base rather than by traffic.
+ */
+const readHydrationSettled = new Set<string>();
+const readHydrationInflight = new Map<string, Promise<void>>();
+
+/**
+ * Hydrate a repo for a *read path* that just found the read-model empty.
+ *
+ * Distinct from {@link backfillRepoFromArchive} in the two ways a read path
+ * needs, both learned from an outage:
+ *
+ * 1. **It never throws.** The shell snapshot awaited the raw backfill, so a
+ *    503 from Jetstream's planner did not degrade a sidebar — it rejected
+ *    `loadShellSnapshot`, and every signed-in surface with it. An archive we
+ *    cannot reach means "no extra rows to show", not "this reader cannot use
+ *    the app".
+ * 2. **It fires at most once per repo.** "No rows" is indistinguishable from
+ *    "no records exist", and most readers own no sidebar lists at all — so the
+ *    old call re-folded ~97% of readers' repos on every shell load, throttled
+ *    only by a 60s cache. A `tracked_repos` row with a `last_seen_seq` means we
+ *    have already folded this repo and the live channel has had it since; the
+ *    read-model is authoritative and the fold is pure waste. Only a repo we
+ *    have genuinely never reconciled is worth a planning request.
+ */
+export function hydrateRepoForRead(did: string): Promise<void> {
+  if (readHydrationSettled.has(did)) {
+    return Promise.resolve();
+  }
+  const inflight = readHydrationInflight.get(did);
+  if (inflight) {
+    return inflight;
+  }
+
+  const run = (async () => {
+    try {
+      const rows = await db
+        .select({ lastSeenSeq: trackedRepos.lastSeenSeq })
+        .from(trackedRepos)
+        .where(eq(trackedRepos.did, did))
+        .limit(1);
+      if (rows[0]?.lastSeenSeq == null) {
+        await backfillRepoFromArchive(did);
+      }
+      readHydrationSettled.add(did);
+    } catch (error: unknown) {
+      // Left unsettled on purpose: a later request retries, and until then the
+      // caller serves whatever the read-model already holds.
+      logEvent("ingest.readHydrationFailed", {
+        did,
+        ok: false,
+        reason: error instanceof Error ? error.message : String(error),
+      });
+    }
+  })().finally(() => readHydrationInflight.delete(did));
+
+  readHydrationInflight.set(did, run);
+  return run;
+}

--- a/apps/standard-reader/src/server/reader/shell-snapshot.server.ts
+++ b/apps/standard-reader/src/server/reader/shell-snapshot.server.ts
@@ -37,7 +37,7 @@ export interface ShellSnapshot {
 }
 
 /** Reader sidebar preferences (list order + collapsed groups) from the DB
- * mirror, with a one-time PDS backfill when no row exists yet. */
+ * mirror, with a one-time archive hydration when no row exists yet. */
 export async function loadSidebarPref(did: string): Promise<SidebarPref> {
   const { db } = await import("#/db/index.server");
   const { sidebarPrefs } = await import("#/db/schema");
@@ -59,10 +59,12 @@ export async function loadSidebarPref(did: string): Promise<SidebarPref> {
 
   let row = await readRow();
   if (!row) {
-    // No row yet — backfill the repo from the archive and retry once.
-    const { backfillRepoFromArchive } =
+    // No row yet — hydrate the repo from the archive and retry once. Best
+    // effort: a reader with no stored preference gets the defaults below, and
+    // an unreachable archive must not take the whole shell down with it.
+    const { hydrateRepoForRead } =
       await import("#/server/ingest/archive-replay");
-    await backfillRepoFromArchive(did);
+    await hydrateRepoForRead(did);
     row = await readRow();
   }
 
@@ -191,8 +193,8 @@ export async function loadOwnSubscriptionLists(
   _client: unknown,
   did: string,
 ): Promise<Array<SubscriptionList>> {
-  // Read from the DB mirror (synced by the tap ingester). Falls back to a PDS
-  // fetch + backfill when no rows exist yet (first visit or pre-sync gap).
+  // Read from the DB mirror (synced by the Jetstream ingester). Falls back to
+  // an archive fold when no rows exist yet (first visit or pre-sync gap).
   const { db } = await import("#/db/index.server");
   const { lists } = await import("#/db/schema");
   const { eq: eqList } = await import("drizzle-orm");
@@ -217,10 +219,11 @@ export async function loadOwnSubscriptionLists(
     );
   }
 
-  // No rows yet — backfill from the archive and retry the DB read.
-  const { backfillRepoFromArchive } =
-    await import("#/server/ingest/archive-replay");
-  await backfillRepoFromArchive(did);
+  // No rows yet — hydrate from the archive and retry the DB read. Most readers
+  // own no lists at all, so this is the common path, not the rare one; see
+  // `hydrateRepoForRead` for why it neither re-folds nor propagates failures.
+  const { hydrateRepoForRead } = await import("#/server/ingest/archive-replay");
+  await hydrateRepoForRead(did);
 
   const refreshed = await db
     .select()


### PR DESCRIPTION
A reader on `blacksky.app` reported the app was unusable. The shell was returning `"Upstream server responded with a 503 error"` — a 503 from Jetstream's `planSnapshot`, surfacing out of `getShellBootstrap`, which is the root loader's first call. Not a degraded sidebar: no app at all.

```
evt="shell.getShellSnapshot"  did=…  ok=false ms=14 error="Upstream server responded with a 503 error"
evt="user.getShellBootstrap"  did=…  ok=false ms=14 error="Upstream server responded with a 503 error"
```

Three DIDs hit it in one 50-second window of `web` logs, so it was never one reader.

## Two bugs, stacked

**It was awaited unguarded.** `loadSidebarPref` and `loadOwnSubscriptionLists` awaited `backfillRepoFromArchive` directly, so a planner failure rejected `loadShellSnapshot`'s `Promise.all` and took every signed-in surface with it. Every other caller of that function already treats it as best effort — `void …catch(() => {})` in `writes.ts`, a one-shot `Set` guard in `saved-lists.ts` and `api-reader.functions.ts`. These two were the exceptions.

**And it ran on nearly every request.** "No rows" cannot distinguish "we have not hydrated this repo" from "this reader owns no lists", and **655 of 676 readers own none** (642 have no `sidebar_prefs` row either). So the common path re-folded a whole repo per shell load, throttled only by a 60s in-process cache. The reporting reader already carried `tracked_repos.last_seen_seq = 24988071585` — we folded their repo months ago; every one of those folds was waste. That volume against one API key is the likeliest reason the planner started shedding us.

## The fix

`hydrateRepoForRead` is the read path's entry into the archive, deliberately weaker than the raw fold in the two ways a read path needs:

- **Skips repos that already carry a `last_seen_seq` watermark.** The sweep folded that repo and the live channel has had it since — the read-model is authoritative, and an empty `lists` read means "no lists", not "not hydrated yet".
- **Resolves rather than throws.** An archive we cannot reach means "no extra rows to show", not "this reader cannot use the app". The DID is left unsettled so a later request retries.

Concurrent callers coalesce, so the two calls one shell snapshot makes cost one fold.

## Testing

- `apps/standard-reader/src/server/ingest/archive-replay.test.ts` — 5 new tests covering the watermark skip, fold-once, resolve-on-503, retry-after-failure, and concurrent coalescing. The first and third fail against the old code.
- `pnpm --filter standard-reader typecheck` ✅
- `pnpm exec oxlint` / `oxfmt --check` ✅
- `pnpm --filter standard-reader exec vitest run src/server/ingest` — 91 passed ✅

`APP_VISION.md` updated: the sidebar-lists mirroring note now describes the watermark rule, and the ingestion section gains "A read path never hard-depends on the archive."

## Not fixed here

Found while triaging, all separate from this PR:

- **The Jetstream live channel has been dead for ~22 hours.** `ingest_state.jetstream.last_event_at = 2026-08-23T17:10:41Z`; every heartbeat since the 14:33 redeploy reads `applied=0 lastSeq=0 idleMs=-1`. Rows still land, but from the reconcile sweep, not the tail — which also means the sweep and these read-path folds are currently generating all of our planning traffic.
- `recompute-cron` is CRASHED on the 14:33 deploy.
- Neon connection timeouts in the ingest logs (`Connection terminated due to connection timeout` on `label_sync_state` writes).
- `reconcile_fail_count` is 7–9 for the affected DIDs, with `reconcile_retry_after` pushed days out by the backoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BsiXs3KiW55Dr96sxykU8y