### PR TITLE
Stop profile edits from taking a day to show up

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -1510,6 +1510,14 @@ AT Proto network (standard.site publications, profiles, follows)
   fetches each actor's profile record and re-resolves their handle on a round-robin ordered by
   `profiles.profile_fetched_at`. The trade is freshness for volume: a display-name edit lands on
   the next sweep, while everything that decides _what_ a reader sees still streams live.
+  The sweep's window bounds staleness for the whole mirror (6 hours at ~16k profiles, well inside
+  its 200-per-minute batch), and `revalidateProfile` buys most of that back where it is noticed:
+  rendering a profile refreshes that one row out of band, and signing in forces the reader's own.
+  Both are fire-and-forget and deduped per DID — the render still serves the mirrored row, and the
+  next one is current. **The signed-in reader's name and avatar come from the same `profiles` row
+  as everyone else's**; `user.name` / `user.image` are a sign-in–time fallback, not a second
+  source of truth, which is what used to let the sidebar and a reader's own profile page disagree
+  about who they were.
 - **Bridged repos.** [Bridgy Fed](https://fed.brid.gy) mirrors the wider web into AT Proto:
   `*.web.brid.gy` is a site Bridgy discovered (tens of thousands of them, thousands of posts each,
   no publisher intent), and `*.ap.brid.gy` is an ActivityPub blog whose author chose to bridge.

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -434,6 +434,19 @@ Check items off as they land.
       the reconcile result carries `migrated: true` + `migratedFrom`/`migratedTo` for observability
       (logged as `ingest.repoReconcile { migrated: true }` and surfaced in the manual reconcile
       API + `pnpm backfill:repo-documents` output).
+- [x] **Profile edits land in hours, not a day** — the move from push to pull left a 24-hour
+      window in which a changed avatar, display name or bio was simply wrong everywhere it was
+      rendered (reported: a reader whose old icon was still standing in for three of their
+      publications). Three changes, none of which reintroduces a network-wide subscription:
+      the sweep window drops to **6 hours** (~44 refreshes/min against a 200-per-minute batch, so
+      ~4x headroom); `revalidateProfile` refreshes a single row **out of band when someone
+      actually looks at that profile**, deduped to once per DID per 15 minutes and capped at four
+      in flight; and **sign-in forces the reader's own row**, so signing out and back in — the
+      obvious thing to try — now fixes it. The reader's sidebar identity reads the `profiles`
+      mirror too, instead of the `user.name`/`user.image` copy that was written at sign-up and
+      then frozen (67 of 540 signed-in accounts were rendering an avatar their owner had already
+      replaced), and that copy now tracks a changed Bluesky avatar on each login rather than only
+      when it was empty.
 
 ## 2. Read-model schema (Drizzle)
 

--- a/apps/standard-reader/src/integrations/auth/callback.server.ts
+++ b/apps/standard-reader/src/integrations/auth/callback.server.ts
@@ -232,6 +232,19 @@ export async function handleAtprotoOAuthCallback(args: {
       console.warn("Failed to schedule Bluesky block sync:", error);
     }
 
+    // Re-mirror the reader's own identity. Profiles are pulled on a sweep whose
+    // window is measured in hours, so without this a reader who changed their
+    // avatar or display name sees the old one on their own profile page — and
+    // signing out and back in, the obvious thing to try, would not have fixed
+    // it. Forced past the dedupe window and not awaited, like the syncs above.
+    try {
+      const { revalidateProfile } =
+        await import("#/server/ingest/profile-refresh");
+      revalidateProfile(did, { force: true });
+    } catch (error) {
+      console.warn("Failed to schedule profile refresh:", error);
+    }
+
     const sessionToken = crypto.randomUUID();
     const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
 

--- a/apps/standard-reader/src/integrations/tanstack-query/api-author.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-author.functions.ts
@@ -17,6 +17,7 @@ import {
   blockFilterDid,
   filterBlockedCards,
 } from "#/server/blocks/blocks";
+import { revalidateProfile } from "#/server/ingest/profile-refresh";
 import { readAccountLabels } from "#/server/labeler/labels.server";
 import { observe } from "#/server/observability/log";
 import {
@@ -199,12 +200,19 @@ async function resolveAuthorProfile(
       avatarUrl: pr.avatarUrl,
       bannerUrl: pr.bannerUrl,
       isBot: pr.isBot,
+      profileFetchedAt: pr.profileFetchedAt,
     })
     .from(pr)
     .where(eq(pr.did, did))
     .limit(1);
 
   if (row) {
+    // A profile page is exactly where a stale avatar or display name is
+    // noticed, and the ingest sweep only guarantees a bound measured in hours.
+    // Refresh this one row out of band so the next render is current; the
+    // helper dedupes, so a hovered list of authors costs one refresh per DID.
+    revalidateProfile(did, { fetchedAt: row.profileFetchedAt });
+
     const [identity, publicProfile] = await Promise.all([
       row.handle ? Promise.resolve(null) : resolveIdentity(did),
       !row.displayName || !row.avatarUrl

--- a/apps/standard-reader/src/integrations/tanstack-query/api-user.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-user.functions.ts
@@ -210,7 +210,7 @@ async function loadSessionFromToken(sessionToken: string) {
     restoreAuthenticatedClient(userRow.did),
     db.query.profiles.findFirst({
       where: eq(schema.profiles.did, userRow.did),
-      columns: { handle: true },
+      columns: { handle: true, displayName: true, avatarUrl: true },
     }),
     resolveIdentity(userRow.did),
   ]);
@@ -223,6 +223,13 @@ async function loadSessionFromToken(sessionToken: string) {
   // redundant here — its display name/avatar are only needed at login — and an
   // uncached round-trip to public.api.bsky.app on every session restore.
   const handle = profileRow?.handle ?? identity.handle ?? null;
+  // Name and avatar come from the same indexed profile as everywhere else in
+  // the app. `user.name` / `user.image` are written at sign-up and refreshed
+  // only on a login that sees a changed avatar, so preferring them here is what
+  // let the sidebar and the reader's own profile page disagree about who they
+  // are. They stay as the fallback for a DID we hold no profile row for.
+  const displayName = profileRow?.displayName ?? userRow.name;
+  const image = profileRow?.avatarUrl ?? userRow.image;
 
   // Granted OAuth scope snapshotted on the callback (`account.scope`). The
   // UI gates collections authoring on this — it's the source of truth for
@@ -236,10 +243,10 @@ async function loadSessionFromToken(sessionToken: string) {
   return {
     user: {
       id: userRow.id,
-      name: userRow.name,
+      name: displayName,
       email: userRow.email,
       did: userRow.did,
-      image: userRow.image,
+      image,
       isAdmin: userRow.isAdmin,
       createdAt: userRow.createdAt,
       updatedAt: userRow.updatedAt,
@@ -411,7 +418,7 @@ const getShellBootstrap = createServerFn({ method: "GET" }).handler(
     const [profileRow, shell] = await Promise.all([
       db.query.profiles.findFirst({
         where: eq(schema.profiles.did, userRow.did),
-        columns: { handle: true },
+        columns: { handle: true, displayName: true, avatarUrl: true },
       }),
       loadShellSnapshot(db, schema, {
         did: userRow.did,
@@ -421,16 +428,19 @@ const getShellBootstrap = createServerFn({ method: "GET" }).handler(
     ]);
 
     const handle = profileRow?.handle ?? null;
+    // Same indexed profile the rest of the app renders — see `hydrateSession`.
+    const displayName = profileRow?.displayName ?? userRow.name;
+    const image = profileRow?.avatarUrl ?? userRow.image;
     span.set("result", "signedIn");
 
     return {
       session: {
         user: {
           id: userRow.id,
-          name: userRow.name,
+          name: displayName,
           email: userRow.email,
           did: userRow.did,
-          image: userRow.image,
+          image,
           isAdmin: userRow.isAdmin,
           createdAt: userRow.createdAt,
           updatedAt: userRow.updatedAt,

--- a/apps/standard-reader/src/lib/bluesky-public-profile.test.ts
+++ b/apps/standard-reader/src/lib/bluesky-public-profile.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { fetchBlueskyPublicProfileFields } from "./bluesky-public-profile";
+import {
+  fetchBlueskyPublicProfileFields,
+  shouldApplyBlueskyAvatarFromPublicUrl,
+} from "./bluesky-public-profile";
 
 function mockProfile(body: Record<string, unknown>) {
   return {
@@ -32,5 +35,36 @@ describe("fetchBlueskyPublicProfileFields", () => {
     );
     const fields = await fetchBlueskyPublicProfileFields("did:plc:x");
     expect(fields?.handle).toBeNull();
+  });
+});
+
+describe("shouldApplyBlueskyAvatarFromPublicUrl", () => {
+  const a = "https://cdn.bsky.app/img/avatar/plain/did:plc:x/bafkreia";
+  const b = "https://cdn.bsky.app/img/avatar/plain/did:plc:x/bafkreib";
+
+  it("seeds an account that has no avatar yet", () => {
+    expect(shouldApplyBlueskyAvatarFromPublicUrl(null, a)).toBe(true);
+    expect(shouldApplyBlueskyAvatarFromPublicUrl("", a)).toBe(true);
+  });
+
+  // The stored copy used to be written once and never revisited, so a reader
+  // who changed their picture kept the old one in the sidebar forever.
+  it("adopts a changed Bluesky avatar", () => {
+    expect(shouldApplyBlueskyAvatarFromPublicUrl(a, b)).toBe(true);
+  });
+
+  it("leaves an unchanged avatar alone", () => {
+    expect(shouldApplyBlueskyAvatarFromPublicUrl(a, a)).toBe(false);
+  });
+
+  it("never clobbers an inlined image with an upstream URL", () => {
+    expect(
+      shouldApplyBlueskyAvatarFromPublicUrl("data:image/png;base64,AAA", a),
+    ).toBe(false);
+  });
+
+  it("ignores a missing upstream avatar", () => {
+    expect(shouldApplyBlueskyAvatarFromPublicUrl(a, null)).toBe(false);
+    expect(shouldApplyBlueskyAvatarFromPublicUrl(a, "  ")).toBe(false);
   });
 });

--- a/apps/standard-reader/src/lib/bluesky-public-profile.ts
+++ b/apps/standard-reader/src/lib/bluesky-public-profile.ts
@@ -126,15 +126,22 @@ export async function fetchBlueskyPublicProfiles(
 
 /**
  * Whether to set `user.image` from Bluesky's public avatar URL.
+ *
+ * The stored value is otherwise written once and kept forever, which froze the
+ * signed-in reader's own avatar at whatever it was on the day they signed up.
+ * So a Bluesky avatar that has since changed replaces the stored one — but an
+ * inlined image the reader supplied themselves (`data:`) is never clobbered by
+ * an upstream URL.
  */
 export function shouldApplyBlueskyAvatarFromPublicUrl(
   currentImage: string | null | undefined,
   blueskyAvatarUrl: string | null | undefined,
 ): boolean {
-  if (!blueskyAvatarUrl || blueskyAvatarUrl.trim() === "") return false;
+  const next = blueskyAvatarUrl?.trim() ?? "";
+  if (next === "") return false;
   const cur = currentImage?.trim() ?? "";
   if (cur === "") return true;
   if (cur.startsWith("data:image/")) return false;
   if (cur.startsWith("blob:")) return true;
-  return false;
+  return cur !== next;
 }

--- a/apps/standard-reader/src/server/ingest/handlers.ts
+++ b/apps/standard-reader/src/server/ingest/handlers.ts
@@ -45,6 +45,7 @@ import {
   userFollows,
 } from "../../db/schema.ts";
 import { blobCid, bskyImageUrl } from "../atproto/blob.ts";
+import { listRepoRecords } from "../atproto/fetch-record.ts";
 import {
   authorPds,
   getCachedIdentity,
@@ -52,6 +53,7 @@ import {
   isUsableHandle,
   primeIdentityHandle,
   refreshIdentity,
+  resolveIdentity,
 } from "../atproto/identity.ts";
 import type {
   BookmarkRecord,

--- a/apps/standard-reader/src/server/ingest/profile-refresh.test.ts
+++ b/apps/standard-reader/src/server/ingest/profile-refresh.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { revalidateProfile } from "./profile-refresh.ts";
+
+const { fetchRepoRecordWithFallback, refreshIdentity, upsertBskyProfile } =
+  vi.hoisted(() => ({
+    fetchRepoRecordWithFallback: vi.fn(),
+    refreshIdentity: vi.fn(),
+    upsertBskyProfile: vi.fn(),
+  }));
+
+vi.mock("../../db/index.ts", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ orderBy: () => ({ limit: async () => [] }) }),
+      }),
+    }),
+    update: () => ({ set: () => ({ where: async () => null }) }),
+  },
+}));
+
+vi.mock("../atproto/fetch-record.ts", () => ({ fetchRepoRecordWithFallback }));
+
+vi.mock("../atproto/identity.ts", () => ({ refreshIdentity }));
+
+vi.mock("./handlers.ts", () => ({
+  applyIdentity: vi.fn(),
+  upsertBskyProfile,
+}));
+
+/** Let the fire-and-forget refresh run to completion. */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+/** A DID nothing else in this file has revalidated — the dedupe memo is
+ * process-wide and deliberately has no reset hook. */
+let next = 0;
+function freshDid(): string {
+  next += 1;
+  return `did:plc:revalidate${next}`;
+}
+
+describe("revalidateProfile", () => {
+  beforeEach(() => {
+    refreshIdentity.mockReset().mockResolvedValue({ handle: null, pds: null });
+    upsertBskyProfile.mockReset().mockResolvedValue(null);
+    fetchRepoRecordWithFallback
+      .mockReset()
+      .mockResolvedValue({ cid: "cid1", value: { displayName: "Vic" } });
+  });
+
+  it("re-mirrors a profile the sweep last touched hours ago", async () => {
+    revalidateProfile(freshDid(), {
+      fetchedAt: new Date(Date.now() - 60 * 60 * 1000),
+    });
+    await settle();
+    expect(upsertBskyProfile).toHaveBeenCalledTimes(1);
+  });
+
+  it("costs nothing for a profile the sweep just covered", async () => {
+    revalidateProfile(freshDid(), { fetchedAt: new Date() });
+    await settle();
+    expect(upsertBskyProfile).not.toHaveBeenCalled();
+  });
+
+  it("refreshes a profile we have never fetched", async () => {
+    revalidateProfile(freshDid(), { fetchedAt: null });
+    await settle();
+    expect(upsertBskyProfile).toHaveBeenCalledTimes(1);
+  });
+
+  // A profile page and a hovercard over the same author must not each cost a
+  // DID-document fetch and a repo read.
+  it("refreshes a DID at most once per window", async () => {
+    const did = freshDid();
+    revalidateProfile(did, { fetchedAt: null });
+    await settle();
+    revalidateProfile(did, { fetchedAt: null });
+    await settle();
+    expect(upsertBskyProfile).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps backing off after a failed refresh", async () => {
+    const did = freshDid();
+    fetchRepoRecordWithFallback.mockRejectedValue(new Error("PDS is down"));
+    revalidateProfile(did, { fetchedAt: null });
+    await settle();
+    fetchRepoRecordWithFallback.mockResolvedValue({ cid: "cid1", value: {} });
+    revalidateProfile(did, { fetchedAt: null });
+    await settle();
+    expect(upsertBskyProfile).not.toHaveBeenCalled();
+  });
+
+  // Sign-in knows the reader's identity may have just changed, so it must not
+  // be gated on when the sweep last looked.
+  it("forces past a freshly-swept row", async () => {
+    revalidateProfile(freshDid(), { fetchedAt: new Date(), force: true });
+    await settle();
+    expect(upsertBskyProfile).toHaveBeenCalledTimes(1);
+  });
+
+  it("still dedupes a forced refresh", async () => {
+    const did = freshDid();
+    revalidateProfile(did, { force: true });
+    await settle();
+    revalidateProfile(did, { force: true });
+    await settle();
+    expect(upsertBskyProfile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/standard-reader/src/server/ingest/profile-refresh.ts
+++ b/apps/standard-reader/src/server/ingest/profile-refresh.ts
@@ -25,6 +25,11 @@ import { applyIdentity, upsertBskyProfile } from "./handlers.ts";
  * sees — publications, documents, subscriptions — still streams live; only the
  * decoration of who wrote it is pulled.
  *
+ * {@link revalidateProfile} buys most of that freshness back where it is
+ * noticed: viewing a profile (or signing in) refreshes that one row out of
+ * band, so the sweep only has to be the backstop for the ~16k profiles nobody
+ * is looking at.
+ *
  * Handles ride along on the same sweep for the same reason: `kinds: ["commit"]`
  * means no `#identity` events either, and taking those network-wide would be
  * the same bad trade.
@@ -34,10 +39,29 @@ import { applyIdentity, upsertBskyProfile } from "./handlers.ts";
 const DEFAULT_BATCH = 200;
 /** Concurrent fetches. Slingshot fronts these, so this is polite, not slow. */
 const DEFAULT_CONCURRENCY = 8;
-/** How old a `profile_fetched_at` must be before the sweep revisits it. */
-const DEFAULT_STALE_AFTER_HOURS = 24;
+/**
+ * How old a `profile_fetched_at` must be before the sweep revisits it — the
+ * upper bound on how long an avatar or display-name edit can be wrong.
+ *
+ * A full cycle costs `rows / hours / 60` refreshes per minute against a
+ * {@link DEFAULT_BATCH} of 200: at ~16k mirrored profiles a 6-hour window is
+ * ~44/min, leaving the sweep about 4x headroom. Under tap this data streamed
+ * live and the window did not exist; six hours is the compromise the pull model
+ * can actually afford (see the header comment).
+ */
+const DEFAULT_STALE_AFTER_HOURS = 6;
 /** Gap between sweeps in the ingest worker. */
 const SWEEP_INTERVAL_MS = 60_000;
+
+/**
+ * How stale a mirrored profile may be before *looking at it* refreshes it, and
+ * the minimum gap between two such refreshes of the same DID.
+ */
+const REVALIDATE_AFTER_MS = 15 * 60 * 1000;
+/** Background revalidations allowed in flight at once, process-wide. */
+const REVALIDATE_CONCURRENCY = 4;
+/** Cap on the dedupe map before the expired half is dropped. */
+const REVALIDATE_MEMO_LIMIT = 5000;
 
 export interface ProfileRefreshResult {
   scanned: number;
@@ -116,6 +140,59 @@ export async function refreshProfiles(
     updated: result.updated,
   });
   return result;
+}
+
+/** Last revalidation attempt per DID, for the {@link revalidateProfile} memo. */
+const revalidatedAt = new Map<string, number>();
+let revalidationsInFlight = 0;
+
+/**
+ * Refresh one profile now, out of band, at most once per
+ * {@link REVALIDATE_AFTER_MS} per DID.
+ *
+ * The sweep bounds staleness across the whole mirror; this is the fast path for
+ * the handful of profiles someone is actually looking at (a profile page, a
+ * hovercard) or that we know just changed (a sign-in). Fire-and-forget by
+ * design: the render that triggers it still serves the mirrored row — awaiting
+ * a PDS round trip to decorate a byline is the wrong trade — and the next one
+ * is current.
+ *
+ * `fetchedAt` is the row's `profile_fetched_at`, so a caller that already read
+ * the profile spends nothing on a row the sweep has covered recently. Pass
+ * `force` when the profile is known to have changed regardless of when we last
+ * looked.
+ */
+export function revalidateProfile(
+  did: string,
+  {
+    fetchedAt = null,
+    force = false,
+  }: { fetchedAt?: Date | null; force?: boolean } = {},
+): void {
+  const now = Date.now();
+  if (!force && fetchedAt && now - fetchedAt.getTime() < REVALIDATE_AFTER_MS) {
+    return;
+  }
+  const last = revalidatedAt.get(did);
+  // The memo is kept even when the refresh fails, so an unreachable repo backs
+  // off for a window instead of re-fetching on every render.
+  if (last !== undefined && now - last < REVALIDATE_AFTER_MS) return;
+  if (revalidationsInFlight >= REVALIDATE_CONCURRENCY) return;
+
+  if (revalidatedAt.size >= REVALIDATE_MEMO_LIMIT) {
+    for (const [key, at] of revalidatedAt) {
+      if (now - at >= REVALIDATE_AFTER_MS) revalidatedAt.delete(key);
+    }
+  }
+  revalidatedAt.set(did, now);
+  revalidationsInFlight += 1;
+  void refreshOne(did)
+    .catch(() => {
+      // Best-effort decoration; the sweep is the guarantee.
+    })
+    .finally(() => {
+      revalidationsInFlight -= 1;
+    });
 }
 
 async function refreshOne(did: string): Promise<"updated" | "missing"> {


### PR DESCRIPTION
Fixes a [reported bug](https://userinput.app/d/did:plc:fip3nyk6tjo3senpq4ei2cxw/3mtu5v3bqxg2h): a reader's profile page was still showing the avatar and bio they replaced, while the sidebar showed the current one. Three of their publications have no icon of their own, so they were falling back to the stale avatar too.

## What was wrong

Two bugs, pointing in opposite directions.

**Profiles went stale for up to a day.** The Jetstream cutover (#158) moved `app.bsky.actor.profile` from push to pull — network-wide it is tens of millions of records for the ~16k actors we display, and Jetstream's DID filter caps at 10,000, below the ~12k publication owners we track. The sweep that replaced it revisited a row every 24 hours, and every avatar, display name and bio in the app reads from that mirror. Under tap this data streamed live, so the window is new.

**The sidebar's copy froze permanently.** `user.name` / `user.image` are written at sign-up, and `shouldApplyBlueskyAvatarFromPublicUrl` refused to overwrite an existing http URL — so on prod, **67 of 540 signed-in accounts** render an avatar their owner already replaced, and 65 a stale display name. That the reporter's sidebar happened to be the *fresh* one is luck about when they signed up; for most readers it is the stale one.

## The fix

Four changes, none of which reintroduces a network-wide subscription:

- **Sweep window 24h → 6h.** A full cycle is ~44 refreshes/min against a 200-per-minute batch, so it keeps ~4x headroom.
- **`revalidateProfile`** refreshes a single row out of band when someone actually looks at that profile, deduped to once per DID per 15 minutes and capped at four in flight, backing off when a repo is unreachable. Fire-and-forget by design — the render that triggers it still serves the mirrored row, and the next one is current.
- **Sign-in forces the reader's own row**, so signing out and back in (the obvious thing to try) now fixes it.
- **The session's name and avatar read the `profiles` mirror**, which that query was already fetching for `handle`; `user.*` stays the fallback for a DID we hold no row for. And that copy now tracks a changed Bluesky avatar on each login instead of only when it was empty — still never clobbering an inlined `data:` image.

## Also in here

`handlers.ts` has been missing its `resolveIdentity` and `listRepoRecords` imports since 592c617c, so `tsc --noEmit` fails on a clean tree. Two import lines, unrelated to this bug, but it blocked verifying the rest.

## Verification

`pnpm typecheck` clean, `pnpm lint` clean repo-wide, 1166 tests pass, `pnpm build` succeeds with no server code in the client bundle (the new static `#/server/ingest/profile-refresh` import follows the same pattern as the existing `#/server/ingest/handlers` imports in sibling `.functions.ts` files).

New tests cover the revalidation gate (fresh row costs nothing, stale/never-fetched refreshes, once per DID per window, backs off after failure, `force` bypasses freshness but not dedupe) and the avatar guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018p2vMkbhYhjvFnN4MiaGde
