### PR TITLE
Make a wedged ingest channel fail instead of going quiet

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -1459,6 +1459,18 @@ AT Proto network (standard.site publications, profiles, follows)
   lists, so awaiting the raw fold re-planned ~97% of readers' repos on every shell load, and one
   503 from the planner rejected `loadShellSnapshot` and every signed-in surface with it. An
   unreachable archive degrades a sidebar; it must never sign a reader out of the product.
+- **Silence is a failure mode, and the channel treats it as one.** `@bsky/jetstream` defaults its
+  download retry policy to `maxAttempts: Infinity` with no `onRetry` hook, so an archive endpoint
+  that keeps failing is retried forever from inside the iterator: no batch, no event, no error —
+  just a heartbeat reporting `idleMs=-1`, which is exactly what an idle network looks like.
+  Production ingested nothing for 22 hours that way. Both Jetstream clients now pass a bounded
+  `retry` with an `onRetry` that logs (`ingest.jetstreamRetry`, `ingest.archiveDownloadRetry`), and
+  the channel runs a stall watchdog on the heartbeat: a **cold start** that yields no batch in five
+  minutes is unambiguously wedged (we always resume from a cursor behind the sealed tip, so the
+  archive phase has a backlog to page), while a **running** channel gets an hour, because on the
+  live tail a multi-minute lull is normal for a filter this narrow. Tripping it exits the process —
+  `process.exitCode` alone never lands, since the worker's HTTP listener keeps the event loop
+  alive — and Railway restarts at the stored cursor.
 - **There is no repo-tracking boundary any more.** This is the load-bearing difference from the
   `tap` era it replaced. tap only streamed repos we had registered with it, so coverage was
   something we had to _construct_: a signal collection to discover publishers, a second instance

--- a/apps/standard-reader/scripts/recompute-cron.mjs
+++ b/apps/standard-reader/scripts/recompute-cron.mjs
@@ -22,16 +22,25 @@ if (!secret) {
 
 const auth = `Basic ${Buffer.from(`admin:${secret}`).toString("base64")}`;
 
+// The endpoint answers 202 and runs the recompute in the background, so this
+// only has to prove the trigger landed. It used to await the whole job, which
+// takes ~318s in production — five seconds past undici's default 300s
+// `headersTimeout` — so the cron crashed with UND_ERR_HEADERS_TIMEOUT every
+// hour on a recompute that had actually succeeded. The job's own outcome is in
+// the ingest worker's `ingest.recompute` log event.
 const startedAt = Date.now();
 const res = await fetch(url, {
   method: "POST",
   headers: { authorization: auth },
+  signal: AbortSignal.timeout(30_000),
 });
 const body = await res.text();
 console.info(
   `[recompute-cron] POST ${url} -> ${res.status} in ${Date.now() - startedAt}ms: ${body}`,
 );
-if (!res.ok) {
+// 409 means a previous run is still going — expected when a recompute overruns
+// the hour, and not a failure of this trigger.
+if (!res.ok && res.status !== 409) {
   throw new Error(
     `[recompute-cron] recompute request failed with status ${res.status}`,
   );

--- a/apps/standard-reader/src/server/ingest/archive-replay.ts
+++ b/apps/standard-reader/src/server/ingest/archive-replay.ts
@@ -104,12 +104,35 @@ function dropLive(fold: RepoFold, collection: string, uri: string): void {
 
 let client: Jetstream | undefined;
 
+/**
+ * Attempts per segment/block download before the fetch is allowed to fail.
+ *
+ * The SDK defaults to `maxAttempts: Infinity` with a 30s backoff ceiling and no
+ * error callback, which is the wrong shape for a fold: the reconcile sweep and
+ * the read path both *await* one, so an archive that keeps 503ing does not fail
+ * them — it hangs them, invisibly and forever. Six attempts is about a minute
+ * of the SDK's jittered backoff, after which the caller gets an error it can
+ * log, skip, or retry on its own schedule.
+ */
+const DOWNLOAD_MAX_ATTEMPTS = 6;
+
 function jetstream(): Jetstream {
   client ??= new Jetstream({
     ...(ingestConfig.jetstreamApiKey
       ? { apiKey: ingestConfig.jetstreamApiKey }
       : {}),
     blockConcurrency: ingestConfig.jetstreamBlockConcurrency,
+    retry: {
+      maxAttempts: DOWNLOAD_MAX_ATTEMPTS,
+      onRetry: (error, info) =>
+        logEvent("ingest.archiveDownloadRetry", {
+          attempt: info.attempt,
+          delayMs: info.delayMs,
+          ok: false,
+          reason: error.message,
+          target: info.target.kind,
+        }),
+    },
     service: ingestConfig.jetstreamService,
   });
   return client;

--- a/apps/standard-reader/src/server/ingest/jetstream-channel.test.ts
+++ b/apps/standard-reader/src/server/ingest/jetstream-channel.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { IngestEvent } from "../atproto/types.ts";
 import type { ProcessResult } from "./consumer.ts";
+import { isStalled } from "./jetstream-channel.ts";
 
 /**
  * The cursor-commit rule, extracted from `startJetstreamChannel`.
@@ -136,5 +137,37 @@ describe("unhandled retries", () => {
 
     expect(await applyWithRetries(event, process_, 3)).toBe("dead-lettered");
     expect(process_).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * The stall watchdog, which exists because a wedged iterator is otherwise
+ * indistinguishable from a quiet network: the SDK retries downloads forever
+ * with no error callback, so the channel yields nothing, logs nothing, and
+ * heartbeats `idleMs=-1` — for 22 hours, in the incident this came from.
+ */
+describe("isStalled", () => {
+  const COLD = 5 * 60_000;
+  const RUNNING = 60 * 60_000;
+
+  it("halts a cold start that has produced nothing", () => {
+    // Every restart resumes from a cursor behind the sealed tip, so the archive
+    // phase always has a backlog and yields its first batch in seconds.
+    expect(isStalled(0, COLD, COLD, RUNNING)).toBe(true);
+  });
+
+  it("gives a cold start time to plan and fetch its first page", () => {
+    expect(isStalled(0, 60_000, COLD, RUNNING)).toBe(false);
+  });
+
+  it("tolerates an overnight lull once batches are flowing", () => {
+    // A midday sample of our collection filter saw six commits in a minute
+    // with a 38s gap. Ten minutes of quiet is normal; restarting on it would
+    // bounce the worker all night.
+    expect(isStalled(1, 10 * 60_000, COLD, RUNNING)).toBe(false);
+  });
+
+  it("still halts a running channel that goes silent for an hour", () => {
+    expect(isStalled(4210, RUNNING, COLD, RUNNING)).toBe(true);
   });
 });

--- a/apps/standard-reader/src/server/ingest/jetstream-channel.ts
+++ b/apps/standard-reader/src/server/ingest/jetstream-channel.ts
@@ -62,6 +62,62 @@ const QUEUE_LIMIT = 2048;
  */
 const UNHANDLED_RETRIES = 3;
 
+/**
+ * How long a *freshly started* channel may yield nothing before we treat it as
+ * wedged (`JETSTREAM_COLD_STALL_MS`).
+ *
+ * The SDK's download retry policy defaults to `maxAttempts: Infinity` with a
+ * 30s backoff ceiling and no error callback, so a segment or block endpoint
+ * that keeps failing is retried forever, silently, from inside the iterator.
+ * The channel then produces no batch, no event, and no error — the heartbeat
+ * reports `idleMs=-1` and nothing else, which is exactly what "quiet network"
+ * looks like. Production sat like that for 22 hours.
+ *
+ * A cold start is the one moment silence is unambiguous. We always resume from
+ * a stored cursor behind the sealed tip, so the archive phase has a backlog to
+ * page and yields its first batch in seconds. Nothing at all after five minutes
+ * is not a quiet network — it is a stuck iterator.
+ */
+const COLD_STALL_TIMEOUT_MS = envInt("JETSTREAM_COLD_STALL_MS", 5 * 60 * 1000);
+
+/**
+ * How long a *running* channel may yield nothing (`JETSTREAM_STALL_MS`).
+ *
+ * Far more generous than the cold-start bound, because on the live tail silence
+ * is genuinely ambiguous: our collection filter is narrow, and a midday sample
+ * saw six commits in a minute with a 38-second gap between two of them. An
+ * overnight lull of several minutes is normal and must not restart the worker.
+ * An hour of it is not.
+ */
+const STALL_TIMEOUT_MS = envInt("JETSTREAM_STALL_MS", 60 * 60 * 1000);
+
+/**
+ * Attempts per segment/block download before the fetch is allowed to fail.
+ *
+ * Bounded on purpose, against the SDK's infinite default: a download that has
+ * failed this many times is not a blip, and surfacing it as an error lets the
+ * channel's own re-plan (or, failing that, a restart) do something about it.
+ * Twelve attempts spans roughly five minutes of the SDK's jittered backoff.
+ */
+const DOWNLOAD_MAX_ATTEMPTS = 12;
+
+/**
+ * Whether a channel that has yielded `batches` batches and has been silent for
+ * `stalledMs` should be considered wedged.
+ *
+ * Exported for the test: the two bounds are the whole point, and getting the
+ * cold-start one wrong either misses the failure it exists for or restarts a
+ * healthy worker every quiet night.
+ */
+export function isStalled(
+  batches: number,
+  stalledMs: number,
+  coldMs = COLD_STALL_TIMEOUT_MS,
+  runningMs = STALL_TIMEOUT_MS,
+): boolean {
+  return stalledMs >= (batches === 0 ? coldMs : runningMs);
+}
+
 function envInt(name: string, fallback: number): number {
   const value = Number(process.env[name]);
   return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
@@ -143,6 +199,22 @@ export function startJetstreamChannel(): { destroy: () => Promise<void> } {
     // cannot replay history and will sit at the cursor's lookback floor.
     ...(apiKey ? { apiKey } : {}),
     blockConcurrency,
+    // Without this the SDK retries every download forever and tells no one
+    // (`maxAttempts: Infinity`, no `onRetry`). `onRetry` is the part that
+    // matters most: a retry storm against the archive is the single failure
+    // mode that looks identical to an idle network from out here.
+    retry: {
+      maxAttempts: DOWNLOAD_MAX_ATTEMPTS,
+      onRetry: (error, info) => {
+        logEvent("ingest.jetstreamRetry", {
+          attempt: info.attempt,
+          delayMs: info.delayMs,
+          ok: false,
+          reason: error.message,
+          target: info.target.kind,
+        });
+      },
+    },
     service,
   });
 
@@ -151,6 +223,13 @@ export function startJetstreamChannel(): { destroy: () => Promise<void> } {
     deadLettered: 0,
     errors: 0,
     lastEventAt: 0,
+    // Distinct from `lastEventAt`, which only moves when a worker dequeues an
+    // event. A batch whose events were all filtered out is still progress —
+    // the iterator is alive and the cursor advances — so the stall watchdog
+    // has to watch batches, not events.
+    lastProgressAt: Date.now(),
+    /** Batches yielded. Zero means we are still in the cold-start window. */
+    batches: 0,
     lastSeq: 0,
     startedAt: Date.now(),
     unhandled: 0,
@@ -293,10 +372,7 @@ export function startJetstreamChannel(): { destroy: () => Promise<void> } {
           // durable progress, so stop it rather than keep consuming events the
           // cursor can never account for.
           stats.errors += 1;
-          console.error("[ingest:jetstream] halting channel", error);
-          fatal = error instanceof Error ? error : new Error(String(error));
-          controller.abort();
-          wakeReader();
+          halt("unhandled event reached the head of the queue", error);
           return;
         }
       }
@@ -305,9 +381,51 @@ export function startJetstreamChannel(): { destroy: () => Promise<void> } {
 
   const workers = Array.from({ length: applyConcurrency }, () => worker());
 
+  /**
+   * Stop the channel and end the process.
+   *
+   * `process.exitCode` alone is not enough here: the ingest service's HTTP
+   * listener keeps the event loop alive forever, so a channel that gave up
+   * would leave a healthy-looking process that ingests nothing. Exiting is the
+   * documented recovery — the stored cursor points at the last fully-applied
+   * batch, and Railway's `ON_FAILURE` policy restarts us there.
+   */
+  let halting = false;
+  function halt(reason: string, error?: unknown): void {
+    if (halting) return;
+    halting = true;
+    console.error(`[ingest:jetstream] halting: ${reason}`, error ?? "");
+    logEvent("ingest.jetstreamHalt", {
+      ok: false,
+      reason,
+      ...(error ? { error: String(error) } : {}),
+    });
+    clearInterval(heartbeat);
+    fatal ??= error instanceof Error ? error : new Error(reason);
+    controller.abort();
+    wakeReader();
+    wakeAllWorkers();
+    void (async () => {
+      const { flushTelemetry } = await import("../observability/log.ts");
+      await flushTelemetry().catch(() => {});
+      // Throwing would only reject a promise nobody awaits, and the HTTP
+      // listener would keep a dead channel's process alive. Exiting IS the
+      // recovery: Railway restarts us at the stored cursor.
+      // oxlint-disable-next-line unicorn/no-process-exit
+      process.exit(1);
+    })();
+  }
+
   const heartbeat = setInterval(() => {
     const idleMs =
       stats.lastEventAt === 0 ? -1 : Date.now() - stats.lastEventAt;
+    const stalledMs = Date.now() - stats.lastProgressAt;
+    if (isStalled(stats.batches, stalledMs)) {
+      halt(
+        `no batch in ${Math.round(stalledMs / 1000)}s (batches=${stats.batches}) — the iterator is wedged`,
+      );
+      return;
+    }
     console.info(
       `[ingest:jetstream] heartbeat: applied=${stats.applied} deadLettered=${stats.deadLettered} unhandled=${stats.unhandled} errors=${stats.errors} queue=${queue.length}/${QUEUE_LIMIT} inflightBatches=${inflight.length} lastSeq=${stats.lastSeq} idleMs=${idleMs}`,
     );
@@ -324,6 +442,11 @@ export function startJetstreamChannel(): { destroy: () => Promise<void> } {
       // cannot keep up and the read loop is being throttled on purpose.
       queueDepth: queue.length,
       queueLimit: QUEUE_LIMIT,
+      batches: stats.batches,
+      // The gauge that would have caught the 22-hour wedge: `idleMs` stays at
+      // -1 when nothing has ever arrived, so it cannot distinguish "quiet" from
+      // "stuck". This one always counts up from the last batch.
+      stalledMs,
       unhandled: stats.unhandled,
     });
   }, 10_000);
@@ -354,6 +477,8 @@ export function startJetstreamChannel(): { destroy: () => Promise<void> } {
         signal: controller.signal,
       })) {
         const now = Date.now();
+        stats.lastProgressAt = now;
+        stats.batches += 1;
         const events = raw.events
           .map((event) => toIngestEvent(event, now))
           .filter((event): event is IngestEvent => event !== null);
@@ -394,8 +519,7 @@ export function startJetstreamChannel(): { destroy: () => Promise<void> } {
   })().catch((error: unknown) => {
     // A deliberate halt aborts the signal itself, so it must still surface.
     if (controller.signal.aborted && !fatal) return;
-    console.error("[ingest:jetstream] channel stopped", error);
-    process.exitCode = 1;
+    halt("channel stopped", error);
   });
 
   console.info(

--- a/apps/standard-reader/src/server/ingest/service.ts
+++ b/apps/standard-reader/src/server/ingest/service.ts
@@ -152,6 +152,12 @@ function requireAuth(req: IncomingMessage, res: ServerResponse): boolean {
   return false;
 }
 
+/**
+ * One recompute at a time. The job runs for minutes and the trigger is hourly,
+ * so a slow run must not stack a second pass on top of the first.
+ */
+let recomputeInFlight = false;
+
 async function handleRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -175,21 +181,36 @@ async function handleRequest(
     if (!requireAuth(req, res)) {
       return;
     }
-    const startedAt = performance.now();
-    try {
-      await recomputeDerived();
-      const ms = Math.round(performance.now() - startedAt);
-      logEvent("ingest.recompute", { ok: true, ms });
-      sendJson(res, 200, { durationMs: ms, ok: true });
-    } catch (error: unknown) {
-      const ms = Math.round(performance.now() - startedAt);
-      logEvent("ingest.recompute", {
-        error: error instanceof Error ? error.message : String(error),
-        ms,
-        ok: false,
-      });
-      throw error;
+    // Answered immediately, on purpose. The recompute takes ~318s in
+    // production and undici's default `headersTimeout` is 300s, so awaiting it
+    // here meant the hourly cron client aborted with `UND_ERR_HEADERS_TIMEOUT`
+    // and Railway marked the service CRASHED — every hour, on work that had in
+    // fact succeeded. The outcome lives in the `ingest.recompute` log event,
+    // which is where anything watching should read it from anyway.
+    if (recomputeInFlight) {
+      sendJson(res, 409, { ok: false, reason: "recompute already running" });
+      return;
     }
+    recomputeInFlight = true;
+    sendJson(res, 202, { ok: true, started: true });
+    const startedAt = performance.now();
+    void recomputeDerived()
+      .then(() => {
+        logEvent("ingest.recompute", {
+          ms: Math.round(performance.now() - startedAt),
+          ok: true,
+        });
+      })
+      .catch((error: unknown) => {
+        logEvent("ingest.recompute", {
+          error: error instanceof Error ? error.message : String(error),
+          ms: Math.round(performance.now() - startedAt),
+          ok: false,
+        });
+      })
+      .finally(() => {
+        recomputeInFlight = false;
+      });
     return;
   }
 


### PR DESCRIPTION
Found while triaging #175. Production has ingested nothing through the live channel for **22 hours**.

```
ingest_state.jetstream.last_event_at = 2026-08-23T17:10:41Z
[ingest:jetstream] heartbeat: applied=0 ... lastSeq=0 idleMs=-1     ← every 10s, for hours
```

The archive was never the problem. The same cursor and collection filter, replayed from a laptop with the same API key, yields its first batch in 4s and 293 batches / 14,493 events in 90s.

## Why it was silent

`@bsky/jetstream` resolves its download retry policy as:

```js
maxAttempts: policy?.maxAttempts ?? Infinity,
baseDelayMs: 250, maxDelayMs: 30_000, onRetry: policy?.onRetry
```

We passed no `retry`, so we inherited **infinite attempts with no error callback**. A segment or block endpoint that keeps failing is retried forever from inside the iterator — no batch, no event, nothing through `onError`. The only thing reaching us was `idleMs=-1`, which is also what an idle network looks like. `stats.lastEventAt` never moves until a *worker dequeues an event*, so it cannot distinguish "quiet" from "stuck", and nothing else was watching.

## What this changes

**Bounded retries, and retries you can see.** Both Jetstream clients — the live channel and the archive-fold client in `archive-replay.ts` — now pass `retry: { maxAttempts, onRetry }`, logging `ingest.jetstreamRetry` / `ingest.archiveDownloadRetry`. The `onRetry` hook is the part that turns this from a 22-hour incident into a one-hour one. The fold client matters independently: the reconcile sweep and the read path both *await* a fold, so infinite retry doesn't fail them, it hangs them.

**A stall watchdog with two bounds**, because silence means different things at different times:

| | bound | why |
|---|---|---|
| cold start (`batches === 0`) | 5 min | We always resume from a cursor behind the sealed tip, so the archive phase has a backlog and yields in seconds. Nothing after five minutes is not a quiet network. |
| running | 60 min | A midday sample of our filter saw 6 commits in a minute with a **38s gap** between two of them. An overnight lull of several minutes is normal and must not bounce the worker. |

Both are env-overridable (`JETSTREAM_COLD_STALL_MS`, `JETSTREAM_STALL_MS`). Progress is tracked per *batch*, not per event — a batch whose events were all filtered out still advances the cursor and still proves the iterator is alive. The heartbeat gains `stalledMs` and `batches`.

**Tripping it exits the process.** `process.exitCode = 1` alone never lands here: the ingest worker's HTTP listener keeps the event loop alive forever. That was true of the pre-existing unhandled-event halt too — it aborted the channel and set an exit code nobody would ever read, leaving a healthy-looking process that ingests nothing. Both halts now route through one `halt()` that logs `ingest.jetstreamHalt`, flushes telemetry, and exits so Railway's `ON_FAILURE` policy restarts at the stored cursor.

## Also: recompute-cron has been CRASHED every hour

```
TypeError: fetch failed
  [cause]: HeadersTimeoutError: Headers Timeout Error  UND_ERR_HEADERS_TIMEOUT
```

`/api/ingest/recompute` awaited the whole job before responding. The job takes **318s** (`evt="ingest.recompute" ok=true ms=317856`) — five seconds past undici's default 300s `headersTimeout`. So the recompute succeeded every single time and the trigger died anyway, and Railway marked the service CRASHED.

The endpoint now answers `202` and runs in the background (outcome still in the `ingest.recompute` log event, which is where anything watching should read it from), returns `409` if a run overruns the hour, and the cron client bounds its own request at 30s and treats 409 as success.

## Testing

- 4 new tests in `jetstream-channel.test.ts` covering the two stall bounds — including that a 10-minute live-tail lull does **not** trip it.
- `pnpm --filter standard-reader exec vitest run src/server` — 480 passed, 11 skipped ✅
- `pnpm --filter standard-reader typecheck` ✅ · `oxlint` ✅ · `oxfmt --check` ✅

## Not fixed here

Still outstanding from the same triage:

- Neon connection instability in the ingest logs (`Connection terminated due to connection timeout` on `label_sync_state` writes). Pool config already looks deliberate; this reads as compute saturation rather than a code bug.
- `reconcile_fail_count` is 7–9 for several DIDs with `reconcile_retry_after` pushed days out by the backoff — likely the same upstream failures, and the new retry logging should say for certain.
- **The stuck cursor itself.** This PR makes the wedge visible and self-healing; it does not restart the currently-wedged worker. That needs a redeploy or a manual restart of the `ingest` service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BsiXs3KiW55Dr96sxykU8y