### PR TITLE
Rank search results by relevance, and stop broad queries costing 16s

### DIFF
--- a/apps/standard-reader/APP_VISION.md
+++ b/apps/standard-reader/APP_VISION.md
@@ -174,9 +174,25 @@ Topics are **derived, never curated** — see
 
 ### Search
 
-- Big editorial search field; live results split into **Publications** and **Articles**.
+- Big editorial search field; live results split into **Publications**, **People**, and
+  **Articles**.
 - Result cards show **query-aware excerpts** (`ts_headline` snippets with highlighted
-  matches in titles and descriptions/bodies).
+  matches in titles and descriptions/bodies). When the query is a phrase the source
+  actually contains, the excerpt highlights the whole phrase rather than scattered words.
+- **Articles are ranked by relevance, not recency.** An ordered tier ladder puts the
+  query-as-a-whole ahead of its parts, and titles ahead of body text: an exact title,
+  then a verbatim substring of the title, then the unstemmed phrase (so "Making" beats
+  "makes"), then the stemmed phrase, then all terms anywhere in title/description/tags,
+  then the author arm, and finally body-only matches — which keep the old
+  newest-first order among themselves.
+- Ranking runs over a **title/description/tags vector**, not `search_vector`: the latter
+  folds in body text, so it is TOASTed and ranking it costs a de-TOAST per row. Backed by
+  the `documents_meta_search_idx` expression index.
+- The candidate pool is **bounded per arm** (title / body / author). A common word matches
+  ~100k documents, and ordering that whole match set took 16s; selective queries never
+  reach a cap and are ranked in full. Broad queries trade completeness for latency.
+- **People** results surface writers directly, instead of the old behavior where a
+  name-shaped query silently folded that author's documents into the article results.
 
 ### Tag directory
 
@@ -1751,7 +1767,8 @@ publication list looked clean.
 ### Later
 
 - Recommendation / trending tuning and quality work.
-- Higher-quality full-text search.
+- Search: typo tolerance and non-English stemming (the ranking is English-only), and a
+  cheaper bound for broad queries than pool truncation.
 
 ### Non-goals (for now)
 

--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -695,7 +695,34 @@ Build each on hip-ui components + StyleX tokens (no raw HTML/inline styles).
 - [x] **Search** — editorial field, live results split into Publications + Articles. Route `/search` with URL `?q=`; paginated search APIs with full counts; load more (publications) + infinite scroll (articles); reuses `PubDirectoryRow` + `ArticleRow`.
 - [x] **Search result snippets** — `ts_headline` excerpts in `searchArticles` /
       `searchPublications`; highlighted `<mark>` terms in `ArticleRow` and
-      `PubDirectoryRow` on `/search`.
+      `PubDirectoryRow` on `/search`. Phrase-aware: when the source contains the whole
+      query the excerpt highlights the phrase, and an unmarked snippet falls back to the
+      description rather than rendering the head of the body.
+- [x] **Search relevance ranking** — articles were ordered `published_at DESC` with no
+      `ts_rank` at all, so a title you already knew ranked below every newer body match
+      ([bug report](https://userinput.app/d/did:plc:fip3nyk6tjo3senpq4ei2cxw/3mtky44lqwi2h)).
+      Tier ladder + `ts_rank` over a title/description/tags vector in
+      `server/reader/document-search.ts`, backed by the `documents_meta_search_idx`
+      expression index (migration 0044, built CONCURRENTLY out of band via
+      `scripts/search-relevance-indexes.sql`). Behind `SEARCH_RANKING=legacy` until the
+      index is built on prod.
+- [x] **Bounded search candidate pool** — a common single word (`q=ai`, ~100k matches)
+      cost **16s** on prod: recency ordering never avoided the work, it still
+      bitmap-scanned and heap-fetched the whole match set. Per-arm `LIMIT` caps
+      (title/body/author) bound it to ~600ms. A 30-day window makes it _worse_ (36s — the
+      lossy GIN bitmap poisons the `BitmapAnd`); `work_mem` 4MB → 256MB only gets 16.1s →
+      9.2s, so it's a follow-up, not a substitute.
+- [x] **Search: People results** — `server/reader/people-search.ts`, reusing
+      `FriendPersonRow`. Replaces the old behavior where any plain-text query ≥3 chars
+      ILIKE'd handles/display names and OR'd up to 50 authors' documents into the article
+      results, indistinguishable from real text matches.
+- [x] **Shared publication search ranking** — `/search` and Discover's directory had
+      separately drifted weights (0.2/0.15/0.15 vs 0.12/0.1/0.05), and both used an
+      un-normalized `ts_rank` (~0.05–0.1) that lost to a hardcoded 0.15 substring bonus.
+      One `server/reader/publication-search.ts`, normalization 32, plus a tie-break —
+      rank alone is not a total order, so OFFSET paging duplicated and dropped rows.
+- [ ] **Retire `SEARCH_RANKING`** — one release after the ranked path is default, delete
+      the flag and the legacy pool arm rather than maintaining two ranking codepaths.
 - [x] **Viewer's own recommend indicator** — document items across every surface (home, latest,
       discover, tag, publication, author, search, saved, history, article byline, and mention hover
       cards) **fill and tint the heart on the document's like count** when the signed-in reader has

--- a/apps/standard-reader/drizzle/0044_document_meta_search_idx.sql
+++ b/apps/standard-reader/drizzle/0044_document_meta_search_idx.sql
@@ -1,0 +1,33 @@
+-- Make article search rankable.
+--
+-- `/search` ordered articles by `published_at DESC` and never called `ts_rank`,
+-- so searching a title you already knew buried it under every newer document
+-- that happened to mention the same words. Ranking needs a vector to rank
+-- *against*, and `documents.search_vector` is the wrong one: it folds in
+-- `text_content`, so it is TOASTed for any real article and `ts_rank` over it
+-- costs a de-TOAST per row (measured on prod: ~190k extra buffer reads for a
+-- single broad query).
+--
+-- This indexes the title/description/tags half of that vector — the same
+-- lexemes and the same A/B/B weights as the first three arms of
+-- `search_vector`, minus the weight-C body text. Title and description average
+-- ~67 and ~34 chars, so the result stays inline and is cheap to both rank and
+-- match against.
+--
+-- An expression index rather than a second generated column on purpose:
+-- `ALTER TABLE ... ADD COLUMN ... GENERATED ALWAYS AS ... STORED` rewrites the
+-- whole table under ACCESS EXCLUSIVE, and `documents` is now ~14 GB across heap
+-- and indexes — that rewrite would run inside Railway's `preDeployCommand` with
+-- traffic waiting on it. 0013 could afford that pattern; this can't.
+--
+-- The query in `src/server/reader/document-search.ts` must repeat this
+-- expression verbatim for the planner to match the index, so both are rendered
+-- from `documentMetaVectorSql` and `document-search.test.ts` asserts this file
+-- still contains what that function produces.
+--
+-- Created CONCURRENTLY on prod out-of-band via
+-- `scripts/search-relevance-indexes.sql` (a plain CREATE INDEX takes a long
+-- lock on `documents`, which is ~3.4M rows); IF NOT EXISTS makes this a no-op
+-- there while still building it on fresh/local/CI databases. Same pattern as
+-- `documents_tags_norm_idx` in 0014 and the trigram indexes in 0003.
+CREATE INDEX IF NOT EXISTS "documents_meta_search_idx" ON "documents" USING gin ((setweight(to_tsvector('english', coalesce(title, '')), 'A') || setweight(to_tsvector('english', coalesce(description, '')), 'B') || setweight(to_tsvector('english', coalesce(immutable_array_to_string(tags), '')), 'B')));

--- a/apps/standard-reader/drizzle/meta/_journal.json
+++ b/apps/standard-reader/drizzle/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1787207677749,
       "tag": "0043_slimy_tusk",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1787207677750,
+      "tag": "0044_document_meta_search_idx",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/standard-reader/perf/lib/fixtures.ts
+++ b/apps/standard-reader/perf/lib/fixtures.ts
@@ -9,6 +9,10 @@ export interface PerfFixtures {
   searchQuery: string;
   /** A handle/name-shaped query exercising the author pre-resolution path. */
   searchAuthorQuery: string;
+  /** A full article title — the case the relevance ranking exists for. */
+  searchTitleQuery: string;
+  /** A common single word, whose match set is large enough to need the pool caps. */
+  searchBroadQuery: string;
 }
 
 function routeFromRecordUri(
@@ -61,6 +65,11 @@ export function loadPerfFixtures(): PerfFixtures {
     searchQuery: process.env.PERF_TEST_SEARCH_QUERY?.trim() || "reader",
     searchAuthorQuery:
       process.env.PERF_TEST_SEARCH_AUTHOR_QUERY?.trim() || "stdout.dev",
+    searchTitleQuery:
+      process.env.PERF_TEST_SEARCH_TITLE_QUERY?.trim() ||
+      "Making Feeds: Custom Logic Requests",
+    searchBroadQuery:
+      process.env.PERF_TEST_SEARCH_BROAD_QUERY?.trim() || "design",
   };
 }
 

--- a/apps/standard-reader/perf/lib/targets.ts
+++ b/apps/standard-reader/perf/lib/targets.ts
@@ -87,6 +87,22 @@ function sharedRouteDefs(): Array<SharedRouteDef> {
       budgetMs: 4000,
     },
     {
+      // The reported bug: a full title the reader already knows.
+      id: "search.title",
+      name: "Search (title)",
+      path: `/search?q=${encodeURIComponent(fixtures.searchTitleQuery)}`,
+      budgetMs: 4000,
+    },
+    {
+      // A common word matches ~100k documents. Before the pool caps this shape
+      // took 16s on prod, so it is the regression guard rather than a stretch
+      // goal — no budget would have passed.
+      id: "search.broad",
+      name: "Search (broad)",
+      path: `/search?q=${encodeURIComponent(fixtures.searchBroadQuery)}`,
+      budgetMs: 5000,
+    },
+    {
       id: "about",
       name: "About",
       path: "/about",

--- a/apps/standard-reader/scripts/search-relevance-indexes.sql
+++ b/apps/standard-reader/scripts/search-relevance-indexes.sql
@@ -1,0 +1,103 @@
+-- Search relevance — prod index creation + verification.
+--
+-- Run this against prod Neon BEFORE merging migration
+-- 0044_document_meta_search_idx.sql, and before setting SEARCH_RANKING to
+-- anything other than `legacy`. Building CONCURRENTLY avoids a long write-lock
+-- on `documents` (~3.4M rows, ~14 GB with indexes); because the migration uses
+-- `CREATE INDEX IF NOT EXISTS`, it then no-ops on prod while still building the
+-- index on fresh/local/CI databases.
+--
+-- Ordering matters. If the migration lands first, Railway's `preDeployCommand`
+-- builds this index under a lock while the deploy waits on it. If the ranked
+-- search path ships first, the title arm has no index to match and degrades to
+-- a sequential scan of every document on every keystroke.
+--
+-- Usage (reads DATABASE_URL from .env — this is a PROD write, run it deliberately):
+--   psql "$DATABASE_URL" -f scripts/search-relevance-indexes.sql
+-- CONCURRENTLY cannot run inside a transaction, so run this file with psql's
+-- default autocommit (do NOT wrap in BEGIN/COMMIT). Expect 20-60 minutes.
+
+-- The title/description/tags half of `documents.search_vector` — see the header
+-- of drizzle/0044_document_meta_search_idx.sql for why this is an expression
+-- index rather than a generated column. The expression must stay byte-identical
+-- to what `documentMetaVectorSql` renders, or the planner silently stops
+-- matching it; `document-search.test.ts` guards that.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS documents_meta_search_idx
+  ON documents USING gin ((
+    setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(description, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(immutable_array_to_string(tags), '')), 'B')
+  ));
+
+-- A failed CONCURRENTLY build leaves an INVALID index behind, which the planner
+-- ignores while it still costs writes. This should return zero rows; if it
+-- lists documents_meta_search_idx, DROP INDEX CONCURRENTLY and re-run.
+SELECT indexrelid::regclass AS invalid_index
+FROM pg_index
+WHERE NOT indisvalid;
+
+-- Expect roughly 150-300 MB (8-12 lexemes/row, against 1452 MB for the
+-- body-inclusive documents_search_idx).
+SELECT pg_size_pretty(pg_relation_size('documents_meta_search_idx')) AS meta_idx_size;
+
+-- ── Verification EXPLAINs (read-only) ────────────────────────────────────────
+-- 1. The title arm must be index-served. Expect a Bitmap Index Scan on
+-- documents_meta_search_idx and NO Seq Scan on documents. This is the one that
+-- decides whether the ranked path is shippable.
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT d.uri
+FROM documents d
+WHERE d.deleted = false
+  AND (
+    setweight(to_tsvector('english', coalesce(d.title, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(d.description, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(immutable_array_to_string(d.tags), '')), 'B')
+  ) @@ websearch_to_tsquery('english', 'Making Feeds: Custom Logic Requests')
+LIMIT 400;
+
+-- 2. The whole ranked page for a broad single word — the regression guard for
+-- the 16s query. Expect each arm's Bitmap Heap Scan to stop at its cap (rows
+-- <= 400) and total execution well under 1500ms.
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT pool.uri
+FROM (
+  (SELECT d.uri, d.title, d.description, d.tags, d.published_at
+   FROM documents d
+   WHERE d.deleted = false
+     AND (
+       setweight(to_tsvector('english', coalesce(d.title, '')), 'A') ||
+       setweight(to_tsvector('english', coalesce(d.description, '')), 'B') ||
+       setweight(to_tsvector('english', coalesce(immutable_array_to_string(d.tags), '')), 'B')
+     ) @@ websearch_to_tsquery('english', 'ai')
+   LIMIT 400)
+  UNION
+  (SELECT d.uri, d.title, d.description, d.tags, d.published_at
+   FROM documents d
+   WHERE d.deleted = false
+     AND d.search_vector @@ websearch_to_tsquery('english', 'ai')
+   LIMIT 400)
+) pool
+ORDER BY
+  ts_rank('{0.05,0.1,0.4,1.0}'::float4[],
+    setweight(to_tsvector('english', coalesce(pool.title, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(pool.description, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(immutable_array_to_string(pool.tags), '')), 'B'),
+    websearch_to_tsquery('english', 'ai'), 32) DESC,
+  pool.published_at DESC, pool.uri DESC
+LIMIT 21;
+
+-- 3. Relevance smoke test, not a plan: the article the bug report named must
+-- come back first. Expect 'Making Feeds: Custom Logic Requests' in row 1.
+SELECT d.title, d.published_at::date,
+  CASE
+    WHEN lower(btrim(d.title)) = lower(btrim('Making Feeds: Custom Logic Requests')) THEN 7
+    WHEN position(lower('Making Feeds: Custom Logic Requests') in lower(d.title)) > 0 THEN 6
+    WHEN to_tsvector('simple', coalesce(d.title, ''))
+         @@ phraseto_tsquery('simple', 'Making Feeds: Custom Logic Requests') THEN 5
+    ELSE 0
+  END AS tier
+FROM documents d
+WHERE d.deleted = false
+  AND d.search_vector @@ websearch_to_tsquery('english', 'Making Feeds: Custom Logic Requests')
+ORDER BY tier DESC, d.published_at DESC
+LIMIT 5;

--- a/apps/standard-reader/src/components/guide/pages/finding-guide-page.tsx
+++ b/apps/standard-reader/src/components/guide/pages/finding-guide-page.tsx
@@ -157,15 +157,18 @@ export function FindingGuidePage() {
       <p {...stylex.props(docsStyles.prose)}>
         <Trans>
           Search covers publication names, people&apos;s handles, topics, and
-          the text of articles. Results are split into publications and
+          the text of articles. Results are split into publications, people, and
           articles, and each result shows the passage that matched with your
           words highlighted, so you can tell a real match from a coincidence
-          without opening it.
+          without opening it. Articles come back in order of how well they
+          answer the query — a title that matches what you typed comes before an
+          article that merely mentions those words somewhere in its body — so
+          searching a headline you half-remember finds it.
         </Trans>
       </p>
       <GuideFigure
         shot="search"
-        alt={t`Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt.`}
+        alt={t`Search results for a query, split into Publications, People, and Articles sections, with the matching words highlighted inside each result's excerpt.`}
       />
 
       <h2 {...stylex.props(docsStyles.h2)} id="topics">

--- a/apps/standard-reader/src/components/reader/cards.tsx
+++ b/apps/standard-reader/src/components/reader/cards.tsx
@@ -1237,7 +1237,14 @@ function ArticleSearchDek({
   article: ArticleCard;
   style: stylex.StyleXStyles;
 }) {
-  if (article.searchSnippetHtml) {
+  // Guard on an actual highlight, mirroring `ArticleTitleContent`. Search asks
+  // `ts_headline` for the whole phrase when the body contains it, so a snippet
+  // can legitimately come back with nothing marked — and an unmarked snippet is
+  // just the head of the body, which reads worse than the description.
+  if (
+    article.searchSnippetHtml &&
+    tsHeadlineHasMatch(article.searchSnippetHtml)
+  ) {
     return <SearchHeadline html={article.searchSnippetHtml} style={style} />;
   }
 

--- a/apps/standard-reader/src/integrations/tanstack-query/api-search.functions.ts
+++ b/apps/standard-reader/src/integrations/tanstack-query/api-search.functions.ts
@@ -2,8 +2,18 @@ import { isDid } from "@atcute/lexicons/syntax";
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import { createServerFn } from "@tanstack/react-start";
 import { getRequest } from "@tanstack/react-start/server";
-import { and, desc, eq, ilike, inArray, isNull, or, sql } from "drizzle-orm";
-import { alias } from "drizzle-orm/pg-core";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  ilike,
+  inArray,
+  isNull,
+  or,
+  sql,
+} from "drizzle-orm";
+import { alias, union } from "drizzle-orm/pg-core";
 import { z } from "zod";
 
 import { STANDARD_NSID } from "#/lib/atproto/nsids";
@@ -29,13 +39,37 @@ import {
 } from "#/server/mutes/mutes";
 import { observe } from "#/server/observability/log";
 import { attachReaderSpanContext } from "#/server/observability/span-context.ts";
+import type { FriendPerson } from "#/server/reader/bsky-friends";
 import { attachCommentCountsToArticles } from "#/server/reader/document-comments";
+import {
+  AUTHOR_POOL_CAP,
+  BODY_POOL_CAP,
+  documentMetaRankSql,
+  documentMetaVectorFor,
+  documentTierSql,
+  isSearchRankingEnabled,
+  SEARCH_POOL_CAP,
+  searchQueryShape,
+  shouldUseAuthorArm,
+  TITLE_POOL_CAP,
+} from "#/server/reader/document-search";
+import {
+  PEOPLE_RESULT_LIMIT,
+  profileNameMatchSql,
+  searchPeople as searchPeopleRows,
+} from "#/server/reader/people-search";
 import {
   discoverEligiblePublicationWhere,
   notExcludedPublicationArticleWhere,
   notWebBridgeArticleWhere,
   notWebBridgePublicationOwnerWhere,
 } from "#/server/reader/publication-filters";
+import {
+  PUBLICATION_COUNT_CAP,
+  publicationSearchMatchSql,
+  publicationSearchRankSql,
+  publicationSearchTerms,
+} from "#/server/reader/publication-search";
 import { attachViewerRecommendedToArticles } from "#/server/reader/recommended-by";
 import {
   documentSearchSnippetHeadline,
@@ -76,6 +110,11 @@ const resolveInput = z.object({
   handle: z.string().trim().min(1).max(253),
 });
 
+const searchPeopleInput = z.object({
+  q: z.string().trim().min(1).max(512),
+  limit: z.number().int().min(1).max(20).default(PEOPLE_RESULT_LIMIT),
+});
+
 export interface SearchPublicationsPage {
   query: string;
   items: Array<PublicationCard>;
@@ -87,6 +126,11 @@ export interface SearchArticlesPage {
   query: string;
   items: Array<ArticleCard>;
   nextOffset: number | null;
+}
+
+export interface SearchPeoplePage {
+  query: string;
+  items: Array<FriendPerson>;
 }
 
 export interface ResolvedPublicationPreview {
@@ -185,7 +229,29 @@ const searchArticles = createServerFn({ method: "GET" })
       span.set("offset", data.offset);
       const did = await attachReaderSpanContext(span, getRequest());
 
+      const rankingEnabled = isSearchRankingEnabled();
+      // Short-circuit past the pool: nothing beyond it was ever a candidate,
+      // and XRPC callers can hand us an arbitrary cursor.
+      if (rankingEnabled && data.offset >= SEARCH_POOL_CAP) {
+        span.set("count", 0);
+        return {
+          query: data.q,
+          items: [],
+          nextOffset: null,
+        } satisfies SearchArticlesPage;
+      }
+
+      const shape = searchQueryShape(data.q);
+      // `websearch_to_tsquery` stays the matcher — it carries the "quoted" and
+      // -negated operators. The phrase queries are scoring-only, so they can
+      // never drop a result that used to match.
       const tsq = sql`websearch_to_tsquery('english', ${data.q})`;
+      const phrase = shape.isMultiToken
+        ? sql`phraseto_tsquery('english', ${data.q})`
+        : null;
+      const simplePhrase = shape.isMultiToken
+        ? sql`phraseto_tsquery('simple', ${data.q})`
+        : null;
       const hints = documentQueryHints(data.q);
       // Resolve author/handle matches up front via a trigram-indexed profile
       // lookup, so the documents predicate stays single-table (index-served)
@@ -197,14 +263,25 @@ const searchArticles = createServerFn({ method: "GET" })
         data.q,
         hints,
       );
-      const matchClause = documentMatchSql(d, tsq, hints, authorMatch);
+      const handleHinted = Boolean(hints.authorHandle ?? hints.authorDid);
+      const useAuthorArm = shouldUseAuthorArm(
+        handleHinted,
+        authorMatch.dids.length,
+      );
+      const authorDids = [
+        ...new Set([
+          ...(useAuthorArm ? authorMatch.dids : []),
+          ...(hints.authorDid ? [hints.authorDid] : []),
+        ]),
+      ];
+      const authorPubUris = useAuthorArm ? authorMatch.pubUris : [];
       const [blockDid, muteDid] = await Promise.all([
         blockFilterDid(db, schema, did),
         muteFilterDid(db, schema, did),
       ]);
-      const articleWhere = and(
+      // Everything except the match itself, shared by every pool arm.
+      const baseWhere = and(
         eq(d.deleted, false),
-        matchClause,
         notExcludedPublicationArticleWhere(p),
         ...(excludeWebBridgeEnabled ? [notWebBridgeArticleWhere(schema)] : []),
         // Search is paginated, so blocked authors are excluded in SQL rather
@@ -230,21 +307,143 @@ const searchArticles = createServerFn({ method: "GET" })
           : []),
       );
 
-      // Page the bare document URIs (newest first) in an inner subquery, then
-      // join back to the real tables in the outer query for the card columns and
-      // the ts_headline snippets — so headline (and the recommend-count subquery)
+      // Columns every arm carries, so the tier and rank can be computed over
+      // the pooled rows without going back to the heap.
+      const poolColumns = {
+        description: d.description,
+        did: d.did,
+        publicationUri: d.publicationUri,
+        publishedAt: d.publishedAt,
+        tags: d.tags,
+        title: d.title,
+        uri: d.uri,
+      };
+      const poolArm = (where: ReturnType<typeof and>) =>
+        db
+          .select(poolColumns)
+          .from(d)
+          .leftJoin(p, eq(p.uri, d.publicationUri))
+          .where(where);
+
+      // The indexed meta-vector expression, repeated verbatim so the planner
+      // can serve the title arm from `documents_meta_search_idx`.
+      const indexedMetaVector = documentMetaVectorFor({
+        description: sql`${d.description}`,
+        tags: sql`${d.tags}`,
+        title: sql`${d.title}`,
+      });
+
+      const authorWhere =
+        authorDids.length > 0 || authorPubUris.length > 0
+          ? (or(
+              ...(authorDids.length > 0 ? [inArray(d.did, authorDids)] : []),
+              ...(authorPubUris.length > 0
+                ? [inArray(d.publicationUri, authorPubUris)]
+                : []),
+            ) ?? null)
+          : null;
+
+      // Each arm's LIMIT is an optimization barrier, so the outer ORDER BY can
+      // never be pushed down and the bound always holds. A selective query
+      // never reaches a cap and is therefore ranked over its whole match set.
+      const arms = [];
+      if (hints.uri) {
+        arms.push(poolArm(and(baseWhere, eq(d.uri, hints.uri))).limit(1));
+      } else if (hints.canonicalLike) {
+        arms.push(
+          poolArm(
+            and(baseWhere, ilike(d.canonicalUrl, hints.canonicalLike)),
+          ).limit(BODY_POOL_CAP),
+        );
+      } else if (rankingEnabled) {
+        arms.push(
+          poolArm(and(baseWhere, sql`(${indexedMetaVector}) @@ ${tsq}`)).limit(
+            TITLE_POOL_CAP,
+          ),
+          poolArm(and(baseWhere, sql`${d.searchVector} @@ ${tsq}`)).limit(
+            BODY_POOL_CAP,
+          ),
+        );
+        if (authorWhere) {
+          arms.push(
+            poolArm(and(baseWhere, authorWhere))
+              // Affordable to order here: `documents_did_published_idx` serves it.
+              .orderBy(desc(d.publishedAt), desc(d.uri))
+              .limit(AUTHOR_POOL_CAP),
+          );
+        }
+      } else {
+        // Legacy: one unbounded arm over the body vector, newest first.
+        arms.push(
+          poolArm(
+            and(
+              baseWhere,
+              or(
+                sql`${d.searchVector} @@ ${tsq}`,
+                ...(authorWhere ? [authorWhere] : []),
+              ) ?? sql`false`,
+            ),
+          ),
+        );
+      }
+
+      const [firstArm, secondArm, ...restArms] = arms;
+      if (!firstArm) throw new Error("search: no candidate pool arms");
+      const pool = (
+        secondArm ? union(firstArm, secondArm, ...restArms) : firstArm
+      ).as("pool");
+
+      const pooledMetaVector = documentMetaVectorFor({
+        description: sql`${pool.description}`,
+        tags: sql`${pool.tags}`,
+        title: sql`${pool.title}`,
+      });
+      // Constant scores under the legacy flag collapse the ordering below to
+      // exactly the previous `published_at DESC, uri DESC`.
+      const tier = rankingEnabled
+        ? documentTierSql({
+            authorDids,
+            authorPubUris,
+            did: sql`${pool.did}`,
+            exact: shape.query,
+            metaVector: pooledMetaVector,
+            phrase,
+            publicationUri: sql`${pool.publicationUri}`,
+            simplePhrase,
+            title: sql`${pool.title}`,
+            tsq,
+          })
+        : sql`0`;
+      const metaRank = rankingEnabled
+        ? documentMetaRankSql(pooledMetaVector, tsq)
+        : sql`0`;
+
+      // Rank and page the bare document URIs in an inner subquery, then join
+      // back to the real tables in the outer query for the card columns and the
+      // ts_headline snippets — so headline (and the recommend-count subquery)
       // run only for the `limit + 1` returned rows, not every matched document.
-      // The inner subquery projects only `uri` on purpose: `articleCardColumns`
-      // selects several columns that share an underlying name (`d.did`/`p.did`,
-      // owner vs. author `handle`/`avatar_url`), which would collide as subquery
-      // output columns. Fetching one extra row tells us whether a next page
-      // exists without an exact count(*) over the whole match set.
+      // The inner subquery projects narrow columns on purpose:
+      // `articleCardColumns` selects several columns that share an underlying
+      // name (`d.did`/`p.did`, owner vs. author `handle`/`avatar_url`), which
+      // would collide as subquery output columns. Fetching one extra row tells
+      // us whether a next page exists without an exact count(*) over the whole
+      // match set.
       const page = db
-        .select({ uri: d.uri })
-        .from(d)
-        .leftJoin(p, eq(p.uri, d.publicationUri))
-        .where(articleWhere)
-        .orderBy(desc(d.publishedAt), desc(d.uri))
+        .select({
+          metaRank: metaRank.as("meta_rank"),
+          publishedAt: pool.publishedAt,
+          tier: tier.as("tier"),
+          uri: pool.uri,
+        })
+        .from(pool)
+        // Ends in `uri` so this is a total order — otherwise OFFSET paging
+        // duplicates and drops rows across pages.
+        .orderBy(
+          desc(tier),
+          desc(metaRank),
+          desc(pool.publishedAt),
+          desc(pool.uri),
+        )
         .limit(data.limit + 1)
         .offset(data.offset)
         .as("page");
@@ -252,11 +451,12 @@ const searchArticles = createServerFn({ method: "GET" })
       const pageRows = await db
         .select({
           ...articleCardColumns(schema),
-          searchTitleHtml: documentSearchTitleHeadline(d.title, tsq),
+          searchTitleHtml: documentSearchTitleHeadline(d.title, tsq, phrase),
           searchSnippetHtml: documentSearchSnippetHeadline(
             d.description,
             d.textContent,
             tsq,
+            phrase,
           ),
           // Which of the document's tags the query actually hit — so the card can
           // show the matching tag (and mark it) even when it isn't a leading tag.
@@ -271,7 +471,19 @@ const searchArticles = createServerFn({ method: "GET" })
         .leftJoin(p, eq(p.uri, d.publicationUri))
         .leftJoin(pr, eq(pr.did, p.did))
         .leftJoin(pa, eq(pa.did, d.did))
-        .orderBy(desc(d.publishedAt), desc(d.uri));
+        // Re-stated from the page subquery's own projected columns so the two
+        // orderings physically cannot drift apart.
+        .orderBy(
+          desc(page.tier),
+          desc(page.metaRank),
+          desc(page.publishedAt),
+          desc(page.uri),
+        );
+
+      span.set("ranking", rankingEnabled ? "v2" : "legacy");
+      span.set("pool.arms", arms.length);
+      span.set("phrase", Boolean(phrase));
+      span.set("authorArm", Boolean(authorWhere));
 
       const hasMore = pageRows.length > data.limit;
       const articleRows = hasMore ? pageRows.slice(0, data.limit) : pageRows;
@@ -299,6 +511,32 @@ const searchArticles = createServerFn({ method: "GET" })
     }),
   );
 
+const searchPeople = createServerFn({ method: "GET" })
+  .middleware([dbMiddleware])
+  .validator(searchPeopleInput)
+  .handler(
+    observe("search.people", async ({ data, context }, span) => {
+      const { db, schema } = context;
+      span.set("q", data.q);
+      const did = await attachReaderSpanContext(span, getRequest());
+      const [blockDid, muteDid] = await Promise.all([
+        blockFilterDid(db, schema, did),
+        muteFilterDid(db, schema, did),
+      ]);
+
+      const items = await searchPeopleRows(db, schema, {
+        blockDid,
+        limit: data.limit,
+        muteDid,
+        q: data.q,
+        readerDid: did,
+      });
+      span.set("count", items.length);
+
+      return { query: data.q, items } satisfies SearchPeoplePage;
+    }),
+  );
+
 /** Indexed publication matches (FTS, URL, handle) with total count. */
 async function searchIndexedPublications(
   db: Db,
@@ -312,30 +550,50 @@ async function searchIndexedPublications(
   const st = schema.publicationStats;
   const pr = schema.profiles;
   const hints = publicationQueryHints(q);
-  const tsq = sql`websearch_to_tsquery('english', ${q})`;
+  const terms = publicationSearchTerms(q, {
+    like: hints.likePattern,
+    urlLike: hints.urlLike,
+  });
+  const armOptions = { matchDisplayName: true };
   const pubWhere = and(
     discoverEligiblePublicationWhere(p),
-    publicationMatchSql(p, pr, tsq, hints),
+    publicationSearchMatchSql(p, pr, terms, armOptions),
     ...(excludeWebBridge ? [notWebBridgePublicationOwnerWhere(schema)] : []),
   );
 
+  // Bound the count instead of counting the whole match set on every keystroke:
+  // walk at most `PUBLICATION_COUNT_CAP` matching rows and let the caller render
+  // a saturated total as "N+". Paging past the cap isn't worth a full count.
+  const countScan = db
+    .select({ one: sql<number>`1` })
+    .from(p)
+    .leftJoin(pr, eq(pr.did, p.did))
+    .where(pubWhere)
+    .limit(PUBLICATION_COUNT_CAP)
+    .as("pub_count_scan");
+
   const [countRow, publicationQueryRows] = await Promise.all([
-    db
-      .select({ count: sql<number>`count(*)::int` })
-      .from(p)
-      .leftJoin(pr, eq(pr.did, p.did))
-      .where(pubWhere),
+    db.select({ count: sql<number>`count(*)::int` }).from(countScan),
     db
       .select({
         ...publicationCardColumns(schema),
-        searchNameHtml: publicationSearchNameHeadline(p.name, tsq),
-        searchSnippetHtml: publicationSearchSnippetHeadline(p.description, tsq),
+        searchNameHtml: publicationSearchNameHeadline(p.name, terms.tsq),
+        searchSnippetHtml: publicationSearchSnippetHeadline(
+          p.description,
+          terms.tsq,
+        ),
       })
       .from(p)
       .leftJoin(st, eq(st.publicationUri, p.uri))
       .leftJoin(pr, eq(pr.did, p.did))
       .where(pubWhere)
-      .orderBy(desc(publicationRankSql(p, pr, tsq, hints)))
+      // Rank alone is not a total order — publications tie constantly, and an
+      // unstable sort makes OFFSET paging duplicate and drop rows.
+      .orderBy(
+        desc(publicationSearchRankSql(p, pr, terms, armOptions)),
+        desc(sql`coalesce(${st.subscriberCount}, 0)`),
+        asc(p.uri),
+      )
       .limit(limit)
       .offset(offset),
   ]);
@@ -538,76 +796,6 @@ async function resolveAuthorMatches(
     ),
   ];
   return { dids, pubUris };
-}
-
-/**
- * Build the article match clause from {@link documentQueryHints} and the
- * pre-resolved {@link AuthorMatch}: an exact record/URL reference matches alone,
- * otherwise the FTS vector is OR-ed with the matched author DIDs / publications
- * (and an explicit author DID hint) so "alice.bsky.social" surfaces her
- * articles alongside ordinary title/body hits. Every arm is a `documents`
- * column, so the OR stays index-servable.
- */
-function documentMatchSql(
-  d: Schema["documents"],
-  tsq: ReturnType<typeof sql>,
-  hints: DocumentQueryHints,
-  authorMatch: AuthorMatch,
-) {
-  if (hints.uri) return eq(d.uri, hints.uri);
-  if (hints.canonicalLike) return ilike(d.canonicalUrl, hints.canonicalLike);
-
-  const parts = [sql`${d.searchVector} @@ ${tsq}`];
-  if (authorMatch.dids.length > 0) {
-    parts.push(inArray(d.did, authorMatch.dids));
-  }
-  if (authorMatch.pubUris.length > 0) {
-    parts.push(inArray(d.publicationUri, authorMatch.pubUris));
-  }
-  if (hints.authorDid) {
-    parts.push(eq(d.did, hints.authorDid));
-  }
-  return or(...parts) ?? sql`false`;
-}
-
-function publicationMatchSql(
-  p: Schema["publications"],
-  pr: Schema["profiles"],
-  tsq: ReturnType<typeof sql>,
-  hints: PublicationQueryHints,
-) {
-  const parts = [
-    sql`${p.searchVector} @@ ${tsq}`,
-    ilike(p.url, hints.likePattern),
-    ilike(pr.handle, hints.likePattern),
-    ilike(pr.displayName, hints.likePattern),
-  ];
-  if (hints.urlLike) {
-    parts.push(ilike(p.url, hints.urlLike));
-  }
-  if (parts.length === 0) return sql`false`;
-  return or(...parts) ?? sql`false`;
-}
-
-function publicationRankSql(
-  p: Schema["publications"],
-  pr: Schema["profiles"],
-  tsq: ReturnType<typeof sql>,
-  hints: PublicationQueryHints,
-) {
-  return sql`greatest(
-    case when ${p.searchVector} @@ ${tsq}
-      then ts_rank(${p.searchVector}, ${tsq})::real
-      else 0::real
-    end,
-    case when ${p.url} ilike ${hints.likePattern} then 0.2::real else 0::real end,
-    case when ${pr.handle} ilike ${hints.likePattern} then 0.15::real else 0::real end,
-    case when ${pr.displayName} ilike ${hints.likePattern} then 0.15::real else 0::real end${
-      hints.urlLike
-        ? sql`, case when ${p.url} ilike ${hints.urlLike} then 0.25::real else 0::real end`
-        : sql``
-    }
-  )`;
 }
 
 /** Resolve publications from the index, or live from the author's repo. */
@@ -885,7 +1073,7 @@ const searchLooseDocAccounts = createServerFn({ method: "GET" })
           and(
             eq(d.deleted, false),
             isNull(d.publicationUri),
-            or(ilike(pr.handle, like), ilike(pr.displayName, like)),
+            profileNameMatchSql(pr, like),
           ),
         )
         .groupBy(pr.did, pr.handle, pr.displayName, pr.avatarUrl)
@@ -950,7 +1138,21 @@ function searchLooseDocAccountsQueryOptions({
   });
 }
 
+function searchPeopleQueryOptions({
+  q = "",
+  limit = PEOPLE_RESULT_LIMIT,
+}: { q?: string; limit?: number } = {}) {
+  const trimmed = q.trim();
+  return queryOptions({
+    queryKey: ["search", "people", trimmed, limit] as const,
+    queryFn: async () => searchPeople({ data: { q: trimmed, limit } }),
+    enabled: trimmed.length > 0,
+  });
+}
+
 export const searchApi = {
+  searchPeople,
+  searchPeopleQueryOptions,
   searchPublications,
   searchArticles,
   searchPublicationsQueryOptions,

--- a/apps/standard-reader/src/locales/ar/messages.po
+++ b/apps/standard-reader/src/locales/ar/messages.po
@@ -560,6 +560,7 @@ msgid "Subscribing…"
 msgstr "جارٍ الاشتراك…"
 
 #: src/routes/_layout.friends.tsx
+#: src/routes/_layout.search.tsx
 msgid "People"
 msgstr ""
 
@@ -1713,6 +1714,10 @@ msgstr ""
 msgid "Compact"
 msgstr ""
 
+#: src/components/guide/pages/finding-guide-page.tsx
+msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications, people, and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it. Articles come back in order of how well they answer the query — a title that matches what you typed comes before an article that merely mentions those words somewhere in its body — so searching a headline you half-remember finds it."
+msgstr ""
+
 #: src/components/reader/blocked-notice.tsx
 msgid "This account"
 msgstr ""
@@ -1904,8 +1909,8 @@ msgid "your collection"
 msgstr "مجموعتك"
 
 #: src/components/guide/pages/finding-guide-page.tsx
-msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
-msgstr ""
+#~ msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "“…made to be read, and not to be measured.”"
@@ -5080,6 +5085,10 @@ msgstr "مقالات موصى بها"
 msgid "You blocked this account, so their writing is hidden."
 msgstr ""
 
+#: src/routes/_layout.search.tsx
+msgid "Loading people matches"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
 msgstr ""
@@ -5355,6 +5364,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
 msgstr "تابع القراءة"
+
+#: src/components/guide/pages/finding-guide-page.tsx
+msgid "Search results for a query, split into Publications, People, and Articles sections, with the matching words highlighted inside each result's excerpt."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "put the article in your Saved queue."
@@ -7896,8 +7909,8 @@ msgid "everything new in the order it was published, with tabs for unread, your 
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
-msgid "Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt."
-msgstr ""
+#~ msgid "Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt."
+#~ msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Do you like Standard Reader?"

--- a/apps/standard-reader/src/locales/de/messages.po
+++ b/apps/standard-reader/src/locales/de/messages.po
@@ -560,6 +560,7 @@ msgid "Subscribing…"
 msgstr "Wird abonniert …"
 
 #: src/routes/_layout.friends.tsx
+#: src/routes/_layout.search.tsx
 msgid "People"
 msgstr ""
 
@@ -1713,6 +1714,10 @@ msgstr ""
 msgid "Compact"
 msgstr ""
 
+#: src/components/guide/pages/finding-guide-page.tsx
+msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications, people, and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it. Articles come back in order of how well they answer the query — a title that matches what you typed comes before an article that merely mentions those words somewhere in its body — so searching a headline you half-remember finds it."
+msgstr ""
+
 #: src/components/reader/blocked-notice.tsx
 msgid "This account"
 msgstr ""
@@ -1904,8 +1909,8 @@ msgid "your collection"
 msgstr "Ihre Sammlung"
 
 #: src/components/guide/pages/finding-guide-page.tsx
-msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
-msgstr ""
+#~ msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "“…made to be read, and not to be measured.”"
@@ -5080,6 +5085,10 @@ msgstr "Empfohlene Artikel"
 msgid "You blocked this account, so their writing is hidden."
 msgstr ""
 
+#: src/routes/_layout.search.tsx
+msgid "Loading people matches"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
 msgstr ""
@@ -5355,6 +5364,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
 msgstr "Weiterlesen"
+
+#: src/components/guide/pages/finding-guide-page.tsx
+msgid "Search results for a query, split into Publications, People, and Articles sections, with the matching words highlighted inside each result's excerpt."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "put the article in your Saved queue."
@@ -7896,8 +7909,8 @@ msgid "everything new in the order it was published, with tabs for unread, your 
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
-msgid "Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt."
-msgstr ""
+#~ msgid "Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt."
+#~ msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Do you like Standard Reader?"

--- a/apps/standard-reader/src/locales/en-XA/messages.po
+++ b/apps/standard-reader/src/locales/en-XA/messages.po
@@ -560,6 +560,7 @@ msgid "Subscribing…"
 msgstr ""
 
 #: src/routes/_layout.friends.tsx
+#: src/routes/_layout.search.tsx
 msgid "People"
 msgstr ""
 
@@ -1713,6 +1714,10 @@ msgstr ""
 msgid "Compact"
 msgstr ""
 
+#: src/components/guide/pages/finding-guide-page.tsx
+msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications, people, and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it. Articles come back in order of how well they answer the query — a title that matches what you typed comes before an article that merely mentions those words somewhere in its body — so searching a headline you half-remember finds it."
+msgstr ""
+
 #: src/components/reader/blocked-notice.tsx
 msgid "This account"
 msgstr ""
@@ -1904,8 +1909,8 @@ msgid "your collection"
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
-msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
-msgstr ""
+#~ msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "“…made to be read, and not to be measured.”"
@@ -5080,6 +5085,10 @@ msgstr ""
 msgid "You blocked this account, so their writing is hidden."
 msgstr ""
 
+#: src/routes/_layout.search.tsx
+msgid "Loading people matches"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
 msgstr ""
@@ -5354,6 +5363,10 @@ msgstr ""
 
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
+msgstr ""
+
+#: src/components/guide/pages/finding-guide-page.tsx
+msgid "Search results for a query, split into Publications, People, and Articles sections, with the matching words highlighted inside each result's excerpt."
 msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
@@ -7896,8 +7909,8 @@ msgid "everything new in the order it was published, with tabs for unread, your 
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
-msgid "Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt."
-msgstr ""
+#~ msgid "Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt."
+#~ msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Do you like Standard Reader?"

--- a/apps/standard-reader/src/locales/en/messages.po
+++ b/apps/standard-reader/src/locales/en/messages.po
@@ -560,6 +560,7 @@ msgid "Subscribing…"
 msgstr "Subscribing…"
 
 #: src/routes/_layout.friends.tsx
+#: src/routes/_layout.search.tsx
 msgid "People"
 msgstr "People"
 
@@ -1713,6 +1714,10 @@ msgstr "For more about how {SITE_NAME} works, see the <0>About</0> page. For que
 msgid "Compact"
 msgstr "Compact"
 
+#: src/components/guide/pages/finding-guide-page.tsx
+msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications, people, and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it. Articles come back in order of how well they answer the query — a title that matches what you typed comes before an article that merely mentions those words somewhere in its body — so searching a headline you half-remember finds it."
+msgstr "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications, people, and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it. Articles come back in order of how well they answer the query — a title that matches what you typed comes before an article that merely mentions those words somewhere in its body — so searching a headline you half-remember finds it."
+
 #: src/components/reader/blocked-notice.tsx
 msgid "This account"
 msgstr "This account"
@@ -1904,8 +1909,8 @@ msgid "your collection"
 msgstr "your collection"
 
 #: src/components/guide/pages/finding-guide-page.tsx
-msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
-msgstr "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
+#~ msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
+#~ msgstr "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
 
 #: src/components/reader/about-view.tsx
 msgid "“…made to be read, and not to be measured.”"
@@ -5080,6 +5085,10 @@ msgstr "Recommended articles"
 msgid "You blocked this account, so their writing is hidden."
 msgstr "You blocked this account, so their writing is hidden."
 
+#: src/routes/_layout.search.tsx
+msgid "Loading people matches"
+msgstr "Loading people matches"
+
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
 msgstr "Light, dark, match your system — or Custom, to choose a palette of your own."
@@ -5355,6 +5364,10 @@ msgstr "In practice this means a reader who subscribes mid-run can come back aft
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
 msgstr "Keep reading"
+
+#: src/components/guide/pages/finding-guide-page.tsx
+msgid "Search results for a query, split into Publications, People, and Articles sections, with the matching words highlighted inside each result's excerpt."
+msgstr "Search results for a query, split into Publications, People, and Articles sections, with the matching words highlighted inside each result's excerpt."
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "put the article in your Saved queue."
@@ -7896,8 +7909,8 @@ msgid "everything new in the order it was published, with tabs for unread, your 
 msgstr "everything new in the order it was published, with tabs for unread, your subscriptions, and the whole network."
 
 #: src/components/guide/pages/finding-guide-page.tsx
-msgid "Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt."
-msgstr "Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt."
+#~ msgid "Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt."
+#~ msgstr "Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt."
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Do you like Standard Reader?"

--- a/apps/standard-reader/src/locales/es/messages.po
+++ b/apps/standard-reader/src/locales/es/messages.po
@@ -560,6 +560,7 @@ msgid "Subscribing…"
 msgstr "Suscribiendo…"
 
 #: src/routes/_layout.friends.tsx
+#: src/routes/_layout.search.tsx
 msgid "People"
 msgstr ""
 
@@ -1713,6 +1714,10 @@ msgstr ""
 msgid "Compact"
 msgstr ""
 
+#: src/components/guide/pages/finding-guide-page.tsx
+msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications, people, and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it. Articles come back in order of how well they answer the query — a title that matches what you typed comes before an article that merely mentions those words somewhere in its body — so searching a headline you half-remember finds it."
+msgstr ""
+
 #: src/components/reader/blocked-notice.tsx
 msgid "This account"
 msgstr ""
@@ -1904,8 +1909,8 @@ msgid "your collection"
 msgstr "su colección"
 
 #: src/components/guide/pages/finding-guide-page.tsx
-msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
-msgstr ""
+#~ msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "“…made to be read, and not to be measured.”"
@@ -5080,6 +5085,10 @@ msgstr "Artículos recomendados"
 msgid "You blocked this account, so their writing is hidden."
 msgstr ""
 
+#: src/routes/_layout.search.tsx
+msgid "Loading people matches"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
 msgstr ""
@@ -5355,6 +5364,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
 msgstr "Seguir leyendo"
+
+#: src/components/guide/pages/finding-guide-page.tsx
+msgid "Search results for a query, split into Publications, People, and Articles sections, with the matching words highlighted inside each result's excerpt."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "put the article in your Saved queue."
@@ -7896,8 +7909,8 @@ msgid "everything new in the order it was published, with tabs for unread, your 
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
-msgid "Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt."
-msgstr ""
+#~ msgid "Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt."
+#~ msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Do you like Standard Reader?"

--- a/apps/standard-reader/src/locales/fr/messages.po
+++ b/apps/standard-reader/src/locales/fr/messages.po
@@ -560,6 +560,7 @@ msgid "Subscribing…"
 msgstr "Abonnement en cours…"
 
 #: src/routes/_layout.friends.tsx
+#: src/routes/_layout.search.tsx
 msgid "People"
 msgstr ""
 
@@ -1713,6 +1714,10 @@ msgstr ""
 msgid "Compact"
 msgstr ""
 
+#: src/components/guide/pages/finding-guide-page.tsx
+msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications, people, and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it. Articles come back in order of how well they answer the query — a title that matches what you typed comes before an article that merely mentions those words somewhere in its body — so searching a headline you half-remember finds it."
+msgstr ""
+
 #: src/components/reader/blocked-notice.tsx
 msgid "This account"
 msgstr ""
@@ -1904,8 +1909,8 @@ msgid "your collection"
 msgstr "votre collection"
 
 #: src/components/guide/pages/finding-guide-page.tsx
-msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
-msgstr ""
+#~ msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "“…made to be read, and not to be measured.”"
@@ -5080,6 +5085,10 @@ msgstr "Articles recommandés"
 msgid "You blocked this account, so their writing is hidden."
 msgstr ""
 
+#: src/routes/_layout.search.tsx
+msgid "Loading people matches"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
 msgstr ""
@@ -5355,6 +5364,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
 msgstr "Continuer la lecture"
+
+#: src/components/guide/pages/finding-guide-page.tsx
+msgid "Search results for a query, split into Publications, People, and Articles sections, with the matching words highlighted inside each result's excerpt."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "put the article in your Saved queue."
@@ -7896,8 +7909,8 @@ msgid "everything new in the order it was published, with tabs for unread, your 
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
-msgid "Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt."
-msgstr ""
+#~ msgid "Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt."
+#~ msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Do you like Standard Reader?"

--- a/apps/standard-reader/src/locales/ja/messages.po
+++ b/apps/standard-reader/src/locales/ja/messages.po
@@ -560,6 +560,7 @@ msgid "Subscribing…"
 msgstr "購読しています…"
 
 #: src/routes/_layout.friends.tsx
+#: src/routes/_layout.search.tsx
 msgid "People"
 msgstr ""
 
@@ -1713,6 +1714,10 @@ msgstr ""
 msgid "Compact"
 msgstr ""
 
+#: src/components/guide/pages/finding-guide-page.tsx
+msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications, people, and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it. Articles come back in order of how well they answer the query — a title that matches what you typed comes before an article that merely mentions those words somewhere in its body — so searching a headline you half-remember finds it."
+msgstr ""
+
 #: src/components/reader/blocked-notice.tsx
 msgid "This account"
 msgstr ""
@@ -1904,8 +1909,8 @@ msgid "your collection"
 msgstr "自分のコレクション"
 
 #: src/components/guide/pages/finding-guide-page.tsx
-msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
-msgstr ""
+#~ msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "“…made to be read, and not to be measured.”"
@@ -5080,6 +5085,10 @@ msgstr "おすすめの記事"
 msgid "You blocked this account, so their writing is hidden."
 msgstr ""
 
+#: src/routes/_layout.search.tsx
+msgid "Loading people matches"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
 msgstr ""
@@ -5355,6 +5364,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
 msgstr "読み続ける"
+
+#: src/components/guide/pages/finding-guide-page.tsx
+msgid "Search results for a query, split into Publications, People, and Articles sections, with the matching words highlighted inside each result's excerpt."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "put the article in your Saved queue."
@@ -7896,8 +7909,8 @@ msgid "everything new in the order it was published, with tabs for unread, your 
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
-msgid "Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt."
-msgstr ""
+#~ msgid "Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt."
+#~ msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Do you like Standard Reader?"

--- a/apps/standard-reader/src/locales/ko/messages.po
+++ b/apps/standard-reader/src/locales/ko/messages.po
@@ -560,6 +560,7 @@ msgid "Subscribing…"
 msgstr "구독하는 중…"
 
 #: src/routes/_layout.friends.tsx
+#: src/routes/_layout.search.tsx
 msgid "People"
 msgstr ""
 
@@ -1713,6 +1714,10 @@ msgstr ""
 msgid "Compact"
 msgstr ""
 
+#: src/components/guide/pages/finding-guide-page.tsx
+msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications, people, and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it. Articles come back in order of how well they answer the query — a title that matches what you typed comes before an article that merely mentions those words somewhere in its body — so searching a headline you half-remember finds it."
+msgstr ""
+
 #: src/components/reader/blocked-notice.tsx
 msgid "This account"
 msgstr ""
@@ -1904,8 +1909,8 @@ msgid "your collection"
 msgstr "내 컬렉션"
 
 #: src/components/guide/pages/finding-guide-page.tsx
-msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
-msgstr ""
+#~ msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "“…made to be read, and not to be measured.”"
@@ -5080,6 +5085,10 @@ msgstr "추천 아티클"
 msgid "You blocked this account, so their writing is hidden."
 msgstr ""
 
+#: src/routes/_layout.search.tsx
+msgid "Loading people matches"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
 msgstr ""
@@ -5355,6 +5364,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
 msgstr "계속 읽기"
+
+#: src/components/guide/pages/finding-guide-page.tsx
+msgid "Search results for a query, split into Publications, People, and Articles sections, with the matching words highlighted inside each result's excerpt."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "put the article in your Saved queue."
@@ -7896,8 +7909,8 @@ msgid "everything new in the order it was published, with tabs for unread, your 
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
-msgid "Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt."
-msgstr ""
+#~ msgid "Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt."
+#~ msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Do you like Standard Reader?"

--- a/apps/standard-reader/src/locales/pt/messages.po
+++ b/apps/standard-reader/src/locales/pt/messages.po
@@ -560,6 +560,7 @@ msgid "Subscribing…"
 msgstr "Se inscrevendo…"
 
 #: src/routes/_layout.friends.tsx
+#: src/routes/_layout.search.tsx
 msgid "People"
 msgstr "Pessoas"
 
@@ -1713,6 +1714,10 @@ msgstr "Para saber mais sobre como o {SITE_NAME} funciona, consulte a página <0
 msgid "Compact"
 msgstr ""
 
+#: src/components/guide/pages/finding-guide-page.tsx
+msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications, people, and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it. Articles come back in order of how well they answer the query — a title that matches what you typed comes before an article that merely mentions those words somewhere in its body — so searching a headline you half-remember finds it."
+msgstr ""
+
 #: src/components/reader/blocked-notice.tsx
 msgid "This account"
 msgstr ""
@@ -1904,8 +1909,8 @@ msgid "your collection"
 msgstr "a sua coleção"
 
 #: src/components/guide/pages/finding-guide-page.tsx
-msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
-msgstr ""
+#~ msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "“…made to be read, and not to be measured.”"
@@ -5080,6 +5085,10 @@ msgstr "Artigos recomendados"
 msgid "You blocked this account, so their writing is hidden."
 msgstr ""
 
+#: src/routes/_layout.search.tsx
+msgid "Loading people matches"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
 msgstr ""
@@ -5355,6 +5364,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
 msgstr "Continuar a ler"
+
+#: src/components/guide/pages/finding-guide-page.tsx
+msgid "Search results for a query, split into Publications, People, and Articles sections, with the matching words highlighted inside each result's excerpt."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "put the article in your Saved queue."
@@ -7896,8 +7909,8 @@ msgid "everything new in the order it was published, with tabs for unread, your 
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
-msgid "Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt."
-msgstr ""
+#~ msgid "Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt."
+#~ msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Do you like Standard Reader?"

--- a/apps/standard-reader/src/locales/zh/messages.po
+++ b/apps/standard-reader/src/locales/zh/messages.po
@@ -560,6 +560,7 @@ msgid "Subscribing…"
 msgstr "正在订阅…"
 
 #: src/routes/_layout.friends.tsx
+#: src/routes/_layout.search.tsx
 msgid "People"
 msgstr ""
 
@@ -1713,6 +1714,10 @@ msgstr ""
 msgid "Compact"
 msgstr ""
 
+#: src/components/guide/pages/finding-guide-page.tsx
+msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications, people, and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it. Articles come back in order of how well they answer the query — a title that matches what you typed comes before an article that merely mentions those words somewhere in its body — so searching a headline you half-remember finds it."
+msgstr ""
+
 #: src/components/reader/blocked-notice.tsx
 msgid "This account"
 msgstr ""
@@ -1904,8 +1909,8 @@ msgid "your collection"
 msgstr "你的合集"
 
 #: src/components/guide/pages/finding-guide-page.tsx
-msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
-msgstr ""
+#~ msgid "Search covers publication names, people's handles, topics, and the text of articles. Results are split into publications and articles, and each result shows the passage that matched with your words highlighted, so you can tell a real match from a coincidence without opening it."
+#~ msgstr ""
 
 #: src/components/reader/about-view.tsx
 msgid "“…made to be read, and not to be measured.”"
@@ -5080,6 +5085,10 @@ msgstr "推荐文章"
 msgid "You blocked this account, so their writing is hidden."
 msgstr ""
 
+#: src/routes/_layout.search.tsx
+msgid "Loading people matches"
+msgstr ""
+
 #: src/components/user-settings-view.tsx
 msgid "Light, dark, match your system — or Custom, to choose a palette of your own."
 msgstr ""
@@ -5355,6 +5364,10 @@ msgstr ""
 #: src/components/reader/article-below-fold.tsx
 msgid "Keep reading"
 msgstr "继续阅读"
+
+#: src/components/guide/pages/finding-guide-page.tsx
+msgid "Search results for a query, split into Publications, People, and Articles sections, with the matching words highlighted inside each result's excerpt."
+msgstr ""
 
 #: src/components/guide/pages/reading-guide-page.tsx
 msgid "put the article in your Saved queue."
@@ -7896,8 +7909,8 @@ msgid "everything new in the order it was published, with tabs for unread, your 
 msgstr ""
 
 #: src/components/guide/pages/finding-guide-page.tsx
-msgid "Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt."
-msgstr ""
+#~ msgid "Search results for a query, split into a Publications section and an Articles section, with the matching words highlighted inside each result's excerpt."
+#~ msgstr ""
 
 #: src/components/reader/atstore-review-prompt.tsx
 msgid "Do you like Standard Reader?"

--- a/apps/standard-reader/src/routes/_layout.search.tsx
+++ b/apps/standard-reader/src/routes/_layout.search.tsx
@@ -26,9 +26,12 @@ import { usePullToRefresh } from "#/components/reader/pull-to-refresh";
 import { searchApi } from "#/integrations/tanstack-query/api-search.functions";
 import { getPublicUrlClient } from "#/lib/public-url";
 import { pageSocialMeta } from "#/lib/site-metadata";
+import { PEOPLE_MIN_QUERY_LENGTH } from "#/server/reader/people-search";
+import { PUBLICATION_COUNT_CAP } from "#/server/reader/publication-search";
 
 import {
   ArticleRow,
+  FriendPersonRow,
   PubDirectoryRow,
   PubDirectoryRowSkeleton,
 } from "../components/reader/cards";
@@ -232,6 +235,33 @@ function PublicationResultsSkeleton({
   );
 }
 
+function PeopleResultsSkeleton({
+  isFirstSection = false,
+}: {
+  isFirstSection?: boolean;
+}) {
+  const { t } = useLingui();
+  return (
+    <div
+      aria-busy="true"
+      aria-label={t`Loading people matches`}
+      {...stylex.props(styles.section, isFirstSection && styles.sectionFirst)}
+    >
+      <SectionHead
+        kicker={<Trans>People</Trans>}
+        title={<SectionTitleSkeleton />}
+      />
+      {Array.from({ length: SKELETON_ROWS }, (_, index) => (
+        <PubDirectoryRowSkeleton
+          key={index}
+          isFirstInSection={index === 0}
+          isLast={index === SKELETON_ROWS - 1}
+        />
+      ))}
+    </div>
+  );
+}
+
 function ArticleResultsSkeleton({
   isFirstSection = false,
 }: {
@@ -338,6 +368,7 @@ function SearchPending() {
       {trimmedQ ? (
         <div {...stylex.props(styles.results)}>
           <PublicationResultsSkeleton />
+          <PeopleResultsSkeleton />
           <ArticleResultsSkeleton />
         </div>
       ) : null}
@@ -347,6 +378,12 @@ function SearchPending() {
 
 function formatMatchCount(i18n: I18n, shown: number, total: number): string {
   if (total === 0) return i18n._(msg`No matches`);
+  // The publication count is bounded (see `PUBLICATION_COUNT_CAP`), so a
+  // saturated total means "at least this many" — say so rather than claiming
+  // an exact figure we deliberately stopped counting at.
+  if (total >= PUBLICATION_COUNT_CAP) {
+    return formatShownCount(i18n, shown, true);
+  }
   if (shown < total) {
     return i18n._(msg`${shown} of ${total} matches`);
   }
@@ -415,6 +452,10 @@ function Search() {
     }),
   });
 
+  const { data: peoplePage, isFetching: peopleFetching } = useQuery({
+    ...searchApi.searchPeopleQueryOptions({ q: debouncedQ }),
+  });
+
   const {
     data: articlePages,
     fetchNextPage,
@@ -475,10 +516,15 @@ function Search() {
   const inputPending = trimmedInput !== debouncedQ;
   const pubsReady = pubPage?.query === debouncedQ;
   const articlesReady = articlePages?.pages[0]?.query === debouncedQ;
+  // Below the trigram floor the server returns nothing, so never wait on it.
+  const peopleEligible = debouncedQ.length >= PEOPLE_MIN_QUERY_LENGTH;
+  const peopleReady = !peopleEligible || peoplePage?.query === debouncedQ;
   const pubsPending = hasQuery && !pubsReady && (inputPending || pubsFetching);
   const articlesPending =
     hasQuery && !articlesReady && (inputPending || articlesFetching);
-  const resultsReady = hasQuery && pubsReady && articlesReady;
+  const peoplePending =
+    hasQuery && !peopleReady && (inputPending || peopleFetching);
+  const resultsReady = hasQuery && pubsReady && articlesReady && peopleReady;
 
   const publicationCountText = i18n._(
     msg`${plural(pubTotal, { one: "# publication", other: "# publications" })}`,
@@ -496,13 +542,21 @@ function Search() {
     : t`Try "climate", "typography", or a handle like stdout.dev`;
 
   const remainingPublications = pubTotal - publications.length;
+  const people =
+    peopleReady && peoplePage?.query === debouncedQ ? peoplePage.items : [];
   const showEmpty =
-    resultsReady && publications.length === 0 && articles.length === 0;
+    resultsReady &&
+    publications.length === 0 &&
+    people.length === 0 &&
+    articles.length === 0;
   const showPublicationSection =
     pubsPending || publications.length > 0 || pubTotal > 0;
+  const showPeopleSection = peoplePending || people.length > 0;
   const showArticleSection = articlesPending || articles.length > 0;
   const publicationSectionFirst = showPublicationSection;
-  const articleSectionFirst = !showPublicationSection && showArticleSection;
+  const peopleSectionFirst = !showPublicationSection && showPeopleSection;
+  const articleSectionFirst =
+    !showPublicationSection && !showPeopleSection && showArticleSection;
 
   return (
     <ReaderContent>
@@ -563,6 +617,32 @@ function Search() {
                     </Button>
                   </div>
                 )}
+              </section>
+            )
+          ) : null}
+
+          {showPeopleSection ? (
+            peoplePending ? (
+              <PeopleResultsSkeleton isFirstSection={peopleSectionFirst} />
+            ) : (
+              <section
+                {...stylex.props(
+                  styles.section,
+                  peopleSectionFirst && styles.sectionFirst,
+                )}
+              >
+                <SectionHead
+                  kicker={<Trans>People</Trans>}
+                  title={formatShownCount(i18n, people.length, false)}
+                />
+                {people.map((person, index) => (
+                  <FriendPersonRow
+                    key={person.did}
+                    person={person}
+                    isFirstInSection={index === 0}
+                    isLast={index === people.length - 1}
+                  />
+                ))}
               </section>
             )
           ) : null}

--- a/apps/standard-reader/src/server/reader/bsky-friends.ts
+++ b/apps/standard-reader/src/server/reader/bsky-friends.ts
@@ -603,7 +603,7 @@ async function displayNamesForDids(
 }
 
 /** Which of `dids` the reader already follows on standard.reader. */
-async function userFollowedDids(
+export async function userFollowedDids(
   db: Db,
   schema: Schema,
   readerDid: string,

--- a/apps/standard-reader/src/server/reader/document-search.test.ts
+++ b/apps/standard-reader/src/server/reader/document-search.test.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { PgDialect } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+
+import {
+  documentMetaVectorDdl,
+  NAME_MATCH_AMBIGUITY_CAP,
+  searchQueryShape,
+  SEARCH_POOL_CAP,
+  shouldUseAuthorArm,
+} from "./document-search";
+
+/** Whitespace-insensitive compare: SQL formatting differs between the
+ * rendered expression and the hand-written migration. */
+const normalize = (text: string) => text.replaceAll(/\s+/g, " ").trim();
+
+describe("searchQueryShape", () => {
+  it("treats a multi-word title as a phrase candidate", () => {
+    const shape = searchQueryShape("  Making Feeds: Custom Logic Requests ");
+    expect(shape.query).toBe("Making Feeds: Custom Logic Requests");
+    expect(shape.tokenCount).toBe(5);
+    expect(shape.isMultiToken).toBe(true);
+  });
+
+  it("does not phrase-score a single word", () => {
+    // `phraseto_tsquery` degenerates to `websearch_to_tsquery` here, so the
+    // phrase tiers would fire on every match and flatten the ranking.
+    expect(searchQueryShape("ai").isMultiToken).toBe(false);
+    expect(searchQueryShape("typography").isMultiToken).toBe(false);
+  });
+
+  it("splits a handle into tokens rather than treating it as one word", () => {
+    expect(searchQueryShape("alice.bsky.social").tokenCount).toBe(3);
+  });
+
+  it("has no tokens for an empty query", () => {
+    expect(searchQueryShape("   ").tokenCount).toBe(0);
+    expect(searchQueryShape("   ").isMultiToken).toBe(false);
+  });
+});
+
+describe("shouldUseAuthorArm", () => {
+  it("arms for a handle hint however many profiles matched", () => {
+    expect(shouldUseAuthorArm(true, 1)).toBe(true);
+    expect(shouldUseAuthorArm(true, 50)).toBe(true);
+  });
+
+  it("arms for plain text that names a few people", () => {
+    expect(shouldUseAuthorArm(false, 1)).toBe(true);
+    expect(shouldUseAuthorArm(false, NAME_MATCH_AMBIGUITY_CAP)).toBe(true);
+  });
+
+  it("drops an ambiguous plain-text term", () => {
+    // "art" used to pull in every document by every profile containing "art",
+    // eating pool budget that real text matches needed.
+    expect(shouldUseAuthorArm(false, NAME_MATCH_AMBIGUITY_CAP + 1)).toBe(false);
+    expect(shouldUseAuthorArm(false, 50)).toBe(false);
+  });
+
+  it("stays off when nothing matched", () => {
+    expect(shouldUseAuthorArm(true, 0)).toBe(false);
+    expect(shouldUseAuthorArm(false, 0)).toBe(false);
+  });
+});
+
+describe("pool caps", () => {
+  it("bounds paging at the total pool size", () => {
+    expect(SEARCH_POOL_CAP).toBe(900);
+  });
+});
+
+describe("meta vector index drift", () => {
+  /**
+   * The planner only matches an expression index when the query repeats the
+   * expression verbatim. Nothing at runtime complains when it stops matching —
+   * search just quietly degrades to a sequential scan of every document — so
+   * assert the migration still indexes exactly what the query asks for.
+   */
+  it("migration 0044 indexes exactly what documentMetaVectorSql renders", () => {
+    const expression = new PgDialect().sqlToQuery(documentMetaVectorDdl()).sql;
+    const migration = readFileSync(
+      fileURLToPath(
+        new URL(
+          "../../../drizzle/0044_document_meta_search_idx.sql",
+          import.meta.url,
+        ),
+      ),
+      "utf8",
+    );
+
+    expect(normalize(migration)).toContain(normalize(expression));
+  });
+
+  it("keeps the runbook's CONCURRENTLY build in step with the migration", () => {
+    const expression = new PgDialect().sqlToQuery(documentMetaVectorDdl()).sql;
+    const runbook = readFileSync(
+      fileURLToPath(
+        new URL(
+          "../../../scripts/search-relevance-indexes.sql",
+          import.meta.url,
+        ),
+      ),
+      "utf8",
+    );
+
+    expect(normalize(runbook)).toContain(normalize(expression));
+  });
+});

--- a/apps/standard-reader/src/server/reader/document-search.ts
+++ b/apps/standard-reader/src/server/reader/document-search.ts
@@ -1,0 +1,209 @@
+import type { SQL } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+
+import type { Schema } from "#/integrations/tanstack-query/api-shapes";
+
+/**
+ * Relevance ranking for article search.
+ *
+ * Article results used to come back strictly newest-first — the `search_vector`
+ * carried A/B/C weights but nothing ever called `ts_rank` on it, so searching a
+ * title you already knew buried it under every newer document that happened to
+ * mention the same words. Ranking is cheap for a selective query (the bitmap
+ * heap scan already fetches the whole match set), so the fix is to rank; the
+ * pool caps below exist because the *match set* is what gets expensive, not the
+ * ranking.
+ */
+
+/**
+ * How many rows each arm of the candidate pool is willing to fetch.
+ *
+ * A bare `LIMIT` short-circuits the bitmap heap scan, which is the only bound
+ * Postgres offers here — measured at ~0.55 ms/row, so the caps put a ceiling of
+ * roughly 500 ms on a query that would otherwise walk 100k+ rows (`q=ai` took
+ * 16 s). A selective query never reaches a cap and is ranked in full.
+ *
+ * Title matches get their own arm rather than sharing one pool: an unordered
+ * sample of a large *body* match set can contain almost no title hits, which is
+ * exactly where ranking has to be good.
+ */
+export const TITLE_POOL_CAP = 400;
+export const BODY_POOL_CAP = 400;
+export const AUTHOR_POOL_CAP = 100;
+/** Past this offset there is nothing left to page — the pool is exhausted. */
+export const SEARCH_POOL_CAP = TITLE_POOL_CAP + BODY_POOL_CAP + AUTHOR_POOL_CAP;
+
+/**
+ * Whether to rank article results, or fall back to the previous newest-first
+ * ordering.
+ *
+ * The ranked path's title arm is only affordable once
+ * `documents_meta_search_idx` exists — without it the expression match is a
+ * sequential scan of every document. Set `SEARCH_RANKING=legacy` to fall back
+ * without a deploy while the index is being built out of band. Remove this once
+ * the index is in place everywhere.
+ */
+export function isSearchRankingEnabled(): boolean {
+  return process.env.SEARCH_RANKING !== "legacy";
+}
+
+/** More profiles than this matching a plain-text query means it isn't a name. */
+export const NAME_MATCH_AMBIGUITY_CAP = 5;
+
+/**
+ * The title/description/tags half of `documents.search_vector` — the same
+ * lexemes and weights as its first three arms, minus the weight-C body text.
+ *
+ * Ranking this rather than `search_vector` is what makes ranking affordable:
+ * `search_vector` is TOASTed for any real article, so `ts_rank` over it costs a
+ * de-TOAST per row, while title + description + tags stay inline.
+ *
+ * Backed by the expression index in `drizzle/0044_document_meta_search_idx.sql`.
+ * The query has to repeat the expression *verbatim* for the planner to match
+ * it, which is why both the query and the DDL are rendered from this one
+ * function — see the drift guard in `document-search.test.ts`.
+ */
+export function documentMetaVectorSql(
+  title: SQL,
+  description: SQL,
+  tags: SQL,
+): SQL {
+  return sql`setweight(to_tsvector('english', coalesce(${title}, '')), 'A') || setweight(to_tsvector('english', coalesce(${description}, '')), 'B') || setweight(to_tsvector('english', coalesce(immutable_array_to_string(${tags}), '')), 'B')`;
+}
+
+/** The meta vector over a `documents` reference, for use in a query. */
+export function documentMetaVectorFor(cols: {
+  title: SQL;
+  description: SQL;
+  tags: SQL;
+}): SQL {
+  return documentMetaVectorSql(cols.title, cols.description, cols.tags);
+}
+
+/** The meta vector over bare column names — exactly what the migration indexes. */
+export function documentMetaVectorDdl(): SQL {
+  return documentMetaVectorSql(
+    sql.raw("title"),
+    sql.raw("description"),
+    sql.raw("tags"),
+  );
+}
+
+export interface SearchQueryShape {
+  /** The trimmed query. */
+  query: string;
+  /** Whitespace/punctuation-separated token count. */
+  tokenCount: number;
+  /**
+   * Whether phrase scoring applies. For a single token `phraseto_tsquery`
+   * degenerates to `websearch_to_tsquery`, so the phrase tiers would fire on
+   * every match and flatten the ranking instead of sharpening it.
+   */
+  isMultiToken: boolean;
+}
+
+export function searchQueryShape(input: string): SearchQueryShape {
+  const query = input.trim();
+  const tokenCount = query.split(/[\s\p{P}]+/u).filter(Boolean).length;
+  return { isMultiToken: tokenCount > 1, query, tokenCount };
+}
+
+/**
+ * Whether to fold an author's documents into the results.
+ *
+ * A handle-shaped query names one account, so it always arms. Plain text only
+ * arms when it resolves to a handful of profiles: otherwise searching "art"
+ * pulled in every document by every profile whose name contained "art", which
+ * both polluted the results and ate the pool budget that real text matches
+ * needed. Those writers now surface in the People section instead.
+ */
+export function shouldUseAuthorArm(
+  hasHandleHint: boolean,
+  profileMatchCount: number,
+): boolean {
+  if (profileMatchCount === 0) return false;
+  if (hasHandleHint) return true;
+  return profileMatchCount <= NAME_MATCH_AMBIGUITY_CAP;
+}
+
+export interface DocumentScoreInput {
+  /** Columns carried through the candidate pool. */
+  title: SQL;
+  metaVector: SQL;
+  /** `websearch_to_tsquery` — the matcher. */
+  tsq: SQL;
+  /** `phraseto_tsquery`, or null for a single-token query. */
+  phrase: SQL | null;
+  /** Unstemmed `phraseto_tsquery('simple', …)`, or null for a single token. */
+  simplePhrase: SQL | null;
+  /** The trimmed query, for the literal title tests. */
+  exact: string;
+  /** Author DIDs / publication URIs, when the author arm is armed. */
+  authorDids: Array<string>;
+  authorPubUris: Array<string>;
+  did: SQL;
+  publicationUri: SQL;
+}
+
+/**
+ * Match quality as an ordered tier, highest first. Tiers rather than a blended
+ * score because there are no magic constants to balance and the top tier lands
+ * on a span attribute, so a bad result is debuggable.
+ *
+ * 7/6/5/4 all test the query *as a whole*, in order; 3 is "all terms, somewhere
+ * in the title/description/tags"; 0 is a body-only match. Tier 5 uses the
+ * unstemmed `simple` dictionary, so an exact word form ("Making") outranks a
+ * stemmed variant ("makes") — the third thing the bug report asked for.
+ *
+ * Tier-0 rows all score `meta_rank = 0`, so the tail of the list keeps today's
+ * `published_at DESC, uri DESC` order exactly. Only a ranked head is prepended.
+ */
+export function documentTierSql(input: DocumentScoreInput): SQL {
+  const arms: Array<SQL> = [
+    sql`when lower(btrim(${input.title})) = lower(btrim(${input.exact})) then 7`,
+    sql`when position(lower(${input.exact}) in lower(${input.title})) > 0 then 6`,
+  ];
+  if (input.simplePhrase) {
+    arms.push(
+      sql`when to_tsvector('simple', coalesce(${input.title}, '')) @@ ${input.simplePhrase} then 5`,
+    );
+  }
+  if (input.phrase) {
+    arms.push(sql`when ${input.metaVector} @@ ${input.phrase} then 4`);
+  }
+  arms.push(sql`when ${input.metaVector} @@ ${input.tsq} then 3`);
+
+  const authorArms: Array<SQL> = [];
+  if (input.authorDids.length > 0) {
+    authorArms.push(sql`${input.did} = any(${input.authorDids})`);
+  }
+  if (input.authorPubUris.length > 0) {
+    authorArms.push(sql`${input.publicationUri} = any(${input.authorPubUris})`);
+  }
+  if (authorArms.length > 0) {
+    arms.push(sql`when ${sql.join(authorArms, sql` or `)} then 1`);
+  }
+
+  return sql`case ${sql.join(arms, sql` `)} else 0 end`;
+}
+
+/**
+ * Relevance within a tier. Normalization 32 (`rank/(rank+1)`) bounds the value
+ * to [0,1); it's monotonic, so it doesn't reorder text matches — it just keeps
+ * the number comparable across tiers. Weights are `{D, C, B, A}`: title 1.0,
+ * description/tags 0.4, body ~0 (the meta vector has no body arm anyway).
+ */
+export function documentMetaRankSql(metaVector: SQL, tsq: SQL): SQL {
+  return sql`ts_rank('{0.05,0.1,0.4,1.0}'::float4[], ${metaVector}, ${tsq}, 32)`;
+}
+
+/** Column references for the `documents` table, for the helpers above. */
+export function documentSearchCols(d: Schema["documents"]) {
+  return {
+    description: sql`${d.description}`,
+    did: sql`${d.did}`,
+    publicationUri: sql`${d.publicationUri}`,
+    tags: sql`${d.tags}`,
+    title: sql`${d.title}`,
+  };
+}

--- a/apps/standard-reader/src/server/reader/people-search.test.ts
+++ b/apps/standard-reader/src/server/reader/people-search.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import type { PersonCandidate } from "./people-search";
+import { personMatchScore, rankPersonRows } from "./people-search";
+
+function person(
+  did: string,
+  overrides: Partial<PersonCandidate> = {},
+): PersonCandidate {
+  return {
+    avatarUrl: null,
+    did,
+    displayName: null,
+    handle: null,
+    publicationCount: 0,
+    publicationNames: [],
+    subscriberCount: 0,
+    ...overrides,
+  };
+}
+
+describe("personMatchScore", () => {
+  it("ranks an exact handle highest", () => {
+    expect(
+      personMatchScore({ displayName: null, handle: "alice.dev" }, "alice.dev"),
+    ).toBe(4);
+  });
+
+  it("ignores a leading @ and case", () => {
+    expect(
+      personMatchScore(
+        { displayName: null, handle: "alice.dev" },
+        "@Alice.Dev",
+      ),
+    ).toBe(4);
+  });
+
+  it("ranks a handle prefix and an exact display name together", () => {
+    expect(
+      personMatchScore({ displayName: null, handle: "alice.dev" }, "alice"),
+    ).toBe(3);
+    expect(
+      personMatchScore(
+        { displayName: "Alice Ng", handle: "a.dev" },
+        "alice ng",
+      ),
+    ).toBe(3);
+  });
+
+  it("ranks a display-name word prefix above a bare substring", () => {
+    expect(
+      personMatchScore({ displayName: "Alice Ng", handle: "a.dev" }, "ng"),
+    ).toBe(2);
+    // "lic" appears inside "Alice" but starts no word.
+    expect(
+      personMatchScore({ displayName: "Alice Ng", handle: "a.dev" }, "lic"),
+    ).toBe(1);
+  });
+
+  it("scores nothing for an empty query", () => {
+    expect(
+      personMatchScore({ displayName: "Alice", handle: "alice.dev" }, "  "),
+    ).toBe(0);
+  });
+});
+
+describe("rankPersonRows", () => {
+  it("puts match quality ahead of reach", () => {
+    const rows = [
+      person("did:plc:big", {
+        displayName: "Alice Adjacent",
+        handle: "big.dev",
+        subscriberCount: 10_000,
+      }),
+      person("did:plc:exact", { handle: "alice", subscriberCount: 1 }),
+    ];
+    expect(rankPersonRows(rows, "alice").map((row) => row.did)).toEqual([
+      "did:plc:exact",
+      "did:plc:big",
+    ]);
+  });
+
+  it("breaks ties on readership, then publications, then did", () => {
+    const rows = [
+      person("did:plc:c", { handle: "alice.c", publicationCount: 1 }),
+      person("did:plc:a", { handle: "alice.a", publicationCount: 1 }),
+      person("did:plc:b", { handle: "alice.b", subscriberCount: 5 }),
+    ];
+    expect(rankPersonRows(rows, "alice").map((row) => row.did)).toEqual([
+      "did:plc:b",
+      "did:plc:a",
+      "did:plc:c",
+    ]);
+  });
+
+  it("does not mutate its input", () => {
+    const rows = [
+      person("did:plc:z", { handle: "zed" }),
+      person("did:plc:a", { handle: "alice" }),
+    ];
+    rankPersonRows(rows, "alice");
+    expect(rows.map((row) => row.did)).toEqual(["did:plc:z", "did:plc:a"]);
+  });
+});

--- a/apps/standard-reader/src/server/reader/people-search.ts
+++ b/apps/standard-reader/src/server/reader/people-search.ts
@@ -1,0 +1,215 @@
+import { and, eq, ilike, inArray, or, sql } from "drizzle-orm";
+
+import type { Db, Schema } from "#/integrations/tanstack-query/api-shapes";
+import { notBlockedByViewer } from "#/server/blocks/blocks";
+import { notMutedByViewer } from "#/server/mutes/mutes";
+import type { FriendPerson } from "#/server/reader/bsky-friends";
+import { userFollowedDids } from "#/server/reader/bsky-friends";
+import { discoverEligiblePublicationWhere } from "#/server/reader/publication-filters";
+
+/**
+ * People results for `/search` — the writers behind the articles, which search
+ * previously surfaced only indirectly by folding matched author DIDs into the
+ * article predicate (where they were indistinguishable from real text matches).
+ *
+ * Rows reuse {@link FriendPerson} and `FriendPersonRow` verbatim: both surfaces
+ * answer "here is a writer, here is their readership, follow them?", and the
+ * follow CTA targets the *person* in each case.
+ */
+
+/** How many matching profiles we're willing to rank. */
+export const PEOPLE_CANDIDATE_LIMIT = 50;
+/** Trigram indexes need a full 3-char gram; shorter terms can't use the index. */
+export const PEOPLE_MIN_QUERY_LENGTH = 3;
+/** How many people the section shows. There is no "load more". */
+export const PEOPLE_RESULT_LIMIT = 5;
+
+/** Handle/display-name substring match, shared with the loose-doc account lookup. */
+export function profileNameMatchSql(pr: Schema["profiles"], like: string) {
+  return or(ilike(pr.handle, like), ilike(pr.displayName, like));
+}
+
+export interface PersonCandidate {
+  did: string;
+  handle: string | null;
+  displayName: string | null;
+  avatarUrl: string | null;
+  publicationNames: Array<string>;
+  publicationCount: number;
+  subscriberCount: number;
+}
+
+/**
+ * How well a profile answers the query, highest first. Ranked in TypeScript
+ * rather than SQL because the candidate set is capped at
+ * {@link PEOPLE_CANDIDATE_LIMIT} rows — a pure comparator is both cheaper than
+ * a second pass over the database and directly unit-testable.
+ */
+export function personMatchScore(
+  candidate: Pick<PersonCandidate, "displayName" | "handle">,
+  query: string,
+): number {
+  const q = query.trim().toLowerCase().replace(/^@/, "");
+  if (q.length === 0) return 0;
+  const handle = candidate.handle?.trim().toLowerCase() ?? "";
+  const name = candidate.displayName?.trim().toLowerCase() ?? "";
+
+  if (handle.length > 0 && handle === q) return 4;
+  if (
+    (handle.length > 0 && handle.startsWith(q)) ||
+    (name.length > 0 && name === q)
+  ) {
+    return 3;
+  }
+  if (name.split(/\s+/).some((word) => word.length > 0 && word.startsWith(q))) {
+    return 2;
+  }
+  return 1;
+}
+
+/** Rank candidates by match quality, then by reach. Total order, so it's stable. */
+export function rankPersonRows<T extends PersonCandidate>(
+  rows: Array<T>,
+  query: string,
+): Array<T> {
+  return rows.toSorted((a, b) => {
+    const score = personMatchScore(b, query) - personMatchScore(a, query);
+    if (score !== 0) return score;
+    if (b.subscriberCount !== a.subscriberCount) {
+      return b.subscriberCount - a.subscriberCount;
+    }
+    if (b.publicationCount !== a.publicationCount) {
+      return b.publicationCount - a.publicationCount;
+    }
+    return a.did < b.did ? -1 : a.did > b.did ? 1 : 0;
+  });
+}
+
+/**
+ * Profiles matching `q` who actually publish here, ranked, capped at `limit`.
+ *
+ * Three steps: a trigram-indexed candidate sweep, one aggregate pass over those
+ * candidates' publications, then the pure ranking above. The aggregate covers
+ * every candidate rather than just the page so readership can participate in
+ * the ranking instead of only breaking ties within an already-chosen page.
+ */
+export async function searchPeople(
+  db: Db,
+  schema: Schema,
+  {
+    q,
+    readerDid = null,
+    blockDid = null,
+    muteDid = null,
+    limit = PEOPLE_RESULT_LIMIT,
+  }: {
+    q: string;
+    /** The signed-in reader, for follow state. */
+    readerDid?: string | null;
+    /** Reader whose blocks apply, or null when block filtering is off. */
+    blockDid?: string | null;
+    /** Reader whose mutes apply, or null when mute filtering is off. */
+    muteDid?: string | null;
+    limit?: number;
+  },
+): Promise<Array<FriendPerson>> {
+  const term = q.trim();
+  if (term.length < PEOPLE_MIN_QUERY_LENGTH) return [];
+
+  const pr = schema.profiles;
+  const p = schema.publications;
+  const d = schema.documents;
+  const st = schema.publicationStats;
+  const like = `%${term}%`;
+
+  const candidates = await db
+    .select({
+      avatarUrl: pr.avatarUrl,
+      did: pr.did,
+      displayName: pr.displayName,
+      handle: pr.handle,
+    })
+    .from(pr)
+    .where(
+      and(
+        profileNameMatchSql(pr, like),
+        // Only people with something to read here. The documents arm keeps
+        // writers whose work is all loose documents (no publication row).
+        or(
+          sql`exists (select 1 from ${p} where ${p.did} = ${pr.did} and ${p.deleted} = false)`,
+          sql`exists (select 1 from ${d} where ${d.did} = ${pr.did} and ${d.deleted} = false limit 1)`,
+        ),
+        ...(blockDid
+          ? [notBlockedByViewer(schema, blockDid, sql`${pr.did}`)]
+          : []),
+        ...(muteDid
+          ? [
+              notMutedByViewer(schema, muteDid, {
+                authorDidExpr: sql`${pr.did}`,
+              }),
+            ]
+          : []),
+      ),
+    )
+    .limit(PEOPLE_CANDIDATE_LIMIT);
+
+  if (candidates.length === 0) return [];
+  const dids = candidates.map((row) => row.did);
+
+  const pubRows = await db
+    .select({
+      did: p.did,
+      name: p.name,
+      subscriberCount: sql<number>`coalesce(${st.subscriberCount}, 0)::int`,
+    })
+    .from(p)
+    .leftJoin(st, eq(st.publicationUri, p.uri))
+    .where(and(inArray(p.did, dids), discoverEligiblePublicationWhere(p)));
+
+  const byDid = new Map<
+    string,
+    { names: Array<string>; subscriberCount: number }
+  >();
+  for (const row of pubRows) {
+    const entry = byDid.get(row.did) ?? { names: [], subscriberCount: 0 };
+    if (row.name) entry.names.push(row.name);
+    entry.subscriberCount += row.subscriberCount;
+    byDid.set(row.did, entry);
+  }
+
+  const ranked = rankPersonRows(
+    candidates.map((row) => {
+      const agg = byDid.get(row.did);
+      return {
+        ...row,
+        publicationCount: agg?.names.length ?? 0,
+        publicationNames: agg?.names ?? [],
+        subscriberCount: agg?.subscriberCount ?? 0,
+      } satisfies PersonCandidate;
+    }),
+    term,
+  ).slice(0, limit);
+
+  const followed = readerDid
+    ? await userFollowedDids(
+        db,
+        schema,
+        readerDid,
+        ranked.map((row) => row.did),
+      )
+    : new Set<string>();
+
+  return ranked.map(
+    (row) =>
+      ({
+        avatarUrl: row.avatarUrl,
+        did: row.did,
+        displayName: row.displayName,
+        handle: row.handle,
+        isFollowing: followed.has(row.did),
+        publicationCount: row.publicationCount,
+        publicationNames: row.publicationNames,
+        subscriberCount: row.subscriberCount,
+      }) satisfies FriendPerson,
+  );
+}

--- a/apps/standard-reader/src/server/reader/publication-search.ts
+++ b/apps/standard-reader/src/server/reader/publication-search.ts
@@ -1,0 +1,159 @@
+import type { SQL } from "drizzle-orm";
+import { ilike, or, sql } from "drizzle-orm";
+
+import type { Schema } from "#/integrations/tanstack-query/api-shapes";
+
+/**
+ * Shared publication match + rank SQL for the two surfaces that search the
+ * publication directory: `/search`'s Publications section
+ * (`api-search.functions.ts`) and Discover's directory field
+ * (`queries.ts` → `discoverDirectoryPublications`). They used to carry
+ * separately hand-tuned weights (0.2/0.15/0.15 vs 0.12/0.1/0.05) that drifted
+ * apart; the only real difference between them is which optional arms they
+ * match on, so those are options rather than a second copy.
+ */
+
+/** How many rows the exact publication count is willing to walk before it says "N+". */
+export const PUBLICATION_COUNT_CAP = 200;
+
+export interface PublicationSearchTerms {
+  /** `%q%` substring pattern for URL / handle / display-name / topic arms. */
+  like: string;
+  /** `q%` prefix pattern, matched against the publication name. */
+  prefix: string;
+  /** The trimmed query, for the exact-name equality test. */
+  exact: string;
+  /** The matcher. Keeps `websearch_to_tsquery`'s quoted/negated operators. */
+  tsq: SQL;
+  /**
+   * Scoring-only phrase query, or null for a single-token query — where
+   * `phraseto_tsquery` degenerates to `tsq` and the phrase tier would fire on
+   * every text match, flattening the ranking instead of sharpening it.
+   */
+  phrase: SQL | null;
+  /** Narrower URL match for platform URLs (e.g. `greengale.app/melodic.stream`). */
+  urlLike: string | null;
+}
+
+export interface PublicationSearchOptions {
+  /**
+   * Substring pattern to use instead of `%query%`. `/search` passes the
+   * publication query hints' pattern, which narrows a platform URL to its slug.
+   */
+  like?: string;
+  urlLike?: string | null;
+}
+
+/** True when the query has two or more whitespace/punctuation-separated tokens. */
+export function isMultiTokenQuery(query: string): boolean {
+  return (
+    query
+      .trim()
+      .split(/[\s\p{P}]+/u)
+      .filter(Boolean).length > 1
+  );
+}
+
+export function publicationSearchTerms(
+  query: string,
+  { like, urlLike = null }: PublicationSearchOptions = {},
+): PublicationSearchTerms {
+  const exact = query.trim();
+  return {
+    exact,
+    like: like ?? `%${exact}%`,
+    phrase: isMultiTokenQuery(exact)
+      ? sql`phraseto_tsquery('english', ${exact})`
+      : null,
+    prefix: `${exact}%`,
+    tsq: sql`websearch_to_tsquery('english', ${exact})`,
+    urlLike,
+  };
+}
+
+export interface PublicationArmOptions {
+  /** Discover's coalesced topic expression, matched as a substring when given. */
+  effectiveTopicExpr?: SQL | null;
+  /** Whether to match the owner's display name (`/search` does; Discover doesn't). */
+  matchDisplayName?: boolean;
+}
+
+export function publicationSearchMatchSql(
+  p: Schema["publications"],
+  pr: Schema["profiles"],
+  terms: PublicationSearchTerms,
+  {
+    effectiveTopicExpr = null,
+    matchDisplayName = false,
+  }: PublicationArmOptions = {},
+) {
+  const parts = [
+    sql`${p.searchVector} @@ ${terms.tsq}`,
+    ilike(p.url, terms.like),
+    ilike(pr.handle, terms.like),
+  ];
+  if (matchDisplayName) {
+    parts.push(ilike(pr.displayName, terms.like));
+  }
+  if (effectiveTopicExpr) {
+    parts.push(
+      sql`lower(btrim(coalesce(${effectiveTopicExpr}, ''))) like lower(${terms.like})`,
+    );
+  }
+  if (terms.urlLike) {
+    parts.push(ilike(p.url, terms.urlLike));
+  }
+  return or(...parts) ?? sql`false`;
+}
+
+/**
+ * Rank on a single 0–1 scale so the tiers are comparable.
+ *
+ * The bug this fixes: `ts_rank` without a normalization bitmask returns raw
+ * values around 0.05–0.1, so a hardcoded 0.15 handle-substring bonus outranked
+ * *every* real full-text match. Normalization 32 (`rank/(rank+1)`) bounds the
+ * score to [0,1) — it's monotonic, so it changes nothing about the relative
+ * order of text matches — and the `0.30 + 0.50 × rank` remap then lands any
+ * text match in [0.30, 0.80), strictly above the substring bonuses (≤ 0.25) and
+ * strictly below the exact/phrase/prefix tiers.
+ */
+export function publicationSearchRankSql(
+  p: Schema["publications"],
+  pr: Schema["profiles"],
+  terms: PublicationSearchTerms,
+  {
+    effectiveTopicExpr = null,
+    matchDisplayName = false,
+  }: PublicationArmOptions = {},
+) {
+  return sql`greatest(
+    case when lower(btrim(${p.name})) = lower(btrim(${terms.exact})) then 1.0::real else 0::real end,${
+      terms.urlLike
+        ? sql`
+    case when ${p.url} ilike ${terms.urlLike} then 0.95::real else 0::real end,`
+        : sql``
+    }${
+      terms.phrase
+        ? sql`
+    case when ${p.searchVector} @@ ${terms.phrase} then 0.9::real else 0::real end,`
+        : sql``
+    }
+    case when ${p.name} ilike ${terms.prefix} then 0.85::real else 0::real end,
+    case when ${p.searchVector} @@ ${terms.tsq}
+      then 0.3::real + 0.5::real * ts_rank('{0.05,0.1,0.4,1.0}'::float4[], ${p.searchVector}, ${terms.tsq}, 32)
+      else 0::real
+    end,
+    case when ${p.url} ilike ${terms.like} then 0.25::real else 0::real end,
+    case when ${pr.handle} ilike ${terms.like} then 0.2::real else 0::real end${
+      matchDisplayName
+        ? sql`,
+    case when ${pr.displayName} ilike ${terms.like} then 0.15::real else 0::real end`
+        : sql``
+    }${
+      effectiveTopicExpr
+        ? sql`,
+    case when lower(btrim(coalesce(${effectiveTopicExpr}, ''))) like lower(${terms.like}) then 0.1::real else 0::real end`
+        : sql``
+    }
+  )`;
+}

--- a/apps/standard-reader/src/server/reader/queries.explain.test.ts
+++ b/apps/standard-reader/src/server/reader/queries.explain.test.ts
@@ -28,6 +28,12 @@ import { db } from "#/db";
 import * as schema from "#/db/schema";
 import { NETWORK_DOCUMENT_COUNT_KEY } from "#/db/schema/network-stats";
 import {
+  BODY_POOL_CAP,
+  documentMetaRankSql,
+  documentMetaVectorSql,
+  TITLE_POOL_CAP,
+} from "#/server/reader/document-search";
+import {
   buildFollowFeedCandidateSql,
   buildTagOverlapScoresSql,
   countNetworkDocuments,
@@ -268,6 +274,118 @@ async function selectTagAnchorDocument(): Promise<{
     publicationUri: (row["publication_uri"] as string | null) ?? null,
   };
 }
+
+/**
+ * Article search.
+ *
+ * Two regressions to guard, both measured on prod before the ranked path
+ * landed:
+ *  - The title arm must be served by `documents_meta_search_idx`. It matches an
+ *    *expression*, so the planner only uses the index when the query repeats
+ *    that expression verbatim — and when it stops matching, nothing fails, the
+ *    query just degrades to a sequential scan of every document.
+ *  - A broad single word matches ~100k documents. Ordering that whole match set
+ *    took 16s (`q=ai`); the per-arm pool caps are what bound it, so a plan whose
+ *    arms exceed their caps means a LIMIT stopped being an optimization barrier.
+ */
+const SEARCH_TITLE_QUERY =
+  process.env.FEED_PERF_SEARCH_TITLE_QUERY ??
+  "Making Feeds: Custom Logic Requests";
+const SEARCH_BROAD_QUERY = process.env.FEED_PERF_SEARCH_BROAD_QUERY ?? "ai";
+
+/** Selective queries rank their whole match set; 151 rows measured at ~10ms warm. */
+const SEARCH_BUDGET_MS = Number(process.env.FEED_PERF_SEARCH_BUDGET_MS ?? 400);
+
+/**
+ * Looser than {@link SEARCH_BUDGET_MS}: the capped arms still touch ~900 heap
+ * rows on a cold page store. The real guard is that this is nowhere near the
+ * 16s it replaced.
+ */
+const SEARCH_BROAD_BUDGET_MS = Number(
+  process.env.FEED_PERF_SEARCH_BROAD_BUDGET_MS ?? 1500,
+);
+
+const META_VECTOR = documentMetaVectorSql(
+  sql`d.title`,
+  sql`d.description`,
+  sql`d.tags`,
+);
+
+/** The candidate pool + ranking, mirroring `searchArticles`. */
+function buildSearchPoolSql(query: string): SQL {
+  const tsq = sql`websearch_to_tsquery('english', ${query})`;
+  const pooledMeta = documentMetaVectorSql(
+    sql`pool.title`,
+    sql`pool.description`,
+    sql`pool.tags`,
+  );
+  return sql`
+    select pool.uri
+    from (
+      (select d.uri, d.title, d.description, d.tags, d.published_at
+       from documents d
+       where d.deleted = false and (${META_VECTOR}) @@ ${tsq}
+       limit ${sql.raw(String(TITLE_POOL_CAP))})
+      union
+      (select d.uri, d.title, d.description, d.tags, d.published_at
+       from documents d
+       where d.deleted = false and d.search_vector @@ ${tsq}
+       limit ${sql.raw(String(BODY_POOL_CAP))})
+    ) pool
+    order by ${documentMetaRankSql(pooledMeta, tsq)} desc,
+             pool.published_at desc, pool.uri desc
+    limit 21
+  `;
+}
+
+describe.skipIf(!RUN)("article search — EXPLAIN", () => {
+  test("the title arm rides documents_meta_search_idx", async () => {
+    const plan = await explainSql(sql`
+      select d.uri from documents d
+      where d.deleted = false
+        and (${META_VECTOR}) @@ websearch_to_tsquery('english', ${SEARCH_TITLE_QUERY})
+      limit ${sql.raw(String(TITLE_POOL_CAP))}
+    `);
+
+    assertNoSeqScanOnDocuments(plan);
+    if (!plan.includes("documents_meta_search_idx")) {
+      expect.fail(
+        `The title arm is not using documents_meta_search_idx. Either the ` +
+          `index has not been built on this database (see ` +
+          `scripts/search-relevance-indexes.sql) or the query expression has ` +
+          `drifted from the indexed one. Full plan:\n\n${plan}`,
+      );
+    }
+  }, 30_000);
+
+  test("a selective query ranks its whole match set within budget", async () => {
+    const plan = await explainSql(buildSearchPoolSql(SEARCH_TITLE_QUERY));
+
+    assertNoSeqScanOnDocuments(plan);
+    assertExecTimeUnder(plan, SEARCH_BUDGET_MS);
+  }, 30_000);
+
+  test("a broad query stays bounded by the pool caps", async () => {
+    const plan = await explainSql(buildSearchPoolSql(SEARCH_BROAD_QUERY));
+
+    assertNoSeqScanOnDocuments(plan);
+    assertExecTimeUnder(plan, SEARCH_BROAD_BUDGET_MS);
+
+    // Every arm must stop at its cap. `actual rows=N` above the cap means a
+    // LIMIT stopped acting as an optimization barrier and the outer ORDER BY
+    // got pushed down into the arm — the 16s shape.
+    const cap = Math.max(TITLE_POOL_CAP, BODY_POOL_CAP);
+    const overCap = [...plan.matchAll(/rows=(\d+) loops=1/g)]
+      .map((match) => Number(match[1]))
+      .filter((rows) => rows > cap * 1.5);
+    if (overCap.length > 0) {
+      expect.fail(
+        `A pool arm returned ${overCap.join(", ")} rows against a ${cap} cap — ` +
+          `the LIMIT is no longer bounding the scan. Full plan:\n\n${plan}`,
+      );
+    }
+  }, 30_000);
+});
 
 async function explainCandidate({
   unreadForDid,

--- a/apps/standard-reader/src/server/reader/queries.ts
+++ b/apps/standard-reader/src/server/reader/queries.ts
@@ -19,7 +19,6 @@ import {
   desc,
   eq,
   exists,
-  ilike,
   inArray,
   isNotNull,
   isNull,
@@ -66,6 +65,11 @@ import {
   notWebBridgePublicationOwnerWhere,
   notWebBridgePublicationWhere,
 } from "#/server/reader/publication-filters";
+import {
+  publicationSearchMatchSql,
+  publicationSearchRankSql,
+  publicationSearchTerms,
+} from "#/server/reader/publication-search";
 import {
   ROTATION_POOL_MULTIPLIER,
   rotateRail,
@@ -2448,19 +2452,15 @@ export async function discoverDirectoryPublications(
   }
 
   const trimmedQuery = query?.trim() ?? "";
-  const tsq = trimmedQuery
-    ? sql`websearch_to_tsquery('english', ${trimmedQuery})`
+  // Shared with `/search`'s Publications section so the two directory searches
+  // can't drift apart again — see `publication-search.ts`.
+  const searchTerms = trimmedQuery
+    ? publicationSearchTerms(trimmedQuery)
     : null;
-  const likePattern = trimmedQuery ? `%${trimmedQuery}%` : null;
+  const searchArms = { effectiveTopicExpr: effectiveTopic };
 
-  if (trimmedQuery && tsq && likePattern) {
-    const searchMatch = or(
-      sql`${p.searchVector} @@ ${tsq}`,
-      ilike(p.url, likePattern),
-      ilike(pr.handle, likePattern),
-      sql`lower(btrim(coalesce(${effectiveTopic}, ''))) like lower(${likePattern})`,
-    );
-    if (searchMatch) conds.push(searchMatch);
+  if (searchTerms) {
+    conds.push(publicationSearchMatchSql(p, pr, searchTerms, searchArms));
   }
 
   const sortName = publicationSortNameSql(p.name, p.url);
@@ -2476,21 +2476,12 @@ export async function discoverDirectoryPublications(
             asc(p.uri),
           ];
 
-  const orderBy =
-    trimmedQuery && tsq && likePattern
-      ? [
-          desc(sql`greatest(
-            case when ${p.searchVector} @@ ${tsq}
-              then ts_rank(${p.searchVector}, ${tsq})::real
-              else 0::real
-            end,
-            case when ${p.url} ilike ${likePattern} then 0.12::real else 0::real end,
-            case when ${pr.handle} ilike ${likePattern} then 0.1::real else 0::real end,
-            case when lower(btrim(coalesce(${effectiveTopic}, ''))) like lower(${likePattern}) then 0.05::real else 0::real end
-          )`),
-          ...sortTieBreak,
-        ]
-      : sortTieBreak;
+  const orderBy = searchTerms
+    ? [
+        desc(publicationSearchRankSql(p, pr, searchTerms, searchArms)),
+        ...sortTieBreak,
+      ]
+    : sortTieBreak;
 
   const rows = await db
     .select({

--- a/apps/standard-reader/src/server/reader/search-headline.ts
+++ b/apps/standard-reader/src/server/reader/search-headline.ts
@@ -11,6 +11,27 @@ export const TS_SNIPPET_HEADLINE_OPTS =
 
 type SqlInput = Column | ReturnType<typeof sql>;
 
+/** How much of the body the snippet is allowed to search for a highlight. */
+const SNIPPET_BODY_CHARS = 20_000;
+
+/**
+ * Highlight the whole phrase when the source actually contains it, and fall
+ * back to the plain term query otherwise.
+ *
+ * Without this a query like "Making Feeds: Custom Logic Requests" lights up a
+ * stray "logic" and "makes" in an unrelated body, which reads as a match and
+ * isn't one. `phrase` is null for single-token queries, where the two queries
+ * are identical anyway.
+ */
+export function headlineQuerySql(
+  sourceVector: SqlInput,
+  tsq: SqlInput,
+  phrase: SqlInput | null,
+): ReturnType<typeof sql> {
+  if (!phrase) return sql`${tsq}`;
+  return sql`case when ${sourceVector} @@ ${phrase} then ${phrase} else ${tsq} end`;
+}
+
 function tsHeadline(
   source: SqlInput,
   tsq: SqlInput,
@@ -32,18 +53,30 @@ function tsHeadline(
 export function documentSearchTitleHeadline(
   title: SqlInput,
   tsq: SqlInput,
+  phrase: SqlInput | null = null,
 ): ReturnType<typeof sql<string | null>> {
-  return tsHeadline(sql`coalesce(${title}, '')`, tsq, TS_TITLE_HEADLINE_OPTS);
+  const source = sql`coalesce(${title}, '')`;
+  return tsHeadline(
+    source,
+    headlineQuerySql(sql`to_tsvector('english', ${source})`, tsq, phrase),
+    TS_TITLE_HEADLINE_OPTS,
+  );
 }
 
 export function documentSearchSnippetHeadline(
   description: SqlInput,
   textContent: SqlInput,
   tsq: SqlInput,
+  phrase: SqlInput | null = null,
 ): ReturnType<typeof sql<string | null>> {
+  // Test the phrase against the same truncated source the headline reads, not
+  // `search_vector`: the body text is already being fetched to build the
+  // headline, so this costs nothing, while `search_vector` would mean a second
+  // TOAST fetch per row.
+  const source = sql`coalesce(${description}, '') || E'\n\n' || coalesce(substring(${textContent} from 1 for ${sql.raw(String(SNIPPET_BODY_CHARS))}), '')`;
   return tsHeadline(
-    sql`coalesce(${description}, '') || E'\n\n' || coalesce(substring(${textContent} from 1 for 12000), '')`,
-    tsq,
+    source,
+    headlineQuerySql(sql`to_tsvector('english', ${source})`, tsq, phrase),
     TS_SNIPPET_HEADLINE_OPTS,
   );
 }
@@ -51,8 +84,14 @@ export function documentSearchSnippetHeadline(
 export function publicationSearchNameHeadline(
   name: SqlInput,
   tsq: SqlInput,
+  phrase: SqlInput | null = null,
 ): ReturnType<typeof sql<string | null>> {
-  return tsHeadline(sql`coalesce(${name}, '')`, tsq, TS_TITLE_HEADLINE_OPTS);
+  const source = sql`coalesce(${name}, '')`;
+  return tsHeadline(
+    source,
+    headlineQuerySql(sql`to_tsvector('english', ${source})`, tsq, phrase),
+    TS_TITLE_HEADLINE_OPTS,
+  );
 }
 
 export function publicationSearchSnippetHeadline(

--- a/apps/standard-reader/src/server/reader/search-relevance.test.ts
+++ b/apps/standard-reader/src/server/reader/search-relevance.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Gated relevance fixtures for article search.
+ *
+ * NOT run by `pnpm test` or CI — like `queries.explain.test.ts`, this needs a
+ * `DATABASE_URL` pointing at prod-scale data, because "does the right article
+ * come first" is only a meaningful question against the real corpus. Opt in
+ * with `FEED_PERF_TEST=1` (`pnpm perf:explain` runs both specs).
+ *
+ * These are the cases the ranking exists for. The first one is the bug report
+ * that prompted it: searching a title you already know used to bury it under
+ * every newer document that happened to contain the same five stems, because
+ * results were ordered `published_at DESC` and never ranked at all.
+ *
+ * Assertions are "in the top 3", not "first". The corpus grows every day and a
+ * near-duplicate crosspost legitimately outranking the original should not turn
+ * this suite red.
+ */
+import type { SQL } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import { describe, expect, test } from "vitest";
+
+import { db } from "#/db";
+import {
+  BODY_POOL_CAP,
+  documentMetaRankSql,
+  documentMetaVectorSql,
+  documentTierSql,
+  searchQueryShape,
+  TITLE_POOL_CAP,
+} from "#/server/reader/document-search";
+
+const RUN = process.env.FEED_PERF_TEST === "1";
+const TOP_N = 3;
+
+interface RelevanceCase {
+  /** What the reader typed. */
+  q: string;
+  /** The document that must come back near the top. */
+  uri: string;
+  why: string;
+}
+
+const RELEVANCE_CASES: Array<RelevanceCase> = [
+  {
+    q: "Making Feeds: Custom Logic Requests",
+    uri: "at://did:plc:6i6n57nrkq6xavqbdo6bvkqr/site.standard.document/3mh2emfart22s",
+    why: "the reported bug — an exact title, published 2026-03-14, behind 150 newer body matches",
+  },
+  {
+    q: "custom logic requests",
+    uri: "at://did:plc:6i6n57nrkq6xavqbdo6bvkqr/site.standard.document/3mh2emfart22s",
+    why: "a partial title still has to find it",
+  },
+];
+
+/** The ranked page, mirroring `searchArticles`' pool + tier ordering. */
+function rankedSearchSql(query: string): SQL {
+  const shape = searchQueryShape(query);
+  const tsq = sql`websearch_to_tsquery('english', ${query})`;
+  const phrase = shape.isMultiToken
+    ? sql`phraseto_tsquery('english', ${query})`
+    : null;
+  const simplePhrase = shape.isMultiToken
+    ? sql`phraseto_tsquery('simple', ${query})`
+    : null;
+  const meta = documentMetaVectorSql(
+    sql`d.title`,
+    sql`d.description`,
+    sql`d.tags`,
+  );
+  const pooledMeta = documentMetaVectorSql(
+    sql`pool.title`,
+    sql`pool.description`,
+    sql`pool.tags`,
+  );
+  const tier = documentTierSql({
+    authorDids: [],
+    authorPubUris: [],
+    did: sql`pool.did`,
+    exact: shape.query,
+    metaVector: pooledMeta,
+    phrase,
+    publicationUri: sql`pool.publication_uri`,
+    simplePhrase,
+    title: sql`pool.title`,
+    tsq,
+  });
+
+  return sql`
+    select pool.uri, pool.title
+    from (
+      (select d.uri, d.title, d.description, d.tags, d.did, d.publication_uri, d.published_at
+       from documents d
+       where d.deleted = false and (${meta}) @@ ${tsq}
+       limit ${sql.raw(String(TITLE_POOL_CAP))})
+      union
+      (select d.uri, d.title, d.description, d.tags, d.did, d.publication_uri, d.published_at
+       from documents d
+       where d.deleted = false and d.search_vector @@ ${tsq}
+       limit ${sql.raw(String(BODY_POOL_CAP))})
+    ) pool
+    order by (${tier}) desc,
+             ${documentMetaRankSql(pooledMeta, tsq)} desc,
+             pool.published_at desc, pool.uri desc
+    limit ${sql.raw(String(TOP_N))}
+  `;
+}
+
+async function topResults(
+  query: string,
+): Promise<Array<{ uri: string; title: string }>> {
+  const result = await db.execute(rankedSearchSql(query));
+  const rows = Array.isArray(result)
+    ? result
+    : ((result as { rows?: Array<unknown> }).rows ?? []);
+  return rows as Array<{ uri: string; title: string }>;
+}
+
+describe.skipIf(!RUN)("article search — relevance", () => {
+  test.each(RELEVANCE_CASES)(
+    "$q finds its article ($why)",
+    async ({ q, uri }) => {
+      const rows = await topResults(q);
+      const uris = rows.map((row) => row.uri);
+
+      if (!uris.includes(uri)) {
+        expect.fail(
+          `Expected ${uri} in the top ${TOP_N} for "${q}", got:\n` +
+            rows
+              .map((row, i) => `  ${i + 1}. ${row.title} — ${row.uri}`)
+              .join("\n"),
+        );
+      }
+    },
+    30_000,
+  );
+
+  test("a broad query still returns a full page", async () => {
+    // No expected top result — "ai" has no single right answer. This only
+    // guards that the pool caps didn't starve the page.
+    const rows = await topResults("ai");
+    expect(rows.length).toBe(TOP_N);
+  }, 30_000);
+});


### PR DESCRIPTION
Fixes the search quality [bug report](https://userinput.app/d/did:plc:fip3nyk6tjo3senpq4ei2cxw/3mtky44lqwi2h) ("Search needs improvement"):

> The general search is hard to find what I actually desire. For example, if I search by an article title I know "Making Feeds: Custom Logic Requests", the search results are terrible, because it's searching for each individual word and their variations, and ranking first any body text matches.
> - The search should consider the article and publication titles as more relevant match.
> - The search should also rank better complete matches for the whole string being searched, not pieces of it.
> - The search shouldn't rank too high variables of the words I'm searching for (…I see multiple high ranking results just because they have "makes" inside their body text).

## The cause

**Article search never ranked.** `api-search.functions.ts` ordered by `published_at DESC, uri DESC` and nothing ever called `ts_rank`, even though `documents.search_vector` carries A/B/C weights. The reporter's screenshots descend 15 Aug, 9 Aug, 8 Aug, 7 Aug, 5 Aug, 29 Jul, 26 Jul, 23 Jul — strictly newest-first.

Their article matched fine. `websearch_to_tsquery` ANDs the stems, so all 151 results contain all five of `make & feed & custom & logic & request`; theirs is the **only phrase match**, published 2026-03-14, so five months of newer body matches sat on top of it.

## The second problem, found while measuring

**Recency ordering never avoided the expensive work.** It still bitmap-scans and heap-fetches the entire match set before the top-N sort. Measured on prod:

| Query | Matches | Before |
| --- | --- | --- |
| `ai` | 102,808 | **16,096 ms** |
| `design` | 81,966 | — |
| the reported title | 151 | 144 ms |

`statement_timeout` is `0` on that compute, so nothing capped it.

## Why ranking is affordable

Ranking is not the cost. The GIN bitmap index scan is cheap even for 108k rows (33–190 ms); *all* the cost is heap fetch + de-TOAST, linear in rows touched. For a selective query the heap fetch is already paid, so ranking those 151 rows costs **9.9 ms**. The unbounded match set is the problem, so this PR bounds that instead.

## What changed

**Relevance ranking** (`server/reader/document-search.ts`) — an ordered tier ladder, mapping 1:1 onto the three asks:

| Tier | Test | Ask |
| --- | --- | --- |
| 7 | title *is* the query | titles matter more |
| 6 | verbatim substring of the title | whole string > pieces |
| 5 | unstemmed phrase (`simple` config) — "Making" beats "makes" | not stem variants |
| 4 | stemmed phrase, in order | whole string > pieces |
| 3 | all terms in title/description/tags | titles matter more |
| 1 | author arm | |
| 0 | body-only | |

Tier-0 rows all score `meta_rank = 0`, so **the tail keeps the previous `published_at DESC, uri DESC` order byte-for-byte** — only a ranked head is prepended.

It ranks a **title/description/tags vector**, not `search_vector`: the latter folds in body text and is TOASTed for any real article, so ranking it costs a de-TOAST per row (~190k extra buffer reads for one broad query).

**Bounding** — per-arm `LIMIT` caps on a title/body/author union pool. A bare `LIMIT` short-circuits the bitmap heap scan, which is the only bound Postgres offers here. Title matches get their own guaranteed arm because an unordered sample of a large *body* match set can contain almost no title hits — exactly where ranking has to be good.

**People section** — a name-shaped query now surfaces the writer. Previously any plain-text query ≥3 chars ILIKE'd handles/display names and OR'd up to 50 authors' documents into the article results, where they were indistinguishable from real text matches ("art" pulled in every author whose name contained "art"). Reuses `FriendPersonRow` as-is.

**Shared publication ranking** — `/search` and Discover's directory had separately drifted weights (0.2/0.15/0.15 vs 0.12/0.1/0.05), and both used an **un-normalized `ts_rank`** (~0.05–0.1) that lost to a hardcoded 0.15 handle-substring bonus. Normalization 32 fixes the inversion. Also adds a tie-break: rank alone is not a total order, so publication OFFSET paging duplicated and dropped rows — a live bug.

**Phrase-aware headlines** — highlight the whole phrase when the source contains it, and fall back to the description when a snippet comes back unmarked. This is precisely what the report saw: a stray "logic" and "makes" lit up in unrelated bodies.

## Results (measured on prod)

- The reported query returns the right article **first, at tier 7**.
- A partial query ("custom logic requests") also returns it first.
- `q=ai`: **16,096 ms → 492 ms**, with the heap scan stopping at exactly 400 rows — confirming the `LIMIT` acts as the optimization barrier the design depends on.

## ⚠️ Merge order matters

The ranked path needs `documents_meta_search_idx` (migration `0044`). It's an **expression index**, not a generated column — `ALTER TABLE … GENERATED ALWAYS AS … STORED` would rewrite a 14 GB table under `ACCESS EXCLUSIVE` inside Railway's `preDeployCommand` with traffic waiting.

1. Build it out of band first: `psql "$DATABASE_URL" -f apps/standard-reader/scripts/search-relevance-indexes.sql` (CONCURRENTLY, ~20–60 min).
2. Then merge. The migration is `CREATE INDEX IF NOT EXISTS`, so it no-ops on prod in milliseconds while still building on fresh/local/CI databases — the same pattern as `documents_tags_norm_idx` (0014) and the trigram indexes (0003).

Until the index exists on prod, set **`SEARCH_RANKING=legacy`** — without it the title arm is a sequential scan of 3.4M rows on every keystroke. Delete the flag and the legacy arm one release later (tracked in TODO.md).

## The honest trade

For a **broad single word**, results are now a ranked sample of ~800 rather than the complete newest-first set, and paging ends at the pool boundary. Selective queries — anything multi-word, plus most single words (`typography` = 794 matches) — never reach a cap and are ranked in full. The alternative was 16 seconds of an order the reporter called useless.

## Ruled out by measurement — please don't retry these

- **Narrowing with `published_at > now() - interval '30 days'` is *worse*: 36,477 ms.** The GIN bitmap goes lossy (`work_mem` is 4 MB), which poisons the `BitmapAnd` and forces a recheck over 89,555 extra rows. (Also ~546k documents are published every 30 days, so the window barely narrows anything.)
- **`work_mem` 4 MB → 256 MB** makes the bitmap exact and gets 16.1 s → 9.2 s. Worth doing as a follow-up, but not a substitute for bounding.

## Testing

- 19 new unit tests (`pnpm test`), including an **index-drift guard** that renders the meta-vector expression and asserts both migration 0044 and the runbook still contain it verbatim. The planner silently stops using an expression index when the query drifts by a character — nothing errors, search just degrades to a seq scan — so this is the highest-value cheap test here.
- Gated EXPLAIN cases in `queries.explain.test.ts` (`pnpm perf:explain`): the title arm must ride `documents_meta_search_idx`, and each pool arm must stop at its cap.
- Gated relevance fixtures in `search-relevance.test.ts` encoding the bug report as `(query, expected URI)`, asserting top-3 so the suite doesn't flake as the corpus grows.
- New perf targets `search.title` and `search.broad`.
- Full suite: typecheck, `oxlint` (0 errors repo-wide), `oxfmt`, `drizzle-kit check`, 1169 passing tests.

**Pre-existing failures, untouched by this PR:** 4 tests in `handlers.test.ts` and 3 tsc errors — `src/server/ingest/handlers.ts` at `main` calls `resolveIdentity` and `listRepoRecords` without importing them.

`APP_VISION.md`, `TODO.md`, and the user-facing guide copy are updated in the same change, per the living-docs rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ESYvedmwXY48bnVb447aW
