### PR TITLE
Stop the weekly thread from rewriting posts people already replied to

### DIFF
--- a/apps/standard-reader/TODO.md
+++ b/apps/standard-reader/TODO.md
@@ -31,10 +31,16 @@ Check items off as they land.
     `RECONCILE_INTERVAL_HOURS`). Config file `railway.reconcile.json`.
   - `thread-cron` — `pnpm thread:post` on `0 16 * * 5`, the weekly "hottest articles" Bluesky
     thread. Config file `railway.thread.json`. **A cron service's start command also runs on every
-    redeploy and restart**, which is how this job posted the same thread several times a week; it
-    is now idempotent at both layers — an ISO-week claim in `weekly_thread_runs` before it
-    composes, and `putRecord` at week-derived rkeys so a run that gets past the claim overwrites
-    that week's thread instead of publishing another. `THREAD_FORCE=1` re-posts deliberately.
+    redeploy and restart**, which is how this job posted the same thread several times a week. It
+    is guarded twice, both times _before_ it writes: an ISO-week claim in `weekly_thread_runs`, and
+    a read of the bot's own repo for a root already carrying this week's marker
+    (`findWeekThreadRoot`) for when the ledger cannot be trusted. `THREAD_FORCE=1` posts a second
+    thread deliberately. The posts themselves are `createRecord` at fresh TIDs and are **never**
+    rewritten — an earlier fix wrote them at week-derived rkeys with `putRecord` so a re-run would
+    "upsert" the thread, which silently mutated posts the network had already replied to and liked:
+    their strongRefs pin a `cid`, so every overwrite orphaned them, and AppViews that had indexed an
+    earlier version disagreed with the PDS about what the post said. A published post is immutable;
+    a duplicate is prevented before the write or not at all.
   - **Runbook gotcha:** Railway auto-detects only the root `railway.json`, so every non-web service
     in this monorepo needs its **Config File Path** set explicitly (Dashboard → service → Settings →
     Config-as-code, or `serviceInstanceUpdate{ railwayConfigFile }` via the GraphQL API) to

--- a/apps/standard-reader/scripts/post-weekly-thread.ts
+++ b/apps/standard-reader/scripts/post-weekly-thread.ts
@@ -13,8 +13,8 @@
  * Posts at most once per ISO week: the run claims the week in
  * `weekly_thread_runs` before composing, so a redeploy, a restart, a retry, or a
  * hand-run of this script on a week that already went out exits without posting
- * — and the posts go to week-derived rkeys via `putRecord`, so even a run that
- * bypasses the claim rewrites that week's thread instead of adding another.
+ * — and a run that bypasses the claim still checks the bot's repo for this
+ * week's thread root before it composes anything.
  *
  * Local: `pnpm thread:post:dev` (loads .env). Add `THREAD_DRY_RUN=1` to compose
  * + log the thread without writing any records or claiming the week; add

--- a/apps/standard-reader/src/db/schema/announce.ts
+++ b/apps/standard-reader/src/db/schema/announce.ts
@@ -5,9 +5,10 @@ import { integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
  * dedupe ledger that makes the Friday cron post exactly once per week.
  *
  * The job creates `app.bsky.feed.post` records at fresh TIDs, so re-running it
- * always writes a brand-new thread rather than overwriting the old one. Nothing
- * about the posting path is idempotent, and plenty of things fire it more than
- * once per week: a redeploy or manual restart of the `thread-cron` service runs
+ * always writes a brand-new thread rather than overwriting the old one — which
+ * it must, since rewriting a published post breaks every reply and like pinning
+ * its `cid`. Nothing about the posting path is idempotent, and plenty of things
+ * fire it more than once per week: a redeploy or manual restart of the `thread-cron` service runs
  * the start command immediately, an operator can run `pnpm thread:post` by
  * hand, and a Railway retry would tick it again. The guard therefore lives
  * here, ahead of the write.

--- a/apps/standard-reader/src/server/announce/config.ts
+++ b/apps/standard-reader/src/server/announce/config.ts
@@ -16,6 +16,13 @@ export const BSKY_POST_MAX_GRAPHEMES = 300;
 /** Collection NSID for a Bluesky post record. */
 export const BSKY_FEED_POST = "app.bsky.feed.post";
 
+/**
+ * Stable phrase every thread root carries. The article count in front of it
+ * varies, so this is the substring — not the whole line — that the repo-side
+ * duplicate guard (`findWeekThreadRoot`) matches a root post on.
+ */
+export const THREAD_ROOT_MARKER = "hottest reads on Standard Reader this week";
+
 /** External-embed thumbnails must fit the PDS blob ceiling (~1 MB). */
 export const MAX_THUMB_BYTES = 976_560;
 

--- a/apps/standard-reader/src/server/announce/ledger.ts
+++ b/apps/standard-reader/src/server/announce/ledger.ts
@@ -1,8 +1,10 @@
 /**
  * Once-per-week guard for the "hottest articles" Bluesky thread.
  *
- * The posting path is not idempotent — every run writes fresh `app.bsky.feed.post`
- * records at new TIDs — so the job has to decide *before* it posts whether this
+ * The posting path is not idempotent and cannot be made so: every run writes
+ * fresh `app.bsky.feed.post` records at new TIDs, and a published post must
+ * never be rewritten to collapse a duplicate (that orphans the replies and likes
+ * pinning its `cid`). So the job has to decide *before* it posts whether this
  * week is already spoken for. That decision is a row in `weekly_thread_runs`
  * keyed by ISO week: claiming the week is the same statement that records it, so
  * two processes racing on the same tick can never both post.
@@ -12,9 +14,9 @@
  * that died mid-flight, and a settle step afterwards.
  *
  * This is the first of two guards: it stops a duplicate run from doing the work.
- * The second lives in the write itself — posts go to week-derived rkeys via
- * `putRecord` (see `./week.ts`), so a run that gets past this one still can't
- * publish a second thread.
+ * The second is a read of the bot's own repo just before composing
+ * (`findWeekThreadRoot` in `./thread.ts`), which catches the cases this row
+ * cannot know about — a wiped table, a different database, a hand-run.
  */
 import { sql } from "drizzle-orm";
 

--- a/apps/standard-reader/src/server/announce/run.test.ts
+++ b/apps/standard-reader/src/server/announce/run.test.ts
@@ -4,7 +4,6 @@ import type * as LedgerModule from "./ledger.ts";
 import type { ClaimResult } from "./ledger.ts";
 import type * as ThreadModule from "./thread.ts";
 import type { PostThreadOptions, StrongRef } from "./thread.ts";
-import { threadRkeys, weekAnchor } from "./week.ts";
 
 vi.mock("../../db/index.ts", () => ({ db: {} }));
 vi.mock("../../db/schema.ts", () => ({}));
@@ -28,9 +27,18 @@ vi.mock("./client.ts", () => ({
 }));
 
 const postThread = vi.fn();
+const findWeekThreadRoot = vi.fn(
+  async (
+    _client: unknown,
+    _repo: string,
+    _periodKey: string,
+  ): Promise<string | null> => null,
+);
 vi.mock("./thread.ts", async (importOriginal) => ({
   ...(await importOriginal<typeof ThreadModule>()),
   fetchThumbBlob: async () => null,
+  findWeekThreadRoot: (client: unknown, repo: string, periodKey: string) =>
+    findWeekThreadRoot(client, repo, periodKey),
   postThread: (
     client: unknown,
     repo: string,
@@ -109,6 +117,7 @@ beforeEach(() => {
   delete process.env.THREAD_FORCE;
   weekInReviewArticles.mockResolvedValue([card(1), card(2)]);
   claimWeek.mockResolvedValue(granted);
+  findWeekThreadRoot.mockResolvedValue(null);
   postThread.mockImplementation(
     async (
       _client: unknown,
@@ -138,24 +147,64 @@ describe("runWeeklyThread once-a-week guard", () => {
     expect(summary.skipped).toBeUndefined();
   });
 
-  it("writes to the week's rkeys, not fresh ones", async () => {
+  it("never hands postThread record keys to write over", async () => {
     await runWeeklyThread();
 
     const options = postThread.mock.calls[0][3] as PostThreadOptions;
-    expect(options.rkeys).toEqual(threadRkeys("2026-W33", 3));
-    expect(options.createdAt).toBe(weekAnchor("2026-W33").toISOString());
+    expect(options).not.toHaveProperty("rkeys");
   });
 
-  it("would rewrite the same records if it ever ran twice", async () => {
-    await runWeeklyThread();
-    vi.setSystemTime(new Date("2026-08-16T09:30:00.000Z")); // Sunday re-run
+  it("stamps the real posting time, not a backdated week anchor", async () => {
+    vi.setSystemTime(new Date("2026-08-16T09:30:00.000Z")); // Sunday catch-up
+
     await runWeeklyThread();
 
-    const [first, second] = postThread.mock.calls.map(
-      (call) => call[3] as PostThreadOptions,
+    const options = postThread.mock.calls[0][3] as PostThreadOptions;
+    expect(options.createdAt).toBe("2026-08-16T09:30:00.000Z");
+  });
+
+  it("checks the repo for this week's thread before composing anything", async () => {
+    await runWeeklyThread();
+
+    expect(findWeekThreadRoot).toHaveBeenCalledWith(
+      expect.anything(),
+      "did:plc:bot",
+      "2026-W33",
     );
-    expect(second.rkeys).toEqual(first.rkeys);
-    expect(second.createdAt).toBe(first.createdAt);
+    expect(findWeekThreadRoot.mock.invocationCallOrder[0]).toBeLessThan(
+      postThread.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("stands down and repairs the ledger when the repo already has the thread", async () => {
+    // The claim was granted — a wiped row, a different DB, a hand-run — but the
+    // thread is demonstrably already out. Posting a second one is unfixable, so
+    // the repo wins over the ledger.
+    findWeekThreadRoot.mockResolvedValue(
+      "at://did:plc:bot/app.bsky.feed.post/existing",
+    );
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const summary = await runWeeklyThread();
+
+    expect(postThread).not.toHaveBeenCalled();
+    expect(markRootPosted).toHaveBeenCalledWith(
+      "2026-W33",
+      "at://did:plc:bot/app.bsky.feed.post/existing",
+    );
+    expect(summary.skipped).toBe("already-posted");
+    expect(summary.rootUri).toBe(
+      "at://did:plc:bot/app.bsky.feed.post/existing",
+    );
+  });
+
+  it("does not post when it cannot tell whether the thread already exists", async () => {
+    findWeekThreadRoot.mockRejectedValue(new Error("PDS down"));
+
+    await expect(runWeeklyThread()).rejects.toThrow("PDS down");
+
+    expect(postThread).not.toHaveBeenCalled();
+    expect(releaseWeek).toHaveBeenCalledWith("2026-W33", "failed", "PDS down");
   });
 
   it("posts nothing when this week's thread already went out", async () => {
@@ -265,12 +314,19 @@ describe("runWeeklyThread once-a-week guard", () => {
     expect(summary.periodKey).toBeNull();
   });
 
-  it("overrides the guard when THREAD_FORCE is set", async () => {
+  it("overrides both guards when THREAD_FORCE is set", async () => {
     process.env.THREAD_FORCE = "1";
+    findWeekThreadRoot.mockResolvedValue(
+      "at://did:plc:bot/app.bsky.feed.post/existing",
+    );
+    vi.spyOn(console, "warn").mockImplementation(() => {});
 
     await runWeeklyThread();
 
     expect(claimWeek).toHaveBeenCalledWith("2026-W33", { force: true });
+    // A forced run posts a genuinely new second thread — it does not reach for
+    // the first one's records to rewrite them.
+    expect(findWeekThreadRoot).not.toHaveBeenCalled();
     expect(postThread).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/standard-reader/src/server/announce/run.ts
+++ b/apps/standard-reader/src/server/announce/run.ts
@@ -18,13 +18,21 @@ import {
  *
  *  1. the run claims the week in `weekly_thread_runs` before composing anything
  *     (`./ledger.ts`), and stands down if the week is already spoken for;
- *  2. the posts themselves are `putRecord`ed at rkeys derived from the week
- *     (`./week.ts`), so a run that gets past the claim regardless overwrites the
- *     week's thread rather than publishing a second one.
+ *  2. immediately before composing, it asks the bot's own repo whether a thread
+ *     root for this week is already there (`findWeekThreadRoot`) and stands
+ *     down if so — the backstop for when the claim cannot be trusted (a wiped
+ *     row, a different database, a hand-run against prod).
+ *
+ * What it deliberately does NOT do is write the posts at week-derived rkeys with
+ * `putRecord`. That made a re-run silently rewrite posts the network had already
+ * replied to, liked and indexed; the orphaned strongRefs and the resulting
+ * AppView disagreements were much worse than the duplicate thread they avoided.
+ * Posts are created at fresh TIDs and never touched again.
  *
  * Set `THREAD_DRY_RUN=1` to compose + log the thread without writing any records
  * (and without claiming the week). `THREAD_FORCE=1` posts anyway when this
- * week's thread already went out.
+ * week's thread already went out — which now means a genuinely second thread,
+ * not a rewrite of the first.
  */
 import type { ArticleCard } from "#/integrations/tanstack-query/api-shapes";
 import { getPublicUrl } from "#/lib/public-url";
@@ -41,6 +49,7 @@ import {
   HOT_WINDOW_DAYS,
   isDryRun,
   isForcedRun,
+  THREAD_ROOT_MARKER,
 } from "./config.ts";
 import {
   claimWeek,
@@ -50,12 +59,13 @@ import {
 } from "./ledger.ts";
 import {
   fetchThumbBlob,
+  findWeekThreadRoot,
   linkFacets,
   mentionFacet,
   postThread,
 } from "./thread.ts";
 import type { Facet, PostSpec } from "./thread.ts";
-import { isoWeekKey, threadRkeys, weekAnchor } from "./week.ts";
+import { isoWeekKey } from "./week.ts";
 
 export interface WeeklyThreadSummary {
   /** Hottest articles selected for the thread. */
@@ -114,9 +124,7 @@ function articleSpec(
   // Reserve budget for the numbering/intro prefix and the byline suffix so the
   // author @mention at the end is never truncated away by the 300-char cap.
   const prefix =
-    index === 0
-      ? `🔥 The ${total} hottest reads on Standard Reader this week\n\n${n}. `
-      : `${n}. `;
+    index === 0 ? `🔥 The ${total} ${THREAD_ROOT_MARKER}\n\n${n}. ` : `${n}. `;
   const suffix = by ? ` — ${by.text}` : "";
   const titleBudget =
     BSKY_POST_MAX_GRAPHEMES - graphemeCount(prefix) - graphemeCount(suffix);
@@ -291,6 +299,27 @@ async function postWeeklyThread(
   const { client, repo, handle } = await loginAsReaderBot();
   console.info(`[thread] posting as @${handle} (${repo})`);
 
+  // Second guard, and the only one that survives the ledger being wrong: the
+  // repo itself. Posts are immutable once out, so there is no way to take back
+  // a duplicate — check before writing rather than overwriting after.
+  if (!isForcedRun()) {
+    const existingRoot = await findWeekThreadRoot(client, repo, periodKey);
+    if (existingRoot) {
+      console.warn(
+        `[thread] ${periodKey} is already in the repo (root=${existingRoot}) but the ledger did not know — standing down and repairing the ledger`,
+      );
+      await markRootPosted(periodKey, existingRoot);
+      return {
+        articles: 0,
+        dryRun: false,
+        periodKey,
+        posted: 0,
+        rootUri: existingRoot,
+        skipped: "already-posted",
+      };
+    }
+  }
+
   const specs: Array<PostSpec> = [];
   for (let i = 0; i < cards.length; i++) {
     const thumb = await fetchThumbBlob(client, cards[i].coverImageUrl);
@@ -298,16 +327,17 @@ async function postWeeklyThread(
   }
   specs.push(ctaSpec(baseUrl));
 
-  // Week-derived rkeys + `putRecord`: if a second run ever gets this far, it
-  // rewrites these same records rather than publishing a second thread.
+  // Fresh TIDs, `createRecord`: these posts are new records that will never be
+  // written over. Both duplicate guards are behind us by this point.
   const refs = await postThread(client, repo, specs, {
-    createdAt: weekAnchor(periodKey).toISOString(),
+    // The real posting instant. A catch-up run says when it actually posted
+    // rather than backdating itself to the week's nominal Friday slot.
+    createdAt: new Date().toISOString(),
     // Stamp the ledger the moment the root post lands — after that the thread
     // is public and no later run may post another, however this process ends.
     onRoot: async (root) => {
       await markRootPosted(periodKey, root.uri);
     },
-    rkeys: threadRkeys(periodKey, specs.length),
   });
   const rootUri = refs[0]?.uri ?? null;
   // Bookkeeping only — the week was already marked `posted` with the root URI

--- a/apps/standard-reader/src/server/announce/thread.test.ts
+++ b/apps/standard-reader/src/server/announce/thread.test.ts
@@ -1,29 +1,29 @@
 import type { Client } from "@atcute/client";
 import { describe, expect, it, vi } from "vitest";
 
-import { buildPostRecord, postThread } from "./thread.ts";
-import { threadRkeys, weekAnchor } from "./week.ts";
+import { buildPostRecord, findWeekThreadRoot, postThread } from "./thread.ts";
 
 const REPO = "did:plc:bot";
-const CREATED_AT = weekAnchor("2026-W33").toISOString();
+const CREATED_AT = "2026-08-14T16:00:00.000Z";
 
-/** A client that records every `putRecord` call and hands back a strongRef. */
+/** A client that records every `createRecord` call and hands back a strongRef. */
 function recordingClient() {
   const calls: Array<{
     collection: string;
     record: Record<string, unknown>;
     repo: string;
-    rkey: string;
   }> = [];
   const client = {
     post: vi.fn(
       async (_nsid: string, init: { input: Record<string, never> }) => {
         const input = init.input as unknown as (typeof calls)[number];
         calls.push(input);
+        // The PDS assigns the rkey; stand in a fresh one per call.
+        const rkey = `tid${calls.length}`;
         return {
           data: {
-            cid: `cid-${input.rkey}`,
-            uri: `at://${input.repo}/${input.collection}/${input.rkey}`,
+            cid: `cid-${rkey}`,
+            uri: `at://${input.repo}/${input.collection}/${rkey}`,
           },
           ok: true as const,
         };
@@ -36,65 +36,78 @@ function recordingClient() {
 const specs = [{ text: "one" }, { text: "two" }, { text: "three" }];
 
 describe("postThread", () => {
-  it("upserts each post at the rkey it was given", async () => {
+  it("creates a record per spec and returns their refs in order", async () => {
     const { calls, client } = recordingClient();
-    const rkeys = threadRkeys("2026-W33", 3);
 
     const refs = await postThread(client, REPO, specs, {
       createdAt: CREATED_AT,
-      rkeys,
     });
 
-    expect(calls.map((call) => call.rkey)).toEqual(rkeys);
-    expect(refs.map((ref) => ref.uri)).toEqual(
-      rkeys.map((rkey) => `at://${REPO}/app.bsky.feed.post/${rkey}`),
-    );
+    expect(calls.map((call) => call.record.text)).toEqual([
+      "one",
+      "two",
+      "three",
+    ]);
+    expect(refs.map((ref) => ref.uri)).toEqual([
+      `at://${REPO}/app.bsky.feed.post/tid1`,
+      `at://${REPO}/app.bsky.feed.post/tid2`,
+      `at://${REPO}/app.bsky.feed.post/tid3`,
+    ]);
   });
 
-  it("writes with putRecord so a re-run overwrites rather than duplicates", async () => {
-    const { client } = recordingClient();
+  // The whole point of the fix: a published post is immutable, so the job may
+  // only ever add records. `putRecord` at a computed rkey is what silently
+  // rewrote posts people had already replied to.
+  it("never writes with putRecord, and never names an rkey", async () => {
+    const { calls, client } = recordingClient();
 
-    await postThread(client, REPO, specs, {
-      createdAt: CREATED_AT,
-      rkeys: threadRkeys("2026-W33", 3),
-    });
+    await postThread(client, REPO, specs, { createdAt: CREATED_AT });
 
     for (const [nsid] of (client.post as ReturnType<typeof vi.fn>).mock.calls) {
-      expect(nsid).toBe("com.atproto.repo.putRecord");
+      expect(nsid).toBe("com.atproto.repo.createRecord");
+    }
+    for (const call of calls) {
+      expect(call).not.toHaveProperty("rkey");
     }
   });
 
-  it("produces identical records on a second run over the same week", async () => {
+  it("writes a second thread rather than reusing the first one's records", async () => {
     const first = recordingClient();
     const second = recordingClient();
-    const options = {
+
+    const a = await postThread(first.client, REPO, specs, {
       createdAt: CREATED_AT,
-      rkeys: threadRkeys("2026-W33", 3),
-    };
+    });
+    const b = await postThread(second.client, REPO, specs, {
+      createdAt: CREATED_AT,
+    });
 
-    await postThread(first.client, REPO, specs, options);
-    await postThread(second.client, REPO, specs, options);
-
-    expect(second.calls).toEqual(first.calls);
+    // Same content, but the PDS picks the keys — neither run can land on a
+    // record the other already published.
+    expect(second.calls.map((c) => c.record)).toEqual(
+      first.calls.map((c) => c.record),
+    );
+    expect(a).toHaveLength(b.length);
   });
 
   it("chains replies root→parent", async () => {
     const { calls, client } = recordingClient();
-    const rkeys = threadRkeys("2026-W33", 3);
 
-    await postThread(client, REPO, specs, { createdAt: CREATED_AT, rkeys });
+    const refs = await postThread(client, REPO, specs, {
+      createdAt: CREATED_AT,
+    });
 
-    const rootUri = `at://${REPO}/app.bsky.feed.post/${rkeys[0]}`;
     expect(calls[0].record.reply).toBeUndefined();
     for (const [i, call] of calls.slice(1).entries()) {
       const reply = call.record.reply as {
-        parent: { uri: string };
-        root: { uri: string };
+        parent: { cid: string; uri: string };
+        root: { cid: string; uri: string };
       };
-      expect(reply.root.uri).toBe(rootUri);
-      expect(reply.parent.uri).toBe(
-        `at://${REPO}/app.bsky.feed.post/${rkeys[i]}`,
-      );
+      expect(reply.root.uri).toBe(refs[0].uri);
+      expect(reply.root.cid).toBe(refs[0].cid);
+      // Each reply pins the *previous* post, by uri and cid.
+      expect(reply.parent.uri).toBe(refs[i].uri);
+      expect(reply.parent.cid).toBe(refs[i].cid);
     }
   });
 
@@ -102,33 +115,158 @@ describe("postThread", () => {
     const { client } = recordingClient();
     const seen: Array<string> = [];
 
-    await postThread(
-      client,
-      REPO,
-      specs.map((spec, i) => ({ ...spec, text: `post-${i}` })),
-      {
-        createdAt: CREATED_AT,
-        onRoot: async () => {
-          seen.push("onRoot");
-        },
-        rkeys: threadRkeys("2026-W33", 3),
+    await postThread(client, REPO, specs, {
+      createdAt: CREATED_AT,
+      onRoot: async () => {
+        seen.push("onRoot");
       },
-    );
+    });
 
     const clientCalls = (client.post as ReturnType<typeof vi.fn>).mock.calls;
     expect(clientCalls).toHaveLength(3);
     expect(seen).toEqual(["onRoot"]); // exactly once, and it ran
   });
+});
 
-  it("refuses to post with fewer rkeys than posts", async () => {
-    const { client } = recordingClient();
+const ROOT_TEXT =
+  "🔥 The 5 hottest reads on Standard Reader this week\n\n1. Hi";
+
+/** A client serving canned `listRecords` pages. */
+function listingClient(
+  pages: Array<{ cursor?: string; records: Array<unknown> }>,
+) {
+  let page = 0;
+  const client = {
+    get: vi.fn(async () => {
+      const current = pages[Math.min(page, pages.length - 1)];
+      page++;
+      return { data: current, ok: true as const };
+    }),
+  };
+  return { client: client as unknown as Client, get: client.get };
+}
+
+function post(rkey: string, value: Record<string, unknown>) {
+  return { uri: `at://${REPO}/app.bsky.feed.post/${rkey}`, value };
+}
+
+describe("findWeekThreadRoot", () => {
+  it("finds this week's root by marker and createdAt", async () => {
+    const { client } = listingClient([
+      {
+        records: [
+          post("r2", {
+            createdAt: "2026-08-14T16:00:00.000Z",
+            text: ROOT_TEXT,
+          }),
+        ],
+      },
+    ]);
+
+    await expect(findWeekThreadRoot(client, REPO, "2026-W33")).resolves.toBe(
+      `at://${REPO}/app.bsky.feed.post/r2`,
+    );
+  });
+
+  it("ignores a root from a different week", async () => {
+    const { client } = listingClient([
+      {
+        records: [
+          post("r1", {
+            createdAt: "2026-08-07T16:00:00.000Z",
+            text: ROOT_TEXT,
+          }),
+        ],
+      },
+    ]);
 
     await expect(
-      postThread(client, REPO, specs, {
-        createdAt: CREATED_AT,
-        rkeys: threadRkeys("2026-W33", 2),
+      findWeekThreadRoot(client, REPO, "2026-W33"),
+    ).resolves.toBeNull();
+  });
+
+  it("ignores replies and unrelated posts in the same week", async () => {
+    const { client } = listingClient([
+      {
+        records: [
+          post("a", {
+            createdAt: "2026-08-14T17:00:00.000Z",
+            text: "Nope! Will get that fixed",
+          }),
+          post("b", {
+            createdAt: "2026-08-14T16:00:01.000Z",
+            reply: { parent: {}, root: {} },
+            text: ROOT_TEXT,
+          }),
+        ],
+      },
+    ]);
+
+    await expect(
+      findWeekThreadRoot(client, REPO, "2026-W33"),
+    ).resolves.toBeNull();
+  });
+
+  // `createdAt` is whatever the writer put there — the old job backdated every
+  // post to the week's nominal Friday — so an older-looking record must not end
+  // the scan while the root it is looking for is still further down.
+  it("keeps scanning past an out-of-order createdAt", async () => {
+    const { client } = listingClient([
+      {
+        cursor: "next",
+        records: [
+          post("backdated", {
+            createdAt: "2026-08-07T16:00:00.000Z",
+            text: "backdated by the old job",
+          }),
+        ],
+      },
+      {
+        records: [
+          post("root", {
+            createdAt: "2026-08-14T16:00:00.000Z",
+            text: ROOT_TEXT,
+          }),
+        ],
+      },
+    ]);
+
+    await expect(findWeekThreadRoot(client, REPO, "2026-W33")).resolves.toBe(
+      `at://${REPO}/app.bsky.feed.post/root`,
+    );
+  });
+
+  it("stops at the page cap rather than walking the whole repo", async () => {
+    const { client, get } = listingClient([
+      {
+        cursor: "next",
+        records: Array.from({ length: 100 }, (_, i) =>
+          post(`p${i}`, {
+            createdAt: "2026-08-14T16:00:00.000Z",
+            text: "not a root",
+          }),
+        ),
+      },
+    ]);
+
+    await expect(
+      findWeekThreadRoot(client, REPO, "2026-W33"),
+    ).resolves.toBeNull();
+    expect(get).toHaveBeenCalledTimes(3);
+  });
+
+  // Fail closed: if we cannot tell whether the thread already exists, the
+  // caller must not go on to post one.
+  it("propagates a transport failure instead of reporting 'no thread'", async () => {
+    const client = {
+      get: vi.fn(async () => {
+        throw new Error("pds unreachable");
       }),
-    ).rejects.toThrow(/one rkey per post/);
+    } as unknown as Client;
+
+    await expect(findWeekThreadRoot(client, REPO, "2026-W33")).rejects.toThrow(
+      /pds unreachable/,
+    );
   });
 });
 

--- a/apps/standard-reader/src/server/announce/thread.ts
+++ b/apps/standard-reader/src/server/announce/thread.ts
@@ -8,9 +8,13 @@
  * `cid`, which is only known after that post is written — so `applyWrites`
  * (which needs all refs up front) can't be used here.
  *
- * Every post is a `putRecord` at a record key derived from the week (see
- * `./week.ts`), which is what stops the weekly job from ever publishing the same
- * thread twice.
+ * Posts are CREATED, never rewritten: `createRecord` at a fresh TID. A published
+ * post is immutable as far as the rest of the network is concerned — replies,
+ * likes and quotes all pin its `cid` — so writing over one at a stable rkey
+ * orphans them onto content that did not exist when they were written and leaves
+ * AppViews disagreeing with the PDS about what the post says. Not publishing the
+ * thread twice is the ledger's job (`./ledger.ts`), backed by
+ * {@link findWeekThreadRoot} below; it is never the write path's.
  */
 import type { Client } from "@atcute/client";
 import { ok } from "@atcute/client";
@@ -18,7 +22,12 @@ import { ok } from "@atcute/client";
 import { utf8ByteLength } from "#/lib/leaflet/utf8";
 import { uploadBlob } from "#/server/atproto/repo-records";
 
-import { BSKY_FEED_POST, MAX_THUMB_BYTES } from "./config.ts";
+import {
+  BSKY_FEED_POST,
+  MAX_THUMB_BYTES,
+  THREAD_ROOT_MARKER,
+} from "./config.ts";
+import { isoWeekKey } from "./week.ts";
 
 /** A `com.atproto.repo.strongRef` target (uri + cid). */
 export interface StrongRef {
@@ -154,36 +163,107 @@ export function buildPostRecord(
 }
 
 /**
- * Write a single post record at a fixed rkey and return its strongRef.
+ * Create a single post record at a fresh TID and return its strongRef.
  *
- * `putRecord`, not `createRecord`: paired with the week-derived rkeys from
- * `./week.ts` it makes posting the thread an upsert. Re-running the job
- * overwrites the week's posts in place instead of publishing a second thread —
- * the fresh-TID `createRecord` this replaced is exactly how the job used to
- * duplicate itself.
+ * `createRecord`, never `putRecord` at a computed rkey: the PDS picks the rkey,
+ * so this can only ever add a post, never rewrite one somebody has already
+ * replied to. Stopping the job from posting twice happens before we get here.
  */
-export async function putPost(
+export async function createPost(
   client: Client,
   repo: string,
-  rkey: string,
   record: Record<string, unknown>,
 ): Promise<StrongRef> {
   const res = await ok(
-    client.post("com.atproto.repo.putRecord", {
+    client.post("com.atproto.repo.createRecord", {
       input: {
         collection: BSKY_FEED_POST,
         record,
         repo,
-        rkey,
       } as never,
     }),
   );
   return { uri: res.uri, cid: res.cid };
 }
 
+/** How many pages of the bot's own posts the duplicate scan will walk. */
+const ROOT_SCAN_PAGE = 100;
+const ROOT_SCAN_MAX_PAGES = 3;
+
+function isRecordValue(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * The AT-URI of a thread root already posted for `periodKey`, or `null`.
+ *
+ * This is the guard that used to be "write to a week-derived rkey and let
+ * `putRecord` collapse the duplicate". That worked by mutating already-published
+ * posts, which is far worse than the duplicate it prevented, so the check moved
+ * here: ask the repo whether this week's thread exists instead of overwriting it
+ * on the assumption that it might.
+ *
+ * Reads the bot's own posts newest-first and looks for a non-reply carrying
+ * {@link THREAD_ROOT_MARKER} whose `createdAt` lands in the target week.
+ *
+ * The scan does not stop early on the first older-looking post: `createdAt` is
+ * whatever the writer put there, not a repo ordering, and this very repo holds
+ * posts the old job backdated to the week's nominal Friday. So it walks a fixed
+ * few pages instead — the week being looked for is always the most recent one,
+ * so its root is realistically on page one, and this runs once a week.
+ *
+ * Deliberately not fail-open: a transport error propagates, so a run that cannot
+ * establish whether the thread already went out does not post one anyway.
+ */
+export async function findWeekThreadRoot(
+  client: Client,
+  repo: string,
+  periodKey: string,
+): Promise<string | null> {
+  let cursor: string | undefined;
+
+  for (let page = 0; page < ROOT_SCAN_MAX_PAGES; page++) {
+    const res = await ok(
+      client.get("com.atproto.repo.listRecords", {
+        params: {
+          collection: BSKY_FEED_POST,
+          limit: ROOT_SCAN_PAGE,
+          repo,
+          ...(cursor ? { cursor } : {}),
+        } as never,
+      }),
+    );
+
+    for (const record of res.records) {
+      const value = record.value;
+      if (!isRecordValue(value)) continue;
+      // Replies are thread posts 2..n, and the CTA — only roots count.
+      if (value.reply) continue;
+
+      const createdAt =
+        typeof value.createdAt === "string"
+          ? Date.parse(value.createdAt)
+          : Number.NaN;
+      if (!Number.isFinite(createdAt)) continue;
+      const week = isoWeekKey(new Date(createdAt));
+
+      if (
+        week === periodKey &&
+        typeof value.text === "string" &&
+        value.text.includes(THREAD_ROOT_MARKER)
+      ) {
+        return record.uri;
+      }
+    }
+
+    if (!res.cursor) return null;
+    cursor = res.cursor;
+  }
+
+  return null;
+}
+
 export interface PostThreadOptions {
-  /** Record key per spec, in thread order — see `threadRkeys()`. */
-  rkeys: Array<string>;
   /** `createdAt` stamped on every post in the thread. */
   createdAt: string;
   /**
@@ -206,23 +286,17 @@ export async function postThread(
   specs: Array<PostSpec>,
   options: PostThreadOptions,
 ): Promise<Array<StrongRef>> {
-  if (options.rkeys.length < specs.length) {
-    throw new Error(
-      `postThread needs one rkey per post (${specs.length} specs, ${options.rkeys.length} rkeys)`,
-    );
-  }
-
   const created: Array<StrongRef> = [];
   let root: StrongRef | null = null;
   let parent: StrongRef | null = null;
 
-  for (const [i, spec] of specs.entries()) {
+  for (const spec of specs) {
     const record = buildPostRecord(
       spec,
       options.createdAt,
       root && parent ? { root, parent } : undefined,
     );
-    const ref = await putPost(client, repo, options.rkeys[i], record);
+    const ref = await createPost(client, repo, record);
     created.push(ref);
     if (!root) {
       root = ref;

--- a/apps/standard-reader/src/server/announce/week.test.ts
+++ b/apps/standard-reader/src/server/announce/week.test.ts
@@ -1,7 +1,6 @@
-import { parse as parseTid, validate as validateTid } from "@atcute/tid";
 import { describe, expect, it } from "vitest";
 
-import { isoWeekKey, threadRkeys, weekAnchor } from "./week.ts";
+import { isoWeekKey } from "./week.ts";
 
 describe("isoWeekKey", () => {
   it("gives every day of one ISO week the same key", () => {
@@ -44,59 +43,19 @@ describe("isoWeekKey", () => {
   });
 });
 
-describe("weekAnchor", () => {
-  it("is that week's Friday at the cron hour", () => {
-    expect(weekAnchor("2026-W33").toISOString()).toBe(
-      "2026-08-14T16:00:00.000Z",
-    );
-    expect(weekAnchor("2026-W34").toISOString()).toBe(
-      "2026-08-21T16:00:00.000Z",
-    );
-  });
-
-  it("round-trips with isoWeekKey", () => {
-    for (const key of ["2025-W01", "2026-W01", "2026-W33", "2026-W53"]) {
-      expect(isoWeekKey(weekAnchor(key))).toBe(key);
-    }
-  });
-
-  it("rejects anything that isn't an ISO week key", () => {
-    expect(() => weekAnchor("2026-08-14")).toThrow(/Not an ISO week key/);
-  });
-});
-
-describe("threadRkeys", () => {
-  it("gives the same week the same keys every time", () => {
-    expect(threadRkeys("2026-W33", 6)).toEqual(threadRkeys("2026-W33", 6));
-  });
-
-  it("gives different weeks different keys", () => {
-    const a = threadRkeys("2026-W33", 6);
-    const b = threadRkeys("2026-W34", 6);
-    expect(a.filter((rkey) => b.includes(rkey))).toEqual([]);
-  });
-
-  it("mints valid, distinct, thread-ordered TIDs", () => {
-    const rkeys = threadRkeys("2026-W33", 6);
-    expect(rkeys).toHaveLength(6);
-    expect(new Set(rkeys).size).toBe(6);
-    for (const rkey of rkeys) expect(validateTid(rkey)).toBe(true);
-    // TIDs sort lexicographically by timestamp, so thread order is rkey order.
-    expect(rkeys.toSorted()).toEqual(rkeys);
-  });
-
-  it("seeds the TIDs from the week's anchor instant", () => {
-    const [first] = threadRkeys("2026-W33", 6);
-    expect(parseTid(first).timestamp).toBe(
-      weekAnchor("2026-W33").getTime() * 1000,
-    );
-  });
-
-  it("keeps a shorter thread's keys a prefix of a longer one's", () => {
-    // An empty-ish week that later re-posts with more articles must reuse the
-    // keys it already wrote rather than shifting every post to a new record.
-    expect(threadRkeys("2026-W33", 4)).toEqual(
-      threadRkeys("2026-W33", 6).slice(0, 4),
-    );
+describe("isoWeekKey ordering", () => {
+  // `findWeekThreadRoot` walks the bot's posts newest-first and stops when a
+  // record's week sorts before the one it wants, so the keys must compare.
+  it("compares lexicographically in calendar order", () => {
+    const keys = [
+      "2025-W52",
+      "2026-W01",
+      "2026-W09",
+      "2026-W10",
+      "2026-W33",
+      "2026-W53",
+      "2027-W01",
+    ];
+    expect(keys.toSorted()).toEqual(keys);
   });
 });

--- a/apps/standard-reader/src/server/announce/week.ts
+++ b/apps/standard-reader/src/server/announce/week.ts
@@ -1,34 +1,26 @@
 /**
- * The week the thread belongs to, and the record keys derived from it.
+ * The week the thread belongs to, and the ledger key derived from it.
  *
- * Everything here is a pure function of the run's calendar week, which is what
- * makes the weekly thread postable exactly once. Two mechanisms hang off it:
+ * The ISO week is the job's identity: `weekly_thread_runs` is keyed by
+ * {@link isoWeekKey}, and claiming that row is what stops a second run from
+ * posting (see `./ledger.ts`). A repo-side check for a root already carrying
+ * this week's marker backs it up (see `findWeekThreadRoot` in `./thread.ts`).
  *
- *  1. `weekly_thread_runs` is keyed by {@link isoWeekKey} — the claim that stops
- *     a second run from doing the work at all (see `./ledger.ts`).
- *  2. The posts themselves are written at {@link threadRkeys} with `putRecord`,
- *     so a run that gets past the claim anyway — the DB unreachable, the guard
- *     forced, a bug — *overwrites* last run's thread instead of publishing a
- *     second one. Fresh TIDs (`tid.now()`) are what made the old job duplicate.
+ * There is deliberately no rkey derivation here. An earlier version minted
+ * deterministic TIDs from the week and wrote the posts with `putRecord`, so a
+ * re-run "upserted" the thread in place. That silently rewrote posts the network
+ * had already seen: replies and likes pin a post's `cid`, so every overwrite
+ * orphaned them onto content that did not exist when they were written, and
+ * AppViews that had indexed an earlier version disagreed with the PDS about what
+ * the post said. Posts are created at fresh TIDs now and never rewritten.
  *
  * Kept transport- and DB-free so the runner, the thread builder, and tests can
  * all share it.
  */
-import { create as createTid } from "@atcute/tid";
 
 /** Millis in a day / week, for the ISO week arithmetic below. */
 const DAY_MS = 86_400_000;
 const WEEK_MS = 7 * DAY_MS;
-
-/**
- * Fixed clock id for every TID this job mints. TIDs encode (timestamp, clockid),
- * so pinning the clockid is what makes the same week always produce the same
- * record keys — the point of the whole scheme.
- */
-const THREAD_CLOCK_ID = 0;
-
-/** The hour the cron fires (`0 16 * * 5`), used as each week's anchor instant. */
-const THREAD_CRON_HOUR_UTC = 16;
 
 /**
  * ISO-8601 week of `date` in UTC (`2026-W33`).
@@ -37,6 +29,10 @@ const THREAD_CRON_HOUR_UTC = 16;
  * re-run over that Friday-to-Sunday tail maps to the same key — which is the
  * window a duplicate post would land in. A run the following week gets a new key
  * and is free to post, as it should be.
+ *
+ * Week keys also compare correctly with `<`/`>`: the ISO year leads and the week
+ * number is zero-padded, which is what lets the repo-side scan in
+ * `findWeekThreadRoot` stop once it walks past the week it is looking for.
  */
 export function isoWeekKey(date: Date): string {
   // Shift to the Thursday of this week: the ISO year is whichever year that
@@ -57,38 +53,4 @@ function isoWeek1Monday(isoYear: number): Date {
   const jan4 = new Date(Date.UTC(isoYear, 0, 4));
   const isoDay = jan4.getUTCDay() === 0 ? 7 : jan4.getUTCDay();
   return new Date(jan4.getTime() - (isoDay - 1) * DAY_MS);
-}
-
-/**
- * The instant a week's thread is *nominally* posted: that week's Friday at the
- * cron hour, UTC. Used as both the TID seed and the records' `createdAt`, so a
- * re-run rewrites byte-identical records rather than shifting the thread's
- * timestamp. A late catch-up run therefore posts under the Friday it stands in
- * for, which is what the thread says it is anyway.
- */
-export function weekAnchor(periodKey: string): Date {
-  const match = /^(\d{4})-W(\d{2})$/.exec(periodKey);
-  if (!match) {
-    throw new Error(`Not an ISO week key: ${periodKey}`);
-  }
-  const monday =
-    isoWeek1Monday(Number(match[1])).getTime() +
-    (Number(match[2]) - 1) * WEEK_MS;
-  // Monday + 4 days = Friday, at the cron hour.
-  return new Date(monday + 4 * DAY_MS + THREAD_CRON_HOUR_UTC * 3_600_000);
-}
-
-/**
- * The `count` record keys this week's thread posts live at, in thread order.
- *
- * TIDs are (timestamp, clockid) pairs, so seeding from the week's anchor instant
- * with a pinned clockid yields the same keys on every run — `putRecord` at those
- * keys is an upsert, and the thread can never be published twice. One
- * microsecond apart keeps them sorting in thread order.
- */
-export function threadRkeys(periodKey: string, count: number): Array<string> {
-  const anchorMicros = weekAnchor(periodKey).getTime() * 1000;
-  return Array.from({ length: count }, (_, i) =>
-    createTid(anchorMicros + i, THREAD_CLOCK_ID),
-  );
 }


### PR DESCRIPTION
The weekly "hottest articles" job minted deterministic TIDs from the ISO
week (fixed clockid, anchor + 1µs per post) and wrote every post with
`putRecord`, so a re-run "upserted" the thread in place instead of
publishing a second one.

That traded a visible duplicate for a much worse, invisible problem: it
mutated posts the network had already seen. A post's identity off-repo is
(uri, cid) — every reply, like and quote pins the cid in a strongRef — so
each overwrite left the URI resolving to content that did not exist when
those refs were written, and AppViews that had indexed an earlier version
disagreed with the PDS about what the post said.

This is live on 2026-W35. `…/post/3mu5q7quc2222` is one URI with two
different articles on it: the PDS serves cid bafyreiaqmh5bpqb… while the
Bluesky AppView serves bafyreibrp6ksmkl…. A reply from a reader pins a
third cid at `…2622` that no longer exists anywhere. The TIDs decode
exactly to threadRkeys("2026-W35", n), so this is the derivation, not a
coincidence.

Published posts are immutable. A duplicate has to be prevented before the
write or not at all:

- postThread now uses `createRecord` at PDS-assigned rkeys and can only
  ever add records. `threadRkeys`/`weekAnchor` are gone.
- The removed second guard is replaced with one that reads instead of
  writes: `findWeekThreadRoot` asks the bot's own repo whether a root
  carrying this week's marker is already there, and the run stands down
  and repairs the ledger if so. It fails closed — a transport error
  propagates rather than reporting "no thread".
- `createdAt` is the real posting instant instead of the week's nominal
  Friday, so a catch-up run stops backdating itself.
- THREAD_FORCE=1 now posts a genuinely new second thread rather than
  silently rewriting the first.

The ISO-week claim in `weekly_thread_runs` is unchanged and remains the
primary guard.

Note this does not repair the records already written; the mangled
2026-W35 thread needs an operator decision, since deleting it would
orphan the replies it collected.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G9qKt1Qjhdmx3XUE1EiTjs