### PR TITLE
Stop the reconcile sweep from rate-limiting us out of the archive

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -1471,6 +1471,17 @@ AT Proto network (standard.site publications, profiles, follows)
   live tail a multi-minute lull is normal for a filter this narrow. Tripping it exits the process —
   `process.exitCode` alone never lands, since the worker's HTTP listener keeps the event loop
   alive — and Railway restarts at the stored cursor.
+- **Archive fetch concurrency is a process-wide budget, not a per-fold one.** `blockConcurrency`
+  bounds in-flight downloads inside a single snapshot iterator, which is not the number that
+  matters when several folds run at once: the reconcile sweep repairs eight repos concurrently, so
+  it was 8 × 16 = 128 requests deep against an endpoint that 429s nearly everything past 64.
+  Jetstream rate-limited us accordingly — `ingest.repoReconcile` logged
+  `Upstream server responded with a 429 error` across thousands of repos, single-repo folds that
+  should cost 200ms took two minutes, and two thirds of the tracked fleet ended up parked in
+  reconcile backoff. `JETSTREAM_FOLD_CONCURRENCY` (default 2) gates concurrent folds in
+  `archive-replay.ts` so `folds × blockConcurrency` lands on the documented 32 shoulder; move the
+  two together, never one alone. `ingest.archiveReplay` reports `waitMs` alongside `ms` so a
+  saturated sweep is visible as queueing rather than as slowness.
 - **There is no repo-tracking boundary any more.** This is the load-bearing difference from the
   `tap` era it replaced. tap only streamed repos we had registered with it, so coverage was
   something we had to _construct_: a signal collection to discover publishers, a second instance

--- a/apps/standard-reader/src/server/ingest/archive-replay.test.ts
+++ b/apps/standard-reader/src/server/ingest/archive-replay.test.ts
@@ -54,9 +54,21 @@ async function* empty(): AsyncGenerator<never> {
   // No archived events for this repo.
 }
 
+const noop = (): void => {};
+
+/** A fold that stays open until the test releases it. */
+function blockingSnapshot(): { release: () => void; gate: Promise<void> } {
+  let release = noop;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { gate, release };
+}
+
 beforeEach(() => {
   rows.length = 0;
   snapshot.mockReset();
+  process.env.JETSTREAM_FOLD_CONCURRENCY = "2";
 });
 
 describe("hydrateRepoForRead", () => {
@@ -113,5 +125,57 @@ describe("hydrateRepoForRead", () => {
     ]);
 
     expect(snapshot).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * The fold semaphore. `blockConcurrency` only bounds downloads inside one
+ * snapshot iterator, so before this existed the reconcile sweep's eight
+ * concurrent repairs put 8 × 16 = 128 block requests in flight against an
+ * endpoint that 429s nearly everything past 64 — and Jetstream duly
+ * rate-limited us across two thirds of the tracked fleet.
+ */
+describe("fold concurrency", () => {
+  it("runs at most JETSTREAM_FOLD_CONCURRENCY folds at once", async () => {
+    const held = blockingSnapshot();
+    let started = 0;
+    snapshot.mockImplementation(() => {
+      started += 1;
+      return {
+        async *[Symbol.asyncIterator]() {
+          await held.gate;
+          yield* [];
+        },
+      };
+    });
+
+    const { foldRepoFromArchive } = await loadModule();
+    const folds = ["a", "b", "c", "d"].map((did) => foldRepoFromArchive(did));
+
+    // Let the first two acquire slots and park in their iterators.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(started).toBe(2);
+
+    held.release();
+    await Promise.all(folds);
+    expect(started).toBe(4);
+  });
+
+  it("hands a freed slot to the next waiter even when a fold throws", async () => {
+    let started = 0;
+    snapshot.mockImplementation(() => {
+      started += 1;
+      // A 429 storm surfaces here, and a slot leaked on the error path would
+      // wedge every later fold in the process.
+      throw new Error("Upstream server responded with a 429 error");
+    });
+
+    const { foldRepoFromArchive } = await loadModule();
+    const results = await Promise.allSettled(
+      ["a", "b", "c", "d", "e"].map((did) => foldRepoFromArchive(did)),
+    );
+
+    expect(results.every((r) => r.status === "rejected")).toBe(true);
+    expect(started).toBe(5);
   });
 });

--- a/apps/standard-reader/src/server/ingest/archive-replay.ts
+++ b/apps/standard-reader/src/server/ingest/archive-replay.ts
@@ -116,6 +116,45 @@ let client: Jetstream | undefined;
  */
 const DOWNLOAD_MAX_ATTEMPTS = 6;
 
+/**
+ * Process-wide gate on concurrent folds.
+ *
+ * `blockConcurrency` bounds in-flight downloads inside *one* snapshot
+ * iterator, so it never saw the whole picture: the reconcile sweep repairs
+ * eight repos at once, which put 8 × 16 = 128 block requests in flight against
+ * a service that 429s nearly everything past 64. Jetstream duly rate-limited
+ * us, every 429 went onto the retry backoff above, single-repo folds that
+ * should take 200ms started taking two minutes, and the failures piled up as
+ * reconcile backoff on two thirds of the tracked fleet. Bounding the retries
+ * makes that visible; this is what stops us causing it.
+ *
+ * A semaphore here rather than a smaller `blockConcurrency`: fold latency is
+ * dominated by the planning round trip, so it is better to let a fold use the
+ * full block budget briefly than to give every fold a slice of it.
+ */
+const foldSlots = { free: ingestConfig.jetstreamFoldConcurrency };
+const foldWaiters: Array<() => void> = [];
+
+async function acquireFoldSlot(): Promise<void> {
+  if (foldSlots.free > 0) {
+    foldSlots.free -= 1;
+    return;
+  }
+  await new Promise<void>((resolve) => foldWaiters.push(resolve));
+}
+
+function releaseFoldSlot(): void {
+  const next = foldWaiters.shift();
+  if (next) {
+    // Hand the slot straight over rather than returning it to the pool: a
+    // waiter that has to re-check `free` can lose the slot to a fold arriving
+    // in the same tick, and under a saturated sweep that starves.
+    next();
+    return;
+  }
+  foldSlots.free += 1;
+}
+
 function jetstream(): Jetstream {
   client ??= new Jetstream({
     ...(ingestConfig.jetstreamApiKey
@@ -173,80 +212,88 @@ export async function foldReposFromArchive(
   const started = performance.now();
   let events = 0;
 
-  for await (const event of jetstream().snapshot({
-    afterSeq: opts.afterSeq ?? 0,
-    collections: INGESTED_COLLECTIONS,
-    dids: dids as ArchiveDids,
-    onError: (error) =>
-      logEvent("ingest.archiveReplayError", {
-        ok: false,
-        reason: error.message,
-      }),
-    // Raw, not typed: typed decode drops every record without a `$type`, and on
-    // this network that is ~0.05% of standard.site records — live publications
-    // and documents included. See `toIngestRecordPayload`.
-    raw: true,
-    ...(opts.signal ? { signal: opts.signal } : {}),
-  })) {
-    // The planner is one-sided (no false negatives, possible false positives),
-    // so a block selected for one DID can carry another's events.
-    const fold = folds.get(event.did);
-    if (!fold) continue;
+  await acquireFoldSlot();
+  // Separated from `ms` so a saturated sweep is legible: `ms` covers the whole
+  // call, `waitMs` says how much of it was spent queued behind other folds.
+  const waitMs = Math.round(performance.now() - started);
+  try {
+    for await (const event of jetstream().snapshot({
+      afterSeq: opts.afterSeq ?? 0,
+      collections: INGESTED_COLLECTIONS,
+      dids: dids as ArchiveDids,
+      onError: (error) =>
+        logEvent("ingest.archiveReplayError", {
+          ok: false,
+          reason: error.message,
+        }),
+      // Raw, not typed: typed decode drops every record without a `$type`, and on
+      // this network that is ~0.05% of standard.site records — live publications
+      // and documents included. See `toIngestRecordPayload`.
+      raw: true,
+      ...(opts.signal ? { signal: opts.signal } : {}),
+    })) {
+      // The planner is one-sided (no false negatives, possible false positives),
+      // so a block selected for one DID can carry another's events.
+      const fold = folds.get(event.did);
+      if (!fold) continue;
 
-    events += 1;
-    fold.empty = false;
-    fold.lastSeq = Math.max(fold.lastSeq, event.seq);
+      events += 1;
+      fold.empty = false;
+      fold.lastSeq = Math.max(fold.lastSeq, event.seq);
 
-    if (event.kind === "account") {
-      // The one marker that means "this repo is gone": everything mirrored for
-      // the DID is an orphan. Deactivations and suspensions are not deletions —
-      // the records still exist and come back when the account does.
-      if (
-        event.account.active === false &&
-        event.account.status === "deleted"
-      ) {
-        fold.gone = true;
+      if (event.kind === "account") {
+        // The one marker that means "this repo is gone": everything mirrored for
+        // the DID is an orphan. Deactivations and suspensions are not deletions —
+        // the records still exist and come back when the account does.
+        if (
+          event.account.active === false &&
+          event.account.status === "deleted"
+        ) {
+          fold.gone = true;
+        }
+        continue;
       }
-      continue;
+
+      if (event.kind === "sync") {
+        // Sync 1.1 divergence: the archive discarded this repo's pre-divergence
+        // rows and follows with the authoritative replacement records. Anything
+        // folded so far is exactly what was discarded, so start the live set over
+        // rather than unioning stale URIs into it.
+        fold.live.clear();
+        continue;
+      }
+
+      if (event.kind !== "commit") continue;
+
+      const { collection, operation, rkey } = event.commit;
+      const uri = buildAtUri(event.did, collection, rkey);
+
+      if (operation === "delete") {
+        dropLive(fold, collection, uri);
+      } else {
+        noteLive(fold, collection, uri);
+      }
+
+      if (opts.skipApply) continue;
+
+      const payload = toIngestRecordPayload(event, { live: false });
+      if (!payload) continue;
+      try {
+        await handleRecord(payload);
+        if (operation === "delete") fold.deleted += 1;
+        else fold.applied += 1;
+      } catch (error: unknown) {
+        logEvent("ingest.archiveReplayApplyFailed", {
+          collection,
+          did: event.did,
+          ok: false,
+          reason: error instanceof Error ? error.message : String(error),
+          uri,
+        });
+      }
     }
-
-    if (event.kind === "sync") {
-      // Sync 1.1 divergence: the archive discarded this repo's pre-divergence
-      // rows and follows with the authoritative replacement records. Anything
-      // folded so far is exactly what was discarded, so start the live set over
-      // rather than unioning stale URIs into it.
-      fold.live.clear();
-      continue;
-    }
-
-    if (event.kind !== "commit") continue;
-
-    const { collection, operation, rkey } = event.commit;
-    const uri = buildAtUri(event.did, collection, rkey);
-
-    if (operation === "delete") {
-      dropLive(fold, collection, uri);
-    } else {
-      noteLive(fold, collection, uri);
-    }
-
-    if (opts.skipApply) continue;
-
-    const payload = toIngestRecordPayload(event, { live: false });
-    if (!payload) continue;
-    try {
-      await handleRecord(payload);
-      if (operation === "delete") fold.deleted += 1;
-      else fold.applied += 1;
-    } catch (error: unknown) {
-      logEvent("ingest.archiveReplayApplyFailed", {
-        collection,
-        did: event.did,
-        ok: false,
-        reason: error instanceof Error ? error.message : String(error),
-        uri,
-      });
-    }
+  } finally {
+    releaseFoldSlot();
   }
 
   logEvent("ingest.archiveReplay", {
@@ -256,6 +303,7 @@ export async function foldReposFromArchive(
     gone: [...folds.values()].filter((f) => f.gone).length,
     ms: Math.round(performance.now() - started),
     ok: true,
+    waitMs,
   });
 
   return folds;

--- a/apps/standard-reader/src/server/ingest/config.ts
+++ b/apps/standard-reader/src/server/ingest/config.ts
@@ -38,13 +38,39 @@ export const ingestConfig = {
   },
 
   /**
-   * Concurrent archive block downloads (`JETSTREAM_BLOCK_CONCURRENCY`).
-   * Throughput plateaus around 16–32 against the public instance and 64 gets
-   * nearly every request 429'd, so 16 is the safe shoulder.
+   * Concurrent archive block downloads **per fold**
+   * (`JETSTREAM_BLOCK_CONCURRENCY`). Throughput plateaus around 16–32 against
+   * the public instance and 64 gets nearly every request 429'd, so 16 is the
+   * safe shoulder.
+   *
+   * Per fold, not per process — the SDK applies this inside one snapshot
+   * iterator (`block-source.ts`), so N folds running at once are N × this many
+   * requests in flight. {@link jetstreamFoldConcurrency} is what keeps that
+   * product on the right side of the shoulder.
    */
   get jetstreamBlockConcurrency(): number {
     const value = Number(process.env.JETSTREAM_BLOCK_CONCURRENCY);
     return Number.isFinite(value) && value > 0 ? Math.floor(value) : 16;
+  },
+
+  /**
+   * Archive folds allowed to run at once, process-wide
+   * (`JETSTREAM_FOLD_CONCURRENCY`).
+   *
+   * The number that was missing. The reconcile sweep repairs eight repos
+   * concurrently and each fold downloads up to
+   * {@link jetstreamBlockConcurrency} blocks at a time, so the sweep alone ran
+   * 128 requests deep against an endpoint documented right above as 429ing
+   * nearly everything at 64. It did — `ingest.repoReconcile` logged
+   * `Upstream server responded with a 429 error` across thousands of repos,
+   * which is how two thirds of the fleet ended up parked in reconcile backoff.
+   *
+   * Two folds × sixteen blocks lands on the 32 shoulder. Raise the block count
+   * and lower this together, never one alone.
+   */
+  get jetstreamFoldConcurrency(): number {
+    const value = Number(process.env.JETSTREAM_FOLD_CONCURRENCY);
+    return Number.isFinite(value) && value > 0 ? Math.floor(value) : 2;
   },
 } as const;
 


### PR DESCRIPTION
Third and last from the #175 triage, and the one the other two were symptoms of: **Jetstream is rate-limiting us**, and it is our own traffic doing it.

```
evt="ingest.repoReconcile" did="…" error="Upstream server responded with a 429 error" failCount=6 ok=false   ← repo after repo
evt="ingest.archiveReplay" dids=1 events=0 empty=1 gone=0 ms=130757 ok=true                                  ← a 200ms fold, taking two minutes
```

```sql
select count(*) filter (where reconcile_fail_count > 0),   -- 10,277
       count(*) filter (where reconcile_retry_after > now()) -- 9,816
from tracked_repos;                                          -- of 15,819
```

Two thirds of the tracked fleet is parked in reconcile backoff, and has been drifting that way since June.

## The number nobody was counting

`blockConcurrency` bounds in-flight downloads **inside one snapshot iterator** — the SDK applies it in `engine/block-source.ts`, per `backfillBatches` call, not per client. `config.ts` already documents the ceiling one line above the setting:

> Throughput plateaus around 16–32 against the public instance and **64 gets nearly every request 429'd**, so 16 is the safe shoulder.

That reasoning holds for *one* fold. The reconcile sweep runs `RECONCILE_CONCURRENCY = 8` repairs at once, each opening its own snapshot iterator: **8 × 16 = 128 requests in flight**, twice the number the comment calls hopeless. Jetstream rate-limited us exactly as documented, the SDK backed off exponentially on every 429 (silently — see #176), single-repo folds stretched to two minutes, and the whole thing surfaced as `reconcile_fail_count` rather than as what it was.

The read path piled on top: before #175, nearly every signed-in page load fired a fold of its own.

## The fix

`JETSTREAM_FOLD_CONCURRENCY` (default **2**) gates concurrent folds process-wide in `archive-replay.ts`, so `folds × blockConcurrency` lands on the 32 shoulder. The two are now documented as one budget — move them together, never one alone.

A semaphore rather than simply shrinking `blockConcurrency`: fold latency is dominated by the planning round trip, so it is better to let one fold use the whole block budget briefly than to give every fold a permanent slice of it. The sweep keeps its 8-way parallelism for everything that is not archive I/O and just queues at the gate.

Freed slots are handed directly to the next waiter rather than returned to a counter — a waiter that has to re-check `free` can lose the slot to a fold arriving in the same tick, which under a saturated sweep starves. `ingest.archiveReplay` now logs `waitMs` next to `ms` so queueing reads as queueing instead of as slowness.

## Testing

- 2 new tests in `archive-replay.test.ts` (alongside the 5 from #175): the gate holds folds past the limit, and a fold that throws — which is exactly what a 429 storm does — still hands its slot on rather than leaking it and wedging every later fold.
- `pnpm --filter standard-reader exec vitest run src/server` — 483 passed, 11 skipped ✅
- `pnpm --filter standard-reader typecheck` ✅ · `oxlint` ✅ · `oxfmt --check` ✅

## Merge order

Branched off `main` (which has #175), **not** off #176. Both this and #176 touch the `jetstream()` client in `archive-replay.ts` — #176 adds the bounded `retry` policy, this adds the semaphore — so whichever lands second needs a trivial rebase. They are complementary: #176 makes a retry storm visible and bounded, this stops us from causing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BsiXs3KiW55Dr96sxykU8y